### PR TITLE
Reduce logging: Calib tasks should not log info messages per TF

### DIFF
--- a/Detectors/CPV/calib/testWorkflow/GainCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/GainCalibratorSpec.h
@@ -101,7 +101,7 @@ class CPVGainCalibratorSpec : public o2::framework::Task
     auto&& digits = pc.inputs().get<gsl::span<o2::cpv::Digit>>("calibdigs");
 
     // fill statistics
-    LOG(info) << "Processing TF " << tfcounter << " with " << digits.size() << " digits";
+    LOG(detail) << "Processing TF " << tfcounter << " with " << digits.size() << " digits";
     mCalibrator->process(digits); // fill TimeSlot with digits from 1 event and check slots for finalization
 
     // inform about results and send output to ccdb

--- a/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
@@ -116,7 +116,7 @@ class CPVNoiseCalibratorSpec : public o2::framework::Task
     auto&& digits = pc.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
     auto&& trigrecs = pc.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("trigrecs");
 
-    LOG(info) << "Processing TF " << tfcounter << " with " << digits.size() << " digits in " << trigrecs.size() << " trigger records.";
+    LOG(detail) << "Processing TF " << tfcounter << " with " << digits.size() << " digits in " << trigrecs.size() << " trigger records.";
     auto& slotTF = mCalibrator->getSlotForTF(tfcounter);
 
     for (auto trigrec = trigrecs.begin(); trigrec != trigrecs.end(); trigrec++) { // event loop
@@ -134,7 +134,7 @@ class CPVNoiseCalibratorSpec : public o2::framework::Task
     auto infoVecSize = mCalibrator->getCcdbInfoBadChannelMapVector().size();
     auto badMapVecSize = mCalibrator->getBadChannelMapVector().size();
     if (infoVecSize > 0) {
-      LOG(info) << "Created " << infoVecSize << " ccdb infos and " << badMapVecSize << " BadChannelMap objects for TF " << tfcounter;
+      LOG(detail) << "Created " << infoVecSize << " ccdb infos and " << badMapVecSize << " BadChannelMap objects for TF " << tfcounter;
     }
     sendOutput(pc.outputs());
   }

--- a/Detectors/CPV/calib/testWorkflow/PedestalCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/PedestalCalibratorSpec.h
@@ -81,7 +81,7 @@ class CPVPedestalCalibratorSpec : public o2::framework::Task
 
     auto&& digits = pc.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
     auto&& trigrecs = pc.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("trigrecs");
-    LOG(info) << "Processing TF " << tfcounter << " with " << digits.size() << " digits in " << trigrecs.size() << " trigger records.";
+    LOG(detail) << "Processing TF " << tfcounter << " with " << digits.size() << " digits in " << trigrecs.size() << " trigger records.";
     auto& slotTF = mCalibrator->getSlotForTF(tfcounter);
 
     for (auto trigrec = trigrecs.begin(); trigrec != trigrecs.end(); trigrec++) { // event loop
@@ -99,7 +99,7 @@ class CPVPedestalCalibratorSpec : public o2::framework::Task
     auto infoVecSize = mCalibrator->getCcdbInfoPedestalsVector().size();
     auto pedsVecSize = mCalibrator->getPedestalsVector().size();
     if (infoVecSize > 0) {
-      LOG(info) << "Created " << infoVecSize << " ccdb infos and " << pedsVecSize << " pedestal objects for TF " << tfcounter;
+      LOG(detail) << "Created " << infoVecSize << " ccdb infos and " << pedsVecSize << " pedestal objects for TF " << tfcounter;
     }
     sendOutput(pc.outputs());
   }

--- a/Detectors/Calibration/workflow/src/MeanVertexCalibratorSpec.cxx
+++ b/Detectors/Calibration/workflow/src/MeanVertexCalibratorSpec.cxx
@@ -51,7 +51,7 @@ void MeanVertexCalibDevice::run(o2::framework::ProcessingContext& pc)
   mCalibrator->process(data);
   sendOutput(pc.outputs());
   const auto& infoVec = mCalibrator->getMeanVertexObjectInfoVector();
