### PR TITLE
Optionally combine entropy decoders to single device 

### DIFF
--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -135,6 +135,14 @@ class CTFCoderBase
   void setSupportBCShifts(bool v = true) { mSupportBCShifts = v; }
   bool getSupportBCShifts() const { return mSupportBCShifts; }
 
+  void setDictBinding(const std::string& s) { mDictBinding = s; }
+  const std::string& getDictBinding() const { return mDictBinding; }
+
+  void setTrigOffsBinding(const std::string& s) { mTrigOffsBinding = s; }
+  const std::string& getTrigOffsBinding() const { return mTrigOffsBinding; }
+
+  const DetID getDet() const { return mDet; }
+
  protected:
   void reportIRFrames();
   std::string getPrefix() const { return o2::utils::Str::concat_string(mDet.getName(), "_CTF: "); }
@@ -151,6 +159,8 @@ class CTFCoderBase
   std::vector<char> loadDictionaryFromTree(TTree* tree);
   std::vector<std::shared_ptr<void>> mCoders; // encoders/decoders
   DetID mDet;
+  std::string mDictBinding{"ctfdict"};
+  std::string mTrigOffsBinding{"trigoffset"};
   CTFDictHeader mExtHeader;      // external dictionary header
   o2::utils::IRFrameSelector mIRFrameSelector; // optional IR frames selector
   float mMemMarginFactor = 1.0f; // factor for memory allocation in EncodedBlocks

