### PR TITLE
TRD: VDrift: Update macro

### DIFF
--- a/Detectors/TRD/calibration/macros/makeDeflectionCorrelation.C
+++ b/Detectors/TRD/calibration/macros/makeDeflectionCorrelation.C
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <string>
 #include <utility>
+#include <tuple>
 #include <vector>
 
 // ROOT header
@@ -39,6 +40,7 @@
 #include <TLatex.h>
 #include <TPaveStats.h>
 #include <TStyle.h>
+#include <TLine.h>
 
 // O2 header
 #include "DataFormatsTRD/Constants.h"
@@ -58,8 +60,6 @@
 #define SNP_MAX 1.0
 #define SNP_MIN -1.0
 #define SNP_BINS DY_BINS
-#define CHAMBER 200
-#define NTRACKLETS 3
 #define FIT_MIN 1000
 #define TRACK_TYPE 15 // 1 = TPC-TRD, 15- ITS-TPC-TRD
 
@@ -68,7 +68,7 @@ static std::vector<std::tuple<double, double, int>> vmap[540];
 static bool good_ccdb_chambers[540];
 static o2::trd::NoiseStatusMCM* noiseMapPtr;
 
-static void ccdbDownload(unsigned int runNumber, std::string ccdb, timePoint queryInterval)
+static void ccdbDownload(unsigned int runNumber, std::string ccdb, std::string noiseMapPath, timePoint queryInterval)
 {
   auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
   ccdbMgr.setURL("http://alice-ccdb.cern.ch/");
@@ -81,7 +81,12 @@ static void ccdbDownload(unsigned int runNumber, std::string ccdb, timePoint que
   const auto endTime = grp->getTimeEnd();
   ccdbMgr.setURL(ccdb);
 
-  noiseMapPtr = ccdbMgr.get<o2::trd::NoiseStatusMCM>("TRD/Calib/NoiseStatusMCM");
+  if (noiseMapPath.empty()) {
+    noiseMapPtr = ccdbMgr.get<o2::trd::NoiseStatusMCM>("TRD/Calib/NoiseStatusMCM");
+  } else {
+    std::unique_ptr<TFile> fInNoiseMap(TFile::Open(noiseMapPath.c_str()));
+    noiseMapPtr = (o2::trd::NoiseStatusMCM*)fInNoiseMap->Get("map");
+  }
 }
 
 static void find_good()
@@ -117,7 +122,7 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
   //----------------------------------------------------
   // CCDB
   //----------------------------------------------------
-  ccdbDownload(runNumber, ccdb, queryInterval);
+  ccdbDownload(runNumber, ccdb, noiseMapPath, queryInterval);
   find_good();
 
   //----------------------------------------------------
@@ -137,13 +142,13 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
   auto hcorrelation_cal =
     new TH2F("hcorrelation_cal",
              "Correlation of #psi (#angle Dy) and #phi (#angle Snp) - ALL",
-             DY_BINS, DY_MIN, DY_MAX, SNP_BINS, SNP_MIN, SNP_MAX);
+             SNP_BINS, SNP_MIN, SNP_MAX, DY_BINS, DY_MIN, DY_MAX);
   hcorrelation_cal->GetXaxis()->SetTitle("#phi");
   hcorrelation_cal->GetYaxis()->SetTitle("#psi");
   hcorrelation_cal->GetZaxis()->SetTitle("entries");
   auto hcorrelation_uncal =
-    new TH2F("hcorrelation_uncal", "Uncalibrated", DY_BINS, DY_MIN, DY_MAX,
-             SNP_BINS, SNP_MIN, SNP_MAX);
+    new TH2F("hcorrelation_uncal", "Uncalibrated",
+             SNP_BINS, SNP_MIN, SNP_MAX, DY_BINS, DY_MIN, DY_MAX);
   hcorrelation_uncal->GetXaxis()->SetTitle("#phi");
   hcorrelation_uncal->GetYaxis()->SetTitle("#psi");
   hcorrelation_uncal->GetZaxis()->SetTitle("entries");
@@ -152,27 +157,70 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
   // Loop - Vars
   //----------------------------------------------------
   std::bitset<6> good;
