### PR TITLE
Adapting MFT assessment histograms ranges and replacing one variable

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
@@ -133,7 +133,7 @@ class GloFwdAssessment
   std::array<std::unique_ptr<TH1F>, 7> mTrackPhiNCls = {nullptr};
   std::array<std::unique_ptr<TH2F>, 7> mTrackXYNCls = {nullptr};
   std::array<std::unique_ptr<TH2F>, 7> mTrackEtaPhiNCls = {nullptr};
-  std::unique_ptr<TH1F> mTrackTanl = nullptr;
+  std::unique_ptr<TH1F> mTrackCotl = nullptr;
 
   // Histos and data for MC analysis
   std::vector<std::string> mNameOfTrackTypes = {"Rec",
@@ -176,7 +176,7 @@ class GloFwdAssessment
     kTH3GMTrackXPullPtEta,
     kTH3GMTrackYPullPtEta,
     kTH3GMTrackPhiPullPtEta,
-    kTH3GMTrackTanlPullPtEta,
+    kTH3GMTrackCotlPullPtEta,
     kTH3GMTrackInvQPtPullPtEta,
     kTH3GMTrackReducedChi2PtEta,
     kTH3GMTrackPtEtaChi2,
@@ -200,7 +200,7 @@ class GloFwdAssessment
     {kTH3GMTrackXPullPtEta, "TH3GMTrackXPullPtEta"},
     {kTH3GMTrackYPullPtEta, "TH3GMTrackYPullPtEta"},
     {kTH3GMTrackPhiPullPtEta, "TH3GMTrackPhiPullPtEta"},
-    {kTH3GMTrackTanlPullPtEta, "TH3GMTrackTanlPullPtEta"},
+    {kTH3GMTrackCotlPullPtEta, "TH3GMTrackCotlPullPtEta"},
     {kTH3GMTrackInvQPtPullPtEta, "TH3GMTrackInvQPtPullPtEta"},
     {kTH3GMTrackReducedChi2PtEta, "TH3GMTrackReducedChi2PtEta"},
     {kTH3GMCloseMatchPtEtaChi2, "TH3GMCloseMatchPtEtaChi2"},
@@ -222,7 +222,7 @@ class GloFwdAssessment
     {kTH3GMTrackXPullPtEta, "TH3GMTrackXPullPtEta"},
     {kTH3GMTrackYPullPtEta, "TH3GMTrackYPullPtEta"},
     {kTH3GMTrackPhiPullPtEta, "TH3GMTrackPhiPullPtEta"},
-    {kTH3GMTrackTanlPullPtEta, "TH3GMTrackTanlPullPtEta"},
+    {kTH3GMTrackCotlPullPtEta, "TH3GMTrackCotlPullPtEta"},
     {kTH3GMTrackInvQPtPullPtEta, "TH3GMTrackInvQPtPullPtEta"},
     {kTH3GMTrackReducedChi2PtEta, "TH3GMTrackReducedChi2PtEta"},
     {kTH3GMCloseMatchPtEtaChi2, "TH3GMCloseMatchPtEtaChi2"},
@@ -244,7 +244,7 @@ class GloFwdAssessment
     {kTH3GMTrackXPullPtEta, {40, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
     {kTH3GMTrackYPullPtEta, {40, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
     {kTH3GMTrackPhiPullPtEta, {40, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
-    {kTH3GMTrackTanlPullPtEta, {40, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
+    {kTH3GMTrackCotlPullPtEta, {40, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
     {kTH3GMTrackInvQPtPullPtEta, {40, 0, 20, 16, 2.2, 3.8, 200, -50, 50}},
     {kTH3GMTrackReducedChi2PtEta, {40, 0, 20, 16, 2.2, 3.8, 1000, 0, 100}},
     {kTH3GMCloseMatchPtEtaChi2, {40, 0, 20, 16, 2.2, 3.8, 1000, 0, 100}},
@@ -266,7 +266,7 @@ class GloFwdAssessment
     {kTH3GMTrackXPullPtEta, R"(p_{t}_{MC})"},
     {kTH3GMTrackYPullPtEta, R"(p_{t}_{MC})"},
     {kTH3GMTrackPhiPullPtEta, R"(p_{t}_{MC})"},
-    {kTH3GMTrackTanlPullPtEta, R"(p_{t}_{MC})"},
+    {kTH3GMTrackCotlPullPtEta, R"(p_{t}_{MC})"},
     {kTH3GMTrackInvQPtPullPtEta, R"(p_{t}_{MC})"},
     {kTH3GMTrackReducedChi2PtEta, R"(p_{t}_{MC})"},
     {kTH3GMCloseMatchPtEtaChi2, R"(p_{t}_{Fit})"},
@@ -288,7 +288,7 @@ class GloFwdAssessment
     {kTH3GMTrackXPullPtEta, R"(\eta_{MC})"},
     {kTH3GMTrackYPullPtEta, R"(\eta_{MC})"},
     {kTH3GMTrackPhiPullPtEta, R"(\eta_{MC})"},
-    {kTH3GMTrackTanlPullPtEta, R"(\eta_{MC})"},
+    {kTH3GMTrackCotlPullPtEta, R"(\eta_{MC})"},
     {kTH3GMTrackInvQPtPullPtEta, R"(\eta_{MC})"},
     {kTH3GMTrackReducedChi2PtEta, R"(\eta_{MC})"},
     {kTH3GMCloseMatchPtEtaChi2, R"(\eta_{Fit})"},
@@ -310,7 +310,7 @@ class GloFwdAssessment
     {kTH3GMTrackXPullPtEta, R"(\Delta X/\sigma_{X})"},
     {kTH3GMTrackYPullPtEta, R"(\Delta Y/\sigma_{Y})"},
     {kTH3GMTrackPhiPullPtEta, R"(\Delta \phi/\sigma_{\phi})"},
-    {kTH3GMTrackTanlPullPtEta, R"(\Delta \tan(\lambda)/\sigma_{tan(\lambda)})"},
+    {kTH3GMTrackCotlPullPtEta, R"(\Delta \cot(\lambda)/\sigma_{cot(\lambda)})"},
     {kTH3GMTrackInvQPtPullPtEta, R"((\Delta q/p_t)/\sigma_{q/p_{t}})"},
     {kTH3GMTrackReducedChi2PtEta, R"(\chi^2/d.f.)"},
     {kTH3GMCloseMatchPtEtaChi2, R"(Match \chi^2)"},
@@ -337,8 +337,8 @@ class GloFwdAssessment
     kInvQPtResMCHVsPt,
     kPhiPullVsEta,
     kPhiPullVsPt,
-    kTanlPullVsEta,
-    kTanlPullVsPt,
+    kCotlPullVsEta,
+    kCotlPullVsPt,
     kInvQPtPullVsEta,
     kInvQPtPullVsPt,
     kNSlicedTH3
@@ -359,8 +359,8 @@ class GloFwdAssessment
     {kInvQPtResMCHVsPt, "InvQPtResMCHVsPt"},
     {kPhiPullVsEta, "PhiPullVsEta"},
     {kPhiPullVsPt, "PhiPullVsPt"},
-    {kTanlPullVsEta, "TanlPullVsEta"},
-    {kTanlPullVsPt, "TanlPullVsPt"},
+    {kCotlPullVsEta, "CotlPullVsEta"},
+    {kCotlPullVsPt, "CotlPullVsPt"},
     {kInvQPtPullVsEta, "InvQPtPullVsEta"},
     {kInvQPtPullVsPt, "InvQPtPullVsPt"}};
 
@@ -379,8 +379,8 @@ class GloFwdAssessment
     {kInvQPtResMCHVsPt, kTH3GMTrackInvQPtResMCHPtEta},
     {kPhiPullVsEta, kTH3GMTrackPhiPullPtEta},
     {kPhiPullVsPt, kTH3GMTrackPhiPullPtEta},
-    {kTanlPullVsEta, kTH3GMTrackTanlPullPtEta},
-    {kTanlPullVsPt, kTH3GMTrackTanlPullPtEta},
+    {kCotlPullVsEta, kTH3GMTrackCotlPullPtEta},
+    {kCotlPullVsPt, kTH3GMTrackCotlPullPtEta},
     {kInvQPtPullVsEta, kTH3GMTrackInvQPtPullPtEta},
     {kInvQPtPullVsPt, kTH3GMTrackInvQPtPullPtEta}};
 

--- a/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
@@ -46,7 +46,7 @@ void GloFwdAssessment::reset()
     mTrackEtaPhiNCls[nHisto]->Reset();
   }
 
-  mTrackTanl->Reset();
+  mTrackCotl->Reset();
 
   if (mUseMC) {
     mPairables.clear();
@@ -88,7 +88,7 @@ void GloFwdAssessment::createHistos()
 
   mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
 
-  mTrackChi2 = std::make_unique<TH1F>("mGlobalFwdChi2", "Track #chi^{2}; #chi^{2}; # entries", 21, -0.5, 20.5);
+  mTrackChi2 = std::make_unique<TH1F>("mGlobalFwdChi2", "Track #chi^{2}; #chi^{2}; # entries", 510, -0.5, 50.5);
 
   mTrackCharge = std::make_unique<TH1F>("mGlobalFwdCharge", "Track Charge; q; # entries", 3, -1.5, 1.5);
 
@@ -109,7 +109,7 @@ void GloFwdAssessment::createHistos()
     mTrackEtaPhiNCls[nHisto]->SetOption("COLZ");
   }
 
-  mTrackTanl = std::make_unique<TH1F>("mGlobalFwdTanl", "Track tan #lambda; tan #lambda; # entries", 100, -25, 0);
+  mTrackCotl = std::make_unique<TH1F>("mGlobalFwdCotl", "Track cot #lambda; cot #lambda; # entries", 100, -25, 0);
 
   // Creating MC-based histos
   if (mUseMC) {
@@ -223,7 +223,7 @@ void GloFwdAssessment::runBasicQC(o2::framework::ProcessingContext& ctx)
     mTrackCharge->Fill(oneTrack.getCharge());
     mTrackPhi->Fill(oneTrack.getPhi());
     mTrackEta->Fill(oneTrack.getEta());
-    mTrackTanl->Fill(oneTrack.getTanl());
+    mTrackCotl->Fill(1. / oneTrack.getTanl());
 
     for (auto minNClusters : sMinNClustersList) {
       if (nClusters >= minNClusters) {
@@ -400,7 +400,7 @@ void GloFwdAssessment::processTrueTracks()
           const auto y_res = fwdTrack.getY() - vyGen;
           const auto eta_res = fwdTrack.getEta() - etaGen;
           const auto phi_res = fwdTrack.getPhi() - phiGen;
-          const auto tanl_res = fwdTrack.getTanl() - tanlGen;
+          const auto cotl_res = (1. / fwdTrack.getTanl()) - (1. / tanlGen);
           const auto invQPt_res = invQPt_Rec - invQPtGen;
           mHistPtVsEta[kRecoTrue]->Fill(eta_Rec, pt_Rec);
           mHistPhiVsEta[kRecoTrue]->Fill(eta_Rec, phi_Rec);
@@ -421,7 +421,7 @@ void GloFwdAssessment::processTrueTracks()
           mTH3Histos[kTH3GMTrackXPullPtEta]->Fill(ptGen, etaGen, x_res / sqrt(fwdTrack.getCovariances()(0, 0)));
           mTH3Histos[kTH3GMTrackYPullPtEta]->Fill(ptGen, etaGen, y_res / sqrt(fwdTrack.getCovariances()(1, 1)));
           mTH3Histos[kTH3GMTrackPhiPullPtEta]->Fill(ptGen, etaGen, phi_res / sqrt(fwdTrack.getCovariances()(2, 2)));
-          mTH3Histos[kTH3GMTrackTanlPullPtEta]->Fill(ptGen, etaGen, tanl_res / sqrt(fwdTrack.getCovariances()(3, 3)));
+          mTH3Histos[kTH3GMTrackCotlPullPtEta]->Fill(ptGen, etaGen, cotl_res / sqrt(1. / fwdTrack.getCovariances()(3, 3)));
           mTH3Histos[kTH3GMTrackInvQPtPullPtEta]->Fill(ptGen, etaGen, invQPt_res / sqrt(fwdTrack.getCovariances()(4, 4)));
           mTH3Histos[kTH3GMTrackInvQPtResolutionPtEta]->Fill(ptGen, etaGen, (invQPt_Rec - invQPtGen) / invQPtGen);
           mTH3Histos[kTH3GMTrackInvQPtResMCHPtEta]->Fill(ptGen, etaGen, (invQPt_MCH - invQPtGen) / invQPtGen);
@@ -477,7 +477,7 @@ void GloFwdAssessment::getHistos(TObjArray& objar)
     objar.Add(mTrackXYNCls[nHisto].get());
     objar.Add(mTrackEtaPhiNCls[nHisto].get());
   }
-  objar.Add(mTrackTanl.get());
+  objar.Add(mTrackCotl.get());
 
   if (mUseMC) {
     objar.Add(mHistPhiRecVsPhiGen.get());
@@ -552,7 +552,7 @@ void GloFwdAssessment::loadHistos()
     mTrackEtaPhiNCls[nHisto] = std::unique_ptr<TH2F>((TH2F*)f->Get(Form("mGlobalFwdEtaPhi_%d_MinClusters", minNClusters)));
   }
 
-  mTrackTanl = std::unique_ptr<TH1F>((TH1F*)f->Get("mGlobalFwdTanl"));
+  mTrackCotl = std::unique_ptr<TH1F>((TH1F*)f->Get("mGlobalFwdCotl"));
 
   // Creating MC-based histos
   if (mUseMC) {

--- a/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
@@ -86,7 +86,7 @@ void GloFwdAssessment::createHistos()
   mTrackNumberOfClusters = std::make_unique<TH1F>("mGlobalFwdNumberOfMFTClusters",
                                                   "Number Of Clusters Per Track; # clusters; # entries", 10, 0.5, 10.5);
 
-  mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 200, -10, 10);
+  mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 100, -5, 5);
 
   mTrackChi2 = std::make_unique<TH1F>("mGlobalFwdChi2", "Track #chi^{2}; #chi^{2}; # entries", 202, -0.5, 100.5);
 

--- a/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
@@ -86,9 +86,9 @@ void GloFwdAssessment::createHistos()
   mTrackNumberOfClusters = std::make_unique<TH1F>("mGlobalFwdNumberOfMFTClusters",
                                                   "Number Of Clusters Per Track; # clusters; # entries", 10, 0.5, 10.5);
 
-  mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
+  mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 200, -10, 10);
 
-  mTrackChi2 = std::make_unique<TH1F>("mGlobalFwdChi2", "Track #chi^{2}; #chi^{2}; # entries", 510, -0.5, 50.5);
+  mTrackChi2 = std::make_unique<TH1F>("mGlobalFwdChi2", "Track #chi^{2}; #chi^{2}; # entries", 202, -0.5, 100.5);
 
   mTrackCharge = std::make_unique<TH1F>("mGlobalFwdCharge", "Track Charge; q; # entries", 3, -1.5, 1.5);
 
@@ -109,7 +109,7 @@ void GloFwdAssessment::createHistos()
     mTrackEtaPhiNCls[nHisto]->SetOption("COLZ");
   }
 
-  mTrackCotl = std::make_unique<TH1F>("mGlobalFwdCotl", "Track cot #lambda; cot #lambda; # entries", 100, -25, 0);
+  mTrackCotl = std::make_unique<TH1F>("mGlobalFwdCotl", "Track cot #lambda; cot #lambda; # entries", 100, -0.25, 0);
 
   // Creating MC-based histos
   if (mUseMC) {

--- a/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
+++ b/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
@@ -153,7 +153,7 @@ class MFTAssessment
   std::array<std::unique_ptr<TH2F>, 7> mTrackEtaPhiNCls = {nullptr};
   std::unique_ptr<TH1F> mCATrackEta = nullptr;
   std::unique_ptr<TH1F> mLTFTrackEta = nullptr;
-  std::unique_ptr<TH1F> mTrackTanl = nullptr;
+  std::unique_ptr<TH1F> mTrackCotl = nullptr;
 
   std::unique_ptr<TH1F> mTrackROFNEntries = nullptr;
   std::unique_ptr<TH1F> mClusterROFNEntries = nullptr;
@@ -199,7 +199,7 @@ class MFTAssessment
     kTH3TrackXPullPtEta,
     kTH3TrackYPullPtEta,
     kTH3TrackPhiPullPtEta,
-    kTH3TrackTanlPullPtEta,
+    kTH3TrackCotlPullPtEta,
     kTH3TrackInvQPtPullPtEta,
     kTH3TrackReducedChi2PtEta,
     kNTH3Histos
@@ -215,7 +215,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, "TH3TrackXPullPtEta"},
     {kTH3TrackYPullPtEta, "TH3TrackYPullPtEta"},
     {kTH3TrackPhiPullPtEta, "TH3TrackPhiPullPtEta"},
-    {kTH3TrackTanlPullPtEta, "TH3TrackTanlPullPtEta"},
+    {kTH3TrackCotlPullPtEta, "TH3TrackCotlPullPtEta"},
     {kTH3TrackInvQPtPullPtEta, "TH3TrackInvQPtPullPtEta"},
     {kTH3TrackReducedChi2PtEta, "TH3TrackReducedChi2PtEta"}};
 
@@ -229,7 +229,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, "TH3TrackXPullPtEta"},
     {kTH3TrackYPullPtEta, "TH3TrackYPullPtEta"},
     {kTH3TrackPhiPullPtEta, "TH3TrackPhiPullPtEta"},
-    {kTH3TrackTanlPullPtEta, "TH3TrackTanlPullPtEta"},
+    {kTH3TrackCotlPullPtEta, "TH3TrackCotlPullPtEta"},
     {kTH3TrackInvQPtPullPtEta, "TH3TrackInvQPtPullPtEta"},
     {kTH3TrackReducedChi2PtEta, "TH3TrackReducedChi2PtEta"}};
 
@@ -243,7 +243,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, {100, 0, 20, 16, -3.8, -2.2, 200, -10, 10}},
     {kTH3TrackYPullPtEta, {100, 0, 20, 16, -3.8, -2.2, 200, -10, 10}},
     {kTH3TrackPhiPullPtEta, {100, 0, 20, 16, -3.8, -2.2, 200, -10, 10}},
-    {kTH3TrackTanlPullPtEta, {100, 0, 20, 16, -3.8, -2.2, 200, -10, 10}},
+    {kTH3TrackCotlPullPtEta, {100, 0, 20, 16, -3.8, -2.2, 200, -10, 10}},
     {kTH3TrackInvQPtPullPtEta, {100, 0, 20, 16, -3.8, -2.2, 1000, -15, 15}},
     {kTH3TrackReducedChi2PtEta, {100, 0, 20, 16, -3.8, -2.2, 1000, 0, 100}}};
 
@@ -257,7 +257,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, R"(p_{t})"},
     {kTH3TrackYPullPtEta, R"(p_{t})"},
     {kTH3TrackPhiPullPtEta, R"(p_{t})"},
-    {kTH3TrackTanlPullPtEta, R"(p_{t})"},
+    {kTH3TrackCotlPullPtEta, R"(p_{t})"},
     {kTH3TrackInvQPtPullPtEta, R"(p_{t})"},
     {kTH3TrackReducedChi2PtEta, R"(p_{t})"}};
 
