### PR TITLE
[EMCAL-688] Remove old container init functions

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -331,21 +331,6 @@ class ClusterFactory
   bool getUseWeightExotic() const { return mUseWeightExotic; }
   void setUseWeightExotic(float useWeightExotic) { mUseWeightExotic = useWeightExotic; }
 
-  void setClustersContainer(gsl::span<const o2::emcal::Cluster> clusterContainer)
-  {
-    mClustersContainer = clusterContainer;
-  }
-
-  void setCellsContainer(gsl::span<const InputType> cellContainer)
-  {
-    mInputsContainer = cellContainer;
-  }
-
-  void setCellsIndicesContainer(gsl::span<const int> indicesContainer)
-  {
-    mCellsIndices = indicesContainer;
-  }
-
   void setContainer(gsl::span<const o2::emcal::Cluster> clusterContainer, gsl::span<const InputType> cellContainer, gsl::span<const int> indicesContainer)
   {
     mClustersContainer = clusterContainer;

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -627,10 +627,18 @@ float ClusterFactory<InputType>::getECross(short towerId, float energy, float co
   short towerId2 = -1;
 
   if (iphi < o2::emcal::EMCAL_ROWS - 1) {
-    towerId1 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi + 1, ieta);
+    try {
+      towerId1 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi + 1, ieta);
+    } catch (InvalidCellIDException& e) {
+      towerId1 = -1 * e.getCellID();
+    }
   }
   if (iphi > 0) {
-    towerId2 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi - 1, ieta);
+    try {
+      towerId2 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi - 1, ieta);
+    } catch (InvalidCellIDException& e) {
+      towerId2 = -1 * e.getCellID();
+    }
   }
 
   // In case of cell in eta = 0 border, depending on SM shift the cross cell index
@@ -639,17 +647,41 @@ float ClusterFactory<InputType>::getECross(short towerId, float energy, float co
   short towerId4 = -1;
 
   if (ieta == o2::emcal::EMCAL_COLS - 1 && !(iSM % 2)) {
-    towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM + 1, iphi, 0);
-    towerId4 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta - 1);
+    try {
+      towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM + 1, iphi, 0);
+    } catch (InvalidCellIDException& e) {
+      towerId3 = -1 * e.getCellID();
+    }
+    try {
+      towerId4 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta - 1);
+    } catch (InvalidCellIDException& e) {
+      towerId4 = -1 * e.getCellID();
+    }
   } else if (ieta == 0 && iSM % 2) {
-    towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta + 1);
-    towerId4 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM - 1, iphi, o2::emcal::EMCAL_COLS - 1);
+    try {
+      towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta + 1);
+    } catch (InvalidCellIDException& e) {
+      towerId3 = -1 * e.getCellID();
+    }
+    try {
+      towerId4 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM - 1, iphi, o2::emcal::EMCAL_COLS - 1);
+    } catch (InvalidCellIDException& e) {
+      towerId4 = -1 * e.getCellID();
+    }
   } else {
     if (ieta < o2::emcal::EMCAL_COLS - 1) {
-      towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta + 1);
+      try {
+        towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta + 1);
+      } catch (InvalidCellIDException& e) {
+        towerId3 = -1 * e.getCellID();
+      }
     }
     if (ieta > 0) {
-      towerId4 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta - 1);
+      try {
+        towerId4 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta - 1);
+      } catch (InvalidCellIDException& e) {
+        towerId4 = -1 * e.getCellID();
+      }
     }
   }
 

--- a/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
@@ -138,9 +138,7 @@ void AnalysisClusterSpec<InputType>::run(framework::ProcessingContext& ctx)
     auto inputEvent = mEventHandler->buildEvent(iev);
 
     mClusterFactory->reset();
-    mClusterFactory->setClustersContainer(inputEvent.mClusters);
-    mClusterFactory->setCellsContainer(Inputs);
-    mClusterFactory->setCellsIndicesContainer(inputEvent.mCellIndices);
+    mClusterFactory->setContainer(inputEvent.mClusters, Inputs, inputEvent.mCellIndices);
 
     //for (const auto& analysisCluster : mClusterFactory) {
     for (int icl = 0; icl < mClusterFactory->getNumberOfClusters(); icl++) {


### PR DESCRIPTION
- Remove the old init functions for the cluster, cell and index container
- Change to the new init function in AnalysisClusterSpec.cxx
- This is part of the PR #11139

[EMCAL-688] Add catch for InvalidCellIDException in getECross

- In the getECross function when trying to get cell IDs from neighbouring cells where there are none, now catch the error and return the negative theoretical cell ID. This way these cells will be ignored, but the code does not exit with an error. This should be similar to AliPhysics now, where we never trow this error, we just returned the negative cell ID in that case.