-  std::array<std::pair<TH2F*, TH2F*>, o2::trd::constants::MAXCHAMBER> hall;
+  std::array<std::tuple<TH2F*, TH2F*, TH2F*, TH2F*, TH2F*, TH2F*, TGraphErrors*, TGraphErrors*>, o2::trd::constants::MAXCHAMBER> hall;
   for (int i = 0; i < o2::trd::constants::MAXCHAMBER; ++i) {
-    hall[i].first =
+    std::get<0>(hall[i]) =
       new TH2F(TString::Format("hcorrelation_cal_ch_%d", i),
-               TString::Format("Calibrated - Chamber %d", i), DY_BINS, DY_MIN,
-               DY_MAX, SNP_BINS, SNP_MIN, SNP_MAX);
-    hall[i].second =
+               TString::Format("Calibrated - Chamber %d", i),
+               SNP_BINS, SNP_MIN, SNP_MAX, DY_BINS, DY_MIN, DY_MAX);
+    std::get<0>(hall[i])->GetXaxis()->SetTitle("#phi");
+    std::get<0>(hall[i])->GetYaxis()->SetTitle("#psi");
+    std::get<0>(hall[i])->GetZaxis()->SetTitle("entries");
+    std::get<1>(hall[i]) =
       new TH2F(TString::Format("hcorrelation_uncal_ch_%d", i),
-               TString::Format("Uncalibrated - Chamber %d", i), DY_BINS,
-               DY_MIN, DY_MAX, SNP_BINS, SNP_MIN, SNP_MAX);
+               TString::Format("Uncalibrated - Chamber %d", i),
+               SNP_BINS, SNP_MIN, SNP_MAX, DY_BINS, DY_MIN, DY_MAX);
+    std::get<1>(hall[i])->GetXaxis()->SetTitle("#phi");
+    std::get<1>(hall[i])->GetYaxis()->SetTitle("#psi");
+    std::get<1>(hall[i])->GetZaxis()->SetTitle("entries");
+    std::get<2>(hall[i]) =
+      new TH2F(TString::Format("hchi2_da30_cal_%d", i),
+               TString::Format("Chi2 vs da Calibrated 30#pm2- Chamber %d", i), 100, -90.0, 90.0, 120,
+               0.0, 12.0);
+    std::get<2>(hall[i])->GetXaxis()->SetTitle("d#alpha");
+    std::get<2>(hall[i])->GetYaxis()->SetTitle("chi2Red");
+    std::get<2>(hall[i])->GetZaxis()->SetTitle("entries");
+    std::get<3>(hall[i]) =
+      new TH2F(TString::Format("hchi2_da30_uncal_%d", i),
+               TString::Format("Chi2 vs da Uncalibrated 30#pm2- Chamber %d", i), 100, -90.0, 90.0, 120,
+               0.0, 12.0);
+    std::get<3>(hall[i])->GetXaxis()->SetTitle("d#alpha");
+    std::get<3>(hall[i])->GetYaxis()->SetTitle("chi2Red");
+    std::get<3>(hall[i])->GetZaxis()->SetTitle("entries");
+    std::get<4>(hall[i]) =
+      new TH2F(TString::Format("hchi2_da10_cal_%d", i),
+               TString::Format("Chi2 vs da Calibrated 10#pm2- Chamber %d", i), 100, -90.0, 90.0, 120,
+               0.0, 12.0);
+    std::get<4>(hall[i])->GetXaxis()->SetTitle("d#alpha");
+    std::get<4>(hall[i])->GetYaxis()->SetTitle("chi2Red");
+    std::get<4>(hall[i])->GetZaxis()->SetTitle("entries");
+    std::get<5>(hall[i]) =
+      new TH2F(TString::Format("hchi2_da10_uncal_%d", i),
+               TString::Format("Chi2 vs da Uncalibrated 10#pm2- Chamber %d", i), 100, -90.0, 90.0, 120,
+               0.0, 12.0);
+    std::get<5>(hall[i])->GetXaxis()->SetTitle("d#alpha");
+    std::get<5>(hall[i])->GetYaxis()->SetTitle("chi2Red");
+    std::get<5>(hall[i])->GetZaxis()->SetTitle("entries");
+    std::get<6>(hall[i]) = new TGraphErrors();
+    std::get<6>(hall[i])->SetNameTitle(TString::Format("gchi2_rms_30_%d", i), TString::Format("Chi2 vs RMS - Chamber %d", i));
+    std::get<6>(hall[i])->GetXaxis()->SetTitle("chi2Red");
+    std::get<6>(hall[i])->GetYaxis()->SetTitle("d#alpha RMS");
+    std::get<7>(hall[i]) = new TGraphErrors();
+    std::get<7>(hall[i])->SetNameTitle(TString::Format("gchi2_rms_10_%d", i), TString::Format("Chi2 vs RMS - Chamber %d", i));
+    std::get<7>(hall[i])->GetXaxis()->SetTitle("chi2Red");
+    std::get<7>(hall[i])->GetYaxis()->SetTitle("d#alpha RMS");
   }
   unsigned int chamber;
   std::array<bool, o2::trd::constants::MAXCHAMBER> good_chambers;
   good_chambers.fill(false);
