### PR TITLE
Revert "Remove TPC starting row cut"

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -40,6 +40,7 @@ struct MatchTPCITSParams : public o2::conf::ConfigurableParamHelper<MatchTPCITSP
   float minTPCTrackR = 50.; ///< cut on minimal TPC tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   float minITSTrackR = 50.; ///< cut on minimal ITS tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   int minTPCClusters = 25; ///< minimum number of clusters to consider
+  int askMinTPCRow = 15;   ///< disregard tracks starting above this row
 
   float cutMatchingChi2 = 30.f; ///< cut on matching chi2
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -373,6 +373,9 @@ void MatchTPCITS::addTPCSeed(const o2::track::TrackParCov& _tr, float t0, float 
   uint8_t clSect = 0, clRow = 0;
   uint32_t clIdx = 0;
   tpcOrig.getClusterReference(mTPCTrackClusIdx, tpcOrig.getNClusterReferences() - 1, clSect, clRow, clIdx);
+  if (clRow > mParams->askMinTPCRow) {
+    return;
+  }
   // create working copy of track param
   bool extConstrained = srcGID.getSource() != GTrackID::TPC;
   if (extConstrained) {


### PR DESCRIPTION
This commit has a negative impact on the ITSTPC matching efficiency, increasing it at low pT (from fakes?) and decreasing it at high pT.

This reverts commit d1be5112b790985f502185840b25a8085d8c59af.

@fmazzasc , @ddobrigk , @noferini , @wiechula , @aschmah

Attached some plots, showing the effect of the PR that we would like to revert. We would like to recover the behaviour of the tag on 4 May.

![image](https://github.com/AliceO2Group/AliceO2/assets/18655040/37b07277-25d6-42af-b846-17b8222b16e3)

![image](https://github.com/AliceO2Group/AliceO2/assets/18655040/070e996a-5cac-40c7-8e24-cfc7ddf5df96)

![image](https://github.com/AliceO2Group/AliceO2/assets/18655040/ce908258-283d-4a41-849e-f5e003cee6be)

![image](https://github.com/AliceO2Group/AliceO2/assets/18655040/f908ca23-e06b-4fb2-89d7-2aef187dfd68)
