### PR TITLE
Distribution of CTP trigger within CollisionContext

### DIFF
--- a/DataFormats/Detectors/CTP/CMakeLists.txt
+++ b/DataFormats/Detectors/CTP/CMakeLists.txt
@@ -17,8 +17,9 @@ o2_add_library(DataFormatsCTP
           src/TriggerOffsetsParam.cxx
   PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
                         O2::Headers
-                        O2::SimulationDataFormat
                         O2::CommonUtils
+                        O2::DetectorsCommonDataFormats
+                        O2::DataFormatsParameters
                         O2::CommonConstants)
 o2_target_root_dictionary(DataFormatsCTP
                           HEADERS include/DataFormatsCTP/Digits.h

--- a/DataFormats/Detectors/CTP/src/DataFormatsCTPLinkDef.h
+++ b/DataFormats/Detectors/CTP/src/DataFormatsCTPLinkDef.h
@@ -14,6 +14,7 @@
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
+#pragma link C++ class std::bitset < 48> + ;
 #pragma link C++ class o2::ctp::CTPDigit + ;
 #pragma link C++ class vector < o2::ctp::CTPDigit> + ;
 #pragma link C++ class o2::ctp::CTPInputDigit + ;

--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -26,6 +26,7 @@ o2_add_library(SimulationDataFormat
                                      O2::DetectorsCommonDataFormats
                                      O2::DataFormatsParameters
                                      O2::DataFormatsCalibration
+                                     O2::DataFormatsCTP
                                      O2::GPUCommon
                                      ROOT::TreePlayer)
 

--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <MathUtils/Cartesian.h>
 #include <DataFormatsCalibration/MeanVertexObject.h>
+#include <DataFormatsCTP/Digits.h>
 
 namespace o2
 {
@@ -141,6 +142,17 @@ class DigitizationContext
 
   static DigitizationContext* loadFromFile(std::string_view filename = "");
 
+  void setCTPDigits(std::vector<o2::ctp::CTPDigit> const* ctpdigits) const
+  {
+    mCTPTrigger = ctpdigits;
+    if (mCTPTrigger) {
+      mHasTrigger = true;
+    }
+  }
+
+  std::vector<o2::ctp::CTPDigit> const* getCTPDigits() const { return mCTPTrigger; }
+  bool hasTriggerInput() const { return mHasTrigger; }
+
  private:
   int mNofEntries = 0;
   int mMaxPartNumber = 0; // max number of parts in any given collision
@@ -169,7 +181,10 @@ class DigitizationContext
   std::string mQEDSimPrefix;                         // prefix for QED production/contribution
   mutable o2::parameters::GRPObject* mGRP = nullptr; //!
 
-  ClassDefNV(DigitizationContext, 4);
+  mutable std::vector<o2::ctp::CTPDigit> const* mCTPTrigger = nullptr; // CTP trigger info associated to this digitization context
+  mutable bool mHasTrigger = false;                                    //
+
+  ClassDefNV(DigitizationContext, 5);
 };
 
 /// function reading the hits from a chain (previously initialized with initSimChains

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -55,7 +55,7 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     TStopwatch timer;
     timer.Start();
     LOG(info) << "CALLING CTP DIGITIZATION";
-    // Input order: T0, V0, ... but O need also poisition of inputs DETInputs
+    // Input order: T0, V0, ... but O need also position of inputs DETInputs
     for (const auto& inp : ft0inputs) {
       finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::FT0});
     }

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -60,6 +60,14 @@ class HMPIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     // read collision context from input
     auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
 
