### PR TITLE
dpl-workflow: remove redundant default, which is in setenv.sh

### DIFF
--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -3,8 +3,6 @@
 source $O2DPG_ROOT/DATA/common/setenv.sh || { echo "setenv.sh failed" 1>&2 && exit 1; }
 source $O2DPG_ROOT/DATA/common/setenv_calib.sh || { echo "setenv_calib.sh failed" 1>&2 && exit 1; }
 
-: ${TPC_CORR_SCALING:=""}             # TPC corr.map lumi scaling options, any combination of --require-ctp-lumi, --corrmap-lumi-mean <float>, --corrmap-lumi-inst <float>
-
 if [[ -z "$WORKFLOW" ]] || [[ -z "$GEN_TOPO_MYDIR" ]]; then
   echo This script must be called from the dpl-workflow.sh and not standalone 1>&2
   exit 1

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -26,7 +26,6 @@ fi
 : ${RECO_NUM_NODES_WORKFLOW:="230"}   # Number of EPNs running this workflow in parallel, to increase multiplicities if necessary, by default assume we are 1 out of 250 servers
 : ${CTF_MINSIZE:="10000000000"}       # accumulate CTFs until file size reached
 : ${CTF_MAX_PER_FILE:="40000"}        # but no more than given number of CTFs per file
-: ${TPC_CORR_SCALING:=""}             # TPC corr.map lumi scaling options, any combination of --require-ctp-lumi, --corrmap-lumi-mean <float>, --corrmap-lumi-inst <float>
 
 workflow_has_parameter CTF && export SAVECTF=1
 workflow_has_parameter GPU && { export GPUTYPE=HIP; export NGPUS=4; }


### PR DESCRIPTION
@shahor02  @martenole : This seems redundant, since it is also set in O2DPG setenv.sh. Should we remove it here?