### PR TITLE
Allow setting material correction type for track interpolation

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -58,6 +58,7 @@ class TPCInterpolationDPL : public Task
   bool mDebugOutput{false};       ///< add more information to the output (track points of ITS, TRD and TOF)
   bool mSendTrackData{false};     ///< if true, not only the clusters but also corresponding track data will be sent
   uint32_t mSlotLength{600u};     ///< the length of one calibration slot required to calculate max number of tracks per TF
+  int mMatCorr{2};                ///< the material correction to be used for track interpolation
   TStopwatch mTimer;
 };
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -51,6 +51,7 @@ void TPCInterpolationDPL::init(InitContext& ic)
   o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
   mSlotLength = ic.options().get<uint32_t>("sec-per-slot");
   mProcessSeeds = ic.options().get<bool>("process-seeds");
+  mMatCorr = ic.options().get<int>("matCorrType");
 }
 
 void TPCInterpolationDPL::updateTimeDependentParams(ProcessingContext& pc)
@@ -80,6 +81,7 @@ void TPCInterpolationDPL::updateTimeDependentParams(ProcessingContext& pc)
       LOG(error) << "No tracks will be processed. maxTracksPerCalibSlot must be greater than slot length in TFs";
     }
     mInterpolation.setMaxTracksPerTF(nTracksPerTfMax);
+    mInterpolation.setMatCorr(static_cast<o2::base::Propagator::MatCorrType>(mMatCorr));
     o2::its::GeometryTGeo::Instance()->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2GRot) | o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L));
   }
   // we may have other params which need to be queried regularly
@@ -281,6 +283,7 @@ DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool
     outputs,
     AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(dataRequest, ggRequest, useMC, processITSTPConly, sendTrackData, debugOutput)},
     Options{
+      {"matCorrType", VariantType::Int, 2, {"material correction type (definition in Propagator.h)"}},
       {"sec-per-slot", VariantType::UInt32, 600u, {"number of seconds per calibration time slot (put 0 for infinite slot length)"}},
       {"process-seeds", VariantType::Bool, false, {"do not remove duplicates, e.g. for ITS-TPC-TRD track also process its seeding ITS-TPC part"}}}};
 }


### PR DESCRIPTION
The TPC track interpolation was actually never using material correction. Thanks to @aschmah for spotting