### PR TITLE
taskwrapper: switch off log monitoring

### DIFF
--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -68,8 +68,9 @@ taskwrapper_cleanup_handler() {
   return 1 2>/dev/null || exit 1
 }
 
-# Function monitoring DPL output for signs of failure
+# Function monitoring (DPL) log output for signs of failure
 monitorlog() {
+    [[ ! "${JOBUTILS_PERFORM_MONITORING}" ]] && exit 0
     # We need to grep on multitude of things:
     # - all sorts of exceptions (may need to fine-tune)
     # - segmentation violation


### PR DESCRIPTION
Switch off the monitoring of log files for signs
of failure by default.

I believe the software is now mature enough and
there should be no more hangs upon failures. So there should be no more need to impose external shutdown.

Let's see how it goes... in any case this can be re-enabled with an environment variable.