### PR TITLE
[EMCAL-565] Add fucntionality to only select specific trigger in calib

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -66,13 +66,14 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   float maxAllowedDeviationFromMax = 10; ///< maximum deviation allowed between the estimated maximum of the fit and the true maximum from the distribution. If deviation is larger then value, the fit likely failed. In this case, the true value is taken
 
   // common parameters
-  std::string calibType = "time";         ///< type of calibration to run
-  std::string localRootFilePath = "";     ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
-  bool enableFastCalib = false;           ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
-  bool enableTimeProfiling = false;       ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
-  bool setSavedSlotAllowed_EMC = true;    ///< if true, saving and loading of calibrations from last run and for next run is enabled
-  bool setSavedSlotAllowedSOR_EMC = true; ///< if true, stored calibrations from last run can be loaded in the next run (if false, storing of the calib histograms is still active in contrast to setSavedSlotAllowed_EMC)
-  long endTimeMargin = 2592000000;        ///< set end TS to 30 days after slot ends (1000 * 60 * 60 * 24 * 30)
+  std::string calibType = "time";                      ///< type of calibration to run
+  std::string localRootFilePath = "";                  ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
+  bool enableFastCalib = false;                        ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
+  bool enableTimeProfiling = false;                    ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
+  bool setSavedSlotAllowed_EMC = true;                 ///< if true, saving and loading of calibrations from last run and for next run is enabled
+  bool setSavedSlotAllowedSOR_EMC = true;              ///< if true, stored calibrations from last run can be loaded in the next run (if false, storing of the calib histograms is still active in contrast to setSavedSlotAllowed_EMC)
+  long endTimeMargin = 2592000000;                     ///< set end TS to 30 days after slot ends (1000 * 60 * 60 * 24 * 30)
+  std::string selectedClassMasks = "C0TVX-B-NOPF-EMC"; ///< name of EMCal min. bias trigger that is used for calibration
 
   // old parameters. Keep them for a bit (can be deleted after september 5th) as otherwise ccdb and o2 version might not be in synch
   unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -283,6 +283,11 @@ bool EMCALChannelCalibrator<DataInput, DataOutput>::adoptSavedData(const o2::cal
     return true;
 
   auto& cont = o2::calibration::TimeSlotCalibration<DataInput>::getSlots();
+
+  if (cont.size() == 0) {
+    LOG(warning) << "cont.size() is 0, calibration objects from previous run cannot be loaded...";
+    return true;
+  }
   auto& slot = cont.at(0);
   DataInput* c = slot.getContainer();
 

--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -33,6 +33,8 @@
 #include "CommonUtils/NameConf.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "Framework/CCDBParamSpec.h"
+#include "DataFormatsCTP/Digits.h"
+#include "DataFormatsCTP/Configuration.h"
 
 // for time measurements
 #include <chrono>
@@ -50,7 +52,7 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   using EMCALCalibParams = o2::emcal::EMCALCalibParams;
 
  public:
-  EMCALChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool params, std::string calibType, bool rejCalibTrg) : mCCDBRequest(req), mLoadCalibParamsFromCCDB(params), mCalibType(calibType), mRejectCalibTriggers(rejCalibTrg) {}
+  EMCALChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool params, std::string calibType, bool rejCalibTrg, bool rejL0Trig) : mCCDBRequest(req), mLoadCalibParamsFromCCDB(params), mCalibType(calibType), mRejectCalibTriggers(rejCalibTrg), mRejectL0Triggers(rejL0Trig) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -87,13 +89,37 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     if (matcher == ConcreteDataMatcher("EMC", "EMCALCALIBPARAM", 0)) {
       LOG(info) << "EMCal CalibParams updated";
       EMCALCalibParams::Instance().printKeyValues(true, true);
-      return;
     }
     if (matcher == ConcreteDataMatcher("EMC", "SCALEFACTORS", 0)) {
       if (mBadChannelCalibrator && EMCALCalibParams::Instance().useScaledHisto_bc) {
         LOG(info) << "Configuring scale factors for bad channel map";
         mBadChannelCalibrator->getCalibExtractor()->setBCMScaleFactors(reinterpret_cast<o2::emcal::EMCALChannelScaleFactors*>(obj));
         mScaleFactorsInitialized = true;
+      }
+    }
+    if (matcher == ConcreteDataMatcher("CTP", "CTPCONFIG", 0)) {
+      // clear current class mask and prepare to fill in the updated values
+      // The trigger names are seperated by a ":" in one string in the calib params
+      mSelectedClassMasks.clear();
+      std::string strSelClassMasks = EMCALCalibParams::Instance().selectedClassMasks;
+      std::string delimiter = ":";
+      size_t pos = 0;
+      std::vector<std::string> vSelMasks;
+      while ((pos = strSelClassMasks.find(delimiter)) != std::string::npos) {
+        vSelMasks.push_back(strSelClassMasks.substr(0, pos));
+        strSelClassMasks.erase(0, pos + delimiter.length());
+      }
+      vSelMasks.push_back(strSelClassMasks);
+
+      auto ctpconf = reinterpret_cast<o2::ctp::CTPConfiguration*>(obj);
+
+      for (auto& cls : ctpconf->getCTPClasses()) {
+        LOG(debug) << "CTP class: " << cls.name << "\t " << cls.classMask;
+
+        if (std::find(vSelMasks.begin(), vSelMasks.end(), cls.name) != vSelMasks.end()) {
+          mSelectedClassMasks.push_back(cls.classMask);
+          LOG(info) << "Setting selected class mask " << cls.name << " to bit " << cls.classMask;
+        }
       }
     }
   }
