### PR TITLE
FT0Digitizer: fixing misleading option --use-ccdb-ft0

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -631,7 +631,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     auto timestamp = o2::raw::HBFUtils::Instance().startTime;
     detList.emplace_back(o2::detectors::DetID::FT0);
     // connect the FT0 digitization
-    specs.emplace_back(o2::ft0::getFT0DigitizerSpec(fanoutsize++, mctruth, !useCCDB));
+    specs.emplace_back(o2::ft0::getFT0DigitizerSpec(fanoutsize++, mctruth, useCCDB));
     // connect the FIT digit writer
     writerSpecs.emplace_back(o2::ft0::getFT0DigitWriterSpec(mctruth));
   }


### PR DESCRIPTION
Misleading option `--use-ccdb-ft0` causes miscalibration for FT0 digitizer based on deprecated calibration object `FT0/Calib/ChannelTimeOffset`. Digitizer is not suppose to use it. This is preliminary suppression of the option. Later remaining peace of related code will be also deleted, due to no use anymore.