### PR TITLE
Enable by default 3-body vertexing

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -52,7 +52,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
     {"disable-cascade-finder", o2::framework::VariantType::Bool, false, {"do not run cascade finder"}},
-    {"enable-3body-finder", o2::framework::VariantType::Bool, false, {"run 3 body finder"}},
+    {"disable-3body-finder", o2::framework::VariantType::Bool, false, {"run 3 body finder"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
     {"require-ctp-lumi", o2::framework::VariantType::Bool, false, {"require CTP lumi for TPC correction scaling"}},
     {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}}};
@@ -75,7 +75,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   bool useMC = false;
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto enableCasc = !configcontext.options().get<bool>("disable-cascade-finder");
-  auto enable3body = configcontext.options().get<bool>("enable-3body-finder");
+  auto enable3body = !configcontext.options().get<bool>("disable-3body-finder");
   auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
 
   GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("vertexing-sources"));


### PR DESCRIPTION
Dear @shahor02

this enables the 3-body decay finder by default.
The timing is the following on few CTFs of the 2022 pp data at 650kHz: 
- wo 3 body
Secondary vertexing total timing: Cpu: 3.212e+01 Real: 3.217e+01 s in 50 slots, nThreads = 1
- with 3 body
Secondary vertexing total timing: Cpu: 3.456e+01 Real: 3.461e+01 s in 50 slots, nThreads = 1

The data size increase is small as the 3 body decays are 1/3 of the cascades.

Cheers,
Max and Francesco
