### PR TITLE
[EMCAL-918] Handling corrupted trailer words

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -153,6 +153,10 @@ class RCUTrailer
   /// \return Size of the payload as number of 32 bit workds
   uint32_t getPayloadSize() const { return mPayloadSize; }
 
+  /// \brief Get number of corrupted trailer words (undefined trailer word code)
+  /// \return Number of trailer word corruptions
+  uint32_t getTrailerWordCorruptions() const { return mWordCorruptions; }
+
   /// \brief Get the firmware version
   /// \return Firmware version
   uint8_t getFirmwareVersion() const { return mFirmwareVersion; }
@@ -438,6 +442,7 @@ class RCUTrailer
   uint8_t mFirmwareVersion = 0;         ///< RCU firmware version
   uint32_t mTrailerSize = 0;            ///< Size of the trailer (in number of 32 bit words)
   uint32_t mPayloadSize = 0;            ///< Size of the payload (in nunber of 32 bit words)
+  uint32_t mWordCorruptions = 0;        ///< Number of trailer word corruptions (decoding only)
   uint32_t mFECERRA = 0;                ///< contains errors related to ALTROBUS transactions
   uint32_t mFECERRB = 0;                ///< contains errors related to ALTROBUS transactions
   ErrorCounters mErrorCounter = {0, 0}; ///< Error counter registers

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -14,6 +14,7 @@
 #include <fmt/format.h>
 #include "CommonConstants/LHCConstants.h"
 #include "EMCALBase/RCUTrailer.h"
+#include <fairlogger/Logger.h>
 
 using namespace o2::emcal;
 
@@ -94,7 +95,8 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
         mAltroConfig.mWord2 = parData & 0x1FFFFFF;
         break;
       default:
-        std::cerr << "Undefined parameter code " << parCode << ", ignore it !\n";
+        LOG(warning) << "RCU trailer: Undefined parameter code " << parCode << " in word " << index << " (0x" << std::hex << word << std::dec << "), ignoring word";
+        mWordCorruptions++;
         break;
     }
   }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
@@ -44,7 +44,8 @@ class RawDecodingError : public std::exception
     HEADER_INVALID,     ///< Header in memory not belonging to requested superpage
     PAGE_START_INVALID, ///< Page position starting outside payload size
     PAYLOAD_INVALID,    ///< Payload in memory not belonging to requested superpage
-    TRAILER_DECODING    ///< Inconsistent trailer in memory (several trailer words missing the trailer marker)
+    TRAILER_DECODING,   ///< Inconsistent trailer in memory (several trailer words missing the trailer marker)
+    TRAILER_INCOMPLETE  ///< Incomplete trailer words (i.e. registers)
   };
 
   /// \brief Constructor
@@ -93,6 +94,8 @@ class RawDecodingError : public std::exception
         return 5;
       case ErrorType_t::TRAILER_DECODING:
         return 6;
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return 7;
     };
     // can never reach this, due to enum class
     // just to make Werror happy
@@ -101,7 +104,7 @@ class RawDecodingError : public std::exception
 
   /// \brief Get the number of error codes
   /// \return Number of error codes
-  static constexpr int getNumberOfErrorTypes() { return 7; }
+  static constexpr int getNumberOfErrorTypes() { return 8; }
 
   static ErrorType_t intToErrorType(unsigned int errortype)
   {
@@ -109,7 +112,7 @@ class RawDecodingError : public std::exception
     static constexpr std::array<ErrorType_t, getNumberOfErrorTypes()> errortypes = {{ErrorType_t::PAGE_NOTFOUND, ErrorType_t::HEADER_DECODING,
                                                                                      ErrorType_t::PAYLOAD_DECODING, ErrorType_t::HEADER_INVALID,
                                                                                      ErrorType_t::PAGE_START_INVALID, ErrorType_t::PAYLOAD_INVALID,
-                                                                                     ErrorType_t::TRAILER_DECODING}};
+                                                                                     ErrorType_t::TRAILER_DECODING, ErrorType_t::TRAILER_INCOMPLETE}};
     return errortypes[errortype];
   }
 
@@ -137,6 +140,8 @@ class RawDecodingError : public std::exception
         return "PayloadCorruption";
       case ErrorType_t::TRAILER_DECODING:
         return "TrailerDecoding";
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return "TrailerIncomplete";
     };
     return "Undefined error";
   }
@@ -177,6 +182,8 @@ class RawDecodingError : public std::exception
         return "Payload corruption";
       case ErrorType_t::TRAILER_DECODING:
         return "Trailer decoding";
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return "Trailer incomplete";
     };
     return "Undefined error";
   }
