### PR TITLE
Some uncorrelated improvements

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -67,7 +67,7 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
     maskTracksMC = GID::getSourcesMask(GID::NONE);
   } else {
     // some detectors do not support MC labels
-    if (maskClustersMC[GID::MCH]) {
+    if (maskClusters[GID::MCH] && maskClustersMC[GID::MCH]) {
       LOG(warn) << "MCH global clusters do not support MC lables, disabling";
       maskClustersMC &= ~GID::getSourceMask(GID::MCH);
     }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -215,7 +215,8 @@ DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool ctpInput, b
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
-                                                                inputs);
+                                                                inputs,
+                                                                true);
   return DataProcessorSpec{
     "residual-aggregator",
     inputs,

--- a/Detectors/TRD/macros/CheckNoiseRun.C
+++ b/Detectors/TRD/macros/CheckNoiseRun.C
@@ -18,14 +18,18 @@
 #include <TH1F.h>
 #include <TCanvas.h>
 #include <TStyle.h>
-#include <RDataFrame.h>
+#include <TBox.h>
+#include <TText.h>
+#include <ROOT/RDataFrame.hxx>
 
 #include <map>
 #include <string>
 #include <ostream>
 #include <fairlogger/Logger.h>
+#include "CCDB/BasicCCDBManager.h"
 #include "TRDBase/Calibrations.h"
 #include "DataFormatsTRD/HelperMethods.h"
+#include "DataFormatsTRD/NoiseCalibration.h"
 
 #endif
 


### PR DESCRIPTION
Important is the change to the residual aggregator in order to query the CCDB objects only once at SOR, since no updated objects are required