@@ -271,7 +271,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, R"(\eta)"},
     {kTH3TrackYPullPtEta, R"(\eta)"},
     {kTH3TrackPhiPullPtEta, R"(\eta)"},
-    {kTH3TrackTanlPullPtEta, R"(\eta)"},
+    {kTH3TrackCotlPullPtEta, R"(\eta)"},
     {kTH3TrackInvQPtPullPtEta, R"(\eta)"},
     {kTH3TrackReducedChi2PtEta, R"(\eta)"}};
 
@@ -285,7 +285,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, R"(\Delta X/\sigma_{X})"},
     {kTH3TrackYPullPtEta, R"(\Delta Y/\sigma_{Y})"},
     {kTH3TrackPhiPullPtEta, R"(\Delta \phi/\sigma_{\phi})"},
-    {kTH3TrackTanlPullPtEta, R"(\Delta \tan(\lambda)/\sigma_{tan(\lambda)})"},
+    {kTH3TrackCotlPullPtEta, R"(\Delta \tan(\lambda)/\sigma_{tan(\lambda)})"},
     {kTH3TrackInvQPtPullPtEta, R"((\Delta q/p_t)/\sigma_{q/p_{t}})"},
     {kTH3TrackReducedChi2PtEta, R"(\chi^2/d.f.)"}};
 
