### PR TITLE
[WIP][FOCAL-10] Merge HBFs which are distributed across timeframes

### DIFF
--- a/Detectors/FOCAL/reconstruction/src/FOCALReconstructionLinkDef.h
+++ b/Detectors/FOCAL/reconstruction/src/FOCALReconstructionLinkDef.h
@@ -21,9 +21,6 @@
 #pragma link C++ class o2::focal::PadDecoder + ;
 #pragma link C++ class o2::focal::PadMapper + ;
 #pragma link C++ class o2::focal::PixelMapper + ;
-#pragma link C++ class o2::focal::PixelMapping + ;
-#pragma link C++ class o2::focal::PixelMappingIB + ;
-#pragma link C++ class o2::focal::PixelMappingOB + ;
 #pragma link C++ class o2::focal::PixelMapperV1 + ;
 #pragma link C++ class o2::focal::PixelDecoder + ;
 #pragma link C++ class o2::focal::PixelLaneHandler + ;

--- a/Detectors/FOCAL/reconstruction/src/PixelMapper.cxx
+++ b/Detectors/FOCAL/reconstruction/src/PixelMapper.cxx
@@ -9,188 +9,137 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <fstream>
 #include <iostream>
+#include <sstream>
+
+#include <TSystem.h>
+
+#include <fairlogger/Logger.h>
 #include <FOCALReconstruction/PixelMapper.h>
 
 using namespace o2::focal;
