### PR TITLE
TPC: Improve SAC decoding

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/SAC.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/SAC.h
@@ -81,7 +81,7 @@ struct dataDef {
   };                         ///
                              ///
   uint32_t pktNumber = 0;    ///< packet number of this front end card. Should always increase by 1
-  uint32_t timeStamp = 0;    ///< tims stamp
+  uint32_t timeStamp = 0;    ///< time stamp
   char dataWords[DataSize];  ///< ASCI encoded SAC data
   uint32_t crc32 = 0;        ///< CRC32 checksum
   uint32_t trailer = 0;      ///< trailer magic word, should always be TrailerWord

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppressionLinkBased.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppressionLinkBased.h
@@ -19,6 +19,7 @@
 #include "GPUCommonDef.h"
 
 #ifndef GPUCA_GPUCODE
+#include <cstdint>
 #include <bitset>
 #endif
 

--- a/Detectors/TPC/calibration/src/SACDecoder.cxx
+++ b/Detectors/TPC/calibration/src/SACDecoder.cxx
@@ -13,6 +13,9 @@
 #include <cassert>
 #include <fstream>
 #include <string_view>
+#if (defined(WITH_OPENMP) || defined(_OPENMP))
+#include <omp.h>
+#endif
 
 #include "Framework/Logger.h"
 
@@ -77,14 +80,14 @@ bool Decoder::process(const char* data, size_t size)
   if (mDebugLevel & (uint32_t)DebugFlags::TimingInfo) {
     auto endTime = HighResClock::now();
     auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime);
-    LOGP(info, "Time to process data of size {}: {} s", size, elapsed_seconds.count());
+    LOGP(detail, "Time to process data of size {}: {} s", size, elapsed_seconds.count());
   }
 
   ++mCollectedDataPackets;
   return isOK;
 }
 
-bool Decoder::decodeChannels(DecodedDataFE& sacs, size_t& carry, int feid)
+int Decoder::decodeChannels(DecodedDataFE& sacs, size_t& carry, int feid)
 {
   const auto& data = mDataStrings[feid];
   const size_t dataSize = data.size();
@@ -92,7 +95,7 @@ bool Decoder::decodeChannels(DecodedDataFE& sacs, size_t& carry, int feid)
   const size_t start = carry;
   while (carry < dataSize) {
     if (carry + 8 >= dataSize) {
-      return false;
+      return 0;
     }
     if (data[carry] >= '0' && data[carry] <= '7') {
       const uint32_t channel = data[carry] - '0';
@@ -105,6 +108,10 @@ bool Decoder::decodeChannels(DecodedDataFE& sacs, size_t& carry, int feid)
           nibble = c - '0';
         } else if ((c >= 'A') && (c <= 'F')) {
           nibble = c - 'A' + 10;
+        } else {
+          LOGP(warning, "Problem decoding data value for FE {}, channel {} at position {} / {}, no valid hex charakter, dump: {}\n",
+               feid, channel, carry, dataSize, std::string_view(&data[start], next));
+          return -1;
         }
         value <<= 4;
         value |= (nibble & 0xF);
@@ -118,15 +125,16 @@ bool Decoder::decodeChannels(DecodedDataFE& sacs, size_t& carry, int feid)
       sacs.currents[channel] = valueSigned;
 
       if (data[carry] != '\n') {
-        LOGP(warning, "Problem decoding data value for FE {}, channel {} at position {} / {}, dump: {}\n",
+        LOGP(warning, "Problem decoding data value for FE {}, channel {} at position {} / {}, CR expected, dump: {}\n",
              feid, channel, carry, dataSize, std::string_view(&data[start], next));
+        return -1;
       }
       ++carry;
     } else {
-      return true;
+      return 1;
     }
   }
-  return true;
+  return 1;
 }
 
 void Decoder::decode(int feid)
@@ -136,6 +144,7 @@ void Decoder::decode(int feid)
   DecodedDataFE decdata;
   DecodedDataFE decAdditional;
   bool aligned{false};
+  bool syncLost{false};
 
   size_t carry = 0;
   size_t deletePosition = 0;
