### PR TITLE
o2-sim: Improvements for more stable initialization

### DIFF
--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -309,6 +309,13 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     } else {
       stateTransition(O2PrimaryServerState::ReadyToServe, "INITTASK");
     }
+
+    // feedback to driver that we are done initializing
+    if (mPipeToDriver != -1) {
+      int message = -111; // special code meaning end of initialization
+      if (write(mPipeToDriver, &message, sizeof(int))) {
+      }
+    }
   }
 
   // function for intermediate/on-the-fly reinitializations

--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -268,6 +268,8 @@ int main(int argc, char* argv[])
   // set the fatal callback for the logger to not do a core dump (since this might interfere with process shutdown sequence
   // since it calls ROOT::TSystem and further child processes)
   fair::Logger::OnFatal([] { throw fair::FatalException("Fatal error occured. Exiting without core dump..."); });
+  // initialy set logger verbosity to medium
+  FairLogger::GetLogger()->SetLogVerbosityLevel("MEDIUM");
 
   // extract the path to FairMQ config
   bpo::options_description desc{"Options"};


### PR DESCRIPTION
Sometimes o2-sim does not startup correctly because the GEANT worker fails to receive a configuration answer from the primary server in time. This is seen in cases when o2-sim is launched as a niced backfill process.

To make the system somewhat more stable, we now try to launch the GEANT worker only after the primary server has undergone initialization. To this end, the server sends a dedicated message on a pipe after it is initialized.

Side change: Take away colored log output (for cleaner log files).