### PR TITLE
DPL: make sending policy per channel

### DIFF
--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -66,11 +66,14 @@ struct InputChannelInfo {
   int pollerIndex = -1;
 };
 
+struct SendingPolicy;
+
 /// Output channel information
 struct OutputChannelInfo {
   std::string name = "invalid";
   ChannelAccountingType channelType = ChannelAccountingType::DPL;
   fair::mq::Channel& channel;
+  SendingPolicy const* policy;
 };
 
 struct OutputChannelState {

--- a/Framework/Core/include/Framework/DataProcessorMatchers.h
+++ b/Framework/Core/include/Framework/DataProcessorMatchers.h
@@ -19,8 +19,15 @@ struct DataProcessorSpec;
 struct DeviceSpec;
 struct ConfigContext;
 
+// A matcher for a given DataProcessorSpec @p spec.
 using DataProcessorMatcher = std::function<bool(DataProcessorSpec const& spec)>;
+// A matcher which is specific to a given DeviceSpec. @a context is the ConfigContext associated with the topology.
 using DeviceMatcher = std::function<bool(DeviceSpec const& spec, ConfigContext const& context)>;
+// A matcher which is specific to a given edge between two DataProcessors, described
+// by @p source and @p dest. @p context is the ConfigContext associated with the topology.
+// NOTE: we use DataProcessorSpecs rather than devices, because when we assign the policy
+//       we do not have all the devices yet.
+using EdgeMatcher = std::function<bool(DataProcessorSpec const& source, DataProcessorSpec const& dest, ConfigContext const& context)>;
 
 /// A set of helper to build policies that need to
 /// be applied based on some DataProcessorSpec property
@@ -32,6 +39,12 @@ struct DataProcessorMatchers {
 
 struct DeviceMatchers {
   static DeviceMatcher matchByName(const char* name);
+};
+
+struct EdgeMatchers {
+  static EdgeMatcher matchSourceByName(const char* name);
+  static EdgeMatcher matchDestByName(const char* name);
+  static EdgeMatcher matchEndsByName(const char* sourceName, const char* destName);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DataSender.h
+++ b/Framework/Core/include/Framework/DataSender.h
@@ -12,7 +12,7 @@
 #define O2_FRAMEWORK_DATASENDER_H_
 
 #include "Framework/RoutingIndices.h"
-#include "Framework/SendingPolicy.h"
+#include "Framework/FairMQDeviceProxy.h"
 #include "Framework/ServiceRegistryRef.h"
 #include "Framework/Tracing.h"
 #include "Framework/OutputSpec.h"
@@ -33,8 +33,7 @@ struct DeviceSpec;
 class DataSender
 {
  public:
-  DataSender(ServiceRegistryRef registry,
-             SendingPolicy const& policy);
+  DataSender(ServiceRegistryRef registry);
   void send(fair::mq::Parts&, ChannelIndex index);
   std::unique_ptr<fair::mq::Message> create(RouteIndex index);
   /// Reset the datasender to a clean state
@@ -55,7 +54,6 @@ class DataSender
   ServiceRegistryRef mRegistry;
   DeviceSpec const& mSpec;
   std::vector<OutputSpec> mOutputs;
-  SendingPolicy mPolicy;
   std::vector<size_t> mDistinctRoutesIndex;
 
   std::vector<std::string> mMetricsNames;

--- a/Framework/Core/include/Framework/OutputRoute.h
+++ b/Framework/Core/include/Framework/OutputRoute.h
@@ -18,6 +18,8 @@
 namespace o2::framework
 {
 
+struct SendingPolicy;
+
 // This uniquely identifies a route out of the device if
 // the OutputSpec @a matcher and @a timeslice match.
 struct OutputRoute {
@@ -25,6 +27,8 @@ struct OutputRoute {
   size_t maxTimeslices;
   OutputSpec matcher;
   std::string channel;
+  // The policy to use to send to on this route.
+  SendingPolicy const* policy;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/SendingPolicy.h
+++ b/Framework/Core/include/Framework/SendingPolicy.h
@@ -22,14 +22,12 @@
 namespace o2::framework
 {
 
-class ServiceRegistry;
-
 class FairMQDeviceProxy;
 
 struct SendingPolicy {
-  using SendingCallback = std::function<void(FairMQDeviceProxy&, fair::mq::Parts&, ChannelIndex channelIndex, ServiceRegistryRef registry)>;
+  using SendingCallback = std::function<void(fair::mq::Parts&, ChannelIndex channelIndex, ServiceRegistryRef registry)>;
   std::string name = "invalid";
-  DeviceMatcher matcher = nullptr;
+  EdgeMatcher matcher = nullptr;
   SendingCallback send = nullptr;
   static std::vector<SendingPolicy> createDefaultPolicies();
 };

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -341,9 +341,8 @@ o2::framework::ServiceSpec CommonServices::dataSender()
   return ServiceSpec{
     .name = "datasender",
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
-      auto& spec = services.get<DeviceSpec const>();
       return ServiceHandle{TypeIdHelpers::uniqueId<DataSender>(),
-                           new DataSender(services, spec.sendingPolicy)};
+                           new DataSender(services)};
     },
     .configure = noConfiguration(),
     .preProcessing = [](ProcessingContext&, void* service) {

--- a/Framework/Core/src/DataProcessorMatchers.cxx
+++ b/Framework/Core/src/DataProcessorMatchers.cxx
@@ -28,4 +28,25 @@ DeviceMatcher DeviceMatchers::matchByName(char const* name_)
     return spec.name == name;
   };
 }
+
+EdgeMatcher EdgeMatchers::matchSourceByName(char const* name_)
+{
+  return [name = std::string(name_)](DataProcessorSpec const& source, DataProcessorSpec const&, ConfigContext const&) {
+    return source.name == name;
+  };
+}
+
+EdgeMatcher EdgeMatchers::matchDestByName(char const* name_)
+{
+  return [name = std::string(name_)](DataProcessorSpec const&, DataProcessorSpec const& dest, ConfigContext const&) {
+    return dest.name == name;
+  };
+}
+
+EdgeMatcher EdgeMatchers::matchEndsByName(char const* source_, char const* dest_)
+{
+  return [sourceName = std::string(source_), destName = std::string(dest_)](DataProcessorSpec const& source, DataProcessorSpec const& dest, ConfigContext const&) {
+    return source.name == sourceName && dest.name == destName;
+  };
+}
 } // namespace o2::framework

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -138,6 +138,7 @@ struct DeviceSpecHelpers {
   /// to the outgoing edges i.e. those which refer
   /// to the act of producing data.
   static void processOutEdgeActions(
+    ConfigContext const& configContext,
     std::vector<DeviceSpec>& devices,
     std::vector<DeviceId>& deviceIndex,
     std::vector<DeviceConnectionId>& connections,
@@ -148,6 +149,7 @@ struct DeviceSpecHelpers {
     const WorkflowSpec& workflow,
     const std::vector<OutputSpec>& outputs,
     std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+    std::vector<SendingPolicy> const& sendingPolicies,
     std::string const& channelPrefix,
     ComputingOffer const& defaultOffer,
     OverrideServiceSpecs const& overrideServices = {});

--- a/Framework/Core/src/FairMQDeviceProxy.cxx
+++ b/Framework/Core/src/FairMQDeviceProxy.cxx
@@ -244,6 +244,7 @@ void FairMQDeviceProxy::bind(std::vector<OutputRoute> const& outputs, std::vecto
           .name = route.channel,
           .channelType = dplChannel,
           .channel = device.fChannels.at(route.channel).at(0),
+          .policy = route.policy,
         };
         mOutputChannelInfos.push_back(info);
         mOutputChannelStates.push_back({0});
@@ -257,10 +258,12 @@ void FairMQDeviceProxy::bind(std::vector<OutputRoute> const& outputs, std::vecto
       mOutputRoutes.emplace_back(RouteState{channelIndex, false});
       ri++;
     }
+#ifndef NDEBUG
     for (auto& route : mOutputRoutes) {
       assert(route.channel.value != -1);
       assert(route.channel.value < mOutputChannelInfos.size());
     }
+#endif
     LOGP(detail, "Total channels found {}, total routes {}", mOutputChannelInfos.size(), mOutputRoutes.size());
     assert(mOutputRoutes.size() == outputs.size());
   }

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -28,8 +28,25 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
 {
   return {SendingPolicy{
             .name = "dispatcher",
-            .matcher = [](DeviceSpec const& spec, ConfigContext const&) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
-            .send = [](FairMQDeviceProxy& proxy, fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+            .matcher = [](DataProcessorSpec const& source, DataProcessorSpec const& dest, ConfigContext const&) { 
+                if (source.name == "Dispatcher") {
+                  return true;
+                }
+                // Check if any of the labels has "Dispatcher" as prefix
+                for (auto const& label : source.labels) {
+                  if (label.value.find("Dispatcher") == 0) {
+                    return true;
+                  }
+                }
+                // Check if any of the destination's labels is "expendable" or "non-critical"
+                for (auto const& label : dest.labels) {
+                  if (label.value == "expendable" || label.value == "non-critical") {
+                    return true;
+                  }
+                }
+                return false; },
+            .send = [](fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+              auto &proxy = registry.get<FairMQDeviceProxy>();
               OutputChannelInfo const& info = proxy.getOutputChannelInfo(channelIndex);
               OutputChannelState& state = proxy.getOutputChannelState(channelIndex);
               // Default timeout is 10ms.
@@ -51,8 +68,9 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
               } }},
           SendingPolicy{
             .name = "profiling",
-            .matcher = [](DeviceSpec const&, ConfigContext const&) { return getenv("DPL_DEBUG_MESSAGE_SIZE"); },
-            .send = [](FairMQDeviceProxy& proxy, fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+            .matcher = [](DataProcessorSpec const&, DataProcessorSpec const&, ConfigContext const&) { return getenv("DPL_DEBUG_MESSAGE_SIZE"); },
+            .send = [](fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+              auto &proxy = registry.get<FairMQDeviceProxy>();
               auto *channel = proxy.getOutputChannel(channelIndex);
               auto timeout = 1000;
               int count = 0;
@@ -76,8 +94,9 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
               } }},
           SendingPolicy{
             .name = "default",
-            .matcher = [](DeviceSpec const&, ConfigContext const&) { return true; },
-            .send = [](FairMQDeviceProxy& proxy, fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+            .matcher = [](DataProcessorSpec const&, DataProcessorSpec const&, ConfigContext const&) { return true; },
+            .send = [](fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+              auto &proxy = registry.get<FairMQDeviceProxy>();
               auto *channel = proxy.getOutputChannel(channelIndex);
               auto timeout = 1000;
               auto res = channel->Send(parts, timeout);

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -420,6 +420,7 @@ TEST_CASE("TestOutEdgeProcessingHelpers")
   WorkflowSpec workflow = defineDataProcessing7();
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
+  auto sendingPolicies = SendingPolicy::createDefaultPolicies();
 
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
@@ -427,8 +428,8 @@ TEST_CASE("TestOutEdgeProcessingHelpers")
   defaultOffer.cpu = 0.01;
   defaultOffer.memory = 0.01;
 
-  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, rm, edgeOutIndex, logicalEdges,
-                                           actions, workflow, globalOutputs, channelPolicies, "", defaultOffer);
+  DeviceSpecHelpers::processOutEdgeActions(*configContext, devices, deviceIndex, connections, rm, edgeOutIndex, logicalEdges,
+                                           actions, workflow, globalOutputs, channelPolicies, sendingPolicies, "", defaultOffer);
 
   std::vector<DeviceId> expectedDeviceIndex = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {1, 0, 1}, {1, 0, 1}, {1, 1, 2}, {1, 1, 2}, {1, 2, 3}, {1, 2, 3}};
   REQUIRE(devices.size() == 4);
@@ -515,24 +516,25 @@ TEST_CASE("TestOutEdgeProcessingHelpers")
   REQUIRE(devices[4].outputs.size() == 0);
   REQUIRE(devices[5].outputs.size() == 0);
 
+  SendingPolicy dummy;
   // Check that the output specs and the timeframe ids are correct
   std::vector<std::vector<OutputRoute>> expectedRoutes = {
     {
-      OutputRoute{0, 3, globalOutputs[0], "from_A_to_B_t0"},
-      OutputRoute{1, 3, globalOutputs[0], "from_A_to_B_t1"},
-      OutputRoute{2, 3, globalOutputs[0], "from_A_to_B_t2"},
+      OutputRoute{0, 3, globalOutputs[0], "from_A_to_B_t0", &dummy},
+      OutputRoute{1, 3, globalOutputs[0], "from_A_to_B_t1", &dummy},
+      OutputRoute{2, 3, globalOutputs[0], "from_A_to_B_t2", &dummy},
     },
     {
-      OutputRoute{0, 2, globalOutputs[1], "from_B_t0_to_C_t0"},
-      OutputRoute{1, 2, globalOutputs[1], "from_B_t0_to_C_t1"},
+      OutputRoute{0, 2, globalOutputs[1], "from_B_t0_to_C_t0", &dummy},
+      OutputRoute{1, 2, globalOutputs[1], "from_B_t0_to_C_t1", &dummy},
     },
     {
-      OutputRoute{0, 2, globalOutputs[1], "from_B_t1_to_C_t0"},
-      OutputRoute{1, 2, globalOutputs[1], "from_B_t1_to_C_t1"},
+      OutputRoute{0, 2, globalOutputs[1], "from_B_t1_to_C_t0", &dummy},
+      OutputRoute{1, 2, globalOutputs[1], "from_B_t1_to_C_t1", &dummy},
     },
     {
-      OutputRoute{0, 2, globalOutputs[1], "from_B_t2_to_C_t0"},
-      OutputRoute{1, 2, globalOutputs[1], "from_B_t2_to_C_t1"},
+      OutputRoute{0, 2, globalOutputs[1], "from_B_t2_to_C_t0", &dummy},
+      OutputRoute{1, 2, globalOutputs[1], "from_B_t2_to_C_t1", &dummy},
     },
   };
 
@@ -710,6 +712,7 @@ TEST_CASE("TestSimpleWildcard")
   SimpleResourceManager rm(resources);
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
+  auto sendingPolicies = SendingPolicy::createDefaultPolicies();
 
   std::vector<DeviceSpec> devices;
   std::vector<DeviceId> deviceIndex;
@@ -747,8 +750,8 @@ TEST_CASE("TestSimpleWildcard")
   defaultOffer.cpu = 0.01;
   defaultOffer.memory = 0.01;
 
-  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, rm, edgeOutIndex, logicalEdges,
-                                           outActions, workflow, globalOutputs, channelPolicies, "", defaultOffer);
+  DeviceSpecHelpers::processOutEdgeActions(*configContext, devices, deviceIndex, connections, rm, edgeOutIndex, logicalEdges,
+                                           outActions, workflow, globalOutputs, channelPolicies, sendingPolicies, "", defaultOffer);
 
   REQUIRE(devices.size() == 2);
   ; // Two devices have outputs: A and Timer

--- a/Framework/TestWorkflows/src/o2DiamondWorkflowLeaky.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflowLeaky.cxx
@@ -46,8 +46,9 @@ void customize(std::vector<CallbacksPolicy>& policies)
 void customize(std::vector<SendingPolicy>& policies)
 {
   policies.push_back(SendingPolicy{
-    .matcher = DeviceMatchers::matchByName("A"),
-    .send = [](FairMQDeviceProxy& proxy, fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+    .matcher = EdgeMatchers::matchSourceByName("A"),
+    .send = [](fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
+      auto& proxy = registry.get<FairMQDeviceProxy>();
       LOG(info) << "A custom policy for sending invoked!";
       auto* channel = proxy.getOutputChannel(channelIndex);
       channel->Send(parts, 0);


### PR DESCRIPTION
This avoids having expendable / non-critical devices blocking the data flow since any device can now drop (non forwarded) data when sending to one.

Notice that this means that non-critical devices must keep into account they might not see as much data as expected.