@@ -161,8 +170,18 @@ void Decoder::decode(int feid)
     // fmt::print("Checking position {} / {}, {}\n", carry, dataSize, std::string_view(&data[carry], std::min(size_t(20), dataSize - carry)));
 
     if (data[carry] >= '0' && data[carry] <= '7') {
-      if (!decodeChannels(decdata, carry, feid)) {
+      const auto status = decodeChannels(decdata, carry, feid);
+      if (status == 0) {
         break;
+      } else if (status == -1) {
+        if (mReAlignType != ReAlignType::None) {
+          LOGP(warn, "trying to re-align data stream\n");
+          aligned = false;
+          syncLost = true;
+        } else {
+          LOGP(error, "stopping decoding\n");
+          break;
+        }
       }
     } else if (data[carry] == 'S') {
       if (carry + 11 >= dataSize) {
@@ -188,38 +207,52 @@ void Decoder::decode(int feid)
         deletePosition = carry; // keep \ns to align in next iteration
         carry += 2;
 
-        if (mDebugStream && (mDebugLevel & (uint32_t)DebugFlags::StreamSingleFE)) {
-          (*mDebugStream) << "d"
-                          << "data=" << decdata
-                          << "feid=" << feid
-                          << "tscount=" << mTSCountFEs[feid]
-                          << "\n";
-        }
-        ++mTSCountFEs[feid].first;
+#pragma omp critical
+        {
+          if (mDebugStream && (mDebugLevel & (uint32_t)DebugFlags::StreamSingleFE)) {
+            (*mDebugStream) << "d"
+                            << "data=" << decdata
+                            << "feid=" << feid
+                            << "tscount=" << mTSCountFEs[feid]
+                            << "\n";
+          }
+          ++mTSCountFEs[feid].first;
 
-        // copy decoded data to output
-        const auto refTime = timeStamp / SampleDistance;
-        auto& currentsTime = mDecodedData.data;
-        const auto nSamples = currentsTime.size();
-        auto firstRefTime = (nSamples > 0) ? currentsTime[0].time : refTime;
-        auto& refCount = mTSCountFEs[feid].second;
-        if ((refCount == 0) && (refTime > 0)) {
-          LOGP(info, "Skipping initial data packet {} with time stamp {} for FE {}", mTSCountFEs[feid].first, timeStamp, feid);
-        } else {
-          if (refCount != refTime) {
-            LOGP(warning, "Unexpected time stamp in FEid {}. Count {} != TS {} ({}), dump: {}", feid, refCount, refTime, timeStamp, std::string_view(&data[streamStart], std::min(size_t(20), dataSize - streamStart - carry)));
+          // copy decoded data to output
+          const auto refTime = timeStamp / SampleDistance;
+          auto& currentsTime = mDecodedData.data;
+          const auto nSamples = currentsTime.size();
+          auto firstRefTime = (nSamples > 0) ? currentsTime[0].time : refTime;
+          auto& refCount = mTSCountFEs[feid].second;
+          // NOTE: use (refTime > 1) instead of (refTime > 0), since in some cases the packet with TS 0 is missing
+          if ((refCount == 0) && (refTime > 1)) {
+            LOGP(info, "Skipping initial data packet {} with time stamp {} for FE {}", mTSCountFEs[feid].first, timeStamp, feid);
+          } else {
+            if (refTime < firstRefTime) {
+              // LOGP(info, "FE {}: {} < {}, adding {} DataPoint(s)", feid, refTime, firstRefTime, firstRefTime - refTime);
+              mDecodedData.insertFront(firstRefTime - refTime);
+              firstRefTime = refTime;
+            } else if (nSamples < refTime - firstRefTime + 1) {
+              // LOGP(info, "FE {}: refTime {}, firstRefTime {}, resize from {} to {}", feid, refTime, firstRefTime, currentsTime.size(), refTime - firstRefTime + 1);
+              mDecodedData.resize(refTime - firstRefTime + 1);
+            }
+            // LOGP(info, "FE {}: insert refTime {} at pos {}, with firstRefTime {}", feid, refTime, refTime - firstRefTime, firstRefTime);
+            mDecodedData.setData(refTime - firstRefTime, refTime, decdata, feid);
+
+            if (refCount != refTime) {
+              LOGP(warning, "Unexpected time stamp in FE {}. Count {} != TS {} ({}), dump: {}", feid, refCount, refTime, timeStamp, std::string_view(&data[streamStart], std::min(size_t(20), dataSize - streamStart - carry)));
+              // NOTE: be graceful in case TS 0 is missing and avoid furhter warnings
+              if (((refCount == 0) && (refTime == 1)) || ((mReAlignType == ReAlignType::AlignAndFillMissing) && syncLost)) {
+                while (refCount < refTime) {
+                  mDecodedData.setData(refCount - firstRefTime, refCount, DecodedDataFE(), feid);
+                  LOGP(warning, "Adding dummy data for FE {}, TS {}", feid, refCount);
+                  ++refCount;
+                }
+                syncLost = false;
+              }
+            }
+            ++refCount;
           }
-          ++refCount;
-          if (refTime < firstRefTime) {
-            // LOGP(info, "FE {}: {} < {}, adding {} DataPoint(s)", feid, refTime, firstRefTime, firstRefTime - refTime);
-            mDecodedData.insertFront(firstRefTime - refTime);
-            firstRefTime = refTime;
-          } else if (nSamples < refTime - firstRefTime + 1) {
-            // LOGP(info, "FE {}: refTime {}, firstRefTime {}, resize from {} to {}", feid, refTime, firstRefTime, currentsTime.size(), refTime - firstRefTime + 1);
-            mDecodedData.resize(refTime - firstRefTime + 1);
-          }
-          // LOGP(info, "FE {}: insert refTime {} at pos {}, with firstRefTime {}", feid, refTime, refTime - firstRefTime, firstRefTime);
-          mDecodedData.setData(refTime - firstRefTime, refTime, decdata, feid);
         }
       }
 
@@ -260,12 +293,24 @@ void Decoder::decode(int feid)
       }
       ++carry;
     } else if (data[carry] >= 'a' && data[carry] <= 'z') {
-      LOGP(info, "Skipping {}", data[carry]);
-      ++carry;
+      if (mReAlignType != ReAlignType::None) {
+        LOGP(error, "Skipping {} for FE {}, trying to re-align data stream", data[carry], feid);
+        aligned = false;
+        syncLost = true;
+      } else {
+        LOGP(error, "Skipping {} for FE {}, might lead to decosing problems", data[carry], feid);
+        ++carry;
+      }
       decdata.reset();
     } else {
-      LOGP(error, "Can't interpret position {} / {}, {}, stopping decoding\n", carry, dataSize, std::string_view(&data[carry - 8], std::min(size_t(20), dataSize - 8 - carry)));
-      break;
+      if (mReAlignType != ReAlignType::None) {
+        LOGP(warn, "Can't interpret position for FE {}, {} / {}, {}, trying to re-align data stream\n", feid, carry, dataSize, std::string_view(&data[carry - 8], std::min(size_t(20), dataSize - 8 - carry)));
+        aligned = false;
+        syncLost = true;
+      } else {
+        LOGP(error, "Can't interpret position for FE {}, {} / {}, {}, stopping decoding\n", feid, carry, dataSize, std::string_view(&data[carry - 8], std::min(size_t(20), dataSize - 8 - carry)));
+        break;
+      }
     }
   }
 
@@ -276,7 +321,7 @@ void Decoder::decode(int feid)
   if (mDebugLevel & (uint32_t)DebugFlags::TimingInfo) {
     auto endTime = HighResClock::now();
     auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime);
-    LOGP(info, "Time to decode feid {}: {} s", feid, elapsed_seconds.count());
+    LOGP(detail, "Time to decode feid {}: {} s", feid, elapsed_seconds.count());
   }
 }
 
