### PR TITLE
Disable TPC corrections for corrmap-lumi-inst<0 or corrmap-lumi-mean<0

### DIFF
--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -62,8 +62,8 @@ void CorrectionMapsLoader::requestCCDBInputs(std::vector<InputSpec>& inputs, std
 //________________________________________________________
 void CorrectionMapsLoader::addOptions(std::vector<ConfigParamSpec>& options)
 {
-  addOption(options, ConfigParamSpec{"corrmap-lumi-mean", VariantType::Float, -1.f, {"override TPC corr.map mean lumi (if > 0)"}});
-  addOption(options, ConfigParamSpec{"corrmap-lumi-inst", VariantType::Float, -1.f, {"override instantaneous CTP lumi (if > 0) for TPC corr.map scaling"}});
+  addOption(options, ConfigParamSpec{"corrmap-lumi-mean", VariantType::Float, 0.f, {"override TPC corr.map mean lumi (if > 0), disable corrections if < 0"}});
+  addOption(options, ConfigParamSpec{"corrmap-lumi-inst", VariantType::Float, 0.f, {"override instantaneous CTP lumi (if > 0) for TPC corr.map scaling, disable corrections if < 0"}});
 }
 
 //________________________________________________________
@@ -116,10 +116,10 @@ void CorrectionMapsLoader::init(o2::framework::InitContext& ic)
   }
   mMeanLumiOverride = ic.options().get<float>("corrmap-lumi-mean");
   mInstLumiOverride = ic.options().get<float>("corrmap-lumi-inst");
-  if (mMeanLumiOverride >= 0.) {
+  if (mMeanLumiOverride != 0.) {
     setMeanLumi(mMeanLumiOverride);
   }
-  if (mInstLumiOverride >= 0.) {
+  if (mInstLumiOverride != 0.) {
     setInstLumi(mInstLumiOverride);
   }
   LOGP(info, "CTP Lumi request for TPC corr.map scaling={}, override values: lumiMean={} lumiInst={}", getUseCTPLumi() ? "ON" : "OFF", mMeanLumiOverride, mInstLumiOverride);

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -67,19 +67,28 @@ class CorrectionMapsHelper
   void setInstLumi(float v)
   {
     if (v != mInstLumi) {
-      setUpdatedLumi();
       mInstLumi = v;
-      mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
-      reportScaling();
+      updateLumiScale();
     }
   }
+
   void setMeanLumi(float v)
   {
     if (v != mMeanLumi) {
-      setUpdatedLumi();
       mMeanLumi = v;
+      updateLumiScale();
+    }
+  }
+
+  void updateLumiScale()
+  {
+    if (mMeanLumi < 0.f || mInstLumi < 0.f) {
+      mLumiScale = -1.f;
+    } else {
       mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
     }
+    setUpdatedLumi();
+    reportScaling();
   }
 
   GPUd() float getInstLumi() const { return mInstLumi; }


### PR DESCRIPTION
The conventions are changed to:
--require-ctp-lumi       : get inst.lumi from CTP input per TF
--corrmap-lumi-inst: >0  : apply scaling overriding inst. lumi to this value (even if CTP input is requested)
                     ==0 : do not override (default), the scaling will be applied if require-ctp-lumi was ON
                     <0  : do not apply corrections at all
--corrmap-lumi-mean: >0  : override mean lumi corresponding to the correction map
                     ==0 : do not override mean lumi (default)
                     <0  : do not apply corrections at all