### PR TITLE
ITS-Studies: add skeleton of an entrypoint for generic ITS-related studies

### DIFF
--- a/Detectors/ITSMFT/ITS/postprocessing/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/postprocessing/CMakeLists.txt
@@ -9,12 +9,5 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calibration)
-add_subdirectory(simulation)
-add_subdirectory(reconstruction)
-add_subdirectory(tracking)
+add_subdirectory(studies)
 add_subdirectory(workflow)
-add_subdirectory(postprocessing)
-add_subdirectory(macros)
-add_subdirectory(QC)

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/CMakeLists.txt
@@ -9,12 +9,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calibration)
-add_subdirectory(simulation)
-add_subdirectory(reconstruction)
-add_subdirectory(tracking)
-add_subdirectory(workflow)
-add_subdirectory(postprocessing)
-add_subdirectory(macros)
-add_subdirectory(QC)
+o2_add_library(ITSPostprocessing
+               SOURCES src/ImpactParameter.cxx
+               PUBLIC_LINK_LIBRARIES O2::GlobalTracking
+                                     O2::GlobalTrackingWorkflowReaders
+                                     O2::GlobalTrackingWorkflowHelpers
+                                     O2::DataFormatsGlobalTracking
+              #                        O2::DetectorsVertexing
+              #                        O2::SimulationDataFormat
+              )

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/ImpactParameter.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/ImpactParameter.h
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Antonio's code
+
+#ifndef O2_IMPACT_PARAMETER_STUDY_H
+#define O2_IMPACT_PARAMETER_STUDY_H
+
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "Framework/Task.h"
+#include "Framework/DataProcessorSpec.h"
+#include "ReconstructionDataFormats/Track.h"
+
+namespace o2
+{
+namespace its
+{
+namespace study
+{
+using mask_t = o2::dataformats::GlobalTrackID::mask_t;
+
+o2::framework::DataProcessorSpec getImpactParameterStudy(mask_t srcTracksMask, mask_t srcClusMask, bool useMC = false);
+} // namespace study
+} // namespace its
+} // namespace o2
+
+#endif // O2_IMPACT_PARAMETER_STUDY_H

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ITSStudiesLinkDef.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ITSStudiesLinkDef.h
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#endif

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
@@ -1,0 +1,119 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Skeleton derived from RS's code in ITSOffStudy
+
+#include "ITSStudies/ImpactParameter.h"
+
+#include "Framework/CCDBParamSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "ReconstructionDataFormats/VtxTrackRef.h"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+
+namespace o2
+{
+namespace its
+{
+namespace study
+{
+using namespace o2::framework;
+using namespace o2::globaltracking;
+
+using PVertex = o2::dataformats::PrimaryVertex;
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+class ImpactParameterStudy : public Task
+{
+ public:
+  ImpactParameterStudy(std::shared_ptr<DataRequest> dr, mask_t src) : mDataRequest(dr), mTracksSrc(src){};
+  ~ImpactParameterStudy() final = default;
+  void run(ProcessingContext&) final;
+  void endOfStream(EndOfStreamContext&) final;
+  void finaliseCCDB(ConcreteDataMatcher&, void*) final;
+  void process(o2::globaltracking::RecoContainer&);
+
+ private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+  GTrackID::mask_t mTracksSrc{};
+
+  // Data
+  std::shared_ptr<DataRequest> mDataRequest;
+  gsl::span<const PVertex> mPVertices;
+};
+
+void ImpactParameterStudy::run(ProcessingContext& pc)
+{
+  o2::globaltracking::RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest.get());
+  updateTimeDependentParams(pc); // Make sure this is called after recoData.collectData, which may load some conditions
+  process(recoData);
+}
+
+void ImpactParameterStudy::process(o2::globaltracking::RecoContainer& recoData)
+{
+  auto trackIndex = recoData.getPrimaryVertexMatchedTracks(); // Global ID's for associated tracks
+  auto vtxRefs = recoData.getPrimaryVertexMatchedTrackRefs(); // references from vertex to these track IDs
+  auto pvertices = recoData.getPrimaryVertices();
+
+  int nv = vtxRefs.size() - 1;      // The last entry is for unassigned tracks, ignore them
+  for (int iv = 0; iv < nv; iv++) { // Loop over PVs
+    const auto& vtref = vtxRefs[iv];
+    const auto& pv = pvertices[iv];
+    int it = vtref.getFirstEntry(), itLim = it + vtref.getEntries();
+    pv.print();
+    for (; it < itLim; it++) {
+      auto tvid = trackIndex[it];
+      if (!recoData.isTrackSourceLoaded(tvid.getSource())) {
+        continue;
+      }
+      const auto& trc = recoData.getTrackParam(tvid); // The actual track
+      if (it < 5) {
+        trc.print();
+      }
+    }
+  }
+}
+
+void ImpactParameterStudy::updateTimeDependentParams(ProcessingContext& pc)
+{
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+  }
+}
+
+void ImpactParameterStudy::endOfStream(EndOfStreamContext& ec)
+{
+}
+
+void ImpactParameterStudy::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+}
+
+DataProcessorSpec getImpactParameterStudy(mask_t srcTracksMask, mask_t srcClustersMask, bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  auto dataRequest = std::make_shared<DataRequest>();
+  dataRequest->requestTracks(srcTracksMask, useMC);
+  // dataRequest->requestClusters(srcClustersMask, useMC);
+  dataRequest->requestPrimaryVertertices(useMC);
+
+  return DataProcessorSpec{
+    "its-study-impactparameter",
+    dataRequest->inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<ImpactParameterStudy>(dataRequest, srcTracksMask)},
+    Options{}};
+}
+} // namespace study
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/postprocessing/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/postprocessing/workflow/CMakeLists.txt
@@ -9,12 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calibration)
-add_subdirectory(simulation)
-add_subdirectory(reconstruction)
-add_subdirectory(tracking)
-add_subdirectory(workflow)
-add_subdirectory(postprocessing)
-add_subdirectory(macros)
-add_subdirectory(QC)
+o2_add_executable(postprocessing-workflow
+                  COMPONENT_NAME its-standalone
+                  SOURCES standalone-postprocessing-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::ITSPostprocessing)

