### PR TITLE
McTracks to o2::McParticles

### DIFF
--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -111,6 +111,16 @@ o2_add_executable(kine-publisher
                   SOURCES o2sim_kine_publisher.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::SimulationDataFormat O2::Steer)
 
+o2_add_executable(mctracks-to-aod
+                  COMPONENT_NAME sim
+                  SOURCES o2sim_mctracks_to_aod.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::SimulationDataFormat)
+
+o2_add_dpl_workflow(mctracks-to-aod-simple-task
+                    SOURCES SimExamples/McTracksToAOD/mctracks_to_aod_simple_task.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework
+                    COMPONENT_NAME Analysis)
+
 o2_data_file(COPY o2simtopology_template.json DESTINATION config)
 
 # * # add a complex simulation as a unit test (if simulation was enabled)

--- a/run/SimExamples/McTracksToAOD/mctracks_to_aod_simple_task.cxx
+++ b/run/SimExamples/McTracksToAOD/mctracks_to_aod_simple_task.cxx
@@ -13,16 +13,10 @@
 #include "Framework/HistogramRegistry.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/runDataProcessing.h"
 
 using namespace o2;
 using namespace o2::framework;
-
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
-{
-  workflowOptions.push_back(ConfigParamSpec{"on-the-fly", o2::framework::VariantType::Bool, false, {"set the inputs for on-the-fly analysis"}});
-}
-
-#include "Framework/runDataProcessing.h"
 
 struct SimpleTask {
 
@@ -51,13 +45,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec specs;
   DataProcessorSpec dSpec = adaptAnalysisTask<SimpleTask>(cfgc, TaskName{"mctracks-to-aod-simple-task"});
-  if (cfgc.options().get<bool>("on-the-fly")) {
-    std::vector<InputSpec> inputs;
-    inputs.emplace_back("McCollisions", "AOD", "MCCOLLISION", 0, Lifetime::Timeframe);
-    inputs.emplace_back("McParticles", "AOD", "MCPARTICLE_001", 0, Lifetime::Timeframe);
-    inputs.emplace_back("McParticles_001Extension", "AOD", "MCPARTICLE_001E", 0, Lifetime::Timeframe);
-    dSpec.inputs = inputs;
-  }
   specs.emplace_back(dSpec);
   return specs;
 }

