### PR TITLE
TPC Painter: Add function for FEC coordinates

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Painter.h
+++ b/Detectors/TPC/base/include/TPCBase/Painter.h
@@ -52,6 +52,7 @@ namespace painter
 enum class Type : int {
   Pad,   ///< drawing pads
   Stack, ///< drawing stacks
+  FEC    ///< drawing of FECs
 };
 
 /// pad corner coordinates
@@ -78,6 +79,9 @@ std::vector<PadCoordinates> getPadCoordinatesSector();
 
 /// create a vector of stack corner coordinate for one full sector
 std::vector<PadCoordinates> getStackCoordinatesSector();
+
+/// create a vector of FEC corner coordinates for one full sector
+std::vector<PadCoordinates> getFECCoordinatesSector();
 
 /// \return returns coordinates for given type
 std::vector<o2::tpc::painter::PadCoordinates> getCoordinates(const Type type);


### PR DESCRIPTION
This can be used to draw the borders of the pads which are readout from the same FEC.

See example plots:
[FEC.pdf without pads](https://github.com/AliceO2Group/AliceO2/files/11506069/FEC.pdf)
[FEC.pdf with pads](https://github.com/AliceO2Group/AliceO2/files/11506079/padplane.pdf)
