### PR TITLE
[FOCAL-13] Make BadChannelMap streamable

### DIFF
--- a/Detectors/FOCAL/calib/include/FOCALCalib/PadBadChannelMap.h
+++ b/Detectors/FOCAL/calib/include/FOCALCalib/PadBadChannelMap.h
@@ -72,7 +72,7 @@ class PadBadChannelMap
  private:
   void init();
   std::size_t getChannelIndex(std::size_t layer, std::size_t channel) const;
-  std::array<MaskType_t, constants::PADS_NLAYERS * constants::PADLAYER_MODULE_NCHANNELS> mChannelStatus;
+  std::array<uint8_t, constants::PADS_NLAYERS * constants::PADLAYER_MODULE_NCHANNELS> mChannelStatus;
 
   ClassDefNV(PadBadChannelMap, 1)
 };

--- a/Detectors/FOCAL/calib/src/PadBadChannelMap.cxx
+++ b/Detectors/FOCAL/calib/src/PadBadChannelMap.cxx
@@ -22,7 +22,7 @@ void PadBadChannelMap::init()
 {
   // Mark all channels as good channels
   for (std::size_t index = 0; index < mChannelStatus.size(); index++) {
-    mChannelStatus[index] = MaskType_t::GOOD_CHANNEL;
+    mChannelStatus[index] = static_cast<uint8_t>(MaskType_t::GOOD_CHANNEL);
   }
 }
 
@@ -33,12 +33,12 @@ void PadBadChannelMap::reset()
 
 void PadBadChannelMap::setChannelStatus(std::size_t layer, std::size_t channel, MaskType_t masktype)
 {
-  mChannelStatus[getChannelIndex(layer, channel)] = masktype;
+  mChannelStatus[getChannelIndex(layer, channel)] = static_cast<uint8_t>(masktype);
 }
 
 PadBadChannelMap::MaskType_t PadBadChannelMap::getChannelStatus(std::size_t layer, std::size_t channel) const
 {
-  return mChannelStatus[getChannelIndex(layer, channel)];
+  return static_cast<MaskType_t>(mChannelStatus[getChannelIndex(layer, channel)]);
 }
 
 std::size_t PadBadChannelMap::getChannelIndex(std::size_t layer, std::size_t channel) const


### PR DESCRIPTION
enumeration datatype was not streamable. Using
uint8_t as underlying datatype.