### PR TITLE
Introduce 64 BC default ITS ROF shift, account in digitization

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/study/src/DumpTracks.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/DumpTracks.cxx
@@ -163,8 +163,8 @@ void DumpTracksSpec::process(o2::globaltracking::RecoContainer& recoData)
   auto trackIndex = recoData.getPrimaryVertexMatchedTracks(); // Global ID's for associated tracks
   auto vtxRefs = recoData.getPrimaryVertexMatchedTrackRefs(); // references from vertex to these track IDs
 
-  float itsBias = 0.5 * mITSROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance().roFrameBiasInBC; // ITS time is supplied in \mus as beginning of ROF
-  float mftBias = 0.5 * mMFTROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance().roFrameBiasInBC; // MFT time is supplied in \mus as beginning of ROF
+  float itsBias = 0.5 * mITSROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance().roFrameBiasInBC * o2::constants::lhc::LHCBunchSpacingNS * 1e-3; // ITS time is supplied in \mus as beginning of ROF
+  float mftBias = 0.5 * mMFTROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance().roFrameBiasInBC * o2::constants::lhc::LHCBunchSpacingNS * 1e-3; // MFT time is supplied in \mus as beginning of ROF
 
   GTrackID::Source prevSrc = GTrackID::Source(-1);
   auto creator = [this, &selBCTF, itsBias, mftBias, &recoData, &prevSrc](auto& _tr, GTrackID _origID, float t0, float terr) {

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
@@ -36,7 +36,7 @@ struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<
   float strobeDelay = DEFStrobeDelay;                 ///< strobe start (in ns) wrt ROF start
   float strobeLengthCont = -1.;                       ///< if < 0, full ROF length - delay
   float strobeLengthTrig = 100.;                      ///< length of the strobe in ns (sig. over threshold checked in this window only)
-  int roFrameBiasInBC = 0;                            ///< bias of the start of ROF wrt orbit start: t_irof = (irof*roFrameLengthInBC + roFrameBiasInBC)*BClengthMUS
+  int roFrameBiasInBC = DEFROFBiasInBC();             ///< bias of the start of ROF wrt orbit start: t_irof = (irof*roFrameLengthInBC + roFrameBiasInBC)*BClengthMUS
 
   // boilerplate stuff + make principal key
   O2ParamDef(DPLAlpideParam, getParamName().data());
@@ -55,6 +55,13 @@ struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<
     // length of RO frame in ns for triggered mode
     return N == o2::detectors::DetID::ITS ? 6000. : 6000.;
   }
+
+  static constexpr int DEFROFBiasInBC()
+  {
+    // default ROF length bias in MC, see https://github.com/AliceO2Group/AliceO2/pull/11108 for ITS
+    return N == o2::detectors::DetID::ITS ? 64 : 0;
+  }
+
   static_assert(N == o2::detectors::DetID::ITS || N == o2::detectors::DetID::MFT, "only DetID::ITS orDetID:: MFT are allowed");
   static_assert(o2::constants::lhc::LHCMaxBunches % DEFROFLengthBC() == 0); // make sure ROF length is divisor of the orbit
 };

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
@@ -67,6 +67,9 @@ class DigiParams
   void setTimeOffset(double sec) { mTimeOffset = sec; }
   double getTimeOffset() const { return mTimeOffset; }
 
+  void setROFrameBiasInBC(int n) { mROFrameBiasInBC = n; }
+  int getROFrameBiasInBC() const { return mROFrameBiasInBC; }
+
   void setChargeThreshold(int v, float frac2Account = 0.1);
   void setNSimSteps(int v);
   void setEnergyToNElectrons(float v) { mEnergyToNElectrons = v; }
@@ -104,7 +107,7 @@ class DigiParams
   float mStrobeDelay = 0.;           ///< strobe start (in ns) wrt ROF start
   float mStrobeLength = 0;           ///< length of the strobe in ns (sig. over threshold checked in this window only)
   double mTimeOffset = -2 * infTime; ///< time offset (in seconds!) to calculate ROFrame from hit time
-
+  int mROFrameBiasInBC = 0;          ///< misalignment of the ROF start in BC
   int mChargeThreshold = 150;              ///< charge threshold in Nelectrons
   int mMinChargeToAccount = 15;            ///< minimum charge contribution to account
   int mNSimSteps = 7;                      ///< number of steps in response simulation

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -136,8 +136,8 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
 {
   // Scan all inputs and create tracks
   mTBrackets.clear();
-  float itsBias = 0.5 * mITSROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance().roFrameBiasInBC; // ITS time is supplied in \mus as beginning of ROF
-  float mftBias = 0.5 * mMFTROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance().roFrameBiasInBC; // MFT time is supplied in \mus as beginning of ROF
+  float itsBias = 0.5 * mITSROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance().roFrameBiasInBC * o2::constants::lhc::LHCBunchSpacingNS * 1e-3; // ITS time is supplied in \mus as beginning of ROF
+  float mftBias = 0.5 * mMFTROFrameLengthMUS + o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance().roFrameBiasInBC * o2::constants::lhc::LHCBunchSpacingNS * 1e-3; // MFT time is supplied in \mus as beginning of ROF
   auto creator = [this, itsBias, mftBias, &vcont](auto& _tr, GIndex _origID, float t0, float terr) {
     if constexpr (!(isMFTTrack<decltype(_tr)>() || isMCHTrack<decltype(_tr)>() || isGlobalFwdTrack<decltype(_tr)>())) { // Skip test for forward tracks; do not contribute to vertex
       if (vcont.find(_origID) != vcont.end()) {                                                                         // track is contributor to vertex, already accounted


### PR DESCRIPTION
Extracted from LHC22m 
![deltaITS](https://user-images.githubusercontent.com/7382029/235383768-f63b8318-1fda-4bc7-8075-26dc31344e9b.png)
