### PR TITLE
CPV: clusterize digits with common side

### DIFF
--- a/Detectors/CPV/base/src/Geometry.cxx
+++ b/Detectors/CPV/base/src/Geometry.cxx
@@ -68,7 +68,8 @@ short Geometry::areNeighbours(unsigned short absId1, unsigned short absId2)
     short rowdiff = TMath::Abs(relId1[1] - relId2[1]);
     short coldiff = TMath::Abs(relId1[2] - relId2[2]);
 
-    if ((coldiff <= 1) && (rowdiff <= 1)) { // At least common vertex
+    // if ((coldiff <= 1) && (rowdiff <= 1)) { // At least common vertex
+    if (coldiff + rowdiff <= 1) { // Common side
       return 1;
     } else {
       if ((relId2[1] > relId1[1]) && (relId2[2] > relId1[2] + 1)) {


### PR DESCRIPTION
Hello! In this commit the clustering algorithm is changed from clustering digits with common vertex to clustering digits with common side. It was checked on real pp data and showed approximately same performance and resources consumption. However It is important for PbPb data where detector occupancy is higher and probability of cluster overlap is greater: no need to merge several neighboring clusters in one.