### PR TITLE
TPC corr.map scaling options

### DIFF
--- a/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
+++ b/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
@@ -126,6 +126,7 @@ void BarrelAlignmentSpec::init(InitContext& ic)
   mTimer.Stop();
   mTimer.Reset();
   o2::base::GRPGeomHelper::instance().setRequest(mGRPGeomRequest);
+
   int dbg = ic.options().get<int>("debug-output"), inst = ic.services().get<const o2::framework::DeviceSpec>().inputTimesliceId;
   mController = std::make_unique<Controller>(mDetMask, mMPsrc, mCosmic, mUseMC, inst);
   if (dbg) {
@@ -178,6 +179,7 @@ void BarrelAlignmentSpec::init(InitContext& ic)
   }
   mIgnoreCCDBAlignment = ic.options().get<bool>("ignore-ccdb-alignment");
   if (!mPostProcessing) {
+    mTPCCorrMapsLoader.init(ic);
     if (GTrackID::includesDet(DetID::TRD, mMPsrc)) {
       mTRDTransformer.reset(new o2::trd::TrackletTransformer);
       if (ic.options().get<bool>("apply-xor")) {
@@ -252,7 +254,7 @@ void BarrelAlignmentSpec::updateTimeDependentParams(ProcessingContext& pc)
     }
 
     mTPCVDriftHelper.extractCCDBInputs(pc);
-    o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
+    mTPCCorrMapsLoader.extractCCDBInputs(pc);
     bool updateMaps = false;
     if (mTPCCorrMapsLoader.isUpdated()) {
       mController->setTPCCorrMaps(&mTPCCorrMapsLoader);
@@ -359,6 +361,14 @@ DataProcessorSpec getBarrelAlignmentSpec(GTrackID::mask_t srcMP, GTrackID::mask_
   std::vector<OutputSpec> outputs;
   auto dataRequest = std::make_shared<DataRequest>();
   bool loadTPCCalib = false;
+  Options opts{
+    ConfigParamSpec{"apply-xor", o2::framework::VariantType::Bool, false, {"flip the 8-th bit of slope and position (for processing TRD CTFs from 2021 pilot beam)"}},
+    ConfigParamSpec{"allow-afterburner-tracks", VariantType::Bool, false, {"allow using ITS-TPC afterburner tracks"}},
+    ConfigParamSpec{"ignore-ccdb-alignment", VariantType::Bool, false, {"do not aplly CCDB alignment to ideal geometry"}},
+    ConfigParamSpec{"initial-params-file", VariantType::String, "", {"initial parameters file"}},
+    ConfigParamSpec{"config-macro", VariantType::String, "", {"configuration macro with signature (o2::align::Controller*, int) to execute from init"}},
+    ConfigParamSpec{"ignore-initial-params-errors", VariantType::Bool, false, {"ignore initial params (if any) errors for precondition"}},
+    ConfigParamSpec{"debug-output", VariantType::Int, 0, {"produce debugging output root files"}}};
   if (!postprocess) {
     dataRequest->requestTracks(src, useMC);
     dataRequest->requestClusters(src, false, skipDetClusters);
@@ -371,7 +381,7 @@ DataProcessorSpec getBarrelAlignmentSpec(GTrackID::mask_t srcMP, GTrackID::mask_
     }
     if (src[DetID::TPC] && !skipDetClusters[DetID::TPC]) {
       o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-      o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs);
+      o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, src[GTrackID::CTP]);
       loadTPCCalib = true;
     }
   }
@@ -390,14 +400,7 @@ DataProcessorSpec getBarrelAlignmentSpec(GTrackID::mask_t srcMP, GTrackID::mask_
     dataRequest->inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<BarrelAlignmentSpec>(srcMP, dataRequest, ccdbRequest, dets, enableCosmic, postprocess, useMC, loadTPCCalib)},
-    Options{
-      ConfigParamSpec{"apply-xor", o2::framework::VariantType::Bool, false, {"flip the 8-th bit of slope and position (for processing TRD CTFs from 2021 pilot beam)"}},
-      ConfigParamSpec{"allow-afterburner-tracks", VariantType::Bool, false, {"allow using ITS-TPC afterburner tracks"}},
-      ConfigParamSpec{"ignore-ccdb-alignment", VariantType::Bool, false, {"do not aplly CCDB alignment to ideal geometry"}},
-      ConfigParamSpec{"initial-params-file", VariantType::String, "", {"initial parameters file"}},
-      ConfigParamSpec{"config-macro", VariantType::String, "", {"configuration macro with signature (o2::align::Controller*, int) to execute from init"}},
-      ConfigParamSpec{"ignore-initial-params-errors", VariantType::Bool, false, {"ignore initial params (if any) errors for precondition"}},
-      ConfigParamSpec{"debug-output", VariantType::Int, 0, {"produce debugging output root files"}}}};
+    opts};
 }
 
 } // namespace align

