### PR TITLE
tof fix to recover tof compressor on epn

### DIFF
--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/CompressedDecodingTask.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/CompressedDecodingTask.h
@@ -38,7 +38,7 @@ using namespace compressed;
 class CompressedDecodingTask : public DecoderBase, public Task
 {
  public:
-  CompressedDecodingTask(bool conet, o2::header::DataDescription dataDesc, std::shared_ptr<o2::base::GRPGeomRequest> gr) : mGGCCDBRequest(gr)
+  CompressedDecodingTask(bool conet, o2::header::DataDescription dataDesc, std::shared_ptr<o2::base::GRPGeomRequest> gr, int norbitPerTF = -1, bool localCmp = false) : mGGCCDBRequest(gr), mNorbitsPerTF(norbitPerTF), mLocalCmp(localCmp)
   {
     mConetMode = conet;
     mDataDesc = dataDesc;
@@ -51,7 +51,12 @@ class CompressedDecodingTask : public DecoderBase, public Task
   void decodeTF(ProcessingContext& pc);
   void endOfStream(EndOfStreamContext& ec) final;
   void postData(ProcessingContext& pc);
-  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final { o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj); }
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
+  {
+    if (mNorbitsPerTF == -1) {
+      o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+    }
+  }
 
  private:
   /** decoding handlers **/
@@ -77,12 +82,14 @@ class CompressedDecodingTask : public DecoderBase, public Task
   uint32_t mCurrentOrbit = 0;
   bool mRowFilter = false;
   bool mMaskNoise = false;
+  bool mLocalCmp = false;
   int mNoiseRate = 1000;
   unsigned long mCreationTime = 0;
+  int mNorbitsPerTF = -1;
   TStopwatch mTimer;
 };
 
-framework::DataProcessorSpec getCompressedDecodingSpec(const std::string& inputDesc, bool conet = false, bool askDISTSTF = true);
+framework::DataProcessorSpec getCompressedDecodingSpec(const std::string& inputDesc, bool conet = false, bool askDISTSTF = true, int norbitPerTF = -1, bool localCmp = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -45,7 +45,9 @@ void CompressedDecodingTask::init(InitContext& ic)
 {
   LOG(debug) << "CompressedDecoding init";
 
-  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+  if (mNorbitsPerTF == -1) {
+    o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+  }
 
   mMaskNoise = ic.options().get<bool>("mask-noise");
   mNoiseRate = ic.options().get<int>("noise-counts");
@@ -141,9 +143,12 @@ void CompressedDecodingTask::run(ProcessingContext& pc)
 {
   mTimer.Start(false);
 
-  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  const uint32_t norbits = o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF();
-  Utils::setNOrbitInTF(norbits);
+  int norbits = mNorbitsPerTF;
+  if (norbits == -1) {
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+    norbits = o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF();
+    mNorbitsPerTF = norbits;
+  }
   mDecoder.setNOrbitInTF(norbits);
 
   static bool isFirstCall = true;
@@ -186,9 +191,10 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
 {
   auto& inputs = pc.inputs();
   const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
-  {
+  if (!mLocalCmp) {
     static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{"TOF", mDataDesc, 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(inputs, dummy)) {
@@ -208,8 +214,10 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
   }
 
   /** loop over inputs routes **/
+
   std::vector<InputSpec> sel{InputSpec{"filter", ConcreteDataTypeMatcher{"TOF", "CRAWDATA"}}};
   for (const auto& ref : InputRecordWalker(pc.inputs(), sel)) {
+    //  for (auto const& ref : o2::framework::InputRecordWalker(pc.inputs())) {
     //  for (auto iit = pc.inputs().begin(), iend = pc.inputs().end(); iit != iend; ++iit) {
     //    if (!iit.isValid()) {
     //      continue;
@@ -220,6 +228,12 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
     const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
     auto payloadIn = ref.payload;
     auto payloadInSize = DataRefUtils::getPayloadSize(ref);
+
+    if (payloadInSize < 1) {
+      continue;
+    }
+
+    //    LOG(info) << "payloadInSize = " << payloadInSize;
 
     DecoderBase::setDecoderBuffer(payloadIn);
     DecoderBase::setDecoderBufferSize(payloadInSize);
@@ -425,20 +439,23 @@ void CompressedDecodingTask::frameHandler(const CrateHeader_t* crateHeader, cons
   }
 };
 
-DataProcessorSpec getCompressedDecodingSpec(const std::string& inputDesc, bool conet, bool askDISTSTF)
+DataProcessorSpec getCompressedDecodingSpec(const std::string& inputDesc, bool conet, bool askDISTSTF, int norbitPerTF, bool localCmp)
 {
   std::vector<InputSpec> inputs;
   if (askDISTSTF) {
     inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
   }
 
-  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
-                                                                true,                           // GRPECS=true for nHBF per TF
-                                                                false,                          // GRPLHCIF
-                                                                false,                          // GRPMagField
-                                                                false,                          // askMatLUT
-                                                                o2::base::GRPGeomRequest::None, // geometry
-                                                                inputs);
+  std::shared_ptr<o2::base::GRPGeomRequest> ccdbRequest;
+  if (norbitPerTF == -1) {
+    ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
+                                                             norbitPerTF == -1,              // GRPECS=true for nHBF per TF
+                                                             false,                          // GRPLHCIF
+                                                             false,                          // GRPMagField
+                                                             false,                          // askMatLUT
+                                                             o2::base::GRPGeomRequest::None, // geometry
+                                                             inputs);
+  }
 
   //  inputs.emplace_back(std::string("x:TOF/" + inputDesc).c_str(), 0, Lifetime::Optional);
   o2::header::DataDescription dataDesc;
@@ -458,7 +475,7 @@ DataProcessorSpec getCompressedDecodingSpec(const std::string& inputDesc, bool c
     inputs,
     //    select(std::string("x:TOF/" + inputDesc).c_str()),
     outputs,
-    AlgorithmSpec{adaptFromTask<CompressedDecodingTask>(conet, dataDesc, ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<CompressedDecodingTask>(conet, dataDesc, ccdbRequest, norbitPerTF, localCmp)},
     Options{
       {"row-filter", VariantType::Bool, false, {"Filter empty row"}},
       {"mask-noise", VariantType::Bool, false, {"Flag to mask noisy digits"}},

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -171,7 +171,7 @@ fi
 [[ -z $DISABLE_ROOT_OUTPUT ]] || needs_root_output o2-gpu-reco-workflow && GPU_OUTPUT+=",send-clusters-per-sector"
 
 has_detector_flp_processing CPV && CPV_INPUT=digits
-! has_detector_flp_processing TOF && TOF_CONFIG+=" --ignore-dist-stf"
+! has_detector_flp_processing TOF && TOF_CONFIG+=" --orbits-per-tf ${NHBPERTF:-32} --ignore-dist-stf --local-cmp"
 
 if [[ $EPNSYNCMODE == 1 ]]; then
   EVE_CONFIG+=" --eve-dds-collection-index 0"


### PR DESCRIPTION
Hi @martenole 
This is to get tof compressor working again on epn.
It now works on my laptop but it should be checked on epn. Can you try it?
Since the problem spotted here
https://alice.its.cern.ch/jira/browse/O2-3681
there is no way at the moment to get tof-compressor and decoder in the same chain if other inputs are required by the decoder (DIST-STF or GRPRequest).
I can easily disable DIST-STF but to disable GRPRequest I need to pass NorbitPerTF as external param, i.e. hardcoded at 32.
This is a temporary solution till we solve the problem with the framework.