@@ -304,8 +304,8 @@ class MFTAssessment
     kInvQPtResSeedVsPt,
     kPhiPullVsEta,
     kPhiPullVsPt,
-    kTanlPullVsEta,
-    kTanlPullVsPt,
+    kCotlPullVsEta,
+    kCotlPullVsPt,
     kInvQPtPullVsEta,
     kInvQPtPullVsPt,
     kNSlicedTH3
@@ -326,8 +326,8 @@ class MFTAssessment
     {kInvQPtResSeedVsPt, "InvQPtResSeedVsPt"},
     {kPhiPullVsEta, "PhiPullVsEta"},
     {kPhiPullVsPt, "PhiPullVsPt"},
-    {kTanlPullVsEta, "TanlPullVsEta"},
-    {kTanlPullVsPt, "TanlPullVsPt"},
+    {kCotlPullVsEta, "CotlPullVsEta"},
+    {kCotlPullVsPt, "CotlPullVsPt"},
     {kInvQPtPullVsEta, "InvQPtPullVsEta"},
     {kInvQPtPullVsPt, "InvQPtPullVsPt"}};
 
@@ -346,8 +346,8 @@ class MFTAssessment
     {kInvQPtResSeedVsPt, kTH3TrackInvQPtResSeedPtEta},
     {kPhiPullVsEta, kTH3TrackPhiPullPtEta},
     {kPhiPullVsPt, kTH3TrackPhiPullPtEta},
