### PR TITLE
[EMCAL-888] Removal of mask column in McCaloLabel table

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1454,7 +1454,7 @@ DECLARE_SOA_COLUMN(AmplitudeA, amplitudeA, std::vector<float>); //! Energy fract
 DECLARE_SOA_TABLE(McCaloLabels_000, "AOD", "MCCALOLABEL", //! Table joined to the calo table containing the MC index (version 000, Run 2 format)
                   mccalolabel::McParticleId, mccalolabel::McMask);
 DECLARE_SOA_TABLE_VERSIONED(McCaloLabels_001, "AOD", "MCCALOLABEL", 1, //! Table joined to the calo table containing multiple MC indices and the amplitude fraction (version 001)
-                            mccalolabel::McParticleIds, mccalolabel::McMask, mccalolabel::AmplitudeA);
+                            mccalolabel::McParticleIds, mccalolabel::AmplitudeA);
 using McCaloLabels = McCaloLabels_000;
 using McCaloLabel = McCaloLabels::iterator;
 


### PR DESCRIPTION
- Remove of Mask column for McCaloLabel table. After careful consideration we concluded that we do not need the mask column in Run3 and thus we decided to drop it.