### PR TITLE
Space-charge: Add conversion of IDCs to space-charge density

### DIFF
--- a/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
@@ -48,12 +48,13 @@ void o2::tpc::IDCDrawHelper::drawSector(const IDCDraw& idc, const unsigned int s
   can->SetTopMargin(0.04f);
   poly->Draw("colz");
 
+  const float sign = (Sector(sector).side() == Side::A) ? 1 : -1;
   for (unsigned int region = startRegion; region < endRegion; ++region) {
     for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
       for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
         const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
-        const auto coordinate = coords[padNum];
-        const float yPos = -static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]) / 2; // local coordinate system is mirrored
+        const auto coordinate = coords[padNum];                                                      // start from y=-13 to +13
+        const float yPos = sign * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]) / 2; // local coordinate system is mirrored for C side
         const float xPos = static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]) / 2;
         poly->Fill(xPos, yPos, idc.getIDC(sector, region, irow, ipad));
       }
@@ -120,11 +121,11 @@ TH2Poly* o2::tpc::IDCDrawHelper::drawSide(const IDCDraw& idc, const o2::tpc::Sid
         for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
           const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
           const float angDeg = 10.f + sector * 20;
-          auto coordinate = coords[padNum];
-          coordinate.rotate(angDeg);
+          auto coordinate = coords[padNum]; // start from y=-13 to +13
+          coordinate.rotate(angDeg);        // start from y=1.2 to +28..
           const float yPos = static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]) / 4;
           const float xPos = static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]) / 4;
-          const auto padTmp = getPad(ipad, region, irow, side);
+          const auto padTmp = getPad(ipad, region, irow, side); // IDCs are in pad coordinates. pad0 A side: y=1.2, pad0 C side: y=28.1
           poly->Fill(xPos, yPos, idc.getIDC(sector, region, irow, padTmp));
         }
       }

--- a/Detectors/TPC/reconstruction/macro/createTPCSpaceChargeCorrection.C
+++ b/Detectors/TPC/reconstruction/macro/createTPCSpaceChargeCorrection.C
@@ -122,7 +122,8 @@ void createTPCSpaceChargeCorrection(
   spaceCharge->setGlobalCorrectionsFromFile(scFile, Side::C);
   TPCFastSpaceChargeCorrectionHelper::instance()->setGlobalSpaceChargeCorrection(getGlobalSpaceChargeCorrection);
 
-  std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0));
+  std::unique_ptr<TPCFastSpaceChargeCorrection> spCorrection = TPCFastSpaceChargeCorrectionHelper::instance()->create();
+  std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0, *spCorrection));
 
   fastTransform->writeToFile(outputFileName, "ccdb_object");
 
@@ -182,7 +183,8 @@ void createTPCSpaceChargeCorrectionLinearCombination(
   }
 
   TPCFastSpaceChargeCorrectionHelper::instance()->setGlobalSpaceChargeCorrection(getGlobalSpaceChargeCorrectionLinearCombination);
