### PR TITLE
Remove TPC starting row cut

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -40,7 +40,6 @@ struct MatchTPCITSParams : public o2::conf::ConfigurableParamHelper<MatchTPCITSP
   float minTPCTrackR = 50.; ///< cut on minimal TPC tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   float minITSTrackR = 50.; ///< cut on minimal ITS tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   int minTPCClusters = 25; ///< minimum number of clusters to consider
-  int askMinTPCRow = 15;   ///< disregard tracks starting above this row
 
   float cutMatchingChi2 = 30.f; ///< cut on matching chi2
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -373,9 +373,6 @@ void MatchTPCITS::addTPCSeed(const o2::track::TrackParCov& _tr, float t0, float 
   uint8_t clSect = 0, clRow = 0;
   uint32_t clIdx = 0;
   tpcOrig.getClusterReference(mTPCTrackClusIdx, tpcOrig.getNClusterReferences() - 1, clSect, clRow, clIdx);
-  if (clRow > mParams->askMinTPCRow) {
-    return;
-  }
   // create working copy of track param
   bool extConstrained = srcGID.getSource() != GTrackID::TPC;
   if (extConstrained) {


### PR DESCRIPTION
@shahor02 , this removes the cut on the starting row of the TPC track in the matching. This helps to recover ~ 10% of the secondary track missing matchings. The number of fakes looks still negligible in the MC. In the plot the algorithm efficiency is defined as: (# of true matched candidates) / (# of candidates with both ITS and TPC tracks)
![c](https://user-images.githubusercontent.com/43742195/235636534-6b8bfaf0-903e-453a-97ad-b4793b60e99f.png)
