### PR TITLE
ITS decoder: fixed bug with getNextChipData

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -330,7 +330,7 @@ ChipPixelData* RawPixelDecoder<Mapping>::getNextChipData(std::vector<ChipPixelDa
     }
   }
   // will need to decode new trigger
-  if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode
+  if (!mDecodeNextAuto || decodeNextTrigger() < 0) { // no more data to decode
     return nullptr;
   }
   return getNextChipData(chipDataVec);
@@ -352,7 +352,7 @@ bool RawPixelDecoder<Mapping>::getNextChipData(ChipPixelData& chipData)
     }
   }
   // will need to decode new trigger
-  if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode
+  if (!mDecodeNextAuto || decodeNextTrigger() < 0) { // no more data to decode
     return false;
   }
   return getNextChipData(chipData); // is it ok to use recursion here?
@@ -389,7 +389,7 @@ ChipPixelData* RawPixelDecoder<ChipMappingMFT>::getNextChipData(std::vector<Chip
     return &chipDataVec[mLastReadChipID];
   }
   // will need to decode new trigger
-  if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode
+  if (!mDecodeNextAuto || decodeNextTrigger() < 0) { // no more data to decode
     return nullptr;
   }
   return getNextChipData(chipDataVec);
@@ -408,7 +408,7 @@ bool RawPixelDecoder<ChipMappingMFT>::getNextChipData(ChipPixelData& chipData)
     return true;
   }
   // will need to decode new trigger
-  if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode
+  if (!mDecodeNextAuto || decodeNextTrigger() < 0) { // no more data to decode
     return false;
   }
   return getNextChipData(chipData); // is it ok to use recursion here?


### PR DESCRIPTION
@shahor02 I open this PR to fix a bug introduced with PR11069 (https://github.com/AliceO2Group/AliceO2/pull/11069/files) when the return value of decodeNextTrigger was changed (request from my side)

This in particular fixes an issue we observe at P2 (after this morning's SW upgrade) with ITS QC FHR task where the loop on `decodeNextChipData` is infinite without this fix, i.e. `decodeNextTrigger` never return 0 and hence `decodeNextChipData` never return a `nullptr` (we operate with decodenexttriggerauto = true). 

Here the loop of the FHR task affected, mentioned just above: https://github.com/AliceO2Group/QualityControl/blob/4597ae73b864e7748ddc33da02106523c39502bb/Modules/ITS/src/ITSFhrTask.cxx#L445