### PR TITLE
[FOCAL-10] Allow event writer to run without dedicated subspecification

### DIFF
--- a/Detectors/FOCAL/workflow/src/event-writer-workflow.cxx
+++ b/Detectors/FOCAL/workflow/src/event-writer-workflow.cxx
@@ -29,6 +29,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{{"event-writer-name", VariantType::String, "focal-event-writer", {"Workflow name"}},
                                        {"subspec", VariantType::UInt32, 0U, {"Input subspecification"}},
+                                       {"no-subspec", VariantType::Bool, false, {"No subspecification (for output from raw STFs)"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -48,10 +49,20 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(MakeRootTreeWriterSpec(workflowname.data(), "focalevents.root", "o2sim",
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<PadLayerEvent>>{InputSpec{"dataapd", "FOC", "PADLAYERS", subspec}, "FOCALPadLayer", "pad-branch-name"},
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<PixelHit>>{InputSpec{"datapixelhit", "FOC", "PIXELHITS", subspec}, "FOCALPixelHit", "pixel-hit-branch-name"},
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<PixelChipRecord>>{InputSpec{"datapixelchip", "FOC", "PIXELCHIPS", subspec}, "FOCALPixelChip", "pixel-chip-branch-name"},
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<TriggerRecord>>{InputSpec{"datatrigger", "FOC", "TRIGGERS", subspec}, "FOCALTrigger", "trigger-branch-name"})());
+  if (cfgc.options().get<bool>("no-subspec")) {
+    // No subspecification defined (i.e. output from the raw-tf-reader workflow): Use concrete data type matcher
+    specs.emplace_back(MakeRootTreeWriterSpec(workflowname.data(), "focalevents.root", "o2sim",
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<PadLayerEvent>>{InputSpec{"dataapd", o2::framework::ConcreteDataTypeMatcher{"FOC", "PADLAYERS"}}, "FOCALPadLayer", "pad-branch-name"},
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<PixelHit>>{InputSpec{"datapixelhit", o2::framework::ConcreteDataTypeMatcher{"FOC", "PIXELHITS"}}, "FOCALPixelHit", "pixel-hit-branch-name"},
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<PixelChipRecord>>{InputSpec{"datapixelchip", o2::framework::ConcreteDataTypeMatcher{"FOC", "PIXELCHIPS"}}, "FOCALPixelChip", "pixel-chip-branch-name"},
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<TriggerRecord>>{InputSpec{"datatrigger", o2::framework::ConcreteDataTypeMatcher{"FOC", "TRIGGERS"}}, "FOCALTrigger", "trigger-branch-name"})());
+  } else {
+    // Subspecification specified: Use full specification
+    specs.emplace_back(MakeRootTreeWriterSpec(workflowname.data(), "focalevents.root", "o2sim",
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<PadLayerEvent>>{InputSpec{"dataapd", "FOC", "PADLAYERS", subspec}, "FOCALPadLayer", "pad-branch-name"},
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<PixelHit>>{InputSpec{"datapixelhit", "FOC", "PIXELHITS", subspec}, "FOCALPixelHit", "pixel-hit-branch-name"},
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<PixelChipRecord>>{InputSpec{"datapixelchip", "FOC", "PIXELCHIPS", subspec}, "FOCALPixelChip", "pixel-chip-branch-name"},
+                                              MakeRootTreeWriterSpec::BranchDefinition<std::vector<TriggerRecord>>{InputSpec{"datatrigger", "FOC", "TRIGGERS", subspec}, "FOCALTrigger", "trigger-branch-name"})());
+  }
   return specs;
 }


### PR DESCRIPTION
- No-subspec mode needed i.e. to subscribe to data
  from raw-tf-reader-workflow
- Option to require dedicated subspec should be
  preserved for i.e. future recalibration