### PR TITLE
extract mean lumi from TPC map (unless >0 override provided)

### DIFF
--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -88,7 +88,7 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
   if (matcher == ConcreteDataMatcher("TPC", "CorrMap", 0)) {
     setCorrMap((o2::gpu::TPCFastTransform*)obj);
     mCorrMap->rectifyAfterReadingFromFile();
-    if (getMeanLumiOverride() < 0 && mCorrMap->getLumi() > 0.) {
+    if (getMeanLumiOverride() <= 0 && mCorrMap->getLumi() > 0.) {
       setMeanLumi(mCorrMap->getLumi());
     }
     LOGP(debug, "MeanLumiOverride={} MeanLumiMap={} -> meanLumi = {}", getMeanLumiOverride(), mCorrMap->getLumi(), getMeanLumi());


### PR DESCRIPTION
trivial, tested locally, merging.