### PR TITLE
TRD noise update default parameter

### DIFF
--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -30,7 +30,7 @@ struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams>
   size_t minEntriesTotal = 40'500; ///< minimum total required for meaningful fits
 
   // parameters related to noise calibration
-  size_t minNumberOfDigits = 100'000'000'000UL; ///< when reached, noise calibration will be finalized
+  size_t minNumberOfDigits = 1'000'000'000UL; ///< when reached, noise calibration will be finalized
 
   // boilerplate
   O2ParamDef(TRDCalibParams, "TRDCalibParams");

--- a/Detectors/TRD/workflow/include/TRDWorkflow/NoiseCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/NoiseCalibSpec.h
@@ -63,7 +63,7 @@ class TRDNoiseCalibSpec : public o2::framework::Task
         sendOutput(pc.outputs());
         mHaveSentOutput = true;
       } else {
-        if ((mNTFsProcessed % 1000) == 0) {
+        if ((mNTFsProcessed % 50) == 0) {
           LOGP(important, "Not processing anymore. Seen {} TFs in total. Run can be stopped", mNTFsProcessed);
         }
       }


### PR DESCRIPTION
Seen today that 100 billion takes too long, because with only a single EPN the largest fraction of input data is dropped because of backpressure