### PR TITLE
o2-sim: Stop tracks when they reach max time of flight

### DIFF
--- a/Common/SimConfig/CMakeLists.txt
+++ b/Common/SimConfig/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(SimConfig
                        src/DigiParams.cxx src/G4Params.cxx
                        src/MatMapParams.cxx
                        src/InteractionDiamondParam.cxx
+                       src/GlobalProcessCutSimParam.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonUtils
                                      O2::DetectorsCommonDataFormats O2::SimulationDataFormat
                                      FairRoot::Base Boost::program_options)
@@ -28,6 +29,7 @@ o2_target_root_dictionary(SimConfig
                                   include/SimConfig/InteractionDiamondParam.h
 		                  include/SimConfig/DigiParams.h
                                   include/SimConfig/G4Params.h
+                                  include/SimConfig/GlobalProcessCutSimParam.h
                                   include/SimConfig/MatMapParams.h)
 
 o2_add_test(Config

--- a/Common/SimConfig/include/SimConfig/GlobalProcessCutSimParam.h
+++ b/Common/SimConfig/include/SimConfig/GlobalProcessCutSimParam.h
@@ -43,7 +43,7 @@ struct GlobalProcessCutSimParam : public o2::conf::ConfigurableParamHelper<Globa
   double DCUTE = 1.0E-3;  // GeV --> 1 MeV
   double DCUTM = 1.0E-3;  // GeV --> 1 MeV
   double PPCUTM = 1.0E-3; // GeV --> 1 MeV
-  double TOFMAX = 0.1;    // seconds
+  double TOFMAX = 1.E10;  // seconds
 
   // boilerplate stuff + make principal key "GlobalSimProcs"
   O2ParamDef(GlobalProcessCutSimParam, "GlobalSimProcs");

--- a/Common/SimConfig/src/GlobalProcessCutSimParam.cxx
+++ b/Common/SimConfig/src/GlobalProcessCutSimParam.cxx
@@ -9,5 +9,5 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "SimSetup/GlobalProcessCutSimParam.h"
+#include "SimConfig/GlobalProcessCutSimParam.h"
 O2ParamImpl(o2::GlobalProcessCutSimParam);

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -39,4 +39,7 @@
 #pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
 
+#pragma link C++ class o2::GlobalProcessCutSimParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::GlobalProcessCutSimParam> + ;
+
 #endif

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -35,13 +35,12 @@ o2_add_library(O2TrivialMCEngineSetup
 )
 
 o2_add_library(SimSetup
-               SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx src/MCReplayParam.cxx
+               SOURCES  src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx src/MCReplayParam.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase O2::SimConfig
 )
 
 o2_target_root_dictionary(SimSetup
                           HEADERS include/SimSetup/SimSetup.h
-                                  include/SimSetup/GlobalProcessCutSimParam.h
                                   include/SimSetup/FlukaParam.h
                                   include/SimSetup/MCReplayParam.h
                           LINKDEF src/GConfLinkDef.h)

--- a/Detectors/gconfig/include/SimSetup/GlobalProcessCutSimParam.h
+++ b/Detectors/gconfig/include/SimSetup/GlobalProcessCutSimParam.h
@@ -43,7 +43,7 @@ struct GlobalProcessCutSimParam : public o2::conf::ConfigurableParamHelper<Globa
   double DCUTE = 1.0E-3;  // GeV --> 1 MeV
   double DCUTM = 1.0E-3;  // GeV --> 1 MeV
   double PPCUTM = 1.0E-3; // GeV --> 1 MeV
-  double TOFMAX = 1.E10;  // seconds
+  double TOFMAX = 0.1;    // seconds
 
   // boilerplate stuff + make principal key "GlobalSimProcs"
   O2ParamDef(GlobalProcessCutSimParam, "GlobalSimProcs");

--- a/Detectors/gconfig/src/GConfLinkDef.h
+++ b/Detectors/gconfig/src/GConfLinkDef.h
@@ -17,8 +17,6 @@
 #pragma link C++ class o2::SimSetup + ;
 
 #pragma link C++ class o2::conf::ConfigurableParam + ;
-#pragma link C++ class o2::GlobalProcessCutSimParam + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::GlobalProcessCutSimParam> + ;
 #pragma link C++ class o2::FlukaParam+ ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::FlukaParam> + ;
 #pragma link C++ class o2::MCReplayParam + ;

--- a/Detectors/gconfig/src/SetCuts.cxx
+++ b/Detectors/gconfig/src/SetCuts.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "SetCuts.h"
-#include "SimSetup/GlobalProcessCutSimParam.h"
+#include "SimConfig/GlobalProcessCutSimParam.h"
 #include "DetectorsBase/MaterialManager.h"
 #include <fairlogger/Logger.h>
 

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -18,7 +18,7 @@ o2_add_library(Steer
                                              O2::DetectorsBase
                                              O2::SimulationDataFormat
                                              O2::DetectorsCommonDataFormats
-                                             O2::Generators O2::SimSetup)
+                                             O2::Generators O2::SimConfig)
 
 o2_add_executable(colcontexttool
                   COMPONENT_NAME steer

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -18,7 +18,7 @@ o2_add_library(Steer
                                              O2::DetectorsBase
                                              O2::SimulationDataFormat
                                              O2::DetectorsCommonDataFormats
-                                             O2::Generators)
+                                             O2::Generators O2::SimSetup)
 
 o2_add_executable(colcontexttool
                   COMPONENT_NAME steer

--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -65,6 +65,7 @@ class O2MCApplicationBase : public FairMCApplication
   std::map<int, std::string> mSensitiveVolumes{}; // collection of all sensitive volumes with
                                                   // keeping track of volumeIds and volume names
 
+  double mLongestTrackTime = 0;
   /// some common parts of finishEvent
   void finishEventCommon();
   TrackRefFcn mTrackRefFcn; // a function hook that gets (optionally) called during Stepping

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -32,7 +32,7 @@
 #include "SimConfig/SimUserDecay.h"
 #include <filesystem>
 #include <CommonUtils/FileSystemUtils.h>
-#include "SimSetup/GlobalProcessCutSimParam.h"
+#include "SimConfig/GlobalProcessCutSimParam.h"
 
 namespace o2
 {

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -32,6 +32,7 @@
 #include "SimConfig/SimUserDecay.h"
 #include <filesystem>
 #include <CommonUtils/FileSystemUtils.h>
+#include "SimSetup/GlobalProcessCutSimParam.h"
 
 namespace o2
 {
@@ -56,6 +57,17 @@ void TypedVectorAttach(const char* name, fair::mq::Channel& channel, fair::mq::P
 void O2MCApplicationBase::Stepping()
 {
   mStepCounter++;
+
+  // check the max time of flight condition
+  const auto tof = fMC->TrackTime();
+  auto& params = o2::GlobalProcessCutSimParam::Instance();
+  if (tof > params.TOFMAX) {
+    fMC->StopTrack();
+    return;
+  }
+
+  mLongestTrackTime = std::max((double)mLongestTrackTime, tof);
+
   if (mCutParams.stepFiltering) {
     // we can kill tracks here based on our
     // custom detector specificities
@@ -181,6 +193,7 @@ bool O2MCApplicationBase::MisalignGeometry()
 void O2MCApplicationBase::finishEventCommon()
 {
   LOG(info) << "This event/chunk did " << mStepCounter << " steps";
+  LOG(info) << "Longest track time is " << mLongestTrackTime;
 
   auto header = static_cast<o2::dataformats::MCEventHeader*>(fMCEventHeader);
   header->getMCEventStats().setNSteps(mStepCounter);
@@ -214,6 +227,7 @@ void O2MCApplicationBase::BeginEvent()
   static_cast<o2::data::Stack*>(GetStack())->setMCEventStats(&header->getMCEventStats());
 
   mStepCounter = 0;
+  mLongestTrackTime = 0;
 }
 
 void addSpecialParticles()


### PR DESCRIPTION
We stop track propagation when the time of flight limit is reached. (Somehow this does not appear to be working correctly by just using the kTOFMAX cut value).

Set the default TOFMAX to 0.1s (instead of 1E10 seconds) which should be enough to capture afterglow effects in TPC etc. Still it prevents hits being created sometimes hours after the event, which in turn leads to crashes in some digitizers.

The commit is only relevant for certain studies, for example when low energy neutron physics is switched on.