@@ -217,6 +224,8 @@ class RawDecodingError : public std::exception
         return "Access to payload not belonging to requested superpage";
       case ErrorType_t::TRAILER_DECODING:
         return "Inconsistent trailer in memory";
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return "Incomplete trailer";
     };
     return "Undefined error";
   }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
@@ -11,11 +11,13 @@
 #ifndef ALICEO2_EMCAL_RAWREADERMEMORY_H
 #define ALICEO2_EMCAL_RAWREADERMEMORY_H
 
+#include <vector>
 #include <gsl/span>
 #include <Rtypes.h>
 
 #include "EMCALBase/RCUTrailer.h"
 #include "EMCALReconstruction/RawBuffer.h"
+#include "EMCALReconstruction/RawDecodingError.h"
 #include "EMCALReconstruction/RawPayload.h"
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
@@ -36,6 +38,46 @@ namespace emcal
 class RawReaderMemory
 {
  public:
+  /// \class MinorError
+  /// \brief Minor (non-crashing) raw decoding errors
+  ///
+  /// Minor errors share the same codes as major raw decoding errors,
+  /// however are not crashing.
+  class MinorError
+  {
+   public:
+    /// \brief Dummy constructor
+    MinorError() = default;
+
+    /// \brief Main constructor
+    /// \param errortype Type of the error
+    /// \param feeID ID of the FEE equipment
+    MinorError(RawDecodingError::ErrorType_t errortype, int feeID) : mErrorType(errortype), mFEEID(feeID) {}
+
+    /// \brief Destructor
+    ~MinorError() = default;
+
+    /// \brief Set the type of the error
+    /// \param errortype Type of the error
+    void setErrorType(RawDecodingError::ErrorType_t errortype) { mErrorType = errortype; }
+
+    /// \brief Set the ID of the FEE equipment
+    /// \param feeID ID of the FEE
+    void setFEEID(int feeID) { mFEEID = feeID; }
+
+    /// \brief Get type of the error
+    /// \return Type of the error
+    RawDecodingError::ErrorType_t getErrorType() const { return mErrorType; }
+
+    /// \brief Get ID of the FEE
+    /// \return ID of the FEE
+    int getFEEID() const { return mFEEID; }
+
+   private:
+    RawDecodingError::ErrorType_t mErrorType; ///< Type of the error
+    int mFEEID;                               ///< ID of the FEC responsible for the ERROR
+  };
+
   /// \brief Constructor
   RawReaderMemory(const gsl::span<const char> rawmemory);
 
@@ -58,8 +100,7 @@ class RawReaderMemory
   /// \brief Read next payload from the stream
   ///
   /// Read the next pages until the stop bit is found.
-  void
-    next();
+  void next();
 
   /// \brief Read the next page from the stream (single DMA page)
   /// \param resetPayload If true the raw payload is reset
@@ -84,6 +125,10 @@ class RawReaderMemory
   /// \brief access to the full raw payload (single or multiple DMA pages)
   /// \return Raw Payload of the data until the stop bit is received.
   const RawPayload& getPayload() const { return mRawPayload; }
+
+  /// \brief Get minor (non-crashing) raw decoding errors
+  /// \return Minor raw decoding errors
+  gsl::span<const MinorError> getMinorErrors() const { return mMinorErrors; }
 
   /// \brief Return size of the payload
   /// \return size of the payload
@@ -123,6 +168,7 @@ class RawReaderMemory
   int mCurrentFEE = -1;                   ///< Current FEE in the data stream
   bool mRawHeaderInitialized = false;     ///< RDH for current page initialized
   bool mPayloadInitialized = false;       ///< Payload for current page initialized
+  std::vector<MinorError> mMinorErrors;   ///< Minor raw decoding errors
 
   ClassDefNV(RawReaderMemory, 1);
 };

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -22,6 +22,7 @@
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/Mapper.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
+#include "EMCALReconstruction/RawReaderMemory.h"
 #include "EMCALReconstruction/RecoContainer.h"
 #include "EMCALReconstruction/ReconstructionErrors.h"
 #include "EMCALWorkflow/CalibLoader.h"
@@ -232,6 +233,8 @@ class RawToCellConverterSpec : public framework::Task
   void handleGainError(const o2::emcal::reconstructionerrors::GainError_t& errortype, int ddlID, int hwaddress);
 
   void handlePageError(const RawDecodingError& e);
+
+  void handleMinorPageError(const RawReaderMemory::MinorError& e);
 
   header::DataHeader::SubSpecificationType mSubspecification = 0;    ///< Subspecification for output channels
   int mNoiseThreshold = 0;                                           ///< Noise threshold in raw fit


### PR DESCRIPTION
Corrupted trailer words are words with the trailer
marker but an invalid trailer word code, for which
the trailer word type cannot be determined. Handled
in the RawReaderMemory as MinorRawDataError (non-
crashing)