### PR TITLE
AOD-Calo: Crash avoidance and error diagnostic

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -139,11 +139,11 @@ class MCTrackT
 
   Double_t GetRapidity() const;
 
-  void GetMomentum(TVector3& momentum);
+  void GetMomentum(TVector3& momentum) const;
 
-  void Get4Momentum(TLorentzVector& momentum);
+  void Get4Momentum(TLorentzVector& momentum) const;
 
-  void GetStartVertex(TVector3& vertex);
+  void GetStartVertex(TVector3& vertex) const;
 
   /// Accessors to the hit mask
   Int_t getHitMask() const { return ((PropEncoding)mProp).hitmask; }
@@ -280,19 +280,19 @@ inline Double_t MCTrackT<T>::GetEnergy() const
 }
 
 template <typename T>
-inline void MCTrackT<T>::GetMomentum(TVector3& momentum)
+inline void MCTrackT<T>::GetMomentum(TVector3& momentum) const
 {
   momentum.SetXYZ(mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ);
 }
 
 template <typename T>
-inline void MCTrackT<T>::Get4Momentum(TLorentzVector& momentum)
+inline void MCTrackT<T>::Get4Momentum(TLorentzVector& momentum) const
 {
   momentum.SetXYZT(mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ, GetEnergy());
 }
 
 template <typename T>
-inline void MCTrackT<T>::GetStartVertex(TVector3& vertex)
+inline void MCTrackT<T>::GetStartVertex(TVector3& vertex) const
 {
   vertex.SetXYZ(mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ);
 }

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -299,6 +299,7 @@ class AODProducerWorkflowDPL : public Task
   // The first two indices are not sparse whereas the trackID index is sparse which explains
   // the combination of vector and map
   std::vector<std::vector<std::unordered_map<int, int>*>> mToStore;
+  o2::steer::MCKinematicsReader* mMCKineReader = nullptr; //!
 
   // production metadata
   std::vector<TString> mMetaDataKeys;


### PR DESCRIPTION
  MC error diagnostic during CaloTable filling
    
    This commit is related to https://alice.its.cern.ch/jira/browse/O2-3799
    
    During filling of the Calo table it:
    
    a) checks if a trackID is stored in mToStore
    b) if not, emits diagnostic information about that track
       for further analysis of the problem
    
    In result, O2-3799 is no longer critical since it shouldn't crash anymore.
    However, the true origin of the problem still needs to be addressed.