### PR TITLE
Skip ROF ramp up data by default, silence desync.message at ramp up

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -115,6 +115,9 @@ class RawPixelDecoder final : public PixelReader
   std::vector<PhysTrigger>& getExternalTriggers() { return mExtTriggers; }
   const std::vector<PhysTrigger>& getExternalTriggers() const { return mExtTriggers; }
 
+  void setSkipRampUpData(bool v = true) { mSkipRampUpData = v; }
+  bool getSkipRampUpData() const { return mSkipRampUpData; }
+
   struct LinkEntry {
     int entry = -1;
   };
@@ -150,6 +153,8 @@ class RawPixelDecoder final : public PixelReader
   std::unordered_map<o2::InteractionRecord, int> mIRPoll;                             // poll for links IR used for synchronization
   bool mFillCalibData = false;                                                        // request to fill calib data from GBT
   bool mAlloEmptyROFs = false;                                                        // do not skip empty ROFs
+  bool mROFRampUpStage = false;                                                       // are we still in the ROF ramp up stage?
+  bool mSkipRampUpData = false;
   int mVerbosity = 0;
   int mNThreads = 1; // number of decoding threads
   // statistics

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -95,6 +95,8 @@ void STFDecoder<Mapping>::init(InitContext& ic)
     mDecoder->setAllowEmptyROFs(ic.options().get<bool>("allow-empty-rofs"));
     mDecoder->setRawDumpDirectory(dumpDir);
     mDecoder->setFillCalibData(mDoCalibData);
+    bool ignoreRampUp = !ic.options().get<bool>("accept-rof-rampup-data");
+    mDecoder->setSkipRampUpData(ignoreRampUp);
   } catch (const std::exception& e) {
     LOG(error) << "exception was thrown in decoder configuration: " << e.what();
     throw;
@@ -390,6 +392,7 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
       {"unmute-extra-lanes", VariantType::Bool, false, {"allow extra lanes to be as verbose as 1st one"}},
       {"allow-empty-rofs", VariantType::Bool, false, {"record ROFs w/o any hit"}},
       {"ignore-noise-map", VariantType::Bool, false, {"do not mask pixels flagged in the noise map"}},
+      {"accept-rof-rampup-data", VariantType::Bool, false, {"do not discard data during ROF ramp up"}},
       {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}}}};
 }
 


### PR DESCRIPTION
@iravasen With this PR the data during the ramp up will not be decoded (ROF vectors will be empty) unless an option `--accept-rof-rampup-data` is passed to `o2-itsmft-stf-decoder`.
If this option is passed, the decoding goes as usual but the error message `Wrong order/duplication...` will be muted during ramp up.
Please confirm that it is OK to not process ramp up digits.