### PR TITLE
Optionally prescale query for objects with non-default ccdb-query-rate

### DIFF
--- a/Framework/CCDBSupport/src/CCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/CCDBHelpers.cxx
@@ -34,6 +34,7 @@ struct CCDBFetcherHelper {
     size_t cacheHit = 0;
     size_t minSize = -1ULL;
     size_t maxSize = 0;
+    int lastCheckedTF = 0;
   };
 
   struct RemapMatcher {
@@ -51,7 +52,9 @@ struct CCDBFetcherHelper {
   std::unordered_map<std::string, o2::ccdb::CcdbApi> apis;
   std::vector<OutputRoute> routes;
   std::unordered_map<std::string, std::string> remappings;
-  size_t queryDownScaleRate = 1;
+  uint32_t lastCheckedTFCounterOrbReset = 0; // last checkecked TFcounter for bulk check
+  int queryPeriodGlo = 1;
+  int queryPeriodFactor = 1;
   int64_t timeToleranceMS = 5000;
 
   o2::ccdb::CcdbApi& getAPI(const std::string& path)
@@ -177,10 +180,10 @@ auto populateCacheWith(std::shared_ptr<CCDBFetcherHelper> const& helper,
                        DataAllocator& allocator) -> void
 {
   std::string ccdbMetadataPrefix = "ccdb-metadata-";
-  bool checkValidityGlo = timingInfo.timeslice % helper->queryDownScaleRate == 0;
+  int objCnt = -1;
   for (auto& route : helper->routes) {
     LOGP(debug, "Fetching object for route {}", DataSpecUtils::describe(route.matcher));
-
+    objCnt++;
     auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
     Output output{concrete.origin, concrete.description, concrete.subSpec, route.matcher.lifetime};
     auto&& v = allocator.makeVector<char>(output);
@@ -188,7 +191,8 @@ auto populateCacheWith(std::shared_ptr<CCDBFetcherHelper> const& helper,
     std::map<std::string, std::string> headers;
     std::string path = "";
     std::string etag = "";
-    bool checkValidity = checkValidityGlo;
+    int chRate = helper->queryPeriodGlo;
+    bool checkValidity = false;
     for (auto& meta : route.matcher.metadata) {
       if (meta.name == "ccdb-path") {
         path = meta.defaultValue.get<std::string>();
@@ -200,17 +204,19 @@ auto populateCacheWith(std::shared_ptr<CCDBFetcherHelper> const& helper,
         LOGP(debug, "Adding metadata {}: {} to the request", key, value);
         metadata[key] = value;
       } else if (meta.name == "ccdb-query-rate") {
-        checkValidity = (timingInfo.timeslice % meta.defaultValue.get<int64_t>() == 0);
+        chRate = meta.defaultValue.get<int>() * helper->queryPeriodFactor;
       }
     }
-    LOGP(debug, "checkValidity is {} for slice {} of {}", checkValidity, timingInfo.timeslice, path);
-
     const auto url2uuid = helper->mapURL2UUID.find(path);
     if (url2uuid != helper->mapURL2UUID.end()) {
       etag = url2uuid->second.etag;
+      checkValidity = int(timingInfo.tfCounter - url2uuid->second.lastCheckedTF) >= chRate;
     } else {
       checkValidity = true; // never skip check if the cache is empty
     }
+
+    LOGP(debug, "checkValidity is {} for tfID {} of {}", checkValidity, timingInfo.tfCounter, path);
+
     const auto& api = helper->getAPI(path);
     if (checkValidity && (!api.isSnapshotMode() || etag.empty())) { // in the snapshot mode the object needs to be fetched only once
       LOGP(detail, "Loading {} for timestamp {}", path, timestamp);
@@ -224,6 +230,7 @@ auto populateCacheWith(std::shared_ptr<CCDBFetcherHelper> const& helper,
       if (headers.find("default") != headers.end()) {
         LOGP(detail, "******** Default entry used for {} ********", path);
       }
+      helper->mapURL2UUID[path].lastCheckedTF = timingInfo.tfCounter;
       if (etag.empty()) {
         helper->mapURL2UUID[path].etag = headers["ETag"]; // update uuid
         helper->mapURL2UUID[path].cacheMiss++;
@@ -263,10 +270,12 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
       std::shared_ptr<CCDBFetcherHelper> helper = std::make_shared<CCDBFetcherHelper>();
       std::unordered_map<std::string, bool> accountedSpecs;
       auto defHost = options.get<std::string>("condition-backend");
-      auto checkRate = static_cast<size_t>(options.get<int64_t>("condition-tf-per-query"));
+      auto checkRate = options.get<int>("condition-tf-per-query");
+      auto checkMult = options.get<int>("condition-tf-per-query-multiplier");
       helper->timeToleranceMS = options.get<int64_t>("condition-time-tolerance");
-      helper->queryDownScaleRate = checkRate > 0 ? checkRate : static_cast<size_t>(-1l);
-      LOGP(info, "CCDB Backend at: {}, validity check for every {} TF", defHost, helper->queryDownScaleRate);
+      helper->queryPeriodGlo = checkRate > 0 ? checkRate : std::numeric_limits<int>::max();
+      helper->queryPeriodFactor = checkMult > 0 ? checkMult : 1;
+      LOGP(info, "CCDB Backend at: {}, validity check for every {} TF{}", defHost, helper->queryPeriodGlo, helper->queryPeriodFactor == 1 ? std::string{} : fmt::format(", (query for high-rate objects downscaled by {})", helper->queryPeriodFactor));
       auto remapString = options.get<std::string>("condition-remap");
       ParserResult result = CCDBHelpers::parseRemappings(remapString.c_str());
       if (!result.error.empty()) {
@@ -303,7 +312,6 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           }
         }
       }
-
       /// Add a callback on stop which dumps the statistics for the caching per
       /// path
       callbacks.set<CallbackService::Id::Stop>([helper]() {
@@ -327,7 +335,7 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           std::map<std::string, std::string> metadata;
           std::map<std::string, std::string> headers;
           std::string etag;
-          bool checkValidity = timingInfo.timeslice % helper->queryDownScaleRate == 0;
+          bool checkValidity = int(timingInfo.tfCounter - helper->lastCheckedTFCounterOrbReset) >= helper->queryPeriodGlo;
           const auto url2uuid = helper->mapURL2UUID.find(path);
           if (url2uuid != helper->mapURL2UUID.end()) {
             etag = url2uuid->second.etag;
@@ -340,6 +348,7 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           auto&& v = allocator.makeVector<char>(output);
           const auto& api = helper->getAPI(path);
           if (checkValidity && (!api.isSnapshotMode() || etag.empty())) { // in the snapshot mode the object needs to be fetched only once
+            helper->lastCheckedTFCounterOrbReset = timingInfo.tfCounter;
             api.loadFileToMemory(v, path, metadata, timingInfo.creation, &headers, etag, helper->createdNotAfter, helper->createdNotBefore);
             if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
               LOGP(fatal, "Unable to find object {}/{}", path, timingInfo.creation);

--- a/Framework/Core/include/Framework/CCDBParamSpec.h
+++ b/Framework/Core/include/Framework/CCDBParamSpec.h
@@ -25,14 +25,14 @@ struct CCDBMetadata {
 ConfigParamSpec ccdbPathSpec(std::string const& path);
 ConfigParamSpec ccdbRunDependent(bool defaultValue = true);
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {}, int64_t qrate = 0);
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {}, int qrate = 0);
 /// Helper to create an InputSpec which will read from a CCDB
 /// Notice that those input specs have some convetions for their metadata:
 ///
 /// `ccdb-path`: is the path in CCDB for the entry
 /// `ccdb-run-dependent`: is a boolean flag to indicate if the entry is run dependent
 /// `ccdb-metadata-<key>`: is a list of metadata to be added to the query, where key is the metadata key
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata = {}, int64_t qrate = 0);
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata = {}, int qrate = 0);
 ConfigParamSpec startTimeParamSpec(int64_t t);
 
 } // namespace o2::framework

--- a/Framework/Core/src/CCDBParamSpec.cxx
+++ b/Framework/Core/src/CCDBParamSpec.cxx
@@ -26,9 +26,9 @@ ConfigParamSpec ccdbRunDependent(bool defaultValue)
   return ConfigParamSpec{"ccdb-run-dependent", VariantType::Bool, defaultValue, {"Give object for specific run number"}, ConfigParamKind::kGeneric};
 }
 
-ConfigParamSpec ccdbQueryRateSpec(int64_t r)
+ConfigParamSpec ccdbQueryRateSpec(int r)
 {
-  return ConfigParamSpec{"ccdb-query-rate", VariantType::Int64, r, {"Query after once every N TFs"}, ConfigParamKind::kGeneric};
+  return ConfigParamSpec{"ccdb-query-rate", VariantType::Int, r, {"Query after once every N TFs"}, ConfigParamKind::kGeneric};
 }
 
 ConfigParamSpec ccdbMetadataSpec(std::string const& key, std::string const& defaultValue)
@@ -40,12 +40,12 @@ ConfigParamSpec ccdbMetadataSpec(std::string const& key, std::string const& defa
                          ConfigParamKind::kGeneric};
 }
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata, int64_t qrate)
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata, int qrate)
 {
   return ccdbParamSpec(path, false, metadata, qrate);
 }
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata, int64_t qrate)
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata, int qrate)
 {
   // Add here CCDB objecs which should be considered run dependent
   std::vector<ConfigParamSpec> result{ccdbPathSpec(path)};
@@ -53,7 +53,7 @@ std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDepe
     result.push_back(ccdbRunDependent(runDependent));
   }
   if (qrate != 0) {
-    result.push_back(ccdbQueryRateSpec(qrate < 0 ? int64_t(std::numeric_limits<int64_t>::max) : qrate));
+    result.push_back(ccdbQueryRateSpec(qrate < 0 ? std::numeric_limits<int>::max() : qrate));
   }
   for (auto& [key, value] : metadata) {
     result.push_back(ccdbMetadataSpec(key, value));

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -226,9 +226,9 @@ std::string defaultConditionBackend()
 }
 
 // get the default value for condition query rate
-int64_t defaultConditionQueryRate()
+int defaultConditionQueryRate()
 {
-  return getenv("DPL_CONDITION_QUERY_RATE") ? std::stoll(getenv("DPL_CONDITION_QUERY_RATE")) : 0;
+  return getenv("DPL_CONDITION_QUERY_RATE") ? std::stoi(getenv("DPL_CONDITION_QUERY_RATE")) : 0;
 }
 
 void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext const& ctx)
