### PR TITLE
[FOCAL-10] Auto-determine whether timeframe has payload from either of the FOCAL-E subsystems

### DIFF
--- a/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
+++ b/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
@@ -77,6 +77,8 @@ class RawDecoderSpec : public framework::Task
   bool mUsePadData = true;
   bool mUsePixelData = true;
   bool mFilterIncomplete = false;
+  bool mTimeframeHasPadData = false;
+  bool mTimeframeHasPixelData = false;
   uint32_t mOutputSubspec = 0;
   PadDecoder mPadDecoder;
   PixelDecoder mPixelDecoder;


### PR DESCRIPTION
Determine subsytems for which payload has been
found and use that in the event building. The option
to disable subsystems separately is kept.