### PR TITLE
[EMCAL-889] AOD-Calo: Avoidance of crash during emcCorrectionTask

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1408,6 +1408,7 @@ void AODProducerWorkflowDPL::addToCaloTable(const TCaloHandler& caloHandler, con
               if (iter != trackStore->end()) {
                 particleIds.emplace_back(iter->second);
               } else {
+                particleIds.emplace_back(-1); // should the mc particle not be in mToStore make sure something (e.g. -1) is saved in particleIds so the length of particleIds is the same es amplitudeFraction!
                 LOG(warn) << "CaloTable: Could not find track for mclabel (" << mclabel.getSourceID() << "," << mclabel.getEventID() << "," << mclabel.getTrackID() << ") in the AOD MC store";
                 if (mMCKineReader) {
                   auto mctrack = mMCKineReader->getTrack(mclabel);


### PR DESCRIPTION
- The fix provided by @sawenzel in PR #11391 results in `particleIds` and `amplitudeFraction` being of unequal lenght which would lead to crashes in the emcCorrectionTask. So for now just fill -1 as particleId to the `particleIds` to make sure the two vectors have equal lenght and we can check for negative indices in the emcCorrectionTask if we need to.