### PR TITLE
Fix bogus wrong bunches diff message

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -61,6 +61,7 @@
 
 #include "ReconstructionDataFormats/GlobalFwdTrack.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
+#include <cmath>
 
 //________________________________________________________
 template <class T>
@@ -130,7 +131,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
   GTrackID::Source currentSource = GTrackID::NSources;
   auto getBCDiff = [startIR = this->startIR, &currentSource](const o2::InteractionRecord& ir) {
     auto bcd = ir.differenceInBC(startIR);
-    if (uint64_t(bcd) > o2::constants::lhc::LHCMaxBunches * 256 && BCDiffErrCount < MAXBCDiffErrCount) {
+    if (std::abs(bcd) > o2::constants::lhc::LHCMaxBunches * 256 && BCDiffErrCount < MAXBCDiffErrCount) {
       LOGP(alarm, "ATTENTION: wrong bunches diff. {} for current IR {} wrt 1st TF orbit {}, source:{}", bcd, ir.asString(), startIR.asString(), GTrackID::getSourceName(currentSource));
       BCDiffErrCount++;
     }


### PR DESCRIPTION
ping @shahor02 
For a proper warning we would need to know the number of HBFs per TF. For this I think we need to pass this as parameter from every device which is using this helper and these devices in turn would need to fetch that info from CCDB if they don't do it anyhow already. But I am not sure if this would be important to have actually?