@@ -122,11 +148,16 @@ class EMCALChannelCalibDevice : public o2::framework::Task
       pc.inputs().get<o2::emcal::EMCALChannelScaleFactors*>("EMC_Scalefactors");
     }
 
+    // prepare CTPConfiguration such that it can be loaded in finalise ccdb
+    pc.inputs().get<o2::ctp::CTPConfiguration*>(getCTPConfigBinding());
+
     if (!mIsConfigured) {
       // configure calibrators (after calib params are loaded from the CCDB)
       configureCalibrators();
       mIsConfigured = true;
     }
+
+    auto ctpDigits = pc.inputs().get<gsl::span<o2::ctp::CTPDigit>>(getCTPDigitsBinding());
 
     // reset EOR behaviour
     if (mTimeCalibrator) {
@@ -156,6 +187,35 @@ class EMCALChannelCalibDevice : public o2::framework::Task
         LOG(debug) << "Trigger: " << trg.getTriggerBits() << "   o2::trigger::Cal " << o2::trigger::Cal;
         if (trg.getTriggerBits() & o2::trigger::Cal) {
           LOG(debug) << "skipping triggered events due to wrong trigger (no Physics trigger)";
+          continue;
+        }
+      }
+
+      // reject all triggers that are not included in the classMask (typically only EMC min. bias should be accepted)
+      uint64_t classMaskCTP = 0;
+      if (mRejectL0Triggers) {
+        bool acceptEvent = false;
+        // Match the EMCal bc to the CTP bc
+        int64_t bcEMC = trg.getBCData().toLong();
+        for (auto& ctpDigit : ctpDigits) {
+          int64_t bcCTP = ctpDigit.intRecord.toLong();
+          LOG(debug) << "bcEMC " << bcEMC << "   bcCTP " << bcCTP;
+          if (bcCTP == bcEMC) {
+            // obtain trigger mask that belongs to the selected bc
+            classMaskCTP = ctpDigit.CTPClassMask.to_ulong();
+            // now check if min bias trigger is not in mask
+            for (const uint64_t& selectedClassMask : mSelectedClassMasks) {
+              if ((classMaskCTP & selectedClassMask) != 0) {
+                LOG(debug) << "trigger " << selectedClassMask << " found! accepting event";
+                acceptEvent = true;
+                break;
+              }
+            }
+            break; // break as bc was matched
+          }
+        }
+        // if current event is not accepted (selected triggers not present), move on to next event
+        if (!acceptEvent) {
           continue;
         }
       }
@@ -222,6 +282,8 @@ class EMCALChannelCalibDevice : public o2::framework::Task
 
   static const char* getCellBinding() { return "EMCCells"; }
   static const char* getCellTriggerRecordBinding() { return "EMCCellsTrgR"; }
+  static const char* getCTPDigitsBinding() { return "CTPDigits"; }
+  static const char* getCTPConfigBinding() { return "CTPConfig"; }
 
  private:
   std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap>> mBadChannelCalibrator;     ///< Bad channel calibrator
@@ -234,7 +296,9 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   bool isBadChannelCalib = true;                                                                                                       ///< Calibration mode bad channel calib (false := time calib)
   bool mLoadCalibParamsFromCCDB = true;                                                                                                ///< Switch for loading calib params from the CCDB
   bool mRejectCalibTriggers = true;                                                                                                    ///! reject calibration triggers in the online calibration
-  std::array<double, 2> timeMeas;
+  bool mRejectL0Triggers = true;                                                                                                       ///! reject EMCal Gamma and Jet triggers in the online calibration
+  std::array<double, 2> timeMeas;                                                                                                      ///! Used for time measurement and holds the start and end time in the run function
+  std::vector<uint64_t> mSelectedClassMasks = {};                                                                                      ///! EMCal minimum bias trigger bit. Only this bit will be used for calibration
 
   //________________________________________________________________
   template <typename DataOutput>
@@ -299,14 +363,14 @@ class EMCALChannelCalibDevice : public o2::framework::Task
       mBadChannelCalibrator->setIsTest(EMCALCalibParams::Instance().enableTestMode_bc);
     }
   }
