### PR TITLE
[O2-3671] ITS-tracking: make road a template class

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -73,7 +73,7 @@ inline static const o2::itsmft::ChipMappingITS& getChipMappingITS()
 }
 
 std::vector<std::unordered_map<int, Label>> loadLabels(const int, const std::string&);
-void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road>>&,
+void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road<5>>>&,
                       const std::unordered_map<int, Label>&);
 
 template <class iterator, typename T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
@@ -13,8 +13,8 @@
 /// \brief
 ///
 
-#ifndef TRACKINGITSU_INCLUDE_ROAD_H_
-#define TRACKINGITSU_INCLUDE_ROAD_H_
+#ifndef TRACKINGCA_INCLUDE_ROAD_H
+#define TRACKINGCA_INCLUDE_ROAD_H
 
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <array>
@@ -28,11 +28,12 @@ namespace o2
 namespace its
 {
 
+template <int maxRoadSize = 5>
 class Road final
 {
  public:
-  Road();
-  Road(int, int);
+  GPUhd() Road() : mCellIds{}, mRoadSize{}, mIsFakeRoad{} { resetRoad(); }
+  GPUhd() Road(int cellLayer, int cellId) : Road() { addCell(cellLayer, cellId); }
 
   int getRoadSize() const;
   int getLabel() const;
@@ -41,30 +42,68 @@ class Road final
   void setFakeRoad(const bool);
   GPUhdni() int& operator[](const int&);
 
-  void resetRoad();
-  void addCell(int, int);
+  GPUhd() void resetRoad()
+  {
+    for (int i = 0; i < maxRoadSize; i++) {
+      mCellIds[i] = constants::its::UnusedIndex;
+    }
+    mRoadSize = 0;
+  }
 
-  static constexpr int mMaxRoadSize = 13;
+  GPUhd() void addCell(int cellLayer, int cellId)
+  {
+    if (mCellIds[cellLayer] == constants::its::UnusedIndex) {
+      ++mRoadSize;
+    }
+
+    mCellIds[cellLayer] = cellId;
+  }
+
+  // static constexpr int maxRoadSize = 13;
 
  private:
-  int mCellIds[mMaxRoadSize];
+  int mCellIds[maxRoadSize];
   int mRoadSize;
   int mLabel;
   bool mIsFakeRoad;
 };
 
-inline int Road::getRoadSize() const { return mRoadSize; }
+template <int maxRoadSize>
+inline int Road<maxRoadSize>::getRoadSize() const
+{
+  return mRoadSize;
+}
 
-inline int Road::getLabel() const { return mLabel; }
+template <int maxRoadSize>
+inline int Road<maxRoadSize>::getLabel() const
+{
+  return mLabel;
+}
 
-inline void Road::setLabel(const int label) { mLabel = label; }
+template <int maxRoadSize>
+inline void Road<maxRoadSize>::setLabel(const int label)
+{
+  mLabel = label;
+}
 
-GPUhdi() int& Road::operator[](const int& i) { return mCellIds[i]; }
+template <int maxRoadSize>
+GPUhdi() int& Road<maxRoadSize>::operator[](const int& i)
+{
+  return mCellIds[i];
+}
 
-inline bool Road::isFakeRoad() const { return mIsFakeRoad; }
+template <int maxRoadSize>
+inline bool Road<maxRoadSize>::isFakeRoad() const
+{
+  return mIsFakeRoad;
+}
 
-inline void Road::setFakeRoad(const bool isFakeRoad) { mIsFakeRoad = isFakeRoad; }
+template <int maxRoadSize>
+inline void Road<maxRoadSize>::setFakeRoad(const bool isFakeRoad)
+{
+  mIsFakeRoad = isFakeRoad;
+}
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITSU_INCLUDE_ROAD_H_ */
+#endif /* TRACKINGCA_INCLUDE_ROAD_H */

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
@@ -28,7 +28,7 @@ namespace o2
 namespace its
 {
 
-template <int maxRoadSize = 5>
+template <unsigned char maxRoadSize = 5>
 class Road final
 {
  public:
@@ -59,46 +59,44 @@ class Road final
     mCellIds[cellLayer] = cellId;
   }
 
-  // static constexpr int maxRoadSize = 13;
-
  private:
   int mCellIds[maxRoadSize];
-  int mRoadSize;
-  int mLabel;
+  // int mLabel;
+  unsigned char mRoadSize;
   bool mIsFakeRoad;
 };
 
-template <int maxRoadSize>
+template <unsigned char maxRoadSize>
 inline int Road<maxRoadSize>::getRoadSize() const
 {
   return mRoadSize;
 }
 
-template <int maxRoadSize>
-inline int Road<maxRoadSize>::getLabel() const
-{
-  return mLabel;
-}
+// template <unsigned char maxRoadSize>
+// inline int Road<maxRoadSize>::getLabel() const
+// {
+//   return mLabel;
+// }
 
-template <int maxRoadSize>
-inline void Road<maxRoadSize>::setLabel(const int label)
-{
-  mLabel = label;
-}
+// template <unsigned char maxRoadSize>
+// inline void Road<maxRoadSize>::setLabel(const int label)
+// {
+//   mLabel = label;
+// }
 
-template <int maxRoadSize>
+template <unsigned char maxRoadSize>
 GPUhdi() int& Road<maxRoadSize>::operator[](const int& i)
 {
   return mCellIds[i];
 }
 
-template <int maxRoadSize>
+template <unsigned char maxRoadSize>
 inline bool Road<maxRoadSize>::isFakeRoad() const
 {
   return mIsFakeRoad;
 }
 
-template <int maxRoadSize>
+template <unsigned char maxRoadSize>
 inline void Road<maxRoadSize>::setFakeRoad(const bool isFakeRoad)
 {
   mIsFakeRoad = isFakeRoad;
@@ -106,4 +104,4 @@ inline void Road<maxRoadSize>::setFakeRoad(const bool isFakeRoad)
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGCA_INCLUDE_ROAD_H */
+#endif

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -153,7 +153,7 @@ class TimeFrame
   std::vector<std::vector<Cell>>& getCells();
   std::vector<std::vector<int>>& getCellsLookupTable();
   std::vector<std::vector<std::vector<int>>>& getCellsNeighbours();
-  std::vector<Road>& getRoads();
+  std::vector<Road<5>>& getRoads();
   std::vector<TrackITSExt>& getTracks(int rof) { return mTracks[rof]; }
   std::vector<MCCompLabel>& getTracksLabel(const int rof) { return mTracksLabel[rof]; }
   std::vector<MCCompLabel>& getLinesLabel(const int rof) { return mLinesLabels[rof]; }
@@ -247,7 +247,7 @@ class TimeFrame
   std::vector<std::vector<Cell>> mCells;
   std::vector<std::vector<int>> mCellsLookupTable;
   std::vector<std::vector<std::vector<int>>> mCellsNeighbours;
-  std::vector<Road> mRoads;
+  std::vector<Road<5>> mRoads;
   std::vector<std::vector<MCCompLabel>> mTracksLabel;
   std::vector<std::vector<TrackITSExt>> mTracks;
   std::vector<int> mBogusClusters; /// keep track of clusters with wild coordinates
@@ -538,7 +538,7 @@ inline std::vector<std::vector<std::vector<int>>>& TimeFrame::getCellsNeighbours
   return mCellsNeighbours;
 }
 
-inline std::vector<Road>& TimeFrame::getRoads() { return mRoads; }
+inline std::vector<Road<5>>& TimeFrame::getRoads() { return mRoads; }
 
 inline gsl::span<Tracklet> TimeFrame::getFoundTracklets(int rofId, int combId)
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -46,7 +46,7 @@ namespace its
 {
 
 class TrackITSExt;
-typedef std::function<int(o2::gpu::GPUChainITS&, std::vector<Road>& roads, std::vector<const Cluster*>&, std::vector<const Cell*>&, const std::vector<std::vector<TrackingFrameInfo>>&, std::vector<TrackITSExt>&)> FuncRunITSTrackFit_t;
+typedef std::function<int(o2::gpu::GPUChainITS&, std::vector<Road<5>>& roads, std::vector<const Cluster*>&, std::vector<const Cell*>&, const std::vector<std::vector<TrackingFrameInfo>>&, std::vector<TrackITSExt>&)> FuncRunITSTrackFit_t;
 
 class TrackerTraits
 {

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -194,52 +194,52 @@ std::vector<std::unordered_map<int, Label>> ioutils::loadLabels(const int events
   return labelsMap;
 }
 
-void ioutils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofstream& duplicateRoadsOutputStream,
-                               std::ofstream& fakeRoadsOutputStream, const std::vector<std::vector<Road<5>>>& roads,
-                               const std::unordered_map<int, Label>& labelsMap)
-{
-  const int numVertices{static_cast<int>(roads.size())};
-  std::unordered_set<int> foundMonteCarloIds{};
+// void ioutils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofstream& duplicateRoadsOutputStream,
+//                                std::ofstream& fakeRoadsOutputStream, const std::vector<std::vector<Road<5>>>& roads,
+//                                const std::unordered_map<int, Label>& labelsMap)
+// {
+//   const int numVertices{static_cast<int>(roads.size())};
+//   std::unordered_set<int> foundMonteCarloIds{};
 
-  correctRoadsOutputStream << EventLabelsSeparator << std::endl;
-  fakeRoadsOutputStream << EventLabelsSeparator << std::endl;
+//   correctRoadsOutputStream << EventLabelsSeparator << std::endl;
+//   fakeRoadsOutputStream << EventLabelsSeparator << std::endl;
 
-  for (int iVertex{0}; iVertex < numVertices; ++iVertex) {
+//   for (int iVertex{0}; iVertex < numVertices; ++iVertex) {
 
-    const std::vector<Road<5>>& currentVertexRoads{roads[iVertex]};
-    const int numRoads{static_cast<int>(currentVertexRoads.size())};
+//     const std::vector<Road<5>>& currentVertexRoads{roads[iVertex]};
+//     const int numRoads{static_cast<int>(currentVertexRoads.size())};
 
-    for (int iRoad{0}; iRoad < numRoads; ++iRoad) {
+//     for (int iRoad{0}; iRoad < numRoads; ++iRoad) {
 
-      const Road<5>& currentRoad{currentVertexRoads[iRoad]};
-      const int currentRoadLabel{currentRoad.getLabel()};
+//       const Road<5>& currentRoad{currentVertexRoads[iRoad]};
+//       const int currentRoadLabel{currentRoad.getLabel()};
 
-      if (!labelsMap.count(currentRoadLabel)) {
+//       if (!labelsMap.count(currentRoadLabel)) {
 
-        continue;
-      }
+//         continue;
+//       }
 
-      const Label& currentLabel{labelsMap.at(currentRoadLabel)};
+//       const Label& currentLabel{labelsMap.at(currentRoadLabel)};
 
-      if (currentRoad.isFakeRoad()) {
+//       if (currentRoad.isFakeRoad()) {
 
-        fakeRoadsOutputStream << currentLabel << std::endl;
+//         fakeRoadsOutputStream << currentLabel << std::endl;
 
-      } else {
+//       } else {
 
-        if (foundMonteCarloIds.count(currentLabel.monteCarloId)) {
+//         if (foundMonteCarloIds.count(currentLabel.monteCarloId)) {
 
-          duplicateRoadsOutputStream << currentLabel << std::endl;
+//           duplicateRoadsOutputStream << currentLabel << std::endl;
 
-        } else {
+//         } else {
 
-          correctRoadsOutputStream << currentLabel << std::endl;
-          foundMonteCarloIds.emplace(currentLabel.monteCarloId);
-        }
-      }
-    }
-  }
-}
+//           correctRoadsOutputStream << currentLabel << std::endl;
+//           foundMonteCarloIds.emplace(currentLabel.monteCarloId);
+//         }
+//       }
+//     }
+//   }
+// }
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -195,7 +195,7 @@ std::vector<std::unordered_map<int, Label>> ioutils::loadLabels(const int events
 }
 
 void ioutils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofstream& duplicateRoadsOutputStream,
-                               std::ofstream& fakeRoadsOutputStream, const std::vector<std::vector<Road>>& roads,
+                               std::ofstream& fakeRoadsOutputStream, const std::vector<std::vector<Road<5>>>& roads,
                                const std::unordered_map<int, Label>& labelsMap)
 {
   const int numVertices{static_cast<int>(roads.size())};
@@ -206,12 +206,12 @@ void ioutils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofs
 
   for (int iVertex{0}; iVertex < numVertices; ++iVertex) {
 
-    const std::vector<Road>& currentVertexRoads{roads[iVertex]};
+    const std::vector<Road<5>>& currentVertexRoads{roads[iVertex]};
     const int numRoads{static_cast<int>(currentVertexRoads.size())};
 
     for (int iRoad{0}; iRoad < numRoads; ++iRoad) {
 
-      const Road& currentRoad{currentVertexRoads[iRoad]};
+      const Road<5>& currentRoad{currentVertexRoads[iRoad]};
       const int currentRoadLabel{currentRoad.getLabel()};
 
       if (!labelsMap.count(currentRoadLabel)) {

--- a/Detectors/ITSMFT/ITS/tracking/src/Road.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Road.cxx
@@ -8,39 +8,11 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-///
-/// \file Road.cxx
-/// \brief
-///
 
 #include "ITStracking/Road.h"
-#include <cassert>
-#include <iostream>
-
 namespace o2
 {
 namespace its
 {
-
-Road::Road() : mCellIds{}, mRoadSize{}, mIsFakeRoad{} { resetRoad(); }
-
-Road::Road(int cellLayer, int cellId) : Road() { addCell(cellLayer, cellId); }
-
-void Road::resetRoad()
-{
-  for (int i = 0; i < mMaxRoadSize; i++) {
-    mCellIds[i] = constants::its::UnusedIndex;
-  }
-  mRoadSize = 0;
-}
-
-void Road::addCell(int cellLayer, int cellId)
-{
-  if (mCellIds[cellLayer] == constants::its::UnusedIndex) {
-    ++mRoadSize;
-  }
-
-  mCellIds[cellLayer] = cellId;
-}
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -409,7 +409,7 @@ unsigned long TimeFrame::getArtefactsMemory()
       size += sizeof(int) * vec.size();
     }
   }
-  return size + sizeof(Road) * mRoads.size();
+  return size + sizeof(Road<5>) * mRoads.size();
 }
 
 void TimeFrame::fillPrimaryVerticesXandAlpha()

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -153,7 +153,7 @@ void Tracker::computeRoadsMClabels()
 
   for (int iRoad{0}; iRoad < roadsNum; ++iRoad) {
 
-    Road& currentRoad{mTimeFrame->getRoads()[iRoad]};
+    Road<5>& currentRoad{mTimeFrame->getRoads()[iRoad]};
     std::vector<std::pair<MCCompLabel, size_t>> occurrences;
     bool isFakeRoad{false};
     bool isFirstRoadCell{true};

--- a/GPU/GPUTracking/Global/GPUChainITS.cxx
+++ b/GPU/GPUTracking/Global/GPUChainITS.cxx
@@ -76,13 +76,13 @@ int GPUChainITS::Finalize() { return 0; }
 
 int GPUChainITS::RunChain() { return 0; }
 
-int GPUChainITS::PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks)
+int GPUChainITS::PrepareAndRunITSTrackFit(std::vector<o2::its::Road<5>>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks)
 {
   mRec->PrepareEvent();
   return RunITSTrackFit(roads, clusters, cells, tf, tracks);
 }
 
-int GPUChainITS::RunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks)
+int GPUChainITS::RunITSTrackFit(std::vector<o2::its::Road<5>>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks)
 {
   auto threadContext = GetThreadContext();
   bool doGPU = GetRecoStepsGPU() & RecoStep::ITSTracking;

--- a/GPU/GPUTracking/Global/GPUChainITS.h
+++ b/GPU/GPUTracking/Global/GPUChainITS.h
@@ -19,6 +19,7 @@
 namespace o2::its
 {
 struct Cluster;
+template <int N>
 class Road;
 class Cell;
 struct TrackingFrameInfo;
@@ -41,8 +42,8 @@ class GPUChainITS : public GPUChain
   int RunChain() override;
   void MemorySize(size_t& gpuMem, size_t& pageLockedHostMem) override;
 
-  int PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks);
-  int RunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks);
+  int PrepareAndRunITSTrackFit(std::vector<o2::its::Road<5>>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks);
+  int RunITSTrackFit(std::vector<o2::its::Road<5>>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks);
 
   o2::its::TrackerTraits* GetITSTrackerTraits();
   o2::its::VertexerTraits* GetITSVertexerTraits();

--- a/GPU/GPUTracking/Global/GPUChainITS.h
+++ b/GPU/GPUTracking/Global/GPUChainITS.h
@@ -19,7 +19,7 @@
 namespace o2::its
 {
 struct Cluster;
-template <int N>
+template <unsigned char N>
 class Road;
 class Cell;
 struct TrackingFrameInfo;

--- a/GPU/GPUTracking/ITS/GPUITSFitter.h
+++ b/GPU/GPUTracking/ITS/GPUITSFitter.h
@@ -20,7 +20,7 @@
 
 namespace o2::its
 {
-template <int N>
+template <unsigned char N>
 class Road;
 struct TrackingFrameInfo;
 struct Cluster;

--- a/GPU/GPUTracking/ITS/GPUITSFitter.h
+++ b/GPU/GPUTracking/ITS/GPUITSFitter.h
@@ -20,6 +20,7 @@
 
 namespace o2::its
 {
+template <int N>
 class Road;
 struct TrackingFrameInfo;
 struct Cluster;
@@ -43,7 +44,7 @@ class GPUITSFitter : public GPUProcessor
   void* SetPointersMemory(void* mem);
 #endif
 
-  GPUd() o2::its::Road* roads()
+  GPUd() o2::its::Road<5>* roads()
   {
     return mRoads;
   }
@@ -85,7 +86,7 @@ class GPUITSFitter : public GPUProcessor
   int mNMaxTracks = 0;
   int* mNTF = nullptr;
   Memory* mMemory = nullptr;
-  o2::its::Road* mRoads = nullptr;
+  o2::its::Road<5>* mRoads = nullptr;
   o2::its::TrackingFrameInfo** mTF = {nullptr};
   GPUITSTrack* mTracks = nullptr;
 

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -74,7 +74,7 @@ GPUdii() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBloc
   int refitCounters[4]{0, 0, 0, 0};
 #endif
   for (int iRoad = get_global_id(0); iRoad < Fitter.NumberOfRoads(); iRoad += get_global_size(0)) {
-    Road& road = Fitter.roads()[iRoad];
+    Road<5>& road = Fitter.roads()[iRoad];
     int clusters[7] = {o2::its::constants::its::UnusedIndex, o2::its::constants::its::UnusedIndex, o2::its::constants::its::UnusedIndex, o2::its::constants::its::UnusedIndex, o2::its::constants::its::UnusedIndex, o2::its::constants::its::UnusedIndex, o2::its::constants::its::UnusedIndex};
     int lastCellLevel = o2::its::constants::its::UnusedIndex;
     CA_DEBUGGER(int nClusters = 2);


### PR DESCRIPTION
@shahor02: this reduces the global size of the Road class from 64 to 32 bytes, lowering the footprint of the tracker.

EDIT: After the latest commit current Road size is now 24Bytes.

CC-ing: @sawenzel 