### PR TITLE
[FOCAL-8] Adding debug mode for pad pedestal DA

### DIFF
--- a/Detectors/FOCAL/calibration/include/FOCALCalibration/PadPedestalCalibDevice.h
+++ b/Detectors/FOCAL/calibration/include/FOCALCalibration/PadPedestalCalibDevice.h
@@ -34,7 +34,7 @@ class PadPedestalCalibDevice : public framework::Task
     MEAN,
     FIT
   };
-  PadPedestalCalibDevice(bool updateCCDB, const std::string& path);
+  PadPedestalCalibDevice(bool updateCCDB, const std::string& path, bool debugMode);
   ~PadPedestalCalibDevice() final = default;
 
   void init(framework::InitContext& ctx) final;
@@ -50,12 +50,13 @@ class PadPedestalCalibDevice : public framework::Task
   PadDecoder mDecoder;
   std::unique_ptr<PadPedestal> mPedestalContainer;
   bool mUpdateCCDB = true;
+  bool mDebug = false;
   std::string mPath = "./";
   Method_t mExtractionMethod = Method_t::MAX;
   std::array<std::unique_ptr<TH2>, 18> mADCDistLayer;
 };
 
-o2::framework::DataProcessorSpec getPadPedestalCalibDevice(bool updateCCDB, const std::string& path);
+o2::framework::DataProcessorSpec getPadPedestalCalibDevice(bool updateCCDB, const std::string& path, bool debug);
 
 } // namespace o2::focal
 

--- a/Detectors/FOCAL/calibration/src/pad-pedestal-calibration-workflow.cxx
+++ b/Detectors/FOCAL/calibration/src/pad-pedestal-calibration-workflow.cxx
@@ -17,6 +17,7 @@
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(o2::framework::ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb cpv calibration objects"}});
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"debug", o2::framework::VariantType::Bool, false, {"debug mode (store calibration objects to local file)"}});
   workflowOptions.push_back(o2::framework::ConfigParamSpec{"path", o2::framework::VariantType::String, "./", {"path to store temp files"}});
   workflowOptions.push_back(o2::framework::ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings"}});
 }
@@ -28,8 +29,9 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   o2::framework::WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   auto useCCDB = configcontext.options().get<bool>("use-ccdb");
+  auto debugMode = configcontext.options().get<bool>("debug");
   auto path = configcontext.options().get<std::string>("path");
 
-  specs.emplace_back(o2::focal::getPadPedestalCalibDevice(useCCDB, path));
+  specs.emplace_back(o2::focal::getPadPedestalCalibDevice(useCCDB, path, debugMode));
   return specs;
 }


### PR DESCRIPTION
In case of the debug mode the extracted pedestals
are written to a file in the same way as if they were
a CCDB object