+  auto nEntries = chain.GetEntries();
 
   //----------------------------------------------------
   // Loop
   //----------------------------------------------------
-  for (int iEntry = 0; iEntry < chain.GetEntries(); ++iEntry) {
+  for (int iEntry = 0; iEntry < nEntries; ++iEntry) {
     chain.GetEntry(iEntry);
-    printf("Started loop %d: Entries: %ld\n", iEntry, qc.size());
+    printf("Started loop %d/%lld: Entries: %ld\n", iEntry, nEntries, qc.size());
     for (const auto& q : qc) {
       //----------------------------------------------------
       // Cuts
@@ -211,20 +259,54 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
           hcorrelation_cal->Fill(phi, psi_cal);
           hcorrelation_uncal->Fill(phi, psi_un);
 
+          float eAngle = psi_cal * TMath::RadToDeg();
+
           good_chambers[chamber] = true;
 
           // Fill all
-          hall[chamber].first->Fill(phi, psi_cal);
-          hall[chamber].second->Fill(phi, psi_un);
+          std::get<0>(hall[chamber])->Fill(phi, psi_cal);
+          std::get<1>(hall[chamber])->Fill(phi, psi_un);
+          if (eAngle >= 28.f && eAngle <= 32.f) {
+            float da_cal = (psi_cal - phi) * TMath::RadToDeg();
+            float da_un = (psi_un - phi) * TMath::RadToDeg();
+            std::get<2>(hall[chamber])->Fill(da_cal, q.reducedChi2);
+            std::get<3>(hall[chamber])->Fill(da_un, q.reducedChi2);
+          } else if (eAngle >= 8.f && eAngle <= 12.f) {
+            float da_cal = (psi_cal - phi) * TMath::RadToDeg();
+            float da_un = (psi_un - phi) * TMath::RadToDeg();
+            std::get<4>(hall[chamber])->Fill(da_cal, q.reducedChi2);
+            std::get<5>(hall[chamber])->Fill(da_un, q.reducedChi2);
+          }
         }
       }
+    }
+  }
+  // Project onto X and get RMS
+  for (int i = 0; i < o2::trd::constants::MAXCHAMBER; ++i) {
+    auto nBins30 = std::get<2>(hall[i])->GetNbinsX();
+    for (int iBin = 1; iBin < nBins30; ++iBin) {
+      auto chi2 = std::get<2>(hall[i])->GetYaxis()->GetBinCenter(iBin);
+      auto proj = std::get<2>(hall[i])->ProjectionX("projX", iBin, iBin + 1);
+      auto rms = proj->GetRMS();
+      auto rmsError = proj->GetRMSError();
+      std::get<6>(hall[i])->AddPoint(chi2, rms);
+      std::get<6>(hall[i])->SetPointError(iBin, 0, rmsError);
+    }
+    auto nBins10 = std::get<4>(hall[i])->GetNbinsX();
+    for (int iBin = 1; iBin < nBins10; ++iBin) {
+      auto chi2 = std::get<2>(hall[i])->GetYaxis()->GetBinCenter(iBin);
+      auto proj = std::get<2>(hall[i])->ProjectionX("projX", iBin, iBin + 1);
+      auto rms = proj->GetRMS();
+      auto rmsError = proj->GetRMSError();
+      std::get<7>(hall[i])->AddPoint(chi2, rms);
+      std::get<7>(hall[i])->SetPointError(iBin, 0, rmsError);
     }
   }
 
   // Find chambers with too few entries
   int i = 0;
   for (auto& h : hall) {
-    if (h.first->GetEntries() < FIT_MIN)
+    if (std::get<0>(h)->GetEntries() < FIT_MIN)
       good_chambers[i] = false;
     ++i;
   }