--- a/run/SimExamples/McTracksToAOD/mctracks_to_aod_simple_task.cxx
+++ b/run/SimExamples/McTracksToAOD/mctracks_to_aod_simple_task.cxx
@@ -1,0 +1,63 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(ConfigParamSpec{"on-the-fly", o2::framework::VariantType::Bool, false, {"set the inputs for on-the-fly analysis"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+struct SimpleTask {
+
+  HistogramRegistry registry{"registry", {}};
+
+  void init(o2::framework::InitContext& ic)
+  {
+    registry.add<TH1>("NEvents", "NEvents", HistType::kTH1F, {{1, 0, 1}}, false);
+    registry.add<TH1>("phi", "phi", HistType::kTH1F, {{100, 0, 2 * PI}}, false);
+    registry.add<TH1>("eta", "eta", HistType::kTH1F, {{100, -5, 5}}, false);
+    registry.add<TH1>("pt", "pt", HistType::kTH1F, {{100, 0, 5}}, false);
+  }
+
+  void process(aod::McCollision const&, aod::McParticles const& mcParticles)
+  {
+    registry.fill(HIST("NEvents"), 0.5);
+    for (auto& mcparticle : mcParticles) {
+      registry.fill(HIST("pt"), mcparticle.pt());
+      registry.fill(HIST("eta"), mcparticle.eta());
+      registry.fill(HIST("phi"), mcparticle.phi());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec specs;
+  DataProcessorSpec dSpec = adaptAnalysisTask<SimpleTask>(cfgc, TaskName{"mctracks-to-aod-simple-task"});
+  if (cfgc.options().get<bool>("on-the-fly")) {
+    std::vector<InputSpec> inputs;
+    inputs.emplace_back("McCollisions", "AOD", "MCCOLLISION", 0, Lifetime::Timeframe);
+    inputs.emplace_back("McParticles", "AOD", "MCPARTICLE_001", 0, Lifetime::Timeframe);
+    inputs.emplace_back("McParticles_001Extension", "AOD", "MCPARTICLE_001E", 0, Lifetime::Timeframe);
+    dSpec.inputs = inputs;
+  }
+  specs.emplace_back(dSpec);
+  return specs;
+}

--- a/run/SimExamples/McTracksToAOD/run.sh
+++ b/run/SimExamples/McTracksToAOD/run.sh
@@ -10,12 +10,13 @@ SIMPROC=$!
 # launch a DPL process (having the right proxy configuration)
 # (Note that the option --o2sim-pid is not strictly necessary when only one o2-sim process is running.
 #  The socket will than be auto-determined.)
-o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} | o2-sim-mctracks-to-aod -b | o2-analysis-mctracks-to-aod-simple-task -b --on-the-fly &
+
+o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} | o2-sim-mctracks-to-aod -b | o2-analysis-mctracks-to-aod-simple-task -b &
 TRACKANAPROC=$!
 
 wait ${SIMPROC}
 wait ${TRACKANAPROC}
 
 
-# the very same analysis task can also directly run on an AO2D with McCollisions and McParticles_001 without the '--on-the-fly' flag:
+# the very same analysis task can also directly run on an AO2D with McCollisions and McParticles:
 # o2-analysis-mctracks-to-aod-simple-task -b --aod-file <AO2DFile>

--- a/run/SimExamples/McTracksToAOD/run.sh
+++ b/run/SimExamples/McTracksToAOD/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -x
+
+NEVENTS=100
+# launch generator process (for 100 min bias Pythia8 events; no Geant; no geometry)
+o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant -m CAVE -e TGeant3 &> sim.log &
+SIMPROC=$!
+
+# launch a DPL process (having the right proxy configuration)
+# (Note that the option --o2sim-pid is not strictly necessary when only one o2-sim process is running.
+#  The socket will than be auto-determined.)
+o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} | o2-sim-mctracks-to-aod -b | o2-analysis-mctracks-to-aod-simple-task -b --on-the-fly &
+TRACKANAPROC=$!
+
+wait ${SIMPROC}
+wait ${TRACKANAPROC}
+
+
+# the very same analysis task can also directly run on an AO2D with McCollisions and McParticles_001 without the '--on-the-fly' flag:
+# o2-analysis-mctracks-to-aod-simple-task -b --aod-file <AO2DFile>

--- a/run/o2sim_mctracks_to_aod.cxx
+++ b/run/o2sim_mctracks_to_aod.cxx
@@ -1,0 +1,174 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/Task.h"
+#include "SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/MCEventHeader.h"
+#include "Framework/AnalysisDataModel.h"
+
+using namespace o2::framework;
+
+struct KineToAOD {
+
+  int eventNumber = 0;
+
+  void init(o2::framework::InitContext& ic) {}
+
+  void run(o2::framework::ProcessingContext& pc)
+  {
+
+    auto mctracks = pc.inputs().get<std::vector<o2::MCTrack>>("mctracks");
+    auto mcheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader");
+
+    auto& mcCollisionsBuilder = pc.outputs().make<TableBuilder>(Output{"AOD", "MCCOLLISION"});
+    auto& mcParticlesBuilder = pc.outputs().make<TableBuilder>(Output{"AOD", "MCPARTICLE_001"});
+    auto& mcParticlesEBuilder = pc.outputs().make<TableBuilder>(Output{"AOD", "MCPARTICLE_001E"});
+
+    auto mcCollisionsCursor = mcCollisionsBuilder.cursor<o2::aod::McCollisions>();
+    auto mcParticlesCursor = mcParticlesBuilder.cursor<o2::aod::StoredMcParticles_001>();
+    auto mcParticlesECursor = mcParticlesEBuilder.cursor<o2::aod::McParticles_001>();
+
+    mcCollisionsCursor(0,
+                       0, // bc
+                       0, // generatorId
+                       mcheader->GetX(),
+                       mcheader->GetY(),
+                       mcheader->GetZ(),
+                       mcheader->GetT(),
+                       1., // weight
+                       mcheader->GetB());
+
+    for (auto& mctrack : mctracks) {
+      int mothers_size = 0;
+      std::vector<int> mothers;
+      int daughters[2];
+
+      if (mctrack.getMotherTrackId() >= 0) {
+        mothers.push_back(mctrack.getMotherTrackId());
+        mothers_size++;
+      }
+      if (mctrack.getSecondMotherTrackId() >= 0) {
+        mothers.push_back(mctrack.getSecondMotherTrackId());
+        mothers_size++;
+      }
+      daughters[0] = -1;
+      daughters[1] = -1;
+      if (mctrack.getFirstDaughterTrackId() >= 0 && mctrack.getLastDaughterTrackId() >= 0) {
+        daughters[0] = mctrack.getFirstDaughterTrackId();
+        daughters[1] = mctrack.getLastDaughterTrackId();
+      } else if (mctrack.getFirstDaughterTrackId() >= 0) {
+        daughters[0] = mctrack.getFirstDaughterTrackId();
+        daughters[1] = mctrack.getLastDaughterTrackId();
+      }
+      int PdgCode = mctrack.GetPdgCode();
+      int statusCode = mctrack.getStatusCode().fullEncoding;
+      int collisionId = 0; // or eventNumber?
+      float weight = mctrack.getWeight();
+      float px = mctrack.Px();
+      float py = mctrack.Py();
+      float pz = mctrack.Pz();
+      float e = mctrack.GetEnergy();
+      float x = mctrack.GetStartVertexCoordinatesX();
+      float y = mctrack.GetStartVertexCoordinatesY();
+      float z = mctrack.GetStartVertexCoordinatesZ();
+      float t = mctrack.GetStartVertexCoordinatesT();
+      int flags = 0;
+      mcParticlesCursor(0,
+                        collisionId,
+                        PdgCode,
+                        statusCode,
+                        flags,
+                        mothers,
+                        daughters,
+                        weight,
+                        px,
+                        py,
+                        pz,
+                        e,
+                        x,
+                        y,
+                        z,
+                        t);
+      float phi = PI + atan2(-1.0f * py, -1.0f * px);
+      float p = sqrt(px * px + py * py + pz * pz);
+      float pt = sqrt(px * px + py * py);
+      float eta;
+      if (p - pz < static_cast<float>(1e-7)) {
+        if (pz < 0.f) {
+          eta = -100.f;
+        } else {
+          eta = 100.f;
+        }
+      } else {
+        eta = 0.5f * log((p + pz) / (p - pz));
+      }
+      float Y;
+      if (e - pz < static_cast<float>(1e-7)) {
+        if (pz < 0.f) {
+          Y = -100.f;
+        } else {
+          Y = 100.f;
+        }
+      } else {
+        Y = 0.5f * log((e + pz) / (e - pz));
+      }
+      mcParticlesECursor(0,
+                         phi,
+                         eta,
+                         pt,
+                         p,
+                         Y,
+                         collisionId,
+                         PdgCode,
+                         statusCode,
+                         flags,
+                         mothers,
+                         daughters,
+                         weight,
+                         px,
+                         py,
+                         pz,
+                         e,
+                         x,
+                         y,
+                         z,
+                         t);
+    }
+    eventNumber++;
+    pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
+    // pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, -1L);
+    pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, eventNumber);
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec specs;
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(OutputLabel{"O2mccollision"}, "AOD", "MCCOLLISION", 0, Lifetime::Timeframe);
+  outputs.emplace_back(OutputLabel{"O2mcparticle_001"}, "AOD", "MCPARTICLE_001", 0, Lifetime::Timeframe);
+  outputs.emplace_back(OutputLabel{"O2mcparticle_001E"}, "AOD", "MCPARTICLE_001E", 0, Lifetime::Timeframe);
+  outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
+  outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("mctracks", "MC", "MCTRACKS", 0., Lifetime::Timeframe);
+  inputs.emplace_back("mcheader", "MC", "MCHEADER", 0., Lifetime::Timeframe);
+  DataProcessorSpec dSpec = DataProcessorSpec{
+    "mctracks-to-aod",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<KineToAOD>()},
+    {}};
+  specs.emplace_back(dSpec);
+  return specs;
+}


### PR DESCRIPTION
Suggestion for a converter McEventHeader/McTracks --> o2::McCollisions/o2::McParticles_001 for on-the-fly MC analysis. The idea is to be able to use the same analysis task for on-the-fly MC analysis and for running on AO2Ds, and also to be able to connect the on-the-fly analysis to tables produced by other standard o2 analysis tasks.

WIP, can probably be done in a more elegant way (ideally without the need for any extra specification of the InputSpec of the analysis task and the --on-the-fly flag)