--- a/Detectors/Align/Workflow/src/barrel-alignment-workflow.cxx
+++ b/Detectors/Align/Workflow/src/barrel-alignment-workflow.cxx
@@ -55,6 +55,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-tpc-tracks", VariantType::Bool, false, {"allow reading TPC tracks"}},
     {"enable-tpc-clusters", VariantType::Bool, false, {"allow reading TPC clusters (will trigger TPC tracks reading)"}},
     {"enable-cosmic", VariantType::Bool, false, {"enable cosmic tracks)"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"postprocessing", VariantType::Int, 0, {"postprocessing bits: 1 - extract alignment objects, 2 - check constraints, 4 - print mpParams/Constraints, 8 - relabel pede results"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -90,6 +91,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   bool loadTPCTracks = configcontext.options().get<bool>("enable-tpc-tracks");
   bool enableCosmic = configcontext.options().get<bool>("enable-cosmic");
   bool useMC = configcontext.options().get<bool>("enable-mc");
+  auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
 
   DetID::mask_t dets = allowedDets & DetID::getMask(configcontext.options().get<std::string>("detectors"));
   DetID::mask_t skipDetClusters; // optionally skip automatically loaded clusters
@@ -137,6 +139,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
         src |= GID::getSourceMask(GID::ITSTPCTRD);
       }
       LOG(info) << "adding TOF request";
+    }
+    if (requireCTPLumi) {
+      src = src | GID::getSourcesMask("CTP");
     }
     // write the configuration used for the workflow
     o2::conf::ConfigurableParam::writeINI("o2_barrel_alignment_configuration.ini");

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -90,6 +90,7 @@ void TPCITSMatchingDPL::init(InitContext& ic)
   mMatching.setNThreads(std::max(1, ic.options().get<int>("nthreads")));
   mMatching.setUseBCFilling(!ic.options().get<bool>("ignore-bc-check"));
   mMatching.setDebugFlag(ic.options().get<int>("debug-tree-flags"));
+  mTPCCorrMapsLoader.init(ic);
 }
 
 void TPCITSMatchingDPL::run(ProcessingContext& pc)
@@ -150,7 +151,7 @@ void TPCITSMatchingDPL::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   mTPCVDriftHelper.extractCCDBInputs(pc);
-  o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
+  mTPCCorrMapsLoader.extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once
     initOnceDone = true;
@@ -232,18 +233,21 @@ DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool 
                                                               o2::base::GRPGeomRequest::Aligned, // geometry
                                                               dataRequest->inputs,
                                                               true); // query only once all objects except mag.field
+
+  Options opts{
+    {"nthreads", VariantType::Int, 1, {"Number of afterburner threads"}},
+    {"ignore-bc-check", VariantType::Bool, false, {"Do not check match candidate against BC filling"}},
+    {"debug-tree-flags", VariantType::Int, 0, {"DebugFlagTypes bit-pattern for debug tree"}}};
+
   o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, src[GTrackID::CTP]);
 
   return DataProcessorSpec{
     "itstpc-track-matcher",
     dataRequest->inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<TPCITSMatchingDPL>(dataRequest, ggRequest, useFT0, calib, skipTPCOnly, useMC)},
-    Options{
-      {"nthreads", VariantType::Int, 1, {"Number of afterburner threads"}},
-      {"ignore-bc-check", VariantType::Bool, false, {"Do not check match candidate against BC filling"}},
-      {"debug-tree-flags", VariantType::Int, 0, {"DebugFlagTypes bit-pattern for debug tree"}}}};
+    opts};
 }
 
 } // namespace globaltracking

