### PR TITLE
DPL Analysis: optimization: avoid doing a full iterator copy when combining selections

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -656,6 +656,13 @@ struct FilteredIndexPolicy : IndexPolicyBase {
     this->setCursor(0);
   }
 
+  void resetSelection(gsl::span<int64_t const> selection)
+  {
+    mSelectedRows = selection;
+    mMaxSelection = selection.size();
+    this->setCursor(0);
+  }
+
   FilteredIndexPolicy() = default;
   FilteredIndexPolicy(FilteredIndexPolicy&&) = default;
   FilteredIndexPolicy(FilteredIndexPolicy const&) = default;
@@ -2556,6 +2563,9 @@ class FilteredBase : public T
     : T{std::move(tables), offset},
       mSelectedRows{getSpan(selection)}
   {
+    if (this->tableSize() != 0) {
+      mFilteredBegin = table_t::filtered_begin(mSelectedRows);
+    }
     resetRanges();
     mFilteredBegin.bindInternalIndices(this);
   }
@@ -2565,6 +2575,10 @@ class FilteredBase : public T
       mSelectedRowsCache{std::move(selection)},
       mCached{true}
   {
+    mSelectedRows = gsl::span{mSelectedRowsCache};
+    if (this->tableSize() != 0) {
+      mFilteredBegin = table_t::filtered_begin(mSelectedRows);
+    }
     resetRanges();
     mFilteredBegin.bindInternalIndices(this);
   }
@@ -2573,6 +2587,9 @@ class FilteredBase : public T
     : T{std::move(tables), offset},
       mSelectedRows{selection}
   {
+    if (this->tableSize() != 0) {
+      mFilteredBegin = table_t::filtered_begin(mSelectedRows);
+    }
     resetRanges();
     mFilteredBegin.bindInternalIndices(this);
   }
@@ -2820,7 +2837,7 @@ class FilteredBase : public T
     if (tableSize() == 0) {
       mFilteredBegin = *mFilteredEnd;
     } else {
-      mFilteredBegin = table_t::filtered_begin(mSelectedRows);
+      mFilteredBegin.resetSelection(mSelectedRows);
     }
   }
 

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -250,7 +250,8 @@ TEST_CASE("TestPartitionIteration")
   REQUIRE(i == 4);
 
   expressions::Filter f1 = aod::test::x < 4.0f;
-  FilteredTest filtered{{testA.asArrowTable()}, o2::soa::selectionToVector(expressions::createSelection(testA.asArrowTable(), f1))};
+  auto selection = expressions::createSelection(testA.asArrowTable(), f1);
+  FilteredTest filtered{{testA.asArrowTable()}, o2::soa::selectionToVector(selection)};
   PartitionFilteredTest p2 = aod::test::y > 9.0f;
   p2.setTable(filtered);
 


### PR DESCRIPTION
When selections are combined (for example nested filtering or slicing a `Filtered` object) avoids constructing an iterator from scratch, only the selection is reset. This should speed up `SmallGroups` and `PresliceUnsorted`, as well as filtered combinations.  