-
-PixelMapping::PixelMapping(unsigned int version) : mVersion(version) {}
-
-PixelMapping::ChipPosition PixelMapping::getPosition(unsigned int laneID, unsigned int chipID) const
-{
-  ChipIdentifier identifier{mUseLanes ? laneID : 0, chipID};
-  auto found = mMapping.find(identifier);
-  if (found == mMapping.end()) {
-    throw InvalidChipException(mVersion, identifier);
-  }
-  return found->second;
-}
-
-void PixelMapping::InvalidChipException::print(std::ostream& stream) const
-{
-  stream << mMessage;
-}
-
-void PixelMapping::VersionException::print(std::ostream& stream) const
-{
-  stream << mMessage;
-}
-
-PixelMappingOB::PixelMappingOB(unsigned int version) : PixelMapping(version) { init(version); }
-
-void PixelMappingOB::init(unsigned int version)
-{
-  if (version >= 2) {
-    throw VersionException(version);
-  }
-  std::cout << "Initializing OB mapping (" << version << ")" << std::endl;
-  switch (version) {
-    case 0:
-      buildVersion0();
-      break;
-
-    case 1:
-      buildVersion1();
-      break;
-
-    default:
-      break;
-  }
-  mUseLanes = true;
-}
-
-void PixelMappingOB::buildVersion0()
-{
-  mMapping.clear();
-  /**                Lane, Chip, Col, Row, Inv Col, Inv Row **/
-  mMapping.insert({{8, 6}, {0, 5, true, false}});
-  mMapping.insert({{8, 5}, {1, 5, true, false}});
-  mMapping.insert({{8, 4}, {2, 5, true, false}});
-  mMapping.insert({{8, 3}, {3, 5, true, false}});
-  mMapping.insert({{8, 2}, {4, 5, true, false}});
-  mMapping.insert({{8, 1}, {5, 5, true, false}});
-  mMapping.insert({{8, 0}, {6, 5, true, false}});
-  mMapping.insert({{6, 8}, {0, 4, false, true}});
-  mMapping.insert({{6, 9}, {1, 4, false, true}});
-  mMapping.insert({{6, 10}, {2, 4, false, true}});
-  mMapping.insert({{6, 11}, {3, 4, false, true}});
-  mMapping.insert({{6, 12}, {4, 4, false, true}});
-  mMapping.insert({{6, 13}, {5, 4, false, true}});
-  mMapping.insert({{6, 14}, {6, 4, false, true}});
-  mMapping.insert({{24, 6}, {0, 1, true, false}});
-  mMapping.insert({{24, 5}, {1, 1, true, false}});
-  mMapping.insert({{24, 4}, {2, 1, true, false}});
-  mMapping.insert({{24, 3}, {3, 1, true, false}});
-  mMapping.insert({{24, 2}, {4, 1, true, false}});
-  mMapping.insert({{24, 1}, {5, 1, true, false}});
-  mMapping.insert({{24, 0}, {6, 1, true, false}});
-  mMapping.insert({{22, 8}, {0, 0, false, true}});
-  mMapping.insert({{22, 9}, {1, 0, false, true}});
-  mMapping.insert({{22, 10}, {2, 0, false, true}});
-  mMapping.insert({{22, 11}, {3, 0, false, true}});
-  mMapping.insert({{22, 12}, {4, 0, false, true}});
-  mMapping.insert({{22, 13}, {5, 0, false, true}});
-  mMapping.insert({{22, 14}, {6, 0, false, true}});
-}
-
-void PixelMappingOB::buildVersion1()
-{
-  mMapping.clear();
-  /**                Lane, Chip, Col, Row, Inv Col, Inv Row **/
-  mMapping.insert({{6, 8}, {0, 3, false, false}});
-  mMapping.insert({{6, 9}, {1, 3, false, false}});
-  mMapping.insert({{6, 10}, {2, 3, false, false}});
-  mMapping.insert({{6, 11}, {3, 3, false, false}});
-  mMapping.insert({{6, 12}, {4, 3, false, false}});
-  mMapping.insert({{6, 13}, {5, 3, false, false}});
-  mMapping.insert({{6, 14}, {6, 3, false, false}});
-  mMapping.insert({{8, 6}, {0, 2, true, true}});
-  mMapping.insert({{8, 5}, {1, 2, true, true}});
-  mMapping.insert({{8, 4}, {2, 2, true, true}});
-  mMapping.insert({{8, 3}, {3, 2, true, true}});
-  mMapping.insert({{8, 2}, {4, 2, true, true}});
-  mMapping.insert({{8, 1}, {5, 2, true, true}});
-  mMapping.insert({{8, 0}, {6, 2, true, true}});
-}
-
-PixelMappingIB::PixelMappingIB(unsigned int version) : PixelMapping(version) { init(version); }
-
-void PixelMappingIB::init(unsigned int version)
-{
-  if (version >= 2) {
-    throw VersionException(version);
-  }
-  std::cout << "Initializing IB mapping (" << version << ")" << std::endl;
-  switch (version) {
-    case 0:
-      buildVersion0();
-      break;
-
-    case 1:
-      buildVersion1();
-      break;
-
-    default:
-      break;
-  }
-  mUseLanes = false;
-}
-
-void PixelMappingIB::buildVersion0()
-{
-  mMapping.clear();
-  mMapping.insert({{0, 0}, {0, 4, false, false}});
-  mMapping.insert({{0, 1}, {1, 4, false, false}});
-  mMapping.insert({{0, 2}, {2, 4, false, false}});
-  mMapping.insert({{0, 3}, {0, 2, false, false}});
-  mMapping.insert({{0, 4}, {1, 2, false, false}});
-  mMapping.insert({{0, 5}, {2, 2, false, false}});
-  mMapping.insert({{0, 6}, {0, 0, false, false}});
-  mMapping.insert({{0, 7}, {1, 0, false, false}});
-  mMapping.insert({{0, 8}, {2, 0, false, false}});
-}
-
-void PixelMappingIB::buildVersion1()
-{
-  mMapping.clear();
-  mMapping.insert({{0, 0}, {0, 5, false, false}});
-  mMapping.insert({{0, 1}, {1, 5, false, false}});
-  mMapping.insert({{0, 2}, {2, 5, false, false}});
-  mMapping.insert({{0, 3}, {0, 3, false, false}});
-  mMapping.insert({{0, 4}, {1, 3, false, false}});
-  mMapping.insert({{0, 5}, {2, 3, false, false}});
-  mMapping.insert({{0, 6}, {0, 1, false, false}});
-  mMapping.insert({{0, 7}, {1, 1, false, false}});
-  mMapping.insert({{0, 8}, {2, 1, false, false}});
-}
 
 PixelMapper::PixelMapper(PixelMapper::MappingType_t mappingtype) : mMappingType(mappingtype)
 {
   switch (mappingtype) {
     case MappingType_t::MAPPING_IB:
-      for (int iversion = 0; iversion < 2; iversion++) {
-        mMappings[iversion] = std::make_shared<PixelMappingIB>(iversion);
-      }
+      mMappingFile = Form("%s/share/Detectors/FOC/files/mapping_ib.data", gSystem->Getenv("O2_ROOT"));
       break;
     case MappingType_t::MAPPING_OB:
-      for (int iversion = 0; iversion < 2; iversion++) {
-        mMappings[iversion] = std::make_shared<PixelMappingOB>(iversion);
-      }
+      mMappingFile = Form("%s/share/Detectors/FOC/files/mapping_ob.data", gSystem->Getenv("O2_ROOT"));
+    default:
+      break;
   };
+
+  if (mMappingFile.length()) {
+    init();
+  }
 }
 
