### PR TITLE
raw-tr-reader option to read only selected TFs

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -479,6 +479,15 @@ input data (obligatory): comma-separated list of input data files and/or files w
 max TF ID to process (<= 0 : infinite)
 
 ```
+--select-tf-ids <id's of TFs to select>
+```
+This is a `tf-reader` device local option allowing selective reading of particular TFs. It is useful when dealing with TF files containing multiple TFs. The comma-separated list of increasing TFs indices must be provided in the format parsed by the `RangeTokenizer<int>`, e.g. `1,4-6,...`.
+Note that the index corresponds not to DataHeader.TFcounter of the TF but to the reader own counter incremented throught all input files (e.g. if 10 raw-TF files with 20 TFs each are provided for the input and the selection of TFs
+`0,2,22,66` is provided, the reader will inject to the DPL the TFs at entries 0 and 2 from the 1st raw-TF file, entry 5 of the second file, entry 6 of the 3d and will finish the job.
+
+
+
+```
 --loop arg (=0)
 ```
 loop N times (-1 = infinite) over input files (but max-tf has priority if positive)

--- a/Detectors/Raw/TFReaderDD/CMakeLists.txt
+++ b/Detectors/Raw/TFReaderDD/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(TFReaderDD
                                      O2::Framework
                                      O2::DetectorsRaw
                                      O2::CommonUtils
+                                     O2::Algorithm
                                      FairMQ::FairMQ)
 
 o2_add_executable(tf-reader-workflow

--- a/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
+++ b/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
@@ -50,7 +50,7 @@ class SubTimeFrameFileReader
   ~SubTimeFrameFileReader();
 
   /// Read a single TF from the file
-  std::unique_ptr<MessagesPerRoute> read(fair::mq::Device* device, const std::vector<o2f::OutputRoute>& outputRoutes, const std::string& rawChannel, bool sup0xccdb, int verbosity);
+  std::unique_ptr<MessagesPerRoute> read(fair::mq::Device* device, const std::vector<o2f::OutputRoute>& outputRoutes, const std::string& rawChannel, size_t slice, bool sup0xccdb, int verbosity);
 
   /// Tell the current position of the file
   inline std::uint64_t position() const { return mFileMapOffset; }

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -23,7 +23,7 @@
 #include "Framework/DataProcessingHelpers.h"
 #include "Framework/RateLimiter.h"
 #include "Headers/DataHeaderHelpers.h"
-
+#include "Algorithm/RangeTokenizer.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include <TStopwatch.h>
 #include <fairmq/Device.h>
@@ -78,6 +78,7 @@ class TFReaderSpec : public o2f::Task
   std::unordered_map<o2h::DataIdentifier, SubSpecCount> mSeenOutputMap;
   int mTFCounter = 0;
   int mTFBuilderCounter = 0;
+  size_t mSelIDEntry = 0; // next TFID to select from the mInput.tfIDs (if non-empty)
   bool mRunning = false;
   TFReaderInp mInput; // command line inputs
   std::thread mTFBuilderThread{};
@@ -94,6 +95,7 @@ TFReaderSpec::TFReaderSpec(const TFReaderInp& rinp) : mInput(rinp)
 //___________________________________________________________
 void TFReaderSpec::init(o2f::InitContext& ic)
 {
+  mInput.tfIDs = o2::RangeTokenizer::tokenize<int>(ic.options().get<std::string>("select-tf-ids"));
   mFileFetcher = std::make_unique<o2::utils::FileFetcher>(mInput.inpdata, mInput.tffileRegex, mInput.remoteRegex, mInput.copyCmd);
   mFileFetcher->setMaxFilesInQueue(mInput.maxFileCache);
   mFileFetcher->setMaxLoops(mInput.maxLoops);
@@ -337,7 +339,10 @@ void TFReaderSpec::TFBuilder()
       continue;
     }
     tfFileName = mFileFetcher ? mFileFetcher->getNextFileInQueue() : "";
-    if (!mRunning || (tfFileName.empty() && !mFileFetcher->isRunning()) || mTFBuilderCounter >= mInput.maxTFs) {
+    if (!mRunning ||
+        (tfFileName.empty() && !mFileFetcher->isRunning()) ||
+        mTFBuilderCounter >= mInput.maxTFs ||
+        (!mInput.tfIDs.empty() && mSelIDEntry >= mInput.tfIDs.size())) {
       // stopped or no more files in the queue is expected or needed
       LOG(info) << "TFReader stops processing";
       if (mFileFetcher) {
@@ -360,13 +365,29 @@ void TFReaderSpec::TFBuilder()
           std::this_thread::sleep_for(sleepTime);
           continue;
         }
-        auto tf = reader.read(mDevice, mOutputRoutes, mInput.rawChannelConfig, mInput.sup0xccdb, mInput.verbosity);
+        auto tf = reader.read(mDevice, mOutputRoutes, mInput.rawChannelConfig, mSelIDEntry, mInput.sup0xccdb, mInput.verbosity);
+        bool acceptTF = true;
         if (tf) {
+          locID++;
+          if (!mInput.tfIDs.empty()) {
+            acceptTF = false;
+            if (mInput.tfIDs[mSelIDEntry] == mTFBuilderCounter) {
+              acceptTF = true;
+              LOGP(info, "Retrieved TF#{} will be pushed as slice {} following user request", mTFBuilderCounter, mSelIDEntry);
+              mSelIDEntry++;
+            } else {
+              LOGP(info, "Retrieved TF#{} will be discared following user request", mTFBuilderCounter);
+            }
+          } else {
+            mSelIDEntry++;
+          }
           mTFBuilderCounter++;
+        }
+        if (!acceptTF) {
+          continue;
         }
         if (mRunning && tf) {
           mTFQueue.push(std::move(tf));
-          locID++;
         } else {
           break;
         }
@@ -468,6 +489,7 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
       LOGP(alarm, R"(To avoid reader filling shm buffer use "--shm-throw-bad-alloc 0 --shm-segment-id 2")");
     }
   }
+  spec.options.emplace_back(o2f::ConfigParamSpec{"select-tf-ids", o2f::VariantType::String, "", {"comma-separated list TF IDs to inject (from cumulative counter of TFs seen)"}});
   spec.options.emplace_back(o2f::ConfigParamSpec{"fetch-failure-threshold", o2f::VariantType::Float, 0.f, {"Fatil if too many failures( >0: fraction, <0: abs number, 0: no threshold)"}});
   spec.algorithm = o2f::adaptFromTask<TFReaderSpec>(rinp);
 

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
@@ -46,6 +46,7 @@ struct TFReaderInp {
   bool sendDummyForMissing = true;
   bool sup0xccdb = false;
   std::vector<o2::header::DataHeader> hdVec;
+  std::vector<int> tfIDs{};
 };
 
 o2::framework::DataProcessorSpec getTFReaderSpec(o2::rawdd::TFReaderInp& rinp);


### PR DESCRIPTION
With --select-tf-ids <id's of TFs to select> only TFs matching to the selection will be read. The comma-separated list of increasing TFs indices must be provided in the format parsed by the RangeTokenizer<int>, e.g. 1,4-6,...
Note that the index corresponds not to DataHeader.TFcounter of the TF but to the reader own counter incremented throught all input files (e.g. if 10 raw-TF files with 20 TFs each are provided for the input and the selection of TFs 0,2,22,66 is provided, the reader will inject to the DPL the TFs at entries 0 and 2 from the 1st raw-TF file, entry 5 of the second file, entry 6 of the 3d and will finish the job.