### PR TITLE
Add TRD pulse height DPL device (dummy)

### DIFF
--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(TRDCalibration
                        src/KrClusterFinder.cxx
                        src/DCSProcessor.cxx
                        src/CalibrationParams.cxx
+                       src/PulseHeight.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
                                      O2::DataFormatsTRD
                                      O2::DataFormatsGlobalTracking
@@ -37,6 +38,7 @@ o2_add_library(TRDCalibration
                                    include/TRDCalibration/CalibrationParams.h
                                    include/TRDCalibration/PadCalibCCDBBuilder.h
                                    include/TRDCalibration/KrClusterFinder.h
+                                   include/TRDCalibration/PulseHeight.h
                                    include/TRDCalibration/DCSProcessor.h)
 
 o2_add_executable(trd-dcs-sim-workflow

--- a/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PulseHeight.h
+/// \brief Creates PH spectra from TRD digits found on tracks
+
+#ifndef O2_TRD_PULSEHEIGHT_H
+#define O2_TRD_PULSEHEIGHT_H
+
+#include "DataFormatsTRD/TrackTRD.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/TrackTriggerRecord.h"
+
+namespace o2
+{
+
+namespace globaltracking
+{
+class RecoContainer;
+}
+
+namespace trd
+{
+
+class PulseHeight
+{
+
+ public:
+  PulseHeight() = default;
+
+  /// Initialize what is needed
+  void init();
+
+  /// Initialize the input arrays
+  void setInput(const o2::globaltracking::RecoContainer& input, gsl::span<const Digit>* digits);
+
+  /// Reset the output
+  void reset();
+
+  /// Main processing function
+  void process();
+
+ private:
+  // input arrays which should not be modified since they are provided externally
+  gsl::span<const TrackTRD> mTracksInITSTPCTRD;                      ///< TRD tracks reconstructed from TPC or ITS-TPC seeds
+  gsl::span<const TrackTRD> mTracksInTPCTRD;                         ///< TRD tracks reconstructed from TPC or TPC seeds
+  gsl::span<const Tracklet64> mTrackletsRaw;                         ///< array of raw tracklets
+  const gsl::span<const Digit>* mDigits = nullptr;                   ///< array of digits
+  gsl::span<const TriggerRecord> mTriggerRecords;                    ///< array of trigger records
+  gsl::span<const TrackTriggerRecord> mTrackTriggerRecordsTPCTRD;    ///< array of track trigger records
+  gsl::span<const TrackTriggerRecord> mTrackTriggerRecordsITSTPCTRD; ///< array of track trigger records
+
+  ClassDefNV(PulseHeight, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_PULSEHEIGHT_H

--- a/Detectors/TRD/calibration/src/PulseHeight.cxx
+++ b/Detectors/TRD/calibration/src/PulseHeight.cxx
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PulseHeight.cxx
+/// \brief Creates PH spectra from TRD digits found on tracks
+
+#include "TRDCalibration/PulseHeight.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include <fairlogger/Logger.h>
+
+using namespace o2::trd;
+using namespace o2::trd::constants;
+
+void PulseHeight::reset()
+{
+}
+
+void PulseHeight::init()
+{
+}
+
+void PulseHeight::setInput(const o2::globaltracking::RecoContainer& input, gsl::span<const Digit>* digits)
+{
+  mTracksInITSTPCTRD = input.getITSTPCTRDTracks<TrackTRD>();
+  mTracksInTPCTRD = input.getTPCTRDTracks<TrackTRD>();
+  mTrackletsRaw = input.getTRDTracklets();
+  mTriggerRecords = input.getTRDTriggerRecords();
+  mTrackTriggerRecordsTPCTRD = input.getTPCTRDTriggers();
+  mTrackTriggerRecordsITSTPCTRD = input.getITSTPCTRDTriggers();
+  mDigits = digits;
+}
+
+void PulseHeight::process()
+{
+  LOGP(info, "Processing {} tracklets and {} digits from {} triggers and {} ITS-TPC-TRD tracks and {} TPC-TRD tracks",
+       mTrackletsRaw.size(), mDigits->size(), mTriggerRecords.size(), mTracksInITSTPCTRD.size(), mTracksInTPCTRD.size());
+}

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -24,6 +24,7 @@ o2_add_library(TRDWorkflow
                        src/KrClustererSpec.cxx
                        include/TRDWorkflow/VdAndExBCalibSpec.h
                        include/TRDWorkflow/GainCalibSpec.h
+                       include/TRDWorkflow/TRDPulseHeightSpec.h
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
@@ -1,0 +1,122 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_PULSEHEIGHTSPEC_H
+#define O2_TRD_PULSEHEIGHTSPEC_H
+
+/// \file   TRDPulseHeightSpec.h
+/// \brief DPL device for creating a pulse height spectrum with digits on tracks
+
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "TRDCalibration/PulseHeight.h"
+
+using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+
+namespace o2
+{
+namespace trd
+{
+
+class PuseHeightDevice : public o2::framework::Task
+{
+ public:
+  PuseHeightDevice(std::shared_ptr<DataRequest> dr) : mDataRequest(dr) {}
+  void init(o2::framework::InitContext& ic) final
+  {
+    mPulseHeight = std::make_unique<PulseHeight>();
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+    if (tinfo.globalRunNumberChanged) { // new run is starting
+      mRunStopRequested = false;
+    }
+    if (mRunStopRequested) {
+      return;
+    }
+    RecoContainer recoData;
+    recoData.collectData(pc, *mDataRequest.get());
+    auto digits = pc.inputs().get<gsl::span<o2::trd::Digit>>("digits");
+    mPulseHeight->setInput(recoData, &digits);
+    mPulseHeight->process();
+    // the output should not be sent for every TF, but be accumulated for some time so that QC can fetch it without any sampling
+    // pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHT", 0, Lifetime::Sporadic}, mPulseHeight->getPHSpectrum());
+    if (pc.transitionState() == TransitionHandlingState::Requested) {
+      LOG(info) << "Run stop requested, finalizing";
+      mRunStopRequested = true;
+    }
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    if (mRunStopRequested) {
+      return;
+    }
+  }
+
+  void stop() final
+  {
+  }
+
+ private:
+  std::shared_ptr<DataRequest> mDataRequest;
+  std::unique_ptr<o2::trd::PulseHeight> mPulseHeight;
+  bool mRunStopRequested = false; // flag that run was stopped (and the last output is sent)
+};
+
+} // namespace trd
+
+namespace framework
+{
+
+DataProcessorSpec getTRDPulseHeightSpec(GID::mask_t src, bool digitsFromReader)
+{
+
+  std::vector<OutputSpec> outputs;
+  // outputs.emplace_back(o2::header::gDataOriginTRD, "PULSEHEIGHT", 0, Lifetime::Sporadic)
+
+  bool isTPCavailable = false;
+  if (GID::includesSource(GID::Source::ITSTPC, src)) {
+    LOGF(debug, "Found ITS-TPC tracks as input, loading ITS-TPC-TRD");
+    src |= GID::getSourcesMask("ITS-TPC-TRD");
+  }
+  if (GID::includesSource(GID::Source::TPC, src)) {
+    LOGF(debug, "Found TPC tracks as input, loading TPC-TRD");
+    src |= GID::getSourcesMask("TPC-TRD");
+    isTPCavailable = true;
+  }
+  GID::mask_t srcClu = GID::getSourcesMask("TRD"); // we don't need all clusters, only TRD tracklets
+
+  auto dataRequest = std::make_shared<DataRequest>();
+  dataRequest->requestTracks(src, false);
+  dataRequest->requestClusters(srcClu, false);
+  dataRequest->inputs.emplace_back("digits", "TRD", "DIGITS", digitsFromReader ? 1 : 0);
+
+  return DataProcessorSpec{
+    "trd-pulseheight",
+    dataRequest->inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<o2::trd::PuseHeightDevice>(dataRequest)},
+    Options{
+      {"enable-root-output", VariantType::Bool, false, {"output PH plot to root file"}} // TODO: implement
+    }};
+}
+} // namespace framework
+} // namespace o2
+
+#endif // O2_TRD_PULSEHEIGHTSPEC_H


### PR DESCRIPTION
A starting point to move the creation of the pulse height spectra from QC into O2, such that
a) we avoid the sampling of digits and get more statistics in the plots
b) the PH plots can be used downstream for example for the T0 calibration

This is currently a dummy.
TODO:
- move the algorithm for creating the PH plot from QC into `PulseHeight::process()`
- add a writer to write the output to a file
- initialization and reset methods (if needed, depending on the output type chosen)