### PR TITLE
Add FOCAL to rawTF reader

### DIFF
--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -353,7 +353,7 @@ void TFReaderSpec::TFBuilder()
     LOG(info) << "Processing file " << tfFileName;
     SubTimeFrameFileReader reader(tfFileName, mInput.detMask);
     size_t locID = 0;
-    //try
+    // try
     {
       while (mRunning && mTFBuilderCounter < mInput.maxTFs) {
         if (mTFQueue.size() >= size_t(mInput.maxTFCache)) {
@@ -388,7 +388,7 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
   // check which inputs are present in files to read
   o2f::DataProcessorSpec spec;
   spec.name = "tf-reader";
-  const DetID::mask_t DEFMask = DetID::getMask("ITS,TPC,TRD,TOF,PHS,CPV,EMC,HMP,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP");
+  const DetID::mask_t DEFMask = DetID::getMask("ITS,TPC,TRD,TOF,PHS,CPV,EMC,HMP,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP,FOC");
   rinp.detMask = DetID::getMask(rinp.detList) & DEFMask;
   rinp.detMaskRawOnly = DetID::getMask(rinp.detListRawOnly) & DEFMask;
   rinp.detMaskNonRawOnly = DetID::getMask(rinp.detListNonRawOnly) & DEFMask;
@@ -432,6 +432,15 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
           rinp.hdVec.emplace_back(o2h::DataHeader{"CELLS", DetID::getDataOrigin(id), 0, 0});      // in abcence of real data this will be sent
           rinp.hdVec.emplace_back(o2h::DataHeader{"CELLSTRGR", DetID::getDataOrigin(id), 0, 0});  // in abcence of real data this will be sent
           rinp.hdVec.emplace_back(o2h::DataHeader{"DECODERERR", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
+        } else if (id == DetID::FOC) {
+          spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "PADLAYERS"}});
+          spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "PIXELHITS"}});
+          spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "PIXELCHIPS"}});
+          spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "TRIGGERS"}});
+          rinp.hdVec.emplace_back(o2h::DataHeader{"PADLAYERS", DetID::getDataOrigin(id), 0, 0});  // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2h::DataHeader{"PIXELHITS", DetID::getDataOrigin(id), 0, 0});  // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2h::DataHeader{"PIXELCHIPS", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2h::DataHeader{"TRIGGERS", DetID::getDataOrigin(id), 0, 0});   // in abcence of real data this will be sent
         }
       }
     }

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -245,7 +245,7 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
       setTimingInfo(*tfPtr.get());
       size_t nparts = 0, dataSize = 0;
       if (mInput.sendDummyForMissing) {
-        for (auto& msgIt : *tfPtr.get()) { // complete with empty output for the specs which were requested but not seen in the data
+        for (auto& msgIt : *tfPtr.get()) { // complete with empty output for the specs which were requested but were not seen in the data
           acknowledgeOutput(*msgIt.second.get(), true);
         }
         addMissingParts(*tfPtr.get());

--- a/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
+++ b/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
@@ -61,7 +61,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   rinp.maxLoops = configcontext.options().get<int>("loop");
   int n = configcontext.options().get<int>("max-tf");
   rinp.maxTFs = n > 0 ? n : 0x7fffffff;
-  rinp.detList = configcontext.options().get<std::string>("onlyDet");
+  auto detlistSelect = configcontext.options().get<std::string>("onlyDet");
+  if (detlistSelect == "all") {
+    // Exclude FOCAL from default detlist (must be selected on request)
+    auto msk = o2::detectors::DetID::getMask("all") & ~o2::detectors::DetID::getMask("FOC");
+    rinp.detList = o2::detectors::DetID::getNames(msk);
+  } else {
+    rinp.detList = detlistSelect;
+  }
   rinp.detListRawOnly = configcontext.options().get<std::string>("raw-only-det");
   rinp.detListNonRawOnly = configcontext.options().get<std::string>("non-raw-only-det");
   rinp.rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");


### PR DESCRIPTION
- Add FOCAL to the list of detectors in order to be able to decode FOCAL data
- Remove FOCAL from default detectors in order to prevent setting up FOCAL raw data by default
- Add option for FOCAL DPL output (in case FOCAL raw decoding workflow is running on the FLP)