--- a/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
@@ -49,6 +49,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -83,8 +84,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
+  auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
 
   GID::mask_t src = alowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+  if (requireCTPLumi) {
+    src = src | GID::getSourcesMask("CTP");
+  }
   GID::mask_t dummy;
   specs.emplace_back(o2::globaltracking::getCosmicsMatchingSpec(src, useMC));
 

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -54,6 +54,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-cascade-finder", o2::framework::VariantType::Bool, false, {"do not run cascade finder"}},
     {"enable-3body-finder", o2::framework::VariantType::Bool, false, {"run 3 body finder"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -75,10 +76,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto enableCasc = !configcontext.options().get<bool>("disable-cascade-finder");
   auto enable3body = configcontext.options().get<bool>("enable-3body-finder");
+  auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
 
   GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("vertexing-sources"));
   GID::mask_t dummy, srcClus = GID::includesDet(DetID::TOF, src) ? GID::getSourceMask(GID::TOF) : dummy; // eventually, TPC clusters will be needed for refit
-
+  if (requireCTPLumi) {
+    src = src | GID::getSourcesMask("CTP");
+  }
   WorkflowSpec specs;
 
   specs.emplace_back(o2::vertexing::getSecondaryVertexingSpec(src, enableCasc, enable3body));

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -64,6 +64,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-dia", o2::framework::VariantType::Bool, false, {"to require diagnostic freq and then write to calib outputs (obsolete since now default)"}},
     {"trd-extra-tolerance", o2::framework::VariantType::Float, 500.0f, {"Extra time tolerance for TRD tracks in ns"}},
     {"write-matchable", o2::framework::VariantType::Bool, false, {"write all matchable pairs in a file (o2matchable_tof.root)"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
     {"combine-devices", o2::framework::VariantType::Bool, false, {"merge DPL source/writer devices"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -92,7 +93,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto diagnostic = configcontext.options().get<bool>("enable-dia");
   auto extratolerancetrd = configcontext.options().get<float>("trd-extra-tolerance");
   auto writeMatchable = configcontext.options().get<bool>("write-matchable");
-
+  auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
   bool writematching = 0;
   bool writecalib = 0;
   auto outputType = configcontext.options().get<std::string>("output-type");
@@ -137,7 +138,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (useFIT) {
     clustermask |= GID::getSourceMask(GID::FT0);
   }
-
+  if (requireCTPLumi) {
+    src = src | GID::getSourcesMask("CTP");
+  }
   if (useMC) {
     mcmaskcl |= GID::getSourceMask(GID::TOF);
   }

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -37,6 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
     {"use-ft0", o2::framework::VariantType::Bool, false, {"use FT0 in matching"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
@@ -77,9 +78,13 @@ WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcont
   if (useFT0) {
     src |= GID::getSourceMask(GID::FT0);
   }
+  auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto calib = configcontext.options().get<bool>("produce-calibration-data");
   auto srcL = src | GID::getSourcesMask("ITS,TPC"); // ITS is neadded always, TPC must be loaded even if bare TPC tracks are not used in matching
+  if (requireCTPLumi) {
+    srcL = srcL | GID::getSourcesMask("CTP");
+  }
 
   o2::framework::WorkflowSpec specs;
   specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(srcL, useFT0, calib, !GID::includesSource(GID::TPC, src), useMC));

--- a/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
@@ -39,6 +39,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of track sources to use"}},
     {"cluster-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of cluster sources to use"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -58,7 +59,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-
+  auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   if (!useMC) {
     LOG(info) << "this task requires MC info, enforcing it";
@@ -66,7 +67,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
   GID::mask_t srcCls = allowedSourcesClus & GID::getSourcesMask(configcontext.options().get<std::string>("cluster-sources"));
-
+  if (requireCTPLumi) {
+    srcTrc = srcTrc | GID::getSourcesMask("CTP");
+    srcCls = srcCls | GID::getSourcesMask("CTP");
+  }
   o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, useMC);
   o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC); // P-vertex is always needed
   specs.emplace_back(o2::trackstudy::getTPCTrackStudySpec(srcTrc, srcCls, useMC));

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -57,6 +57,7 @@ o2_add_library(TPCCalibration
                                      O2::GPUO2Interface
                                      O2::GPUTracking
                                      O2::TPCFastTransformation
+                                     O2::DataFormatsCTP
                                      O2::CCDB)
 
 o2_target_root_dictionary(TPCCalibration

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -29,6 +29,8 @@ namespace framework
 class ProcessingContext;
 class ConcreteDataMatcher;
 class InputSpec;
+class ConfigParamSpec;
+class InitContext;
 } // namespace framework
 
 namespace tpc
@@ -43,10 +45,15 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
 
 #ifndef GPUCA_GPUCODE_DEVICE
   bool accountCCDBInputs(const o2::framework::ConcreteDataMatcher& matcher, void* obj);
-  static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs);
-  static void extractCCDBInputs(o2::framework::ProcessingContext& pc);
-  static void addInput(std::vector<o2::framework::InputSpec>& inputs, o2::framework::InputSpec&& isp);
+  void extractCCDBInputs(o2::framework::ProcessingContext& pc);
   void updateVDrift(float vdriftCorr, float vdrifRef, float driftTimeOffset = 0);
+  void init(o2::framework::InitContext& ic);
+  static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, bool requestCTPLumi = false);
+  static void addOptions(std::vector<o2::framework::ConfigParamSpec>& options);
+
+ protected:
+  static void addOption(std::vector<o2::framework::ConfigParamSpec>& options, o2::framework::ConfigParamSpec&& osp);
+  static void addInput(std::vector<o2::framework::InputSpec>& inputs, o2::framework::InputSpec&& isp);
 #endif
 };
 

--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -16,7 +16,12 @@
 #include "Framework/ProcessingContext.h"
 #include "Framework/CCDBParamSpec.h"
 #include "Framework/InputRecord.h"
+#include "Framework/ConfigParamSpec.h"
 #include "Framework/ConcreteDataMatcher.h"
+#include "Framework/InitContext.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "DataFormatsCTP/LumiInfo.h"
 
 using namespace o2::tpc;
 using namespace o2::framework;
@@ -37,13 +42,28 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
 {
   pc.inputs().get<o2::gpu::TPCFastTransform*>("tpcCorrMap");
   pc.inputs().get<o2::gpu::TPCFastTransform*>("tpcCorrMapRef"); // not used at the moment
+  if (getUseCTPLumi() && mInstLumiOverride <= 0.) {
+    auto lumiObj = pc.inputs().get<o2::ctp::LumiInfo>("CTPLumi");
+    setInstLumi(lumiObj.getLumi());
+  }
 }
 
 //________________________________________________________
-void CorrectionMapsLoader::requestCCDBInputs(std::vector<InputSpec>& inputs)
+void CorrectionMapsLoader::requestCCDBInputs(std::vector<InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, bool requestCTPLumi)
 {
   addInput(inputs, {"tpcCorrMap", "TPC", "CorrMap", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalCorrMap), {}, 1)});          // time-dependent
   addInput(inputs, {"tpcCorrMapRef", "TPC", "CorrMapRef", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalCorrMapRef), {}, 0)}); // load once
