### PR TITLE
DPL: Make DPLRawPageSequencer more robust against bad input data via sanity check

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -78,7 +78,7 @@ add_executable(o2-test-framework-utils
   test/test_DPLRawParser.cxx
   test/test_DPLRawPageSequencer.cxx
 )
-target_link_libraries(o2-test-framework-utils PRIVATE O2::Framework O2::DPLUtils)
+target_link_libraries(o2-test-framework-utils PRIVATE O2::Framework O2::DPLUtils O2::DetectorsRaw)
 target_link_libraries(o2-test-framework-utils PRIVATE O2::Catch2)
 
 get_filename_component(outdir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../tests ABSOLUTE)
@@ -95,6 +95,6 @@ foreach(b
               SOURCES test/benchmark_${b}.cxx
               COMPONENT_NAME DPLUtils
               LABELS dplutils benchmark
-              PUBLIC_LINK_LIBRARIES O2::DPLUtils benchmark::benchmark)
+              PUBLIC_LINK_LIBRARIES O2::DPLUtils benchmark::benchmark O2::DetectorsRaw)
 endforeach()
 endif()

--- a/Framework/Utils/test/RawPageTestData.cxx
+++ b/Framework/Utils/test/RawPageTestData.cxx
@@ -54,6 +54,7 @@ DataSet createData(std::vector<InputSpec> const& inputspecs, std::vector<DataHea
       if (amendRdh) {
         amendRdh(*header);
       }
+      header->memorySize = PAGESIZE;
       header->offsetToNext = PAGESIZE;
       *reinterpret_cast<decltype(value)*>(wrtptr + header->headerSize) = value;
       wrtptr += PAGESIZE;

--- a/Framework/Utils/test/test_DPLRawPageSequencer.cxx
+++ b/Framework/Utils/test/test_DPLRawPageSequencer.cxx
@@ -94,7 +94,8 @@ TEST_CASE("test_DPLRawPageSequencer")
   auto insertPages = [&pages](const char* ptr, size_t n, uint32_t subSpec) -> void {
     pages.emplace_back(ptr, n);
   };
-  parser(isSameRdh, insertPages);
+  int retVal = parser(isSameRdh, insertPages);
+  REQUIRE(retVal == 0);
 
   // a second parsing step based on forward search
   std::vector<std::pair<const char*, size_t>> pagesByForwardSearch;

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -430,7 +430,15 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     };
     // the sequencer processes all inputs matching the filter and finds sequences of consecutive
     // raw pages based on the matcher predicate, and calls the inserter for each sequence
-    DPLRawPageSequencer(pc.inputs(), filter)(isSameRdh, insertPages, preCheck);
+    if (DPLRawPageSequencer(pc.inputs(), filter)(isSameRdh, insertPages, preCheck)) {
+      LOG(error) << "DPLRawPageSequencer failed to process TPC raw data - skipping time frame";
+      for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {
+        for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+          tpcZSmetaPointers[i][j].clear();
+          tpcZSmetaSizes[i][j].clear();
+        }
+      }
+    }
 
     int totalCount = 0;
     for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -409,7 +409,10 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     auto isSameRdh = [](const char* left, const char* right) -> bool {
       return o2::raw::RDHUtils::getFEEID(left) == o2::raw::RDHUtils::getFEEID(right) && o2::raw::RDHUtils::getDetectorField(left) == o2::raw::RDHUtils::getDetectorField(right);
     };
-    auto insertPages = [&tpcZSmetaPointers, &tpcZSmetaSizes](const char* ptr, size_t count, uint32_t subSpec) -> void {
+    auto preCheck = [](const char* ptr, size_t count, uint32_t subSpec) -> bool {
+      return (rdh_utils::getLink(ptr) == rdh_utils::UserLogicLinkID || rdh_utils::getLink(ptr) == rdh_utils::ILBZSLinkID || rdh_utils::getLink(ptr) == rdh_utils::DLBZSLinkID) && o2::raw::RDHUtils::getDetectorField(ptr) == 2;
+    };
+    auto insertPages = [&tpcZSmetaPointers, &tpcZSmetaSizes, preCheck](const char* ptr, size_t count, uint32_t subSpec) -> void {
       if (subSpec == 0xdeadbeef) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         static int contDeadBeef = 0;
@@ -418,16 +421,16 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
         }
         return;
       }
-      int rawcru = rdh_utils::getCRU(ptr);
-      int rawendpoint = rdh_utils::getEndPoint(ptr);
-      if ((rdh_utils::getLink(ptr) == rdh_utils::UserLogicLinkID || rdh_utils::getLink(ptr) == rdh_utils::ILBZSLinkID || rdh_utils::getLink(ptr) == rdh_utils::DLBZSLinkID) && o2::raw::RDHUtils::getDetectorField(ptr) == 2) {
+      if (preCheck(ptr, count, subSpec)) {
+        int rawcru = rdh_utils::getCRU(ptr);
+        int rawendpoint = rdh_utils::getEndPoint(ptr);
         tpcZSmetaPointers[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].emplace_back(ptr);
         tpcZSmetaSizes[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].emplace_back(count);
       }
     };
     // the sequencer processes all inputs matching the filter and finds sequences of consecutive
     // raw pages based on the matcher predicate, and calls the inserter for each sequence
-    DPLRawPageSequencer(pc.inputs(), filter)(isSameRdh, insertPages);
+    DPLRawPageSequencer(pc.inputs(), filter)(isSameRdh, insertPages, preCheck);
 
     int totalCount = 0;
     for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {


### PR DESCRIPTION
@ktf : I need `O2::DetectorsRaw` for the RDH check.
The RawPageSequencer is header only anyway, but this means that the framework test and benchmark for the rawpagesequencer need to be linked against `O2::DetectorsRaw`. I hope that is OK, otherwise we need to relocate the DPLRawPageSequencer