### PR TITLE
DPL: early release of buffers in aod reader

### DIFF
--- a/Framework/AnalysisSupport/src/DataInputDirector.cxx
+++ b/Framework/AnalysisSupport/src/DataInputDirector.cxx
@@ -389,25 +389,25 @@ bool DataInputDescriptor::readTree(DataAllocator& outputs, header::DataHeader dh
 
   // create table output
   auto o = Output(dh);
-  auto& t2t = outputs.make<TreeToTable>(o);
+  auto t2t = outputs.make<TreeToTable>(o);
 
   // add branches to read
   // fill the table
   auto colnames = getColumnNames(dh);
-  t2t.setLabel(tree->GetName());
+  t2t->setLabel(tree->GetName());
   if (colnames.size() == 0) {
     totalSizeCompressed += tree->GetZipBytes();
     totalSizeUncompressed += tree->GetTotBytes();
-    t2t.addAllColumns(tree);
+    t2t->addAllColumns(tree);
   } else {
     for (auto& colname : colnames) {
       TBranch* branch = tree->GetBranch(colname.c_str());
       totalSizeCompressed += branch->GetZipBytes("*");
       totalSizeUncompressed += branch->GetTotBytes("*");
     }
-    t2t.addAllColumns(tree, std::move(colnames));
+    t2t->addAllColumns(tree, std::move(colnames));
   }
-  t2t.fill(tree);
+  t2t->fill(tree);
   delete tree;
 
   mIOTime += (uv_hrtime() - ioStart);

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -220,7 +220,7 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
   context.addBuffer(std::move(header), buffer, std::move(finalizer), routeIndex);
 }
 
-void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
+void DataAllocator::adopt(const Output& spec, LifetimeHolder<TreeToTable>& t2t)
 {
   auto& timingInfo = mRegistry.get<TimingInfo>();
   RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
@@ -233,13 +233,20 @@ void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
   };
   auto buffer = std::make_shared<FairMQResizableBuffer>(creator);
 
+  t2t.callback = [buffer = buffer, transport = context.proxy().getOutputTransport(routeIndex)](TreeToTable& tree) {
+    // Serialization happens in here, so that we can
+    // get rid of the intermediate tree 2 table object, saving memory.
+    auto table = tree.finalize();
+    doWriteTable(buffer, table.get());
+    // deletion happens in the caller
+  };
+
   /// To finalise this we write the table to the buffer.
   /// FIXME: most likely not a great idea. We should probably write to the buffer
   ///        directly in the TableBuilder, incrementally.
-  auto finalizer = [payload = t2t](std::shared_ptr<FairMQResizableBuffer> b) -> void {
-    auto table = payload->finalize();
-    doWriteTable(b, table.get());
-    delete payload;
+  auto finalizer = [](std::shared_ptr<FairMQResizableBuffer> b) -> void {
+    // This is empty because we already serialised the object when
+    // the LifetimeHolder goes out of scope.
   };
 
   context.addBuffer(std::move(header), buffer, std::move(finalizer), routeIndex);


### PR DESCRIPTION
This introduces the concept of LifetimeHolder, which allows getting rid of intermediate objects as soon as they get out of scope, rather than waiting for the processing to be done.

In particular this PR uses it for the TreeToTable codepath, effectively cutting in half the common needs of the AOD reader.