@@ -284,6 +329,7 @@ void Decoder::runDecoding()
 {
   const auto startTime = HighResClock::now();
 
+#pragma omp parallel for num_threads(sNThreads)
   for (size_t feid = 0; feid < NumberFEs; ++feid) {
     decode(feid);
   }
@@ -291,15 +337,17 @@ void Decoder::runDecoding()
   if (mDebugLevel & (uint32_t)DebugFlags::TimingInfo) {
     auto endTime = HighResClock::now();
     auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime);
-    LOGP(info, "Time to decode all feids {} s, {} s per packet ({})", elapsed_seconds.count(), elapsed_seconds.count() / mCollectedDataPackets, mCollectedDataPackets);
+    LOGP(detail, "Time to decode all feids {} s, {} s per packet ({})", elapsed_seconds.count(), elapsed_seconds.count() / mCollectedDataPackets, mCollectedDataPackets);
   }
 }
 
-void Decoder::streamDecodedData()
+void Decoder::streamDecodedData(bool streamAll)
 {
   if (mDebugStream && (mDebugLevel & (uint32_t)DebugFlags::StreamFinalData)) {
+    const size_t nDecodedData = (streamAll) ? mDecodedData.data.size() : mDecodedData.getNGoodEntries();
+    LOGP(info, "streamDecodedData (streamAll {}): {} / {}", streamAll, nDecodedData, mDecodedData.data.size());
     auto refTime = mDecodedData.referenceTime;
-    for (size_t ientry = 0; ientry < mDecodedData.getNGoodEntries(); ++ientry) {
+    for (size_t ientry = 0; ientry < nDecodedData; ++ientry) {
       auto& currentData = mDecodedData.data[ientry];
       auto fes = mDecodedData.fes[ientry].to_ulong();
       auto nfes = mDecodedData.fes[ientry].count();
@@ -323,7 +371,7 @@ void Decoder::finalize()
   }
 
   runDecoding();
-  streamDecodedData();
+  streamDecodedData(true);
 
   if (mDebugStream) {
     mDebugStream->Close();

--- a/Detectors/TPC/workflow/src/SACProcessorSpec.cxx
+++ b/Detectors/TPC/workflow/src/SACProcessorSpec.cxx
@@ -32,7 +32,7 @@
 #include "TPCCalibration/SACDecoder.h"
 #include "TPCWorkflow/SACProcessorSpec.h"
 
-using HighResClock = std::chrono::high_resolution_clock;
+using HighResClock = std::chrono::steady_clock;
 using namespace o2::framework;
 
 namespace o2::tpc
@@ -53,6 +53,16 @@ class SACProcessorDevice : public Task
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
     mDebugLevel = ic.options().get<uint32_t>("debug-level");
     mDecoder.setDebugLevel(mDebugLevel);
+
+    mAggregateTFs = ic.options().get<uint32_t>("aggregate-tfs");
+
+    const auto nthreadsDecoding = ic.options().get<uint32_t>("nthreads-decoding");
+    sac::Decoder::setNThreads(nthreadsDecoding);
+
+    const auto reAlignType = ic.options().get<uint32_t>("try-re-align");
+    if (reAlignType <= uint32_t(sac::Decoder::ReAlignType::MaxType)) {
+      mDecoder.setReAlignType(sac::Decoder::ReAlignType(reAlignType));
+    }
   }
 
   void run(ProcessingContext& pc) final
@@ -103,14 +113,18 @@ class SACProcessorDevice : public Task
       }
     }
 
-    mDecoder.runDecoding();
-    sendData(pc.outputs());
+    if ((mProcessedTFs > 0) && !(mProcessedTFs % mAggregateTFs)) {
+      mDecoder.runDecoding();
+      sendData(pc.outputs());
+    }
 
     if (mDebugLevel & (uint32_t)sac::Decoder::DebugFlags::TimingInfo) {
       auto endTime = HighResClock::now();
       auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime);
       LOGP(info, "Time spent for TF {}, firstTForbit {}: {} s", tinfo.tfCounter, tinfo.firstTForbit, elapsed_seconds.count());
     }