-    {kTanlPullVsEta, kTH3TrackTanlPullPtEta},
-    {kTanlPullVsPt, kTH3TrackTanlPullPtEta},
+    {kCotlPullVsEta, kTH3TrackCotlPullPtEta},
+    {kCotlPullVsPt, kTH3TrackCotlPullPtEta},
     {kInvQPtPullVsEta, kTH3TrackInvQPtPullPtEta},
     {kInvQPtPullVsPt, kTH3TrackInvQPtPullPtEta}};
 

--- a/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
+++ b/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
@@ -285,7 +285,7 @@ class MFTAssessment
     {kTH3TrackXPullPtEta, R"(\Delta X/\sigma_{X})"},
     {kTH3TrackYPullPtEta, R"(\Delta Y/\sigma_{Y})"},
     {kTH3TrackPhiPullPtEta, R"(\Delta \phi/\sigma_{\phi})"},
-    {kTH3TrackCotlPullPtEta, R"(\Delta \tan(\lambda)/\sigma_{tan(\lambda)})"},
+    {kTH3TrackCotlPullPtEta, R"(\Delta \cot(\lambda)/\sigma_{cot(\lambda)})"},
     {kTH3TrackInvQPtPullPtEta, R"((\Delta q/p_t)/\sigma_{q/p_{t}})"},
     {kTH3TrackReducedChi2PtEta, R"(\chi^2/d.f.)"}};
 