-const PixelMapping& PixelMapper::getMapping(unsigned int feeID) const
+void PixelMapper::init()
 {
-  return *(mMappings[feeID % 2]);
+  if (gSystem->AccessPathName(mMappingFile.data())) {
+    throw MappingNotSetException();
+  }
+  LOG(debug) << "Reading pixel mapping from file: " << mMappingFile;
+  mMapping.clear();
+  std::ifstream reader(mMappingFile);
+  std::string buffer;
+  while (std::getline(reader, buffer)) {
+    auto delimiter = buffer.find("//");
+    std::string data = buffer;
+    if (delimiter == 0) {
+      // whole line commented out
+      continue;
+    }
+    if (delimiter != std::string::npos) {
+      data = buffer.substr(0, delimiter);
+    }
+    LOG(debug) << "Processing line: " << data;
+    std::stringstream decoder(data);
+    std::string linebuffer;
+    std::vector<int> identifiers;
+    while (std::getline(decoder, linebuffer, ',')) {
+      identifiers.push_back(std::stoi(linebuffer));
+    }
+    if (identifiers.size() < 8) {
+      LOG(error) << "Chip coordinates not fully defined (" << data << "), skipping ...";
+    }
+    ChipIdentifier nextIdentifier;
+    nextIdentifier.mFEEID = identifiers[0];
+    nextIdentifier.mLaneID = identifiers[1];
+    nextIdentifier.mChipID = identifiers[2];
+    ChipPosition nextPosition;
+    nextPosition.mLayer = identifiers[3];
+    nextPosition.mColumn = identifiers[4];
+    nextPosition.mRow = identifiers[5];
+    nextPosition.mInvertColumn = (identifiers[6] == 1 ? true : false);
+    nextPosition.mInvertRow = (identifiers[7] == 1 ? true : false);
+    LOG(debug) << "Inserting chip: (FEE " << nextIdentifier.mFEEID << ", Lane " << nextIdentifier.mLaneID << ", Chip " << nextIdentifier.mChipID << ") -> (Layer " << nextPosition.mLayer << ", Col " << nextPosition.mColumn << ", Row " << nextPosition.mRow << ", Inv Col " << (nextPosition.mInvertColumn ? "yes" : "no") << ", Inv Row " << (nextPosition.mInvertRow ? "yes" : "no") << ")";
+    if (mMapping.find(nextIdentifier) != mMapping.end()) {
+      LOG(error) << "Chip with FEE" << nextIdentifier.mFEEID << ", Lane " << nextIdentifier.mLaneID << ", Chip " << nextIdentifier.mChipID << " already present, not overwriting ...";
+      continue;
+    }
+    mMapping.insert({nextIdentifier, nextPosition});
+    if (nextPosition.mRow + 1 > mNumberOfRows) {
+      mNumberOfRows = nextPosition.mRow + 1;
+    }
+    if (nextPosition.mColumn + 1 > mNumberOfColumns) {
+      mNumberOfColumns = nextPosition.mColumn + 1;
+    }
+  }
+  LOG(info) << "Pixel Mapper: Found " << mMapping.size() << " chips, in " << mNumberOfColumns << " colums and " << mNumberOfRows << " rows";
+  reader.close();
 }
 
