### PR TITLE
TPC residual aggregator: Don't write TForbits in meta file

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
@@ -404,11 +404,6 @@ void ResidualAggregator::finalizeSlot(Slot& slot)
     try {
       std::ofstream metaFileOut(metaFileNameTmp);
       metaFileOut << fileMetaData;
-      metaFileOut << "TFOrbits: ";
-      for (size_t i = 0; i < cont->tfOrbits.size(); i++) {
-        metaFileOut << fmt::format("{}{}", i ? ", " : "", cont->tfOrbits[i]);
-      }
-      metaFileOut << '\n';
       metaFileOut.close();
       std::filesystem::rename(metaFileNameTmp, metaFileName);
     } catch (std::exception const& e) {


### PR DESCRIPTION
I saw there were many catalogue registration errors for the output files from the residual aggregation.
Alice traced it down to the very large meta data files which contained around 200k integer values for the first TF orbits. Since this is an optional field in the meta data one can skip writing them.