### PR TITLE
Silence some compiler warnings

### DIFF
--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/RawEventData.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/RawEventData.h
@@ -54,7 +54,7 @@ struct EventData {
   static constexpr size_t MaxNelements = 12;
   int16_t time : 12;
   int16_t charge : 13;
-  uint8_t pmBits : 8;
+  uint16_t pmBits : 8;
   uint8_t reservedField : 3;
   uint8_t channelID : 4;
   void generateFlags()

--- a/Detectors/Align/include/Align/AlignableDetectorTOF.h
+++ b/Detectors/Align/include/Align/AlignableDetectorTOF.h
@@ -24,7 +24,7 @@ namespace o2
 namespace align
 {
 
-class AlignableDetectorTOF : public AlignableDetector
+class AlignableDetectorTOF final : public AlignableDetector
 {
  public:
   AlignableDetectorTOF() = default;

--- a/Detectors/Align/include/Align/AlignableDetectorTPC.h
+++ b/Detectors/Align/include/Align/AlignableDetectorTPC.h
@@ -23,7 +23,7 @@ namespace o2
 namespace align
 {
 
-class AlignableDetectorTPC : public AlignableDetector
+class AlignableDetectorTPC final : public AlignableDetector
 {
  public:
   //

--- a/Detectors/Align/include/Align/AlignableDetectorTRD.h
+++ b/Detectors/Align/include/Align/AlignableDetectorTRD.h
@@ -25,7 +25,7 @@ namespace o2
 namespace align
 {
 
-class AlignableDetectorTRD : public AlignableDetector
+class AlignableDetectorTRD final : public AlignableDetector
 {
  public:
   //


### PR DESCRIPTION
- classes which have a destructor marked as final cannot be inherited from, so should be marked as final as well
- GCC does not like packed bitfields which cross the width of their type (`time` and `charge` occupy 25 bits, therefore the last bit of `pmBits` crosses the width of 16 bits). The layout stays the same with this change