@@ -252,7 +252,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
                 {"condition-not-before", VariantType::Int64, 0ll, {"do not fetch from CCDB objects created before provide timestamp"}},
                 {"condition-not-after", VariantType::Int64, 3385078236000ll, {"do not fetch from CCDB objects created after the timestamp"}},
                 {"condition-remap", VariantType::String, "", {"remap condition path in CCDB based on the provided string."}},
-                {"condition-tf-per-query", VariantType::Int64, defaultConditionQueryRate(), {"check condition validity per requested number of TFs, fetch only once if <0"}},
+                {"condition-tf-per-query", VariantType::Int, defaultConditionQueryRate(), {"check condition validity per requested number of TFs, fetch only once if <=0"}},
+                {"condition-tf-per-query-multiplier", VariantType::Int, 1, {"check conditions once per this amount of nominal checks"}},
                 {"condition-time-tolerance", VariantType::Int64, 5000ll, {"prefer creation time if its difference to orbit-derived time exceeds threshold (ms), impose if <0"}},
                 {"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
                 {"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},


### PR DESCRIPTION
Option `--condition-tf-per-query-multiplier N` will downscale by N the query rate for objects whose `CCDBParamSpec` was defined with non-trivial `ccdb-query-rate M` option (e.g. request query at every TF for `M=1`).
The check for such an object will be done once the previously checked `timingInfo.TFCounter has ID < N*M` (note the change: before the check would be done only for (timingInfo.timeSlice % M) == 0.

Also, the `--condition-tf-per-query M` will trigger a check not for `(timingInfo.timeSlice % M) == 0` but once previously checked TFCounter is more than M TFs old.

@martenole e.g. with ` --condition-tf-per-query-multiplier 360` the workflow will query objects line VDrift or BField only once per `~ 1 second` instead of every TF.