### PR TITLE
By default avoid MD5 calc. for epn2eos metadata

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/FileMetaData.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/FileMetaData.h
@@ -45,7 +45,7 @@ struct FileMetaData {             // https://docs.google.com/document/d/1nH9EZEF
   size_t size{};                  // 6, default the size of the lurl file, optional
   int persistent{};               // 16, default is forever, optional
   std::vector<uint32_t> tfOrbits; // 15, comma-sep. list of 1st orbits of TFs, optional
-  bool fillFileData(const std::string& fname);
+  bool fillFileData(const std::string& fname, bool md5 = false);
   void setDataTakingContext(const o2::framework::DataTakingContext& dtc);
   std::string asString() const;
 };

--- a/DataFormats/Detectors/Common/src/FileMetaData.cxx
+++ b/DataFormats/Detectors/Common/src/FileMetaData.cxx
@@ -20,13 +20,15 @@
 
 using namespace o2::dataformats;
 
-bool FileMetaData::fillFileData(const std::string& fname)
+bool FileMetaData::fillFileData(const std::string& fname, bool md5)
 {
   try {
     lurl = std::filesystem::canonical(fname).string();
     size = std::filesystem::file_size(lurl);
-    std::unique_ptr<TMD5> md5ptr{TMD5::FileChecksum(fname.c_str())};
-    md5 = md5ptr->AsString();
+    if (md5) {
+      std::unique_ptr<TMD5> md5ptr{TMD5::FileChecksum(fname.c_str())};
+      md5 = md5ptr->AsString();
+    }
     ctime = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
   } catch (std::exception const& e) {
     LOG(error) << "Failed to fill metadata for file " << fname << ", reason: " << e.what();


### PR DESCRIPTION
As it takes > 2 s/GB, becoming too slow for CTF file. The MD5 can be still calculated by reguesting it explicitly  FileMetaData::fillFileData(const std::string& fname, bool md5)