### PR TITLE
CTFReader dateLimiter acts on injection rather than reading

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -177,3 +177,6 @@ To apply TF rate limiting (make sure that no more than N TFs are in processing) 
 too all workflows (e.g. via ARGS_ALL).
 The IPCID is the NUMA domain ID (usually 0 on non-EPN workflow).
 Additionally, one may throttle on the free SHM by providing an option to the reader `--timeframes-shm-limit <shm-size>`.
+
+Note that by default the reader reads into the memory the CTF data and prepares all output messages but injects them only once the rate-limiter allows that.
+With the option `--limit-tf-before-reading` set also the preparation of the data to inject will be conditioned by the green light from the rate-limiter.

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -34,6 +34,7 @@ struct CTFReaderInp {
   std::vector<int> ctfIDs{};
   bool skipSkimmedOutTF = false;
   bool allowMissingDetectors = false;
+  bool checkTFLimitBeforeReading = false;
   bool sup0xccdb = false;
   int maxFileCache = 1;
   int64_t delay_us = 0;
@@ -41,7 +42,7 @@ struct CTFReaderInp {
   int maxTFs = -1;
   unsigned int subspec = 0;
   unsigned int decSSpecEMC = 0;
-  int tfRateLimit = 0;
+  int tfRateLimit = -999;
   size_t minSHM = 0;
 };
 

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -117,8 +117,7 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
   if (device != mDevice) {
     throw std::runtime_error(fmt::format("FMQDevice has changed, old={} new={}", fmt::ptr(mDevice), fmt::ptr(device)));
   }
-  static bool initOnceDone = false;
-  if (!initOnceDone) {
+  if (mInput.tfRateLimit == -999) {
     mInput.tfRateLimit = std::stoi(device->fConfig->GetValue<std::string>("timeframes-rate-limit"));
   }
   auto acknowledgeOutput = [this](fair::mq::Parts& parts, bool verbose = false) {

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
@@ -36,7 +36,7 @@ struct TFReaderInp {
   o2::detectors::DetID::mask_t detMaskRawOnly{};
   o2::detectors::DetID::mask_t detMaskNonRawOnly{};
   size_t minSHM = 0;
-  int tfRateLimit = 0;
+  int tfRateLimit = -999;
   int maxTFCache = 1;
   int maxFileCache = 1;
   int verbosity = 0;

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -78,7 +78,7 @@ class RawReaderSpecs : public o2f::Task
   uint32_t mMaxTFID = 0xffffffff; // last TF to extrct
   int mRunNumber = 0;             // run number to pass
   int mVerbosity = 0;
-  int mTFRateLimit = 0;
+  int mTFRateLimit = -999;
   bool mPreferCalcTF = false;
   size_t mMinSHM = 0;
   size_t mLoopsDone = 0;
@@ -170,8 +170,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
   mTimer.Start(false);
   auto device = ctx.services().get<o2f::RawDeviceService>().device();
   assert(device);
-  static bool initOnceDone = false;
-  if (!initOnceDone) {
+  if (mTFRateLimit == -999) {
     mTFRateLimit = std::stoi(device->fConfig->GetValue<std::string>("timeframes-rate-limit"));
   }
   auto findOutputChannel = [&ctx, this](o2h::DataHeader& h) {


### PR DESCRIPTION
By default the ctf-reader reads into the memory the CTF data and prepares all output messages but injects them only once the rate-limiter allows that. With the option --limit-tf-before-reading set also the preparation of the data to inject will be conditioned by the green light from the rate-limiter.