+  if (requestCTPLumi) {
+    addInput(inputs, {"lumi", "CTP", "LUMI", 0, Lifetime::Timeframe});
+  }
+  addOptions(options);
+}
+
+//________________________________________________________
+void CorrectionMapsLoader::addOptions(std::vector<ConfigParamSpec>& options)
+{
+  addOption(options, ConfigParamSpec{"corrmap-lumi-mean", VariantType::Float, -1.f, {"override TPC corr.map mean lumi (if > 0)"}});
+  addOption(options, ConfigParamSpec{"corrmap-lumi-inst", VariantType::Float, -1.f, {"override instantaneous CTP lumi (if > 0) for TPC corr.map scaling"}});
 }
 
 //________________________________________________________
@@ -55,11 +75,23 @@ void CorrectionMapsLoader::addInput(std::vector<InputSpec>& inputs, InputSpec&& 
 }
 
 //________________________________________________________
+void CorrectionMapsLoader::addOption(std::vector<ConfigParamSpec>& options, ConfigParamSpec&& osp)
+{
+  if (std::find(options.begin(), options.end(), osp) == options.end()) {
+    options.emplace_back(osp);
+  }
+}
+
+//________________________________________________________
 bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher, void* obj)
 {
   if (matcher == ConcreteDataMatcher("TPC", "CorrMap", 0)) {
     setCorrMap((o2::gpu::TPCFastTransform*)obj);
     mCorrMap->rectifyAfterReadingFromFile();
+    if (getMeanLumiOverride() < 0 && mCorrMap->getLumi() > 0.) {
+      setMeanLumi(mCorrMap->getLumi());
+    }
+    LOGP(debug, "MeanLumiOverride={} MeanLumiMap={} -> meanLumi = {}", getMeanLumiOverride(), mCorrMap->getLumi(), getMeanLumi());
     setUpdatedMap();
     return true;
   }
@@ -70,5 +102,26 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
     return true;
   }
   return false;
+}
+
+//________________________________________________________
+void CorrectionMapsLoader::init(o2::framework::InitContext& ic)
+{
+  const auto& inputRouts = ic.services().get<const o2::framework::DeviceSpec>().inputs;
+  for (const auto& route : inputRouts) {
+    if (route.matcher == InputSpec{"CTPLumi", "CTP", "LUMI", 0, Lifetime::Timeframe}) {
+      setUseCTPLumi(true);
+      break;
+    }
+  }
+  mMeanLumiOverride = ic.options().get<float>("corrmap-lumi-mean");
+  mInstLumiOverride = ic.options().get<float>("corrmap-lumi-inst");
+  if (mMeanLumiOverride >= 0.) {
+    setMeanLumi(mMeanLumiOverride);
+  }
+  if (mInstLumiOverride >= 0.) {
+    setInstLumi(mInstLumiOverride);
+  }
+  LOGP(info, "CTP Lumi request for TPC corr.map scaling={}, override values: lumiMean={} lumiInst={}", getUseCTPLumi() ? "ON" : "OFF", mMeanLumiOverride, mInstLumiOverride);
 }
 #endif // #ifndef GPUCA_GPUCODE_DEVICE

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -82,7 +82,8 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,           
                                     int zsOnTheFly = 0,
                                     bool askDISTSTF = true,
                                     bool selIR = false,
-                                    bool filteredInp = false);
+                                    bool filteredInp = false,
+                                    bool requireCTPLumi = false);
 
 void cleanupCallback();
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -56,6 +56,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    mTPCCorrMapsLoader.init(ic);
     // setting up the histogram ranges
     const auto nBins = ic.options().get<int>("nBins");
     auto reldEdxMin = ic.options().get<float>("reldEdxMin");
@@ -182,7 +183,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
       pc.inputs().get<std::unordered_map<std::string, o2::tpc::CalDet<float>>*>("tpcresidualgainmap");
     }
     mTPCVDriftHelper.extractCCDBInputs(pc);
-    o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
+    mTPCCorrMapsLoader.extractCCDBInputs(pc);
     bool updateMaps = false;
     if (mTPCCorrMapsLoader.isUpdated()) {
       mPadGainTracks.setTPCCorrMaps(&mTPCCorrMapsLoader);
@@ -239,7 +240,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, const bool debug, const bool useLastExtractedMapAsReference, const std::string polynomialsFile, bool disablePolynomialsCCDB)
+DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, const bool debug, const bool useLastExtractedMapAsReference, const std::string polynomialsFile, bool disablePolynomialsCCDB, bool requestCTPLumi)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("trackTPC", gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe);
@@ -259,7 +260,29 @@ DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, c
   }
 
   o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs);
