### PR TITLE
Adding job ID to user agent string.

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -366,6 +366,10 @@ class CcdbApi //: public DatabaseInterface
 #endif
 
  private:
+
+  // Sets the unique agent ID
+  void setUniqueAgentID();
+
   // internal helper function to update a CCDB file with meta information
   static void updateMetaInformationInLocalFile(std::string const& filename, std::map<std::string, std::string> const* headers, CCDBQuery const* querysummary = nullptr);
 

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -366,7 +366,6 @@ class CcdbApi //: public DatabaseInterface
 #endif
 
  private:
-
   // Sets the unique agent ID
   void setUniqueAgentID();
 

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -55,8 +55,7 @@ unique_ptr<TJAlienCredentials> CcdbApi::mJAlienCredentials = nullptr;
 
 CcdbApi::CcdbApi()
 {
-  std::string host = boost::asio::ip::host_name();
-  mUniqueAgentID = fmt::format("{}-{}-{}", host, getCurrentTimestamp() / 1000, o2::utils::Str::getRandomString(6));
+  setUniqueAgentID();
 
   mIsCCDBDownloaderEnabled = getenv("ALICEO2_ENABLE_MULTIHANDLE_CCDBAPI") && atoi(getenv("ALICEO2_ENABLE_MULTIHANDLE_CCDBAPI"));
   if (mIsCCDBDownloaderEnabled) {
@@ -69,6 +68,17 @@ CcdbApi::~CcdbApi()
   curl_global_cleanup();
   if (mDownloader) {
     delete mDownloader;
+  }
+}
+
+void CcdbApi::setUniqueAgentID()
+{
+  std::string host = boost::asio::ip::host_name();
+  char const* jobID = getenv("ALIEN_PROC_ID");
+  if (jobID) {
+    mUniqueAgentID = fmt::format("{}-{}-{}-{}", host, getCurrentTimestamp() / 1000, o2::utils::Str::getRandomString(6), jobID);
+  } else {
+    mUniqueAgentID = fmt::format("{}-{}-{}", host, getCurrentTimestamp() / 1000, o2::utils::Str::getRandomString(6));
   }
 }
 


### PR DESCRIPTION
I was asked by Costin to add the job ID to the user agent field. The ID will be omitted if it's environment variable is absent.