### PR TITLE
[FOCAL-12] FOCAL Pad Pedestal DA

### DIFF
--- a/Detectors/FOCAL/calib/CMakeLists.txt
+++ b/Detectors/FOCAL/calib/CMakeLists.txt
@@ -9,7 +9,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calib)
-add_subdirectory(reconstruction)
-add_subdirectory(workflow)
+o2_add_library(FOCALCalib
+    SOURCES src/PadPedestal.cxx
+    PUBLIC_LINK_LIBRARIES O2::DataFormatsFOCAL Boost::serialization
+)
+
+o2_target_root_dictionary(
+    FOCALCalib
+    HEADERS include/FOCALCalib/PadPedestal.h
+)

--- a/Detectors/FOCAL/calib/include/FOCALCalib/PadPedestal.h
+++ b/Detectors/FOCAL/calib/include/FOCALCalib/PadPedestal.h
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_FOCAL_PADPEDESTAL_H
+#define ALICEO2_FOCAL_PADPEDESTAL_H
+
+#include <array>
+#include <exception>
+#include <string>
+#include <unordered_map>
+
+#include <boost/container_hash/hash.hpp>
+
+#include "TH1.h"
+#include "Rtypes.h"
+
+namespace o2::focal
+{
+
+class PadPedestal
+{
+ public:
+  struct ChannelID {
+    std::size_t mLayer;
+    std::size_t mChannel;
+
+    bool operator==(const ChannelID& other) const
+    {
+      return mLayer == other.mLayer && mChannel == other.mChannel;
+    }
+  };
+
+  struct ChannelIDHasher {
+
+    /// \brief Functor implementation
+    /// \param s Channel for which to determine a hash value
+    /// \return hash value for channel ID
+    size_t operator()(const ChannelID& s) const
+    {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, s.mLayer);
+      boost::hash_combine(seed, s.mChannel);
+      return seed;
+    }
+  };
+
+  class InvalidChannelException : public std::exception
+  {
+   public:
+    InvalidChannelException(std::size_t layer, std::size_t channel) : mLayer(layer), mChannel(channel)
+    {
+      mMessage = "Invalid channel: Layer " + std::to_string(mLayer) + ", channel " + std::to_string(mChannel);
+    }
+    ~InvalidChannelException() noexcept final = default;
+
+    const char* what() const noexcept final { return mMessage.data(); }
+
+    std::size_t getLayer() const noexcept { return mLayer; }
+    std::size_t getChannel() const noexcept { return mChannel; }
+
+   private:
+    std::size_t mLayer;
+    std::size_t mChannel;
+    std::string mMessage;
+  };
+
+  class InvalidLayerException : public std::exception
+  {
+   public:
+    InvalidLayerException(std::size_t layer) : mLayer(layer)
+    {
+      mMessage = "Access to invalid layer " + std::to_string(layer);
+    }
+    ~InvalidLayerException() noexcept final = default;
+
+    const char* what() const noexcept final { return mMessage.data(); }
+    std::size_t getLayer() const noexcept { return mLayer; }
+
+   private:
+    std::size_t mLayer = 0;
+    std::string mMessage;
+  };
+
+  PadPedestal() = default;
+  ~PadPedestal() = default;
+
+  void clear();
+  void setPedestal(std::size_t layer, std::size_t channel, double pedestal);
+  double getPedestal(std::size_t layer, std::size_t channel) const;
+
+  TH1* getHistogramRepresentation(int layer) const;
+  std::array<TH1*, 18> getLayerHistogramRepresentations() const;
+
+ private:
+  std::unordered_map<ChannelID, double, ChannelIDHasher> mPedestalValues;
+  ClassDefNV(PadPedestal, 1);
+};
+
+} // namespace o2::focal
+#endif // ALICEO2_FOCAL_PADPEDESTAL_H

--- a/Detectors/FOCAL/calib/src/FOCALCalibLinkDef.h
+++ b/Detectors/FOCAL/calib/src/FOCALCalibLinkDef.h
@@ -1,0 +1,19 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::focal::PadPedestal + ;
+#endif