--- a/Detectors/ITSMFT/ITS/postprocessing/workflow/standalone-postprocessing-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/workflow/standalone-postprocessing-workflow.cxx
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSStudies/ImpactParameter.h"
+#include "Framework/CallbacksPolicy.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"track-sources", VariantType::String, std::string{"ITS,ITS-TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC,ITS-TPC-TRD"}, {"comma-separated list of track sources to use"}},
+    {"cluster-sources", VariantType::String, std::string{"ITS"}, {"comma-separated list of cluster sources to use"}},
+    {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options, "o2_tfidinfo.root");
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  GID::mask_t allowedSourcesTrc = GID::getSourcesMask("ITS,ITS-TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC,ITS-TPC-TRD");
+  GID::mask_t allowedSourcesClus = GID::getSourcesMask("ITS");
+
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+  srcTrc |= GID::getSourcesMask("ITS");
+  GID::mask_t srcCls = allowedSourcesClus & GID::getSourcesMask(configcontext.options().get<std::string>("cluster-sources"));
+
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, useMC);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC); // P-vertex is always needed
+
+  specs.emplace_back(o2::its::study::getImpactParameterStudy(srcTrc, srcCls, useMC));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}


### PR DESCRIPTION
The idea is copied from @shahor02 ITSOffset study.

I would like to gather a set of tasks, each performing some specific study related to ITS reco/tracking output, rather than spreading custom macros.

Current schema would be to have a single executable where one can choose which analysis to perform (if not all, by default), will see if this scales.

This way I hope to factorise the struggle related to the understanding of the DPL I/O and configuration for new/temporary contributors.
I also would like to maintain a single codebase for a tool to run systematic test/checks on data/MC given reconstruction objects.

In current PR I also included the skeleton of the impact parameter study that @apalasciano is going to integrate.