+    if (context->hasTriggerInput()) {
+      auto ctpdigits = context->getCTPDigits();
+      LOG(info) << "Yes, we have CTP digits";
+      LOG(info) << "We have " << ctpdigits->size() << " digits";
+    } else {
+      LOG(info) << "No trigger input available ... selftriggering";
+    }
+
     context->initSimChains(o2::detectors::DetID::HMP, mSimChains);
 
     auto& irecords = context->getEventRecords();

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -45,17 +45,25 @@ namespace o2
 namespace steer
 {
 
-DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::string>& simprefixes, const std::vector<int>& tpcsectors)
+std::vector<o2::ctp::CTPDigit>* ctptrigger = nullptr;
+
+DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::string>& simprefixes, const std::vector<int>& tpcsectors, bool withTrigger)
 {
   uint64_t activeSectors = 0;
   for (const auto& tpcsector : tpcsectors) {
     activeSectors |= (uint64_t)0x1 << tpcsector;
   }
 
-  auto doit = [range, tpcsectors, activeSectors](ProcessingContext& pc) {
+  auto doit = [range, tpcsectors, activeSectors, withTrigger](ProcessingContext& pc) {
     auto& mgr = steer::HitProcessingManager::instance();
     const auto& context = mgr.getDigitizationContext();
     auto eventrecords = context.getEventRecords();
+
+    if (withTrigger) {
+      // fetch the digits and transport them as part of the context
+      LOG(info) << "Setting CTP trigger object to " << ctptrigger;
+      context.setCTPDigits(ctptrigger);
+    }
 
     for (auto const& sector : tpcsectors) {
       // Note: the TPC sector header was serving the sector to lane mapping before
@@ -88,9 +96,25 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
   };
 
   // init function return a lambda taking a ProcessingContext
-  auto initIt = [simprefixes, doit](InitContext& ctx) {
+  auto initIt = [simprefixes, doit, withTrigger](InitContext& ctx) {
     // initialize fundamental objects
     auto& mgr = steer::HitProcessingManager::instance();
+
+    if (withTrigger) {
+      // fetch the ctp trigger/digit information from the CTP file
+      auto triggerf = TFile(ctx.options().get<std::string>("triggerfile").c_str(), "OPEN");
+      auto tr = (TTree*)triggerf.Get("o2sim");
+      if (!tr) {
+        LOG(fatal) << "Did not find CTP TTree";
+      }
+      auto br = tr->GetBranch("CTPDigits");
+      if (!br) {
+        LOG(fatal) << "Did not find CTPDigit branch";
+      }
+      br->SetAddress(&ctptrigger);
+      br->GetEntry(0);
+      LOG(info) << " Read " << ctptrigger->size() << " CTP digits ";
+    }
 
     // init gRandom
     gRandom->SetSeed(ctx.options().get<int>("seed"));
@@ -234,6 +258,7 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
       {"qed-x-section-ratio", VariantType::Float, -1.f, {"Ratio of cross sections QED/hadronic events. Determines QED interaction rate from hadronic interaction rate."}},
       {"outcontext", VariantType::String, "collisioncontext.root", {"Output file for collision context"}},
       {"incontext", VariantType::String, "", {"Take collision context from this file"}},
+      {"triggerfile", VariantType::String, "ctpdigits.root", {"Name of the CTP trigger/digit file to use"}},
       {"seed", VariantType::Int, 0, {"Random seed for collision context generation"}},
       {"ncollisions,n",
        VariantType::Int,

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.h
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.h
@@ -23,7 +23,7 @@ struct SubspecRange {
   int max = 0;
 };
 
-o2::framework::DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::string>& simprefixes, const std::vector<int>& tpcsectors);
+o2::framework::DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::string>& simprefixes, const std::vector<int>& tpcsectors, bool withTrigger = false);
 }
 } // namespace o2
 

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -202,6 +202,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"trd-digit-downscaling", VariantType::Int, 1, {"only keep TRD digits for every n-th trigger"}});
 
   workflowOptions.push_back(ConfigParamSpec{"combine-devices", VariantType::Bool, false, {"combined multiple DPL worker/writer devices"}});
+
+  // to enable distribution of triggers
+  workflowOptions.push_back(ConfigParamSpec{"with-trigger", VariantType::Bool, false, {"enable distribution of CTP trigger digits"}});
 }
 
 void customize(std::vector<o2::framework::DispatchPolicy>& policies)
@@ -788,6 +791,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
 
   // The SIM Reader. NEEDS TO BE LAST
-  specs[0] = o2::steer::getSimReaderSpec({firstOtherChannel, fanoutsize}, simPrefixes, tpcsectors);
+  bool withTrigger = configcontext.options().get<bool>("with-trigger");
+  LOG(info) << " TRIGGER " << withTrigger;
+  specs[0] = o2::steer::getSimReaderSpec({firstOtherChannel, fanoutsize}, simPrefixes, tpcsectors, withTrigger);
   return specs;
 }


### PR DESCRIPTION
This gives the (preliminary) possibility to distribute CTPdigits (momentarily, trigger decisions for FT0 MVTX) for digitizers.

This will work for MC that runs digitization in stages: 
*) First FT0 + CTP
*) Then digitizers that trigger on FT0 MVTX

In a future PR, this can be done with proper DPL-inputs, but this PR should already unblock work, where detectors need access to CTP trigger records.

There is a small example in HMPID, showing how the CTP triggers can be accessed.