--- a/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
+++ b/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
@@ -72,7 +72,7 @@ void MFTAssessment::reset()
   }
   mCATrackEta->Reset();
   mLTFTrackEta->Reset();
-  mTrackTanl->Reset();
+  mTrackCotl->Reset();
 
   mTrackROFNEntries->Reset();
   mClusterROFNEntries->Reset();
@@ -139,7 +139,7 @@ void MFTAssessment::createHistos()
 
   mTrackInvQPt = std::make_unique<TH1F>("mMFTTrackInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
 
-  mTrackChi2 = std::make_unique<TH1F>("mMFTTrackChi2", "Track #chi^{2}/NDF; #chi^{2}/NDF; # entries", 210, -0.5, 20.5);
+  mTrackChi2 = std::make_unique<TH1F>("mMFTTrackChi2", "Track #chi^{2}/NDF; #chi^{2}/NDF; # entries", 510, -0.5, 50.5);
 
   mTrackCharge = std::make_unique<TH1F>("mMFTTrackCharge", "Track Charge; q; # entries", 3, -1.5, 1.5);
 
@@ -184,7 +184,7 @@ void MFTAssessment::createHistos()
 
   mLTFTrackEta = std::make_unique<TH1F>("mMFTLTFTrackEta", "LTF Track #eta; #eta; # entries", 50, -4, -2);
 
-  mTrackTanl = std::make_unique<TH1F>("mMFTTrackTanl", "Track tan #lambda; tan #lambda; # entries", 100, -25, 0);
+  mTrackCotl = std::make_unique<TH1F>("mMFTTrackCotl", "Track cot #lambda; cot #lambda; # entries", 100, -25, 0);
 
   mClusterROFNEntries = std::make_unique<TH1F>("mMFTClustersROFSize", "MFT Cluster ROFs size; ROF Size; # entries", MaxClusterROFSize, 0, MaxClusterROFSize);
 
@@ -367,7 +367,7 @@ void MFTAssessment::runASyncQC(o2::framework::ProcessingContext& ctx)
     mTrackCharge->Fill(oneTrack.getCharge());
     mTrackPhi->Fill(oneTrack.getPhi());
     mTrackEta->Fill(oneTrack.getEta());
-    mTrackTanl->Fill(oneTrack.getTanl());
+    mTrackCotl->Fill(1. / oneTrack.getTanl());
 
     for (auto idisk = 0; idisk < 5; idisk++) {
       clsEntriesForRedundancy[idisk] = {-1, -1};
@@ -612,7 +612,7 @@ void MFTAssessment::processTrueAndFakeTracks()
           auto y_res = mftTrack.getY() - vyGen;
           auto eta_res = mftTrack.getEta() - etaGen;
           auto phi_res = mftTrack.getPhi() - phiGen;
-          auto tanl_res = mftTrack.getTanl() - tanlGen;
+          auto cotl_res = (1. / mftTrack.getTanl()) - (1. / tanlGen);
           auto invQPt_res = invQPt_Rec - invQPtGen;
           mHistPtVsEta[kRecoTrue]->Fill(eta_Rec, pt_Rec);
           mHistPhiVsEta[kRecoTrue]->Fill(eta_Rec, phi_Rec);
@@ -639,7 +639,7 @@ void MFTAssessment::processTrueAndFakeTracks()
           mTH3Histos[kTH3TrackXPullPtEta]->Fill(ptGen, etaGen, x_res / sqrt(mftTrack.getCovariances()(0, 0)));
           mTH3Histos[kTH3TrackYPullPtEta]->Fill(ptGen, etaGen, y_res / sqrt(mftTrack.getCovariances()(1, 1)));
           mTH3Histos[kTH3TrackPhiPullPtEta]->Fill(ptGen, etaGen, phi_res / sqrt(mftTrack.getCovariances()(2, 2)));
-          mTH3Histos[kTH3TrackTanlPullPtEta]->Fill(ptGen, etaGen, tanl_res / sqrt(mftTrack.getCovariances()(3, 3)));
+          mTH3Histos[kTH3TrackCotlPullPtEta]->Fill(ptGen, etaGen, cotl_res / sqrt(1. / mftTrack.getCovariances()(3, 3)));
           mTH3Histos[kTH3TrackInvQPtPullPtEta]->Fill(ptGen, etaGen, invQPt_res / sqrt(mftTrack.getCovariances()(4, 4)));
           mTH3Histos[kTH3TrackInvQPtResolutionPtEta]->Fill(ptGen, etaGen, (invQPt_Rec - invQPtGen) / invQPtGen);
           mTH3Histos[kTH3TrackInvQPtResSeedPtEta]->Fill(ptGen, etaGen, (invQPt_Seed - invQPtGen) / invQPtGen);
@@ -701,7 +701,7 @@ void MFTAssessment::getHistos(TObjArray& objar)
   }
   objar.Add(mCATrackEta.get());
   objar.Add(mLTFTrackEta.get());
-  objar.Add(mTrackTanl.get());
+  objar.Add(mTrackCotl.get());
 
   objar.Add(mTrackROFNEntries.get());
   objar.Add(mClusterROFNEntries.get());
@@ -901,7 +901,7 @@ bool MFTAssessment::loadHistos()
 
   mLTFTrackEta = std::unique_ptr<TH1F>((TH1F*)f->Get("mMFTLTFTrackEta"));
 
-  mTrackTanl = std::unique_ptr<TH1F>((TH1F*)f->Get("mMFTTrackTanl"));
+  mTrackCotl = std::unique_ptr<TH1F>((TH1F*)f->Get("mMFTTrackCotl"));
 
   mClusterROFNEntries = std::unique_ptr<TH1F>((TH1F*)f->Get("mMFTClustersROFSize"));
 

--- a/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
+++ b/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
@@ -137,9 +137,9 @@ void MFTAssessment::createHistos()
   mLTFTrackNumberOfClusters = std::make_unique<TH1F>("mMFTLTFTrackNumberOfClusters",
                                                      "Number Of Clusters Per LTF Track; # clusters; # entries", 10, 0.5, 10.5);
 
-  mTrackInvQPt = std::make_unique<TH1F>("mMFTTrackInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
+  mTrackInvQPt = std::make_unique<TH1F>("mMFTTrackInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 200, -10, 10);
 
-  mTrackChi2 = std::make_unique<TH1F>("mMFTTrackChi2", "Track #chi^{2}/NDF; #chi^{2}/NDF; # entries", 510, -0.5, 50.5);
+  mTrackChi2 = std::make_unique<TH1F>("mMFTTrackChi2", "Track #chi^{2}/NDF; #chi^{2}/NDF; # entries", 210, -0.5, 20.5);
 
   mTrackCharge = std::make_unique<TH1F>("mMFTTrackCharge", "Track Charge; q; # entries", 3, -1.5, 1.5);
 
@@ -184,7 +184,7 @@ void MFTAssessment::createHistos()
 
   mLTFTrackEta = std::make_unique<TH1F>("mMFTLTFTrackEta", "LTF Track #eta; #eta; # entries", 50, -4, -2);
 
-  mTrackCotl = std::make_unique<TH1F>("mMFTTrackCotl", "Track cot #lambda; cot #lambda; # entries", 100, -25, 0);
+  mTrackCotl = std::make_unique<TH1F>("mMFTTrackCotl", "Track cot #lambda; cot #lambda; # entries", 100, -0.25, 0);
 
   mClusterROFNEntries = std::make_unique<TH1F>("mMFTClustersROFSize", "MFT Cluster ROFs size; ROF Size; # entries", MaxClusterROFSize, 0, MaxClusterROFSize);
 


### PR DESCRIPTION
Adapting the histogram ranges for histograms and replacing tanl variable to cotl (cotangent lambda) only at both MFT and GlobalFwd assessment workflow level (to be decided later if we apply this to track parameters) 