### PR TITLE
[EMCAL-840] Add container for EMCal time slew params

### DIFF
--- a/Detectors/EMCAL/calib/CMakeLists.txt
+++ b/Detectors/EMCAL/calib/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(EMCALCalib
         SOURCES src/CalibContainerErrors.cxx
         src/BadChannelMap.cxx
         src/TimeCalibrationParams.cxx
+        src/TimeCalibrationSlewingParams.cxx
         src/TimeCalibParamL1Phase.cxx
         src/TempCalibrationParams.cxx
         src/TempCalibParamSM.cxx
@@ -31,6 +32,7 @@ o2_add_library(EMCALCalib
 o2_target_root_dictionary(EMCALCalib
         HEADERS include/EMCALCalib/BadChannelMap.h
         include/EMCALCalib/TimeCalibrationParams.h
+        include/EMCALCalib/TimeCalibrationSlewingParams.h
         include/EMCALCalib/TimeCalibParamL1Phase.h
         include/EMCALCalib/TempCalibrationParams.h
         include/EMCALCalib/TempCalibParamSM.h

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationSlewingParams.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationSlewingParams.h
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class TimeCalibrationSlewingParams
+/// \brief CCDB container for the time calibration slewing coefficients
+/// \ingroup EMCALcalib
+/// \author Joshua Konig <joshua.konig@cern.ch>, Goethe-University Frankfurt
+/// \since Apr 5th, 2023
+
+#ifndef TIMECALIBRATIONSLEWINGPARAMS_H_
+#define TIMECALIBRATIONSLEWINGPARAMS_H_
+
+#include <array>
+#include <cmath>
+#include <numeric>
+#include <cfloat>
+#include <Rtypes.h>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+class TimeCalibrationSlewingParams
+{
+
+ public:
+  /// \brief Constructor
+  TimeCalibrationSlewingParams() = default;
+
+  /// \brief Constructor
+  /// \param arr parameters of third oder polynomial function
+  TimeCalibrationSlewingParams(std::array<double, 4> arr);
+
+  /// \brief Destructor
+  ~TimeCalibrationSlewingParams() = default;
+
+  /// \brief Comparison of two time calibration coefficients
+  /// \return true if the two list of time calibration coefficients are the same, false otherwise
+  bool operator==(const TimeCalibrationSlewingParams& other) const;
+
+  /// \brief Add time calibration slewing function to the container
+  /// \param arr parameter for 3rd order polynomial function
+  void addTimeSlewingParam(const std::array<double, 4> arr);
+
+  /// \brief Get time calibration slewing parameter index of function
+  /// \param index index for parameter
+  double getTimeSlewingParam(const unsigned int index) const;
+
+  /// \brief Get value of time calib slewing for a given energy
+  /// \param energy energy of cell
+  double eval(const double energy) const;
+
+ private:
+  std::array<double, 4> arrParams; ///< parameter for 3rd order polynomial
+
+  // ClassDefOverride(TimeCalibrationSlewingParams, 1);
+  ClassDefNV(TimeCalibrationSlewingParams, 1);
+};
+
+} // namespace emcal
+
+} // namespace o2
+#endif // TIMECALIBRATIONSLEWINGPARAMS_H_

--- a/Detectors/EMCAL/calib/src/TimeCalibrationSlewingParams.cxx
+++ b/Detectors/EMCAL/calib/src/TimeCalibrationSlewingParams.cxx
@@ -1,0 +1,59 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalib/TimeCalibrationSlewingParams.h"
+
+// using namespace o2::emcal;
+namespace o2
+{
+
+namespace emcal
+{
+
+bool TimeCalibrationSlewingParams::operator==(const TimeCalibrationSlewingParams& other) const
+{
+  for (int i = 0; i < 4; ++i) {
+    if (std::abs(arrParams[i] - other.getTimeSlewingParam(i)) > DBL_EPSILON) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TimeCalibrationSlewingParams::TimeCalibrationSlewingParams(std::array<double, 4> arr)
+{
+  arrParams = arr;
+}
+
+void TimeCalibrationSlewingParams::addTimeSlewingParam(std::array<double, 4> arr)
+{
+  arrParams = arr;
+}
+
+double TimeCalibrationSlewingParams::getTimeSlewingParam(unsigned int index) const
+{
+  if (index >= 4) {
+    return -1;
+  }
+  return arrParams[index];
+}
+
+double TimeCalibrationSlewingParams::eval(double energy) const
+{
+  double val = 0;
+  for (unsigned int i = 0; i < arrParams.size(); ++i) {
+    val += arrParams[i] * std::pow(energy, i);
+  }
+  return val;
+}
+
+} // namespace emcal
+} // namespace o2


### PR DESCRIPTION
- EMCal cell time is slightly dependent on the cell energy
- To take out the residual difference as function of the cell energy, a time slewing correction is needed
- The TimeCalibrationSlewingParams provide a simple container to store a polynomial function of 3rd order that can be evaluated at a certain energy
- The implementation of the actual correction will follow in a second step