+  Options opts{
+    {"nBins", VariantType::Int, 20, {"Number of bins per histogram"}},
+    {"reldEdxMin", VariantType::Int, 0, {"Minimum x coordinate of the histogram for Q/(dE/dx)"}},
+    {"reldEdxMax", VariantType::Int, 3, {"Maximum x coordinate of the histogram for Q/(dE/dx)"}},
+    {"underflowBin", VariantType::Bool, false, {"Using under flow bin"}},
+    {"overflowBin", VariantType::Bool, true, {"Using overflow flow bin"}},
+    {"momMin", VariantType::Float, 0.3f, {"minimum momentum of the tracks which are used for the pad-by-pad gain map"}},
+    {"momMax", VariantType::Float, 1.f, {"maximum momentum of the tracks which are used for the pad-by-pad gain map"}},
+    {"etaMax", VariantType::Float, 1.f, {"maximum eta of the tracks which are used for the pad-by-pad gain map"}},
+    {"disable-log-transform", VariantType::Bool, false, {"Disable the transformation of q/dedx -> log(1 + q/dedx)"}},
+    {"do-not-normalize", VariantType::Bool, false, {"Do not normalize the cluster charge to the dE/dx"}},
+    {"mindEdx", VariantType::Float, 0.f, {"Minimum accepted dE/dx value"}},
+    {"maxdEdx", VariantType::Float, -1.f, {"Maximum accepted dE/dx value (-1=accept all dE/dx)"}},
+    {"minClusters", VariantType::Int, 50, {"minimum number of clusters of tracks which are used for the pad-by-pad gain map"}},
+    {"gainMapFile", VariantType::String, "", {"file to reference gain map, which will be used for correcting the cluster charge"}},
+    {"dedxRegionType", VariantType::Int, 2, {"using the dE/dx per chamber (0), stack (1) or per sector (2)"}},
+    {"dedxType", VariantType::Int, 0, {"recalculating the dE/dx (0), using it from tracking (1)"}},
+    {"chargeType", VariantType::Int, 0, {"Using qMax (0) or qTot (1) for the dE/dx and the pad-by-pad histograms"}},
+    {"propagateTrack", VariantType::Bool, false, {"Propagating the track instead of performing a refit for obtaining track parameters."}},
+    {"useEveryNthTF", VariantType::Int, 10, {"Using only a fraction of the data: 1: Use every TF, 10: Use only every tenth TF."}},
+    {"maxTracksPerTF", VariantType::Int, 10000, {"Maximum number of processed tracks per TF (-1 for processing all tracks)"}},
+  };
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs, opts, requestCTPLumi);
 
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
                                                                 false,                          // GRPECS=true
@@ -277,28 +300,7 @@ DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, c
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<TPCCalibPadGainTracksDevice>(ccdbRequest, publishAfterTFs, debug, useLastExtractedMapAsReference, polynomialsFile, disablePolynomialsCCDB)},
-    Options{
-      {"nBins", VariantType::Int, 20, {"Number of bins per histogram"}},
-      {"reldEdxMin", VariantType::Int, 0, {"Minimum x coordinate of the histogram for Q/(dE/dx)"}},
-      {"reldEdxMax", VariantType::Int, 3, {"Maximum x coordinate of the histogram for Q/(dE/dx)"}},
-      {"underflowBin", VariantType::Bool, false, {"Using under flow bin"}},
-      {"overflowBin", VariantType::Bool, true, {"Using overflow flow bin"}},
-      {"momMin", VariantType::Float, 0.3f, {"minimum momentum of the tracks which are used for the pad-by-pad gain map"}},
-      {"momMax", VariantType::Float, 1.f, {"maximum momentum of the tracks which are used for the pad-by-pad gain map"}},
-      {"etaMax", VariantType::Float, 1.f, {"maximum eta of the tracks which are used for the pad-by-pad gain map"}},
-      {"disable-log-transform", VariantType::Bool, false, {"Disable the transformation of q/dedx -> log(1 + q/dedx)"}},
-      {"do-not-normalize", VariantType::Bool, false, {"Do not normalize the cluster charge to the dE/dx"}},
-      {"mindEdx", VariantType::Float, 0.f, {"Minimum accepted dE/dx value"}},
-      {"maxdEdx", VariantType::Float, -1.f, {"Maximum accepted dE/dx value (-1=accept all dE/dx)"}},
-      {"minClusters", VariantType::Int, 50, {"minimum number of clusters of tracks which are used for the pad-by-pad gain map"}},
-      {"gainMapFile", VariantType::String, "", {"file to reference gain map, which will be used for correcting the cluster charge"}},
-      {"dedxRegionType", VariantType::Int, 2, {"using the dE/dx per chamber (0), stack (1) or per sector (2)"}},
-      {"dedxType", VariantType::Int, 0, {"recalculating the dE/dx (0), using it from tracking (1)"}},
-      {"chargeType", VariantType::Int, 0, {"Using qMax (0) or qTot (1) for the dE/dx and the pad-by-pad histograms"}},
-      {"propagateTrack", VariantType::Bool, false, {"Propagating the track instead of performing a refit for obtaining track parameters."}},
-      {"useEveryNthTF", VariantType::Int, 10, {"Using only a fraction of the data: 1: Use every TF, 10: Use only every tenth TF."}},
-      {"maxTracksPerTF", VariantType::Int, 10000, {"Maximum number of processed tracks per TF (-1 for processing all tracks)"}},
-    }}; // end DataProcessorSpec
+    opts}; // end DataProcessorSpec
 }
 
 } // namespace tpc