-  LOG(info) << "Processed TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.size() << " vertices, for which we created " << infoVec.size() << " objects for TF " << mCalibrator->getCurrentTFInfo().tfCounter;
+  LOG(detail) << "Processed TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.size() << " vertices, for which we created " << infoVec.size() << " objects for TF " << mCalibrator->getCurrentTFInfo().tfCounter;
 }
 
 //_________________________________________________________________

--- a/Detectors/FIT/raw/include/FITRaw/DigitBlockFIT.h
+++ b/Detectors/FIT/raw/include/FITRaw/DigitBlockFIT.h
@@ -240,7 +240,7 @@ class DigitBlockFIT : public DigitBlockBase<DigitType, ChannelDataType>
     inputTree->SetBranchAddress(decltype(vecChannelData)::value_type::sDigitBranchName, &ptrVecChannelData);
     for (int iEntry = 0; iEntry < inputTree->GetEntries(); iEntry++) {
       inputTree->GetEntry(iEntry);
-      LOG(info) << "Processing TF " << iEntry;
+      LOG(detail) << "Processing TF " << iEntry;
       digitBlockProc.processDigitBlockPerTF(DigitBlockBase_t::template makeDigitBlock<DigitBlockFIT_t>(vecDigit, vecChannelData));
     }
   }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -138,7 +138,7 @@ class ResidualAggregatorDevice : public o2::framework::Task
     }
 
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mAggregator->getCurrentTFInfo());
-    LOG(info) << "Processing TF " << mAggregator->getCurrentTFInfo().tfCounter << " with " << trkData->size() << " tracks and " << residualsData.size() << " unbinned residuals associated to them";
+    LOG(detail) << "Processing TF " << mAggregator->getCurrentTFInfo().tfCounter << " with " << trkData->size() << " tracks and " << residualsData.size() << " unbinned residuals associated to them";
     mAggregator->process(residualsData, trackRefs, orbitResetTime, trkDataPtr, lumi);
     std::chrono::duration<double, std::milli> runDuration = std::chrono::high_resolution_clock::now() - runStartTime;
     LOGP(debug, "Duration for run method: {} ms. From this taken for time dependent param update: {} ms",

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -32,7 +32,7 @@ bool NoiseCalibrator::processTimeFrameClusters(gsl::span<const o2::itsmft::CompC
                                                gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
   static int nTF = 0;
-  LOG(info) << "Processing TF# " << nTF++ << " of " << clusters.size() << " clusters in" << rofs.size() << " ROFs";
+  LOG(detail) << "Processing TF# " << nTF++ << " of " << clusters.size() << " clusters in" << rofs.size() << " ROFs";
   // extract hits
   auto pattIt = patterns.begin();
   mChipIDs.clear();
@@ -104,7 +104,7 @@ bool NoiseCalibrator::processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> 
                                              gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
   static int nTF = 0;
-  LOG(info) << "Processing TF# " << nTF++ << " of " << digits.size() << " digits in " << rofs.size() << " ROFs";
+  LOG(detail) << "Processing TF# " << nTF++ << " of " << digits.size() << " digits in " << rofs.size() << " ROFs";
   mChipIDs.clear();
   for (const auto& rof : rofs) {
     int chipID = -1;

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
@@ -29,7 +29,7 @@ bool NoiseSlotCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClust
                                            gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
   calibration::TFType nTF = rofs[0].getBCData().orbit / 256;
-  LOG(info) << "Processing TF# " << nTF;
+  LOG(detail) << "Processing TF# " << nTF;
 
   auto& slotTF = getSlotForTF(nTF);
   auto& noiseMap = *(slotTF.getContainer());

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibrator.cxx
@@ -29,7 +29,7 @@ bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
                                        gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
   static int nTF = 0;
-  LOG(info) << "Processing TF# " << nTF++;
+  LOG(detail) << "Processing TF# " << nTF++;
 
   for (const auto& rof : rofs) {
     auto digitsInFrame = rof.getROFData(digits);
@@ -51,7 +51,7 @@ bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
                                        gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
   static int nTF = 0;
-  LOG(info) << "Processing TF# " << nTF++;
+  LOG(detail) << "Processing TF# " << nTF++;
 
   auto pattIt = patterns.begin();
   for (const auto& rof : rofs) {

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseSlotCalibrator.cxx
@@ -29,7 +29,7 @@ bool NoiseSlotCalibrator::processTimeFrame(calibration::TFType nTF,
                                            gsl::span<const o2::itsmft::Digit> const& digits,
                                            gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
-  LOG(info) << "Processing TF# " << nTF;
+  LOG(detail) << "Processing TF# " << nTF;
 
   auto& slotTF = getSlotForTF(nTF);
   auto& noiseMap = *(slotTF.getContainer());
@@ -54,7 +54,7 @@ bool NoiseSlotCalibrator::processTimeFrame(calibration::TFType nTF,
                                            gsl::span<const unsigned char> const& patterns,
                                            gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
-  LOG(info) << "Processing TF# " << nTF;
+  LOG(detail) << "Processing TF# " << nTF;
 
   auto& slotTF = getSlotForTF(nTF);
   auto& noiseMap = *(slotTF.getContainer());

--- a/Detectors/PHOS/calib/src/PHOSBadMapCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSBadMapCalibDevice.cxx
@@ -69,7 +69,7 @@ void PHOSBadMapCalibDevice::run(o2::framework::ProcessingContext& ctx)
   // scan Cells stream, collect occupancy
   if (mMode == 0) { //  Cell occupancy and time
     auto cells = ctx.inputs().get<gsl::span<o2::phos::Cell>>("cells");
-    LOG(info) << "[PHOSBadMapCalibDevice - run]  Received " << cells.size() << " cells, running calibration ...";
+    LOG(detail) << "[PHOSBadMapCalibDevice - run]  Received " << cells.size() << " cells, running calibration ...";
     for (const auto& c : cells) {
       float e = c.getEnergy();
       if (e > mElowMin && e < mElowMax) {

--- a/Detectors/PHOS/calib/src/PHOSL1phaseCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSL1phaseCalibDevice.cxx
@@ -39,7 +39,7 @@ void PHOSL1phaseCalibDevice::run(o2::framework::ProcessingContext& pc)
   auto tfcounter = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("cells").header)->tfCounter;
   auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
   auto cellTR = pc.inputs().get<gsl::span<TriggerRecord>>("cellTR");
-  LOG(info) << "Processing TF with " << cells.size() << " cells and " << cellTR.size() << " TrigRecords";
+  LOG(detail) << "Processing TF with " << cells.size() << " cells and " << cellTR.size() << " TrigRecords";
   mCalibrator->process(tfcounter, cells, cellTR);
 }
 

--- a/Detectors/PHOS/calib/src/PHOSRunbyrunCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSRunbyrunCalibDevice.cxx
@@ -54,7 +54,7 @@ void PHOSRunbyrunCalibDevice::run(o2::framework::ProcessingContext& pc)
   auto tfcounter = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("clusters").header)->tfCounter;
   auto clusters = pc.inputs().get<gsl::span<Cluster>>("clusters");
   auto cluTR = pc.inputs().get<gsl::span<TriggerRecord>>("cluTR");
-  LOG(info) << "Processing TF with " << clusters.size() << " clusters and " << cluTR.size() << " TriggerRecords";
+  LOG(detail) << "Processing TF with " << clusters.size() << " clusters and " << cluTR.size() << " TriggerRecords";
   mCalibrator->process(tfcounter, clusters, cluTR);
 }
 

--- a/Detectors/PHOS/calib/src/PHOSTurnonCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSTurnonCalibDevice.cxx
@@ -50,7 +50,7 @@ void PHOSTurnonCalibDevice::run(o2::framework::ProcessingContext& pc)
   auto clusters = pc.inputs().get<gsl::span<Cluster>>("clusters");
   auto cluTR = pc.inputs().get<gsl::span<TriggerRecord>>("clusterTriggerRecords");
 
-  LOG(info) << "[PHOSTurnonCalibDevice - run]  Received " << cells.size() << " cells and " << clusters.size() << " clusters, running calibration";
+  LOG(detail) << "[PHOSTurnonCalibDevice - run]  Received " << cells.size() << " cells and " << clusters.size() << " clusters, running calibration";
 
   mCalibrator->process(tfcounter, cells, cellTR, clusters, cluTR);
 }

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
@@ -82,7 +82,7 @@ class TOFCalibCollectorDevice : public o2::framework::Task
     }
 
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCollector->getCurrentTFInfo());
-    LOG(info) << "Processing TF " << mCollector->getCurrentTFInfo().tfCounter << " with " << data.size() << " tracks";
+    LOG(detail) << "Processing TF " << mCollector->getCurrentTFInfo().tfCounter << " with " << data.size() << " tracks";
     mCollector->process(data);
     sendOutput(pc.outputs());
   }

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -158,7 +158,7 @@ class TOFChannelCalibDevice : public o2::framework::Task
     mCalibrator->setCalibTOFapi(mcalibTOFapi);
 
     auto data = pc.inputs().get<gsl::span<T>>("input");
-    LOG(info) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
+    LOG(detail) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
 
     if (mUseCCDB) { // setting the timestamp to get the LHCPhase correction; if we don't use CCDB, then it can stay to 0 as set when creating the calibTOFapi above
       const auto tfOrbitFirst = pc.services().get<o2::framework::TimingInfo>().firstTForbit;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
@@ -81,7 +81,7 @@ class CalibratorPadGainTracksDevice : public Task
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     mCalibrator->process(*histomaps.get());
     const auto& infoVec = mCalibrator->getTFinterval();
-    LOGP(info, "Created {} objects for TF {} and time stamp {}", infoVec.size(), mCalibrator->getCurrentTFInfo().tfCounter, mCalibrator->getCurrentTFInfo().creation);
+    LOGP(detail, "Created {} objects for TF {} and time stamp {}", infoVec.size(), mCalibrator->getCurrentTFInfo().tfCounter, mCalibrator->getCurrentTFInfo().creation);
 
     if (mCalibrator->hasCalibrationData()) {
       mRunNumber = mCalibrator->getCurrentTFInfo().runNumber;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/LaserTracksCalibratorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/LaserTracksCalibratorSpec.h
@@ -55,7 +55,7 @@ class LaserTracksCalibratorDevice : public o2::framework::Task
     const auto dph = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("laserTracks").header);
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     auto data = pc.inputs().get<gsl::span<TrackTPC>>("laserTracks");
-    LOGP(info, "Processing TF {} and {} tracks", mCalibrator->getCurrentTFInfo().tfCounter, data.size());
+    LOGP(detail, "Processing TF {} and {} tracks", mCalibrator->getCurrentTFInfo().tfCounter, data.size());
 
     mCalibrator->process(data);
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -171,7 +171,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     if (nTracks == 0) {
       return;
     }
-    LOGP(info, "Processing TF {} with {} tracks by considering {} tracks", currentTF, nTracks, mMaxTracksPerTF);
+    LOGP(detail, "Processing TF {} with {} tracks by considering {} tracks", currentTF, nTracks, mMaxTracksPerTF);
 
     if (!mDisablePolynomialsCCDB) {
       pc.inputs().get<o2::tpc::CalibdEdxTrackTopologyPolContainer*>("tpctopologygain");

--- a/Detectors/TPC/workflow/src/CalibdEdxSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalibdEdxSpec.cxx
@@ -76,7 +76,7 @@ class CalibdEdxDevice : public Task
     const auto tfcounter = o2::header::get<DataProcessingHeader*>(pc.inputs().get("tracks").header)->startTime;
     const auto tracks = pc.inputs().get<gsl::span<TrackTPC>>("tracks");
 
-    LOGP(info, "Processing TF {} with {} tracks", tfcounter, tracks.size());
+    LOGP(detail, "Processing TF {} with {} tracks", tfcounter, tracks.size());
     mCalib->fill(tracks);
 
     // store run number and CCDB time only once

--- a/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
@@ -87,13 +87,13 @@ class CalibratordEdxDevice : public Task
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
     const auto tracks = pc.inputs().get<gsl::span<tpc::TrackTPC>>("tracks");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
-    LOGP(info, "Processing TF {} with {} tracks", mCalibrator->getCurrentTFInfo().tfCounter, tracks.size());
+    LOGP(detail, "Processing TF {} with {} tracks", mCalibrator->getCurrentTFInfo().tfCounter, tracks.size());
     mRunNumber = mCalibrator->getCurrentTFInfo().runNumber;
     mCalibrator->process(tracks);
     sendOutput(pc.outputs());
 
     const auto& infoVec = mCalibrator->getTFinterval();
-    LOGP(info, "Created {} objects for TF {}", infoVec.size(), mCalibrator->getCurrentTFInfo().tfCounter);
+    LOGP(detail, "Created {} objects for TF {}", infoVec.size(), mCalibrator->getCurrentTFInfo().tfCounter);
   }
 
   void endOfStream(EndOfStreamContext& eos) final

--- a/Detectors/TPC/workflow/src/TPCIntegrateClusterSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCIntegrateClusterSpec.cxx
@@ -64,7 +64,7 @@ class TPCIntegrateClusters : public Task
     const auto& clusters = getWorkflowTPCInput(pc);
     const o2::tpc::ClusterNativeAccess& clIndex = clusters->clusterIndex;
     const auto nCL = clIndex.nClustersTotal;
-    LOGP(info, "Processing TF {} with {} clusters", processing_helpers::getCurrentTF(pc), nCL);
+    LOGP(detail, "Processing TF {} with {} clusters", processing_helpers::getCurrentTF(pc), nCL);
 
     // init only once
     if (mInitICCBuffer) {

--- a/Detectors/TPC/workflow/src/TPCVDriftTglCalibSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCVDriftTglCalibSpec.cxx
@@ -55,7 +55,7 @@ class TPCVDriftTglCalibSpec : public Task
     auto data = pc.inputs().get<gsl::span<o2::dataformats::Triplet<float, float, float>>>("input");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     if (data.size()) {
-      LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.size() - 2 << " tracks"; // 1st entry is for VDrift, 2nd for the offset
+      LOG(detail) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.size() - 2 << " tracks"; // 1st entry is for VDrift, 2nd for the offset
     }
     mCalibrator->process(data);
     if (pc.transitionState() == TransitionHandlingState::Requested) {

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -65,7 +65,7 @@ class VdAndExBCalibDevice : public o2::framework::Task
     mCalibrator->retrievePrev(pc);
     auto dataAngRes = pc.inputs().get<o2::trd::AngularResidHistos>("input");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
-    LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << dataAngRes.getNEntries() << " AngularResidHistos entries";
+    LOG(detail) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << dataAngRes.getNEntries() << " AngularResidHistos entries";
     mCalibrator->process(dataAngRes);
     sendOutput(pc.outputs());
     std::chrono::duration<double, std::milli> runDuration = std::chrono::high_resolution_clock::now() - runStartTime;


### PR DESCRIPTION
@shahor02 @chiarazampolli : This reduces all calib workflow logging that is per TF to detail, which was info before.
I think we cannot sustain this, this was producing as much as the DPL processing reporting, which we also have to reduce.

If some workflows want some per TF logging, they have to implement automatic downscaling. But I would start with this to suppress everything, and then we can selectively enable (with downscaling) what is really needed.