### PR TITLE
[EMCAL-840] Add TimeCalibSlewingParasm to LinkDef

### DIFF
--- a/Detectors/EMCAL/calib/src/EMCALCalibLinkDef.h
+++ b/Detectors/EMCAL/calib/src/EMCALCalibLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class o2::emcal::CalibDB + ;
 #pragma link C++ class o2::emcal::BadChannelMap + ;
 #pragma link C++ class o2::emcal::TimeCalibrationParams + ;
+#pragma link C++ class o2::emcal::TimeCalibrationSlewingParams + ;
 #pragma link C++ class o2::emcal::TimeCalibParamL1Phase + ;
 #pragma link C++ class o2::emcal::TempCalibrationParams + ;
 #pragma link C++ class o2::emcal::TempCalibParamSM + ;


### PR DESCRIPTION
- In recent commit https://github.com/AliceO2Group/AliceO2/pull/11184 the time calibration slewing container was introduced. However it was not added to the linkdef which is needed to create an instance of the object.