--- a/Detectors/TPC/workflow/src/tpc-calib-gainmap-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calib-gainmap-tracks.cxx
@@ -41,6 +41,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"useLastExtractedMapAsReference", VariantType::Bool, false, {"enabling iterative extraction of the gain map: Using the extracted gain map from the previous iteration to correct the cluster charge"}},
     {"polynomialsFile", VariantType::String, "", {"file containing the polynomials for the track topology correction"}},
     {"disablePolynomialsCCDB", VariantType::Bool, false, {"Do not load the polynomials from the CCDB"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -56,13 +57,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
   o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcpadgaintrackscalibrator_configuration.ini");
-
+  auto requireCTPLumi = config.options().get<bool>("require-ctp-lumi");
   const auto debug = config.options().get<bool>("debug");
   const auto publishAfterTFs = (uint32_t)config.options().get<int>("publish-after-tfs");
   const bool useLastExtractedMapAsReference = config.options().get<bool>("useLastExtractedMapAsReference");
   const std::string polynomialsFile = config.options().get<std::string>("polynomialsFile");
   const auto disablePolynomialsCCDB = config.options().get<bool>("disablePolynomialsCCDB");
 
-  WorkflowSpec workflow{getTPCCalibPadGainTracksSpec(publishAfterTFs, debug, useLastExtractedMapAsReference, polynomialsFile, disablePolynomialsCCDB)};
+  WorkflowSpec workflow{getTPCCalibPadGainTracksSpec(publishAfterTFs, debug, useLastExtractedMapAsReference, polynomialsFile, disablePolynomialsCCDB, requireCTPLumi)};
   return workflow;
 }

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -68,6 +68,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCHwClusterer.peakChargeThreshold=4;...')"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
     {"filtered-input", VariantType::Bool, false, {"Filtered tracks, clusters input, prefix dataDescriptors with F"}},
+    {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"select-ir-frames", VariantType::Bool, false, {"Subscribe and filter according to external IR Frames"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -137,7 +138,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   std::vector<int> laneConfiguration = tpcSectors; // Currently just a copy of the tpcSectors, why?
   auto nLanes = cfgc.options().get<int>("tpc-lanes");
   auto inputType = cfgc.options().get<std::string>("input-type");
-
+  auto requireCTPLumi = cfgc.options().get<bool>("require-ctp-lumi");
   // depending on whether to dispatch early (prompt) and on the input type, we
   // set the matcher. Note that this has to be in accordance with the OutputSpecs
   // configured for the PublisherSpec
@@ -177,7 +178,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                                 !cfgc.options().get<bool>("no-tpc-zs-on-the-fly"), //
                                                 !cfgc.options().get<bool>("ignore-dist-stf"),      //
                                                 cfgc.options().get<bool>("select-ir-frames"),
-                                                cfgc.options().get<bool>("filtered-input"));
+                                                cfgc.options().get<bool>("filtered-input"),
+                                                requireCTPLumi);
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -67,6 +67,7 @@ namespace trd
 void TRDGlobalTracking::init(InitContext& ic)
 {
   o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+  mTPCCorrMapsLoader.init(ic);
   mTimer.Stop();
   mTimer.Reset();
 }
@@ -75,7 +76,7 @@ void TRDGlobalTracking::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   mTPCVDriftHelper.extractCCDBInputs(pc);
-  o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
+  mTPCCorrMapsLoader.extractCCDBInputs(pc);
   // pc.inputs().get<TopologyDictionary*>("cldict"); // called by the RecoContainer to trigger finaliseCCDB
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once
@@ -831,7 +832,8 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, boo
                                                               inputs,
                                                               true);
   o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs);
+  Options opts;
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs, opts, src[GTrackID::CTP]);
 
   // Request PID policy data
   if (withPID) {
@@ -884,7 +886,7 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, boo
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<TRDGlobalTracking>(useMC, withPID, policy, dataRequest, ggRequest, src, trigRecFilterActive, strict)},
-    Options{}};
+    opts};
 }
 
 } // namespace trd

--- a/Framework/Core/include/Framework/ConfigParamSpec.h
+++ b/Framework/Core/include/Framework/ConfigParamSpec.h
@@ -54,6 +54,11 @@ struct ConfigParamSpec {
   ConfigParamSpec(std::string _name, ParamType _type, HelpString _help)
     : name(_name), type(_type), defaultValue(VariantType::Empty), help(_help), kind{ConfigParamKind::kGeneric} {}
 
+  bool operator==(ConfigParamSpec const& that) const
+  {
+    return name == that.name && type == that.type;
+  }
+
   std::string name;
   ParamType type;
   Variant defaultValue;

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "CorrectionMapsHelper.h"
+#include "Framework/Logger.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
 
@@ -71,4 +72,10 @@ void CorrectionMapsHelper::setCorrMapRef(std::unique_ptr<TPCFastTransform>&& m)
   }
   delete mCorrMapRef;
   mCorrMapRef = m.release();
