### PR TITLE
update MCH tracking limits

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/TrackerParam.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/TrackerParam.h
@@ -42,8 +42,8 @@ struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
   bool moreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
   bool refineTracks = true;    ///< refine the tracks in the end using cluster resolution
 
-  std::size_t maxCandidates = 100000; ///< maximum number of track candidates above which the tracking abort
-  double maxTrackingDuration = 1000.; ///< maximum tracking duration in second above which the tracking abort
+  std::size_t maxCandidates = 50000; ///< maximum number of track candidates above which the tracking abort
+  double maxTrackingDuration = 300.; ///< maximum tracking duration in second above which the tracking abort
 
   O2ParamDef(TrackerParam, "MCHTracking");
 };


### PR DESCRIPTION
- The limitation on the number of candidates is further reduced to speedup as much as possible the tracking by removing a few outliers without loosing (a priori) the events of interest, neither in pp, nor in PbPb. The highest speedup I observed is 30% in pp with the larger tracking roads used with misaligned chambers, because there are more outliers with this settings.
- The limitation on the tracking time is set with some margin (as it is machine dependent) just as a security in case of rare pathological event, if any. There were none in the pp and PbPb runs I tested with the new settings.

Those parameters are meant to be used in asynchronous reconstruction, for physics.