### PR TITLE
Add hyperhelium4 mass to the physics constants

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -38,6 +38,7 @@ constexpr float MassHelium3 = 2.8083916;
 constexpr float MassAlpha = 3.7273794;
 constexpr float MassHyperTriton = 2.992;
 constexpr float MassHyperhydrog4 = 3.931;
+constexpr float MassHyperhelium4 = 3.9218;
 constexpr float MassXiMinus = 1.32171;
 constexpr float MassOmegaMinus = 1.67245;
 


### PR DESCRIPTION
This value comes from a STAR QM2022 talk by Yue-Hang Leung. Reference to slides: 

https://indico.cern.ch/event/895086/contributions/4724928/attachments/2422354/4146273/qm2022hypernucleiv9.pdf