### PR TITLE
Fix in TPC NCrossedPadrows calc. for AO2D

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1286,6 +1286,7 @@ void AODProducerWorkflowDPL::countTPCClusters(const o2::globaltracking::RecoCont
         for (int j = i + 1; j < lim; j++) {
           if (clMap[j]) {
             counters.crossed++;
+            break;
           }
         }
       }


### PR DESCRIPTION
The NCrossedPadrows before this fix is wrong (overestimated and not bound by NRows).

Trivial fix, merging.