### PR TITLE
DPL Analysis: Cached unsorted slicing

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -641,7 +641,7 @@ struct IndexManager<Builds<IDX>> {
 /// Manager template to handle slice caching
 template <typename T>
 struct PresliceManager {
-  static bool registerCache(T&, std::vector<std::pair<std::string, std::string>>&)
+  static bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>& )
   {
     return false;
   }
@@ -654,7 +654,7 @@ struct PresliceManager {
 
 template <typename T>
 struct PresliceManager<Preslice<T>> {
-  static bool registerCache(Preslice<T>& container, std::vector<std::pair<std::string, std::string>>& bsks)
+  static bool registerCache(Preslice<T>& container, std::vector<StringPair>& bsks, std::vector<StringPair>&)
   {
     auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.first == container.bindingKey.first) && (entry.second == container.bindingKey.second); });
     if (locate == bsks.end()) {
@@ -666,6 +666,24 @@ struct PresliceManager<Preslice<T>> {
   static bool updateSliceInfo(Preslice<T>& container, ArrowTableSlicingCache& cache)
   {
     container.updateSliceInfo(cache.getCacheFor(container.getBindingKey()));
+    return true;
+  }
+};
+
+template <typename T>
+struct PresliceManager<PresliceUnsorted<T>> {
+  static bool registerCache(PresliceUnsorted<T>& container, std::vector<StringPair>&, std::vector<StringPair>& bsksU)
+  {
+    auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.first == container.bindingKey.first) && (entry.second == container.bindingKey.second); });
+    if (locate == bsksU.end()) {
+      bsksU.emplace_back(container.getBindingKey());
+    }
+    return true;
+  }
+
+  static bool updateSliceInfo(PresliceUnsorted<T>& container, ArrowTableSlicingCache& cache)
+  {
+    container.updateSliceInfo(cache.getCacheUnsortedFor(container.getBindingKey()));
     return true;
   }
 };

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -641,7 +641,7 @@ struct IndexManager<Builds<IDX>> {
 /// Manager template to handle slice caching
 template <typename T>
 struct PresliceManager {
-  static bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>& )
+  static bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>&)
   {
     return false;
   }

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -19,6 +19,8 @@
 
 namespace o2::framework
 {
+using ListVector = std::vector<std::vector<int64_t>>;
+
 struct SliceInfoPtr {
   gsl::span<int const> values;
   gsl::span<int64_t const> counts;
@@ -26,32 +28,56 @@ struct SliceInfoPtr {
   std::pair<int64_t, int64_t> getSliceFor(int value) const;
 };
 
+struct SliceInfoUnsortedPtr {
+  gsl::span<int const> values;
+  ListVector const* groups;
+
+  gsl::span<int64_t const> getSliceFor(int value) const;
+};
+
+using StringPair = std::pair<std::string, std::string>;
+
 struct ArrowTableSlicingCacheDef {
   constexpr static ServiceKind service_kind = ServiceKind::Global;
-  std::vector<std::pair<std::string, std::string>> bindingsKeys;
+  std::vector<StringPair> bindingsKeys;
+  std::vector<StringPair> bindingsKeysUnsorted;
 
-  void setCaches(std::vector<std::pair<std::string, std::string>>&& bsks);
+  void setCaches(std::vector<StringPair>&& bsks);
+  void setCachesUnsorted(std::vector<StringPair>&& bsks);
 };
 
 struct ArrowTableSlicingCache {
   constexpr static ServiceKind service_kind = ServiceKind::Stream;
 
-  std::vector<std::pair<std::string, std::string>> bindingsKeys;
+  std::vector<StringPair> bindingsKeys;
   std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int32Type>>> values;
   std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int64Type>>> counts;
 
-  ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>&& bsks);
+  std::vector<StringPair> bindingsKeysUnsorted;
+  std::vector<std::vector<int>> valuesUnsorted;
+  std::vector<ListVector> groups;
+
+  ArrowTableSlicingCache(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted = {});
 
   // set caching information externally
-  void setCaches(std::vector<std::pair<std::string, std::string>>&& bsks);
+  void setCaches(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted = {});
 
   // update slicing info cache entry (assumes it is already present)
   arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table> const& table);
+  arrow::Status updateCacheEntryUnsorted(int pos, std::shared_ptr<arrow::Table> const& table);
+
+  // helper to locate cache position
+  std::pair<int, bool> getCachePos(StringPair const& bindingKey) const;
+  int getCachePosSortedFor(StringPair const& bindingKey) const;
+  int getCachePosUnsortedFor(StringPair const& bindingKey) const;
 
   // get slice from cache for a given value
-  SliceInfoPtr getCacheFor(std::pair<std::string, std::string> const& bindingKey) const;
+  SliceInfoPtr getCacheFor(StringPair const& bindingKey) const;
+  SliceInfoUnsortedPtr getCacheUnsortedFor(StringPair const& bindingKey) const;
+  SliceInfoPtr getCacheForPos(int pos) const;
+  SliceInfoUnsortedPtr getCacheUnsortedForPos(int pos) const;
 
-  static void validateOrder(std::pair<std::string, std::string> const& bindingKey, std::shared_ptr<arrow::Table> const& input);
+  static void validateOrder(StringPair const& bindingKey, std::shared_ptr<arrow::Table> const& input);
 };
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -51,22 +51,17 @@ struct GroupSlicer {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       if constexpr (o2::soa::relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
         auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
+        auto bk = std::make_pair(binding, mIndexColumnName);
         if constexpr (!o2::soa::is_smallgroups_v<std::decay_t<T>>) {
           if (table.size() == 0) {
             return;
           }
-          auto bk = std::make_pair(binding, mIndexColumnName);
           sliceInfos[index] = mSlices->getCacheFor(bk);
         } else {
           if (table.tableSize() == 0) {
             return;
           }
-          // use generic splitting approach
-          o2::framework::sliceByColumnGeneric(mIndexColumnName.c_str(),
-                                              binding.c_str(),
-                                              table.asArrowTable(),
-                                              static_cast<int32_t>(mGt->tableSize()),
-                                              &filterGroups[index]);
+          sliceInfosUnsorted[index] = mSlices->getCacheUnsortedFor(bk);
         }
       }
     }