+}
+
+//________________________________________________________
+void CorrectionMapsHelper::reportScaling()
+{
+  LOGP(info, "InstLumiOverride={}, UseCTPLumi={} -> instLumi={}, meanLumi={} -> LumiScale={}", getInstLumiOverride(), getUseCTPLumi(), getInstLumi(), getMeanLumi(), getLumiScale());
 }

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -63,16 +63,23 @@ class CorrectionMapsHelper
 
   void setCorrMap(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
   void setCorrMapRef(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
-
+  void reportScaling();
   void setInstLumi(float v)
   {
-    mInstLumi = v;
-    mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
+    if (v != mInstLumi) {
+      setUpdatedLumi();
+      mInstLumi = v;
+      mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
+      reportScaling();
+    }
   }
   void setMeanLumi(float v)
   {
-    mMeanLumi = v;
-    mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
+    if (v != mMeanLumi) {
+      setUpdatedLumi();
+      mMeanLumi = v;
+      mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
+    }
   }
 
   GPUd() float getInstLumi() const { return mInstLumi; }
@@ -94,15 +101,27 @@ class CorrectionMapsHelper
   void setOwner(bool v);
   void acknowledgeUpdate() { mUpdatedFlags = 0; }
 
+  void setUseCTPLumi(bool v) { mUseCTPLumi = v; }
+  bool getUseCTPLumi() const { return mUseCTPLumi; }
+
+  void setMeanLumiOverride(float f) { mMeanLumiOverride = f; }
+  float getMeanLumiOverride() const { return mMeanLumiOverride; }
+
+  void setInstLumiOverride(float f) { mInstLumiOverride = f; }
+  float getInstLumiOverride() const { return mInstLumiOverride; }
+
  protected:
   enum UpdateFlags { MapBit = 0x1,
                      MapRefBit = 0x2,
                      LumiBit = 0x4 };
   bool mOwner = false; // is content of pointers owned by the helper
+  bool mUseCTPLumi = false; // require CTP Lumi for mInstLumi
   int mUpdatedFlags = 0;
   float mInstLumi = 0.;                            // instanteneous luminosity (a.u)
   float mMeanLumi = 0.;                            // mean luminosity of the map (a.u)
   float mLumiScale = 0.;                           // precalculated mInstLumi/mMeanLumi
+  float mMeanLumiOverride = -1.f;                  // optional value to override mean lumi
+  float mInstLumiOverride = -1.f;                  // optional value to override inst lumi
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMap{nullptr};    // current transform
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapRef{nullptr}; // reference transform
 #ifndef GPUCA_ALIROOT_LIB

--- a/GPU/TPCFastTransformation/TPCFastTransform.h
+++ b/GPU/TPCFastTransformation/TPCFastTransform.h
@@ -497,6 +497,7 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
                                                                                          << "u=" << u
                                                                                          << "row=" << row
                                                                                          << "slice=" << slice
+                                                                                         << "scale=" << scale
                                                                                          // original local coordinates
                                                                                          << "ly=" << ly
                                                                                          << "lz=" << lz

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -82,6 +82,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
     bool askDISTSTF = true;
     bool runTRDTracking = false;
     bool readTRDtracklets = false;
+    bool requireCTPLumi = false;
   };
 
   GPURecoWorkflowSpec(CompletionPolicyData* policyData, Config const& specconfig, std::vector<int> const& tpcsectors, unsigned long tpcSectorMask, std::shared_ptr<o2::base::GRPGeomRequest>& ggr);
@@ -93,12 +94,13 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   void stop() final;
   o2::framework::Inputs inputs();
   o2::framework::Outputs outputs();
+  o2::framework::Options options();
 
   void deinitialize();
 
  private:
   /// initialize TPC options from command line
-  void initFunctionTPC();
+  void initFunctionTPC(o2::framework::InitContext& ic);
   /// storing new calib objects in buffer
   void finaliseCCDBTPC(o2::framework::ConcreteDataMatcher& matcher, void* obj);
   /// asking for newer calib objects

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -219,7 +219,7 @@ void GPURecoWorkflowSpec::init(InitContext& ic)
     }
 
     // initialize TPC calib objects
-    initFunctionTPC();
+    initFunctionTPC(ic);
     mConfig->configCalib.fastTransform = mFastTransformHelper->getCorrMap();
     mConfig->configCalib.fastTransformRef = mFastTransformHelper->getCorrMapRef();
     mConfig->configCalib.fastTransformHelper = mFastTransformHelper.get();
@@ -868,6 +868,15 @@ void GPURecoWorkflowSpec::doCalibUpdates(o2::framework::ProcessingContext& pc)
   }
 }
 
+Options GPURecoWorkflowSpec::options()
+{
+  Options opts;
+  if (mSpecConfig.outputTracks) {
+    o2::tpc::CorrectionMapsLoader::addOptions(opts);
+  }
+  return opts;
+}
+
 Inputs GPURecoWorkflowSpec::inputs()
 {
   Inputs inputs;
@@ -879,7 +888,8 @@ Inputs GPURecoWorkflowSpec::inputs()
     inputs.emplace_back("tpctopologygain", gDataOriginTPC, "TOPOLOGYGAIN", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalTopologyGain)));
     inputs.emplace_back("tpcthreshold", gDataOriginTPC, "PADTHRESHOLD", 0, Lifetime::Condition, ccdbParamSpec("TPC/Config/FEEPad"));
     o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
-    o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs);
+    Options optsDummy;
+    mFastTransformHelper->requestCCDBInputs(inputs, optsDummy, mSpecConfig.requireCTPLumi); // option filled here is lost
   }
   if (mSpecConfig.decompressTPC) {
     inputs.emplace_back(InputSpec{"input", ConcreteDataTypeMatcher{gDataOriginTPC, mSpecConfig.decompressTPCFromROOT ? o2::header::DataDescription("COMPCLUSTERS") : o2::header::DataDescription("COMPCLUSTERSFLAT")}, Lifetime::Timeframe});
@@ -928,6 +938,7 @@ Inputs GPURecoWorkflowSpec::inputs()
     inputs.emplace_back("trdtriggerrec", o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe);
     inputs.emplace_back("trdtrigrecmask", o2::header::gDataOriginTRD, "TRIGRECMASK", 0, Lifetime::Timeframe);
   }