-  std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0));
+  std::unique_ptr<TPCFastSpaceChargeCorrection> spCorrection = TPCFastSpaceChargeCorrectionHelper::instance()->create();
+  std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0, *spCorrection));
   fastTransform->writeToFile(outputFileName, "ccdb_object");
 
   if (debug > 0) {
@@ -230,7 +232,9 @@ void createTPCSpaceChargeCorrectionAnalytical(
 
   TPCFastSpaceChargeCorrectionHelper::instance()->setLocalSpaceChargeCorrection(getLocalSpaceChargeCorrection);
 
-  std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0));
+  std::unique_ptr<TPCFastSpaceChargeCorrection> spCorrection = TPCFastSpaceChargeCorrectionHelper::instance()->create();
+  std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0, *spCorrection));
+
   fastTransform->writeToFile(outputFileName, "ccdb_object");
 
   if (debug > 0) {
@@ -425,7 +429,9 @@ void debugInterpolation(utils::TreeStreamRedirector& pcstream,
           // the original correction
           double gdC[3] = {0, 0, 0};
           Side side = slice < geo.getNumberOfSlicesA() ? Side::A : Side::C;
-          spaceCharge->getCorrections(gx, gy, gz, side, gdC[0], gdC[1], gdC[2]);
+          if (spaceCharge) {
+            spaceCharge->getCorrections(gx, gy, gz, side, gdC[0], gdC[1], gdC[2]);
+          }
           float ldxC, ldyC, ldzC;
           geo.convGlobalToLocal(slice, gdC[0], gdC[1], gdC[2], ldxC, ldyC, ldzC);
 
@@ -437,18 +443,24 @@ void debugInterpolation(utils::TreeStreamRedirector& pcstream,
 
           float pointCyl[3] = {gz, r, phi};
           double efield[3] = {0.0, 0.0, 0.0};
-          double charge = spaceCharge->getDensityCyl(pointCyl[0], pointCyl[1], pointCyl[2], side);
-          double potential = spaceCharge->getPotentialCyl(pointCyl[0], pointCyl[1], pointCyl[2], side);
-          spaceCharge->getElectricFieldsCyl(pointCyl[0], pointCyl[1], pointCyl[2], side, efield[0], efield[1], efield[2]);
-          spaceCharge->getLocalDistortionsCyl(pointCyl[0], pointCyl[1], pointCyl[2], side, ldD[0], ldD[1], ldD[2]);
-          spaceCharge->getDistortions(gx, gy, gz, side, gdD[0], gdD[1], gdD[2]);
+          double charge = 0;
+          double potential = 0;
+          if (spaceCharge) {
+            charge = spaceCharge->getDensityCyl(pointCyl[0], pointCyl[1], pointCyl[2], side);
+            potential = spaceCharge->getPotentialCyl(pointCyl[0], pointCyl[1], pointCyl[2], side);
+            spaceCharge->getElectricFieldsCyl(pointCyl[0], pointCyl[1], pointCyl[2], side, efield[0], efield[1], efield[2]);
+            spaceCharge->getLocalDistortionsCyl(pointCyl[0], pointCyl[1], pointCyl[2], side, ldD[0], ldD[1], ldD[2]);
+            spaceCharge->getDistortions(gx, gy, gz, side, gdD[0], gdD[1], gdD[2]);
+          }
 
           double gD[3] = {gx + gdD[0], gy + gdD[1], gz + gdD[2]};
           float rD = std::sqrt(gD[0] * gD[0] + gD[1] * gD[1]);
 
           // correction for the distorted point
           double gdDC[3] = {0, 0, 0};
-          spaceCharge->getCorrections(gD[0], gD[1], gD[2], side, gdDC[0], gdDC[1], gdDC[2]);
+          if (spaceCharge) {
+            spaceCharge->getCorrections(gD[0], gD[1], gD[2], side, gdDC[0], gdDC[1], gdDC[2]);
+          }
 
           // exB
           float ldxC_ExB = 0, ldyC_ExB = 0, ldzC_ExB = 0;

--- a/Detectors/TPC/spacecharge/include/TPCSpaceCharge/DataContainer3D.h
+++ b/Detectors/TPC/spacecharge/include/TPCSpaceCharge/DataContainer3D.h
@@ -185,6 +185,7 @@ struct DataContainer3D {
 
   /// operator overload
   DataContainer3D<DataT>& operator*=(const DataT value);
+  DataContainer3D<DataT>& operator+=(const DataContainer3D<DataT>& other);
 
  private:
   unsigned short mZVertices{};   ///< number of z vertices

--- a/Detectors/TPC/spacecharge/src/DataContainer3D.cxx
+++ b/Detectors/TPC/spacecharge/src/DataContainer3D.cxx
@@ -234,6 +234,13 @@ DataContainer3D<DataT>& DataContainer3D<DataT>::operator*=(const DataT value)
 }
 
 template <typename DataT>
+DataContainer3D<DataT>& DataContainer3D<DataT>::operator+=(const DataContainer3D<DataT>& other)
+{
+  std::transform(mData.begin(), mData.end(), other.mData.begin(), mData.begin(), std::plus<>());
+  return *this;
+}
+
+template <typename DataT>
 size_t DataContainer3D<DataT>::getIndexZ(size_t index, const int nz, const int nr, const int nphi)
 {
   const size_t iphi = index / (nz * nr);


### PR DESCRIPTION
other changes:
- Add function to set the space-charge density from two histograms (A and C-side)
- Add function to convert IDCs to the space-charge density
- Add function to add charge from other object (e.g. Adding space-charge density from primary ionization to space-charge density from IDCs)
- Speed up rebinning by directly filling the space-charge density

createTPCSpaceChargeCorrection
- Fix initialization of fastTransform
- Add protection when dumping to TTree

IDCs
- fix sign for drawing local coordinates