--- a/Detectors/FOCAL/calib/src/PadPedestal.cxx
+++ b/Detectors/FOCAL/calib/src/PadPedestal.cxx
@@ -1,0 +1,78 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <DataFormatsFOCAL/Constants.h>
+#include <FOCALCalib/PadPedestal.h>
+
+#include <fairlogger/Logger.h>
+
+using namespace o2::focal;
+
+void PadPedestal::clear()
+{
+}
+
+void PadPedestal::setPedestal(std::size_t layer, std::size_t channel, double pedestal)
+{
+  if (layer >= constants::PADS_NLAYERS) {
+    throw InvalidChannelException(layer, channel);
+  }
+  if (channel >= constants::PADLAYER_MODULE_NCHANNELS) {
+    throw InvalidChannelException(layer, channel);
+  }
+  auto found = mPedestalValues.find({layer, channel});
+  if (found == mPedestalValues.end()) {
+    mPedestalValues.insert({{layer, channel}, pedestal});
+  } else {
+    found->second = pedestal;
+  }
+}
+
+double PadPedestal::getPedestal(std::size_t layer, std::size_t channel) const
+{
+  auto found = mPedestalValues.find({layer, channel});
+  if (found == mPedestalValues.end()) {
+    throw InvalidChannelException(layer, channel);
+  }
+  return found->second;
+}
+
+TH1* PadPedestal::getHistogramRepresentation(int layer) const
+{
+  if (layer > 18) {
+    throw InvalidLayerException(layer);
+  }
+  std::string histname = "PedestalsLayer" + std::to_string(layer),
+              histtitle = "Pedestals in layer " + std::to_string(layer);
+  auto pedestalHist = new TH1F(histname.data(), histtitle.data(), constants::PADLAYER_MODULE_NCHANNELS, -0.5, constants::PADLAYER_MODULE_NCHANNELS - 0.5);
+  pedestalHist->SetDirectory(nullptr);
+  pedestalHist->SetStats(false);
+  pedestalHist->SetXTitle("Channel");
+  pedestalHist->SetYTitle("Pedestal (ADC counts)");
+  for (std::size_t channel = 0; channel < constants::PADLAYER_MODULE_NCHANNELS; channel++) {
+    double pedestal = 0;
+    try {
+      pedestal = getPedestal(layer, channel);
+    } catch (InvalidChannelException& e) {
+      LOG(error) << e.what();
+    }
+    pedestalHist->SetBinContent(channel + 1, pedestal);
+  }
+  return pedestalHist;
+}
+std::array<TH1*, 18> PadPedestal::getLayerHistogramRepresentations() const
+{
+  std::array<TH1*, 18> pedestalHistograms;
+  for (int layer = 0; layer < 18; layer++) {
+    pedestalHistograms[layer] = getHistogramRepresentation(layer);
+  }
+  return pedestalHistograms;
+}

--- a/Detectors/FOCAL/calibration/CMakeLists.txt
+++ b/Detectors/FOCAL/calibration/CMakeLists.txt
@@ -9,8 +9,20 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calib)
-add_subdirectory(calibration)
-add_subdirectory(reconstruction)
-add_subdirectory(workflow)
+o2_add_library(FOCALCalibration
+    SOURCES src/PadPedestalCalibDevice.cxx
+    PUBLIC_LINK_LIBRARIES O2::Framework
+    O2::DataFormatsFOCAL
+    O2::DetectorsRaw
+    O2::FOCALCalib
+    O2::FOCALReconstruction
+    O2::DetectorsCalibration
+    ROOT::Hist)
+
+o2_add_executable(pad-pedestal-calibration-workflow
+    COMPONENT_NAME focal
+    SOURCES src/pad-pedestal-calibration-workflow.cxx
+    PUBLIC_LINK_LIBRARIES O2::Framework
+    O2::DataFormatsFOCAL
+    O2::FOCALCalibration
+    O2::DetectorsCalibration)

