### PR TITLE
[EMCAL-565] Add minimum cell energy cut for bad channel analysis

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -47,6 +47,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool UpdateAtEndOfRunOnly_bc = false; ///< switch to enable trigger of calibration only at end of run
   float minNHitsForMeanEnergyCut = 100; ///< mean number of hits per cell that is needed to cut on the mean energy per hit. Needed for high energy intervals as outliers can distort the distribution
   float minNHitsForNHitCut = 1;         ///< mean number of hits per cell that is needed to cut on the mean number of hits. Needed for high energy intervals as outliers can distort the distribution
+  float minCellEnergy_bc = 0.075;       ///< minimum cell energy considered for filling the histograms for bad channel calib. Should speedup the filling of the histogram to suppress noise
 
   // parameters for time calibration
   unsigned int minNEvents_tc = 1e7;      ///< minimum number of events to trigger the calibration

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -51,6 +51,10 @@ void EMCALChannelData::fill(const gsl::span<const o2::emcal::Cell> data)
   mEvents++;
   for (auto cell : data) {
     double cellEnergy = cell.getEnergy();
+    if (cellEnergy < o2::emcal::EMCALCalibParams::Instance().minCellEnergy_bc) {
+      LOG(debug) << "skipping cell ID " << cell.getTower() << ": with energy = " << cellEnergy << " below  threshold of " << o2::emcal::EMCALCalibParams::Instance().minCellEnergy_bc;
+      continue;
+    }
     int id = cell.getTower();
     LOG(debug) << "inserting in cell ID " << id << ": energy = " << cellEnergy;
     mHisto(cellEnergy, id);


### PR DESCRIPTION
- To reduce the CPU consumption, a minimum cell energy cut is done to reject noisy cells.
- The bad channel calibration only considers cells above 100 MeV, so filling cells much below this threshold is not needed.
- The value is set to 75 MeV in the calibParams and can be modified there of needed