-};
+}; // namespace calibration
 
 } // namespace calibration
 
 namespace framework
 {
 
-DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, const bool loadCalibParamsFromCCDB, const bool rejectCalibTrigger)
+DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, const bool loadCalibParamsFromCCDB, const bool rejectCalibTrigger, const bool rejectL0Trigger, const bool ctpcfgperrun)
 {
   using device = o2::calibration::EMCALChannelCalibDevice;
   using clbUtils = o2::calibration::Utils;
@@ -328,6 +392,7 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
   std::vector<InputSpec> inputs;
   inputs.emplace_back(device::getCellBinding(), o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe);
   inputs.emplace_back(device::getCellTriggerRecordBinding(), o2::header::gDataOriginEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe);
+  // inputs.emplace_back("EMCTriggers", "EMC", "CELLSTRGR", 0, Lifetime::Timeframe)
   // for loading the channelCalibParams from the ccdb
   if (loadCalibParamsFromCCDB) {
     inputs.emplace_back("EMC_CalibParam", o2::header::gDataOriginEMC, "EMCALCALIBPARAM", 0, Lifetime::Condition, ccdbParamSpec("EMC/Config/CalibParam"));
@@ -335,6 +400,12 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
   if (calibType.find("badchannel") != std::string::npos) {
     inputs.emplace_back("EMC_Scalefactors", o2::header::gDataOriginEMC, "SCALEFACTORS", 0, Lifetime::Condition, ccdbParamSpec(CalibDB::getCDBPathChannelScaleFactors()));
   }
+  // inputs.emplace_back("EMC_BadChannelMap", o2::header::gDataOriginEMC, "BADCHANNELMAP", 0, Lifetime::Condition, ccdbParamSpec("EMC/Calib/BadChannelMap"));
+
+  // data request needed for rejection of EMCal trigger
+  inputs.emplace_back(device::getCTPConfigBinding(), "CTP", "CTPCONFIG", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/Config", ctpcfgperrun));
+  inputs.emplace_back(device::getCTPDigitsBinding(), "CTP", "DIGITS", 0, Lifetime::Timeframe);
+
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
                                                                 true,                           // GRPECS=true
                                                                 false,                          // GRPLHCIF
@@ -342,11 +413,12 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
+
   return DataProcessorSpec{
     processorName,
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, loadCalibParamsFromCCDB, calibType, rejectCalibTrigger)},
+    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, loadCalibParamsFromCCDB, calibType, rejectCalibTrigger, rejectL0Trigger)},
     Options{}};
 }
 

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -39,7 +39,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"calibType", VariantType::String, "time", {"choose which calibration should be performed: time for tiem calibration, badchannel for bad channel calibration"}},
     {"no-loadCalibParamsFromCCDB", VariantType::Bool, false, {"disabled by default such that calib params are taken from the ccdb. If enabled, calib params are taken from EMCALCalibParams.h directly"}},
-    {"no-rejectCalibTrigger", VariantType::Bool, false, {"disabled by default such that calib triggers are rejected. If enabled, calibration triggers (LED events etc.) also enter the calibration"}}};
+    {"no-rejectCalibTrigger", VariantType::Bool, false, {"disabled by default such that calib triggers are rejected. If enabled, calibration triggers (LED events etc.) also enter the calibration"}},
+    {"no-rejectL0Trigger", VariantType::Bool, false, {"disabled by default such that L0 triggers are rejected. If enabled, L0 triggers (Gamma trigger and jet trigger) also enter the calibration"}},
+    {"ctpconfig-per-run", VariantType::Bool, false, {"Use CTP config per run. 1 -- on (Data), 0 -- off (MC)"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -53,9 +55,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   std::string calibType = cfgc.options().get<std::string>("calibType");
   bool loadCalibParamsFromCCDB = !cfgc.options().get<bool>("no-loadCalibParamsFromCCDB");
   bool rejectCalibTrigger = !cfgc.options().get<bool>("no-rejectCalibTrigger");
+  bool rejectL0Trigger = !cfgc.options().get<bool>("no-rejectL0Trigger");
+  bool ctpcfgperrun = cfgc.options().get<bool>("ctpconfig-per-run");
 
   WorkflowSpec specs;
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger));
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger, rejectL0Trigger, ctpcfgperrun));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   // o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
- When EMCal gamma or jet triggers are used during data taking, these events have to be rejected as otherwise the energy spectrum would have turn-on curves, which might result in a wrong calibration of time and bad channels. Therefore, only specific triggers are allowed in the analysis.
- The selection of triggers can be configures via the calib params. A string of : speparated trigger names can be defined there. Only those triggers will be selected.
- The trigger names are checked at the initialization in finaliseCCDB (each time the CTP config changes) and mapped to the corresponding trigger bit
- For each emcal trigger, the bc from the ctp is matched with the bc of the emcal event and it is then checked if one of the selected triggers is contained in the current event