--- a/Detectors/FOCAL/calibration/include/FOCALCalibration/PadPedestalCalibDevice.h
+++ b/Detectors/FOCAL/calibration/include/FOCALCalibration/PadPedestalCalibDevice.h
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_FOCAL_PADPEDESTALCALIBDEVICE_H
+#define ALICEO2_FOCAL_PADPEDESTALCALIBDEVICE_H
+
+#include <array>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <gsl/span>
+#include <TH2.h>
+#include "Framework/DataAllocator.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "FOCALCalib/PadPedestal.h"
+#include "FOCALReconstruction/PadDecoder.h"
+
+namespace o2::focal
+{
+
+class PadPedestalCalibDevice : public framework::Task
+{
+ public:
+  enum Method_t {
+    MAX,
+    MEAN,
+    FIT
+  };
+  PadPedestalCalibDevice(bool updateCCDB, const std::string& path);
+  ~PadPedestalCalibDevice() final = default;
+
+  void init(framework::InitContext& ctx) final;
+  void run(framework::ProcessingContext& ctx) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  void sendData(o2::framework::DataAllocator& output);
+  void calculatePedestals();
+  double evaluatePedestal(TH1* channel);
+  void processRawData(const gsl::span<const char> padWords);
+
+  PadDecoder mDecoder;
+  std::unique_ptr<PadPedestal> mPedestalContainer;
+  bool mUpdateCCDB = true;
+  std::string mPath = "./";
+  Method_t mExtractionMethod = Method_t::MAX;
+  std::array<std::unique_ptr<TH2>, 18> mADCDistLayer;
+};
+
+o2::framework::DataProcessorSpec getPadPedestalCalibDevice(bool updateCCDB, const std::string& path);
+
+} // namespace o2::focal
+
+#endif

