### PR TITLE
Send MID calibration data at periodic intervals

### DIFF
--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
@@ -92,7 +92,7 @@ class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<Cali
   void setThreshold(double threshold) { mThreshold = threshold; }
 
  private:
-  std::vector<ColumnData> mBadChannels; /// List of bad channels
+  std::vector<ColumnData> mBadChannels{}; /// List of bad channels
   double mThreshold = 0.9;              /// dead channels threshold
   double mTimeOrTriggers = 0;           /// Events counter
 

--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibratorParam.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibratorParam.h
@@ -26,8 +26,10 @@ namespace mid
  */
 struct ChannelCalibratorParam : public o2::conf::ConfigurableParamHelper<ChannelCalibratorParam> {
 
-  float maxNoise = 10000.f; ///< maximum allowed noise value (Hz)
-  float maxDead = 0.9f;     ///< maximum fraction of time a strip was not responding to FET
+  float maxNoise = 10000.f;                  ///< maximum allowed noise value (Hz)
+  float maxDead = 0.9f;                      ///< maximum fraction of time a strip was not responding to FET
+  unsigned long int nCalibTriggers = 115000; ///< Number of calibration triggers before sending
+  bool onlyAtEndOfStream = false;            ///< Run only at end of stream
 
   O2ParamDef(ChannelCalibratorParam, "MIDChannelCalibratorParam");
 };

--- a/Detectors/MUON/MID/Workflow/README.md
+++ b/Detectors/MUON/MID/Workflow/README.md
@@ -194,23 +194,39 @@ Also, if the fraction of times a given channel did not reply to FET over the tot
 
 The common usage is:
 
-```bash
+```shell
 o2-raw-file-reader-workflow --input-conf MIDraw.cfg | o2-mid-raw-to-digits-workflow | o2-mid-calibration-workflow
 ```
 
 The noise threshold (in Hz) can be changed with:
 
-```bash
-o2-mid-calibration-workflow --configKeyValues="MIDChannelCalibratorParam.maxNoise=1000
+```shell
+o2-mid-calibration-workflow --configKeyValues="MIDChannelCalibratorParam.maxNoise=1000"
 ```
 
 The dead channel threshold (fraction) can be changed with:
 
-```bash
-o2-mid-calibration-workflow --configKeyValues="MIDChannelCalibratorParam.maxDead=1000
+```shell
+o2-mid-calibration-workflow --configKeyValues="MIDChannelCalibratorParam.maxDead=1000"
 ```
 
-Notice that the answer to the FET does not arrive at the same BC for all strips.
+The calibration data can be either sent at EOS or when a configurable threshold is reached.
+The default is currently the second.
+To send the calibration data at EOS, one can do:
+
+```shell
+o2-mid-calibration-workflow --configKeyValues="MIDChannelCalibratorParam.onlyAtEndOfStream=1"
+```
+
+Otherwise, one can configure the desired statistics in terms of number of calibration triggers with:
+
+```shell
+o2-mid-calibration-workflow --configKeyValues="MIDChannelCalibratorParam.nCalibTriggers=120000"
+```
+
+The current default is `115000`. The value was chosen based on the current configuration of a calibration run, during which we send calibration triggers at a rate of 1 kHz for 2 minutes (for a total of 120000).
+
+Finally, notice that the answer to the FET does not arrive at the same BC for all strips.
 Some channels are slightly delayed, with a dispersion that seems to be of +- 1 BC maximum.
 To avoid declaring as dead some channels whose response is simply delayed, the workflow merges into a FET event the response of strips occurring in a window around the FET.
 This window can be changed with:


### PR DESCRIPTION
The MID calibration data are produced in a dedicated run. So the output was built using the full statistics of the run, computing the calibration data only at the end.
However, this requires the EOS or stop mechanisms to work properly. This was the case, but some recent development seems to have broken the synchronisation with the QC.
The bad channels are correctly generated and stored in the CCDB, but the corresponding QC plot is empty.
Since the treatment of objects produced at EOS is quite sensitive, I decided to generate a list of bad channels when enough statistics is reached (typically at half of the calibration run with the current rate of 1kHz and duration of 2 minutes).
In this way we should be less dependent on modification/optimisation of the EOS processes.