-std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelMapping::InvalidChipException& error)
+PixelMapper::ChipPosition PixelMapper::getPosition(unsigned int feeID, unsigned int laneID, unsigned int chipID) const
+{
+  auto cardindex = feeID & 0x00FF;
+  checkInitialized();
+  ChipIdentifier identifier{cardindex, laneID, chipID};
+  auto found = mMapping.find(identifier);
+  if (found == mMapping.end()) {
+    throw InvalidChipException(identifier);
+  }
+  return found->second;
+}
+
+void PixelMapper::checkInitialized() const
+{
+  if (!mMapping.size()) {
+    throw UninitException();
+  }
+}
+
+void PixelMapper::InvalidChipException::print(std::ostream& stream) const
+{
+  stream << mMessage;
+}
+
+void PixelMapper::UninitException::print(std::ostream& stream) const
+{
+  stream << what();
+}
+
+void PixelMapper::MappingNotSetException::print(std::ostream& stream) const
+{
+  stream << what();
+}
+
+std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelMapper::InvalidChipException& error)
 {
   error.print(stream);
   return stream;
 }
 
-std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelMapping::VersionException& error)
+std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelMapper::UninitException& error)
+{
+  error.print(stream);
+  return stream;
+}
+
+std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelMapper::MappingNotSetException& error)
 {
   error.print(stream);
   return stream;

--- a/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
+++ b/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
@@ -25,7 +25,7 @@
 #include "DataFormatsFOCAL/TriggerRecord.h"
 #include "FOCALReconstruction/PadDecoder.h"
 #include "FOCALReconstruction/PixelDecoder.h"
-#include "FOCALReconstruction/PixelMapperV1.h"
+#include "FOCALReconstruction/PixelMapper.h"
 
 namespace o2::focal
 {
@@ -82,7 +82,7 @@ class RawDecoderSpec : public framework::Task
   uint32_t mOutputSubspec = 0;
   PadDecoder mPadDecoder;
   PixelDecoder mPixelDecoder;
-  std::unique_ptr<PixelMapperV1> mPixelMapping;
+  std::unique_ptr<PixelMapper> mPixelMapping;
   std::map<o2::InteractionRecord, HBFData> mHBFs;
   std::vector<TriggerRecord> mOutputTriggerRecords;
   std::vector<PixelHit> mOutputPixelHits;

--- a/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
+++ b/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
@@ -62,6 +62,9 @@ class RawDecoderSpec : public framework::Task
   int decodePixelData(const gsl::span<const char> pixelWords, o2::InteractionRecord& hbIR, int fecID);
   std::array<PadLayerEvent, constants::PADS_NLAYERS> createPadLayerEvent(const o2::focal::PadData& data) const;
   void fillChipToLayer(PixelLayerEvent& pixellayer, const PixelChip& chipData, int feeID);
+  void fillEventContainer(gsl::span<const std::array<o2::focal::PadLayerEvent, 20>> currentpads,
+                          gsl::span<const std::array<o2::focal::PixelLayerEvent, 2>> currentpixels,
+                          gsl::span<const o2::InteractionRecord> currenttriggers);
   void fillEventPixeHitContainer(std::vector<PixelHit>& eventHits, std::vector<PixelChipRecord>& eventChips, const PixelLayerEvent& pixelLayer, int layerIndex);
   int filterIncompletePixelsEventsHBF(HBFData& data, const std::vector<int>& expectFEEs);
   void buildEvents();
@@ -84,6 +87,7 @@ class RawDecoderSpec : public framework::Task
   PixelDecoder mPixelDecoder;
   std::unique_ptr<PixelMapper> mPixelMapping;
   std::map<o2::InteractionRecord, HBFData> mHBFs;
+  std::map<o2::InteractionRecord, HBFData> mBackupBuffer;
   std::vector<TriggerRecord> mOutputTriggerRecords;
   std::vector<PixelHit> mOutputPixelHits;
   std::vector<PixelChipRecord> mOutputPixelChips;

--- a/Detectors/FOCAL/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/FOCAL/workflow/src/RawDecoderSpec.cxx
@@ -38,23 +38,23 @@ void RawDecoderSpec::init(framework::InitContext& ctx)
     mDisplayInconsistent = true;
   }
   auto mappingfile = ctx.options().get<std::string>("pixelmapping");
-  PixelMapperV1::MappingType_t mappingtype = PixelMapperV1::MappingType_t::MAPPING_UNKNOWN;
+  PixelMapper::MappingType_t mappingtype = PixelMapper::MappingType_t::MAPPING_UNKNOWN;
   auto chiptype = ctx.options().get<std::string>("pixeltype");
   if (chiptype == "IB") {
     LOG(info) << "Using mapping type: IB";
-    mappingtype = PixelMapperV1::MappingType_t::MAPPING_IB;
+    mappingtype = PixelMapper::MappingType_t::MAPPING_IB;
   } else if (chiptype == "OB") {
     LOG(info) << "Using mapping type: OB";
-    mappingtype = PixelMapperV1::MappingType_t::MAPPING_OB;
+    mappingtype = PixelMapper::MappingType_t::MAPPING_OB;
   } else {
     LOG(fatal) << "Unkown mapping type for pixels: " << chiptype;
   }
   if (mappingfile == "default") {
     LOG(info) << "Using default pixel mapping for pixel type " << chiptype;
-    mPixelMapping = std::make_unique<PixelMapperV1>(mappingtype);
+    mPixelMapping = std::make_unique<PixelMapper>(mappingtype);
   } else {
     LOG(info) << "Using user-defined mapping: " << mappingfile;
-    mPixelMapping = std::make_unique<PixelMapperV1>(PixelMapperV1::MappingType_t::MAPPING_UNKNOWN);
+    mPixelMapping = std::make_unique<PixelMapper>(PixelMapper::MappingType_t::MAPPING_UNKNOWN);
     mPixelMapping->setMappingFile(mappingfile, mappingtype);
   }
 }
@@ -363,7 +363,7 @@ int RawDecoderSpec::decodePixelData(const gsl::span<const char> pixelWords, o2::
         try {
           auto chipPosition = mPixelMapping->getPosition(feeID, chip);
           fillChipToLayer(foundHBF->second.mPixelEvent[index][chipPosition.mLayer], chip, feeID);
-        } catch (PixelMapperV1::InvalidChipException& e) {
+        } catch (PixelMapper::InvalidChipException& e) {
           LOG(warning) << e;
         }
       }
@@ -378,7 +378,7 @@ int RawDecoderSpec::decodePixelData(const gsl::span<const char> pixelWords, o2::
         try {
           auto chipPosition = mPixelMapping->getPosition(feeID, chip);
           fillChipToLayer(current[chipPosition.mLayer], chip, feeID);
-        } catch (PixelMapperV1::InvalidChipException& e) {
+        } catch (PixelMapper::InvalidChipException& e) {
           LOG(warning) << e;
         }
       }


### PR DESCRIPTION
In case Pad and Pixel HBIRs are in different timeframes
(observed in case of subscribing to RawTF) a merging
procedure across timeframes must be applied. For this
HBFs where only one subsystem was found are kept in a buffer
and merged with the other part once we find the HBF of the
second detector.