### PR TITLE
DPL Analysis: filling vector columns with vector or span input

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -78,10 +78,13 @@ struct WritingCursor<soa::Table<PC...>> {
 
  private:
   template <typename T>
-  static decltype(auto) extract(T const& arg)
+  static decltype(auto) extract(T& arg)
   {
     if constexpr (soa::is_soa_iterator_v<T>) {
       return arg.globalIndex();
+    } else if constexpr (framework::is_base_of_template_v<std::vector, T> ||
+                         framework::is_gsl_span_v<gsl::span, T>) {
+      return VectorOrSpan<typename T::value_type>{std::ref(arg)};
     } else {
       static_assert(!framework::has_type_v<T, framework::pack<PC...>>, "Argument type mismatch");
       return arg;

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -102,7 +102,7 @@ O2_ARROW_STL_CONVERSION(std::string, StringType)
 } // namespace detail
 
 template <typename T>
-using VectorOrSpan = std::variant<std::reference_wrapper<std::vector<T>>, std::reference_wrapper<gsl::span<T>>>;//std::vector<T>
+using VectorOrSpan = std::variant<std::reference_wrapper<std::vector<T>>, std::reference_wrapper<gsl::span<T>>>; // std::vector<T>
 
 void addLabelToSchema(std::shared_ptr<arrow::Schema>& schema, const char* label);
 

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -751,7 +751,7 @@ class TableBuilder
       using objType_t = pack_element_t<0, framework::pack<ARGS...>>;
       auto persister = persistTuple(framework::pack<objType_t>{}, columnNames);
       // Callback used to fill the builders
-      return [persister = persister](unsigned int slot, typename BuilderMaker<objType_t>::FillType const& arg) -> void {
+      return [persister = persister](unsigned int slot, typename BuilderMaker<objType_t>::FillType arg) -> void {
         persister(slot, std::forward_as_tuple(arg));
       };
     } else if constexpr (sizeof...(ARGS) >= 1) {

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -55,7 +55,7 @@ using is_base_of_template = typename is_base_of_template_impl<base, derived>::ty
 template <template <typename...> class base, typename derived>
 inline constexpr bool is_base_of_template_v = is_base_of_template<base, derived>::value;
 
-template <template <typename, size_t> class base, typename derived>
+template <template <typename, std::size_t> class base, typename derived>
 struct is_gsl_span_impl {
   template <typename T, size_t S>
   static constexpr std::true_type test(const base<T, S>*);
@@ -63,10 +63,10 @@ struct is_gsl_span_impl {
   using type = decltype(test(std::declval<derived*>()));
 };
 
-template <template <typename, size_t> class base, typename derived>
+template <template <typename, std::size_t> class base, typename derived>
 using is_gsl_span_t = typename is_gsl_span_impl<base, derived>::type;
 
-template <template <typename, size_t> class base, typename derived>
+template <template <typename, std::size_t> class base, typename derived>
 inline constexpr bool is_gsl_span_v = is_gsl_span_t<base, derived>::value;
 
 } // namespace o2::framework

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -57,7 +57,7 @@ inline constexpr bool is_base_of_template_v = is_base_of_template<base, derived>
 
 template <template <typename, std::size_t> class base, typename derived>
 struct is_gsl_span_impl {
-  template <typename T, size_t S>
+  template <typename T, std::size_t S>
   static constexpr std::true_type test(const base<T, S>*);
   static constexpr std::false_type test(...);
   using type = decltype(test(std::declval<derived*>()));

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -55,6 +55,20 @@ using is_base_of_template = typename is_base_of_template_impl<base, derived>::ty
 template <template <typename...> class base, typename derived>
 inline constexpr bool is_base_of_template_v = is_base_of_template<base, derived>::value;
 
+template <template <typename, size_t> class base, typename derived>
+struct is_gsl_span_impl {
+  template <typename T, size_t S>
+  static constexpr std::true_type test(const base<T, S>*);
+  static constexpr std::false_type test(...);
+  using type = decltype(test(std::declval<derived*>()));
+};
+
+template <template <typename, size_t> class base, typename derived>
+using is_gsl_span_t = typename is_gsl_span_impl<base, derived>::type;
+
+template <template <typename, size_t> class base, typename derived>
+inline constexpr bool is_gsl_span_v = is_gsl_span_t<base, derived>::value;
+
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_TRAITS_H_


### PR DESCRIPTION
This change permits using both `std::vector` and `gsl::span` as an input for filling variable size array columns in arrow tables with DPL cursor. This can be useful, for example, when a skimmed table is filled, so that the span returned from the original table can be filled directly, without copying its content to a vector first.

@ktf do you have any comments on the implementation? Probably it can be improved.
@pbuehler 