+
+    ++mProcessedTFs;
   }
 
   void sendData(DataAllocator& output)
@@ -133,8 +147,10 @@ class SACProcessorDevice : public Task
   }
 
  private:
-  uint32_t mDebugLevel{0}; ///< Debug level
-  sac::Decoder mDecoder;   ///< Decoder for SAC data
+  size_t mProcessedTFs{0};   ///< Number of processed TFs
+  uint32_t mDebugLevel{0};   ///< Debug level
+  uint32_t mAggregateTFs{0}; ///< Debug level
+  sac::Decoder mDecoder;     ///< Decoder for SAC data
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
 };
 
@@ -152,8 +168,8 @@ o2::framework::DataProcessorSpec getSACProcessorSpec()
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("TPC", "DECODEDSAC", 0, Lifetime::Timeframe);
-  outputs.emplace_back("TPC", "REFTIMESAC", 0, Lifetime::Timeframe);
+  outputs.emplace_back("TPC", "DECODEDSAC", 0, Lifetime::Sporadic);
+  outputs.emplace_back("TPC", "REFTIMESAC", 0, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "tpc-sac-processor",
@@ -162,6 +178,9 @@ o2::framework::DataProcessorSpec getSACProcessorSpec()
     AlgorithmSpec{adaptFromTask<device>(ccdbRequest)},
     Options{
       {"debug-level", VariantType::UInt32, 0u, {"amount of debug to show"}},
+      {"nthreads-decoding", VariantType::UInt32, 1u, {"Number of threads used for decoding"}},
+      {"aggregate-tfs", VariantType::UInt32, 1u, {"Number of TFs to aggregate before running decoding"}},
+      {"try-re-align", VariantType::UInt32, 0u, {"Try to re-align data stream in case of missing packets. 0 - no; 1 - yes; 2 - yes, and fill missing packets"}},
     } // end Options
   };  // end DataProcessorSpec
 }


### PR DESCRIPTION
* Parallel decoding option
* Add missing initialization
* Add option to re-align data stream in case packets are missing
* Add option to inject dummy data in case packets are missing
* Add option to accumulate data over several TFs before decoding and sending