### PR TITLE
Strangeness tracking: Mother mass calculation: pass arrays by reference

### DIFF
--- a/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
+++ b/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
@@ -124,7 +124,7 @@ class StrangenessTracker
     return (qPos - qNeg) / (qPos + qNeg);
   };
 
-  double calcMotherMass(std::array<float, 3> pDauFirst, std::array<float, 3> pDauSecond, PID pidDauFirst, PID pidDauSecond)
+  double calcMotherMass(const std::array<float, 3>& pDauFirst, const std::array<float, 3>& pDauSecond, PID pidDauFirst, PID pidDauSecond)
   {
     double m2DauFirst = PID::getMass2(pidDauFirst);
     double m2DauSecond = PID::getMass2(pidDauSecond);


### PR DESCRIPTION
Follow up on PR #11388:
Passing arrays by reference in mother mass calculation.