### PR TITLE
[O2-1787] Add side bar in the Cage side panels. Fix small overlap with services

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
@@ -124,6 +124,8 @@ class V3Cage : public V11Geometry
   static const Double_t sCageSidePanelGuideWide; ///< Side panel guide X width
   static const Double_t sCageSidePanelGuidThik1; ///< Side panel guide thickness
   static const Double_t sCageSidePanelGuidThik2; ///< Side panel guide thickness
+  static const Double_t sCageSidePanelMidBarWid; ///< Side panel middle bar width
+  static const Double_t sCageSidePanelSidBarWid; ///< Side panel side bar width
 
   static const Double_t sCageSidePanelRail1Ypos[2]; ///< Side panel rail 1 Y pos
   static const Double_t sCageSidePanelRail2Ypos;    ///< Side panel rail 2 Y pos

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
@@ -2935,7 +2935,7 @@ void V3Services::createAllITSServices(TGeoVolume* mother, const TGeoManager* mgr
   static const Double_t sIBServicesZOut = 253.45 * sCm;
 
   static const Double_t sIBServicesR1max = 13.3 * sCm;
-  static const Double_t sIBServicesR2max = 43.63 * sCm;
+  static const Double_t sIBServicesR2max = 43.53 * sCm;
 
   static const Double_t sIBServicesCarbonThick = 0.2 * sCm;
   static const Double_t sIBServicesCopperThick = 0.018 * sCm;
@@ -2945,7 +2945,7 @@ void V3Services::createAllITSServices(TGeoVolume* mother, const TGeoManager* mgr
   static const Double_t sOBServicesZIn = 83.0 * sCm;
   static const Double_t sOBServicesZOut = 248.00 * sCm;
 
-  static const Double_t sOBServicesRmax = 47.3 * sCm;
+  static const Double_t sOBServicesRmax = 47.2 * sCm;
 
   static const Double_t sOBServicesTotalThick = 4.42 * sCm;
   static const Double_t sOBServicesCarbonThick = 0.25 * sCm;
@@ -2994,7 +2994,7 @@ void V3Services::createAllITSServices(TGeoVolume* mother, const TGeoManager* mgr
   rmax = ibPolySh->GetRmax(2) - sIBServicesPolymerThick / 1.8;
   ibWaterSh->DefineSection(2, sIBServicesZOut, rmin, rmax);
 
-  // The Inner Barrel services as Tube's
+  // The Outer Barrel services as Tube's
   // Carbon
   rmin = sOBServicesRmax - sOBServicesTotalThick;
   zlen = sOBServicesZOut - sOBServicesZIn;


### PR DESCRIPTION
Two side bars belonging to the rails inside the lateral panels of the ITS Cage were added: this should improve the material budget description with respect to real data. These new elements were inserted in the V3Cage class.
At the same time a small overlap between the panels and the rough elements describing the ITS services (passed unnoticed in the first implementation) was fixed in the V3Services class.