@@ -207,18 +202,19 @@ struct GroupSlicer {
         } else {
           // generic split
           if constexpr (soa::is_soa_filtered_v<std::decay_t<A1>>) {
+            auto selection = sliceInfosUnsorted[index].getSliceFor(pos);
             // intersect selections
             o2::soa::SelectionVector s;
             if (selections[index]->empty()) {
-              if (!filterGroups[index].empty()) {
-                std::copy((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), std::back_inserter(s));
+              if (!selection.empty()) {
+                std::copy(selection.begin(), selection.end(), std::back_inserter(s));
               }
             } else {
-              if (!filterGroups[index].empty()) {
+              if (!selection.empty()) {
                 if constexpr (std::decay_t<A1>::applyFilters) {
-                  std::set_intersection((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
+                  std::set_intersection(selection.begin(), selection.end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
                 } else {
-                  std::copy((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), std::back_inserter(s));
+                  std::copy(selection.begin(), selection.end(), std::back_inserter(s));
                 }
               }
             }
@@ -241,11 +237,11 @@ struct GroupSlicer {
     typename grouping_t::iterator mGroupingElement;
     uint64_t position = 0;
     gsl::span<int64_t const> groupSelection;
-    std::array<ListVector, sizeof...(A)> filterGroups;
     std::array<gsl::span<int64_t const> const*, sizeof...(A)> selections;
     std::array<gsl::span<int64_t const>::iterator, sizeof...(A)> starts;
 
     std::array<SliceInfoPtr, sizeof...(A)> sliceInfos;
+    std::array<SliceInfoUnsortedPtr, sizeof...(A)> sliceInfosUnsorted;
     ArrowTableSlicingCache* mSlices;
   };
 

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -32,7 +32,7 @@ std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_p
   if (tables.size() == 1) {
     return tables[0];
   }
-  for (auto i = 0u; i < tables.size() - 1; ++i) {
+  for (auto i = 0U; i < tables.size() - 1; ++i) {
     if (tables[i]->num_rows() != tables[i + 1]->num_rows()) {
       throw o2::framework::runtime_error_f("Tables %s and %s have different sizes (%d vs %d) and cannot be joined!",
                                            tables[i]->schema()->metadata()->Get("label").ValueOrDie().c_str(),
@@ -103,7 +103,7 @@ std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared
 arrow::ChunkedArray* getIndexFromLabel(arrow::Table* table, const char* label)
 {
   auto index = table->schema()->GetAllFieldIndices(label);
-  if (index.empty() == true) {
+  if (index.empty()) {
     o2::framework::throw_error(o2::framework::runtime_error_f("Unable to find column with label %s", label));
   }
   return table->column(index[0]).get();

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -99,8 +99,8 @@ SliceInfoPtr ArrowTableSlicingCache::getCacheFor(std::pair<std::string, std::str
 
 void ArrowTableSlicingCache::validateOrder(const std::pair<std::string, std::string>& bindingKey, const std::shared_ptr<arrow::Table>& input)
 {
-  auto& [target, key] = bindingKey;
-  auto column = input->GetColumnByName(key.c_str());
+  auto const& [target, key] = bindingKey;
+  auto column = input->GetColumnByName(key);
   auto array0 = static_cast<arrow::NumericArray<arrow::Int32Type>>(column->chunk(0)->data());
   int32_t prev = 0;
   int32_t cur = array0.Value(0);

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -34,25 +34,49 @@ std::pair<int64_t, int64_t> SliceInfoPtr::getSliceFor(int value) const
   return {offset, 0};
 }
 
-void ArrowTableSlicingCacheDef::setCaches(std::vector<std::pair<std::string, std::string>>&& bsks)
+gsl::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
+{
+  auto locate = std::find(values.begin(), values.end(), value);
+  if (locate == values.end()) {
+    return {};
+  }
+
+  return {(*groups)[value].data(), (*groups)[value].size()};
+}
+
+void ArrowTableSlicingCacheDef::setCaches(std::vector<StringPair>&& bsks)
 {
   bindingsKeys = bsks;
 }
 
-ArrowTableSlicingCache::ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>&& bsks)
-  : bindingsKeys{bsks}
+void ArrowTableSlicingCacheDef::setCachesUnsorted(std::vector<StringPair>&& bsks)
+{
+  bindingsKeysUnsorted = bsks;
+}
+
+ArrowTableSlicingCache::ArrowTableSlicingCache(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted)
+  : bindingsKeys{bsks},
+    bindingsKeysUnsorted{bsksUnsorted}
 {
   values.resize(bindingsKeys.size());
   counts.resize(bindingsKeys.size());
+
+  valuesUnsorted.resize(bindingsKeysUnsorted.size());
+  groups.resize(bindingsKeysUnsorted.size());
 }
 
-void ArrowTableSlicingCache::setCaches(std::vector<std::pair<std::string, std::string>>&& bsks)
+void ArrowTableSlicingCache::setCaches(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted)
 {
   bindingsKeys = bsks;
+  bindingsKeysUnsorted = bsksUnsorted;
   values.clear();
   values.resize(bindingsKeys.size());
   counts.clear();
   counts.resize(bindingsKeys.size());
+  valuesUnsorted.clear();
+  valuesUnsorted.resize(bindingsKeysUnsorted.size());
+  groups.clear();
+  groups.resize(bindingsKeysUnsorted.size());
 }
 
 arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<arrow::Table> const& table)
@@ -76,15 +100,89 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
   return arrow::Status::OK();
 }
 
-SliceInfoPtr ArrowTableSlicingCache::getCacheFor(std::pair<std::string, std::string> const& bindingKey) const
+arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const std::shared_ptr<arrow::Table>& table)
 {
-  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](std::pair<std::string, std::string> const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
-  if (locate == bindingsKeys.end()) {
-    throw runtime_error_f("Slicing cache miss for %s/%s", bindingKey.first.c_str(), bindingKey.second.c_str());
+  valuesUnsorted[pos].clear();
+  groups[pos].clear();
+  if (table->num_rows() == 0) {
+    return arrow::Status::OK();
   }
-  auto i = std::distance(bindingsKeys.begin(), locate);
+  auto& [b, k] = bindingsKeysUnsorted[pos];
+  auto column = table->GetColumnByName(k);
+  auto row = 0;
+  for (auto iChunk = 0; iChunk < column->num_chunks(); ++iChunk) {
+    auto chunk = static_cast<arrow::NumericArray<arrow::Int32Type>>(column->chunk(iChunk)->data());
+    for (auto iElement = 0; iElement < chunk.length(); ++iElement) {
+      auto v = chunk.Value(iElement);
+      if (v >= 0) {
+        if (std::find(valuesUnsorted[pos].begin(), valuesUnsorted[pos].end(), v) == valuesUnsorted[pos].end()) {
+          valuesUnsorted[pos].push_back(v);
+        }
+        if (groups[pos].size() <= v) {
+          groups[pos].resize(v + 1);
+        }
+        (groups[pos])[v].push_back(row);
+      }
+      ++row;
+    }
+  }
+  std::sort(valuesUnsorted[pos].begin(), valuesUnsorted[pos].end());
+  return arrow::Status::OK();
+}
 
-  if (values[i] == nullptr && counts[i] == nullptr) {
+std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const StringPair& bindingKey) const
+{
+  auto pos = getCachePosSortedFor(bindingKey);
+  if (pos != -1) {
+    return {pos, true};
+  }
+  pos = getCachePosUnsortedFor(bindingKey);
+  if (pos != -1) {
+    return {pos, false};
+  }
+  throw runtime_error_f("%s/%s not found neither in sorted or unsorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
+}
+
+int ArrowTableSlicingCache::getCachePosSortedFor(StringPair const& bindingKey) const
+{
+  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](StringPair const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
+  if (locate != bindingsKeys.end()) {
+    return std::distance(bindingsKeys.begin(), locate);
+  }
+  return -1;
+}
+
+int ArrowTableSlicingCache::getCachePosUnsortedFor(StringPair const& bindingKey) const
+{
+  auto locate_unsorted = std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](StringPair const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
+  if (locate_unsorted != bindingsKeysUnsorted.end()) {
+    return std::distance(bindingsKeysUnsorted.begin(), locate_unsorted);
+  }
+  return -1;
+}
+SliceInfoPtr ArrowTableSlicingCache::getCacheFor(StringPair const& bindingKey) const
+{
+  auto [p, s] = getCachePos(bindingKey);
+  if (!s) {
+    throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
+  }
+
+  return getCacheForPos(p);
+}
+
+SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const StringPair& bindingKey) const
+{
+  auto [p, s] = getCachePos(bindingKey);
+  if (s) {
+    throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
+  }
+
+  return getCacheUnsortedForPos(p);
+}
+
+SliceInfoPtr ArrowTableSlicingCache::getCacheForPos(int pos) const
+{
+  if (values[pos] == nullptr && counts[pos] == nullptr) {
     return {
       {},
       {} //
@@ -92,12 +190,20 @@ SliceInfoPtr ArrowTableSlicingCache::getCacheFor(std::pair<std::string, std::str
   }
 
   return {
-    {reinterpret_cast<int const*>(values[i]->values()->data()), static_cast<size_t>(values[i]->length())},
-    {reinterpret_cast<int64_t const*>(counts[i]->values()->data()), static_cast<size_t>(counts[i]->length())} //
+    {reinterpret_cast<int const*>(values[pos]->values()->data()), static_cast<size_t>(values[pos]->length())},
+    {reinterpret_cast<int64_t const*>(counts[pos]->values()->data()), static_cast<size_t>(counts[pos]->length())} //
   };
 }
 
-void ArrowTableSlicingCache::validateOrder(const std::pair<std::string, std::string>& bindingKey, const std::shared_ptr<arrow::Table>& input)
+SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedForPos(int pos) const
+{
+  return {
+    {reinterpret_cast<int const*>(valuesUnsorted[pos].data()), valuesUnsorted[pos].size()},
+    &(groups[pos]) //
+  };
+}
+
+void ArrowTableSlicingCache::validateOrder(StringPair const& bindingKey, const std::shared_ptr<arrow::Table>& input)
 {
   auto const& [target, key] = bindingKey;
   auto column = input->GetColumnByName(key);

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -143,6 +143,12 @@ struct KTask {
   std::shared_ptr<int> someSharedInt;
 };
 
+struct LTask {
+  SliceCache cache;
+  PresliceUnsorted<aod::McCollisionLabels> perMcCol = aod::mccollisionlabel::mcCollisionId;
+  void process(aod::McCollision const&, soa::SmallGroups<soa::Join<aod::Collisions, aod::McCollisionLabels>> const&) {}
+};
+
 TEST_CASE("AdaptorCompilation")
 {
   auto cfgc = makeEmptyConfigContext();
@@ -201,6 +207,9 @@ TEST_CASE("AdaptorCompilation")
   auto task11 = adaptAnalysisTask<KTask>(*cfgc, TaskName{"test11"});
   REQUIRE(task11.options.size() == 3);
   REQUIRE(task11.inputs.size() == 1);
+
+  auto task12 = adaptAnalysisTask<LTask>(*cfgc, TaskName{"test12"});
+  REQUIRE(task12.inputs.size() == 3);
 }
 
 TEST_CASE("TestPartitionIteration")

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -416,7 +416,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
 
   auto tt = std::make_tuple(t);
   ArrowTableSlicingCache slices({}, {{soa::getLabelFromType<aod::TrksXU>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
-  slices.updateCacheEntryUnsorted(0, trkTable);
+  auto s = slices.updateCacheEntryUnsorted(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -415,7 +415,8 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   REQUIRE(t.size() == 10 * (20 - 4));
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({});
+  ArrowTableSlicingCache slices({}, {{soa::getLabelFromType<aod::TrksXU>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  slices.updateCacheEntryUnsorted(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;


### PR DESCRIPTION
* Extends caching service to handle cache for grouping tables that are not sorted by the index
* Introduces `PresliceUnsorted`, providing the function similar to `Preslice` for tables that are not sorted by the grouping index
* Updates `GroupSlicer` and `SmallGroups` to use the cache service
* Introduces `sliceBy`/`sliceByCachedUnsorted` functions for tables that are not sorted by the grouping index