--- a/Detectors/FOCAL/calibration/src/PadPedestalCalibDevice.cxx
+++ b/Detectors/FOCAL/calibration/src/PadPedestalCalibDevice.cxx
@@ -1,0 +1,224 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <filesystem>
+#include <string>
+
+#include <TFile.h>
+#include <TF1.h>
+#include <TH1.h>
+
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CommonConstants/Triggers.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "DataFormatsFOCAL/Constants.h"
+#include "DetectorsCalibration/Utils.h"
+#include "DetectorsRaw/RDHUtils.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/InputRecordWalker.h"
+#include "Framework/WorkflowSpec.h"
+#include "FOCALCalibration/PadPedestalCalibDevice.h"
+
+using namespace o2::focal;
+
+PadPedestalCalibDevice::PadPedestalCalibDevice(bool updateCCDB, const std::string& path) : mUpdateCCDB(updateCCDB), mPath(path) {}
+
+void PadPedestalCalibDevice::init(framework::InitContext& ctx)
+{
+  std::string histname, histtitle;
+  for (auto layer = 0; layer < 18; layer++) {
+    histname = "PADADC_Layer" + std::to_string(layer);
+    histtitle = "Pad ADC distribution Layer " + std::to_string(layer);
+    mADCDistLayer[layer] = std::make_unique<TH2D>(histname.data(), histtitle.data(), constants::PADLAYER_MODULE_NCHANNELS, -0.5, constants::PADLAYER_MODULE_NCHANNELS - 0.5, 2000, 0., 2000.);
+    mADCDistLayer[layer]->SetDirectory(nullptr);
+  }
+
+  auto calibmethod = ctx.options().get<std::string>("calibmethod");
+  if (calibmethod == "mean") {
+    mExtractionMethod = Method_t::MEAN;
+  } else if (calibmethod == "fit") {
+    mExtractionMethod = Method_t::FIT;
+  } else {
+    LOG(error) << "Unknown calibration method - using default (mean) instead";
+  }
+  LOG(info) << "Writing calibration histograms in path: " << mPath;
+}
+
+void PadPedestalCalibDevice::run(framework::ProcessingContext& ctx)
+{
+  std::vector<char> rawbuffer;
+  for (const auto& rawData : framework::InputRecordWalker(ctx.inputs())) {
+    if (rawData.header != nullptr && rawData.payload != nullptr) {
+      const auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(rawData);
+
+      gsl::span<const char> databuffer(rawData.payload, payloadSize);
+      int currentpos = 0;
+      int currentfee = 0;
+      bool firstHBF = true;
+      while (currentpos < databuffer.size()) {
+        auto rdh = reinterpret_cast<const o2::header::RDHAny*>(databuffer.data() + currentpos);
+        auto trigger = o2::raw::RDHUtils::getTriggerType(rdh);
+        if (trigger & o2::trigger::HB) {
+          // HB trigger received
+          if (o2::raw::RDHUtils::getStop(rdh)) {
+            // Data ready
+            if (rawbuffer.size()) {
+              // Only process if we actually have payload (skip empty HBF)
+              if (currentfee == 0xcafe) { // Use FEE ID 0xcafe for PAD data
+                processRawData(rawbuffer);
+              }
+            } else {
+              LOG(debug) << "Payload size 0 - skip empty HBF";
+            }
+          } else {
+            rawbuffer.clear();
+            currentfee = o2::raw::RDHUtils::getFEEID(rdh);
+          }
+        }
+
+        if (o2::raw::RDHUtils::getMemorySize(rdh) == o2::raw::RDHUtils::getHeaderSize(rdh)) {
+          // Skip page if emtpy
+          currentpos += o2::raw::RDHUtils::getOffsetToNext(rdh);
+          continue;
+        }
+
+        // non-0 payload size:
+        auto payloadsize = o2::raw::RDHUtils::getMemorySize(rdh) - o2::raw::RDHUtils::getHeaderSize(rdh);
+        auto page_payload = databuffer.subspan(currentpos + o2::raw::RDHUtils::getHeaderSize(rdh), payloadsize);
+        std::copy(page_payload.begin(), page_payload.end(), std::back_inserter(rawbuffer));
+        currentpos += o2::raw::RDHUtils::getOffsetToNext(rdh);
+      }
+    }
+  }
+}
+
+void PadPedestalCalibDevice::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  LOG(info) << "Data collected - calculating pedestals and sending them";
+  calculatePedestals();
+  sendData(ec.outputs());
+}
+
+void PadPedestalCalibDevice::sendData(o2::framework::DataAllocator& output)
+{
+
+  if (mUpdateCCDB) {
+    // prepare all info to be sent to CCDB
+    o2::ccdb::CcdbObjectInfo info;
+    auto image = o2::ccdb::CcdbApi::createObjectImage(mPedestalContainer.get(), &info);
+
+    auto flName = o2::ccdb::CcdbApi::generateFileName("Pedestals");
+    info.setPath("FOC/Calib/PadPedestals");
+    info.setObjectType("Pedestals");
+    info.setFileName(flName);
+
+    const auto now = std::chrono::system_clock::now();
+    long timeStart = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+    info.setStartValidityTimestamp(timeStart);
+    info.setEndValidityTimestamp(o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+    std::map<std::string, std::string> md;
+    info.setMetaData(md);
+
+    LOG(info) << "Sending object FOC/Calib/PadPedestals";
+
+    header::DataHeader::SubSpecificationType subSpec{(header::DataHeader::SubSpecificationType)0};
+    output.snapshot(framework::Output{o2::calibration::Utils::gDataOriginCDBPayload, "FOC_PADPEDESTALS", subSpec}, *image.get());
+    output.snapshot(framework::Output{o2::calibration::Utils::gDataOriginCDBWrapper, "FOC_PADPEDESTALS", subSpec}, info);
+  }
+
+  // store ADC distributions in local file
+  std::filesystem::path filepath(mPath);
+  filepath.append("FOCALPadPedestals.root");
+  LOG(info) << "Writing ADC distribution to " << filepath.c_str();
+  TFile distwriter(filepath.c_str(), "RECREATE");
+  distwriter.cd();
+  for (int layer = 0; layer < mADCDistLayer.size(); layer++) {
+    mADCDistLayer[layer]->Write();
+  }
+}
+
+void PadPedestalCalibDevice::processRawData(const gsl::span<const char> padWords)
+{
+  constexpr std::size_t EVENTSIZEPADGBT = 1180,
+                        EVENTSIZECHAR = EVENTSIZEPADGBT * sizeof(PadGBTWord) / sizeof(char);
+  auto nevents = padWords.size() / (EVENTSIZECHAR);
+  for (int ievent = 0; ievent < nevents; ievent++) {
+    gsl::span<const PadGBTWord> padWordsGBT(reinterpret_cast<const PadGBTWord*>(padWords.data()), padWords.size() / sizeof(PadGBTWord));
+    mDecoder.reset();
+    mDecoder.decodeEvent(padWordsGBT);
+    // Fill histograms
+    for (auto layer = 0; layer < 18; layer++) {
+      auto layerdata = mDecoder.getData().getDataForASIC(layer).getASIC();
+      for (std::size_t chan = 0; chan < constants::PADLAYER_MODULE_NCHANNELS; chan++) {
+        mADCDistLayer[layer]->Fill(chan, layerdata.getChannel(chan).getADC());
+      }
+    }
+  }
+}
+
+void PadPedestalCalibDevice::calculatePedestals()
+{
+  mPedestalContainer = std::make_unique<PadPedestal>();
+  int nPedestals = 0;
+  for (std::size_t layer = 0; layer < 18; layer++) {
+    for (std::size_t channel = 0; channel < constants::PADLAYER_MODULE_NCHANNELS; channel++) {
+      std::unique_ptr<TH1> channelADC(mADCDistLayer[layer]->ProjectionY("channelADC", channel + 1, channel + 1));
+      try {
+        mPedestalContainer->setPedestal(layer, channel, evaluatePedestal(channelADC.get()));
+        nPedestals++;
+      } catch (PadPedestal::InvalidChannelException& e) {
+        LOG(error) << "Failure accessing setting pedestal: " << e.what();
+      }
+    }
+  }
+  LOG(info) << "Found pedestals for " << nPedestals << " channels";
+}
+
+double PadPedestalCalibDevice::evaluatePedestal(TH1* channel)
+{
+  double pedestal = 0;
+  switch (mExtractionMethod) {
+    case Method_t::MAX: {
+      // Max model - get center of the maximum bin
+      int maxbin = channel->GetMaximumBin();
+      pedestal = channel->GetBinCenter(maxbin);
+      break;
+    }
+    case Method_t::MEAN: {
+      // Mean model - get the mean of the distribution
+      pedestal = channel->GetMean();
+      break;
+    }
+    case Method_t::FIT: {
+      // Fit model - fit full distribution with Gauss and take mean
+      TF1 pedmodal("pedmodel", "gaus", 0, 2000);
+      channel->Fit(&pedmodal, "Q");
+      pedestal = pedmodal.GetParameter(1);
+      break;
+    }
+  }
+  return pedestal;
+}
+
+o2::framework::DataProcessorSpec o2::focal::getPadPedestalCalibDevice(bool updateCCDB, const std::string& path)
+{
+  std::vector<o2::framework::OutputSpec> outputs;
+  outputs.emplace_back(framework::ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "FOC_PADPEDESTALS"}, o2::framework::Lifetime::Sporadic);
+  outputs.emplace_back(framework::ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "FOC_PADPEDESTALS"}, o2::framework::Lifetime::Sporadic);
+
+  return o2::framework::DataProcessorSpec{"FOCALPadPedestalCalibDevice",
+                                          o2::framework::select("A:FOC/RAWDATA"),
+                                          outputs,
+                                          o2::framework::adaptFromTask<o2::focal::PadPedestalCalibDevice>(updateCCDB, path),
+                                          o2::framework::Options{
+                                            {"calibmethod", o2::framework::VariantType::String, "max", {"Method used for pedestal evaluation"}}}};
+}

--- a/Detectors/FOCAL/calibration/src/pad-pedestal-calibration-workflow.cxx
+++ b/Detectors/FOCAL/calibration/src/pad-pedestal-calibration-workflow.cxx
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "FOCALCalibration/PadPedestalCalibDevice.h"
+#include "Framework/DataProcessorSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb cpv calibration objects"}});
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"path", o2::framework::VariantType::String, "./", {"path to store temp files"}});
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
+{
+  o2::framework::WorkflowSpec specs;
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  auto useCCDB = configcontext.options().get<bool>("use-ccdb");
+  auto path = configcontext.options().get<std::string>("path");
+
+  specs.emplace_back(o2::focal::getPadPedestalCalibDevice(useCCDB, path));
+  return specs;
+}


### PR DESCRIPTION
* [FOCAL-12] Add structure for Pad pedestals

  One pedestal value per layer and channel.
  Throwing InvalidChannelException in case of
  invalid channel in filling and access to non-existing
  channel in reading.

* [FOCAL-12] Pedestal calibration DA for Pads

  Pedestal calibration based on ADC distribution
  with random trigger for each layer and channel
  separately. Various methods (Max bin, mean,
  gauss fit) are available for the pedestal determination.