@@ -239,7 +321,7 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
   for (int i = 0; i < o2::trd::constants::MAXCHAMBER; ++i) {
     x_all[i] = i;
     if (good_chambers[i] && good_ccdb_chambers[i]) {
-      auto fitResCal = hall[i].first->Fit("pol1", "SQC", "", -0.6, -0.2);
+      auto fitResCal = std::get<0>(hall[i])->Fit("pol1", "SQC", "", -0.6, -0.2);
       if (fitResCal.Get() != nullptr) {
         p0_cal[i] = fitResCal->Parameter(0);
         p0e_cal[i] = fitResCal->ParError(0);
@@ -252,7 +334,7 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
         p1e_cal[i] = 0.0;
       }
 
-      auto fitResUncal = hall[i].second->Fit("pol1", "SQC", "", -0.6, -0.2);
+      auto fitResUncal = std::get<1>(hall[i])->Fit("pol1", "SQC", "", -0.6, -0.2);
       if (fitResUncal.Get() != nullptr) {
         p0_uncal[i] = fitResUncal->Parameter(0);
         p0e_uncal[i] = fitResUncal->ParError(0);
@@ -346,12 +428,49 @@ void makeDeflectionCorrelation(unsigned int runNumber = 523677, std::string ccdb
   // ----------------------------------------------------
   // Write
   // ----------------------------------------------------
+  auto diagLine = new TLine(-1.0, -1.0, 1.0, 1.0);
+  diagLine->SetLineColor(kBlue);
   outFilePtr->mkdir("chambers");
   outFilePtr->cd("chambers");
-  for (auto& hist : hall) {
-    hist.first->Write();
-    hist.second->Write();
+  for (int i = 0; i < o2::trd::constants::MAXCHAMBER; ++i) {
+    c = new TCanvas(Form("chamber_%d_cor", i), Form("Chamber %d Correlation", i));
+    c->Divide(2, 1);
+    c->cd(1);
+    std::get<0>(hall[i])->Draw("colz");
+    gPad->SetLogz();
+    diagLine->Draw();
+    c->cd(2);
+    std::get<1>(hall[i])->Draw("colz");
+    gPad->SetLogz();
+    diagLine->Draw();
+    c->Write();
+
+    c = new TCanvas(Form("chamber_%d_chi2", i), Form("Chamber %d Chi2", i));
+    c->Divide(2, 2);
+    c->cd(1);
+    std::get<2>(hall[i])->Draw("colz");
+    gPad->SetLogz();
+    c->cd(2);
+    std::get<3>(hall[i])->Draw("colz");
+    gPad->SetLogz();
+    c->cd(3);
+    std::get<4>(hall[i])->Draw("colz");
+    gPad->SetLogz();
+    c->cd(4);
+    std::get<5>(hall[i])->Draw("colz");
+    gPad->SetLogz();
+    c->Write();
+
+    c = new TCanvas(Form("chamber_%d_rms", i), Form("Chamber %d RMS", i));
+    c->Divide(2, 1);
+    c->cd(1);
+    std::get<6>(hall[i])->Draw("A");
+    c->cd(2);
+    std::get<7>(hall[i])->Draw("A");
+
+    c->Write();
   }
+  outFilePtr->cd("..");
 
   // ----------------------------------------------------
   // No tracklets in chamber


### PR DESCRIPTION
This patch updates the makeDeflectionCorrelation macro to be more flexible and allows for more 'interesting' plots.

The main idea is search for cuts (on chi2, nTracklets) that would be appropriate for the vdrift and exb calibration.

Note: This is not tested, I only upload the code so that @luisabergmann can work with it.