### PR TITLE
Enable using CCDB VDrift in TPC Digitizer

### DIFF
--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -246,7 +246,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     auto& cdb = o2::tpc::CDBInterface::instance();
     cdb.setUseDefaults(!mUseCalibrationsFromCCDB);
     // whatever are global settings for CCDB usage, we have to extract the TPC vdrift from CCDB for anchored simulations
-    //    mTPCVDriftHelper.extractCCDBInputs(pc);
+    mTPCVDriftHelper.extractCCDBInputs(pc);
     if (mTPCVDriftHelper.isUpdated()) {
       const auto& vd = mTPCVDriftHelper.getVDriftObject();
       LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",


### PR DESCRIPTION
@chiarazampolli @sawenzel let me know if this should be merged to avoid conflicts with ongoing/planned MCs.
Note that although the vdrift provided from the command line as `TPCGasParam.DriftV` ConfigurableParam overrides the vdrift from the CCDB, the CCDB object is still always loaded and its new part, the time offset, is applied unless it is in turn overridden from the command line by `TPCDetParam.DriftTimeOffset` ConfigurableParam.