### PR TITLE
[EMCAL-551] Fix aliasing problem in EMCAL cell type

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -183,7 +183,7 @@ class Cell
   CellData* getDataRepresentation() { return reinterpret_cast<CellData*>(mCellWords); }
   const CellData* getDataRepresentation() const { return reinterpret_cast<const CellData*>(mCellWords); }
 
-  uint16_t mCellWords[3]; ///< data word
+  char mCellWords[6]; ///< data word
 
   ClassDefNV(Cell, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -25,12 +25,12 @@ const float TIME_SHIFT = 600.,
 
 Cell::Cell()
 {
-  memset(mCellWords, 0, sizeof(uint16_t) * 3);
+  memset(mCellWords, 0, 6);
 }
 
 Cell::Cell(short tower, float energy, float time, ChannelType_t ctype)
 {
-  memset(mCellWords, 0, sizeof(uint16_t) * 3);
+  memset(mCellWords, 0, 6);
   setTower(tower);
   setTimeStamp(time);
   setEnergy(energy);


### PR DESCRIPTION
With default -fstrict-aliasing option that comes with -O2, only void* and char* may alias other data types, so the reinterpret_cast in getDataRepresentation is undefined behavior