+
   return inputs;
 };
 
@@ -979,7 +990,7 @@ Outputs GPURecoWorkflowSpec::outputs()
   return outputSpecs;
 };
 
-void GPURecoWorkflowSpec::initFunctionTPC()
+void GPURecoWorkflowSpec::initFunctionTPC(InitContext& ic)
 {
   mdEdxCalibContainer.reset(new o2::tpc::CalibdEdxContainer());
   mTPCVDriftHelper.reset(new o2::tpc::VDriftHelper());
@@ -988,6 +999,7 @@ void GPURecoWorkflowSpec::initFunctionTPC()
   mFastTransformRef = std::move(TPCFastTransformHelperO2::instance()->create(0));
   mFastTransformHelper->setCorrMap(mFastTransform.get()); // just to reserve the space
   mFastTransformHelper->setCorrMapRef(mFastTransformRef.get());
+  mFastTransformHelper->init(ic);
 
   if (mConfParam->dEdxDisableTopologyPol) {
     LOGP(info, "Disabling loading of track topology correction using polynomials from CCDB");
@@ -1181,7 +1193,7 @@ bool GPURecoWorkflowSpec::fetchCalibsCCDBTPC(ProcessingContext& pc, T& newCalibO
 
       if (mSpecConfig.outputTracks) {
         mTPCVDriftHelper->extractCCDBInputs(pc);
-        o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
+        mFastTransformHelper->extractCCDBInputs(pc);
       }
       if (mTPCVDriftHelper->isUpdated() || mFastTransformHelper->isUpdated()) {
         const auto& vd = mTPCVDriftHelper->getVDriftObject();
@@ -1205,6 +1217,9 @@ bool GPURecoWorkflowSpec::fetchCalibsCCDBTPC(ProcessingContext& pc, T& newCalibO
           mFastTransformHelperNew.reset(new o2::tpc::CorrectionMapsLoader);
           mFastTransformHelperNew->setInstLumi(mFastTransformHelper->getInstLumi());
           mFastTransformHelperNew->setMeanLumi(mFastTransformHelper->getMeanLumi());
+          mFastTransformHelperNew->setUseCTPLumi(mFastTransformHelper->getUseCTPLumi());
+          mFastTransformHelperNew->setMeanLumiOverride(mFastTransformHelper->getMeanLumiOverride());
+          mFastTransformHelperNew->setInstLumiOverride(mFastTransformHelper->getInstLumiOverride());
           mFastTransformHelperNew->setCorrMap(mFastTransformNew ? mFastTransformNew.get() : mFastTransform.get());
           mFastTransformHelperNew->setCorrMapRef(mFastTransformRefNew ? mFastTransformRefNew.get() : mFastTransformRef.get());
           newCalibObjects.fastTransformHelper = mFastTransformHelperNew.get();

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -3,6 +3,8 @@
 source $O2DPG_ROOT/DATA/common/setenv.sh || { echo "setenv.sh failed" 1>&2 && exit 1; }
 source $O2DPG_ROOT/DATA/common/setenv_calib.sh || { echo "setenv_calib.sh failed" 1>&2 && exit 1; }
 
+: ${TPC_CORR_SCALING:=""}             # TPC corr.map lumi scaling options, any combination of --require-ctp-lumi, --corrmap-lumi-mean <float>, --corrmap-lumi-inst <float>
+
 if [[ -z "$WORKFLOW" ]] || [[ -z "$GEN_TOPO_MYDIR" ]]; then
   echo This script must be called from the dpl-workflow.sh and not standalone 1>&2
   exit 1
@@ -25,7 +27,7 @@ if [[ $CALIB_TPC_TIMEGAIN == 1 ]]; then
 fi
 if [[ $CALIB_TPC_RESPADGAIN == 1 ]]; then
   : ${SCALEEVENTS_TPC_RESPADGAIN:=40}
-  add_W o2-tpc-calib-gainmap-tracks "--publish-after-tfs 30 --useEveryNthTF $SCALEEVENTS_TPC_RESPADGAIN"
+  add_W o2-tpc-calib-gainmap-tracks "--publish-after-tfs 30 --useEveryNthTF $SCALEEVENTS_TPC_RESPADGAIN  $TPC_CORR_SCALING"
 fi
 if [[ $CALIB_ZDC_TDC == 1 ]]; then add_W o2-zdc-tdccalib-epn-workflow "" "" 0; fi
 if [[ $CALIB_FT0_TIMEOFFSET == 1 ]]; then add_W o2-calibration-ft0-time-spectra-processor; fi


### PR DESCRIPTION
All workflows which need TPC correction maps got an extra option `--require-ctp-lumi`, 
if active it will request CTP LumiInfo which will be used to rescale the TPC corrections
maps a la Run2.
Additionally, every device using TPC corr.maps got extra options
`--corrmap-lumi-mean <float>` and `--corrmap-lumi-inst <float>` which allow to
override the mean lumi characterizing the map and instantaneous lumi for rescaling
(normally expected from CTP LumiInfo).