### PR TITLE
Avoid ROOT warning in EMCAL calib

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -249,7 +249,7 @@ bool EMCALChannelCalibrator<DataInput, DataOutput>::saveLastSlotData(TFile& fl)
     auto histTime = c->getHistoTime();
 
     TH2F hEnergy = o2::utils::TH2FFromBoost(hist);
-    TH2F hTime = o2::utils::TH2FFromBoost(histTime);
+    TH2F hTime = o2::utils::TH2FFromBoost(histTime, "histTime");
     TH1D hNEvents("hNEvents", "hNEvents", 1, 0, 1);
     hNEvents.SetBinContent(1, c->getNEvents());
 


### PR DESCRIPTION
We see some errors in the IL which are actually ROOT warnings written to stderr and therefore picked up by our stderr monitor:

E	3	00:07:47.506		STDERR	stderr/calib-emcalchannel-badch	2fd1hDtUD6h	537421	stderr: Warning in <TFile::Append>: Replacing existing TH1: hist (Potential memory leak).

This is because o2::utils::TH2FFromBoost assigns by default the name "hist" to the histogram it returns.

That was not a real issue. This simply fixes the warning.