### PR TITLE
Improvements to CTP-FT0 triggering in MC

### DIFF
--- a/DataFormats/Detectors/CTP/src/Configuration.cxx
+++ b/DataFormats/Detectors/CTP/src/Configuration.cxx
@@ -605,7 +605,7 @@ int CTPConfiguration::assignDescriptors()
   return 0;
 }
 ///
-/// Run Managet to manage Config and Scalers
+/// Run Manager to manage Config and Scalers
 ///
 void CTPRunManager::init()
 {

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/Digit.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/Digit.h
@@ -50,6 +50,7 @@ struct DetTrigInput {
               (isSCnt << Triggers::bitSCen))
   {
   }
+  bool isVertex() const { return mInputs.test(Triggers::bitVertex); }
   ClassDefNV(DetTrigInput, 1);
 };
 

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -27,15 +27,16 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
   std::map<o2::detectors::DetID::ID, std::vector<CTPInput>> det2ctpinp = mCTPConfiguration->getDet2InputMap();
   // To be taken from config database ?
   std::map<std::string, uint64_t> detInputName2Mask =
-    {{"MVBA", 1}, {"MVIR", 0x10}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MT0A", 1}, {"MT0C", 2}, {"MTVX", 0x10}, {"MTCE", 8}, {"MTSC", 0x4}, {"0U0A", 1}, {"0U0C", 2}, {"0UVX", 0x10}, {"0UCE", 8}, {"0USC", 0x4}};
+    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10}};
+
+  // pre-sorting detector inputs per interaction record
   std::map<o2::InteractionRecord, std::vector<const CTPInputDigit*>> predigits;
   for (auto const& inp : detinputs) {
     predigits[inp.intRecord].push_back(&inp);
   }
+
   std::vector<CTPDigit> digits;
   for (auto const& hits : predigits) {
-    CTPDigit data;
-    data.intRecord = hits.first;
     std::bitset<CTP_NINPUTS> inpmaskcoll = 0;
     for (auto const inp : hits.second) {
       switch (inp->detector) {
@@ -43,42 +44,54 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           // see dummy database above
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::FT0]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            }
           }
           break;
         }
         case o2::detectors::DetID::FV0: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::FV0]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            }
           }
           break;
         }
         case o2::detectors::DetID::FDD: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::FDD]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            }
           }
           break;
         }
         case o2::detectors::DetID::EMC: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            }
           }
           break;
         }
         case o2::detectors::DetID::PHS: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::PHS]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            }
           }
           break;
         }
         case o2::detectors::DetID::ZDC: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::ZDC]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+            }
           }
           break;
         }
@@ -87,11 +100,16 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           LOG(error) << "CTP Digitizer: unknown detector:" << inp->detector;
           break;
       }
+    } // end loop over trigger input for this interaction
+    if (inpmaskcoll.to_ullong()) {
+      // we put the trigger only when non-trivial
+      CTPDigit data;
+      data.intRecord = hits.first;
+      data.CTPInputMask = inpmaskcoll;
+      calculateClassMask(inpmaskcoll, data.CTPClassMask);
+      digits.emplace_back(data);
+      LOG(info) << "Trigger-Event " << data.intRecord.bc << " " << data.intRecord.orbit << " Input mask:" << inpmaskcoll;
     }
-    LOG(info) << data.intRecord.bc << " " << data.intRecord.orbit << " Input mask:" << inpmaskcoll;
-    data.CTPInputMask = inpmaskcoll;
-    calculateClassMask(inpmaskcoll, data.CTPClassMask);
-    digits.emplace_back(data);
   }
   return std::move(digits);
 }


### PR DESCRIPTION
* CTP digitizer: apply trigger input mask only when input test succeeded
* CTP digitizer: Only create non-trivial CTPdigits (whenever mask collector is non-zero)

* add function to FT0 trigger to see easily see if it was vertex
* minor spelling fixes and code-reformating for better understandability

This is the result of some debugging. I noticed that CTP digitizer emits too many CTPdigits in comparison to FT0 vertex triggers, which shouldn't be the case for the default config which only triggers on T0-MTVX.