--- a/Detectors/Base/include/DetectorsBase/DPLWorkflowUtils.h
+++ b/Detectors/Base/include/DetectorsBase/DPLWorkflowUtils.h
@@ -257,14 +257,21 @@ o2::framework::DataProcessorSpec specCombiner(std::string const& name, std::vect
     void run(o2::framework::ProcessingContext& pc)
     {
       std::cerr << "Processing Combined with " << mNThreads << " threads\n";
-      size_t nt = tasks.size();
+      if (mNThreads > 1) {
+        size_t nt = tasks.size();
 #ifdef WITH_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
 #endif
-      for (size_t i = 0; i < nt; i++) {
-        auto t = tasks[i];
-        std::cerr << " Executing sub-device " << t.name << "\n";
-        t.algorithm.onProcess(pc);
+        for (size_t i = 0; i < nt; i++) {
+          auto& t = tasks[i];
+          std::cerr << " Executing sub-device " << t.name << "\n";
+          t.algorithm.onProcess(pc);
+        }
+      } else {
+        for (auto& t : tasks) {
+          std::cerr << " Executing sub-device " << t.name << "\n";
+          t.algorithm.onProcess(pc);
+        }
       }
     }
 

--- a/Detectors/Base/include/DetectorsBase/DPLWorkflowUtils.h
+++ b/Detectors/Base/include/DetectorsBase/DPLWorkflowUtils.h
@@ -28,6 +28,11 @@
 #include "Framework/DataSpecUtils.h"
 #include <vector>
 #include <unordered_map>
+#include <iostream>
+#ifdef WITH_OPENMP
+#include <omp.h>
+#include "TROOT.h"
+#endif
 
 namespace o2
 {
@@ -160,7 +165,12 @@ o2::framework::DataProcessorSpec specCombiner(std::string const& name, std::vect
     }
     for (auto& is : spec.inputs) {
       if (inputBindings.find(is.binding) != inputBindings.end()) {
-        LOG(error) << "Found duplicate input binding " << is.binding;
+        // we can accept duplicate binding if it is bound to the same spec (e.g. ccdbParamSpec)
+        if (std::find(combinedInputSpec.begin(), combinedInputSpec.end(), is) == combinedInputSpec.end()) {
+          LOG(error) << "Found duplicate input binding with different spec.:" << is.binding;
+        } else {
+          continue; // consider as already accounted
+        }
       }
       combinedInputSpec.push_back(is);
       inputBindings[is.binding] = 1;
@@ -212,6 +222,16 @@ o2::framework::DataProcessorSpec specCombiner(std::string const& name, std::vect
     void init(o2::framework::InitContext& ic)
     {
       std::cerr << "Init Combined\n";
+      mNThreads = std::max(1, ic.options().get<int>("combine-nthreads"));
+      if (mNThreads > 1) {
+#ifdef WITH_OPENMP
+        LOGP(info, "Combined tasks will be run with {} threads", mNThreads);
+        ROOT::EnableThreadSafety();
+#else
+        LOGP(warn, "{} threads requested for combined tasks but OpenMP is not detected, link it from the workflow CMakeList", mNThreads);
+        mNThreads = 1;
+#endif
+      }
       for (auto& t : tasks) {
         // the init function actually creates the onProcess function
         // which we have to do here (maybe some more stuff needed)
@@ -236,8 +256,13 @@ o2::framework::DataProcessorSpec specCombiner(std::string const& name, std::vect
 
     void run(o2::framework::ProcessingContext& pc)
     {
-      std::cerr << "Processing Combined\n";
-      for (auto& t : tasks) {
+      std::cerr << "Processing Combined with " << mNThreads << " threads\n";
+      size_t nt = tasks.size();
+#ifdef WITH_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
+#endif
+      for (size_t i = 0; i < nt; i++) {
+        auto t = tasks[i];
         std::cerr << " Executing sub-device " << t.name << "\n";
         t.algorithm.onProcess(pc);
       }
@@ -246,7 +271,10 @@ o2::framework::DataProcessorSpec specCombiner(std::string const& name, std::vect
    private:
     std::vector<DataProcessorSpec> tasks;
     std::unordered_map<std::string, std::unordered_map<std::string, std::string>> optionsRemap;
+    int mNThreads = 1;
   };
+
+  combinedOptions.emplace_back(ConfigParamSpec{"combine-nthreads", VariantType::Int, 1, {"Number of threads for combined tasks"}});
 
   return DataProcessorSpec{
     name,

--- a/Detectors/Base/src/CTFCoderBase.cxx
+++ b/Detectors/Base/src/CTFCoderBase.cxx
@@ -51,13 +51,13 @@ void CTFCoderBase::updateTimeDependentParams(ProcessingContext& pc, bool askTree
   setFirstTFOrbit(pc.services().get<o2::framework::TimingInfo>().firstTForbit);
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) { // this params need to be queried only once
     if (mOpType == OpType::Decoder) {
-      pc.inputs().get<o2::ctp::TriggerOffsetsParam*>("trigoffset"); // this is a configurable param
+      pc.inputs().get<o2::ctp::TriggerOffsetsParam*>(mTrigOffsBinding); // this is a configurable param
     }
     if (mLoadDictFromCCDB) {
       if (askTree) {
-        pc.inputs().get<TTree*>("ctfdict"); // just to trigger the finaliseCCDB
+        pc.inputs().get<TTree*>(mDictBinding); // just to trigger the finaliseCCDB
       } else {
-        pc.inputs().get<std::vector<char>*>("ctfdict"); // just to trigger the finaliseCCDB
+        pc.inputs().get<std::vector<char>*>(mDictBinding); // just to trigger the finaliseCCDB
       }
     }
   }

--- a/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
@@ -31,6 +31,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_CPV");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -52,7 +53,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_CPV");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
   auto& clusters = pc.outputs().make<std::vector<Cluster>>(OutputRef{"clusters"});
@@ -81,8 +82,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "CPV", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "CPV", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "CPV", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CPV/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_CPV", "CPV", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_CPV", "CPV", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CPV/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -10,6 +10,7 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(CTFWorkflow
+               TARGETVARNAME targetName
                SOURCES src/CTFWriterSpec.cxx
                        src/CTFReaderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
@@ -46,6 +47,12 @@ o2_add_library(CTFWorkflow
                                      O2::Algorithm
                                      O2::CommonUtils)
 
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
 o2_add_executable(writer-workflow
                   SOURCES src/ctf-writer-workflow.cxx
                   COMPONENT_NAME ctf
@@ -55,4 +62,3 @@ o2_add_executable(reader-workflow
                   SOURCES src/ctf-reader-workflow.cxx
                   COMPONENT_NAME ctf
                   PUBLIC_LINK_LIBRARIES O2::CTFWorkflow)
-

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -10,7 +10,6 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(CTFWorkflow
-               TARGETVARNAME targetName
                SOURCES src/CTFWriterSpec.cxx
                        src/CTFReaderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
@@ -47,12 +46,6 @@ o2_add_library(CTFWorkflow
                                      O2::Algorithm
                                      O2::CommonUtils)
 
-
-if (OpenMP_CXX_FOUND)
-    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
-    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
-endif()
-
 o2_add_executable(writer-workflow
                   SOURCES src/ctf-writer-workflow.cxx
                   COMPONENT_NAME ctf
@@ -61,4 +54,10 @@ o2_add_executable(writer-workflow
 o2_add_executable(reader-workflow
                   SOURCES src/ctf-reader-workflow.cxx
                   COMPONENT_NAME ctf
+                  TARGETVARNAME targetName
                   PUBLIC_LINK_LIBRARIES O2::CTFWorkflow)
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -21,6 +21,7 @@
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Algorithm/RangeTokenizer.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
 
 // Specific detectors specs
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
@@ -38,6 +39,9 @@
 #include "CPVWorkflow/EntropyDecoderSpec.h"
 #include "ZDCWorkflow/EntropyDecoderSpec.h"
 #include "CTPWorkflow/EntropyDecoderSpec.h"
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
 
 using namespace o2::framework;
 using DetID = o2::detectors::DetID;
@@ -72,6 +76,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   //
   options.push_back(ConfigParamSpec{"timeframes-shm-limit", VariantType::String, "0", {"Minimum amount of SHM required in order to publish data"}});
   options.push_back(ConfigParamSpec{"metric-feedback-channel-format", VariantType::String, "name=metric-feedback,type=pull,method=connect,address=ipc://{}metric-feedback-{},transport=shmem,rateLogging=0", {"format for the metric-feedback channel for TF rate limiting"}});
+  options.push_back(ConfigParamSpec{"combine-devices", VariantType::Bool, false, {"combine multiple DPL devices (entropy decoders)"}});
   std::swap(workflowOptions, options);
 }
 
@@ -134,54 +139,108 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   specs.push_back(o2::ctf::getCTFReaderSpec(ctfInput));
 
+  auto pipes = configcontext.options().get<std::string>("pipeline");
+  std::unordered_map<std::string, int> plines;
+  auto ptokens = o2::utils::Str::tokenize(pipes, ',');
+  for (auto& token : ptokens) {
+    auto split = token.find(":");
+    if (split == std::string::npos) {
+      throw std::runtime_error("bad pipeline definition. Syntax <processor>:<pipeline>");
+    }
+    auto key = token.substr(0, split);
+    token.erase(0, split + 1);
+    size_t error;
+    auto value = std::stoll(token, &error, 10);
+    if (token[error] != '\0') {
+      throw std::runtime_error("Bad pipeline definition. Expecting integer");
+    }
+    if (value > 1) {
+      plines[key] = value;
+    }
+  }
+
+  std::vector<WorkflowSpec> decSpecsV;
+
+  auto addSpecs = [&decSpecsV, &plines](DataProcessorSpec&& s) {
+    auto entry = plines.find(s.name);
+    size_t mult = (entry == plines.end() || entry->second < 2) ? 1 : entry->second;
+    if (mult > decSpecsV.size()) {
+      decSpecsV.resize(mult);
+    }
+    decSpecsV[mult - 1].push_back(s);
+  };
+
   // add decoders for all allowed detectors.
   if (ctfInput.detMask[DetID::ITS]) {
-    specs.push_back(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::ITS), verbosity, configcontext.options().get<bool>("its-digits"), ctfInput.subspec));
+    addSpecs(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::ITS), verbosity, configcontext.options().get<bool>("its-digits"), ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::MFT]) {
-    specs.push_back(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::MFT), verbosity, configcontext.options().get<bool>("mft-digits"), ctfInput.subspec));
+    addSpecs(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::MFT), verbosity, configcontext.options().get<bool>("mft-digits"), ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::TPC]) {
-    specs.push_back(o2::tpc::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::tpc::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::TRD]) {
-    specs.push_back(o2::trd::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::trd::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::TOF]) {
-    specs.push_back(o2::tof::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::tof::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::FT0]) {
-    specs.push_back(o2::ft0::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::ft0::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::FV0]) {
-    specs.push_back(o2::fv0::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::fv0::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::FDD]) {
-    specs.push_back(o2::fdd::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::fdd::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::MID]) {
-    specs.push_back(o2::mid::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::mid::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::MCH]) {
-    specs.push_back(o2::mch::getEntropyDecoderSpec(verbosity, "mch-entropy-decoder", ctfInput.subspec));
+    addSpecs(o2::mch::getEntropyDecoderSpec(verbosity, "mch-entropy-decoder", ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::EMC]) {
-    specs.push_back(o2::emcal::getEntropyDecoderSpec(verbosity, ctfInput.subspec, ctfInput.decSSpecEMC));
+    addSpecs(o2::emcal::getEntropyDecoderSpec(verbosity, ctfInput.subspec, ctfInput.decSSpecEMC));
   }
   if (ctfInput.detMask[DetID::PHS]) {
-    specs.push_back(o2::phos::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::phos::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::CPV]) {
-    specs.push_back(o2::cpv::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::cpv::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::ZDC]) {
-    specs.push_back(o2::zdc::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::zdc::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::HMP]) {
-    specs.push_back(o2::hmpid::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::hmpid::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
   }
   if (ctfInput.detMask[DetID::CTP]) {
-    specs.push_back(o2::ctp::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+    addSpecs(o2::ctp::getEntropyDecoderSpec(verbosity, ctfInput.subspec));
+  }
+
+  bool combine = configcontext.options().get<bool>("combine-devices");
+  if (!combine) {
+    for (auto& decSpecs : decSpecsV) {
+      for (auto& s : decSpecs) {
+        specs.push_back(s);
+      }
+    }
+  } else {
+    std::vector<DataProcessorSpec> remaining;
+    if (decSpecsV.size() && decSpecsV[0].size()) {
+      specs.push_back(specCombiner("EntropyDecoders", decSpecsV[0], remaining)); // processing w/o pipelining
+    }
+    for (size_t i = 1; i < decSpecsV.size(); i++) { // add pipelined processes separately, consider combining them to separate groups (need to have modify argument of pipeline option)
+      auto& decSpecs = decSpecsV[i];
+      for (auto& s : decSpecs) {
+        specs.push_back(s);
+      }
+    }
+    for (auto& s : remaining) {
+      specs.push_back(s);
+    }
   }
 
   return std::move(specs);

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -31,6 +31,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_CTP");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -52,7 +53,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc, true);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_CTP");
 
   auto& digits = pc.outputs().make<std::vector<CTPDigit>>(OutputRef{"digits"});
   auto& lumi = pc.outputs().make<LumiInfo>(OutputRef{"lumi"});
@@ -81,8 +82,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "CTP", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "CTP", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "CTP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/CTFDictionaryTree"));
+  inputs.emplace_back("ctf_CTP", "CTP", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_CTP", "CTP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/CTFDictionaryTree"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
@@ -31,6 +31,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity, unsigned int sspecOut) : m
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_EMC");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -52,7 +53,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_EMC");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers", mSSpecOut});
   auto& cells = pc.outputs().make<std::vector<Cell>>(OutputRef{"cells", mSSpecOut});
@@ -81,8 +82,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspecInp, un
     OutputSpec{{"ctfrep"}, "EMC", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "EMC", "CTFDATA", sspecInp, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "EMC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("EMC/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_EMC", "EMC", "CTFDATA", sspecInp, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_EMC", "EMC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("EMC/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setDictBinding("ctfdict_FDD");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -51,7 +52,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_FDD");
 
   auto& digits = pc.outputs().make<std::vector<o2::fdd::Digit>>(OutputRef{"digits"});
   auto& channels = pc.outputs().make<std::vector<o2::fdd::ChannelData>>(OutputRef{"channels"});
@@ -80,8 +81,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "FDD", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "FDD", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "FDD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FDD/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_FDD", "FDD", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_FDD", "FDD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FDD/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setDictBinding("ctfdict_FT0");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -51,7 +52,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_FT0");
 
   auto& digits = pc.outputs().make<std::vector<o2::ft0::Digit>>(OutputRef{"digits"});
   auto& channels = pc.outputs().make<std::vector<o2::ft0::ChannelData>>(OutputRef{"channels"});
@@ -80,8 +81,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "FT0", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "FT0", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "FT0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FT0/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_FT0", "FT0", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_FT0", "FT0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FT0/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setDictBinding("ctfdict_FV0");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -51,7 +52,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_FV0");
 
   auto& digits = pc.outputs().make<std::vector<o2::fv0::Digit>>(OutputRef{"digits"});
   auto& channels = pc.outputs().make<std::vector<o2::fv0::ChannelData>>(OutputRef{"channels"});
@@ -80,8 +81,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "FV0", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "FV0", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "FV0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FV0/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_FV0", "FV0", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_FV0", "FV0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FV0/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_HMP");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -69,7 +70,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_HMP");
 
   auto& triggers = pc.outputs().make<std::vector<Trigger>>(OutputRef{"triggers"});
   auto& digits = pc.outputs().make<std::vector<Digit>>(OutputRef{"digits"});
@@ -98,8 +99,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "HMP", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "HMP", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "HMP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("HMP/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_HMP", "HMP", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_HMP", "HMP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("HMP/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
@@ -53,6 +53,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   bool mGetDigits{false};
   bool mMaskNoise{false};
   bool mUseClusterDictionary{true};
+  std::string mDetPrefix{};
 
   std::string mCTFDictPath{};
   TStopwatch mTimer;

--- a/Detectors/MUON/MCH/CTF/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/CTF/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setDictBinding("ctfdict_MCH");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -69,7 +70,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_MCH");
 
   auto& rofs = pc.outputs().make<std::vector<o2::mch::ROFRecord>>(OutputRef{"rofs", 0});
   auto& digits = pc.outputs().make<std::vector<o2::mch::Digit>>(OutputRef{"digits", 0});
@@ -99,8 +100,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, const char* specName, uns
   };
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "MCH", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "MCH", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MCH/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_MCH", "MCH", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_MCH", "MCH", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MCH/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -32,6 +32,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setDictBinding("ctfdict_MID");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -53,7 +54,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_MID");
   std::array<std::vector<o2::mid::ROFRecord>, NEvTypes> rofs{};
   std::array<std::vector<o2::mid::ColumnData>, NEvTypes> cols{};
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
@@ -91,8 +92,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   }
   outputs.emplace_back(OutputSpec{{"ctfrep"}, "MID", "CTFDECREP", 0, Lifetime::Timeframe});
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "MID", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "MID", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MID/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_MID", "MID", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_MID", "MID", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MID/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -31,6 +31,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_PHS");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -52,7 +53,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_PHS");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
   auto& cells = pc.outputs().make<std::vector<Cell>>(OutputRef{"cells"});
@@ -81,8 +82,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "PHS", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "PHS", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "PHS", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("PHS/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_PHS", "PHS", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_PHS", "PHS", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("PHS/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -31,6 +31,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setDictBinding("ctfdict_TOF");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -52,7 +53,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_TOF");
 
   auto& digitheader = pc.outputs().make<DigitHeader>(OutputRef{"digitheader"});
   auto& digits = pc.outputs().make<std::vector<Digit>>(OutputRef{"digits"});
@@ -103,8 +104,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, o2::header::gDataOriginTOF, "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "TOF", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "TOF", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_TOF", "TOF", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_TOF", "TOF", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/TPC/workflow/include/TPCWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
     mTimer.Stop();
     mTimer.Reset();
     mCTFCoder.setVerbosity(verbosity);
+    mCTFCoder.setDictBinding("ctfdict_TPC");
   }
   ~EntropyDecoderSpec() override = default;
   void init(o2::framework::InitContext& ic) final;

--- a/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
@@ -45,7 +45,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc, true);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_TPC");
 
   auto& compclusters = pc.outputs().make<std::vector<char>>(OutputRef{"output"});
   if (buff.size()) {
@@ -67,8 +67,8 @@ void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "TPC", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionaryTree"));
+  inputs.emplace_back("ctf_TPC", "TPC", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_TPC", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionaryTree"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -50,6 +50,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_TRD");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -86,7 +87,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_TRD");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
   auto& tracklets = pc.outputs().make<std::vector<Tracklet64>>(OutputRef{"tracklets"});
@@ -117,8 +118,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "TRD", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "TRD", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "TRD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TRD/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_TRD", "TRD", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_TRD", "TRD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TRD/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
@@ -32,6 +32,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
   mCTFCoder.setSupportBCShifts(true);
+  mCTFCoder.setDictBinding("ctfdict_ZDC");
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -58,7 +59,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_ZDC");
 
   auto& bcdata = pc.outputs().make<std::vector<o2::zdc::BCData>>(OutputRef{"trig"});
   auto& chans = pc.outputs().make<std::vector<o2::zdc::ChannelData>>(OutputRef{"chan"});
@@ -89,8 +90,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     OutputSpec{{"ctfrep"}, "ZDC", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("ctf", "ZDC", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "ZDC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("ZDC/Calib/CTFDictionary"));
+  inputs.emplace_back("ctf_ZDC", "ZDC", "CTFDATA", sspec, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict_ZDC", "ZDC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("ZDC/Calib/CTFDictionary"));
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{

--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -112,6 +112,19 @@ class ConfigParamRegistry
     throw std::invalid_argument(std::string("bad type for option: ") + key);
   }
 
+  template <typename T>
+  void override(const char* key, const T& val) const
+  {
+    assert(mStore.get());
+    try {
+      mStore->store().put(key, val);
+    } catch (std::exception& e) {
+      throw std::invalid_argument(std::string("failed to store an option: ") + key + " (" + e.what() + ")");
+    } catch (...) {
+      throw std::invalid_argument(std::string("failed to store an option: ") + key);
+    }
+  }
+
  private:
   std::unique_ptr<ConfigParamStore> mStore;
 };


### PR DESCRIPTION
o2-ctf-reader-workflow with option --combine-devices will merge all non-pipelined entropy decoders
to a single device. Option --combine-nthreads <N=1> will be automatically added to allow running task::run
methods of this process with openMP threads.
At the moment only non-pipelined processes can be combined. In principle, one can create additionally
combined processes for all devices with the same multiplicity but to pipeline them one would need to modify
or append --pipeline option from the parent workflow creation code.