### PR TITLE
[WIP] Trap configuration events calibrator

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(DataFormatsTRD
                        src/Digit.cxx
                        src/KrCluster.cxx
                        src/NoiseCalibration.cxx
+                       src/TrapConfigEvent.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
 o2_target_root_dictionary(DataFormatsTRD
@@ -46,7 +47,8 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/CalT0.h
                        include/DataFormatsTRD/SignalArray.h
                        include/DataFormatsTRD/CompressedDigit.h
-                       include/DataFormatsTRD/CompressedHeader.h)
+                       include/DataFormatsTRD/CompressedHeader.h
+                       include/DataFormatsTRD/TrapConfigEvent.h)
 
 o2_add_test(Digit
             COMPONENT_NAME trd
@@ -64,3 +66,10 @@ o2_add_test(RawData
             LABELS trd
             )
 
+o2_add_test(TrapConfigEvent
+            COMPONENT_NAME trd
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD
+            SOURCES test/testTrapConfigEvent.cxx
+            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+            LABELS trd
+)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/AngularResidHistos.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/AngularResidHistos.h
@@ -16,6 +16,7 @@
 #define ALICEO2_ANGRESIDHISTOS_H
 
 #include "DataFormatsTRD/Constants.h"
+
 #include "Rtypes.h"
 #include <array>
 #include <gsl/span>

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -94,6 +94,10 @@ constexpr unsigned int ETYPEPHYSICSTRIGGER = 0x2;     ///< CRU Half Chamber head
 constexpr unsigned int ETYPECALIBRATIONTRIGGER = 0x3; ///< CRU Half Chamber header eventtype definition
 constexpr int MAXCRUERRORVALUE = 0x2;                 ///< Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
 constexpr int INVALIDPRETRIGGERPHASE = 0xf;           ///< Invalid value for phase, used to signify there is no hcheader.
+constexpr int CONFIGEVENTNUMBER = 0x47;               ///< Major version number in Digit HC Header defining a configuration "digit" event
+constexpr int CONFIGEVENTENDA = 0x42424242;           ///< End of packed config event in message to be passed on for processing
+constexpr int CONFIGEVENTENDB = 0xedededed;           ///< End of packed config event in message to be passed on for processing
+constexpr int CONFIGEVNETBLOCKENDMARKER = 0x7fff00fe; ///< End marker for a configuration event block.
 
 } // namespace constants
 } // namespace trd

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
@@ -72,6 +72,7 @@ class Digit
   void setMCM(int row, int col) { mMCM = HelperMethods::getMCMfromPad(row, col); } // set MCM from pad row, column
   void setChannel(int channel) { mChannel = channel; }
   void setDetector(int det) { mDetector = ((mDetector & 0xf000) | (det & 0xfff)); }
+  void setPhase(unsigned int phase) { mDetector &= phase << 12; }
   void setADC(ArrayADC const& adc) { mADC = adc; }
   void setADC(const gsl::span<ADC_t>& adc) { std::copy(adc.begin(), adc.end(), mADC.begin()); }
   void setPreTrigPhase(int phase) { mDetector = (((phase & 0xf) << 12) | (mDetector & 0xfff)); }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -13,6 +13,7 @@
 #define ALICEO2_TRD_HELPERMETHODS_HH
 
 #include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/RawData.h"
 #include <iostream>
 
 namespace o2
@@ -203,6 +204,25 @@ struct HelperMethods {
     rob = (mcmCol >= constants::NMCMROBINCOL) ? (row / constants::NMCMROBINROW) * 2 + 1 : (row / constants::NMCMROBINROW) * 2;
     mcm = (row % constants::NMCMROBINROW) * constants::NMCMROBINCOL + (mcmCol % constants::NMCMROBINCOL);
     channel = constants::NADCMCM - 1 - ((chamberIndex % constants::NCHANNELSPERROW) % constants::NADCMCM);
+  }
+
+  static int getMCMId(int sector, int stack, int layer, int rob, int mcm)
+  {
+    // return the mcmid of the indexed mcm
+    int mcmid = (sector * constants::NSTACK * constants::NLAYER + stack * constants::NLAYER + layer) * constants::NROBC1 * constants::NMCMROB + rob * constants::NMCMROB + mcm;
+    return mcmid;
+  }
+
+  static int getMCMId(int det, int rob, int mcm)
+  {
+    // return the mcmid of the indexed mcm
+    int mcmid = det * constants::NROBC1 * constants::NMCMROB + rob * constants::NMCMROB + mcm;
+    return mcmid;
+  }
+
+  static int getHCIDFromDigitHCHeader(DigitHCHeader header)
+  {
+    return header.supermodule * constants::NHCPERSEC + header.stack * constants::NLAYER * 2 + header.layer * 2 + header.side;
   }
 };
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <cstdint>
 #include <ostream>
+#include <bitset>
 #include "DataFormatsTRD/Constants.h"
 #include "Rtypes.h"
 
@@ -427,6 +428,55 @@ struct LinkToHCIDMapping {
   std::map<int, int> linkIDToHCID;
   std::map<int, int> hcIDToLinkID;
   ClassDefNV(LinkToHCIDMapping, 1);
+};
+
+struct DigitHCHeaderAll {
+  // store all the digit hcheaders for carrying them around all together.
+  // all 4 of them are 32 bit integers and its simpler to just store them like that.
+  std::array<uint32_t, 4> mHeaders;
+  std::bitset<4> mHasHeader;
+  bool isSet(int header) { return mHasHeader.test(header); }
+  void setHeader(uint32_t header, uint32_t value)
+  {
+    mHasHeader.set(header);
+    mHeaders[header] = value;
+  }
+  uint32_t getHeader(uint32_t header)
+  {
+    if (isSet(header))
+      return mHeaders[header];
+    else
+      return 0;
+  }
+  uint32_t getHeader()
+  {
+    if (isSet(0)) {
+      return mHeaders[0];
+    } else
+      return 0;
+  }
+  uint32_t getHeader1()
+  {
+    if (isSet(1)) {
+      return mHeaders[1];
+    } else
+      return 0;
+  }
+  uint32_t getHeader2()
+  {
+    if (isSet(2)) {
+      return mHeaders[2];
+    } else
+      return 0;
+  }
+  uint32_t getHeader3()
+  {
+    if (isSet(3)) {
+      return mHeaders[3];
+    } else
+      return 0;
+  }
+  void reset() { mHeaders.fill(0); } ///< reset the headers to zero
 };
 
 uint32_t setHalfCRUHeader(HalfCRUHeader& cruhead, int crurdhversion, int bunchcrossing, int stopbits, int endpoint, int eventtype, int feeid, int cruid);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -119,7 +119,8 @@ enum OptionBits {
   TRDVerboseErrorsBit,
   TRDIgnore2StageTrigger,
   TRDGenerateStats,
-  TRDOnlyCalibrationTriggerBit
+  TRDOnlyCalibrationTriggerBit,
+  TRDEnableConfigEvents
 }; // this is currently 16 options, the array is 16, if you add here you need to change the 16;
 
 //Data to be stored and accumulated on an event basis.

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
@@ -85,8 +85,8 @@ class TrapRegInfo
   void logTrapRegInfo(); // output the contents to log info
 
  private:
-  //TrapRegInfo(const TrapRegInfo& rhs);
-  //TrapRegInfo& operator=(const TrapRegInfo& rhs);
+  // TrapRegInfo(const TrapRegInfo& rhs);
+  // TrapRegInfo& operator=(const TrapRegInfo& rhs);
 
   // fixed properties of the register
   // which do not need to be stored on a per mcm basis
@@ -616,9 +616,9 @@ class TrapConfigEvent
   void setConfigVersion(uint32_t version) { mTrapConfigEventVersion = version; }           // these must some how be gotten from git or wingdb.
   void setConfigNumber(uint32_t number) { mTrapConfigEventNumber = number; }               // these must be gotten from git or wingdb.
   void setConfigSavedVersion(uint16_t version) { mTrapConfigEventSavedVersion = version; } // the version that is saved, for the ability to later save the config differently.
-  const uint32_t getConfigVersion()const { return mTrapConfigEventVersion; }                          // these must some how be gotten from git or wingdb.
-  const uint32_t getConfigName()const { return mTrapConfigEventNumber; }                              // these must be gotten from git or wingdb.
-  const uint16_t getConfigSavedVersion()const { return mTrapConfigEventSavedVersion; }                // the version that is saved, for the ability to later save the config differently.
+  const uint32_t getConfigVersion() const { return mTrapConfigEventVersion; }              // these must some how be gotten from git or wingdb.
+  const uint32_t getConfigName() const { return mTrapConfigEventNumber; }                  // these must be gotten from git or wingdb.
+  const uint16_t getConfigSavedVersion() const { return mTrapConfigEventSavedVersion; }    // the version that is saved, for the ability to later save the config differently.
 
   bool operator==(const TrapConfigEvent& rhs);
 
@@ -628,32 +628,31 @@ class TrapConfigEvent
   uint32_t getTrapReg(uint32_t index, int detector, int rob, int mcm);
 
   const bool isHCIDPresent(int hcid) const { return mHCIDPresent.test(hcid); }
-  void HCIDIsPresent( int hcid)  {  mHCIDPresent.set(hcid); }
-  uint32_t countHCIDPresent(){return mHCIDPresent.count();}
+  void HCIDIsPresent(int hcid) { mHCIDPresent.set(hcid); }
+  uint32_t countHCIDPresent() { return mHCIDPresent.count(); }
   const std::bitset<constants::MAXHALFCHAMBER>& getHCIDPresent() const { return mHCIDPresent; }
   const bool isMCMPresent(int mcmid) const { return mMCMPresent.test(mcmid); }
-  void MCMIsPresent( int mcmid)  {  mMCMPresent.set(mcmid); }
-  void clearMCMPresent(){ mMCMPresent.reset();}
+  void MCMIsPresent(int mcmid) { mMCMPresent.set(mcmid); }
+  void clearMCMPresent() { mMCMPresent.reset(); }
   const std::bitset<constants::MAXMCMCOUNT>& getMCMPresent() const { return mMCMPresent; }
-  uint32_t countMCMPresent(){return mMCMPresent.count();}
-  
+  uint32_t countMCMPresent() { return mMCMPresent.count(); }
+
   bool ignoreWord(int offset) const { return mWordNumberIgnore.test(offset); }
- 
-    // required for a container for calibration
-  //void fill(const TrapConfigEvent& input);
-  //void fill(const gsl::span<const TrapConfigEvent> input); // dummy!
-  //void merge(const TrapConfigEvent* prev);
-  //void print();
-  //void reset(){a=0;};
-  
+
+  // required for a container for calibration
+  // void fill(const TrapConfigEvent& input);
+  // void fill(const gsl::span<const TrapConfigEvent> input); // dummy!
+  // void merge(const TrapConfigEvent* prev);
+  // void print();
+  // void reset(){a=0;};
 
  private:
-  std::array<o2::trd::TrapRegInfo, kLastReg> mTrapRegisters;                              //!< store of layout of each block of mTrapRegisterSize, populated via initialiseRegisters
-  std::bitset<o2::trd::constants::MAXMCMCOUNT> mMCMPresent{0};                            //!< does the mcm actually receive data.
-  std::bitset<o2::trd::constants::MAXHALFCHAMBER> mHCIDPresent{0};                           //!< did the link actually receive data.
-  //std::array<uint32_t, kTrapRegistersSize * o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
+  std::array<o2::trd::TrapRegInfo, kLastReg> mTrapRegisters;       //!< store of layout of each block of mTrapRegisterSize, populated via initialiseRegisters
+  std::bitset<o2::trd::constants::MAXMCMCOUNT> mMCMPresent{0};     //!< does the mcm actually receive data.
+  std::bitset<o2::trd::constants::MAXHALFCHAMBER> mHCIDPresent{0}; //!< did the link actually receive data.
+  // std::array<uint32_t, kTrapRegistersSize * o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
   std::array<std::array<uint32_t, kTrapRegistersSize>, o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
-  std::map<uint16_t, uint16_t> mTrapRegistersAddressIndexMap;                             //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
+  std::map<uint16_t, uint16_t> mTrapRegistersAddressIndexMap;                                        //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
   std::bitset<kTrapRegistersSize> mWordNumberIgnore;
   void initialiseRegisters();
 
@@ -665,42 +664,45 @@ class TrapConfigEvent
 
 class TrapConfigEventSlot : public TrapConfigEvent
 {
-  //This is the class to hold trapconfig events coming from the parser to the aggregator,
+  // This is the class to hold trapconfig events coming from the parser to the aggregator,
   //
-  public: 
-    TrapConfigEventSlot()= default;
-    TrapConfigEventSlot(const TrapConfigEventSlot&)= default;
-    ~TrapConfigEventSlot()= default;
-    void reset(){a=1;};
-  bool addEntry(float deltaAlpha, float impactAngle, int chamberId){a=2;return true;}
+ public:
+  TrapConfigEventSlot() = default;
+  TrapConfigEventSlot(const TrapConfigEventSlot&) = default;
+  ~TrapConfigEventSlot() = default;
+  void reset() { a = 1; };
+  bool addEntry(float deltaAlpha, float impactAngle, int chamberId)
+  {
+    a = 2;
+    return true;
+  }
   float getHistogramEntry(int index) const { return a; }
   int getBinCount(int index) const { return a; }
   size_t getNEntries() const { return a; }
-  
- // required for a container for calibration
+
+  // required for a container for calibration
   void fill(const TrapConfigEventSlot& input);
   void fill(const gsl::span<const TrapConfigEventSlot> input);
   void merge(const TrapConfigEventSlot* prev);
   void print();
 
-  bool isRegisterSeen(int mcmid, int regidx){return mcmMissedRegister[mcmid].test(regidx);}
-  void setRegisterSeen(int mcmid, int regidx){mcmMissedRegister[mcmid].set(regidx);}
-  int getMCMParsingStatus(int mcmid){return mMCMParsingStatus[mcmid];}
-  void setMCMParsingStatus(int mcmid, int status){mMCMParsingStatus[mcmid]= status;}
-  void clearParsingStatus(){mMCMParsingStatus.fill(0);}
-  std::map<uint32_t,uint32_t>& getRegisterMapForMCM(int mcmid){ return mTrapRegistersFrequencyMap[mcmid];}
+  bool isRegisterSeen(int mcmid, int regidx) { return mcmMissedRegister[mcmid].test(regidx); }
+  void setRegisterSeen(int mcmid, int regidx) { mcmMissedRegister[mcmid].set(regidx); }
+  int getMCMParsingStatus(int mcmid) { return mMCMParsingStatus[mcmid]; }
+  void setMCMParsingStatus(int mcmid, int status) { mMCMParsingStatus[mcmid] = status; }
+  void clearParsingStatus() { mMCMParsingStatus.fill(0); }
+  std::map<uint32_t, uint32_t>& getRegisterMapForMCM(int mcmid) { return mTrapRegistersFrequencyMap[mcmid]; }
 
-  private:
-    int a; 
-    std::array<std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>, kTrapRegistersSize> mConfigData;            //!< one block of data per mcm.
-    std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;               //!< frequency map for values in the respective registers
-    std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                                      //!< count of different value in the registers for a mcm,register used to find most frequent value.
-    std::array<int, o2::trd::constants::MAXMCMCOUNT> mMCMParsingStatus{0};                                        //!< status of what was found, errors types in the parsing
-    std::array<std::bitset<TrapConfigEvent::kLastReg>, o2::trd::constants::MAXMCMCOUNT> mcmMissedRegister;        //!< bitpattern of which registers were seen and not seen for a given mcm.
+ private:
+  int a;
+  std::array<std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>, kTrapRegistersSize> mConfigData;     //!< one block of data per mcm.
+  std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;        //!< frequency map for values in the respective registers
+  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                               //!< count of different value in the registers for a mcm,register used to find most frequent value.
+  std::array<int, o2::trd::constants::MAXMCMCOUNT> mMCMParsingStatus{0};                                 //!< status of what was found, errors types in the parsing
+  std::array<std::bitset<TrapConfigEvent::kLastReg>, o2::trd::constants::MAXMCMCOUNT> mcmMissedRegister; //!< bitpattern of which registers were seen and not seen for a given mcm.
 
   ClassDefNV(TrapConfigEventSlot, 1);
 };
-
 
 }; // namespace o2::trd
 #endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
@@ -106,19 +106,17 @@ class TrapRegInfo
   ClassDefNV(TrapRegInfo, 1);
 };
 
-struct MCMEvent
-{//TODO add comments 
+struct MCMEvent { // TODO add comments
   MCMEvent() = default;
-  MCMEvent(int mcmid){setMCMId(mcmid);}
-  //MCMEvent(std::array<uint32_t,kTrapRegistersSize>& data);
+  MCMEvent(int mcmid) { setMCMId(mcmid); }
+  // MCMEvent(std::array<uint32_t,kTrapRegistersSize>& data);
   ~MCMEvent() = default;
-  uint32_t const getMCMId(){return mMCMId;}
-  void setMCMId(const uint32_t mcmid){mMCMId=mcmid;}
+  uint32_t const getMCMId() { return mMCMId; }
+  void setMCMId(const uint32_t mcmid) { mMCMId = mcmid; }
   std::array<uint32_t, kTrapRegistersSize> mRegisterData; //!< a block of mcm register data.
   uint32_t mMCMId;                                        //!< the id of this mcm.
-  ClassDefNV(MCMEvent,1);
+  ClassDefNV(MCMEvent, 1);
 };
- 
 
 class TrapConfigEvent
 {
@@ -654,16 +652,17 @@ class TrapConfigEvent
   void fill(const gsl::span<const TrapConfigEvent> input); // dummy!
   void merge(const TrapConfigEvent* prev);
   void print();
-  void reset(){a=0;};
-  int getRegisterBase(int reg){return mTrapRegisters[reg].getBase();}
+  void reset() { a = 0; };
+  int getRegisterBase(int reg) { return mTrapRegisters[reg].getBase(); }
+
  private:
   int a;
-  std::array<TrapRegInfo, kLastReg> mTrapRegisters;       //!< store of layout of each block of mTrapRegisterSize, populated via initialiseRegisters
-  std::bitset<constants::MAXMCMCOUNT> mMCMPresent{0};     //!< does the mcm actually receive data.
-  std::bitset<constants::MAXHALFCHAMBER> mHCIDPresent{0}; //!< did the link actually receive data.
-  std::vector<MCMEvent> mConfigData;                      //!< vector of register data blocks
-  std::array<int32_t,constants::MAXHALFCHAMBER> mConfigDataIndex{-1}; //!< one block of data per mcm.
-  std::unique_ptr<std::map<uint16_t, uint16_t>> mTrapRegistersAddressIndexMap;                                        //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
+  std::array<TrapRegInfo, kLastReg> mTrapRegisters;                            //!< store of layout of each block of mTrapRegisterSize, populated via initialiseRegisters
+  std::bitset<constants::MAXMCMCOUNT> mMCMPresent{0};                          //!< does the mcm actually receive data.
+  std::bitset<constants::MAXHALFCHAMBER> mHCIDPresent{0};                      //!< did the link actually receive data.
+  std::vector<MCMEvent> mConfigData;                                           //!< vector of register data blocks
+  std::array<int32_t, constants::MAXHALFCHAMBER> mConfigDataIndex{-1};         //!< one block of data per mcm.
+  std::unique_ptr<std::map<uint16_t, uint16_t>> mTrapRegistersAddressIndexMap; //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
   std::bitset<kTrapRegistersSize> mWordNumberIgnore;
   void initialiseRegisters();
 
@@ -673,42 +672,38 @@ class TrapConfigEvent
   ClassDefNV(TrapConfigEvent, 1);
 };
 
-
-
 class TrapConfigEventTimeSlot
 {
-  public :
-    TrapConfigEventTimeSlot() = default;
-    ~TrapConfigEventTimeSlot() = default;
-    std::array<std::array<uint32_t,kTrapRegistersSize>,constants::MAXHALFCHAMBER> mConfigData;
+ public:
+  TrapConfigEventTimeSlot() = default;
+  ~TrapConfigEventTimeSlot() = default;
+  std::array<std::array<uint32_t, kTrapRegistersSize>, constants::MAXHALFCHAMBER> mConfigData;
   //  std::bitset<constants::MAXHALFCHAMBER> mMCMPresent;
   // required for a container for calibration
-  void fill(const TrapConfigEventTimeSlot& input){a=0;};
-  void fill(const TrapConfigEvent& input){a=0;};
-  void fill(const gsl::span<const TrapConfigEventTimeSlot> input){a=0;} // dummy!
-//  void fill(const gsl::span<const TrapConfigEvent> input){a=0;} // dummy!
-  void merge(const TrapConfigEventTimeSlot* prev){a=0;};
-  void print(){a=0;};
-  void reset(){a=0;};
-  uint16_t getNEntries(){return a;}
+  void fill(const TrapConfigEventTimeSlot& input) { a = 0; };
+  void fill(const TrapConfigEvent& input) { a = 0; };
+  void fill(const gsl::span<const TrapConfigEventTimeSlot> input) { a = 0; } // dummy!
+                                                                             //  void fill(const gsl::span<const TrapConfigEvent> input){a=0;} // dummy!
+  void merge(const TrapConfigEventTimeSlot* prev) { a = 0; };
+  void print() { a = 0; };
+  void reset() { a = 0; };
+  uint16_t getNEntries() { return a; }
   int a;
 };
-
 
 //    std::array<std::array<uint32_t, kTrapRegistersSize>, o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
 //  std::bitset<o2::trd::constants::MAXMCMCOUNT> mMCMPresent{0};     //!< does the mcm actually receive data.
 //  std::bitset<o2::trd::constants::MAXHALFCHAMBER> mHCIDPresent{0}; //!< did the link actually receive data.
 
-
-  /*int a;
-  std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;      //!< frequency map for values in the respective registers
-  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                             //!< count of different value in the registers for a mcm,register used to find most frequent value.
-  std::array<int, o2::trd::constants::MAXMCMCOUNT> mMCMParsingStatus{0};                                 //!< status of what was found, errors types in the parsing
-  std::array<std::bitset<TrapConfigEvent::kLastReg>, o2::trd::constants::MAXMCMCOUNT> mcmMissedRegister; //!< bitpattern of which registers were seen and not seen for a given mcm.
-  std::vector<MCMEvent> mMCMData;                                                                        //!< incoming event data, it will *always* be a subset of the full trapconfigs, this maps mcmid to mcmregisterdata.
-  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMIndex;                                       //!< incoming event data, index into the mMCMData vector.
-  std::array<uint16_t, o2::trd::constants::MAXMCMCOUNT> mLastRegisterSeen;                               //!< the last register seen for a given mcm, most likely bailed out due to failed parsing.
-  ClassDefNV(TrapConfigEventMessage, 2);*/
+/*int a;
+std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;      //!< frequency map for values in the respective registers
+std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                             //!< count of different value in the registers for a mcm,register used to find most frequent value.
+std::array<int, o2::trd::constants::MAXMCMCOUNT> mMCMParsingStatus{0};                                 //!< status of what was found, errors types in the parsing
+std::array<std::bitset<TrapConfigEvent::kLastReg>, o2::trd::constants::MAXMCMCOUNT> mcmMissedRegister; //!< bitpattern of which registers were seen and not seen for a given mcm.
+std::vector<MCMEvent> mMCMData;                                                                        //!< incoming event data, it will *always* be a subset of the full trapconfigs, this maps mcmid to mcmregisterdata.
+std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMIndex;                                       //!< incoming event data, index into the mMCMData vector.
+std::array<uint16_t, o2::trd::constants::MAXMCMCOUNT> mLastRegisterSeen;                               //!< the last register seen for a given mcm, most likely bailed out due to failed parsing.
+ClassDefNV(TrapConfigEventMessage, 2);*/
 
 }; // namespace o2::trd
 //

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
@@ -1,0 +1,706 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPCONFIGEVENT_H
+#define O2_TRDTRAPCONFIGEVENT_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include <fairlogger/Logger.h>
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/RawData.h"
+
+#include <string>
+#include <map>
+#include <array>
+#include <bitset>
+#include <gsl/span>
+
+namespace o2::trd
+{
+
+static const int kTrapRegistersSize = 151; //!< size of our compressed trap registers in units of 32 bits
+
+enum TrapRegStorage {
+  PerMCM,
+  PerROB,
+  PerLayer,
+  PerHalfChamber,
+  PerSector,
+  PerGlobal,
+  PerBP
+  /*  kAllocNone,
+      kAllocGlobal,
+      kAllocByDetector,
+      kAllocByHC,
+      kAllocByMCM,
+      kAllocByMergerType,
+      kAllocByLayer,
+      kAllocByMCMinSM,*/
+};
+
+class TrapRegInfo
+{
+  // class to store the parameters associated with a register
+  // some info related to the hardware, some to the packing/unpacking we do here.
+ public:
+  TrapRegInfo() = default;
+  TrapRegInfo(const std::string& name, int addr, int nBits, int base, int wordoffset, bool ignorechange, uint32_t max);
+
+  ~TrapRegInfo();
+
+  void init(const std::string& name, int addr, int nBits, int base, int wordnumber, bool ignorechange, uint32_t max);
+
+  // getters and setters, this is just a storage class.
+  std::string getName() { return mName; }
+  unsigned short getAddr() { return mAddr; }
+  unsigned short getNbits() { return mNbits; }
+  unsigned int getBase() { return mBase; }
+  unsigned int getWordNumber() { return mWordNumber; }
+  unsigned int getDataWordNumber() { return mDataWordNumber; }
+  unsigned int getShift() { return mShift; }
+  uint32_t getMask() { return mMask; }
+  uint32_t getMax() { return mMax; }
+  bool getIgnoreChange() { return mIgnoreChange; }
+
+  void setName(const std::string name) { mName = name; }
+  void setAddr(const uint32_t addr) { mAddr = addr; }
+  void setNbits(const uint32_t bits) { mNbits = bits; }
+  void setBase(const uint32_t base) { mBase = base; }
+  void setWordNumber(const uint32_t wordnum) { mWordNumber = wordnum; }
+  void setDataWordNumber(const uint32_t datawordnum) { mDataWordNumber = datawordnum; }
+  void setShift(const uint32_t shift) { mShift = shift; }
+  void setMask(const uint32_t mask) { mMask = mask; }
+  void setMax(uint32_t max) { mMax = pow(2, max) - 1; }
+  void setIgnoreChange(const uint32_t ignorechange) { mIgnoreChange = ignorechange; }
+
+  void logTrapRegInfo(); // output the contents to log info
+
+ private:
+  //TrapRegInfo(const TrapRegInfo& rhs);
+  //TrapRegInfo& operator=(const TrapRegInfo& rhs);
+
+  // fixed properties of the register
+  // which do not need to be stored on a per mcm basis
+  std::string mName;        //!< Name of the register
+  uint16_t mAddr;           //!< Address in GIO of TRAP
+  uint16_t mNbits;          //!< Number of bits, from 1 to 32
+  uint32_t mBase;           //!< base of this registers block, i.e. TFL?? will have 0 and is in the range [0,kTrapRegistersSize]
+  uint32_t mWordNumber;     //!< word number offset, of size Nbits, in the block of registers
+  uint32_t mDataWordNumber; //!< offset, into "compressed" 32 bit words for the 32 bit word containing this register, offset from the base;
+  uint32_t mMask;           //!< mask to extract register from the word identified by WordNumber
+  uint32_t mMax;            //!< max is not the same as the mask, some values come in as 15 bit mask but are only 12 or 13 bits for max, IRQ values for example
+  uint32_t mShift;          //!< shift to extract the register
+  bool mIgnoreChange;       //!< we are not concerned with this value changing for purposes of the differential comparison.
+  ClassDefNV(TrapRegInfo, 1);
+};
+
+class TrapConfigEvent
+{
+  // class that is actually stored in ccdb.
+  // it holds a compressed version of what comes in the config events
+ public:
+  // enum of all TRAP registers, to be used for access to them
+  // registers in the order they come in.
+  enum TrapReg {
+    kTPL00,
+    kTPL01,
+    kTPL02,
+    kTPL03,
+    kTPL04,
+    kTPL05,
+    kTPL06,
+    kTPL07,
+    kTPL08,
+    kTPL09,
+    kTPL0A,
+    kTPL0B,
+    kTPL0C,
+    kTPL0D,
+    kTPL0E,
+    kTPL0F,
+    kTPL10,
+    kTPL11,
+    kTPL12,
+    kTPL13,
+    kTPL14,
+    kTPL15,
+    kTPL16,
+    kTPL17,
+    kTPL18,
+    kTPL19,
+    kTPL1A,
+    kTPL1B,
+    kTPL1C,
+    kTPL1D,
+    kTPL1E,
+    kTPL1F,
+    kTPL20,
+    kTPL21,
+    kTPL22,
+    kTPL23,
+    kTPL24,
+    kTPL25,
+    kTPL26,
+    kTPL27,
+    kTPL28,
+    kTPL29,
+    kTPL2A,
+    kTPL2B,
+    kTPL2C,
+    kTPL2D,
+    kTPL2E,
+    kTPL2F,
+    kTPL30,
+    kTPL31,
+    kTPL32,
+    kTPL33,
+    kTPL34,
+    kTPL35,
+    kTPL36,
+    kTPL37,
+    kTPL38,
+    kTPL39,
+    kTPL3A,
+    kTPL3B,
+    kTPL3C,
+    kTPL3D,
+    kTPL3E,
+    kTPL3F,
+    kTPL40,
+    kTPL41,
+    kTPL42,
+    kTPL43,
+    kTPL44,
+    kTPL45,
+    kTPL46,
+    kTPL47,
+    kTPL48,
+    kTPL49,
+    kTPL4A,
+    kTPL4B,
+    kTPL4C,
+    kTPL4D,
+    kTPL4E,
+    kTPL4F,
+    kTPL50,
+    kTPL51,
+    kTPL52,
+    kTPL53,
+    kTPL54,
+    kTPL55,
+    kTPL56,
+    kTPL57,
+    kTPL58,
+    kTPL59,
+    kTPL5A,
+    kTPL5B,
+    kTPL5C,
+    kTPL5D,
+    kTPL5E,
+    kTPL5F,
+    kTPL60,
+    kTPL61,
+    kTPL62,
+    kTPL63,
+    kTPL64,
+    kTPL65,
+    kTPL66,
+    kTPL67,
+    kTPL68,
+    kTPL69,
+    kTPL6A,
+    kTPL6B,
+    kTPL6C,
+    kTPL6D,
+    kTPL6E,
+    kTPL6F,
+    kTPL70,
+    kTPL71,
+    kTPL72,
+    kTPL73,
+    kTPL74,
+    kTPL75,
+    kTPL76,
+    kTPL77,
+    kTPL78,
+    kTPL79,
+    kTPL7A,
+    kTPL7B,
+    kTPL7C,
+    kTPL7D,
+    kTPL7E,
+    kTPL7F,
+    kFGA0,
+    kFGA1,
+    kFGA2,
+    kFGA3,
+    kFGA4,
+    kFGA5,
+    kFGA6,
+    kFGA7,
+    kFGA8,
+    kFGA9,
+    kFGA10,
+    kFGA11,
+    kFGA12,
+    kFGA13,
+    kFGA14,
+    kFGA15,
+    kFGA16,
+    kFGA17,
+    kFGA18,
+    kFGA19,
+    kFGA20,
+    kFGF0,
+    kFGF1,
+    kFGF2,
+    kFGF3,
+    kFGF4,
+    kFGF5,
+    kFGF6,
+    kFGF7,
+    kFGF8,
+    kFGF9,
+    kFGF10,
+    kFGF11,
+    kFGF12,
+    kFGF13,
+    kFGF14,
+    kFGF15,
+    kFGF16,
+    kFGF17,
+    kFGF18,
+    kFGF19,
+    kFGF20,
+    kCPU0CLK,
+    kCPU1CLK,
+    kCPU2CLK,
+    kCPU3CLK,
+    kNICLK,
+    kFILCLK,
+    kPRECLK,
+    kADCEN,
+    kNIODE,
+    kNIOCE,
+    kNIIDE,
+    kNIICE,
+    kEBIS,
+    kEBIT,
+    kEBIL,
+    kTPVT,
+    kTPVBY,
+    kTPCT,
+    kTPCL,
+    kTPCBY,
+    kTPD,
+    kTPCI0,
+    kTPCI1,
+    kTPCI2,
+    kTPCI3,
+    kEBIN,
+    kFLBY,
+    kFPBY,
+    kFGBY,
+    kFTBY,
+    kFCBY,
+    kFLL00,
+    kFLL01,
+    kFLL02,
+    kFLL03,
+    kFLL04,
+    kFLL05,
+    kFLL06,
+    kFLL07,
+    kFLL08,
+    kFLL09,
+    kFLL0A,
+    kFLL0B,
+    kFLL0C,
+    kFLL0D,
+    kFLL0E,
+    kFLL0F,
+    kFLL10,
+    kFLL11,
+    kFLL12,
+    kFLL13,
+    kFLL14,
+    kFLL15,
+    kFLL16,
+    kFLL17,
+    kFLL18,
+    kFLL19,
+    kFLL1A,
+    kFLL1B,
+    kFLL1C,
+    kFLL1D,
+    kFLL1E,
+    kFLL1F,
+    kFLL20,
+    kFLL21,
+    kFLL22,
+    kFLL23,
+    kFLL24,
+    kFLL25,
+    kFLL26,
+    kFLL27,
+    kFLL28,
+    kFLL29,
+    kFLL2A,
+    kFLL2B,
+    kFLL2C,
+    kFLL2D,
+    kFLL2E,
+    kFLL2F,
+    kFLL30,
+    kFLL31,
+    kFLL32,
+    kFLL33,
+    kFLL34,
+    kFLL35,
+    kFLL36,
+    kFLL37,
+    kFLL38,
+    kFLL39,
+    kFLL3A,
+    kFLL3B,
+    kFLL3C,
+    kFLL3D,
+    kFLL3E,
+    kFLL3F,
+    kTPPT0,
+    kTPFS,
+    kTPFE,
+    kTPPGR,
+    kTPPAE,
+    kTPQS0,
+    kTPQE0,
+    kTPQS1,
+    kTPQE1,
+    kEBD,
+    kEBAQA,
+    kEBSIA,
+    kEBSF,
+    kEBSIM,
+    kEBPP,
+    kEBPC,
+    kFPTC,
+    kFPNP,
+    kFPCL,
+    kFGTA,
+    kFGTB,
+    kFGCL,
+    kFTAL,
+    kFTLL,
+    kFTLS,
+    kFCW1,
+    kFCW2,
+    kFCW3,
+    kFCW4,
+    kFCW5,
+    kTPFP,
+    kTPHT,
+    kADCMSK,
+    kADCINB,
+    kADCDAC,
+    kADCPAR,
+    kADCTST,
+    kSADCAZ,
+    kPASADEL,
+    kPASAPHA,
+    kPASAPRA,
+    kPASADAC,
+    kPASASTL,
+    kPASAPR1,
+    kPASAPR0,
+    kSADCTRG,
+    kSADCRUN,
+    kSADCPWR,
+    kL0TSIM,
+    kSADCEC,
+    kSADCMC,
+    kSADCOC,
+    kSADCGTB,
+    kSEBDEN,
+    kSEBDOU,
+    kSML0,
+    kSML1,
+    kSML2,
+    kSMMODE,
+    kNITM0,
+    kNITM1,
+    kNITM2,
+    kNIP4D,
+    kARBTIM,
+    kIA0IRQ0,
+    kIA0IRQ1,
+    kIA0IRQ2,
+    kIA0IRQ3,
+    kIA0IRQ4,
+    kIA0IRQ5,
+    kIA0IRQ6,
+    kIA0IRQ7,
+    kIA0IRQ8,
+    kIA0IRQ9,
+    kIA0IRQA,
+    kIA0IRQB,
+    kIA0IRQC,
+    kIRQSW0,
+    kIRQHW0,
+    kIRQHL0,
+    kIA1IRQ0,
+    kIA1IRQ1,
+    kIA1IRQ2,
+    kIA1IRQ3,
+    kIA1IRQ4,
+    kIA1IRQ5,
+    kIA1IRQ6,
+    kIA1IRQ7,
+    kIA1IRQ8,
+    kIA1IRQ9,
+    kIA1IRQA,
+    kIA1IRQB,
+    kIA1IRQC,
+    kIRQSW1,
+    kIRQHW1,
+    kIRQHL1,
+    kIA2IRQ0,
+    kIA2IRQ1,
+    kIA2IRQ2,
+    kIA2IRQ3,
+    kIA2IRQ4,
+    kIA2IRQ5,
+    kIA2IRQ6,
+    kIA2IRQ7,
+    kIA2IRQ8,
+    kIA2IRQ9,
+    kIA2IRQA,
+    kIA2IRQB,
+    kIA2IRQC,
+    kIRQSW2,
+    kIRQHW2,
+    kIRQHL2,
+    kIA3IRQ0,
+    kIA3IRQ1,
+    kIA3IRQ2,
+    kIA3IRQ3,
+    kIA3IRQ4,
+    kIA3IRQ5,
+    kIA3IRQ6,
+    kIA3IRQ7,
+    kIA3IRQ8,
+    kIA3IRQ9,
+    kIA3IRQA,
+    kIA3IRQB,
+    kIA3IRQC,
+    kIRQSW3,
+    kIRQHW3,
+    kIRQHL3,
+    kCTGDINI,
+    kCTGCTRL,
+    kMEMRW,
+    kMEMCOR,
+    kDMDELA,
+    kDMDELS,
+    kNMOD,
+    kNDLY,
+    kNED,
+    kNTRO,
+    kNRRO,
+    kNBND,
+    kNP0,
+    kNP1,
+    kNP2,
+    kNP3,
+    kC08CPU0,
+    kC09CPU0, // will be q2 pid window settings.
+    kC10CPU0,
+    kC11CPU0,
+    kC12CPUA,
+    kC13CPUA,
+    kC14CPUA,
+    kC15CPUA,
+    kC08CPU1,
+    kC09CPU1, // version of trap code.
+    kC10CPU1,
+    kC11CPU1,
+    kC08CPU2,
+    kC09CPU2,
+    kC10CPU2,
+    kC11CPU2,
+    kC08CPU3,
+    kC09CPU3,
+    kC10CPU3,
+    kC11CPU3,
+    kNES,
+    kNTP,
+    kNCUT,
+    kPASACHM,
+    kLastReg
+  };
+
+ public:
+  TrapConfigEvent();
+  ~TrapConfigEvent() = default;
+
+  TrapConfigEvent(const TrapConfigEvent& A);
+  // get a config register value by index, addr, and name, via mcm index
+  uint32_t getRegisterValue(uint32_t regidx, int mcmidx);
+  bool setRegisterValue(uint32_t data, uint32_t regidx, int mcmidx);
+  uint32_t getRegisterValueByIdx(uint32_t regidx, int mcmidx);
+  bool setRegisterValueByIdx(uint32_t data, uint32_t regidx, int mcmidx);
+  uint32_t getRegisterValueByAddr(uint32_t addr, int mcmidx);
+  bool setRegisterValueByAddr(uint32_t data, uint32_t addr, int mcmidx);
+  uint32_t getRegisterValueByName(const std::string& name, int mcmidx);
+  bool setRegisterValueByName(uint32_t data, const std::string& regname, int mcmidx);
+
+  // get a config register value by index, addr, and name, via sector/stack/layer/rob/mcm
+  // no setters for sector/stack/layer/rob/mcm as writing, we only write from retrieved config events.
+  // uint32_t getRegisterValueByIdx(uint32_t regix, int sector, int stack, int layer, int rob, int mcm);
+  // uint32_t getRegisterValueByAddr(uint32_t regaddr, int sector, int stack, int layer, int rob, int mcm);
+  // uint32_t getRegisterValueByIdx(uint32_t regix, int detector, int rob, int mcm);
+  // uint32_t getRegisterValueByAddr(uint32_t regaddr, int detector, int rob, int mcm);
+
+  // get a registers name by addres and index;
+  std::string getRegNameByAddr(uint16_t addr);
+  std::string getRegNameByIdx(unsigned int regidx);
+
+  // get a registers index (enum value) by address or name
+  int32_t getRegIndexByAddr(unsigned int addr);
+  int32_t getRegIndexByName(const std::string& name);
+
+  // get a registers address by index or name
+  int32_t getRegAddrByIdx(unsigned int regidx);
+  int32_t getRegAddrByName(const std::string& name);
+
+  bool isValidAddress(uint32_t addr);
+  const std::string getRegisterName(unsigned int index) { return mTrapRegisters[index].getName(); }
+  const uint32_t getRegisterMax(unsigned int index) { return mTrapRegisters[index].getMax(); }
+  const uint32_t getRegisterNBits(unsigned int index) { return mTrapRegisters[index].getNbits(); }
+
+  // get the indenfiying characteristics of a register given its address.
+  void getRegisterByAddr(uint32_t registeraddr, std::string& regname, int32_t& newregidx, int32_t& numberbits);
+
+  // return all the registers for a particular mcm
+  void getAllRegisters(int mcmidx, std::array<uint32_t, kLastReg>& registers);
+
+  // return all the mcm values for a particular register index
+  void getAllMCMByIndex(int regindex, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& registers);
+
+  // return all the mcm values for a particular register name
+  void getAllMCMByName(std::string registername, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms);
+
+  // return all the mcm for a particular register address
+  void getAllMCMByAddress(int registeraddress, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms);
+
+  // return all the config data in an unpacked array.
+  void getAll(std::array<uint32_t, kLastReg * o2::trd::constants::MAXMCMCOUNT>& configdata);
+
+  // return the full unpacked config event.
+  bool printRegister(int regindex, int det, int rob, int mcm);
+  // bool printRegister(TrapRegInfo* reg, int det, int rob, int mcm);
+
+  const std::array<o2::trd::TrapRegInfo, kLastReg>& getTrapRegisters() { return mTrapRegisters; }
+
+  uint32_t getRegisterMax(int idx) { return mTrapRegisters[idx].getMax(); }
+
+  // population pending
+  void setConfigVersion(uint32_t version) { mTrapConfigEventVersion = version; }           // these must some how be gotten from git or wingdb.
+  void setConfigNumber(uint32_t number) { mTrapConfigEventNumber = number; }               // these must be gotten from git or wingdb.
+  void setConfigSavedVersion(uint16_t version) { mTrapConfigEventSavedVersion = version; } // the version that is saved, for the ability to later save the config differently.
+  const uint32_t getConfigVersion()const { return mTrapConfigEventVersion; }                          // these must some how be gotten from git or wingdb.
+  const uint32_t getConfigName()const { return mTrapConfigEventNumber; }                              // these must be gotten from git or wingdb.
+  const uint16_t getConfigSavedVersion()const { return mTrapConfigEventSavedVersion; }                // the version that is saved, for the ability to later save the config differently.
+
+  bool operator==(const TrapConfigEvent& rhs);
+
+  // for compliance with the same interface to o2::trd::TrapConfigEvent and its run1/2 inherited interface:
+  // only these 2 are used in the simulations.
+  uint32_t getDmemUnsigned(uint32_t address, int detector, int rob, int mcm);
+  uint32_t getTrapReg(uint32_t index, int detector, int rob, int mcm);
+
+  const bool isHCIDPresent(int hcid) const { return mHCIDPresent.test(hcid); }
+  void HCIDIsPresent( int hcid)  {  mHCIDPresent.set(hcid); }
+  uint32_t countHCIDPresent(){return mHCIDPresent.count();}
+  const std::bitset<constants::MAXHALFCHAMBER>& getHCIDPresent() const { return mHCIDPresent; }
+  const bool isMCMPresent(int mcmid) const { return mMCMPresent.test(mcmid); }
+  void MCMIsPresent( int mcmid)  {  mMCMPresent.set(mcmid); }
+  void clearMCMPresent(){ mMCMPresent.reset();}
+  const std::bitset<constants::MAXMCMCOUNT>& getMCMPresent() const { return mMCMPresent; }
+  uint32_t countMCMPresent(){return mMCMPresent.count();}
+  
+  bool ignoreWord(int offset) const { return mWordNumberIgnore.test(offset); }
+ 
+    // required for a container for calibration
+  //void fill(const TrapConfigEvent& input);
+  //void fill(const gsl::span<const TrapConfigEvent> input); // dummy!
+  //void merge(const TrapConfigEvent* prev);
+  //void print();
+  //void reset(){a=0;};
+  
+
+ private:
+  std::array<o2::trd::TrapRegInfo, kLastReg> mTrapRegisters;                              //!< store of layout of each block of mTrapRegisterSize, populated via initialiseRegisters
+  std::bitset<o2::trd::constants::MAXMCMCOUNT> mMCMPresent{0};                            //!< does the mcm actually receive data.
+  std::bitset<o2::trd::constants::MAXHALFCHAMBER> mHCIDPresent{0};                           //!< did the link actually receive data.
+  //std::array<uint32_t, kTrapRegistersSize * o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
+  std::array<std::array<uint32_t, kTrapRegistersSize>, o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
+  std::map<uint16_t, uint16_t> mTrapRegistersAddressIndexMap;                             //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
+  std::bitset<kTrapRegistersSize> mWordNumberIgnore;
+  void initialiseRegisters();
+
+  uint32_t mTrapConfigEventNumber;       //!< the version number coming from the config that is written to the traps, from config register C09CPU01
+  uint32_t mTrapConfigEventVersion;      //!< the version of the coming from the config that is written to the traps, from DigitHCHeader (svn version number)
+  uint16_t mTrapConfigEventSavedVersion; //!< the version that is saved, for the ability to later save the config differently.
+  ClassDefNV(TrapConfigEvent, 1);
+};
+
+class TrapConfigEventSlot : public TrapConfigEvent
+{
+  //This is the class to hold trapconfig events coming from the parser to the aggregator,
+  //
+  public: 
+    TrapConfigEventSlot()= default;
+    TrapConfigEventSlot(const TrapConfigEventSlot&)= default;
+    ~TrapConfigEventSlot()= default;
+    void reset(){a=1;};
+  bool addEntry(float deltaAlpha, float impactAngle, int chamberId){a=2;return true;}
+  float getHistogramEntry(int index) const { return a; }
+  int getBinCount(int index) const { return a; }
+  size_t getNEntries() const { return a; }
+  
+ // required for a container for calibration
+  void fill(const TrapConfigEventSlot& input);
+  void fill(const gsl::span<const TrapConfigEventSlot> input);
+  void merge(const TrapConfigEventSlot* prev);
+  void print();
+
+  bool isRegisterSeen(int mcmid, int regidx){return mcmMissedRegister[mcmid].test(regidx);}
+  void setRegisterSeen(int mcmid, int regidx){mcmMissedRegister[mcmid].set(regidx);}
+  int getMCMParsingStatus(int mcmid){return mMCMParsingStatus[mcmid];}
+  void setMCMParsingStatus(int mcmid, int status){mMCMParsingStatus[mcmid]= status;}
+  void clearParsingStatus(){mMCMParsingStatus.fill(0);}
+  std::map<uint32_t,uint32_t>& getRegisterMapForMCM(int mcmid){ return mTrapRegistersFrequencyMap[mcmid];}
+
+  private:
+    int a; 
+    std::array<std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>, kTrapRegistersSize> mConfigData;            //!< one block of data per mcm.
+    std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;               //!< frequency map for values in the respective registers
+    std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                                      //!< count of different value in the registers for a mcm,register used to find most frequent value.
+    std::array<int, o2::trd::constants::MAXMCMCOUNT> mMCMParsingStatus{0};                                        //!< status of what was found, errors types in the parsing
+    std::array<std::bitset<TrapConfigEvent::kLastReg>, o2::trd::constants::MAXMCMCOUNT> mcmMissedRegister;        //!< bitpattern of which registers were seen and not seen for a given mcm.
+
+  ClassDefNV(TrapConfigEventSlot, 1);
+};
+
+
+}; // namespace o2::trd
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
@@ -628,7 +628,7 @@ class TrapConfigEvent
   const uint32_t getConfigName() const { return mTrapConfigEventNumber; }                  // these must be gotten from git or wingdb.
   const uint16_t getConfigSavedVersion() const { return mTrapConfigEventSavedVersion; }    // the version that is saved, for the ability to later save the config differently.
 
-  bool operator==(const TrapConfigEvent& rhs);
+  bool isConfigDifferent(const TrapConfigEvent& trapconfigevent);
 
   // for compliance with the same interface to o2::trd::TrapConfigEvent and its run1/2 inherited interface:
   // only these 2 are used in the simulations.
@@ -661,8 +661,8 @@ class TrapConfigEvent
   std::bitset<constants::MAXMCMCOUNT> mMCMPresent{0};                          //!< does the mcm actually receive data.
   std::bitset<constants::MAXHALFCHAMBER> mHCIDPresent{0};                      //!< did the link actually receive data.
   std::vector<MCMEvent> mConfigData;                                           //!< vector of register data blocks
-  std::array<int32_t, constants::MAXHALFCHAMBER> mConfigDataIndex{-1};         //!< one block of data per mcm.
-  std::unique_ptr<std::map<uint16_t, uint16_t>> mTrapRegistersAddressIndexMap; //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
+  std::array<int32_t, constants::MAXMCMCOUNT> mConfigDataIndex{-1};         //!< one block of data per mcm.
+ std::map<uint16_t, uint16_t> mTrapRegistersAddressIndexMap; //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
   std::bitset<kTrapRegistersSize> mWordNumberIgnore;
   void initialiseRegisters();
 
@@ -679,14 +679,13 @@ class TrapConfigEventTimeSlot
   ~TrapConfigEventTimeSlot() = default;
   std::array<std::array<uint32_t, kTrapRegistersSize>, constants::MAXHALFCHAMBER> mConfigData;
   //  std::bitset<constants::MAXHALFCHAMBER> mMCMPresent;
-  // required for a container for calibration
-  void fill(const TrapConfigEventTimeSlot& input) { a = 0; };
-  void fill(const TrapConfigEvent& input) { a = 0; };
-  void fill(const gsl::span<const TrapConfigEventTimeSlot> input) { a = 0; } // dummy!
-                                                                             //  void fill(const gsl::span<const TrapConfigEvent> input){a=0;} // dummy!
-  void merge(const TrapConfigEventTimeSlot* prev) { a = 0; };
-  void print() { a = 0; };
-  void reset() { a = 0; };
+  // required for a container for calibratio
+  void fill(const TrapConfigEventTimeSlot& input);
+  void fill(const TrapConfigEvent& input);
+  void fill(const gsl::span<const TrapConfigEventTimeSlot> input);
+  void merge(const TrapConfigEventTimeSlot* prev);
+  void print();
+  void reset();
   uint16_t getNEntries() { return a; }
   int a;
 };

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
@@ -119,21 +119,6 @@ struct MCMEvent
   ClassDefNV(MCMEvent,1);
 };
  
-class TrapConfigEventTimeSlot
-{
-  public :
-    TrapConfigEventTimeSlot() = default;
-    ~TrapConfigEventTimeSlot() = default;
-    std::array<std::array<uint32_t,kTrapRegistersSize>,constants::MAXHALFCHAMBER> mConfigData;
-    std::bitset<constants::MAXHALFCHAMBER> mMCMPresent;
-  // required for a container for calibration
-  void fill(const TrapConfigEventTimeSlot& input){a=0;};
-  void fill(const gsl::span<const TrapConfigEventTimeSlot> input){a=0;} // dummy!
-  void merge(const TrapConfigEventTimeSlot* prev){a=0;};
-  void print(){a=0;};
-  void reset(){a=0;};
-  int a;
-};
 
 class TrapConfigEvent
 {
@@ -689,6 +674,27 @@ class TrapConfigEvent
 };
 
 
+
+class TrapConfigEventTimeSlot
+{
+  public :
+    TrapConfigEventTimeSlot() = default;
+    ~TrapConfigEventTimeSlot() = default;
+    std::array<std::array<uint32_t,kTrapRegistersSize>,constants::MAXHALFCHAMBER> mConfigData;
+  //  std::bitset<constants::MAXHALFCHAMBER> mMCMPresent;
+  // required for a container for calibration
+  void fill(const TrapConfigEventTimeSlot& input){a=0;};
+  void fill(const TrapConfigEvent& input){a=0;};
+  void fill(const gsl::span<const TrapConfigEventTimeSlot> input){a=0;} // dummy!
+//  void fill(const gsl::span<const TrapConfigEvent> input){a=0;} // dummy!
+  void merge(const TrapConfigEventTimeSlot* prev){a=0;};
+  void print(){a=0;};
+  void reset(){a=0;};
+  uint16_t getNEntries(){return a;}
+  int a;
+};
+
+
 //    std::array<std::array<uint32_t, kTrapRegistersSize>, o2::trd::constants::MAXMCMCOUNT> mConfigData; //!< one block of data per mcm.
 //  std::bitset<o2::trd::constants::MAXMCMCOUNT> mMCMPresent{0};     //!< does the mcm actually receive data.
 //  std::bitset<o2::trd::constants::MAXHALFCHAMBER> mHCIDPresent{0}; //!< did the link actually receive data.
@@ -705,4 +711,14 @@ class TrapConfigEvent
   ClassDefNV(TrapConfigEventMessage, 2);*/
 
 }; // namespace o2::trd
+//
+namespace o2::framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::trd::TrapConfigEvent> : std::true_type {
+};
+} // namespace o2::framework
+
 #endif

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -39,6 +39,9 @@
 #pragma link C++ class o2::trd::LinkToHCIDMapping + ;
 #pragma link C++ class o2::trd::ChannelInfo + ;
 #pragma link C++ class o2::trd::ChannelInfoContainer + ;
+#pragma link C++ class o2::trd::TrapRegInfo + ;
+#pragma link C++ class o2::trd::TrapConfigEvent + ;
+#pragma link C++ class o2::trd::TrapConfigEventSlot + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TrackTriggerRecord> + ;
@@ -49,6 +52,11 @@
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEvent> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEventSlot> + ;
+//#pragma link C++ class std::array<std::map<uint32_t, uint32_t>, 433> +; 
+//#pragma link C++ class  std::map<uint32_t, std::map<uint32_t, uint32_t>> + ; 
+
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -41,7 +41,7 @@
 #pragma link C++ class o2::trd::ChannelInfoContainer + ;
 #pragma link C++ class o2::trd::TrapRegInfo + ;
 #pragma link C++ class o2::trd::TrapConfigEvent + ;
-#pragma link C++ class o2::trd::TrapConfigEventSlot + ;
+#pragma link C++ class o2::trd::TrapConfigEventTimeSlot + ;
 #pragma link C++ class std::vector < int > +;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
@@ -53,9 +53,8 @@
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
-#pragma link C++ class std::vector < o2::trd::TrapConfigEventSlot> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEvent> + ;
-#pragma link C++ class std::vector < o2::trd::TrapConfigEventSlot> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEventTimeSlot> + ;
 #pragma link C++ class std::map <uint16_t, uint16_t> +;
 //#pragma link C++ class  std::unordered_map<int, MCMEvent> + ;
 //#pragma link C++ class std::vector < o2::trd::MCMEvent> + ;

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -42,6 +42,7 @@
 #pragma link C++ class o2::trd::TrapRegInfo + ;
 #pragma link C++ class o2::trd::TrapConfigEvent + ;
 #pragma link C++ class o2::trd::TrapConfigEventSlot + ;
+#pragma link C++ class std::vector < int > +;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TrackTriggerRecord> + ;
@@ -52,10 +53,13 @@
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEventSlot> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEvent> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEventSlot> + ;
-// #pragma link C++ class std::array<std::map<uint32_t, uint32_t>, 433> +;
-// #pragma link C++ class  std::map<uint32_t, std::map<uint32_t, uint32_t>> + ;
+#pragma link C++ class std::map <uint16_t, uint16_t> +;
+//#pragma link C++ class  std::unordered_map<int, MCMEvent> + ;
+//#pragma link C++ class std::vector < o2::trd::MCMEvent> + ;
+//#pragma link C++ class o2::trd::MCMEvent + ;
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -42,7 +42,7 @@
 #pragma link C++ class o2::trd::TrapRegInfo + ;
 #pragma link C++ class o2::trd::TrapConfigEvent + ;
 #pragma link C++ class o2::trd::TrapConfigEventTimeSlot + ;
-#pragma link C++ class std::vector < int > +;
+#pragma link C++ class std::vector < int> + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TrackTriggerRecord> + ;
@@ -55,10 +55,10 @@
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEvent> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEventTimeSlot> + ;
-#pragma link C++ class std::map <uint16_t, uint16_t> +;
-//#pragma link C++ class  std::unordered_map<int, MCMEvent> + ;
-//#pragma link C++ class std::vector < o2::trd::MCMEvent> + ;
-//#pragma link C++ class o2::trd::MCMEvent + ;
+#pragma link C++ class std::map < uint16_t, uint16_t> + ;
+// #pragma link C++ class  std::unordered_map<int, MCMEvent> + ;
+// #pragma link C++ class std::vector < o2::trd::MCMEvent> + ;
+// #pragma link C++ class o2::trd::MCMEvent + ;
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -54,9 +54,8 @@
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEvent> + ;
 #pragma link C++ class std::vector < o2::trd::TrapConfigEventSlot> + ;
-//#pragma link C++ class std::array<std::map<uint32_t, uint32_t>, 433> +; 
-//#pragma link C++ class  std::map<uint32_t, std::map<uint32_t, uint32_t>> + ; 
-
+// #pragma link C++ class std::array<std::map<uint32_t, uint32_t>, 433> +;
+// #pragma link C++ class  std::map<uint32_t, std::map<uint32_t, uint32_t>> + ;
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -372,17 +372,17 @@ void printDigitHCHeaders(o2::trd::DigitHCHeader& header, uint32_t headers[3], in
            header.word, header.res, header.side, header.stack, header.layer, header.supermodule,
            header.numberHCW, header.minor, header.major, header.version);
       break;
-    case 0:
+    case 1:
       o2::trd::DigitHCHeader1 header1;
       header1.word = headers[offset];
       LOGF(info, "%s Digit HalfChamber Header1 Raw:0x%08x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x", (good) ? "" : "*Corrupt*", header1.word, header1.res, header1.ptrigcount, header1.ptrigphase, header1.bunchcrossing, header1.numtimebins);
       break;
-    case 1:
+    case 2:
       o2::trd::DigitHCHeader2 header2;
       header2.word = headers[offset];
       LOGF(info, "%s Digit HalfChamber Header2 Raw:0x%08x reserve:0x%08x PedestalFilter:0x%01x GainFilter:0x%01x TailFilter:0x%01x CrosstalkFilter:0x%01x Non-linFilter:0x%01x RawDataBypassFilter:0x%01x DigitFilterCommonAdditive:0x%02x ", (good) ? "" : "*Corrupt*", header2.word, header2.res, header2.dfilter, header2.rfilter, header2.nlfilter, header2.xtfilter, header2.tfilter, header2.gfilter, header2.pfilter);
       break;
-    case 2:
+    case 3:
       o2::trd::DigitHCHeader3 header3;
       header3.word = headers[offset];
       LOGF(info, "%s Digit HalfChamber Header3: Raw:0x%08x reserve:0x%08x readout program revision:0x%08x assembler program version:0x%01x", (good) ? "" : "*Corrupt*", header3.word, header3.res, header3.svnrver, header3.svnver);

--- a/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
@@ -1,0 +1,931 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+//  TRAP config as received from the trap chips in the form of            //
+//  configuration events, configs are packed into digit events.           //
+//  Header major version defines the config event payload follows as a    //
+//  known block.                                                          //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#include "DataFormatsTRD/RawData.h"
+
+#include <fairlogger/Logger.h>
+
+#include <array>
+
+using namespace o2::trd;
+
+TrapConfigEvent::TrapConfigEvent()
+{
+  initialiseRegisters();
+  setConfigSavedVersion(2);
+}
+
+TrapConfigEvent::TrapConfigEvent(const TrapConfigEvent& A)
+{
+  LOGP(info, "TrapConfigEvent Copy Constructor Called   .....");
+}
+
+void TrapConfigEvent::initialiseRegisters()
+{
+  // initialize all TRAP registers
+  mTrapRegisters[kTPL00].init("TPL00", 0x3180, 5, 0, 0, false, 5);
+  mTrapRegisters[kTPL01].init("TPL01", 0x3181, 5, 0, 1, false, 5);
+  mTrapRegisters[kTPL02].init("TPL02", 0x3182, 5, 0, 2, false, 5);
+  mTrapRegisters[kTPL03].init("TPL03", 0x3183, 5, 0, 3, false, 5);
+  mTrapRegisters[kTPL04].init("TPL04", 0x3184, 5, 0, 4, false, 5);
+  mTrapRegisters[kTPL05].init("TPL05", 0x3185, 5, 0, 5, false, 5);
+  mTrapRegisters[kTPL06].init("TPL06", 0x3186, 5, 0, 6, false, 5);
+  mTrapRegisters[kTPL07].init("TPL07", 0x3187, 5, 0, 7, false, 5);
+  mTrapRegisters[kTPL08].init("TPL08", 0x3188, 5, 0, 8, false, 5);
+  mTrapRegisters[kTPL09].init("TPL09", 0x3189, 5, 0, 9, false, 5);
+  mTrapRegisters[kTPL0A].init("TPL0A", 0x318A, 5, 0, 10, false, 5);
+  mTrapRegisters[kTPL0B].init("TPL0B", 0x318B, 5, 0, 11, false, 5);
+  mTrapRegisters[kTPL0C].init("TPL0C", 0x318C, 5, 0, 12, false, 5);
+  mTrapRegisters[kTPL0D].init("TPL0D", 0x318D, 5, 0, 13, false, 5);
+  mTrapRegisters[kTPL0E].init("TPL0E", 0x318E, 5, 0, 14, false, 5);
+  mTrapRegisters[kTPL0F].init("TPL0F", 0x318F, 5, 0, 15, false, 5);
+  mTrapRegisters[kTPL10].init("TPL10", 0x3190, 5, 0, 16, false, 5);
+  mTrapRegisters[kTPL11].init("TPL11", 0x3191, 5, 0, 17, false, 5);
+  mTrapRegisters[kTPL12].init("TPL12", 0x3192, 5, 0, 18, false, 5);
+  mTrapRegisters[kTPL13].init("TPL13", 0x3193, 5, 0, 19, false, 5);
+  mTrapRegisters[kTPL14].init("TPL14", 0x3194, 5, 0, 20, false, 5);
+  mTrapRegisters[kTPL15].init("TPL15", 0x3195, 5, 0, 21, false, 5);
+  mTrapRegisters[kTPL16].init("TPL16", 0x3196, 5, 0, 22, false, 5);
+  mTrapRegisters[kTPL17].init("TPL17", 0x3197, 5, 0, 23, false, 5);
+  mTrapRegisters[kTPL18].init("TPL18", 0x3198, 5, 0, 24, false, 5);
+  mTrapRegisters[kTPL19].init("TPL19", 0x3199, 5, 0, 25, false, 5);
+  mTrapRegisters[kTPL1A].init("TPL1A", 0x319A, 5, 0, 26, false, 5);
+  mTrapRegisters[kTPL1B].init("TPL1B", 0x319B, 5, 0, 27, false, 5);
+  mTrapRegisters[kTPL1C].init("TPL1C", 0x319C, 5, 0, 28, false, 5);
+  mTrapRegisters[kTPL1D].init("TPL1D", 0x319D, 5, 0, 29, false, 5);
+  mTrapRegisters[kTPL1E].init("TPL1E", 0x319E, 5, 0, 30, false, 5);
+  mTrapRegisters[kTPL1F].init("TPL1F", 0x319F, 5, 0, 31, false, 5);
+  mTrapRegisters[kTPL20].init("TPL20", 0x31A0, 5, 0, 32, false, 5);
+  mTrapRegisters[kTPL21].init("TPL21", 0x31A1, 5, 0, 33, false, 5);
+  mTrapRegisters[kTPL22].init("TPL22", 0x31A2, 5, 0, 34, false, 5);
+  mTrapRegisters[kTPL23].init("TPL23", 0x31A3, 5, 0, 35, false, 5);
+  mTrapRegisters[kTPL24].init("TPL24", 0x31A4, 5, 0, 36, false, 5);
+  mTrapRegisters[kTPL25].init("TPL25", 0x31A5, 5, 0, 37, false, 5);
+  mTrapRegisters[kTPL26].init("TPL26", 0x31A6, 5, 0, 38, false, 5);
+  mTrapRegisters[kTPL27].init("TPL27", 0x31A7, 5, 0, 39, false, 5);
+  mTrapRegisters[kTPL28].init("TPL28", 0x31A8, 5, 0, 40, false, 5);
+  mTrapRegisters[kTPL29].init("TPL29", 0x31A9, 5, 0, 41, false, 5);
+  mTrapRegisters[kTPL2A].init("TPL2A", 0x31AA, 5, 0, 42, false, 5);
+  mTrapRegisters[kTPL2B].init("TPL2B", 0x31AB, 5, 0, 43, false, 5);
+  mTrapRegisters[kTPL2C].init("TPL2C", 0x31AC, 5, 0, 44, false, 5);
+  mTrapRegisters[kTPL2D].init("TPL2D", 0x31AD, 5, 0, 45, false, 5);
+  mTrapRegisters[kTPL2E].init("TPL2E", 0x31AE, 5, 0, 46, false, 5);
+  mTrapRegisters[kTPL2F].init("TPL2F", 0x31AF, 5, 0, 47, false, 5);
+  mTrapRegisters[kTPL30].init("TPL30", 0x31B0, 5, 0, 48, false, 5);
+  mTrapRegisters[kTPL31].init("TPL31", 0x31B1, 5, 0, 49, false, 5);
+  mTrapRegisters[kTPL32].init("TPL32", 0x31B2, 5, 0, 50, false, 5);
+  mTrapRegisters[kTPL33].init("TPL33", 0x31B3, 5, 0, 51, false, 5);
+  mTrapRegisters[kTPL34].init("TPL34", 0x31B4, 5, 0, 52, false, 5);
+  mTrapRegisters[kTPL35].init("TPL35", 0x31B5, 5, 0, 53, false, 5);
+  mTrapRegisters[kTPL36].init("TPL36", 0x31B6, 5, 0, 54, false, 5);
+  mTrapRegisters[kTPL37].init("TPL37", 0x31B7, 5, 0, 55, false, 5);
+  mTrapRegisters[kTPL38].init("TPL38", 0x31B8, 5, 0, 56, false, 5);
+  mTrapRegisters[kTPL39].init("TPL39", 0x31B9, 5, 0, 57, false, 5);
+  mTrapRegisters[kTPL3A].init("TPL3A", 0x31BA, 5, 0, 58, false, 5);
+  mTrapRegisters[kTPL3B].init("TPL3B", 0x31BB, 5, 0, 59, false, 5);
+  mTrapRegisters[kTPL3C].init("TPL3C", 0x31BC, 5, 0, 60, false, 5);
+  mTrapRegisters[kTPL3D].init("TPL3D", 0x31BD, 5, 0, 61, false, 5);
+  mTrapRegisters[kTPL3E].init("TPL3E", 0x31BE, 5, 0, 62, false, 5);
+  mTrapRegisters[kTPL3F].init("TPL3F", 0x31BF, 5, 0, 63, false, 5);
+  mTrapRegisters[kTPL40].init("TPL40", 0x31C0, 5, 0, 64, false, 5);
+  mTrapRegisters[kTPL41].init("TPL41", 0x31C1, 5, 0, 65, false, 5);
+  mTrapRegisters[kTPL42].init("TPL42", 0x31C2, 5, 0, 66, false, 5);
+  mTrapRegisters[kTPL43].init("TPL43", 0x31C3, 5, 0, 67, false, 5);
+  mTrapRegisters[kTPL44].init("TPL44", 0x31C4, 5, 0, 68, false, 5);
+  mTrapRegisters[kTPL45].init("TPL45", 0x31C5, 5, 0, 69, false, 5);
+  mTrapRegisters[kTPL46].init("TPL46", 0x31C6, 5, 0, 70, false, 5);
+  mTrapRegisters[kTPL47].init("TPL47", 0x31C7, 5, 0, 71, false, 5);
+  mTrapRegisters[kTPL48].init("TPL48", 0x31C8, 5, 0, 72, false, 5);
+  mTrapRegisters[kTPL49].init("TPL49", 0x31C9, 5, 0, 73, false, 5);
+  mTrapRegisters[kTPL4A].init("TPL4A", 0x31CA, 5, 0, 74, false, 5);
+  mTrapRegisters[kTPL4B].init("TPL4B", 0x31CB, 5, 0, 75, false, 5);
+  mTrapRegisters[kTPL4C].init("TPL4C", 0x31CC, 5, 0, 76, false, 5);
+  mTrapRegisters[kTPL4D].init("TPL4D", 0x31CD, 5, 0, 77, false, 5);
+  mTrapRegisters[kTPL4E].init("TPL4E", 0x31CE, 5, 0, 78, false, 5);
+  mTrapRegisters[kTPL4F].init("TPL4F", 0x31CF, 5, 0, 79, false, 5);
+  mTrapRegisters[kTPL50].init("TPL50", 0x31D0, 5, 0, 80, false, 5);
+  mTrapRegisters[kTPL51].init("TPL51", 0x31D1, 5, 0, 81, false, 5);
+  mTrapRegisters[kTPL52].init("TPL52", 0x31D2, 5, 0, 82, false, 5);
+  mTrapRegisters[kTPL53].init("TPL53", 0x31D3, 5, 0, 83, false, 5);
+  mTrapRegisters[kTPL54].init("TPL54", 0x31D4, 5, 0, 84, false, 5);
+  mTrapRegisters[kTPL55].init("TPL55", 0x31D5, 5, 0, 85, false, 5);
+  mTrapRegisters[kTPL56].init("TPL56", 0x31D6, 5, 0, 86, false, 5);
+  mTrapRegisters[kTPL57].init("TPL57", 0x31D7, 5, 0, 87, false, 5);
+  mTrapRegisters[kTPL58].init("TPL58", 0x31D8, 5, 0, 88, false, 5);
+  mTrapRegisters[kTPL59].init("TPL59", 0x31D9, 5, 0, 89, false, 5);
+  mTrapRegisters[kTPL5A].init("TPL5A", 0x31DA, 5, 0, 90, false, 5);
+  mTrapRegisters[kTPL5B].init("TPL5B", 0x31DB, 5, 0, 91, false, 5);
+  mTrapRegisters[kTPL5C].init("TPL5C", 0x31DC, 5, 0, 92, false, 5);
+  mTrapRegisters[kTPL5D].init("TPL5D", 0x31DD, 5, 0, 93, false, 5);
+  mTrapRegisters[kTPL5E].init("TPL5E", 0x31DE, 5, 0, 94, false, 5);
+  mTrapRegisters[kTPL5F].init("TPL5F", 0x31DF, 5, 0, 95, false, 5);
+  mTrapRegisters[kTPL60].init("TPL60", 0x31E0, 5, 0, 96, false, 5);
+  mTrapRegisters[kTPL61].init("TPL61", 0x31E1, 5, 0, 97, false, 5);
+  mTrapRegisters[kTPL62].init("TPL62", 0x31E2, 5, 0, 98, false, 5);
+  mTrapRegisters[kTPL63].init("TPL63", 0x31E3, 5, 0, 99, false, 5);
+  mTrapRegisters[kTPL64].init("TPL64", 0x31E4, 5, 0, 100, false, 5);
+  mTrapRegisters[kTPL65].init("TPL65", 0x31E5, 5, 0, 101, false, 5);
+  mTrapRegisters[kTPL66].init("TPL66", 0x31E6, 5, 0, 102, false, 5);
+  mTrapRegisters[kTPL67].init("TPL67", 0x31E7, 5, 0, 103, false, 5);
+  mTrapRegisters[kTPL68].init("TPL68", 0x31E8, 5, 0, 104, false, 5);
+  mTrapRegisters[kTPL69].init("TPL69", 0x31E9, 5, 0, 105, false, 5);
+  mTrapRegisters[kTPL6A].init("TPL6A", 0x31EA, 5, 0, 106, false, 5);
+  mTrapRegisters[kTPL6B].init("TPL6B", 0x31EB, 5, 0, 107, false, 5);
+  mTrapRegisters[kTPL6C].init("TPL6C", 0x31EC, 5, 0, 108, false, 5);
+  mTrapRegisters[kTPL6D].init("TPL6D", 0x31ED, 5, 0, 109, false, 5);
+  mTrapRegisters[kTPL6E].init("TPL6E", 0x31EE, 5, 0, 110, false, 5);
+  mTrapRegisters[kTPL6F].init("TPL6F", 0x31EF, 5, 0, 111, false, 5);
+  mTrapRegisters[kTPL70].init("TPL70", 0x31F0, 5, 0, 112, false, 5);
+  mTrapRegisters[kTPL71].init("TPL71", 0x31F1, 5, 0, 113, false, 5);
+  mTrapRegisters[kTPL72].init("TPL72", 0x31F2, 5, 0, 114, false, 5);
+  mTrapRegisters[kTPL73].init("TPL73", 0x31F3, 5, 0, 115, false, 5);
+  mTrapRegisters[kTPL74].init("TPL74", 0x31F4, 5, 0, 116, false, 5);
+  mTrapRegisters[kTPL75].init("TPL75", 0x31F5, 5, 0, 117, false, 5);
+  mTrapRegisters[kTPL76].init("TPL76", 0x31F6, 5, 0, 118, false, 5);
+  mTrapRegisters[kTPL77].init("TPL77", 0x31F7, 5, 0, 119, false, 5);
+  mTrapRegisters[kTPL78].init("TPL78", 0x31F8, 5, 0, 120, false, 5);
+  mTrapRegisters[kTPL79].init("TPL79", 0x31F9, 5, 0, 121, false, 5);
+  mTrapRegisters[kTPL7A].init("TPL7A", 0x31FA, 5, 0, 122, false, 5);
+  mTrapRegisters[kTPL7B].init("TPL7B", 0x31FB, 5, 0, 123, false, 5);
+  mTrapRegisters[kTPL7C].init("TPL7C", 0x31FC, 5, 0, 124, false, 5);
+  mTrapRegisters[kTPL7D].init("TPL7D", 0x31FD, 5, 0, 125, false, 5);
+  mTrapRegisters[kTPL7E].init("TPL7E", 0x31FE, 5, 0, 126, false, 5);
+  mTrapRegisters[kTPL7F].init("TPL7F", 0x31FF, 5, 0, 127, false, 5);
+  mTrapRegisters[kFGA0].init("FGA0", 0x30A0, 6, 22, 0, false, 6);
+  mTrapRegisters[kFGA1].init("FGA1", 0x30A1, 6, 22, 1, false, 6);
+  mTrapRegisters[kFGA2].init("FGA2", 0x30A2, 6, 22, 2, false, 6);
+  mTrapRegisters[kFGA3].init("FGA3", 0x30A3, 6, 22, 3, false, 6);
+  mTrapRegisters[kFGA4].init("FGA4", 0x30A4, 6, 22, 4, false, 6);
+  mTrapRegisters[kFGA5].init("FGA5", 0x30A5, 6, 22, 5, false, 6);
+  mTrapRegisters[kFGA6].init("FGA6", 0x30A6, 6, 22, 6, false, 6);
+  mTrapRegisters[kFGA7].init("FGA7", 0x30A7, 6, 22, 7, false, 6);
+  mTrapRegisters[kFGA8].init("FGA8", 0x30A8, 6, 22, 8, false, 6);
+  mTrapRegisters[kFGA9].init("FGA9", 0x30A9, 6, 22, 9, false, 6);
+  mTrapRegisters[kFGA10].init("FGA10", 0x30AA, 6, 22, 10, false, 6);
+  mTrapRegisters[kFGA11].init("FGA11", 0x30AB, 6, 22, 11, false, 6);
+  mTrapRegisters[kFGA12].init("FGA12", 0x30AC, 6, 22, 12, false, 6);
+  mTrapRegisters[kFGA13].init("FGA13", 0x30AD, 6, 22, 13, false, 6);
+  mTrapRegisters[kFGA14].init("FGA14", 0x30AE, 6, 22, 14, false, 6);
+  mTrapRegisters[kFGA15].init("FGA15", 0x30AF, 6, 22, 15, false, 6);
+  mTrapRegisters[kFGA16].init("FGA16", 0x30B0, 6, 22, 16, false, 6);
+  mTrapRegisters[kFGA17].init("FGA17", 0x30B1, 6, 22, 17, false, 6);
+  mTrapRegisters[kFGA18].init("FGA18", 0x30B2, 6, 22, 18, false, 6);
+  mTrapRegisters[kFGA19].init("FGA19", 0x30B3, 6, 22, 19, false, 6);
+  mTrapRegisters[kFGA20].init("FGA20", 0x30B4, 6, 22, 20, false, 6);
+  mTrapRegisters[kFGF0].init("FGF0", 0x3080, 10, 27, 0, false, 10);
+  mTrapRegisters[kFGF1].init("FGF1", 0x3081, 10, 27, 1, false, 10);
+  mTrapRegisters[kFGF2].init("FGF2", 0x3082, 10, 27, 2, false, 10);
+  mTrapRegisters[kFGF3].init("FGF3", 0x3083, 10, 27, 3, false, 10);
+  mTrapRegisters[kFGF4].init("FGF4", 0x3084, 10, 27, 4, false, 10);
+  mTrapRegisters[kFGF5].init("FGF5", 0x3085, 10, 27, 5, false, 10);
+  mTrapRegisters[kFGF6].init("FGF6", 0x3086, 10, 27, 6, false, 10);
+  mTrapRegisters[kFGF7].init("FGF7", 0x3087, 10, 27, 7, false, 10);
+  mTrapRegisters[kFGF8].init("FGF8", 0x3088, 10, 27, 8, false, 10);
+  mTrapRegisters[kFGF9].init("FGF9", 0x3089, 10, 27, 9, false, 10);
+  mTrapRegisters[kFGF10].init("FGF10", 0x308A, 10, 27, 10, false, 10);
+  mTrapRegisters[kFGF11].init("FGF11", 0x308B, 10, 27, 11, false, 10);
+  mTrapRegisters[kFGF12].init("FGF12", 0x308C, 10, 27, 12, false, 10);
+  mTrapRegisters[kFGF13].init("FGF13", 0x308D, 10, 27, 13, false, 10);
+  mTrapRegisters[kFGF14].init("FGF14", 0x308E, 10, 27, 14, false, 10);
+  mTrapRegisters[kFGF15].init("FGF15", 0x308F, 10, 27, 15, false, 10);
+  mTrapRegisters[kFGF16].init("FGF16", 0x3090, 10, 27, 16, false, 10);
+  mTrapRegisters[kFGF17].init("FGF17", 0x3091, 10, 27, 17, false, 10);
+  mTrapRegisters[kFGF18].init("FGF18", 0x3092, 10, 27, 18, false, 10);
+  mTrapRegisters[kFGF19].init("FGF19", 0x3093, 10, 27, 19, false, 10);
+  mTrapRegisters[kFGF20].init("FGF20", 0x3094, 10, 27, 20, false, 10);
+  mTrapRegisters[kCPU0CLK].init("CPU0CLK", 0x0A20, 5, 34, 0, false, 5);
+  mTrapRegisters[kCPU1CLK].init("CPU1CLK", 0x0A22, 5, 34, 1, false, 5);
+  mTrapRegisters[kCPU2CLK].init("CPU2CLK", 0x0A24, 5, 34, 2, false, 5);
+  mTrapRegisters[kCPU3CLK].init("CPU3CLK", 0x0A26, 5, 34, 3, false, 5);
+  mTrapRegisters[kNICLK].init("NICLK", 0x0A28, 5, 34, 4, false, 5);
+  mTrapRegisters[kFILCLK].init("FILCLK", 0x0A2A, 5, 34, 5, false, 5);
+  mTrapRegisters[kPRECLK].init("PRECLK", 0x0A2C, 5, 34, 6, false, 5);
+  mTrapRegisters[kADCEN].init("ADCEN", 0x0A2E, 5, 34, 7, false, 5);
+  mTrapRegisters[kNIODE].init("NIODE", 0x0A30, 5, 34, 8, false, 5);
+  mTrapRegisters[kNIOCE].init("NIOCE", 0x0A32, 5, 34, 9, false, 5);
+  mTrapRegisters[kNIIDE].init("NIIDE", 0x0A34, 5, 34, 10, false, 5);
+  mTrapRegisters[kNIICE].init("NIICE", 0x0A36, 5, 34, 11, false, 5);
+  mTrapRegisters[kEBIS].init("EBIS", 0x3014, 15, 36, 0, false, 15);
+  mTrapRegisters[kEBIT].init("EBIT", 0x3015, 15, 36, 1, false, 15);
+  mTrapRegisters[kEBIL].init("EBIL", 0x3016, 15, 36, 2, false, 15);
+  mTrapRegisters[kTPVT].init("TPVT", 0x3042, 6, 38, 0, false, 6);
+  mTrapRegisters[kTPVBY].init("TPVBY", 0x3043, 6, 38, 1, false, 6);
+  mTrapRegisters[kTPCT].init("TPCT", 0x3044, 6, 38, 2, false, 6);
+  mTrapRegisters[kTPCL].init("TPCL", 0x3045, 6, 38, 3, false, 6);
+  mTrapRegisters[kTPCBY].init("TPCBY", 0x3046, 6, 38, 4, false, 6);
+  mTrapRegisters[kTPD].init("TPD", 0x3047, 6, 38, 5, false, 6);
+  mTrapRegisters[kTPCI0].init("TPCI0", 0x3048, 6, 38, 6, false, 6);
+  mTrapRegisters[kTPCI1].init("TPCI1", 0x3049, 6, 38, 7, false, 6);
+  mTrapRegisters[kTPCI2].init("TPCI2", 0x304A, 6, 38, 8, false, 6);
+  mTrapRegisters[kTPCI3].init("TPCI3", 0x304B, 6, 38, 9, false, 6);
+  mTrapRegisters[kEBIN].init("EBIN", 0x3017, 5, 40, 0, false, 5);
+  mTrapRegisters[kFLBY].init("FLBY", 0x3018, 5, 40, 1, false, 5);
+  mTrapRegisters[kFPBY].init("FPBY", 0x3019, 5, 40, 2, false, 5);
+  mTrapRegisters[kFGBY].init("FGBY", 0x301A, 5, 40, 3, false, 5);
+  mTrapRegisters[kFTBY].init("FTBY", 0x301B, 5, 40, 4, false, 5);
+  mTrapRegisters[kFCBY].init("FCBY", 0x301C, 5, 40, 5, false, 5);
+  mTrapRegisters[kFLL00].init("FLL00", 0x3100, 6, 41, 0, false, 6);
+  mTrapRegisters[kFLL01].init("FLL01", 0x3101, 6, 41, 1, false, 6);
+  mTrapRegisters[kFLL02].init("FLL02", 0x3102, 6, 41, 2, false, 6);
+  mTrapRegisters[kFLL03].init("FLL03", 0x3103, 6, 41, 3, false, 6);
+  mTrapRegisters[kFLL04].init("FLL04", 0x3104, 6, 41, 4, false, 6);
+  mTrapRegisters[kFLL05].init("FLL05", 0x3105, 6, 41, 5, false, 6);
+  mTrapRegisters[kFLL06].init("FLL06", 0x3106, 6, 41, 6, false, 6);
+  mTrapRegisters[kFLL07].init("FLL07", 0x3107, 6, 41, 7, false, 6);
+  mTrapRegisters[kFLL08].init("FLL08", 0x3108, 6, 41, 8, false, 6);
+  mTrapRegisters[kFLL09].init("FLL09", 0x3109, 6, 41, 9, false, 6);
+  mTrapRegisters[kFLL0A].init("FLL0A", 0x310A, 6, 41, 10, false, 6);
+  mTrapRegisters[kFLL0B].init("FLL0B", 0x310B, 6, 41, 11, false, 6);
+  mTrapRegisters[kFLL0C].init("FLL0C", 0x310C, 6, 41, 12, false, 6);
+  mTrapRegisters[kFLL0D].init("FLL0D", 0x310D, 6, 41, 13, false, 6);
+  mTrapRegisters[kFLL0E].init("FLL0E", 0x310E, 6, 41, 14, false, 6);
+  mTrapRegisters[kFLL0F].init("FLL0F", 0x310F, 6, 41, 15, false, 6);
+  mTrapRegisters[kFLL10].init("FLL10", 0x3110, 6, 41, 16, false, 6);
+  mTrapRegisters[kFLL11].init("FLL11", 0x3111, 6, 41, 17, false, 6);
+  mTrapRegisters[kFLL12].init("FLL12", 0x3112, 6, 41, 18, false, 6);
+  mTrapRegisters[kFLL13].init("FLL13", 0x3113, 6, 41, 19, false, 6);
+  mTrapRegisters[kFLL14].init("FLL14", 0x3114, 6, 41, 20, false, 6);
+  mTrapRegisters[kFLL15].init("FLL15", 0x3115, 6, 41, 21, false, 6);
+  mTrapRegisters[kFLL16].init("FLL16", 0x3116, 6, 41, 22, false, 6);
+  mTrapRegisters[kFLL17].init("FLL17", 0x3117, 6, 41, 23, false, 6);
+  mTrapRegisters[kFLL18].init("FLL18", 0x3118, 6, 41, 24, false, 6);
+  mTrapRegisters[kFLL19].init("FLL19", 0x3119, 6, 41, 25, false, 6);
+  mTrapRegisters[kFLL1A].init("FLL1A", 0x311A, 6, 41, 26, false, 6);
+  mTrapRegisters[kFLL1B].init("FLL1B", 0x311B, 6, 41, 27, false, 6);
+  mTrapRegisters[kFLL1C].init("FLL1C", 0x311C, 6, 41, 28, false, 6);
+  mTrapRegisters[kFLL1D].init("FLL1D", 0x311D, 6, 41, 29, false, 6);
+  mTrapRegisters[kFLL1E].init("FLL1E", 0x311E, 6, 41, 30, false, 6);
+  mTrapRegisters[kFLL1F].init("FLL1F", 0x311F, 6, 41, 31, false, 6);
+  mTrapRegisters[kFLL20].init("FLL20", 0x3120, 6, 41, 32, false, 6);
+  mTrapRegisters[kFLL21].init("FLL21", 0x3121, 6, 41, 33, false, 6);
+  mTrapRegisters[kFLL22].init("FLL22", 0x3122, 6, 41, 34, false, 6);
+  mTrapRegisters[kFLL23].init("FLL23", 0x3123, 6, 41, 35, false, 6);
+  mTrapRegisters[kFLL24].init("FLL24", 0x3124, 6, 41, 36, false, 6);
+  mTrapRegisters[kFLL25].init("FLL25", 0x3125, 6, 41, 37, false, 6);
+  mTrapRegisters[kFLL26].init("FLL26", 0x3126, 6, 41, 38, false, 6);
+  mTrapRegisters[kFLL27].init("FLL27", 0x3127, 6, 41, 39, false, 6);
+  mTrapRegisters[kFLL28].init("FLL28", 0x3128, 6, 41, 40, false, 6);
+  mTrapRegisters[kFLL29].init("FLL29", 0x3129, 6, 41, 41, false, 6);
+  mTrapRegisters[kFLL2A].init("FLL2A", 0x312A, 6, 41, 42, false, 6);
+  mTrapRegisters[kFLL2B].init("FLL2B", 0x312B, 6, 41, 43, false, 6);
+  mTrapRegisters[kFLL2C].init("FLL2C", 0x312C, 6, 41, 44, false, 6);
+  mTrapRegisters[kFLL2D].init("FLL2D", 0x312D, 6, 41, 45, false, 6);
+  mTrapRegisters[kFLL2E].init("FLL2E", 0x312E, 6, 41, 46, false, 6);
+  mTrapRegisters[kFLL2F].init("FLL2F", 0x312F, 6, 41, 47, false, 6);
+  mTrapRegisters[kFLL30].init("FLL30", 0x3130, 6, 41, 48, false, 6);
+  mTrapRegisters[kFLL31].init("FLL31", 0x3131, 6, 41, 49, false, 6);
+  mTrapRegisters[kFLL32].init("FLL32", 0x3132, 6, 41, 50, false, 6);
+  mTrapRegisters[kFLL33].init("FLL33", 0x3133, 6, 41, 51, false, 6);
+  mTrapRegisters[kFLL34].init("FLL34", 0x3134, 6, 41, 52, false, 6);
+  mTrapRegisters[kFLL35].init("FLL35", 0x3135, 6, 41, 53, false, 6);
+  mTrapRegisters[kFLL36].init("FLL36", 0x3136, 6, 41, 54, false, 6);
+  mTrapRegisters[kFLL37].init("FLL37", 0x3137, 6, 41, 55, false, 6);
+  mTrapRegisters[kFLL38].init("FLL38", 0x3138, 6, 41, 56, false, 6);
+  mTrapRegisters[kFLL39].init("FLL39", 0x3139, 6, 41, 57, false, 6);
+  mTrapRegisters[kFLL3A].init("FLL3A", 0x313A, 6, 41, 58, false, 6);
+  mTrapRegisters[kFLL3B].init("FLL3B", 0x313B, 6, 41, 59, false, 6);
+  mTrapRegisters[kFLL3C].init("FLL3C", 0x313C, 6, 41, 60, false, 6);
+  mTrapRegisters[kFLL3D].init("FLL3D", 0x313D, 6, 41, 61, false, 6);
+  mTrapRegisters[kFLL3E].init("FLL3E", 0x313E, 6, 41, 62, false, 6);
+  mTrapRegisters[kFLL3F].init("FLL3F", 0x313F, 6, 41, 63, false, 6);
+  mTrapRegisters[kTPPT0].init("TPPT0", 0x3000, 7, 54, 0, false, 7);
+  mTrapRegisters[kTPFS].init("TPFS", 0x3001, 7, 54, 1, false, 7);
+  mTrapRegisters[kTPFE].init("TPFE", 0x3002, 7, 54, 2, false, 7);
+  mTrapRegisters[kTPPGR].init("TPPGR", 0x3003, 7, 54, 3, false, 7);
+  mTrapRegisters[kTPPAE].init("TPPAE", 0x3004, 7, 54, 4, false, 7);
+  mTrapRegisters[kTPQS0].init("TPQS0", 0x3005, 7, 54, 5, false, 7);
+  mTrapRegisters[kTPQE0].init("TPQE0", 0x3006, 7, 54, 6, false, 7);
+  mTrapRegisters[kTPQS1].init("TPQS1", 0x3007, 7, 54, 7, false, 7);
+  mTrapRegisters[kTPQE1].init("TPQE1", 0x3008, 7, 54, 8, false, 7);
+  mTrapRegisters[kEBD].init("EBD", 0x3009, 7, 54, 9, false, 7);
+  mTrapRegisters[kEBAQA].init("EBAQA", 0x300A, 7, 54, 10, false, 7);
+  mTrapRegisters[kEBSIA].init("EBSIA", 0x300B, 7, 54, 11, false, 7);
+  mTrapRegisters[kEBSF].init("EBSF", 0x300C, 7, 54, 12, false, 7);
+  mTrapRegisters[kEBSIM].init("EBSIM", 0x300D, 7, 54, 13, false, 7);
+  mTrapRegisters[kEBPP].init("EBPP", 0x300E, 7, 54, 14, false, 7);
+  mTrapRegisters[kEBPC].init("EBPC", 0x300F, 7, 54, 15, false, 7);
+  mTrapRegisters[kFPTC].init("FPTC", 0x3020, 10, 58, 0, false, 10);
+  mTrapRegisters[kFPNP].init("FPNP", 0x3021, 10, 58, 1, false, 10);
+  mTrapRegisters[kFPCL].init("FPCL", 0x3022, 10, 58, 2, false, 10);
+  mTrapRegisters[kFGTA].init("FGTA", 0x3028, 15, 59, 0, false, 15);
+  mTrapRegisters[kFGTB].init("FGTB", 0x3029, 15, 59, 1, false, 15);
+  mTrapRegisters[kFGCL].init("FGCL", 0x302A, 15, 59, 2, false, 15);
+  mTrapRegisters[kFTAL].init("FTAL", 0x3030, 10, 61, 0, false, 10);
+  mTrapRegisters[kFTLL].init("FTLL", 0x3031, 10, 61, 1, false, 10);
+  mTrapRegisters[kFTLS].init("FTLS", 0x3032, 10, 61, 2, false, 10);
+  mTrapRegisters[kFCW1].init("FCW1", 0x3038, 10, 62, 0, false, 10);
+  mTrapRegisters[kFCW2].init("FCW2", 0x3039, 10, 62, 1, false, 10);
+  mTrapRegisters[kFCW3].init("FCW3", 0x303A, 10, 62, 2, false, 10);
+  mTrapRegisters[kFCW4].init("FCW4", 0x303B, 10, 62, 3, false, 10);
+  mTrapRegisters[kFCW5].init("FCW5", 0x303C, 10, 62, 4, false, 10);
+  mTrapRegisters[kTPFP].init("TPFP", 0x3040, 15, 64, 0, false, 15);
+  mTrapRegisters[kTPHT].init("TPHT", 0x3041, 15, 64, 1, false, 15);
+  mTrapRegisters[kADCMSK].init("ADCMSK", 0x3050, 32, 65, 0, false, 32);
+  mTrapRegisters[kADCINB].init("ADCINB", 0x3051, 5, 66, 0, false, 5);
+  mTrapRegisters[kADCDAC].init("ADCDAC", 0x3052, 5, 66, 1, false, 5);
+  mTrapRegisters[kADCPAR].init("ADCPAR", 0x3053, 32, 67, 0, false, 32);
+  mTrapRegisters[kADCTST].init("ADCTST", 0x3054, 5, 68, 0, false, 5);
+  mTrapRegisters[kSADCAZ].init("SADCAZ", 0x3055, 5, 68, 1, false, 5);
+  mTrapRegisters[kPASADEL].init("PASADEL", 0x3158, 10, 69, 0, false, 10);
+  mTrapRegisters[kPASAPHA].init("PASAPHA", 0x3159, 10, 69, 1, false, 10);
+  mTrapRegisters[kPASAPRA].init("PASAPRA", 0x315A, 10, 69, 2, false, 10);
+  mTrapRegisters[kPASADAC].init("PASADAC", 0x315B, 10, 69, 3, false, 10);
+  mTrapRegisters[kPASASTL].init("PASASTL", 0x315D, 10, 71, 0, false, 10);
+  mTrapRegisters[kPASAPR1].init("PASAPR1", 0x315E, 10, 71, 1, false, 10);
+  mTrapRegisters[kPASAPR0].init("PASAPR0", 0x315F, 10, 71, 2, false, 10);
+  mTrapRegisters[kSADCTRG].init("SADCTRG", 0x3161, 5, 72, 0, false, 5);
+  mTrapRegisters[kSADCRUN].init("SADCRUN", 0x3162, 5, 72, 1, false, 5);
+  mTrapRegisters[kSADCPWR].init("SADCPWR", 0x3163, 5, 72, 2, false, 5);
+  mTrapRegisters[kL0TSIM].init("L0TSIM", 0x3165, 15, 73, 0, false, 15);
+  mTrapRegisters[kSADCEC].init("SADCEC", 0x3166, 15, 73, 1, false, 15);
+  mTrapRegisters[kSADCMC].init("SADCMC", 0x3170, 10, 74, 0, false, 10);
+  mTrapRegisters[kSADCOC].init("SADCOC", 0x3171, 10, 74, 1, false, 10);
+  mTrapRegisters[kSADCGTB].init("SADCGTB", 0x3172, 32, 75, 0, false, 32);
+  mTrapRegisters[kSEBDEN].init("SEBDEN", 0x3178, 5, 76, 0, false, 5);
+  mTrapRegisters[kSEBDOU].init("SEBDOU", 0x3179, 5, 76, 1, false, 5);
+  mTrapRegisters[kSML0].init("SML0", 0x0A00, 15, 77, 0, false, 15);
+  mTrapRegisters[kSML1].init("SML1", 0x0A01, 15, 77, 1, false, 15);
+  mTrapRegisters[kSML2].init("SML2", 0x0A02, 15, 77, 2, false, 15);
+  mTrapRegisters[kSMMODE].init("SMMODE", 0x0A03, 16, 79, 0, false, 16);
+  mTrapRegisters[kNITM0].init("NITM0", 0x0A08, 15, 80, 0, false, 12);
+  mTrapRegisters[kNITM1].init("NITM1", 0x0A09, 15, 80, 1, false, 12);
+  mTrapRegisters[kNITM2].init("NITM2", 0x0A0A, 15, 80, 2, false, 12);
+  mTrapRegisters[kNIP4D].init("NIP4D", 0x0A0B, 15, 80, 3, false, 12);
+  mTrapRegisters[kARBTIM].init("ARBTIM", 0x0A3F, 16, 82, 0, false, 12);
+  mTrapRegisters[kIA0IRQ0].init("IA0IRQ0", 0x0B00, 15, 83, 0, true, 12);
+  mTrapRegisters[kIA0IRQ1].init("IA0IRQ1", 0x0B01, 15, 83, 1, true, 12);
+  mTrapRegisters[kIA0IRQ2].init("IA0IRQ2", 0x0B02, 15, 83, 2, true, 12);
+  mTrapRegisters[kIA0IRQ3].init("IA0IRQ3", 0x0B03, 15, 83, 3, true, 12);
+  mTrapRegisters[kIA0IRQ4].init("IA0IRQ4", 0x0B04, 15, 83, 4, true, 12);
+  mTrapRegisters[kIA0IRQ5].init("IA0IRQ5", 0x0B05, 15, 83, 5, true, 12);
+  mTrapRegisters[kIA0IRQ6].init("IA0IRQ6", 0x0B06, 15, 83, 6, true, 12);
+  mTrapRegisters[kIA0IRQ7].init("IA0IRQ7", 0x0B07, 15, 83, 7, true, 12);
+  mTrapRegisters[kIA0IRQ8].init("IA0IRQ8", 0x0B08, 15, 83, 8, true, 12);
+  mTrapRegisters[kIA0IRQ9].init("IA0IRQ9", 0x0B09, 15, 83, 9, true, 12);
+  mTrapRegisters[kIA0IRQA].init("IA0IRQA", 0x0B0A, 15, 83, 10, true, 12);
+  mTrapRegisters[kIA0IRQB].init("IA0IRQB", 0x0B0B, 15, 83, 11, true, 12);
+  mTrapRegisters[kIA0IRQC].init("IA0IRQC", 0x0B0C, 15, 83, 12, true, 12);
+  mTrapRegisters[kIRQSW0].init("IRQSW0", 0x0B0D, 15, 83, 13, true, 13);
+  mTrapRegisters[kIRQHW0].init("IRQHW0", 0x0B0E, 15, 83, 14, true, 13);
+  mTrapRegisters[kIRQHL0].init("IRQHL0", 0x0B0F, 15, 83, 15, true, 13);
+  mTrapRegisters[kIA1IRQ0].init("IA1IRQ0", 0x0B20, 15, 91, 0, true, 12);
+  mTrapRegisters[kIA1IRQ1].init("IA1IRQ1", 0x0B21, 15, 91, 1, true, 12);
+  mTrapRegisters[kIA1IRQ2].init("IA1IRQ2", 0x0B22, 15, 91, 2, true, 12);
+  mTrapRegisters[kIA1IRQ3].init("IA1IRQ3", 0x0B23, 15, 91, 3, true, 12);
+  mTrapRegisters[kIA1IRQ4].init("IA1IRQ4", 0x0B24, 15, 91, 4, true, 12);
+  mTrapRegisters[kIA1IRQ5].init("IA1IRQ5", 0x0B25, 15, 91, 5, true, 12);
+  mTrapRegisters[kIA1IRQ6].init("IA1IRQ6", 0x0B26, 15, 91, 6, true, 12);
+  mTrapRegisters[kIA1IRQ7].init("IA1IRQ7", 0x0B27, 15, 91, 7, true, 12);
+  mTrapRegisters[kIA1IRQ8].init("IA1IRQ8", 0x0B28, 15, 91, 8, true, 12);
+  mTrapRegisters[kIA1IRQ9].init("IA1IRQ9", 0x0B29, 15, 91, 9, true, 12);
+  mTrapRegisters[kIA1IRQA].init("IA1IRQA", 0x0B2A, 15, 91, 10, true, 12);
+  mTrapRegisters[kIA1IRQB].init("IA1IRQB", 0x0B2B, 15, 91, 11, true, 12);
+  mTrapRegisters[kIA1IRQC].init("IA1IRQC", 0x0B2C, 15, 91, 12, true, 12);
+  mTrapRegisters[kIRQSW1].init("IRQSW1", 0x0B2D, 15, 91, 13, true, 13);
+  mTrapRegisters[kIRQHW1].init("IRQHW1", 0x0B2E, 15, 91, 14, true, 13);
+  mTrapRegisters[kIRQHL1].init("IRQHL1", 0x0B2F, 15, 91, 15, true, 13);
+  mTrapRegisters[kIA2IRQ0].init("IA2IRQ0", 0x0B40, 15, 99, 0, true, 12);
+  mTrapRegisters[kIA2IRQ1].init("IA2IRQ1", 0x0B41, 15, 99, 1, true, 12);
+  mTrapRegisters[kIA2IRQ2].init("IA2IRQ2", 0x0B42, 15, 99, 2, true, 12);
+  mTrapRegisters[kIA2IRQ3].init("IA2IRQ3", 0x0B43, 15, 99, 3, true, 12);
+  mTrapRegisters[kIA2IRQ4].init("IA2IRQ4", 0x0B44, 15, 99, 4, true, 12);
+  mTrapRegisters[kIA2IRQ5].init("IA2IRQ5", 0x0B45, 15, 99, 5, true, 12);
+  mTrapRegisters[kIA2IRQ6].init("IA2IRQ6", 0x0B46, 15, 99, 6, true, 12);
+  mTrapRegisters[kIA2IRQ7].init("IA2IRQ7", 0x0B47, 15, 99, 7, true, 12);
+  mTrapRegisters[kIA2IRQ8].init("IA2IRQ8", 0x0B48, 15, 99, 8, true, 12);
+  mTrapRegisters[kIA2IRQ9].init("IA2IRQ9", 0x0B49, 15, 99, 9, true, 12);
+  mTrapRegisters[kIA2IRQA].init("IA2IRQA", 0x0B4A, 15, 99, 10, true, 12);
+  mTrapRegisters[kIA2IRQB].init("IA2IRQB", 0x0B4B, 15, 99, 11, true, 12);
+  mTrapRegisters[kIA2IRQC].init("IA2IRQC", 0x0B4C, 15, 99, 12, true, 12);
+  mTrapRegisters[kIRQSW2].init("IRQSW2", 0x0B4D, 15, 99, 13, true, 13);
+  mTrapRegisters[kIRQHW2].init("IRQHW2", 0x0B4E, 15, 99, 14, true, 13);
+  mTrapRegisters[kIRQHL2].init("IRQHL2", 0x0B4F, 15, 99, 15, true, 13);
+  mTrapRegisters[kIA3IRQ0].init("IA3IRQ0", 0x0B60, 15, 107, 0, true, 12);
+  mTrapRegisters[kIA3IRQ1].init("IA3IRQ1", 0x0B61, 15, 107, 1, true, 12);
+  mTrapRegisters[kIA3IRQ2].init("IA3IRQ2", 0x0B62, 15, 107, 2, true, 12);
+  mTrapRegisters[kIA3IRQ3].init("IA3IRQ3", 0x0B63, 15, 107, 3, true, 12);
+  mTrapRegisters[kIA3IRQ4].init("IA3IRQ4", 0x0B64, 15, 107, 4, true, 12);
+  mTrapRegisters[kIA3IRQ5].init("IA3IRQ5", 0x0B65, 15, 107, 5, true, 12);
+  mTrapRegisters[kIA3IRQ6].init("IA3IRQ6", 0x0B66, 15, 107, 6, true, 12);
+  mTrapRegisters[kIA3IRQ7].init("IA3IRQ7", 0x0B67, 15, 107, 7, true, 12);
+  mTrapRegisters[kIA3IRQ8].init("IA3IRQ8", 0x0B68, 15, 107, 8, true, 12);
+  mTrapRegisters[kIA3IRQ9].init("IA3IRQ9", 0x0B69, 15, 107, 9, true, 12);
+  mTrapRegisters[kIA3IRQA].init("IA3IRQA", 0x0B6A, 15, 107, 10, true, 12);
+  mTrapRegisters[kIA3IRQB].init("IA3IRQB", 0x0B6B, 15, 107, 11, true, 12);
+  mTrapRegisters[kIA3IRQC].init("IA3IRQC", 0x0B6C, 15, 107, 12, true, 12);
+  mTrapRegisters[kIRQSW3].init("IRQSW3", 0x0B6D, 15, 107, 13, true, 13);
+  mTrapRegisters[kIRQHW3].init("IRQHW3", 0x0B6E, 15, 107, 14, true, 13);
+  mTrapRegisters[kIRQHL3].init("IRQHL3", 0x0B6F, 15, 107, 15, true, 13);
+  mTrapRegisters[kCTGDINI].init("CTGDINI", 0x0B80, 32, 115, 0, false, 32);
+  mTrapRegisters[kCTGCTRL].init("CTGCTRL", 0x0B81, 16, 116, 0, false, 16);
+  mTrapRegisters[kMEMRW].init("MEMRW", 0xD000, 10, 117, 0, false, 10);
+  mTrapRegisters[kMEMCOR].init("MEMCOR", 0xD001, 10, 117, 1, false, 10);
+  mTrapRegisters[kDMDELA].init("DMDELA", 0xD002, 10, 117, 2, false, 10);
+  mTrapRegisters[kDMDELS].init("DMDELS", 0xD003, 10, 117, 3, false, 10);
+  mTrapRegisters[kNMOD].init("NMOD", 0x0D40, 31, 119, 0, false, 31);
+  mTrapRegisters[kNDLY].init("NDLY", 0x0D41, 31, 119, 1, false, 31);
+  mTrapRegisters[kNED].init("NED", 0x0D42, 31, 119, 2, false, 31);
+  mTrapRegisters[kNTRO].init("NTRO", 0x0D43, 31, 119, 3, false, 31);
+  mTrapRegisters[kNRRO].init("NRRO", 0x0D44, 31, 119, 4, false, 31);
+  mTrapRegisters[kNBND].init("NBND", 0x0D47, 16, 124, 0, false, 16);
+  mTrapRegisters[kNP0].init("NP0", 0x0D48, 15, 125, 0, false, 15);
+  mTrapRegisters[kNP1].init("NP1", 0x0D49, 15, 125, 1, false, 15);
+  mTrapRegisters[kNP2].init("NP2", 0x0D4A, 15, 125, 2, false, 15);
+  mTrapRegisters[kNP3].init("NP3", 0x0D4B, 15, 125, 3, false, 15);
+  mTrapRegisters[kC08CPU0].init("C08CPU0", 0x0C00, 32, 126, 0, true, 32);
+  mTrapRegisters[kC09CPU0].init("C09CPU0", 0x0C01, 32, 127, 0, false, 32); // Q2 start, end and tracklet format
+  mTrapRegisters[kC10CPU0].init("C10CPU0", 0x0C02, 32, 128, 0, true, 32);
+  mTrapRegisters[kC11CPU0].init("C11CPU0", 0x0C03, 32, 129, 0, true, 32);
+  mTrapRegisters[kC12CPUA].init("C12CPUA", 0x0C04, 32, 130, 0, true, 32);
+  mTrapRegisters[kC13CPUA].init("C13CPUA", 0x0C05, 32, 131, 0, true, 32);
+  mTrapRegisters[kC14CPUA].init("C14CPUA", 0x0C06, 32, 132, 0, true, 32);
+  mTrapRegisters[kC15CPUA].init("C15CPUA", 0x0C07, 32, 133, 0, true, 32);
+  mTrapRegisters[kC08CPU1].init("C08CPU1", 0x0C08, 32, 134, 0, true, 32);
+  mTrapRegisters[kC09CPU1].init("C09CPU1", 0x0C09, 32, 135, 0, false, 32); // source version 24bit version + # of commits
+  mTrapRegisters[kC10CPU1].init("C10CPU1", 0x0C0A, 32, 136, 0, true, 32);
+  mTrapRegisters[kC11CPU1].init("C11CPU1", 0x0C0B, 32, 137, 0, true, 32);
+  mTrapRegisters[kC08CPU2].init("C08CPU2", 0x0C10, 32, 138, 0, true, 32);
+  mTrapRegisters[kC09CPU2].init("C09CPU2", 0x0C11, 32, 139, 0, false, 32); // free
+  mTrapRegisters[kC10CPU2].init("C10CPU2", 0x0C12, 32, 140, 0, true, 32);
+  mTrapRegisters[kC11CPU2].init("C11CPU2", 0x0C13, 32, 141, 0, true, 32);
+  mTrapRegisters[kC08CPU3].init("C08CPU3", 0x0C18, 32, 142, 0, true, 32);
+  mTrapRegisters[kC09CPU3].init("C09CPU3", 0x0C19, 32, 143, 0, false, 32); // free
+  mTrapRegisters[kC10CPU3].init("C10CPU3", 0x0C1A, 32, 144, 0, true, 32);
+  mTrapRegisters[kC11CPU3].init("C11CPU3", 0x0C1B, 32, 145, 0, true, 32);
+  mTrapRegisters[kNES].init("NES", 0x0D45, 31, 146, 0, false, 31);
+  mTrapRegisters[kNTP].init("NTP", 0x0D46, 31, 147, 0, false, 31);
+  mTrapRegisters[kNCUT].init("NCUT", 0x0D4C, 32, 148, 0, false, 32);
+  mTrapRegisters[kPASACHM].init("PASACHM", 0x315C, 32, 149, 0, false, 19);
+  // mTrapRegisters[kSMCMD].init("SMCMD", 0x0A04, 16, 0x0000);
+
+  for (int reg = 0; reg < kLastReg; ++reg) {
+    // reindex to speed things up, this time by address, map instead of a rather large lookup table.
+    auto addr = mTrapRegisters[reg].getAddr();
+    mTrapRegistersAddressIndexMap[addr] = reg;
+    // build index of wordnumbers, to speed up comparisons.
+    // this indexes ::  [raw block offset:ignorechange]
+    auto wordnumber = mTrapRegisters[reg].getWordNumber();
+    mWordNumberIgnore.set(wordnumber) = mTrapRegisters[reg].getIgnoreChange();
+  }
+  // build index of wordnumbers, to speed up comparisons.
+}
+
+uint32_t TrapConfigEvent::getRegisterValue(const uint32_t regidx, const int mcmidx)
+{
+  // get the register value based on the address of the register;
+  // find register in mTrapRegisters.
+  // calculate the offset from the base for the register and get the mask.
+  if ((regidx < 0) || (regidx >= kLastReg) || (mcmidx < 0 || mcmidx >= o2::trd::constants::MAXMCMCOUNT)) {
+    return 0; // TODO this could be a problem ?!
+  }
+  int mcmoffset = 0;//mcmidx * kTrapRegistersSize;                                 // get the start offset for this mcm
+  int regbase = mcmoffset + mTrapRegisters[regidx].getBase();                  // get the base of this register in the underlying storage block
+  int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber();        // get the offset to the register in question
+  uint32_t data = mConfigData[mcmidx][regoffset] >> mTrapRegisters[regidx].getShift(); // get the data and shift it as needed
+  data &= mTrapRegisters[regidx].getMask();                                    // mask the data off as need be.
+  LOGP(info, " returning data of {:08x}", data);
+  return data;
+}
+
+bool TrapConfigEvent::setRegisterValue(uint32_t data, uint32_t regidx, int mcmidx)
+{
+  if (regidx < 0 || regidx >= kLastReg || mcmidx < 0 || mcmidx >= o2::trd::constants::MAXMCMCOUNT) {
+    return false;
+  }
+  int mcmoffset = 0;//mcmidx * kTrapRegistersSize;                          // get the start offset for this mcm
+  int regbase = mcmoffset + mTrapRegisters[regidx].getBase();           // get the base of this register in the underlying storage block
+  int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber(); // get the offset to the register in question
+  data &= mTrapRegisters[regidx].getMask();                             // mask the data off as need be.
+  uint32_t notdatamask = ~(mTrapRegisters[regidx].getMask() << mTrapRegisters[regidx].getShift());
+  data = data << mTrapRegisters[regidx].getShift();
+  mConfigData[mcmidx][regoffset] = mConfigData[mcmidx][regoffset] & notdatamask;
+  mConfigData[mcmidx][regoffset] = mConfigData[mcmidx][regoffset] | data;
+  return true;
+}
+
+uint32_t TrapConfigEvent::getRegisterValueByIdx(uint32_t regidx, int mcmidx)
+{
+  return getRegisterValue(regidx, mcmidx);
+}
+
+bool TrapConfigEvent::setRegisterValueByIdx(uint32_t data, uint32_t regidx, int mcmidx)
+{
+  return setRegisterValue(data, regidx, mcmidx);
+}
+
+uint32_t TrapConfigEvent::getRegisterValueByAddr(uint32_t addr, int mcmidx)
+{
+  int index = getRegIndexByAddr(addr);
+  if (index >= 0) {
+    return getRegisterValueByIdx(index, mcmidx);
+  } else
+    return 0;
+}
+
+bool TrapConfigEvent::setRegisterValueByAddr(uint32_t data, uint32_t addr, int mcmidx)
+{
+  int index = getRegIndexByAddr(addr);
+  if (index >= 0) {
+    return setRegisterValueByIdx(data, index, mcmidx);
+  }
+  return false;
+}
+
+uint32_t TrapConfigEvent::getRegisterValueByName(const std::string& regname, int mcmidx)
+{
+  int index = getRegIndexByName(regname);
+  return getRegisterValueByIdx(index, mcmidx);
+}
+
+bool TrapConfigEvent::setRegisterValueByName(uint32_t data, const std::string& regname, int mcmidx)
+{
+  int index = getRegIndexByName(regname);
+  if (index < 0) {
+    return false;
+  }
+  return setRegisterValueByIdx(data, index, mcmidx);
+}
+/*
+uint32_t TrapConfigEvent::getRegisterValueByIdx(uint32_t regidx, int sector, int stack, int layer, int rob, int mcm)
+{
+  int mcmidx = HelperMethods::getMCMId(sector, stack, layer, rob, mcm);
+  LOGP(info, "mcmidx {} in getRegisterValueByIdx({},{},{},{},{}", mcmidx, sector, stack, layer, rob, mcm);
+  return getRegisterValueByIdx(regidx, mcmidx);
+}
+
+uint32_t TrapConfigEvent::getRegisterValueByAddr(uint32_t regaddr, int sector, int stack, int layer, int rob, int mcm)
+{
+  int mcmidx = HelperMethods::getMCMId(sector, stack, layer, rob, mcm);
+  return getRegisterValueByAddr(regaddr, mcmidx);
+}
+
+uint32_t TrapConfigEvent::getRegisterValueByIdx(uint32_t regidx, int detector, int rob, int mcm)
+{
+  int mcmidx = detector * o2::trd::constants::NROBC1 * o2::trd::constants::NMCMROB + rob * o2::trd::constants::NROBC1 + mcm;
+  return getRegisterValueByIdx(regidx, mcmidx);
+}
+
+uint32_t TrapConfigEvent::getRegisterValueByAddr(uint32_t regaddr, int detector, int rob, int mcm)
+{
+  // TODO put this calculation in helpermethods
+  int mcmidx = detector * o2::trd::constants::NROBC1 * o2::trd::constants::NMCMROB + rob * o2::trd::constants::NROBC1 + mcm;
+  return getRegisterValueByAddr(regaddr, mcmidx);
+}
+*/
+std::string TrapConfigEvent::getRegNameByAddr(uint16_t addr)
+{
+  std::string name = "";
+  if (auto search = mTrapRegistersAddressIndexMap.find(addr); search != mTrapRegistersAddressIndexMap.end()) {
+    name = mTrapRegisters.at(mTrapRegistersAddressIndexMap[addr]).getName();
+  }
+  return name;
+}
+
+std::string TrapConfigEvent::getRegNameByIdx(unsigned int regidx)
+{
+  if ((regidx >= 0) && (regidx < kLastReg)) {
+    return mTrapRegisters[regidx].getName();
+  } else {
+    return "";
+  }
+}
+
+int32_t TrapConfigEvent::getRegIndexByAddr(unsigned int addr)
+{
+  if (isValidAddress(addr)) {
+    return mTrapRegistersAddressIndexMap[addr];
+  } else
+    return -1;
+}
+
+bool TrapConfigEvent::isValidAddress(uint32_t addr)
+{
+  auto search = mTrapRegistersAddressIndexMap.find(addr);
+  return (search != mTrapRegistersAddressIndexMap.end());
+}
+
+int32_t TrapConfigEvent::getRegIndexByName(const std::string& name)
+{
+  // there is no index for this but its not used online
+  int counter = 0;
+  for (auto& reg : mTrapRegisters) {
+    if (reg.getName() == name) {
+      return counter;
+    }
+    counter++;
+  }
+  return -1; // error condition
+}
+
+int32_t TrapConfigEvent::getRegAddrByIdx(unsigned int regidx)
+{
+  if ((regidx < 0) && (regidx > kLastReg)) {
+    return -1;
+  }
+  return mTrapRegisters[regidx].getAddr();
+}
+
+int32_t TrapConfigEvent::getRegAddrByName(const std::string& name)
+{
+  // there is no index for this but its not used online
+  for (auto& reg : mTrapRegisters) {
+    if (reg.getName() == name) {
+      return reg.getAddr();
+    }
+  }
+  return -1; // error condition
+}
+
+void TrapConfigEvent::getRegisterByAddr(uint32_t registeraddr, std::string& regname, int32_t& newregidx, int32_t& numberbits)
+{
+  int idx = -1;
+  idx = getRegIndexByAddr(registeraddr);
+  if (idx >= 0) {
+    regname = mTrapRegisters[idx].getName();
+    numberbits = mTrapRegisters[idx].getNbits();
+    newregidx = idx;
+  } else {
+    regname = "";
+    numberbits = -1;
+    newregidx = -1;
+  }
+}
+
+// get all the values for a given register values for a given mcm
+void TrapConfigEvent::getAllRegisters(int mcmidx, std::array<uint32_t, kLastReg>& mcmregisters)
+{
+  for (int reg = 0; reg < kLastReg; ++reg) {
+    mcmregisters[reg] = getRegisterValueByIdx(reg, mcmidx);
+  }
+}
+
+// get all the values for a given register, all mcms
+void TrapConfigEvent::getAllMCMByIndex(int regidx, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms)
+{
+  if ((regidx >= 0) && (regidx < kLastReg)) {
+  }
+  for (int mcm = 0; mcm < o2::trd::constants::MAXMCMCOUNT; ++mcm) {
+    mcms[mcm] = getRegisterValueByIdx(regidx, mcm);
+  }
+}
+
+// get all the values for a given register name, all mcms
+void TrapConfigEvent::getAllMCMByName(std::string registername, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms) // return all the mcm values for a particular register name
+{
+  int regindex = getRegIndexByName(registername);
+  for (int mcm = 0; mcm < o2::trd::constants::MAXMCMCOUNT; ++mcm) {
+    mcms[mcm] = getRegisterValueByIdx(regindex, mcm);
+  }
+}
+
+// get all the values for a given register address, all mcms
+void TrapConfigEvent::getAllMCMByAddress(int registeraddress, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms)
+{
+  int regindex = getRegIndexByAddr(registeraddress);
+  if (regindex >= 0) {
+    for (int mcm = 0; mcm < o2::trd::constants::MAXMCMCOUNT; ++mcm) {
+      mcms[mcm] = getRegisterValueByIdx(regindex, mcm);
+    }
+  }
+}
+
+// get all the values for a given register values for all the mcm
+void TrapConfigEvent::getAll(std::array<uint32_t, kLastReg * o2::trd::constants::MAXMCMCOUNT>& configdata)
+{
+  for (int mcm = 0; mcm < constants::MAXMCMCOUNT; ++mcm) {
+    for (int reg = 0; reg < kLastReg; ++reg) {
+      configdata[mcm * kLastReg + reg] = getRegisterValueByIdx(reg, mcm);
+    }
+  }
+}
+
+bool TrapConfigEvent::printRegister(int regindex, int det, int rob, int mcm)
+{
+  // print the value stored in the given register
+  // if it is individual a valid MCM has to be specified
+  if ((det >= 0 && det < o2::trd::constants::MAXCHAMBER) &&
+      (rob >= 0 && rob < o2::trd::constants::NROBC1) &&
+      (mcm >= 0 && mcm < o2::trd::constants::NMCMROB + 2)) {
+    int mcmid = HelperMethods::getMCMId(det, rob, mcm);
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+uint32_t TrapConfigEvent::getDmemUnsigned(uint32_t address, int detector, int rob, int mcm)
+{
+  uint32_t data = 0;
+  uint32_t mcmidx;
+  if ((detector >= 0 && detector < o2::trd::constants::MAXCHAMBER) &&
+      (rob >= 0 && rob < o2::trd::constants::NROBC1) &&
+      (mcm >= 0 && mcm < o2::trd::constants::NMCMROB + 2)) {
+    mcmidx = HelperMethods::getMCMId(detector, rob, mcm);
+    data = getRegisterValueByAddr(address, mcmidx);
+  }
+  return data;
+}
+
+uint32_t TrapConfigEvent::getTrapReg(uint32_t index, int detector, int rob, int mcm)
+{
+
+  uint32_t data = 0;
+  uint32_t mcmidx;
+  if ((detector >= 0 && detector < o2::trd::constants::MAXCHAMBER) &&
+      (rob >= 0 && rob < o2::trd::constants::NROBC1) &&
+      (mcm >= 0 && mcm < o2::trd::constants::NMCMROB + 2)) {
+    mcmidx = HelperMethods::getMCMId(detector, rob, mcm);
+    data = getRegisterValueByIdx(index, mcmidx);
+  }
+  return data;
+}
+
+bool TrapConfigEvent::operator==(const TrapConfigEvent& rhs)
+{
+  // is other different from this.
+  // v1 walk through all 32 bit ints and compare, ignore the internals, ones to ignore are 32 bit themselves.
+  // TODO do we care where the difference is?
+  uint32_t max = constants::MAXMCMCOUNT;
+  uint32_t maxreg = TrapConfigEvent::kLastReg;
+  //start with the biggest granularity and work down.
+  //compare hcid in the 2.
+  //this would be simpler with != but that is removed in c++20
+  if (getHCIDPresent() == rhs.getHCIDPresent()) {
+    //we can continue the bitpattern of half chambers is the same.
+  } else {
+    for (int hcid = 0; hcid < constants::MAXHALFCHAMBER; ++hcid) {
+      if (isHCIDPresent(hcid) == 0 && rhs.isHCIDPresent(hcid) == 1) {
+        // it is not in the ccdb but now is present, this is a change and needs to be saved.
+        LOGP(info, " hcid {} is present in new but not in ccdb version", hcid);
+        return false;
+      }
+      //other cases we can continue.
+      //1. both present its ok.
+      //2. present in ccdb but not in current one.
+    }
+  }
+  if (getMCMPresent() == rhs.getMCMPresent()) {
+    //we can continue the bit pattern of mcm in the config are the same
+  } else {
+    for (int mcmid = 0; mcmid < constants::MAXMCMCOUNT; ++mcmid) {
+      if (isMCMPresent(mcmid) == 0 && rhs.isMCMPresent(mcmid) == 1) {
+        // it is not in the ccdb but now is present, this is a change and needs to be saved.
+        return false;
+      }
+      //other cases we can continue.
+      //1. both present its ok.
+      //2. present in ccdb but not in current one.
+    }
+  }
+  //Now the long part, compare the register data
+  //There is no need to unpack registers. We can simply store their underlying 32 bit stored value.
+  for (int mcm = 0; mcm < max; ++mcm) {
+    for (int rawoffset = 0; rawoffset < kTrapRegistersSize; ++rawoffset) {
+      if (!ignoreWord(rawoffset)) { // we do indeed care if this register is different.
+        if (mConfigData[mcm][rawoffset] != rhs.mConfigData[mcm][rawoffset]) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+TrapRegInfo::TrapRegInfo(const std::string& name, int addr, int nBits, int base, int wordoffset, bool ignorechange, uint32_t max)
+{
+  init(name, addr, nBits, base, wordoffset, ignorechange, max);
+}
+
+TrapRegInfo::~TrapRegInfo() = default;
+
+// void TrapRegister::init(const char* name, int addr, int nBits, int resetValue)
+void TrapRegInfo::init(const std::string& name, int addr, int nbits, int base, int wordnumber, bool ignorechange, uint32_t max)
+{
+  // initialise a TRAP register information
+  // uint32_t mNbits,mBase,mWordNumber,mShift,mMask,mMax;
+  // see headerfile for exact definition, WordNumber: the sequence of register in a block of data, like registers.
+  int bitoffset;
+  int gapbits = 0;
+  int bitwordoffset32; // the beginning of the 32 bit word containing this reg
+  int packedwordsize = 30;
+  if (addr != 0) {
+    mAddr = addr;
+    mName = name;
+    mNbits = nbits;
+    mBase = base;
+    mWordNumber = wordnumber;
+    mMax = pow(2, max) - 1; // this can be different from the mask, not sure why.
+    packedwordsize = 30;
+    if (mNbits > 30 || mNbits == 16 || mNbits == 4) { // these are 32 bit aligned the rest are 30 bit aligned.
+      packedwordsize = 32;
+      if (mNbits == 31) {
+        gapbits = 1;
+      }
+    }
+    mDataWordNumber = mWordNumber * (nbits + gapbits) / packedwordsize; // the 32 bit word offset to the word containing the register in question
+    bitoffset = mWordNumber * (nbits)-mDataWordNumber * packedwordsize; // the offset bit with in that word for the start of this register
+    mMask = (1 << mNbits) - 1;                                          // e.g. 5 = 0x1f 10=0x3ff
+    mShift = 32 - bitoffset - mNbits;                                   // 32-remainder= the right hand side of bits that need to be dropped.
+    if (mNbits == 32) {
+      mShift = 0;
+      mMask = 0xffffffff;
+    }
+    if (mNbits == 31) {
+      mShift = 1;
+    }
+  } else {
+    LOGP(warn, "Initialising an TRAP register with address of {:08x} ", addr);
+    mAddr = 0;
+    mName = "";
+    mNbits = 0;
+    mBase = 0;
+    mWordNumber = 0;
+    mMax = 0;
+    mShift = 0;
+  }
+}
+
+void TrapRegInfo::logTrapRegInfo()
+{
+  LOGP(info, " TrapRegInfo : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax());
+}
+
+
+void TrapConfigEventSlot::print()
+{
+  //walk through MCMSeen, and print out the mcm seen for this config event.
+  uint32_t startmcm = 0;
+  uint32_t endmcm = 0;
+  uint32_t lastseenmcm = 0;
+  bool continuousmcm = false;
+  std::string mcmList;
+  std::string totalList;
+  totalList += "MCMs seen:";
+  LOGP(debug, "Which MCM were seen in this event so far:");
+
+  uint32_t mcmposition = 0;
+for (int mcmcount=0;mcmcount < constants::MAXCHAMBER; ++mcmcount) {
+    auto seenmcm=0;//TODO pull from map of maps isMCMPresent(mcmcount);
+
+    LOGP(debug,"{} {} {} :: pos: {} : start: {} end: {} seen {} lastseen {} mcmList {}",__FILE__, __func__, __LINE__, mcmposition, startmcm, endmcm, seenmcm, lastseenmcm, mcmList);
+    if (seenmcm == 0 && lastseenmcm == 1) {
+      //dump string
+      mcmList += fmt::format("-{},", mcmposition - 1);
+      //    LOGP(info,"{}",mcmList);
+      totalList += mcmList;
+      mcmList = "";
+    }
+    if (lastseenmcm == 0 && seenmcm == 1) {
+      startmcm = seenmcm;
+      mcmList = fmt::format("{}", mcmposition);
+    }
+    if (lastseenmcm == 1 && seenmcm == 1) {
+      //do nothing but add a - for 1 or more of these.
+    }
+    lastseenmcm = seenmcm;
+    mcmposition++;
+  }
+  totalList += mcmList;
+  LOGP(debug, "{}", totalList);
+}
+
+
+void TrapConfigEventSlot::merge(const TrapConfigEventSlot* prev)
+{
+  LOGP(info," Merge called for TrapConfigEvent {} {} {}",__FILE__,__func__,__LINE__);
+  //std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                                      //!< count of different value in the registers for a mcm,register used to find most frequent value.
+  //take the 2 slots (trapconfigeventslot) and merge the update the map of maps of value.
+  //this will be collapsed in the finalise of the calibrator, for the object to be written to the ccdb.
+  
+}
+
+void TrapConfigEventSlot::fill(const TrapConfigEventSlot& input)
+{
+  LOGP(info," fill called for TrapConfigEvent {} {} {}",__FILE__,__func__,__LINE__);
+}
+
+void TrapConfigEventSlot::fill(const gsl::span<const TrapConfigEventSlot> input)
+{
+  LOGP(info," fill called for TrapConfigEvent {} {} {}",__FILE__,__func__,__LINE__);
+}

--- a/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
@@ -513,6 +513,10 @@ bool TrapConfigEvent::setRegisterValue(uint32_t data, uint32_t regidx, int mcmid
     return false;
   }
   int mcmoffset = 0;                                                    // mcmidx * kTrapRegistersSize;                          // get the start offset for this mcm
+  if(mMCMIndex[mcmidx]==-1){
+    // we dont have this register in the data store yet.
+    mConfigData[mcmidx].
+  }
   int regbase = mcmoffset + mTrapRegisters[regidx].getBase();           // get the base of this register in the underlying storage block
   int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber(); // get the offset to the register in question
   data &= mTrapRegisters[regidx].getMask();                             // mask the data off as need be.
@@ -871,7 +875,7 @@ void TrapRegInfo::logTrapRegInfo()
   LOGP(info, " TrapRegInfo : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax());
 }
 
-void TrapConfigEventSlot::print()
+void TrapConfigEvent::print()
 {
   // walk through MCMSeen, and print out the mcm seen for this config event.
   uint32_t startmcm = 0;
@@ -909,7 +913,7 @@ void TrapConfigEventSlot::print()
   LOGP(debug, "{}", totalList);
 }
 
-void TrapConfigEventSlot::merge(const TrapConfigEventSlot* prev)
+void TrapConfigEvent::merge(const TrapConfigEvent* prev)
 {
   LOGP(info, " Merge called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
   // std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                                      //!< count of different value in the registers for a mcm,register used to find most frequent value.
@@ -917,12 +921,12 @@ void TrapConfigEventSlot::merge(const TrapConfigEventSlot* prev)
   // this will be collapsed in the finalise of the calibrator, for the object to be written to the ccdb.
 }
 
-void TrapConfigEventSlot::fill(const TrapConfigEventSlot& input)
+void TrapConfigEvent::fill(const TrapConfigEvent& input)
 {
   LOGP(info, " fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
 }
 
-void TrapConfigEventSlot::fill(const gsl::span<const TrapConfigEventSlot> input)
+void TrapConfigEvent::fill(const gsl::span<const TrapConfigEvent> input)
 {
   LOGP(info, " fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
 }

--- a/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
@@ -514,12 +514,12 @@ bool TrapConfigEvent::setRegisterValue(uint32_t data, uint32_t regidx, int mcmid
     return false;
   }
   int mcmoffset = 0;                                                    // mcmidx * kTrapRegistersSize;                          // get the start offset for this mcm
-  if(mConfigDataIndex[mcmidx]==-1){
+  if (mConfigDataIndex[mcmidx] == -1) {
     // we dont have this register in the data store yet.
     mConfigData.emplace_back(mcmidx);
-    mConfigDataIndex[mcmidx]=mConfigData.size()-1;
+    mConfigDataIndex[mcmidx] = mConfigData.size() - 1;
   }
-  int regbase = mTrapRegisters[regidx].getBase();           // get the base of this register in the underlying storage block
+  int regbase = mTrapRegisters[regidx].getBase();                       // get the base of this register in the underlying storage block
   int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber(); // get the offset to the register in question
   data &= mTrapRegisters[regidx].getMask();                             // mask the data off as need be.
   uint32_t notdatamask = ~(mTrapRegisters[regidx].getMask() << mTrapRegisters[regidx].getShift());
@@ -906,4 +906,3 @@ void TrapConfigEvent::fill(const gsl::span<const TrapConfigEvent> input)
 {
   LOGP(info, " fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
 }
-

--- a/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
@@ -498,11 +498,11 @@ uint32_t TrapConfigEvent::getRegisterValue(const uint32_t regidx, const int mcmi
   if ((regidx < 0) || (regidx >= kLastReg) || (mcmidx < 0 || mcmidx >= o2::trd::constants::MAXMCMCOUNT)) {
     return 0; // TODO this could be a problem ?!
   }
-  int mcmoffset = 0;//mcmidx * kTrapRegistersSize;                                 // get the start offset for this mcm
-  int regbase = mcmoffset + mTrapRegisters[regidx].getBase();                  // get the base of this register in the underlying storage block
-  int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber();        // get the offset to the register in question
+  int mcmoffset = 0;                                                                   // mcmidx * kTrapRegistersSize;                                 // get the start offset for this mcm
+  int regbase = mcmoffset + mTrapRegisters[regidx].getBase();                          // get the base of this register in the underlying storage block
+  int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber();                // get the offset to the register in question
   uint32_t data = mConfigData[mcmidx][regoffset] >> mTrapRegisters[regidx].getShift(); // get the data and shift it as needed
-  data &= mTrapRegisters[regidx].getMask();                                    // mask the data off as need be.
+  data &= mTrapRegisters[regidx].getMask();                                            // mask the data off as need be.
   LOGP(info, " returning data of {:08x}", data);
   return data;
 }
@@ -512,7 +512,7 @@ bool TrapConfigEvent::setRegisterValue(uint32_t data, uint32_t regidx, int mcmid
   if (regidx < 0 || regidx >= kLastReg || mcmidx < 0 || mcmidx >= o2::trd::constants::MAXMCMCOUNT) {
     return false;
   }
-  int mcmoffset = 0;//mcmidx * kTrapRegistersSize;                          // get the start offset for this mcm
+  int mcmoffset = 0;                                                    // mcmidx * kTrapRegistersSize;                          // get the start offset for this mcm
   int regbase = mcmoffset + mTrapRegisters[regidx].getBase();           // get the base of this register in the underlying storage block
   int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber(); // get the offset to the register in question
   data &= mTrapRegisters[regidx].getMask();                             // mask the data off as need be.
@@ -768,11 +768,11 @@ bool TrapConfigEvent::operator==(const TrapConfigEvent& rhs)
   // TODO do we care where the difference is?
   uint32_t max = constants::MAXMCMCOUNT;
   uint32_t maxreg = TrapConfigEvent::kLastReg;
-  //start with the biggest granularity and work down.
-  //compare hcid in the 2.
-  //this would be simpler with != but that is removed in c++20
+  // start with the biggest granularity and work down.
+  // compare hcid in the 2.
+  // this would be simpler with != but that is removed in c++20
   if (getHCIDPresent() == rhs.getHCIDPresent()) {
-    //we can continue the bitpattern of half chambers is the same.
+    // we can continue the bitpattern of half chambers is the same.
   } else {
     for (int hcid = 0; hcid < constants::MAXHALFCHAMBER; ++hcid) {
       if (isHCIDPresent(hcid) == 0 && rhs.isHCIDPresent(hcid) == 1) {
@@ -780,26 +780,26 @@ bool TrapConfigEvent::operator==(const TrapConfigEvent& rhs)
         LOGP(info, " hcid {} is present in new but not in ccdb version", hcid);
         return false;
       }
-      //other cases we can continue.
-      //1. both present its ok.
-      //2. present in ccdb but not in current one.
+      // other cases we can continue.
+      // 1. both present its ok.
+      // 2. present in ccdb but not in current one.
     }
   }
   if (getMCMPresent() == rhs.getMCMPresent()) {
-    //we can continue the bit pattern of mcm in the config are the same
+    // we can continue the bit pattern of mcm in the config are the same
   } else {
     for (int mcmid = 0; mcmid < constants::MAXMCMCOUNT; ++mcmid) {
       if (isMCMPresent(mcmid) == 0 && rhs.isMCMPresent(mcmid) == 1) {
         // it is not in the ccdb but now is present, this is a change and needs to be saved.
         return false;
       }
-      //other cases we can continue.
-      //1. both present its ok.
-      //2. present in ccdb but not in current one.
+      // other cases we can continue.
+      // 1. both present its ok.
+      // 2. present in ccdb but not in current one.
     }
   }
-  //Now the long part, compare the register data
-  //There is no need to unpack registers. We can simply store their underlying 32 bit stored value.
+  // Now the long part, compare the register data
+  // There is no need to unpack registers. We can simply store their underlying 32 bit stored value.
   for (int mcm = 0; mcm < max; ++mcm) {
     for (int rawoffset = 0; rawoffset < kTrapRegistersSize; ++rawoffset) {
       if (!ignoreWord(rawoffset)) { // we do indeed care if this register is different.
@@ -871,10 +871,9 @@ void TrapRegInfo::logTrapRegInfo()
   LOGP(info, " TrapRegInfo : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax());
 }
 
-
 void TrapConfigEventSlot::print()
 {
-  //walk through MCMSeen, and print out the mcm seen for this config event.
+  // walk through MCMSeen, and print out the mcm seen for this config event.
   uint32_t startmcm = 0;
   uint32_t endmcm = 0;
   uint32_t lastseenmcm = 0;
@@ -885,12 +884,12 @@ void TrapConfigEventSlot::print()
   LOGP(debug, "Which MCM were seen in this event so far:");
 
   uint32_t mcmposition = 0;
-for (int mcmcount=0;mcmcount < constants::MAXCHAMBER; ++mcmcount) {
-    auto seenmcm=0;//TODO pull from map of maps isMCMPresent(mcmcount);
+  for (int mcmcount = 0; mcmcount < constants::MAXCHAMBER; ++mcmcount) {
+    auto seenmcm = 0; // TODO pull from map of maps isMCMPresent(mcmcount);
 
-    LOGP(debug,"{} {} {} :: pos: {} : start: {} end: {} seen {} lastseen {} mcmList {}",__FILE__, __func__, __LINE__, mcmposition, startmcm, endmcm, seenmcm, lastseenmcm, mcmList);
+    LOGP(debug, "{} {} {} :: pos: {} : start: {} end: {} seen {} lastseen {} mcmList {}", __FILE__, __func__, __LINE__, mcmposition, startmcm, endmcm, seenmcm, lastseenmcm, mcmList);
     if (seenmcm == 0 && lastseenmcm == 1) {
-      //dump string
+      // dump string
       mcmList += fmt::format("-{},", mcmposition - 1);
       //    LOGP(info,"{}",mcmList);
       totalList += mcmList;
@@ -901,7 +900,7 @@ for (int mcmcount=0;mcmcount < constants::MAXCHAMBER; ++mcmcount) {
       mcmList = fmt::format("{}", mcmposition);
     }
     if (lastseenmcm == 1 && seenmcm == 1) {
-      //do nothing but add a - for 1 or more of these.
+      // do nothing but add a - for 1 or more of these.
     }
     lastseenmcm = seenmcm;
     mcmposition++;
@@ -910,22 +909,20 @@ for (int mcmcount=0;mcmcount < constants::MAXCHAMBER; ++mcmcount) {
   LOGP(debug, "{}", totalList);
 }
 
-
 void TrapConfigEventSlot::merge(const TrapConfigEventSlot* prev)
 {
-  LOGP(info," Merge called for TrapConfigEvent {} {} {}",__FILE__,__func__,__LINE__);
-  //std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                                      //!< count of different value in the registers for a mcm,register used to find most frequent value.
-  //take the 2 slots (trapconfigeventslot) and merge the update the map of maps of value.
-  //this will be collapsed in the finalise of the calibrator, for the object to be written to the ccdb.
-  
+  LOGP(info, " Merge called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
+  // std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                                      //!< count of different value in the registers for a mcm,register used to find most frequent value.
+  // take the 2 slots (trapconfigeventslot) and merge the update the map of maps of value.
+  // this will be collapsed in the finalise of the calibrator, for the object to be written to the ccdb.
 }
 
 void TrapConfigEventSlot::fill(const TrapConfigEventSlot& input)
 {
-  LOGP(info," fill called for TrapConfigEvent {} {} {}",__FILE__,__func__,__LINE__);
+  LOGP(info, " fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
 }
 
 void TrapConfigEventSlot::fill(const gsl::span<const TrapConfigEventSlot> input)
 {
-  LOGP(info," fill called for TrapConfigEvent {} {} {}",__FILE__,__func__,__LINE__);
+  LOGP(info, " fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
 }

--- a/DataFormats/Detectors/TRD/test/testTrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/test/testTrapConfigEvent.cxx
@@ -1,0 +1,255 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TRD_TrapConfigEvent
+/// \file testTRDTrapConfigEvent
+/// \brief This task tests the trap config
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <algorithm>
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/HelperMethods.h"
+
+namespace o2::trd
+{
+
+// structs to make defining the tests easier.
+struct mcmIndexing {
+  uint mSector;
+  uint mStack;
+  uint mLayer;
+  uint mRob;
+  uint mMcm;
+  mcmIndexing(int sector, int stack, int layer, int rob, int mcm) : mSector(sector), mStack(stack), mLayer(layer), mRob(rob), mMcm(mcm){};
+};
+
+struct addresstest {
+  uint32_t mAddress;
+  uint32_t mValue;
+  addresstest(uint32_t address, uint32_t value) : mAddress(address), mValue(value){};
+};
+
+// vectors of what and where we want to test.
+std::vector<int> mcmids = {0, 1, 127, 128, 12917, 69119, 69120, 69130};
+std::vector<mcmIndexing> mcmfullindex = {{0, 0, 0, 0, 0}, {0, 0, 0, 0, 1}, {0, 0, 0, 7, 15}, {0, 0, 1, 0, 0}, {3, 1, 4, 7, 5}, {17, 4, 5, 7, 15}, {17, 4, 5, 8, 15}, {18, 0, 0, 1, 2}}; // decomposition of the line above, last 2 of course being fictitious
+
+std::vector<uint32_t> registersOfInterest; // store of the registers we want to look at.
+std::vector<addresstest> registervalues;   // index by address,value
+
+void trapregCheck(std::unique_ptr<TrapConfigEvent>& trapconfig, uint32_t mcmidx, int mcmidxcount)
+{
+  // loop over the mcm
+  // loop over the register
+  for (const auto& [key, value] : registervalues) {
+    uint32_t address = key;
+    uint32_t index = trapconfig->getRegIndexByAddr(address);
+    std::string name = trapconfig->getRegNameByAddr(address);
+    if (trapconfig->setRegisterValueByIdx(value, index, mcmidx)) {
+      BOOST_CHECK_EQUAL(trapconfig->getRegisterValueByIdx(index, mcmidx), value);
+      BOOST_CHECK_EQUAL(trapconfig->getRegisterValueByAddr(address, mcmidx), value);
+      BOOST_CHECK_EQUAL(trapconfig->getRegisterValueByIdx(index, HelperMethods::getMCMId(mcmfullindex[mcmidxcount].mSector, mcmfullindex[mcmidxcount].mStack, mcmfullindex[mcmidxcount].mLayer, mcmfullindex[mcmidxcount].mRob, mcmfullindex[mcmidxcount].mMcm)), value);
+      BOOST_CHECK_EQUAL(trapconfig->getRegisterValueByAddr(address, HelperMethods::getMCMId(mcmfullindex[mcmidxcount].mSector, mcmfullindex[mcmidxcount].mStack, mcmfullindex[mcmidxcount].mLayer, mcmfullindex[mcmidxcount].mRob, mcmfullindex[mcmidxcount].mMcm)), value);
+      BOOST_CHECK_EQUAL(trapconfig->getRegisterValueByName(name, mcmidx), value);
+    }
+  }
+}
+
+/// \brief Test the trap register generation functions
+//
+BOOST_AUTO_TEST_CASE(TRDTrapConfigEventInternals)
+{
+  // test trap register initialisation
+  TrapRegInfo trapreg;
+  trapreg.init("testreg", 0x3000, 6, 0, 1, false, 6);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 20);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x3f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 6, 0, 5, false, 6);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 26);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x3f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+  trapreg.init("testreg", 0x3000, 5, 0, 1, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 22);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 5, 0, 4, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 7);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 5, 0, 5, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 2);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 5, 0, 6, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 27);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+  trapreg.init("testreg", 0x3000, 31, 0, 1, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 1);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x7fffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+  trapreg.init("testreg", 0x3000, 31, 0, 0, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 1);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x7fffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 32, 0, 0, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 0);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0xffffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 32, 0, 1, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 0);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0xffffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(TRDTrapConfigEventGetSet)
+{
+
+  std::unique_ptr<TrapConfigEvent> trapconfig(new TrapConfigEvent());
+
+  std::vector<uint32_t> registerAddressToLookAt = {
+    0x3180, // first register TPL00
+    0x3185, // TPL05 last reg of first 32 bit word
+    0x3186, // TPL06 first reg of second 32 bit word
+    0x3187, // TPL07 second reg of second 32 bit word
+    0x31ff, // TPL7F last TPL register
+    0x30A0, // FGA0 first reg after TPL7f
+    0x30A4, // last 6bit reg in a 32 bit word
+    0x30A5, // the next 6bit reg, first in the subsequent 32 bit word
+    0x30A6, // the next 6bit reg, second in the subsequent 32 bit word
+    0x30A7, // the next 6bit reg, third in the subsequent 32 bit word
+    0x30B4, // last 6 bit register
+    0x3080, // first 10 bit register
+    0x308C, // next 2 of 10 bit  register spanning a 32 bit data word.
+    0x308D, // 2nd part of above
+    0x313F, //
+    0x3000, //
+    0x3002, //
+    0x3003, //
+    0x300F, //
+    0x3020, //
+    0x3022, //
+    0x3028, //
+    0x302A, // 15 bits last of the set by itself in a lone 32 bit reg
+    0x3030, //
+    0x3050, //
+    0x3051, //
+    0x3052, // 5 bit in the middle of a register and the last of the set.
+    0x3053, //
+    0x0B6C, // last 10 bit word
+    0x0B6D, // then a 32 bit register again
+    0x0B6E, // first 15 bit reg
+    0x0B6F, // last 15 bit reg in a 32bit word
+    0x0B80, // first
+    0x0B81, // second
+    0xD000, // lone 32 bit reg
+    0xD001, // lone 16 bit reg
+    0xD002, // first 10 after a 16
+    0xD003, // middle 10 in a 32 bit word (30 used)
+    0x0D40, // last 10 bit in a 32 bit word
+    0x0D41, // 11 bit in the subsequent 32 bit word*/
+    0x315C  // last register
+  };
+
+  // setup the resgisters we will look at chosen for various reasons, size, on the edges, changes of register bit size
+  for (auto& reg : registerAddressToLookAt) {
+    registersOfInterest.push_back(trapconfig->getRegIndexByAddr(reg));
+    // add a zero value, value of 1, mid point and its max.
+    auto max = trapconfig->getRegisterMax(reg);
+    registervalues.emplace_back(addresstest(reg, 0));
+    registervalues.emplace_back(addresstest(reg, 1));
+    registervalues.emplace_back(addresstest(reg, max / 2));
+    registervalues.emplace_back(addresstest(reg, max));
+  }
+
+  // walk through map and test
+  int count = 0;
+  for (auto& mcm : mcmids) {
+    trapregCheck(trapconfig, mcm, count);
+    ++count;
+  }
+  // all those values have been written so we can now try read those back in bulk
+  std::unique_ptr<std::array<uint32_t, constants::MAXMCMCOUNT * TrapConfigEvent::kLastReg>> allregisters(new std::array<uint32_t, constants::MAXMCMCOUNT * TrapConfigEvent::kLastReg>()); // all data
+  std::unique_ptr<std::array<uint32_t, constants::MAXMCMCOUNT>> allregisterdata(new std::array<uint32_t, constants::MAXMCMCOUNT>());                                                      // data for a single register across all mcm
+  std::unique_ptr<std::array<uint32_t, TrapConfigEvent::kLastReg>> allmcmregisters(new std::array<uint32_t, TrapConfigEvent::kLastReg>());                                                // data for a single mcm, all registers.
+  std::memset(&allregisters->at(0), 0, sizeof(uint32_t));
+  std::memset(&allregisterdata->at(0), 0, sizeof(uint32_t));
+  std::memset(&allmcmregisters->at(0), 0, sizeof(uint32_t));
+  // loop over all registers written in trapregcheck and check the incoming array that those values are set.
+  int registerindex = 0;
+  uint32_t registerreadvalue = 0;
+  for (int valuecount = 0; valuecount < 4; ++valuecount) {
+    // loop over each of the value sets 0,1,mid, max
+    std::vector<uint32_t> addressesseen;
+    std::map<uint32_t, uint32_t> setValues;
+    // loop through all registers for pulling out the valuecount instance of each, put data in and then check against the regall;
+    // its sorted so we know a key will come 4 times sequentially, and use valuecount to denote which value we are working with.
+    for (int regtest = valuecount; regtest < registervalues.size(); regtest += 4) { // loop over the 4th elements to pull out like values, 0,1,max/2,max
+      registerreadvalue = registervalues[regtest].mValue;
+      for (auto& mcmidx : mcmids) {
+        uint32_t address = registervalues[regtest].mAddress;
+
+        uint32_t index = trapconfig->getRegIndexByAddr(address);
+        std::string name = trapconfig->getRegNameByAddr(address);
+        uint32_t retval = trapconfig->setRegisterValueByIdx(registerreadvalue, index, mcmidx);
+      }
+    }
+    // all registers now written to ccdbconfig for this value set
+    int elemcount = 0;
+    // now check the values that were written
+    trapconfig->getAll(*allregisters);
+    // check done in next double for loop
+    uint32_t value = 0;
+    int registersofinterestindex = 0;
+    for (auto& reg : registersOfInterest) {
+      // pull out the values on for a register
+      trapconfig->getAllMCMByAddress(reg, *allregisterdata);
+      // check the values are set correctly
+      for (auto& mcmidx : mcmids) {
+        // loop over all mcm for the given register
+        if (mcmidx < constants::MAXMCMCOUNT) {
+          auto regidx = reg;
+          value = registervalues[registersofinterestindex * 4 + valuecount].mValue;
+          BOOST_CHECK_EQUAL(allregisterdata->at(mcmidx), value);
+          BOOST_CHECK_EQUAL(allregisters->at(mcmidx * TrapConfigEvent::kLastReg + regidx), value); // do the big one at the same time as the little one, pointless repeating the loop seperately
+        }
+      }
+      ++registersofinterestindex;
+    }
+
+    for (auto& mcmidx : mcmids) {
+      if (mcmidx < constants::MAXMCMCOUNT) {
+        // pull out the values on for a specific mcm
+        trapconfig->getAllRegisters(mcmidx, *allmcmregisters);
+        // check the values are set correctly
+        int regcount = 0;
+        for (auto& reg : registersOfInterest) {
+          // loop over all registers for the given mcmq
+          uint32_t regindex = reg;
+          value = registervalues[regcount * 4 + valuecount].mValue;
+          BOOST_CHECK_EQUAL(allmcmregisters->at(regindex), value);
+          ++regcount;
+        }
+      }
+    }
+  }
+}
+// still to test
+// get
+} // namespace o2::trd

--- a/Detectors/TRD/base/macros/OCDB2CCDB.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDB.C
@@ -72,7 +72,7 @@
 #include "TRDBase/ChamberStatus.h"
 #include "TRDBase/CalOnlineGainTables.h"
 #include "TRDBase/FeeParam.h"
-#include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/TrapConfig.h"
 #include "DataFormatsTRD/Constants.h"
 #endif
 

--- a/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
@@ -72,7 +72,7 @@
 //#include "TRDBase/ChamberNoise.h"
 //#include "TRDBase/CalOnlineGainTables.h"
 //#include "TRDBase/FeeParam.h"
-#include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/TrapConfig.h"
 
 using namespace std;
 using namespace o2::ccdb;

--- a/Detectors/TRD/base/macros/PrintTrapConfig.C
+++ b/Detectors/TRD/base/macros/PrintTrapConfig.C
@@ -72,7 +72,7 @@
 //#include "TRDBase/ChamberNoise.h"
 //#include "TRDBase/CalOnlineGainTables.h"
 //#include "TRDBase/FeeParam.h"
-#include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/TrapConfig.h"
 
 using namespace std;
 using namespace o2::ccdb;

--- a/Detectors/TRD/base/macros/TestTrapSim.C
+++ b/Detectors/TRD/base/macros/TestTrapSim.C
@@ -16,7 +16,7 @@
 #include "CCDB/BasicCCDBManager.h"
 
 #include "TRDSimulation/TrapSimulator.h"
-#include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/TrapConfig.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/Constants.h"
 

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(TRDCalibration
                        src/CalibratorNoise.cxx
                        src/PadCalibCCDBBuilder.cxx
                        src/KrClusterFinder.cxx
+                       src/CalibratorConfigEvents.cxx
                        src/DCSProcessor.cxx
                        src/CalibrationParams.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
@@ -35,6 +36,7 @@ o2_add_library(TRDCalibration
                                    include/TRDCalibration/CalibrationParams.h
                                    include/TRDCalibration/PadCalibCCDBBuilder.h
                                    include/TRDCalibration/KrClusterFinder.h
+                                   include/TRDCalibration/CalibratorConfigEvents.h
                                    include/TRDCalibration/DCSProcessor.h)
 
 o2_add_executable(trd-dcs-sim-workflow

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -28,10 +28,12 @@ struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams>
   unsigned int chi2RedMax = 6;     ///< maximum reduced chi2 acceptable for track quality
   size_t minEntriesChamber = 75;   ///< minimum number of entries per chamber to fit single time slot
   size_t minEntriesTotal = 40'500; ///< minimum total required for meaningful fits
-
   // parameters related to noise calibration
   size_t minNumberOfDigits = 1'000'000'000UL; ///< when reached, noise calibration will be finalized
-
+  // parameters for config events.
+  uint32_t configEventAccumulationTime = 15; ///< time to accumulate config events before comparison to 
+  bool takeAllConfigEvents = 0; ///< do we save all the intermediary config events
+  
   // boilerplate
   O2ParamDef(TRDCalibParams, "TRDCalibParams");
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -31,9 +31,9 @@ struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams>
   // parameters related to noise calibration
   size_t minNumberOfDigits = 1'000'000'000UL; ///< when reached, noise calibration will be finalized
   // parameters for config events.
-  uint32_t configEventAccumulationTime = 15; ///< time to accumulate config events before comparison to 
-  bool takeAllConfigEvents = 0; ///< do we save all the intermediary config events
-  
+  uint32_t configEventAccumulationTime = 15; ///< time to accumulate config events before comparison to
+  bool takeAllConfigEvents = 0;              ///< do we save all the intermediary config events
+
   // boilerplate
   O2ParamDef(TRDCalibParams, "TRDCalibParams");
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
@@ -36,9 +36,9 @@
 namespace o2::trd
 {
 
-class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration<o2::trd::TrapConfigEventSlot>
+class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration<o2::trd::TrapConfigEventTimeSlot>
 {
-  using Slot = o2::calibration::TimeSlot<o2::trd::TrapConfigEventSlot>;
+  using Slot = o2::calibration::TimeSlot<o2::trd::TrapConfigEventTimeSlot>;
 
  public:
   CalibratorConfigEvents() = default;
@@ -53,7 +53,7 @@ class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration
 
   void closeFile();
 
-  const std::vector<o2::trd::TrapConfigEventSlot>& getCcdbObjectVector() const { return mObjectVector; }
+  const std::vector<o2::trd::TrapConfigEventTimeSlot>& getCcdbObjectVector() const { return mObjectVector; }
   std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
 
   void initProcessing();
@@ -73,8 +73,8 @@ class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration
   o2::ccdb::CcdbObjectInfo mCCDBInfo;                                ///< CCDB infos filled with CCDB description of accompanying CCDB calibration object
   o2::trd::TrapConfigEvent mCCDBObject;                              ///< CCDB calibration  object of TrapConfigEvent
   std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector;                 ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
-  std::vector<o2::trd::TrapConfigEventSlot> mObjectVector;           ///< vector of CCDB calibration objects waiting to be merged
-  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap; //!< count of different value in the registers for a mcm,register used to find most frequent value.
+  std::vector<o2::trd::TrapConfigEventTimeSlot> mObjectVector;       ///< vector of CCDB calibration objects waiting to be merged
+  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap; //!< count of different value in the registers for a mcm,register used to find most frequent value for then collapsing into the TrapConfigEvent.
   ClassDefOverride(CalibratorConfigEvents, 1);
 };
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
@@ -53,8 +53,8 @@ class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration
 
   void closeFile();
 
-  const o2::trd::TrapConfigEvent& getCcdbObject() const { return mCCDBObject; }
-  o2::ccdb::CcdbObjectInfo& getCcdbObjectInfo() { return mCCDBInfo; }
+  const std::vector<o2::trd::TrapConfigEventSlot>& getCcdbObjectVector() const { return mObjectVector; }
+  std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
 
   void initProcessing();
 
@@ -74,7 +74,7 @@ class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration
   o2::trd::TrapConfigEvent mCCDBObject;                              ///< CCDB calibration  object of TrapConfigEvent
   std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector;                 ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
   std::vector<o2::trd::TrapConfigEventSlot> mObjectVector;           ///< vector of CCDB calibration objects waiting to be merged
-
+  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap; //!< count of different value in the registers for a mcm,register used to find most frequent value.
   ClassDefOverride(CalibratorConfigEvents, 1);
 };
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
@@ -1,0 +1,83 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorVdExB.h
+/// \brief TimeSlot-based calibration of vDrift and ExB
+/// \author Ole Schmidt
+
+#ifndef O2_TRD_CALIBRATORCONFIGEVENTS_H
+#define O2_TRD_CALIBRATORCONFIGEVENTS_H
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "DataFormatsTRD/CalVdriftExB.h"
+#include "TRDCalibration/CalibrationParams.h"
+
+#include "Rtypes.h"
+#include "TProfile.h"
+#include "TFile.h"
+#include "TTree.h"
+
+#include <array>
+#include <cstdlib>
+#include <memory>
+
+namespace o2::trd
+{
+
+class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration<o2::trd::TrapConfigEventSlot>
+{
+  using Slot = o2::calibration::TimeSlot<o2::trd::TrapConfigEventSlot>;
+
+ public:
+  CalibratorConfigEvents() = default;
+  ~CalibratorConfigEvents() final = default;
+
+  bool hasEnoughData(const Slot& slot) const final;
+  void initOutput() final;
+  void finalizeSlot(Slot& slot) final;
+  Slot& emplaceNewSlot(bool front, TFType tStart, TFType tEnd) final;
+
+  void createFile();
+
+  void closeFile();
+
+  const o2::trd::TrapConfigEvent& getCcdbObject() const { return mCCDBObject; }
+  o2::ccdb::CcdbObjectInfo& getCcdbObjectInfo() { return mCCDBInfo; }
+
+  void initProcessing();
+
+  /// Initialize the fit values once with the previous valid ones if they are
+  /// available.
+  void retrievePrev(o2::framework::ProcessingContext& pc);
+
+ private:
+  bool mInitCompleted;
+  const TRDCalibParams& mParams{TRDCalibParams::Instance()}; ///< reference to calibration parameters
+  size_t mTimeBeforeComparison{mParams.configEventAccumulationTime};///< time of accumulating data and before comparison will be done
+  bool mEnableOutput{false};                                 ///< enable output of configevent to a root file instead of the ccdb
+  bool mSaveAllChanges=false;                                ///< Do we save all the changes to configs as they come in.
+  std::unique_ptr<TFile> mOutFile{nullptr};                  ///< output file
+  std::unique_ptr<TTree> mOutTree{nullptr};                  ///< output tree
+  o2::ccdb::CcdbObjectInfo mCCDBInfo;                        ///< CCDB infos filled with CCDB description of accompanying CCDB calibration object
+  o2::trd::TrapConfigEvent mCCDBObject;                      ///< CCDB calibration  object of TrapConfigEvent
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector;         ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::TrapConfigEventSlot> mObjectVector;       ///< vector of CCDB calibration objects waiting to be merged 
+  
+  ClassDefOverride(CalibratorConfigEvents, 1);
+};
+
+} // namespace o2::trd
+
+#endif // O2_TRD_CALIBRATORVDEXB_H

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
@@ -64,17 +64,17 @@ class CalibratorConfigEvents final : public o2::calibration::TimeSlotCalibration
 
  private:
   bool mInitCompleted;
-  const TRDCalibParams& mParams{TRDCalibParams::Instance()}; ///< reference to calibration parameters
-  size_t mTimeBeforeComparison{mParams.configEventAccumulationTime};///< time of accumulating data and before comparison will be done
-  bool mEnableOutput{false};                                 ///< enable output of configevent to a root file instead of the ccdb
-  bool mSaveAllChanges=false;                                ///< Do we save all the changes to configs as they come in.
-  std::unique_ptr<TFile> mOutFile{nullptr};                  ///< output file
-  std::unique_ptr<TTree> mOutTree{nullptr};                  ///< output tree
-  o2::ccdb::CcdbObjectInfo mCCDBInfo;                        ///< CCDB infos filled with CCDB description of accompanying CCDB calibration object
-  o2::trd::TrapConfigEvent mCCDBObject;                      ///< CCDB calibration  object of TrapConfigEvent
-  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector;         ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
-  std::vector<o2::trd::TrapConfigEventSlot> mObjectVector;       ///< vector of CCDB calibration objects waiting to be merged 
-  
+  const TRDCalibParams& mParams{TRDCalibParams::Instance()};         ///< reference to calibration parameters
+  size_t mTimeBeforeComparison{mParams.configEventAccumulationTime}; ///< time of accumulating data and before comparison will be done
+  bool mEnableOutput{false};                                         ///< enable output of configevent to a root file instead of the ccdb
+  bool mSaveAllChanges = false;                                      ///< Do we save all the changes to configs as they come in.
+  std::unique_ptr<TFile> mOutFile{nullptr};                          ///< output file
+  std::unique_ptr<TTree> mOutTree{nullptr};                          ///< output tree
+  o2::ccdb::CcdbObjectInfo mCCDBInfo;                                ///< CCDB infos filled with CCDB description of accompanying CCDB calibration object
+  o2::trd::TrapConfigEvent mCCDBObject;                              ///< CCDB calibration  object of TrapConfigEvent
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector;                 ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::TrapConfigEventSlot> mObjectVector;           ///< vector of CCDB calibration objects waiting to be merged
+
   ClassDefOverride(CalibratorConfigEvents, 1);
 };
 

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -54,8 +54,8 @@ void CalibratorConfigEvents::initProcessing()
 
   // set tree addresses
   if (mEnableOutput) {
-    //mOutTree->Branch("trapconfigevent", &mTrapConfigEvent);
-    // what do we want to save?
+    // mOutTree->Branch("trapconfigevent", &mTrapConfigEvent);
+    //  what do we want to save?
   }
 
   mInitCompleted = true;
@@ -66,32 +66,29 @@ void CalibratorConfigEvents::retrievePrev(o2::framework::ProcessingContext& pc)
   // We either get a pointer to a valid object from the last ~hour or to the default object
   // which is always present. The first has precedence over the latter.
   auto mTrapConfigEvent = pc.inputs().get<o2::trd::TrapConfigEvent*>("trapconfigevent");
-  LOG(info) << "Calibrator: From CCDB retrieved " << mTrapConfigEvent->getConfigVersion(); 
-
+  LOG(info) << "Calibrator: From CCDB retrieved " << mTrapConfigEvent->getConfigVersion();
 }
 
-bool CalibratorConfigEvents::hasEnoughData(const Slot& slot) const  
+bool CalibratorConfigEvents::hasEnoughData(const Slot& slot) const
 {
-  //determine if this slot has enough data ... normal calibration.
-  //this method triggers a merge and a finaliseSlot.
-  //if the slot does not have enough data this slot together with the next one are merged.
-  
-  //We therefore have 2 options :
-  //a:keep all the difference and ergo, save to ccdb after each slot.
-  //b: the normal option, accumulate for 10,15 minutes and then compare and write to ccdb if new.
-  auto container= slot.getContainer();
-  bool timereached=0;
-  if(mSaveAllChanges) {
+  // determine if this slot has enough data ... normal calibration.
+  // this method triggers a merge and a finaliseSlot.
+  // if the slot does not have enough data this slot together with the next one are merged.
+
+  // We therefore have 2 options :
+  // a:keep all the difference and ergo, save to ccdb after each slot.
+  // b: the normal option, accumulate for 10,15 minutes and then compare and write to ccdb if new.
+  auto container = slot.getContainer();
+  bool timereached = 0;
+  if (mSaveAllChanges) {
     return 1;
-  }
-  else {
-    //case b:
-    // we just care about the time taken since the beginning.
+  } else {
+    // case b:
+    //  we just care about the time taken since the beginning.
     //
-    if(timereached){
+    if (timereached) {
       return true;
-    }
-    else {
+    } else {
       return false;
     }
   }
@@ -102,7 +99,7 @@ void CalibratorConfigEvents::finalizeSlot(Slot& slot)
   TStopwatch timer;
   timer.Start();
   initProcessing();
-  
+
   timer.Stop();
   LOGF(info, "Done merging TrapConfigs. CPU time: %f, real time: %f", timer.CpuTime(), timer.RealTime());
 
@@ -112,21 +109,21 @@ void CalibratorConfigEvents::finalizeSlot(Slot& slot)
   }
 
   // assemble CCDB object
-  
+
   auto className = o2::utils::MemFileHelper::getClassName(mCCDBObject);
   auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
   std::map<std::string, std::string> metadata; // TODO: do we want to store any meta data?
   long startValidity = slot.getStartTimeMS() - 10 * o2::ccdb::CcdbObjectInfo::SECOND;
-  o2::ccdb::CcdbObjectInfo mInfoVector;         ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  o2::ccdb::CcdbObjectInfo mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
   mInfoVector.setPath("TRD/TrapConfigEvent");
   mInfoVector.setObjectType(className);
   mInfoVector.setFileName(fileName);
   mInfoVector.setMetaData(metadata);
   mInfoVector.setStartValidityTimestamp(startValidity);
-  mInfoVector.setEndValidityTimestamp(startValidity + o2::ccdb::CcdbObjectInfo::MINUTE*15);
-  //remove the 15 minute and change to update  on next start.
-  //mObjectVector=.push_back(mCCDBObject);
-  //mCCDBObjext is already filled.
+  mInfoVector.setEndValidityTimestamp(startValidity + o2::ccdb::CcdbObjectInfo::MINUTE * 15);
+  // remove the 15 minute and change to update  on next start.
+  // mObjectVector=.push_back(mCCDBObject);
+  // mCCDBObjext is already filled.
 }
 
 o2::calibration::TimeSlot<o2::trd::TrapConfigEventSlot>& CalibratorConfigEvents::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -66,7 +66,7 @@ void CalibratorConfigEvents::retrievePrev(o2::framework::ProcessingContext& pc)
   // We either get a pointer to a valid object from the last ~hour or to the default object
   // which is always present. The first has precedence over the latter.
   auto mTrapConfigEvent = pc.inputs().get<o2::trd::TrapConfigEventTimeSlot*>("trapconfigevent");
-  LOG(info) << "Calibrator: From CCDB retrieved ";// << mTrapConfigEvent->getConfigVersion();
+  LOG(info) << "Calibrator: From CCDB retrieved "; // << mTrapConfigEvent->getConfigVersion();
 }
 
 bool CalibratorConfigEvents::hasEnoughData(const Slot& slot) const

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -40,7 +40,7 @@ using namespace o2::trd::constants;
 namespace o2::trd
 {
 
-using Slot = o2::calibration::TimeSlot<o2::trd::CalibratorConfigEvents>;
+using Slot = o2::calibration::TimeSlot<o2::trd::TrapConfigEventTimeSlot>;
 
 void CalibratorConfigEvents::initOutput()
 {
@@ -126,11 +126,11 @@ void CalibratorConfigEvents::finalizeSlot(Slot& slot)
   // mCCDBObjext is already filled.
 }
 
-o2::calibration::TimeSlot<o2::trd::TrapConfigEventSlot>& CalibratorConfigEvents::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)
+o2::calibration::TimeSlot<o2::trd::TrapConfigEventTimeSlot>& CalibratorConfigEvents::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)
 {
   auto& container = getSlots();
   auto& slot = front ? container.emplace_front(tStart, tEnd) : container.emplace_back(tStart, tEnd);
-  slot.setContainer(std::make_unique<o2::trd::TrapConfigEventSlot>());
+  slot.setContainer(std::make_unique<o2::trd::TrapConfigEventTimeSlot>());
   return slot;
 }
 

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -1,0 +1,172 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorConfigEvents.cxx
+/// \brief TimeSlot-based calibration of vDrift and ExB
+/// \author Ole Schmidt
+
+#include "Framework/ProcessingContext.h"
+#include "Framework/TimingInfo.h"
+#include "Framework/InputRecord.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CommonUtils/NameConf.h"
+#include "CommonUtils/MemFileHelper.h"
+
+#include "DataFormatsTRD/Constants.h"
+#include "TRDCalibration/CalibratorConfigEvents.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "TRDBase/GeometryBase.h"
+
+#include "TStopwatch.h"
+#include <TFile.h>
+#include <TTree.h>
+
+#include <string>
+#include <map>
+#include <memory>
+#include <ctime>
+
+using namespace o2::trd::constants;
+
+namespace o2::trd
+{
+
+using Slot = o2::calibration::TimeSlot<o2::trd::CalibratorConfigEvents>;
+
+void CalibratorConfigEvents::initOutput()
+{
+}
+
+void CalibratorConfigEvents::initProcessing()
+{
+  if (mInitCompleted) {
+    return;
+  }
+
+  // set tree addresses
+  if (mEnableOutput) {
+    //mOutTree->Branch("trapconfigevent", &mTrapConfigEvent);
+    // what do we want to save?
+  }
+
+  mInitCompleted = true;
+}
+
+void CalibratorConfigEvents::retrievePrev(o2::framework::ProcessingContext& pc)
+{
+  // We either get a pointer to a valid object from the last ~hour or to the default object
+  // which is always present. The first has precedence over the latter.
+  auto mTrapConfigEvent = pc.inputs().get<o2::trd::TrapConfigEvent*>("trapconfigevent");
+  LOG(info) << "Calibrator: From CCDB retrieved " << mTrapConfigEvent->getConfigVersion(); 
+
+}
+
+bool CalibratorConfigEvents::hasEnoughData(const Slot& slot) const  
+{
+  //determine if this slot has enough data ... normal calibration.
+  //this method triggers a merge and a finaliseSlot.
+  //if the slot does not have enough data this slot together with the next one are merged.
+  
+  //We therefore have 2 options :
+  //a:keep all the difference and ergo, save to ccdb after each slot.
+  //b: the normal option, accumulate for 10,15 minutes and then compare and write to ccdb if new.
+  auto container= slot.getContainer();
+  bool timereached=0;
+  if(mSaveAllChanges) {
+    return 1;
+  }
+  else {
+    //case b:
+    // we just care about the time taken since the beginning.
+    //
+    if(timereached){
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+}
+void CalibratorConfigEvents::finalizeSlot(Slot& slot)
+{
+  // do actual calibration for the data provided in the given slot
+  TStopwatch timer;
+  timer.Start();
+  initProcessing();
+  
+  timer.Stop();
+  LOGF(info, "Done merging TrapConfigs. CPU time: %f, real time: %f", timer.CpuTime(), timer.RealTime());
+
+  // Fill Tree and log to debug
+  if (mEnableOutput) {
+    mOutTree->Fill();
+  }
+
+  // assemble CCDB object
+  
+  auto className = o2::utils::MemFileHelper::getClassName(mCCDBObject);
+  auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
+  std::map<std::string, std::string> metadata; // TODO: do we want to store any meta data?
+  long startValidity = slot.getStartTimeMS() - 10 * o2::ccdb::CcdbObjectInfo::SECOND;
+  o2::ccdb::CcdbObjectInfo mInfoVector;         ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  mInfoVector.setPath("TRD/TrapConfigEvent");
+  mInfoVector.setObjectType(className);
+  mInfoVector.setFileName(fileName);
+  mInfoVector.setMetaData(metadata);
+  mInfoVector.setStartValidityTimestamp(startValidity);
+  mInfoVector.setEndValidityTimestamp(startValidity + o2::ccdb::CcdbObjectInfo::MINUTE*15);
+  //remove the 15 minute and change to update  on next start.
+  //mObjectVector=.push_back(mCCDBObject);
+  //mCCDBObjext is already filled.
+}
+
+o2::calibration::TimeSlot<o2::trd::TrapConfigEventSlot>& CalibratorConfigEvents::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)
+{
+  auto& container = getSlots();
+  auto& slot = front ? container.emplace_front(tStart, tEnd) : container.emplace_back(tStart, tEnd);
+  slot.setContainer(std::make_unique<o2::trd::TrapConfigEventSlot>());
+  return slot;
+}
+
+void CalibratorConfigEvents::createFile()
+{
+  mEnableOutput = true;
+  mOutFile = std::make_unique<TFile>("trd_configevents.root", "RECREATE");
+  if (mOutFile->IsZombie()) {
+    LOG(error) << "Failed to create output file!";
+    mEnableOutput = false;
+    return;
+  }
+  mOutTree = std::make_unique<TTree>("calib", "Config Events");
+  LOG(info) << "Created output file trd_configevents.root";
+}
+
+void CalibratorConfigEvents::closeFile()
+{
+  if (!mEnableOutput) {
+    return;
+  }
+
+  try {
+    mOutFile->cd();
+    mOutTree->Write();
+    mOutTree.reset();
+    mOutFile->Close();
+    mOutFile.reset();
+  } catch (std::exception const& e) {
+    LOG(error) << "Failed to write calibration data file, reason: " << e.what();
+  }
+  // after closing, we won't open a new file
+  mEnableOutput = false;
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -65,8 +65,8 @@ void CalibratorConfigEvents::retrievePrev(o2::framework::ProcessingContext& pc)
 {
   // We either get a pointer to a valid object from the last ~hour or to the default object
   // which is always present. The first has precedence over the latter.
-  auto mTrapConfigEvent = pc.inputs().get<o2::trd::TrapConfigEvent*>("trapconfigevent");
-  LOG(info) << "Calibrator: From CCDB retrieved " << mTrapConfigEvent->getConfigVersion();
+  auto mTrapConfigEvent = pc.inputs().get<o2::trd::TrapConfigEventTimeSlot*>("trapconfigevent");
+  LOG(info) << "Calibrator: From CCDB retrieved ";// << mTrapConfigEvent->getConfigVersion();
 }
 
 bool CalibratorConfigEvents::hasEnoughData(const Slot& slot) const
@@ -81,7 +81,7 @@ bool CalibratorConfigEvents::hasEnoughData(const Slot& slot) const
   auto container = slot.getContainer();
   bool timereached = 0;
   if (mSaveAllChanges) {
-    return 1;
+    return true;
   } else {
     // case b:
     //  we just care about the time taken since the beginning.

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -18,9 +18,9 @@
 #pragma link C++ class o2::trd::CalibratorVdExB + ;
 #pragma link C++ class o2::trd::CalibratorConfigEvents + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::calibration::TimeSlot < o2::trd::TrapConfigEventSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::trd::TrapConfigEventTimeSlot> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::TrapConfigEventSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::TrapConfigEventTimeSlot> + ;
 #pragma link C++ class o2::trd::CalibratorNoise + ;
 #pragma link C++ class o2::trd::ChannelInfoDetailed + ;
 #pragma link C++ class o2::trd::TrackBasedCalib + ;

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -16,8 +16,11 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::trd::CalibratorVdExB + ;
+#pragma link C++ class o2::trd::CalibratorConfigEvents + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::trd::TrapConfigEventSlot> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::TrapConfigEventSlot> + ;
 #pragma link C++ class o2::trd::CalibratorNoise + ;
 #pragma link C++ class o2::trd::ChannelInfoDetailed + ;
 #pragma link C++ class o2::trd::TrackBasedCalib + ;

--- a/Detectors/TRD/macros/CMakeLists.txt
+++ b/Detectors/TRD/macros/CMakeLists.txt
@@ -31,5 +31,10 @@ o2_add_test_root_macro(CheckNoiseRun.C
                        PUBLIC_LINK_LIBRARIES O2::TRDBase
                        LABELS trd)
 
+o2_add_test_root_macro(CheckTrapConfig.C
+                       PUBLIC_LINK_LIBRARIES O2::TRDBase O2::DataFormatsTRD
+                       LABELS trd)
+
 install(FILES CheckNoiseRun.C
     DESTINATION share/Detectors/TRD/macros/)
+

--- a/Detectors/TRD/macros/CheckConfigEvent.C
+++ b/Detectors/TRD/macros/CheckConfigEvent.C
@@ -31,7 +31,7 @@ using namespace o2::trd;
 
 constexpr int kMINENTRIES = 100;
 
-void CheckDigits(std::string configeventfile = "trddigits.root", uint32_t mcmid=42)
+void CheckDigits(std::string configeventfile = "trddigits.root", uint32_t mcmid = 42)
 {
   TFile* fin = TFile::Open(configeventfile.data());
   TTree* configeventTree = (TTree*)fin->Get("o2sim");
@@ -41,7 +41,7 @@ void CheckDigits(std::string configeventfile = "trddigits.root", uint32_t mcmid=
 
   LOG(info) << nev << " entries found";
   configeventTree->GetEvent(0);
-  for (int reg=0;reg<433;++reg) {
-    LOGP(info,"register :{}, value :{} ",trapconfigevent->getRegisterName(reg),trapconfigevent->getRegisterValue(reg,mcmid));
+  for (int reg = 0; reg < 433; ++reg) {
+    LOGP(info, "register :{}, value :{} ", trapconfigevent->getRegisterName(reg), trapconfigevent->getRegisterValue(reg, mcmid));
   }
 }

--- a/Detectors/TRD/macros/CheckConfigEvent.C
+++ b/Detectors/TRD/macros/CheckConfigEvent.C
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CheckConfigEvent.C
+/// \brief Check a config event
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TFile.h>
+#include <TTree.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+
+#include <fairlogger/Logger.h>
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#endif
+
+using namespace o2::trd;
+
+constexpr int kMINENTRIES = 100;
+
+void CheckDigits(std::string configeventfile = "trddigits.root", uint32_t mcmid=42)
+{
+  TFile* fin = TFile::Open(configeventfile.data());
+  TTree* configeventTree = (TTree*)fin->Get("o2sim");
+  TrapConfigEvent* trapconfigevent = nullptr;
+  configeventTree->SetBranchAddress("ConfigEvent", &trapconfigevent);
+  int nev = configeventTree->GetEntries();
+
+  LOG(info) << nev << " entries found";
+  configeventTree->GetEvent(0);
+  for (int reg=0;reg<433;++reg) {
+    LOGP(info,"register :{}, value :{} ",trapconfigevent->getRegisterName(reg),trapconfigevent->getRegisterValue(reg,mcmid));
+  }
+}

--- a/Detectors/TRD/macros/CheckTrapConfig.C
+++ b/Detectors/TRD/macros/CheckTrapConfig.C
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file checkTrapConfig.C
+/// \brief Extract information from a TrapConfig or series of them and then either plot or dump text
+/// \author Sean Murray
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+// ROOT header
+#include <TFile.h>
+#include <TAxis.h>
+#include <TGraph.h>
+#include <TH1F.h>
+#include <TCanvas.h>
+#include <TMultiGraph.h>
+
+// O2 header
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CcdbApi.h"
+#include "DataFormatsTRD/TrapConfig.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DataFormatsTRD/Constants.h"
+
+#include <map>
+#include <string>
+#include <vector>
+#endif
+
+using namespace std;
+using namespace o2::trd;
+using namespace o2::trd::constants;
+using timePoint = o2::parameters::GRPECSObject::timePoint;
+
+std::map<timePoint, std::unique_ptr<TrapConfig>> trapConfigMap;
+// Download the values and populate the map.
+void ccdbDownload(unsigned int runNumber, std::string ccdb, timePoint queryInterval)
+{
+  auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
+  ccdbMgr.setURL("http://alice-ccdb.cern.ch/");
+  auto runDuration = ccdbMgr.getRunDuration(runNumber);
+  std::map<std::string, std::string> md;
+  md["runNumber"] = std::to_string(runNumber);
+  const auto* grp = ccdbMgr.getSpecific<o2::parameters::GRPECSObject>("GLO/Config/GRPECS", (runDuration.first + runDuration.second) / 2, md);
+  grp->print();
+  const auto startTime = grp->getTimeStart();
+  const auto endTime = grp->getTimeEnd();
+  ccdbMgr.setURL(ccdb);
+
+  for (timePoint time = startTime; time < endTime; time += queryInterval) {
+    ccdbMgr.setTimestamp(time);
+    std::cout << "Downloading TrapConfig at time " << time << std::endl;
+    // std::unique_ptr<TrapConfig> trapconfig3 = std::make_unique<TrapConfig>(ccdbMgr.get<o2::trd::TrapConfig>("TRD/TrapConfig/TrapConfig"));
+    // trapConfigMap[time].push_back(trapconfig3);
+    trapConfigMap[time].push_back(std::make_unique<o2::trd::TrapConfig>(ccdbMgr.get<o2::trd::TrapConfig>("TRD/TrapConfig/TrapConfig")));
+    /*    for (int iDet = 0; iDet < 540; ++iDet) {
+      vmap[iDet].push_back(std::make_tuple(
+        calVdriftExB->getVdrift(iDet), calVdriftExB->getExB(iDet), static_cast<int>(time - startTime)));
+    }*/
+  }
+}
+
+void CheckTrapConfig(unsigned int runNumber = 523677, std::string ccdb = "http://ccdb-test.cern.ch:8080", timePoint queryInterval = 900000)
+{
+  //  ccdbDownload(runNumber, ccdb, queryInterval);
+}

--- a/Detectors/TRD/reconstruction/CMakeLists.txt
+++ b/Detectors/TRD/reconstruction/CMakeLists.txt
@@ -8,6 +8,7 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
+#add_compile_options(-O0 -g -fPIC) 
 
 o2_add_library(TRDReconstruction
                SOURCES src/CTFCoder.cxx
@@ -15,6 +16,7 @@ o2_add_library(TRDReconstruction
                        src/CruRawReader.cxx
                        src/DataReaderTask.cxx
                        src/EventRecord.cxx
+                       src/TrapConfigEventParser.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
                                      O2::DataFormatsTRD
                                      O2::DataFormatsTPC

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -22,6 +22,8 @@
 #include <set>
 #include <utility>
 #include <array>
+#include <TH2F.h>
+#include <TFile.h>
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -139,6 +141,14 @@ class CruRawReader
 
   // to check for which half-chambers we have seen correct headers and for which we have seen wrong ones
   void printHalfChamberHeaderReport() const;
+  // get a hit pattern of the hcid that had tracklets
+  std::bitset<1080>& getTrackletsHCID() { return mTrackletsHCID; }
+
+  // reset the bit pattern of which half chambers fired and which not
+  void resetTrackletsHCID() { mTrackletsHCID.reset(); }
+
+  // Does this time frame have config events in it.
+  bool isConfigEvent() { return mTimeFrameHasConfigEvent; }
 
  private:
   // these variables are configured externally
@@ -164,6 +174,7 @@ class CruRawReader
   HalfCRUHeader mPreviousHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   bool mPreviousHalfCRUHeaderSet;       // flag, whether we can use mPreviousHalfCRUHeader for additional sanity checks
   DigitHCHeader mDigitHCHeader;         // Digit HalfChamber header we are currently on.
+  DigitHCHeaderAll mDigitHCHeaderAll;   // Store all the possible parts of the Digit HC Header
   uint16_t mTimeBins{constants::TIMEBINS}; // the number of time bins to be read out (default 30, can be overwritten from digit HC header)
   bool mHaveSeenDigitHCHeader3{false};     // flag, whether we can compare an incoming DigitHCHeader3 with a header we have seen before
   uint32_t mPreviousDigitHCHeadersvnver;  // svn ver in the digithalfchamber header, used for validity checks
@@ -178,6 +189,9 @@ class CruRawReader
   std::set<std::pair<int, int>> mHalfChamberMismatches; // first element is HCID from RDH and second element is HCID from TrackletHCHeader
 
   o2::InteractionRecord mIR;
+  bool mFirstConfigIR{true};
+  o2::InteractionRecord mLastConfigIR;
+  std::chrono::duration<double, std::micro> mTotalConfigTime;
   std::array<uint32_t, 15> mCurrentHalfCRULinkLengths;
   std::array<uint32_t, 15> mCurrentHalfCRULinkErrorFlags;
 
@@ -193,6 +207,9 @@ class CruRawReader
   uint32_t mWordsRejected = 0;         // those words rejected before tracklet and digit parsing could start
 
   EventRecordContainer mEventRecords; // store data range indexes into the above vectors.
+
+  std::bitset<1080> mTrackletsHCID;
+  bool mTimeFrameHasConfigEvent;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
@@ -17,7 +17,9 @@
 #include <fairlogger/Logger.h>
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/RawDataStats.h"
+#include "DataFormatsTRD/RawData.h"
 #include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
 
 namespace o2::framework
 {
@@ -99,6 +101,7 @@ class EventRecordContainer
   void incLinkWordsRead(int hcid, int count) { mTFStats.mLinkWordsRead[hcid] += count; }
   void incLinkWordsRejected(int hcid, int count) { mTFStats.mLinkWordsRejected[hcid] += count; }
   void incMajorVersion(int version) { mTFStats.mDataFormatRead[version]++; }
+  void addConfigEvent(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>& data, uint32_t start, uint32_t end, uint32_t configeventlength, DigitHCHeaderAll& digithcheaders, InteractionRecord& ir);
 
   void incParsingError(int error, int hcid)
   {
@@ -114,6 +117,8 @@ class EventRecordContainer
   int mCurrEventRecord = 0;
   std::vector<EventRecord> mEventRecords;
   TRDDataCountersPerTimeFrame mTFStats;
+  std::vector<uint32_t> mConfigEventData; ///< unparse config event data, format : IR, HcHeader, event data, repeat.
+  bool mConfigEventPresent{false};
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
@@ -104,13 +104,13 @@ class TrapConfigEventParser
   bool isNewConfig();
   TrapConfigEvent getNewConfig() { return *mTrapConfigEvent.get(); };
   TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
-  //TrapConfigEvent getNewConfig() { return *mTrapConfigEvent.get(); };
-  //TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
+  // TrapConfigEvent getNewConfig() { return *mTrapConfigEvent.get(); };
+  // TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
   void sendTrapConfigEvent(framework::ProcessingContext& pc);
   // write the current config to a file
   void writeFile(int eventcount);
-  uint32_t countHCIDPresent(){return mTrapConfigEvent->countHCIDPresent();}
-  uint32_t countMCMPresent(){return mTrapConfigEvent->countMCMPresent();}
+  uint32_t countHCIDPresent() { return mTrapConfigEvent->countHCIDPresent(); }
+  uint32_t countMCMPresent() { return mTrapConfigEvent->countMCMPresent(); }
 
   // flush the stats that are config event specific
   // a single parse is almost certainly not going to contain the complete event, this is then run after we think we have the complete set.
@@ -135,14 +135,14 @@ class TrapConfigEventParser
   uint32_t mOffsetToRegister = 0;
   //  std::map<int, std::tuple<std::string, int, int>> TrapRegisterMap_addr;
   // std::array<int, 0xe000> mTrapRegistersAddressIndex; // index by address into mTrapRegisters.
-  //std::array<int, o2::trd::constants::MAXMCMCOUNT> mMcmParsingStatus{0};                                  // status of what was found, errors types in the parsing
+  // std::array<int, o2::trd::constants::MAXMCMCOUNT> mMcmParsingStatus{0};                                  // status of what was found, errors types in the parsing
   std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT * TrapConfigEvent::kLastReg> mCurrentMCMRegisters; // store the registers for all the mcm registers.
-//  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberLastSeen;                          // timestamp
-//  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberSeenSinceLastWritten;              // timestamp
-//  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberFrequencyInAccumulation;           // frequency in accumulation period.
-//  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMLastSeen;                                     // timestamp
-//  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMSeenSinceLastWritten;                         // timestamp
-//  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMFrequencyInAccumulation;                      // frequency in accumulation.
+                                                                                                          //  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberLastSeen;                          // timestamp
+                                                                                                          //  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberSeenSinceLastWritten;              // timestamp
+                                                                                                          //  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberFrequencyInAccumulation;           // frequency in accumulation period.
+                                                                                                          //  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMLastSeen;                                     // timestamp
+                                                                                                          //  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMSeenSinceLastWritten;                         // timestamp
+                                                                                                          //  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMFrequencyInAccumulation;                      // frequency in accumulation.
   std::array<int, 8 * 16> mcmSeen;                                                                        // the mcm has been seen with or with out error, local to a link
   std::array<int, 8 * 16> mcmMCM;                                                                         // the mcm has been seen with or with out error, local to a link
   std::array<int, 8 * 16> mcmROB;                                                                         // the mcm has been seen with or with out error, local to a link
@@ -158,11 +158,11 @@ class TrapConfigEventParser
   std::array<int, TrapConfigEvent::kLastReg> mRegisterCount{0}; // register frequency, a count of how many times each register appears
   std::string mTrapConfigEventName;                             // TOOD figure how to pull this in or seperately put it in the CCDB
   std::string mTrapConfigEventVersion;
-  //TrapConfigEvent mTrapConfigEvent;
-  //TrapConfigEvent mCCDBTrapConfigEvent;
+  // TrapConfigEvent mTrapConfigEvent;
+  // TrapConfigEvent mCCDBTrapConfigEvent;
   std::shared_ptr<TrapConfigEventSlot> mTrapConfigEventSlot;
   std::shared_ptr<TrapConfigEvent> mTrapConfigEvent;
-  //std::shared_ptr<TrapConfigEvent> mCCDBTrapConfigEvent;
+  // std::shared_ptr<TrapConfigEvent> mCCDBTrapConfigEvent;
   std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers
   std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                        // count of different value in the registers for a mcm,register used to find most frequent value.
   int configcount = 0;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
@@ -117,7 +117,9 @@ class TrapConfigEventParser
   int flushParsingStats();
   int analyseMaps();
   int analyseMcmSeen();
-  int64_t getConfigSize() { return sizeof(*mTrapConfigEventMessage); };
+  int64_t getConfigSize() { return sizeof(*mTrapConfigEvent); };
+  void setMCMParsingStatus(uint32_t mcmid, int status){ mMcmParsingStatus[mcmid]=status;}                     // no end
+  int getMCMParsingStatus(uint32_t mcmid){ return mMcmParsingStatus[mcmid];}                     // no end
 
  private:
   uint32_t mCurrentHCID = 0;
@@ -135,8 +137,7 @@ class TrapConfigEventParser
   uint32_t mOffsetToRegister = 0;
   //  std::map<int, std::tuple<std::string, int, int>> TrapRegisterMap_addr;
   // std::array<int, 0xe000> mTrapRegistersAddressIndex; // index by address into mTrapRegisters.
-  // std::array<int, o2::trd::constants::MAXMCMCOUNT> mMcmParsingStatus{0};                                  // status of what was found, errors types in the parsing
-  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT * TrapConfigEvent::kLastReg> mCurrentMCMRegisters; // store the registers for all the mcm registers.
+  std::array<int, o2::trd::constants::MAXMCMCOUNT> mMcmParsingStatus{0};                                  // status of what was found, errors types in the parsing
                                                                                                           //  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberLastSeen;                          // timestamp
                                                                                                           //  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberSeenSinceLastWritten;              // timestamp
                                                                                                           //  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberFrequencyInAccumulation;           // frequency in accumulation period.
@@ -164,7 +165,7 @@ class TrapConfigEventParser
   std::shared_ptr<TrapConfigEvent> mTrapConfigEvent;
   // std::shared_ptr<TrapConfigEvent> mCCDBTrapConfigEvent;
   std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers
-  //std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                        // count of different value in the registers for a mcm,register used to find most frequent value.   Not needed here, as this is now 1 time frame, it will be used in the aggregator.
+  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                        // count of different value in the registers for a mcm,register used to find most frequent value.   Not needed here, as this is now 1 time frame, it will be used in the aggregator.
   int configcount = 0;
   ClassDefNV(TrapConfigEventParser, 1);
 };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
@@ -1,0 +1,173 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPCONFIGPARSER_H
+#define O2_TRDTRAPCONFIGPARSER_H
+
+#include <fairlogger/Logger.h>
+#include "CommonDataFormat/InteractionRecord.h"
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/RawData.h"
+
+#include <chrono>  // chrono::system_clock
+#include <ctime>   // localtime
+#include <sstream> // stringstream
+#include <iomanip> // put_time
+#include <string>  // string
+#include <vector>
+#include <memory>
+#include <map>
+#include <tuple>
+#include <bitset>
+#include <gsl/span>
+#include "Rtypes.h"
+#include "TH2F.h"
+
+// Configuration of the TRD Tracklet Processor
+// (TRD Front-End Electronics)
+// There is a manual to describe all the internals of the electronics.
+// A very detailed manual, will try put it in the source code.
+// TRAP registers
+// TRAP data memory (DMEM)
+//
+
+namespace o2::trd
+{
+
+/*struct regmap_addr {
+  std::string name;
+  int index;
+  int bitwidth;
+};
+
+struct regmap {
+  std::string name;
+  int address;
+  int bitwidth;
+};
+*/
+
+enum TrapConfigEventErrorTypes {
+  kTrapConfigEventAllGood,
+  kTrapConfigEventNoEnd,
+  kTrapConfigEventNoBegin,
+  kTrapConfigEventNoGarbageEnd,
+  kTrapConfigEventNoGarbageBegin,
+  kTrapConfigEventLastError
+}; // possible errors for parsing.
+
+class TrapConfigEventParser
+{
+  // class used to unpack the trap config events, and figure out what to do to them.
+ public:
+  TrapConfigEventParser();
+  ~TrapConfigEventParser();
+
+  // int getTrapReg(TrapReg reg, int det = -1, int rob = -1, int mcm = -1);
+
+  unsigned int getDmemUnsigned(int addr, int det, int rob, int mcm);
+
+  // helper methods
+  std::string getConfigVersion() { return mTrapConfigEventVersion; }
+  std::string getConfigName() { return mTrapConfigEventName; }
+  void setConfigVersion(std::string version) { mTrapConfigEventVersion = version; } // these must some how be gotten from git or wingdb.
+  void setConfigName(std::string name) { mTrapConfigEventName = name; }             // these must be gotten from git or wingdb.
+
+  // TrapReg getRegByAddress(int address);
+
+  void printMCMRegisterCount(int hcid);
+  void unpackBlockHeader(uint32_t& header, uint32_t& registerdata, uint32_t& step, uint32_t& bwidth, uint32_t& nwords, uint32_t& registeraddr, uint32_t& exit_flag);
+  bool parse(std::vector<uint32_t>& data);
+  int parseLink(std::vector<uint32_t>& data, uint32_t start, uint32_t end);
+  int parseSingleData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward);
+  int parseBlockData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward);
+
+  bool checkRegister(uint32_t& registeraddr, uint32_t& registerdata);
+
+  void FillHistograms(int eventnum); //;TH2F *hists[6])
+  void compareToTrackletsHCID(std::bitset<1080> trackletshcid);
+  std::array<int, TrapConfigEvent::kLastReg>& getStartRegArray() { return mStartReg; }      // the number of time this register was read as the first register
+  std::array<int, TrapConfigEvent::kLastReg>& getStopRegArray() { return mStopReg; }        // the number of time this register was read as the last register
+  std::array<int, TrapConfigEvent::kLastReg>& getMissedRegArray() { return mMissedReg; }    // the number of times this register was not read
+  std::array<int, TrapConfigEvent::kLastReg>& getRegisterCount() { return mRegisterCount; } // total count for each register
+  void init(){};
+  bool isNewConfig();
+  TrapConfigEvent getNewConfig() { return *mTrapConfigEvent.get(); };
+  TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
+  //TrapConfigEvent getNewConfig() { return *mTrapConfigEvent.get(); };
+  //TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
+  void sendTrapConfigEvent(framework::ProcessingContext& pc);
+  // write the current config to a file
+  void writeFile(int eventcount);
+  uint32_t countHCIDPresent(){return mTrapConfigEvent->countHCIDPresent();}
+  uint32_t countMCMPresent(){return mTrapConfigEvent->countMCMPresent();}
+
+  // flush the stats that are config event specific
+  // a single parse is almost certainly not going to contain the complete event, this is then run after we think we have the complete set.
+  int flushParsingStats();
+  int analyseMaps();
+  int analyseMcmSeen();
+  int64_t getConfigSize() { return sizeof(*mTrapConfigEventSlot); };
+
+ private:
+  uint32_t mCurrentHCID = 0;
+  DigitMCMHeader mCurrentMCMHeader;
+  uint32_t mCurrentMCMID = 0;
+  uint32_t mCurrentDataIndex = 0;
+  uint32_t mLastRegIndex = 0;
+  uint32_t mRegistersReadForCurrentMCM = 0;
+  uint32_t mCurrentRegisterWordsCount = 0;
+  uint32_t mPreviousRegisterAddressRead = 0;
+  uint32_t mRegisterErrorGap = 0;
+  int32_t mCurrentRegisterIndex = 0;
+  int32_t mPreviousRegisterIndex = 0;
+  uint32_t mRegisterBase = 0;
+  uint32_t mOffsetToRegister = 0;
+  //  std::map<int, std::tuple<std::string, int, int>> TrapRegisterMap_addr;
+  // std::array<int, 0xe000> mTrapRegistersAddressIndex; // index by address into mTrapRegisters.
+  //std::array<int, o2::trd::constants::MAXMCMCOUNT> mMcmParsingStatus{0};                                  // status of what was found, errors types in the parsing
+  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT * TrapConfigEvent::kLastReg> mCurrentMCMRegisters; // store the registers for all the mcm registers.
+//  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberLastSeen;                          // timestamp
+//  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberSeenSinceLastWritten;              // timestamp
+//  std::array<uint32_t, o2::trd::constants::MAXHALFCHAMBER> mHalfChamberFrequencyInAccumulation;           // frequency in accumulation period.
+//  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMLastSeen;                                     // timestamp
+//  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMSeenSinceLastWritten;                         // timestamp
+//  std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT> mMCMFrequencyInAccumulation;                      // frequency in accumulation.
+  std::array<int, 8 * 16> mcmSeen;                                                                        // the mcm has been seen with or with out error, local to a link
+  std::array<int, 8 * 16> mcmMCM;                                                                         // the mcm has been seen with or with out error, local to a link
+  std::array<int, 8 * 16> mcmROB;                                                                         // the mcm has been seen with or with out error, local to a link
+  std::array<int, 8 * 16> mcmSeenMissedRegister;                                                          // the mcm does not have a complete set of registers, local to a link
+  bool firsttime = false;
+  //  static bool mRegisterAddressMapInitialised;
+  InteractionRecord mIR;
+  InteractionRecord mPreviousIR;
+  std::time_t mConfigDate;
+  std::array<int, TrapConfigEvent::kLastReg> mStartReg{0};      // count which register a config starts at
+  std::array<int, TrapConfigEvent::kLastReg> mStopReg{0};       // count which register a config stops at.
+  std::array<int, TrapConfigEvent::kLastReg> mMissedReg{0};     // count the number of missed reigsters
+  std::array<int, TrapConfigEvent::kLastReg> mRegisterCount{0}; // register frequency, a count of how many times each register appears
+  std::string mTrapConfigEventName;                             // TOOD figure how to pull this in or seperately put it in the CCDB
+  std::string mTrapConfigEventVersion;
+  //TrapConfigEvent mTrapConfigEvent;
+  //TrapConfigEvent mCCDBTrapConfigEvent;
+  std::shared_ptr<TrapConfigEventSlot> mTrapConfigEventSlot;
+  std::shared_ptr<TrapConfigEvent> mTrapConfigEvent;
+  //std::shared_ptr<TrapConfigEvent> mCCDBTrapConfigEvent;
+  std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers
+  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                        // count of different value in the registers for a mcm,register used to find most frequent value.
+  int configcount = 0;
+  ClassDefNV(TrapConfigEventParser, 1);
+};
+
+} // namespace o2::trd
+#endif

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
@@ -117,7 +117,7 @@ class TrapConfigEventParser
   int flushParsingStats();
   int analyseMaps();
   int analyseMcmSeen();
-  int64_t getConfigSize() { return sizeof(*mTrapConfigEventSlot); };
+  int64_t getConfigSize() { return sizeof(*mTrapConfigEventMessage); };
 
  private:
   uint32_t mCurrentHCID = 0;
@@ -160,11 +160,11 @@ class TrapConfigEventParser
   std::string mTrapConfigEventVersion;
   // TrapConfigEvent mTrapConfigEvent;
   // TrapConfigEvent mCCDBTrapConfigEvent;
-  std::shared_ptr<TrapConfigEventSlot> mTrapConfigEventSlot;
+  //std::shared_ptr<TrapConfigEventMessage> mTrapConfigEventMessage;
   std::shared_ptr<TrapConfigEvent> mTrapConfigEvent;
   // std::shared_ptr<TrapConfigEvent> mCCDBTrapConfigEvent;
   std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers
-  std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                        // count of different value in the registers for a mcm,register used to find most frequent value.
+  //std::map<uint32_t, std::map<uint32_t, uint32_t>> mTrapValueFrequencyMap;                        // count of different value in the registers for a mcm,register used to find most frequent value.   Not needed here, as this is now 1 time frame, it will be used in the aggregator.
   int configcount = 0;
   ClassDefNV(TrapConfigEventParser, 1);
 };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
@@ -118,8 +118,8 @@ class TrapConfigEventParser
   int analyseMaps();
   int analyseMcmSeen();
   int64_t getConfigSize() { return sizeof(*mTrapConfigEvent); };
-  void setMCMParsingStatus(uint32_t mcmid, int status){ mMcmParsingStatus[mcmid]=status;}                     // no end
-  int getMCMParsingStatus(uint32_t mcmid){ return mMcmParsingStatus[mcmid];}                     // no end
+  void setMCMParsingStatus(uint32_t mcmid, int status) { mMcmParsingStatus[mcmid] = status; } // no end
+  int getMCMParsingStatus(uint32_t mcmid) { return mMcmParsingStatus[mcmid]; }                // no end
 
  private:
   uint32_t mCurrentHCID = 0;
@@ -161,7 +161,7 @@ class TrapConfigEventParser
   std::string mTrapConfigEventVersion;
   // TrapConfigEvent mTrapConfigEvent;
   // TrapConfigEvent mCCDBTrapConfigEvent;
-  //std::shared_ptr<TrapConfigEventMessage> mTrapConfigEventMessage;
+  // std::shared_ptr<TrapConfigEventMessage> mTrapConfigEventMessage;
   std::shared_ptr<TrapConfigEvent> mTrapConfigEvent;
   // std::shared_ptr<TrapConfigEvent> mCCDBTrapConfigEvent;
   std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -596,7 +596,7 @@ bool CruRawReader::processHalfCRU(int iteration)
           // advance data pointers to the end;
           int counter = 0;
           mTimeFrameHasConfigEvent = true;
-          //LOGP(debug, "New Config event for : on hcid : {}  link: {} -- for IR  bc: {} orbit:{}  Trackletwords : {}", halfChamberId, currentlinkindex, mIR.bc, mIR.orbit, trackletWordsRead);
+          // LOGP(debug, "New Config event for : on hcid : {}  link: {} -- for IR  bc: {} orbit:{}  Trackletwords : {}", halfChamberId, currentlinkindex, mIR.bc, mIR.orbit, trackletWordsRead);
           if (mOptions[TRDEnableConfigEvents]) {
             // avoid filing the events unless we enable it.
             mEventRecords.addConfigEvent(mHBFPayload, mHBFoffset32, endOfCurrentLink, configeventlength * 8, mDigitHCHeaderAll, mIR);

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -43,6 +43,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"disable-stats", VariantType::Bool, false, {"Do not generate stat messages for qc"}},
     {"disable-root-output", VariantType::Bool, false, {"Do not write the digits and tracklets to file"}},
+    {"enable-config-events", VariantType::Bool, false, {"Permit the handling of config events"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
 }
@@ -66,6 +67,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "RAWSTATS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("TRD", "CONFEVT", 0, Lifetime::Sporadic);
 
   std::bitset<16> binaryoptions;
   binaryoptions[o2::trd::TRDVerboseBit] = cfgc.options().get<bool>("verbose");
@@ -73,6 +75,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
   binaryoptions[o2::trd::TRDGenerateStats] = !cfgc.options().get<bool>("disable-stats");
   binaryoptions[o2::trd::TRDOnlyCalibrationTriggerBit] = cfgc.options().get<bool>("onlycalibrationtrigger");
+  binaryoptions[o2::trd::TRDEnableConfigEvents] = cfgc.options().get<bool>("enable-config-events");
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, binaryoptions)};
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -44,13 +44,16 @@ void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
 
 void DataReaderTask::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
+  LOG(info) << " finalise CCDB " << __func__ << " " << __LINE__;
   if (matcher == ConcreteDataMatcher("CTP", "Trig_Offset", 0)) {
     LOG(info) << " CTP/Config/TriggerOffsets updated.";
     o2::ctp::TriggerOffsetsParam::Instance().printKeyValues();
+    LOG(info) << "trigger offset done from ctp ";
     return;
   } else if (matcher == ConcreteDataMatcher("TRD", "LinkToHcid", 0)) {
     LOG(info) << "Updated Link ID to HCID mapping";
     mReader.setLinkMap((const o2::trd::LinkToHCIDMapping*)obj);
+    LOG(info) << "link to hcid mapping done ";
     return;
   }
 }
@@ -125,7 +128,8 @@ void DataReaderTask::run(ProcessingContext& pc)
       LOG(info) << "relevant vectors to read : " << mReader.getTrackletsFound() << " tracklets and " << mReader.getDigitsFound() << " compressed digits";
     }
   }
-
+  // end of time frame build a list of links that fired, in particular for major=0x47
+  // check hcid with tracklets vs hcid that had no config events.
   mReader.buildDPLOutputs(pc);
   std::chrono::duration<double, std::milli> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
   LOGP(info, "Digits: {}, Tracklets: {}, DataRead in: {:.3f} MB, Rejected: {:.3f} kB for TF {} in {} ms",

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -48,7 +48,7 @@ void EventRecord::sortTrackletsByDetector()
 
 void EventRecordContainer::sendData(o2::framework::ProcessingContext& pc, bool generatestats)
 {
-  //at this point we know the total number of tracklets and digits and triggers.
+  // at this point we know the total number of tracklets and digits and triggers.
   size_t digitcount = 0;
   size_t trackletcount = 0;
   std::vector<Tracklet64> tracklets;
@@ -71,7 +71,7 @@ void EventRecordContainer::sendData(o2::framework::ProcessingContext& pc, bool g
     pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "RAWSTATS", 0, o2::framework::Lifetime::Timeframe}, mTFStats);
   }
   if (mConfigEventPresent) {
-    LOGP(info,"ZZZ Sending config event with size of {}",mConfigEventData.size());
+    LOGP(info, "ZZZ Sending config event with size of {}", mConfigEventData.size());
     pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "CONFEVT", 0, o2::framework::Lifetime::Condition}, mConfigEventData);
   }
 }

--- a/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
@@ -86,7 +86,7 @@ bool TrapConfigEventParser::checkRegister(uint32_t& registeraddr, uint32_t& regi
       if (registeraddr != mTrapConfigEvent.get()->getRegAddrByIdx(mRegistersReadForCurrentMCM)) {
         // if (registeraddr != std::get<1>(TrapRegisterMap[mRegistersReadForCurrentMCM]))
         mRegisterErrorGap += abs((int)mRegistersReadForCurrentMCM - (int)newregidx) + 1; // +1 as reg index is zero based.
-        setMCMParsingStatus(mCurrentMCMID, 3);                     // no end
+        setMCMParsingStatus(mCurrentMCMID, 3);                                           // no end
         LOGP(debug, " get mTrapConfigEvent.get()->getRegNameByAddr( {:08x} ) at func:{} line:{}", registeraddr, __func__, __LINE__);
         auto tmpnamebyaddr = mTrapConfigEvent.get()->getRegNameByAddr(registeraddr);
         LOGP(debug, " got mTrapConfigEvent.get()->getRegNameByAddr( {:08x} ) at func:{} line:{}", registeraddr, __func__, __LINE__);
@@ -242,7 +242,7 @@ int TrapConfigEventParser::parseSingleData(std::vector<uint32_t>& data, uint32_t
           LOGP(warn, "assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
         } else {
           mTrapRegistersFrequencyMap[mRegistersReadForCurrentMCM - 1][regdata]++;
-          //TODO move to calibrator mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
+          // TODO move to calibrator mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
         }
         // TODO this is not saving it to the CCDBConfig at all !
         //   if(mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM-1) == "ADCMSK"){
@@ -324,21 +324,21 @@ int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t 
       }
       if (mCurrentMCMID < o2::trd::constants::MAXMCMCOUNT && mRegistersReadForCurrentMCM < TrapConfigEvent::kLastReg) {
         LOGP(debug, "Adding block register {:09x} [{:08x}] name: {}  for mcm {} mCurrentRegisterWordsCount {} mRegistersReadForCurrentMCM {} regindex {} header {:08x} with badreg:{}", registeraddr, registerdata, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), mCurrentMCMID, mCurrentRegisterWordsCount, mRegistersReadForCurrentMCM, idx, header, badreg);
-       // auto index=mConfigDataIndex[mCurrentMCMID];//
-      //  if (mTrapConfigEvent->mConfigData[index].mRegisterData[mRegistersReadForCurrentMCM] != registerdata) {
-          //this was if (mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM] != registerdata) {
-          if (mRegistersReadForCurrentMCM > 0) {
-            mTrapConfigEvent.get()->setRegisterValueByIdx(registerdata, mRegistersReadForCurrentMCM - 1, mCurrentMCMID);
-            // mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
-            auto regdata = registerdata; // mTrapConfigEventMessage.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mcmid);
-            auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
-            if (regdata > regmax) {
-              LOGP(warn, "{} assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", __LINE__, regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
-            } else {
-              mTrapRegistersFrequencyMap[mRegistersReadForCurrentMCM - 1][regdata]++;
-             // mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1][regdata]++;                         // count of different value in the registers for a mcm,register used to find probably value.
-             // mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
-            }
+        // auto index=mConfigDataIndex[mCurrentMCMID];//
+        //  if (mTrapConfigEvent->mConfigData[index].mRegisterData[mRegistersReadForCurrentMCM] != registerdata) {
+        // this was if (mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM] != registerdata) {
+        if (mRegistersReadForCurrentMCM > 0) {
+          mTrapConfigEvent.get()->setRegisterValueByIdx(registerdata, mRegistersReadForCurrentMCM - 1, mCurrentMCMID);
+          // mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
+          auto regdata = registerdata; // mTrapConfigEventMessage.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mcmid);
+          auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
+          if (regdata > regmax) {
+            LOGP(warn, "{} assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", __LINE__, regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
+          } else {
+            mTrapRegistersFrequencyMap[mRegistersReadForCurrentMCM - 1][regdata]++;
+            // mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1][regdata]++;                         // count of different value in the registers for a mcm,register used to find probably value.
+            // mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
+          }
           }
         } else {
           LOGP(debug, "if statement failed for currentmcmregister {:08x}  registerdata {:08x}", mRegistersReadForCurrentMCM, registerdata);
@@ -352,14 +352,14 @@ int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t 
           // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
           setMCMParsingStatus(mCurrentMCMID, 1);
         }
-     // } else {
-    //    LOGP(warn, "if (mCurrentMCMRegisters[mCurrentMCMID * kLastReg + mRegistersReadForCurrentMCM] != registerdata mCurrentMCMID:{} kLastReg:{} mRegistersReadForCurrentMCM:{} mCurrentMCMRegisters[mCurrentMCMID*kLastReg+mRegistersReadForCurrentMCM]=={} != {}", mCurrentMCMID, TrapConfigEvent::kLastReg, mRegistersReadForCurrentMCM, mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM], registerdata);
-     // }
-      registeraddr += step;
-      header = header >> bwidth; // this is not used for the bwidth=31 case
-      if (idx >= end) {
-        LOGP(error, "no end markermore data, {} words read Config parsing getting out due to end of data at line : {}", idx, __LINE__);
-        return false;
+        // } else {
+        //    LOGP(warn, "if (mCurrentMCMRegisters[mCurrentMCMID * kLastReg + mRegistersReadForCurrentMCM] != registerdata mCurrentMCMID:{} kLastReg:{} mRegistersReadForCurrentMCM:{} mCurrentMCMRegisters[mCurrentMCMID*kLastReg+mRegistersReadForCurrentMCM]=={} != {}", mCurrentMCMID, TrapConfigEvent::kLastReg, mRegistersReadForCurrentMCM, mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM], registerdata);
+        // }
+        registeraddr += step;
+        header = header >> bwidth; // this is not used for the bwidth=31 case
+        if (idx >= end) {
+          LOGP(error, "no end markermore data, {} words read Config parsing getting out due to end of data at line : {}", idx, __LINE__);
+          return false;
       }
     }
   } else {
@@ -524,21 +524,21 @@ int TrapConfigEventParser::analyseMaps()
   //
   // std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;
   // this is moved to Calibrator when processing the timeslots.
-/*  if (configcount > 8) {
-    uint oldmcm = 0;
-    for (auto& valuemap : mTrapValueFrequencyMap) {
-      LOGP(debug, "ZZZ1 valuemap.second.size():{} ", valuemap.second.size());
+  /*  if (configcount > 8) {
+      uint oldmcm = 0;
+      for (auto& valuemap : mTrapValueFrequencyMap) {
+        LOGP(debug, "ZZZ1 valuemap.second.size():{} ", valuemap.second.size());
 
-      for (const auto& elem : valuemap.second) {
-        uint64_t mcmidreg = valuemap.first;
-        uint64_t mcmid = mcmidreg / TrapConfigEvent::kLastReg;
-        uint64_t regid = mcmidreg - mcmid * TrapConfigEvent::kLastReg;
-        LOGP(debug, "ZZZ mcm:{} reg:{} mcmidreg:{} mcmid*lastreg:{} value:{} count:{}", mcmid, regid, mcmidreg, mcmid * TrapConfigEvent::kLastReg, elem.first, elem.second);
+        for (const auto& elem : valuemap.second) {
+          uint64_t mcmidreg = valuemap.first;
+          uint64_t mcmid = mcmidreg / TrapConfigEvent::kLastReg;
+          uint64_t regid = mcmidreg - mcmid * TrapConfigEvent::kLastReg;
+          LOGP(debug, "ZZZ mcm:{} reg:{} mcmidreg:{} mcmid*lastreg:{} value:{} count:{}", mcmid, regid, mcmidreg, mcmid * TrapConfigEvent::kLastReg, elem.first, elem.second);
+        }
       }
     }
-  }
-  configcount++;
-  */
+    configcount++;
+    */
   return 1;
 }
 

--- a/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
@@ -62,12 +62,11 @@ bool TrapConfigEventParser::checkRegister(uint32_t& registeraddr, uint32_t& regi
   mOffsetToRegister = mRegisterBase + newregidx;
   // Are the registers sequential
   if (newregidx != mLastRegIndex + 1 && newregidx != 0) {
-    mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,5); // missing registers
+    mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 5); // missing registers
     for (int miss = mLastRegIndex; miss < newregidx; ++miss) {
       mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
     }
     LOGP(warn, " register step mismatch : went from {:06x} ({}) i:{} to {:06x} ({}) i:{} and mcmid: {} mMcmParsingStatus[{}]=5", mPreviousRegisterAddressRead, mTrapConfigEvent.get()->getRegNameByAddr(mPreviousRegisterAddressRead), mLastRegIndex, registeraddr, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), newregidx, registerdata, mCurrentMCMID, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID), mCurrentMCMID);
-    
   }
   mLastRegIndex = newregidx;
   if (numberbits >= 0 || regname != "" || newregidx >= 0) {
@@ -79,7 +78,7 @@ bool TrapConfigEventParser::checkRegister(uint32_t& registeraddr, uint32_t& regi
       mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 6); // no end
       mStopReg[mPreviousRegisterIndex]++;
       mStopReg[mCurrentRegisterIndex]++;
-      LOGP(warn, " current register index is less than previous, we have looped back mcmId[{}] = {} and mcmId[{}]= {} current register index {} previousregisteraddressread {} ", mCurrentMCMID, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID), mCurrentMCMID + 1, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID+1), mCurrentRegisterIndex, mPreviousRegisterAddressRead);
+      LOGP(warn, " current register index is less than previous, we have looped back mcmId[{}] = {} and mcmId[{}]= {} current register index {} previousregisteraddressread {} ", mCurrentMCMID, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID), mCurrentMCMID + 1, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID + 1), mCurrentRegisterIndex, mPreviousRegisterAddressRead);
       for (int miss = mRegistersReadForCurrentMCM; miss < newregidx; ++miss) {
         mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
                             //   mcmMissedRegister[currentrob * constants::NMCMROB + currentmcm].set(miss);
@@ -88,7 +87,7 @@ bool TrapConfigEventParser::checkRegister(uint32_t& registeraddr, uint32_t& regi
       if (registeraddr != mTrapConfigEvent.get()->getRegAddrByIdx(mRegistersReadForCurrentMCM)) {
         // if (registeraddr != std::get<1>(TrapRegisterMap[mRegistersReadForCurrentMCM]))
         mRegisterErrorGap += abs((int)mRegistersReadForCurrentMCM - (int)newregidx) + 1; // +1 as reg index is zero based.
-        mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 3); // no end
+        mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 3);                     // no end
         LOGP(debug, " get mTrapConfigEvent.get()->getRegNameByAddr( {:08x} ) at func:{} line:{}", registeraddr, __func__, __LINE__);
         auto tmpnamebyaddr = mTrapConfigEvent.get()->getRegNameByAddr(registeraddr);
         LOGP(debug, " got mTrapConfigEvent.get()->getRegNameByAddr( {:08x} ) at func:{} line:{}", registeraddr, __func__, __LINE__);
@@ -204,7 +203,7 @@ void TrapConfigEventParser::FillHistograms(int eventnum)
   canvas->Write();
   // canvas->Print("ConfigEvents.gif+");
   file->Write();
- // mMcmParsingStatus.fill(0);
+  // mMcmParsingStatus.fill(0);
   LOG(debug) << " Walk through frequency map : ";
   int regcount = 0;
   for (auto& regmap : mTrapRegistersFrequencyMap) {
@@ -278,7 +277,7 @@ bool TrapConfigEventParser::parse(std::vector<uint32_t>& data)
     position++;
     uint32_t length = data[position++];
     LOGP(debug, " Link length : {}", length);
-    //printDigitHCHeader(a, &data[digithcheaderextra]);
+    // printDigitHCHeader(a, &data[digithcheaderextra]);
     mCurrentHCID = HelperMethods::getHCIDFromDigitHCHeader(a);
     start = position;
     end = start + length;
@@ -288,12 +287,12 @@ bool TrapConfigEventParser::parse(std::vector<uint32_t>& data)
     auto trailer1 = data[position++];
     auto trailer2 = data[position++];
     LOGP(debug, "Trailers : {:08x} {:08x}", trailer1, trailer2);
-    //TOOD do something with else remove:
-    //std::array<int, 8 * 16> mcmSeen;                                                                   // the mcm has been seen with or with out error, local to a link
-    //std::array<int, 8 * 16> mcmMCM;                                                                    // the mcm has been seen with or with out error, local to a link
-    //std::array<int, 8 * 16> mcmROB;                                                                    // the mcm has been seen with or with out error, local to a link
-    //std::array<int, 8 * 16> mcmSeenMissedRegister;                                                     // the mcm does not have a complete set of registers, local to a link
-    //std::array<std::bitset<TrapConfigEvent::kLastReg>, 8 * 16> mcmMissedRegister;                           // bitpattern of which registers were seen and not seen for a given mcm.
+    // TOOD do something with else remove:
+    // std::array<int, 8 * 16> mcmSeen;                                                                   // the mcm has been seen with or with out error, local to a link
+    // std::array<int, 8 * 16> mcmMCM;                                                                    // the mcm has been seen with or with out error, local to a link
+    // std::array<int, 8 * 16> mcmROB;                                                                    // the mcm has been seen with or with out error, local to a link
+    // std::array<int, 8 * 16> mcmSeenMissedRegister;                                                     // the mcm does not have a complete set of registers, local to a link
+    // std::array<std::bitset<TrapConfigEvent::kLastReg>, 8 * 16> mcmMissedRegister;                           // bitpattern of which registers were seen and not seen for a given mcm.
   }
   // are we complete enough to now compare ?
   analyseMaps();
@@ -327,8 +326,8 @@ int TrapConfigEventParser::parseSingleData(std::vector<uint32_t>& data, uint32_t
       // update frequency map:
       if (mRegistersReadForCurrentMCM > 0) {
         mTrapConfigEvent.get()->setRegisterValueByIdx(registerdata, mRegistersReadForCurrentMCM - 1, mCurrentMCMID);
-        //mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
-        auto regdata = registerdata;       // mTrapConfigEventSlot.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mCurrentMCMID);
+        // mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
+        auto regdata = registerdata; // mTrapConfigEventSlot.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mCurrentMCMID);
         auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
         if (regdata > regmax) {
           LOGP(warn, "assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
@@ -345,7 +344,7 @@ int TrapConfigEventParser::parseSingleData(std::vector<uint32_t>& data, uint32_t
       mRegisterCount[mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr)]++; // keep a count of seen and accepted registers
       if (mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID) < 2) {
         // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
-        mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,1);
+        mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 1);
       }
     }
     if (idx >= end && data[idx] != constants::CONFIGEVNETBLOCKENDMARKER) {
@@ -420,8 +419,8 @@ int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t 
         if (mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM] != registerdata) {
           if (mRegistersReadForCurrentMCM > 0) {
             mTrapConfigEvent.get()->setRegisterValueByIdx(registerdata, mRegistersReadForCurrentMCM - 1, mCurrentMCMID);
-            //mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
-            auto regdata = registerdata;       // mTrapConfigEventSlot.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mcmid);
+            // mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
+            auto regdata = registerdata; // mTrapConfigEventSlot.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mcmid);
             auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
             if (regdata > regmax) {
               LOGP(warn, "{} assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", __LINE__, regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
@@ -431,7 +430,7 @@ int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t 
               mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
               mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1] = registerdata;
             }
-            mTrapConfigEventSlot->setRegisterSeen(mCurrentMCMID,1);
+            mTrapConfigEventSlot->setRegisterSeen(mCurrentMCMID, 1);
           }
         } else {
           LOGP(debug, "if statement failed for currentmcmregister {:08x}  registerdata {:08x}", mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM], registerdata);
@@ -443,7 +442,7 @@ int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t 
         // }
         if (mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID) < 2) {
           // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
-          mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,1);
+          mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 1);
         }
       } else {
         LOGP(warn, "if (mCurrentMCMRegisters[mCurrentMCMID * kLastReg + mRegistersReadForCurrentMCM] != registerdata mCurrentMCMID:{} kLastReg:{} mRegistersReadForCurrentMCM:{} mCurrentMCMRegisters[mCurrentMCMID*kLastReg+mRegistersReadForCurrentMCM]=={} != {}", mCurrentMCMID, TrapConfigEvent::kLastReg, mRegistersReadForCurrentMCM, mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM], registerdata);
@@ -545,7 +544,7 @@ int TrapConfigEventParser::parseLink(std::vector<uint32_t>& data, uint32_t start
       // mcm header
       mCurrentMCMHeader.word = data[idx];
       LOGP(debug, "header at data[{}] had : {:06} registers, last register read : {:08x} ({}) and a register gap of {}", idx, mCurrentRegisterWordsCount, mPreviousRegisterAddressRead, mTrapConfigEvent.get()->getRegNameByAddr(mPreviousRegisterAddressRead), mRegisterErrorGap);
-      //printDigitMCMHeader(mCurrentMCMHeader);
+      // printDigitMCMHeader(mCurrentMCMHeader);
       if (idx != start) {
         int index = mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm;
         if (index < constants::NMCMROB * constants::NROBC1) {
@@ -562,13 +561,13 @@ int TrapConfigEventParser::parseLink(std::vector<uint32_t>& data, uint32_t start
       mPreviousRegisterIndex = 0;                                                                                    // register index of the last register read.
       mCurrentRegisterIndex = 0;                                                                                     // index of the current register
       mCurrentMCMID = (mCurrentHCID / 2) * 128 + mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm; // current rob is 0-7/0-5 and currentmcm is 0-16.
-      mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,1);
+      mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 1);
       if (data[idx] == 0) {
         LOGP(warn, "Breaking as a zero after endmarker idx: {} ", idx);
         LOGP(debug, "header at data[{}] had : {:06} registers, last register read : {:08x} ({}) and a register gap of {}", idx, mCurrentRegisterWordsCount, mPreviousRegisterAddressRead, mTrapConfigEvent.get()->getRegNameByAddr(mPreviousRegisterAddressRead), mRegisterErrorGap);
         break;
       }
-      //mcmSeen[mCurrentMCMHeader.rob * 16 + mCurrentMCMHeader.mcm] = 0;
+      // mcmSeen[mCurrentMCMHeader.rob * 16 + mCurrentMCMHeader.mcm] = 0;
       endmarker = false;
       mLastRegIndex = 0;
       mRegisterBase = mCurrentMCMID * 432;
@@ -601,7 +600,7 @@ int TrapConfigEventParser::parseLink(std::vector<uint32_t>& data, uint32_t start
     } // end block case
   }   // end while
   // loop over which mcms never sent data.
-  //printMCMRegisterCount(mCurrentHCID);
+  // printMCMRegisterCount(mCurrentHCID);
   return false; // we only get here if the max length of the block reached!
 }
 
@@ -615,7 +614,7 @@ int TrapConfigEventParser::analyseMaps()
 {
   // loop through the maps of registers and determine, per mcm, per rob, per halfchamber, per chamber, constants.
   //
-  //std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;
+  // std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;
   if (configcount > 8) {
     uint oldmcm = 0;
     for (auto& valuemap : mTrapValueFrequencyMap) {
@@ -633,13 +632,12 @@ int TrapConfigEventParser::analyseMaps()
   return 1;
 }
 
-
 int TrapConfigEventParser::analyseMcmSeen()
 {
   // loop through the maps of registers and determine, per mcm, per rob, per halfchamber, per chamber, constants.
   //
   //
-  //std::array<uint64_t,32> mcmpresentcount{0};
+  // std::array<uint64_t,32> mcmpresentcount{0};
   /* std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mMcmMaps;
   for(auto& mcmcount : mMCMCurrentEvent){
     LOGP(info,"###mcmcount of {} ", mcmcount);

--- a/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
@@ -1,0 +1,675 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+//  TRAP config Parser                                                    //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include <fairlogger/Logger.h>
+#include "Framework/ProcessingContext.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/DataProcessorSpec.h"
+
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+
+#include "TRDReconstruction/TrapConfigEventParser.h"
+
+#include <TH2F.h>
+#include <TFile.h>
+#include <TCanvas.h>
+
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <array>
+#include <bitset>
+
+using namespace o2::trd;
+
+TrapConfigEventParser::TrapConfigEventParser()
+{
+  LOGP(info, "Creating trapconfig event object");
+  mTrapConfigEventSlot = std::make_shared<TrapConfigEventSlot>();
+  mTrapConfigEvent = std::make_shared<TrapConfigEvent>();
+}
+
+TrapConfigEventParser::~TrapConfigEventParser()
+{
+}
+
+bool TrapConfigEventParser::checkRegister(uint32_t& registeraddr, uint32_t& registerdata)
+{
+  mPreviousRegisterAddressRead = registeraddr;
+  int32_t numberbits = 0;
+  std::string regname = "";
+  int32_t newregidx = 0;
+  bool badregister = true;
+  mTrapConfigEvent.get()->getRegisterByAddr(registeraddr, regname, newregidx, numberbits);
+  mOffsetToRegister = mRegisterBase + newregidx;
+  // Are the registers sequential
+  if (newregidx != mLastRegIndex + 1 && newregidx != 0) {
+    mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,5); // missing registers
+    for (int miss = mLastRegIndex; miss < newregidx; ++miss) {
+      mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
+    }
+    LOGP(warn, " register step mismatch : went from {:06x} ({}) i:{} to {:06x} ({}) i:{} and mcmid: {} mMcmParsingStatus[{}]=5", mPreviousRegisterAddressRead, mTrapConfigEvent.get()->getRegNameByAddr(mPreviousRegisterAddressRead), mLastRegIndex, registeraddr, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), newregidx, registerdata, mCurrentMCMID, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID), mCurrentMCMID);
+    
+  }
+  mLastRegIndex = newregidx;
+  if (numberbits >= 0 || regname != "" || newregidx >= 0) {
+    // this is a bogus or unknown register
+    LOGP(debug, "good register : name:{} newregindex:{} numberofbits:{}, lastregindex:{} registeraddr:{:08x} ", regname, newregidx, numberbits, mPreviousRegisterIndex, registeraddr);
+    mCurrentRegisterIndex = newregidx;
+    if (mCurrentRegisterIndex < mPreviousRegisterIndex) {
+      mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 4); // no end
+      mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 6); // no end
+      mStopReg[mPreviousRegisterIndex]++;
+      mStopReg[mCurrentRegisterIndex]++;
+      LOGP(warn, " current register index is less than previous, we have looped back mcmId[{}] = {} and mcmId[{}]= {} current register index {} previousregisteraddressread {} ", mCurrentMCMID, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID), mCurrentMCMID + 1, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID+1), mCurrentRegisterIndex, mPreviousRegisterAddressRead);
+      for (int miss = mRegistersReadForCurrentMCM; miss < newregidx; ++miss) {
+        mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
+                            //   mcmMissedRegister[currentrob * constants::NMCMROB + currentmcm].set(miss);
+      }
+    } else {
+      if (registeraddr != mTrapConfigEvent.get()->getRegAddrByIdx(mRegistersReadForCurrentMCM)) {
+        // if (registeraddr != std::get<1>(TrapRegisterMap[mRegistersReadForCurrentMCM]))
+        mRegisterErrorGap += abs((int)mRegistersReadForCurrentMCM - (int)newregidx) + 1; // +1 as reg index is zero based.
+        mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID, 3); // no end
+        LOGP(debug, " get mTrapConfigEvent.get()->getRegNameByAddr( {:08x} ) at func:{} line:{}", registeraddr, __func__, __LINE__);
+        auto tmpnamebyaddr = mTrapConfigEvent.get()->getRegNameByAddr(registeraddr);
+        LOGP(debug, " got mTrapConfigEvent.get()->getRegNameByAddr( {:08x} ) at func:{} line:{}", registeraddr, __func__, __LINE__);
+        std::string tmpnamebyidx = ""; // mTrapConfigEventSlot.get()->getRegNameByIdx(mRegistersReadForCurrentMCM);
+        auto tmpregidxbyaddr = mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr);
+        LOGP(warn, " current register is not sequential to previous register, we have a gap : {} from {} to {} mRegisterErrorGap now : {} name compare {} ?= {} at {} mMcmParsingStatus[{}]={}", abs((int)mRegistersReadForCurrentMCM - (int)newregidx),
+             mRegistersReadForCurrentMCM, tmpregidxbyaddr, mRegisterErrorGap, tmpnamebyaddr, tmpnamebyidx, __LINE__, mCurrentMCMID, mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID));
+        mRegistersReadForCurrentMCM = newregidx + 1;
+        for (int miss = mRegistersReadForCurrentMCM; miss < newregidx; ++miss) {
+          mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
+        }
+        LOGP(warn, " Registers are non-sequential : {} from {} to {} mRegisterErrorGap now : {} name compare {} ?= {} at {}", abs(mRegistersReadForCurrentMCM - mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr)), mRegistersReadForCurrentMCM, mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr), mRegisterErrorGap, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), "" /*mTrapConfigEventSlot.get()->getRegNameByIdx(mRegistersReadForCurrentMCM)*/, __LINE__);
+      } else {
+        LOGP(debug, " Registers are sequential : {} from {} to {} mRegisterErrorGap now : {} name compare {} ?= {} at {}", abs(mRegistersReadForCurrentMCM - mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr)), mRegistersReadForCurrentMCM, mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr), mRegisterErrorGap, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), "" /*mTrapConfigEventSlot.get()->getRegNameByIdx(mRegistersReadForCurrentMCM)*/, __LINE__);
+        mRegistersReadForCurrentMCM++;
+        badregister = false;
+      }
+    }
+    mCurrentRegisterWordsCount++;
+  } else {
+    LOGP(warn, "bad register : name:'{}' newregindex:{} numberofbits:{}, lastregindex:{} registeraddr:{:08x} ?= ", regname, newregidx, numberbits, mPreviousRegisterIndex, registeraddr);
+  }
+  mPreviousRegisterIndex = mCurrentRegisterIndex;
+  return badregister;
+}
+
+void TrapConfigEventParser::compareToTrackletsHCID(std::bitset<1080> trackletshcid)
+{
+  // loop over config hcid and if its not present check if the config event had tracklets.
+  // this is of course not conclusive but a start.
+  for (int i = 0; i < constants::MAXCHAMBER; ++i) {
+    if (mTrapConfigEvent->isHCIDPresent(i)) {
+      if (trackletshcid.test(i)) {
+        LOGP(debug, "Config event had tracklets for hcid {}", i);
+      } else {
+        LOGP(debug, "Config event had no tracklets for hcid {}", i);
+      }
+    } else {
+      if (trackletshcid.test(i) && !mTrapConfigEvent->isHCIDPresent(i)) {
+        LOGP(debug, "No Config event but we have tracklets for HCID  {}", i);
+      }
+    }
+  }
+}
+
+void TrapConfigEventParser::writeFile(int eventcount)
+{
+  // TFile *file = TFile(Form("ccdbtrapconfig_%d.root",eventcount);
+  // mTrapConfigEventSlot.get()->Write();
+  // file->Close();
+}
+
+void TrapConfigEventParser::FillHistograms(int eventnum)
+{ // TODO move this to a script to run over a TrapConfigEvent3
+  // take the mMcmParsingStatus and fill in the per mcm per layer graph
+  // 1 hist per layer, 6 layers
+  TH2F* layerconfig[6];
+  std::unique_ptr<TFile> file(TFile::Open(Form("Event_%d_Histograms.root", eventnum), "RECREATE"));
+  LOGP(debug, "Now to fill Event_%i_Histograms.root", eventnum);
+  TH1F *missed, *start, *stop, *regcounts;
+  missed = new TH1F(Form("MissedRegistersEvent_%d", eventnum), Form("Missed registers for mcm that read out in event %d;register;count", eventnum), 500, -0.5, 499.5);
+  start = new TH1F(Form("StartRegistersEvent_%d", eventnum), Form("Starting registers for mcm that read out in event %d;register;count", eventnum), 500, -0.5, 499.5);
+  stop = new TH1F(Form("StopRegistersEvent_%d", eventnum), Form("Stopping registers for mcm that read out in event %d;register;count", eventnum), 500, -0.5, 499.5);
+  regcounts = new TH1F(Form("CounterRegistersEvent_%d", eventnum), Form("Counts of seen registers for mcm that read out in event %d;register;count", eventnum), 500, -0.5, 499.5);
+  int loopcounter = 0;
+  for (auto& counts : mStopReg) {
+    LOG(debug) << " in stopreg loop with count of " << loopcounter << " and counts of : " << counts;
+    loopcounter++;
+    stop->SetBinContent(loopcounter, counts);
+  }
+  loopcounter = 0;
+  for (auto& counts : mStartReg) {
+    loopcounter++;
+    start->SetBinContent(loopcounter, counts);
+  }
+  loopcounter = 0;
+  for (auto& counts : mMissedReg) {
+    loopcounter++;
+    missed->SetBinContent(loopcounter, counts);
+  }
+  loopcounter = 0;
+  for (auto& counts : mRegisterCount) {
+    loopcounter++;
+    regcounts->SetBinContent(loopcounter, counts);
+  }
+
+  for (int i = 0; i < 6; i++) {
+    layerconfig[i] = new TH2F(Form("ConfigErrorsPerLayerEvent_%d_layer_%d", eventnum, i), Form("Config Errors per mcm in layer %d event %d;stack;sector", i, eventnum), 76, -0.5, 75.5, 144, -0.5, 143.5);
+  }
+  for (int mcmid = 0; mcmid < o2::trd::constants::MAXMCMCOUNT; ++mcmid) {
+    int detector = mcmid / 128; // hcid/2;
+    int sm = detector / 30;
+    int detLoc = detector % 30;
+    int layer = detector % 6;
+    int stack = detLoc / 6;
+    int sec = detector / 30;
+    int rem = mcmid - (mcmid / 128) * 128;
+    int mcm = rem - (rem / 16) * 16;
+    int rob = rem / 16;
+    int row = rob + sm * 8;
+    int col = stack * 16 + mcm;
+    layerconfig[layer]->SetBinContent(col, row, mTrapConfigEventSlot->getMCMParsingStatus(mcmid));
+  }
+  std::unique_ptr<TCanvas> canvas(new TCanvas("canvas", "Config Event parsing problems"));
+  canvas->Divide(3, 2);
+  for (int i = 0; i < 6; i++) {
+    canvas->cd(i + 1);
+    layerconfig[i]->SetStats(0);
+    layerconfig[i]->Draw("col");
+  }
+  canvas->Modified(true);
+  canvas->Update();
+  canvas->Write();
+  // canvas->Print("ConfigEvents.gif+");
+  file->Write();
+ // mMcmParsingStatus.fill(0);
+  LOG(debug) << " Walk through frequency map : ";
+  int regcount = 0;
+  for (auto& regmap : mTrapRegistersFrequencyMap) {
+    LOG(debug) << "Register : " << regcount << " " << mTrapConfigEvent.get()->getRegNameByIdx(regcount) << " with " << regmap.size() << " entries";
+    for (const auto& elem : regmap) {
+      LOGP(debug, "[{:08x}] = {}", elem.first, elem.second);
+    }
+    regcount++;
+  }
+
+  /*  this is huge, enable for debugging purposes at your peril
+  for (int mcm = 0; mcm < o2::trd::constants::MAXMCMCOUNT; ++mcm) {
+    LOGP(info, "MCM : {} ", mcm);
+    for (int reg = 0; reg < TrapConfigEvent::kLastReg; ++reg) {
+      LOGP(info, "register of {} = {:08x}", mTrapConfigEvent.get()->getRegNameByIdx(reg), mCurrentMCMRegisters[mcm * TrapConfigEvent::kLastReg + reg]);
+  }
+  }*/
+}
+
+void TrapConfigEventParser::printMCMRegisterCount(int hcid)
+{
+  int roboffset = 1;
+  if (hcid % 2 == 0) {
+    roboffset = 0;
+  }
+  std::stringstream errorMCM;
+  LOGP(info, "bp rob for hcid : {}....", hcid);
+  for (int robidx = roboffset; robidx < 8; robidx += 2) {
+    std::stringstream display;
+    display << "bp rob:" << robidx << " ";
+    for (int mcmidx = 0; mcmidx < 16; ++mcmidx) {
+      display << fmt::format("[{:04} ({:04})] ", mcmSeen[robidx * 16 + mcmidx], mcmSeenMissedRegister[robidx * constants::NROBC1 + mcmidx]);
+      if (mcmSeen[robidx * 16 + mcmidx] != 433)
+        errorMCM << fmt::format("[{:04} ({:04}) == hcid:{} mcm:{} rob:{} ] ", mcmSeen[robidx * constants::NROBC1 + mcmidx], mcmSeenMissedRegister[robidx * constants::NROBC1 + mcmidx], hcid, mcmMCM[robidx * constants::NROBC1 + mcmidx], mcmROB[robidx * constants::NROBC1 + mcmidx]);
+    }
+    LOG(info) << display.str();
+  }
+  LOG(info) << errorMCM.str();
+  LOG(info) << "bp rob ....";
+}
+
+void TrapConfigEventParser::unpackBlockHeader(uint32_t& header, uint32_t& registerdata, uint32_t& step, uint32_t& bwidth, uint32_t& nwords, uint32_t& registeraddr, uint32_t& exit_flag)
+{
+  registerdata = (header >> 2) & 0xFFFF; // 16 bit data
+  step = (header >> 1) & 0x0003;
+  bwidth = ((header >> 3) & 0x001F) + 1;
+  // check that the bit width matches what is should be
+  nwords = (header >> 8) & 0x00FF;
+  registeraddr = (header >> 16) & 0xFFFF;
+  exit_flag = (step == 0) || (step == 3) || (nwords == 0);
+}
+
+bool TrapConfigEventParser::parse(std::vector<uint32_t>& data)
+{
+  // data comes in as ir, digithcheaderall, data payload.
+  uint32_t start = 0;
+  uint32_t end = 0;
+  int position = 0;
+  while (position < data.size()) {
+    LOGP(debug, " bc : {} orbit: {}", data[position], data[position + 1]);
+    position += 2;
+    DigitHCHeader a;
+    a.word = data[position++];
+    LOGP(debug, " DigitHCHeader 0 {:08x}", a.word);
+    int digithcheaderextra = position;
+    LOGP(debug, " DigitHCHeader 1 {:08x}", data[position]);
+    position++;
+    LOGP(debug, " DigitHCHeader 2 {:08x}", data[position]);
+    position++;
+    LOGP(debug, " DigitHCHeader 3 {:08x}", data[position]);
+    position++;
+    uint32_t length = data[position++];
+    LOGP(debug, " Link length : {}", length);
+    //printDigitHCHeader(a, &data[digithcheaderextra]);
+    mCurrentHCID = HelperMethods::getHCIDFromDigitHCHeader(a);
+    start = position;
+    end = start + length;
+    mTrapConfigEvent->isHCIDPresent(mCurrentHCID);
+    parseLink(data, start, end);
+    position += end - start;
+    auto trailer1 = data[position++];
+    auto trailer2 = data[position++];
+    LOGP(debug, "Trailers : {:08x} {:08x}", trailer1, trailer2);
+    //TOOD do something with else remove:
+    //std::array<int, 8 * 16> mcmSeen;                                                                   // the mcm has been seen with or with out error, local to a link
+    //std::array<int, 8 * 16> mcmMCM;                                                                    // the mcm has been seen with or with out error, local to a link
+    //std::array<int, 8 * 16> mcmROB;                                                                    // the mcm has been seen with or with out error, local to a link
+    //std::array<int, 8 * 16> mcmSeenMissedRegister;                                                     // the mcm does not have a complete set of registers, local to a link
+    //std::array<std::bitset<TrapConfigEvent::kLastReg>, 8 * 16> mcmMissedRegister;                           // bitpattern of which registers were seen and not seen for a given mcm.
+  }
+  // are we complete enough to now compare ?
+  analyseMaps();
+  analyseMcmSeen();
+  return true;
+}
+
+int TrapConfigEventParser::parseSingleData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward)
+{
+  uint32_t registerdata = (header >> 2) & 0xFFFF;  // 16 bit data
+  uint32_t registeraddr = (header >> 18) & 0x3FFF; // 14 bit address
+  uint16_t data_hi = 0;
+  uint32_t err = 0;
+  LOGP(debug, "single data raw:{:08x} idx: addr : {:08x} data : {:08x}", data[idx], idx, registeraddr, registerdata);
+  ++idx;
+  if (registeraddr != 0x1FFF) {
+    if (header & 0x02) { // check if > 16 bits
+      data_hi = data[idx];
+      LOGP(debug, "read {:08x} for data > 16 bits", data_hi);
+      ++idx;
+      err += ((data_hi ^ (registerdata | 1)) & 0xFFFF) != 0;
+      registerdata = (data_hi & 0xFFFF0000) | registerdata;
+    }
+    auto badreg = checkRegister(registeraddr, registerdata);
+    if (badreg == true) {
+      fastforward = true;
+      return false;
+    }
+    if (mCurrentMCMID < o2::trd::constants::MAXMCMCOUNT && mRegistersReadForCurrentMCM - 1 < TrapConfigEvent::kLastReg) {
+      LOGP(debug, "Adding single register {:08x} [{:08x}] name: {} for mcm {}, mCurrentRegisterWordsCount {} mRegistersReadForCurrentMCM:{} regindex {} with badreg:{}", registeraddr, registerdata, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), mCurrentMCMID, mCurrentRegisterWordsCount, mRegistersReadForCurrentMCM, idx, badreg);
+      // update frequency map:
+      if (mRegistersReadForCurrentMCM > 0) {
+        mTrapConfigEvent.get()->setRegisterValueByIdx(registerdata, mRegistersReadForCurrentMCM - 1, mCurrentMCMID);
+        //mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
+        auto regdata = registerdata;       // mTrapConfigEventSlot.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mCurrentMCMID);
+        auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
+        if (regdata > regmax) {
+          LOGP(warn, "assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
+        } else {
+          mTrapRegistersFrequencyMap[mRegistersReadForCurrentMCM - 1][regdata]++;
+          mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
+        }
+        mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1] = regdata;
+        // TODO this is not saving it to the CCDBConfig at all !
+        //   if(mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM-1) == "ADCMSK"){
+        //   LOGP(debug,"** just added {:08x} data to _ADCMSK for mCurrentMCMID {}",registerdata,mCurrentMCMID);
+        //   }
+      }
+      mRegisterCount[mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr)]++; // keep a count of seen and accepted registers
+      if (mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID) < 2) {
+        // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
+        mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,1);
+      }
+    }
+    if (idx >= end && data[idx] != constants::CONFIGEVNETBLOCKENDMARKER) {
+      LOGP(error, "(single-write): no more data, missing end marker Config leaving parsing due to no more data at line {}", __LINE__);
+      return false;
+    }
+
+  } else {
+    LOGP(warn, "Config while parsing leaving parsing due to 1fff as addr");
+    return err;
+  }
+
+  return true;
+}
+
+int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward)
+{
+  uint32_t step = 0, bwidth = 0, nwords = 0, err = 0, exit_flag = 0;
+  uint32_t registeraddr;
+  uint32_t registerdata;
+  uint32_t msk = 0;
+  int32_t bitcnt = 0;
+  unpackBlockHeader(header, registerdata, step, bwidth, nwords, registeraddr, exit_flag);
+  LOGP(debug, "unpacked, registeraddr:{:08x} step : {} bwidth {} nwords {} exit_flag {} registerdata {}", registeraddr, step, bwidth, nwords, exit_flag, registerdata);
+  if (mTrapConfigEvent.get()->isValidAddress(registeraddr)) {
+    auto trapregindex = mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr);
+    if (bwidth != mTrapConfigEvent.get()->getRegisterNBits(trapregindex)) {
+      // check that the bit width matches what it should be
+      //  something is corrupt. What we read does not match what we expect.
+      //  log to info for now until figured out. TODO take out info
+      LOGP(warn, " probably corrupt data : bwidth of {} does not match expected bandwidth of {} for reg {} registeraddr of : {:08x} registerindex : {}", bwidth, mTrapConfigEvent.get()->getRegisterNBits(trapregindex), mTrapConfigEvent.get()->getRegisterName(trapregindex), registeraddr, trapregindex);
+      // TODO bail out but how far ? just mcm or whole link?
+    }
+  } else {
+    LOGP(warn, "trapreg address {:08x} is not valid", registeraddr);
+  }
+  if (exit_flag) {
+    LOGP(warn, "Exit flag found.");
+    fastforward = true;
+    return err;
+  }
+  if (bwidth == 31 || (bwidth > 4 && bwidth < 8) || bwidth == 10 || bwidth == 15) {
+    // TODO the part after 31 is probably not required given the above if statement of bwidth, when its out mechanism is figured out.
+    //  only possible values for blocks of registers is 5, 6, 7, 10, 15, and 31
+    msk = (1 << bwidth) - 1;
+    bitcnt = 0;
+    while (nwords > 0) {
+      LOGP(debug, "bwidth {}: read {:08x}  ", bwidth, data[idx]);
+      if (bwidth == 31)
+        ++idx;
+      --nwords;
+      bitcnt -= bwidth;
+      err += (data[idx] & 1);
+      LOGP(debug, "bitcnt {}: err: {:08x}  ", bitcnt, err);
+      if (bwidth != 31 && bitcnt < 0) { // handle the settings for when there are multiple registers packed into 1 word
+        LOGP(debug, "block next data [{}] {:08x} at line {} nwords {}", idx, data[idx], __LINE__, nwords);
+        header = data[idx];
+        idx++;
+        err += (header & 1);
+        header = header >> 1;
+        bitcnt = 31 - bwidth;
+        registerdata = header & (1 << bwidth) - 1;
+        LOGP(debug, "block next data registerdata : {:08x} header: {} bwidth {} at line {} nwords {}", registerdata, header, bwidth, idx, data[idx], __LINE__, nwords);
+      }
+      auto badreg = checkRegister(registeraddr, registerdata);
+      if (badreg == true) {
+        fastforward = true;
+        continue;
+      }
+      if (mCurrentMCMID < o2::trd::constants::MAXMCMCOUNT && mRegistersReadForCurrentMCM < TrapConfigEvent::kLastReg) {
+        LOGP(debug, "Adding block register {:09x} [{:08x}] name: {}  for mcm {} mCurrentRegisterWordsCount {} mRegistersReadForCurrentMCM {} regindex {} header {:08x} with badreg:{}", registeraddr, registerdata, mTrapConfigEvent.get()->getRegNameByAddr(registeraddr), mCurrentMCMID, mCurrentRegisterWordsCount, mRegistersReadForCurrentMCM, idx, header, badreg);
+        if (mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM] != registerdata) {
+          if (mRegistersReadForCurrentMCM > 0) {
+            mTrapConfigEvent.get()->setRegisterValueByIdx(registerdata, mRegistersReadForCurrentMCM - 1, mCurrentMCMID);
+            //mMCMCurrentEvent[mCurrentMCMID]++; // registers seen for this mcm
+            auto regdata = registerdata;       // mTrapConfigEventSlot.get()->getRegisterValueByIdx(mRegistersReadForCurrentMCM-1,mcmid);
+            auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
+            if (regdata > regmax) {
+              LOGP(warn, "{} assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", __LINE__, regdata, regmax, mTrapConfigEvent.get()->getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
+            } else {
+              mTrapRegistersFrequencyMap[mRegistersReadForCurrentMCM - 1][regdata]++;
+              mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1][regdata]++;                         // count of different value in the registers for a mcm,register used to find probably value.
+              mTrapValueFrequencyMap[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1].insert(std::make_pair(regdata, 1)); // count of different value in the registers for a mcm,register used to find probably value.
+              mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM - 1] = registerdata;
+            }
+            mTrapConfigEventSlot->setRegisterSeen(mCurrentMCMID,1);
+          }
+        } else {
+          LOGP(debug, "if statement failed for currentmcmregister {:08x}  registerdata {:08x}", mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM], registerdata);
+        }
+
+        mRegisterCount[mTrapConfigEvent.get()->getRegIndexByAddr(registeraddr)]++; // keep a count of seen and accepted registers
+        // if( mTrapRegisters[].CanIgnore()==false){
+        //   mMcMDataHasChanged[mRegistersReadForCurrentMCM]=true;
+        // }
+        if (mTrapConfigEventSlot->getMCMParsingStatus(mCurrentMCMID) < 2) {
+          // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
+          mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,1);
+        }
+      } else {
+        LOGP(warn, "if (mCurrentMCMRegisters[mCurrentMCMID * kLastReg + mRegistersReadForCurrentMCM] != registerdata mCurrentMCMID:{} kLastReg:{} mRegistersReadForCurrentMCM:{} mCurrentMCMRegisters[mCurrentMCMID*kLastReg+mRegistersReadForCurrentMCM]=={} != {}", mCurrentMCMID, TrapConfigEvent::kLastReg, mRegistersReadForCurrentMCM, mCurrentMCMRegisters[mCurrentMCMID * TrapConfigEvent::kLastReg + mRegistersReadForCurrentMCM], registerdata);
+      }
+      registeraddr += step;
+      header = header >> bwidth; // this is not used for the bwidth=31 case
+      if (idx >= end) {
+        LOGP(error, "no end markermore data, {} words read Config parsing getting out due to end of data at line : {}", idx, __LINE__);
+        return false;
+      }
+    }
+  } else {
+    // must be corrupt data header.
+    LOGP(warn, "Unknown bwidth from block header of {}", bwidth);
+  }
+  if (data[idx] != constants::CONFIGEVNETBLOCKENDMARKER) {
+    LOGP(debug, "increment idx to {} due trailer of block data data[{}]={:08x} to data[{}]={:08x}", idx + 1, idx, data[idx], idx + 1, data[idx + 1]);
+    ++idx; // jump over the block trailer
+  }
+  if (data[idx + 1] == constants::CONFIGEVNETBLOCKENDMARKER || data[idx] == 0x00007fff) {
+    LOGP(debug, "end of block ignoring bogus : {:08x}?", data[idx]);
+  }
+
+  return idx;
+}
+
+int TrapConfigEventParser::parseLink(std::vector<uint32_t>& data, uint32_t start, uint32_t end)
+{
+  mTrapConfigEvent->HCIDIsPresent(mCurrentHCID);
+  uint32_t step, bwidth, nwords, idx, err, exit_flag;
+  int32_t bitcnt, werr;
+  uint16_t registeraddr;
+  uint32_t registerdata, msk, header, data_hi, rawdat;
+  mOffsetToRegister = 0; // offset of a register into the raw storage area
+  mcmSeen.fill(-1);
+  mcmMCM.fill(-1);
+  mcmROB.fill(-1);
+  mcmSeenMissedRegister.fill(-1);
+  //  for(auto regbit : mcmMissedRegister){ // bitpattern of which registers were seen and not seen for a given mcm.
+  //    regbit.reset(); // set bitset to 0
+  //  }
+  // mcmheader, header, then data
+  idx = 0; // index in the packed configuration
+  err = 0;
+  mLastRegIndex = 0;
+  int previdx = 0;
+  int datalength = data.size();
+
+  int rawidx = 0;
+  mRegisterErrorGap = 0;
+  mCurrentRegisterIndex = 0;
+  mPreviousRegisterIndex = 0;
+  /*uint32_t mCurrentHCID=0;
+  DigitMCMHeader mCurrentMCMHeader;
+  uint32_t mCurrentMCMID=0;
+  uint32_t mCurrentDataIndex=0;
+  uint32_t mLastRegIndex=0;
+  uint32_t mRegistersReadForCurrentMCM = 0;
+  uint32_t mCurrentRegisterWordsCount = 0;
+  uint32_t mPreviousRegisterAddressRead = 0;
+  uint32_t mRegisterErrorGap = 0;*/
+  bool endmarker = false;
+  bool fastforward = false;
+  // for (idx=start;idx<end/2;++idx) {
+  //   LOGP(/*info*/info, " data[{} = {:08x}]", idx, data[idx]);
+  // }
+  idx = start;
+  bool firstfastforward = true;
+  while (idx < end) {
+    LOGP(debug, "************** Raw data : data[{}] = {:08x}", idx, data[idx]);
+    if (fastforward) {
+      LOGP(debug, "** fastforward on data ::  Raw data : data[{}] = {:08x}", idx, data[idx]);
+      // loop until the next digitmcmheader, or end.
+      // search for :
+      //  a : end marker
+      //  b : mcmheader
+      //  c : end of data
+      while (data[idx] && fastforward) {
+        if (firstfastforward) {
+          LOGP(warn, "fastforwaring from idx:{} for mcm {}", idx, mCurrentMCMID);
+          firstfastforward = false;
+        }
+        // read until we find an end marker, ignoring the data coming in so as not to pollute the configs.
+        if (data[idx] == constants::CONFIGEVNETBLOCKENDMARKER) {
+          // LOGP(warn, " end marker found ");
+          ++idx; // go past the end marker with the expectation of a DigitMCMHeader to come next.
+          endmarker = true;
+          fastforward = false;
+          continue;
+        } else {
+          // LOGP(warn, " no end marker found ");
+        }
+        ++idx;
+      }
+      fastforward = false;
+      continue;
+    }
+    if (idx == start || endmarker) {
+      // mcm header
+      mCurrentMCMHeader.word = data[idx];
+      LOGP(debug, "header at data[{}] had : {:06} registers, last register read : {:08x} ({}) and a register gap of {}", idx, mCurrentRegisterWordsCount, mPreviousRegisterAddressRead, mTrapConfigEvent.get()->getRegNameByAddr(mPreviousRegisterAddressRead), mRegisterErrorGap);
+      //printDigitMCMHeader(mCurrentMCMHeader);
+      if (idx != start) {
+        int index = mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm;
+        if (index < constants::NMCMROB * constants::NROBC1) {
+          mcmSeen[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mCurrentRegisterWordsCount; // registers seen for this mcm
+          LOGP(debug, "mcmSeen updated at {}, with value : {} rob {} * 16 + mcm {} ", mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm, mCurrentRegisterWordsCount, (uint32_t)mCurrentMCMHeader.rob, (uint32_t)mCurrentMCMHeader.mcm);
+          mcmSeenMissedRegister[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mRegisterErrorGap; // registers missed for this mcm
+          mcmMCM[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mCurrentMCMHeader.mcm;            // registers seen for this mcm
+          mcmROB[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mCurrentMCMHeader.rob;            // registers seen for this mcm
+        }
+      }
+      mCurrentRegisterWordsCount = 0;                                                                                // count of register words read for this mcm
+      mRegistersReadForCurrentMCM = 0;                                                                               // count of registers read for this mcm
+      mRegisterErrorGap = 0;                                                                                         // reset the count as we are starting a fresh
+      mPreviousRegisterIndex = 0;                                                                                    // register index of the last register read.
+      mCurrentRegisterIndex = 0;                                                                                     // index of the current register
+      mCurrentMCMID = (mCurrentHCID / 2) * 128 + mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm; // current rob is 0-7/0-5 and currentmcm is 0-16.
+      mTrapConfigEventSlot->setMCMParsingStatus(mCurrentMCMID,1);
+      if (data[idx] == 0) {
+        LOGP(warn, "Breaking as a zero after endmarker idx: {} ", idx);
+        LOGP(debug, "header at data[{}] had : {:06} registers, last register read : {:08x} ({}) and a register gap of {}", idx, mCurrentRegisterWordsCount, mPreviousRegisterAddressRead, mTrapConfigEvent.get()->getRegNameByAddr(mPreviousRegisterAddressRead), mRegisterErrorGap);
+        break;
+      }
+      //mcmSeen[mCurrentMCMHeader.rob * 16 + mCurrentMCMHeader.mcm] = 0;
+      endmarker = false;
+      mLastRegIndex = 0;
+      mRegisterBase = mCurrentMCMID * 432;
+      ++idx;
+      continue; // dont parse and go back through the loop
+    }
+    if (data[idx] == constants::CONFIGEVNETBLOCKENDMARKER || (data[idx] == 0x7ffff && data[idx + 1] == constants::CONFIGEVNETBLOCKENDMARKER)) {
+      // end marker next value which should be a header.
+      LOGP(debug, "after end marker Header :  address:{0:08x}  words: {1:08x} width: {2:08x} astep: {3:08x} zero: {4:08x} at idx : {5:0d} gap: {6:0d}", (data[idx + 1] >> 16) & 0xffff, (data[idx + 1] >> 8) & 0xff, (data[idx + 1] >> 3) & 0x1f, (data[idx + 1] >> 1) & 0x3, data[idx + 1] & 0x1, idx, idx - previdx);
+      previdx = idx;
+      endmarker = true;
+      ++idx;
+      if (data[idx] == constants::CONFIGEVNETBLOCKENDMARKER) {
+        ++idx; // handle the second case of the previous if statement.
+      }
+      continue;
+    }
+    header = data[idx];
+    LOGP(debug, "************** Raw data : data[{}] = {:08x}", idx, data[idx]);
+    /*****************
+    SINGLE DATA
+    *****************/
+    if (header & 0x01) { // single data
+      parseSingleData(data, header, idx, end, fastforward);
+    } else {
+      /*****************
+    BLOCK DATA
+    *****************/
+      parseBlockData(data, header, idx, end, fastforward);
+    } // end block case
+  }   // end while
+  // loop over which mcms never sent data.
+  //printMCMRegisterCount(mCurrentHCID);
+  return false; // we only get here if the max length of the block reached!
+}
+
+int TrapConfigEventParser::flushParsingStats()
+{
+  mTrapConfigEventSlot->clearParsingStatus();
+  return 1;
+}
+
+int TrapConfigEventParser::analyseMaps()
+{
+  // loop through the maps of registers and determine, per mcm, per rob, per halfchamber, per chamber, constants.
+  //
+  //std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mTrapRegistersFrequencyMap;
+  if (configcount > 8) {
+    uint oldmcm = 0;
+    for (auto& valuemap : mTrapValueFrequencyMap) {
+      LOGP(debug, "ZZZ1 valuemap.second.size():{} ", valuemap.second.size());
+
+      for (const auto& elem : valuemap.second) {
+        uint64_t mcmidreg = valuemap.first;
+        uint64_t mcmid = mcmidreg / TrapConfigEvent::kLastReg;
+        uint64_t regid = mcmidreg - mcmid * TrapConfigEvent::kLastReg;
+        LOGP(debug, "ZZZ mcm:{} reg:{} mcmidreg:{} mcmid*lastreg:{} value:{} count:{}", mcmid, regid, mcmidreg, mcmid * TrapConfigEvent::kLastReg, elem.first, elem.second);
+      }
+    }
+  }
+  configcount++;
+  return 1;
+}
+
+
+int TrapConfigEventParser::analyseMcmSeen()
+{
+  // loop through the maps of registers and determine, per mcm, per rob, per halfchamber, per chamber, constants.
+  //
+  //
+  //std::array<uint64_t,32> mcmpresentcount{0};
+  /* std::array<std::map<uint32_t, uint32_t>, TrapConfigEvent::kLastReg> mMcmMaps;
+  for(auto& mcmcount : mMCMCurrentEvent){
+    LOGP(info,"###mcmcount of {} ", mcmcount);
+    auto idx=mcmcount;
+    mMcmMaps[idx][mcmcount]++;
+  }
+  for (auto& mcmmap : mMcmMaps) {
+    for (const auto& elem : mcmmap) {
+      LOGP(info, "[{:08x}] = {}", elem.first, elem.second);
+    }
+  }
+  int regcount=0;
+  for (auto& regmap : mTrapRegistersFrequencyMap) {
+    for (const auto& elem : regmap) {
+      LOGP(debug, "[{:08x}] = {}", elem.first, elem.second);
+    }
+    regcount++;
+  }
+*/
+  return 1;
+}
+
+bool TrapConfigEventParser::isNewConfig()
+{
+  //  if(mCCDBTrapConfigEvent == mTrapConfigEventSlot) return true;
+  return false;
+}
+
+void TrapConfigEventParser::sendTrapConfigEvent(framework::ProcessingContext& pc)
+{
+  LOGP(info, "About to send message with first value of copied trapconfigevent A is tpl00 : {}", mTrapConfigEvent.get()->getRegisterValue(0, 31361));
+  pc.outputs().snapshot(framework::Output{o2::header::gDataOriginTRD, "TRDCFG", 0, framework::Lifetime::Condition}, *mTrapConfigEvent.get());
+}

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -25,8 +25,8 @@
 #include <gsl/span>
 
 #include "TRDBase/FeeParam.h"
-#include "TRDSimulation/TrapConfig.h"
 
+#include "DataFormatsTRD/TrapConfigEvent.h"
 #include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/RawData.h"
@@ -107,7 +107,7 @@ class TrapSimulator
   ~TrapSimulator() = default;
 
   // Initialize MCM by the position parameters
-  void init(TrapConfig* trapconfig, int det, int rob, int mcm);
+  void init(TrapConfigEvent* trapconfig, int det, int rob, int mcm);
 
   bool checkInitialized() const { return mInitialized; }
 
@@ -138,7 +138,7 @@ class TrapSimulator
   int getDetector() const { return mDetector; }; // Returns Chamber ID (0-539)
   int getRobPos() const { return mRobPos; };     // Returns ROB position (0-7)
   int getMcmPos() const { return mMcmPos; };     // Returns MCM position (0-17) (16,17 are mergers)
-  int getNumberOfTimeBins() const { return mNTimeBin; }; // Set via TrapConfig, but should be the same as o2::trd::constants::TIMEBINS
+  int getNumberOfTimeBins() const { return mNTimeBin; }; // Set via TrapConfigEvent, but should be the same as o2::trd::constants::TIMEBINS
 
   // transform Tracklet64 data into raw data format (up to 4 32-bit words)
   // FIXME offset is not used, should it be removed?
@@ -189,12 +189,11 @@ class TrapSimulator
   // I/O
   void printFitRegXml(std::ostream& os) const;
   void printTrackletsXml(std::ostream& os) const;
-  void printAdcDatTxt(std::ostream& os) const;
   void printAdcDatHuman(std::ostream& os) const;
   void printAdcDatXml(std::ostream& os) const;
   void printAdcDatDatx(std::ostream& os, bool broadcast = kFALSE, int timeBinOffset = -1) const;
 
-  static bool readPackedConfig(TrapConfig* cfg, int hc, unsigned int* data, int size);
+  static bool readPackedConfig(TrapConfigEvent* cfg, int hc, unsigned int* data, int size);
 
   // DMEM addresses
   static constexpr int mgkDmemAddrLUTcor0 = 0xC02A;
@@ -214,7 +213,7 @@ class TrapSimulator
   static constexpr int mgkDmemAddrDeflCutEnd = 0xc055;   // DMEM end address of deflection cut
   static constexpr int mgkDmemAddrTimeOffset = 0xc3fe;   // DMEM address of time offset t0
   static constexpr int mgkDmemAddrYcorr = 0xc3ff;        // DMEM address of y correction (mis-alignment)
-  static constexpr int mQ2Startbin = 3;              // Start range of Q2, for now here. TODO pull from a revised TrapConfig?
+  static constexpr int mQ2Startbin = 3;                  // Start range of Q2, for now here. TODO pull from a revised TrapConfigEvent?
   static constexpr int mQ2Endbin = 5;                // End range of Q2, also pull from a revised trapconfig at some point.
 
   static const int mgkFormatIndex;   // index for format settings in stream
@@ -275,7 +274,7 @@ class TrapSimulator
 
   // Parameter classes
   FeeParam* mFeeParam{FeeParam::instance()}; // FEE parameters, a singleton
-  TrapConfig* mTrapConfig{nullptr};          // TRAP config
+  TrapConfigEvent* mTrapConfigEvent{nullptr}; // TRAP config
 
   // Sort functions as in TRAP
   void sort2(uint16_t idx1i, uint16_t idx2i, uint16_t val1i, uint16_t val2i,

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -18,11 +18,6 @@
 #pragma link C++ class o2::trd::Detector + ;
 #pragma link C++ class o2::base::DetImpl < o2::trd::Detector> + ;
 #pragma link C++ class o2::trd::TRsim + ;
-#pragma link C++ class o2::trd::TrapConfigHandler + ;
-#pragma link C++ class o2::trd::TrapConfig + ;
-#pragma link C++ class o2::trd::TrapConfig::TrapValue + ;
-#pragma link C++ class o2::trd::TrapConfig::TrapDmemWord + ;
-#pragma link C++ class o2::trd::TrapConfig::TrapRegister + ;
 #pragma link C++ class o2::trd::TrapSimulator + ;
 // dictionaries for the internal classes of TrapSimulator are needed for the debug output
 #pragma link C++ class o2::trd::TrapSimulator::FitReg + ;
@@ -30,6 +25,8 @@
 #pragma link C++ class o2::trd::Trap2CRU + ;
 #pragma link C++ class o2::trd::SimParam + ;
 #pragma link C++ class o2::trd::TRDSimParams + ;
+#pragma link C++ class o2::trd::TrapConfig + ;
+#pragma link C++ class o2::trd::TrapConfigHandler + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDSimParams> + ;
 
 #endif

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -20,7 +20,7 @@
 
 #include "TRDSimulation/SimParam.h"
 #include "TRDBase/CalOnlineGainTables.h"
-#include "TRDSimulation/TrapConfigHandler.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
 #include "TRDSimulation/TrapSimulator.h"
 #include "fairlogger/Logger.h"
 #include "DataFormatsTRD/Digit.h"
@@ -44,7 +44,7 @@ using namespace o2::trd::constants;
 const int TrapSimulator::mgkFormatIndex = std::ios_base::xalloc();
 const std::array<unsigned short, 4> TrapSimulator::mgkFPshifts{11, 14, 17, 21};
 
-void TrapSimulator::init(TrapConfig* trapconfig, int det, int robPos, int mcmPos)
+void TrapSimulator::init(TrapConfigEvent* trapconfig, int det, int robPos, int mcmPos)
 {
   //
   // Initialize the class with new MCM position information
@@ -64,8 +64,8 @@ void TrapSimulator::init(TrapConfig* trapconfig, int det, int robPos, int mcmPos
   mTrkltWordEmpty = (format << Tracklet64::formatbs) | (hcid << Tracklet64::hcidbs) | (row << Tracklet64::padrowbs) | (column << Tracklet64::colbs);
 
   if (!mInitialized) {
-    mTrapConfig = trapconfig;
-    mNTimeBin = mTrapConfig->getTrapReg(TrapConfig::kC13CPUA, mDetector, mRobPos, mMcmPos);
+    mTrapConfigEvent = trapconfig;
+    mNTimeBin = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kC13CPUA, mDetector, mRobPos, mMcmPos);
     mZSMap.resize(NADCMCM);
     mADCR.resize(mNTimeBin * NADCMCM);
     mADCF.resize(mNTimeBin * NADCMCM);
@@ -314,20 +314,6 @@ void TrapSimulator::printTrackletsXml(ostream& os) const
   os << "</nginject>" << std::endl;
 }
 
-void TrapSimulator::printAdcDatTxt(ostream& os) const
-{
-  // print ADC data in text format (suitable as Modelsim stimuli)
-
-  os << "# MCM " << mMcmPos << " on ROB " << mRobPos << " in detector " << mDetector << std::endl;
-
-  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-    for (int iChannel = 0; iChannel < NADCMCM; ++iChannel) {
-      os << std::setw(5) << (getDataRaw(iChannel, iTimeBin) >> mgkAddDigits);
-    }
-    os << std::endl;
-  }
-}
-
 void TrapSimulator::printAdcDatHuman(ostream& os) const
 {
   // print ADC data in human-readable format
@@ -393,37 +379,6 @@ void TrapSimulator::printAdcDatXml(ostream& os) const
   os << "</nginject>" << std::endl;
 }
 
-void TrapSimulator::printAdcDatDatx(ostream& os, bool broadcast, int timeBinOffset) const
-{
-  // print ADC data in datx format (to send to FEE)
-
-  mTrapConfig->printDatx(os, 2602, 1, 0, 127); // command to enable the ADC clock - necessary to write ADC values to MCM
-  os << std::endl;
-
-  int addrOffset = 0x2000;
-  int addrStep = 0x80;
-  int addrOffsetEBSIA = 0x20;
-
-  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-    for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
-      if ((iTimeBin < timeBinOffset) || (iTimeBin >= mNTimeBin + timeBinOffset)) {
-        if (broadcast == false) {
-          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, 10, getRobPos(), getMcmPos());
-        } else {
-          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, 10, 0, 127);
-        }
-      } else {
-        if (broadcast == false) {
-          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, (getDataFiltered(iChannel, iTimeBin - timeBinOffset) / 4), getRobPos(), getMcmPos());
-        } else {
-          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, (getDataFiltered(iChannel, iTimeBin - timeBinOffset) / 4), 0, 127);
-        }
-      }
-    }
-    os << std::endl;
-  }
-}
-
 void TrapSimulator::noiseTest(int nsamples, int mean, int sigma, int inputGain, int inputTail)
 {
   // This function can be used to test the filters.
@@ -436,7 +391,7 @@ void TrapSimulator::noiseTest(int nsamples, int mean, int sigma, int inputGain, 
   // 1: pedestal output
   // 2: gain output
   // The input has to be chosen from a stage before.
-  // The filter behaviour is controlled by the TRAP parameters from TrapConfig in the
+  // The filter behaviour is controlled by the TRAP parameters from TrapConfigEvent in the
   // same way as in normal simulation.
   // The functions produces four histograms with the values at the different stages.
 
@@ -630,11 +585,11 @@ void TrapSimulator::draw(int choice, int index)
     for (int iTrkl = 0; iTrkl < mTrackletArray64.size(); iTrkl++) {
       Tracklet64 trkl = mTrackletArray64[iTrkl];
       float position = trkl.getPosition();
-      int ndrift = mTrapConfig->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos) >> 5;
+      int ndrift = mTrapConfigEvent->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos) >> 5;
       float slope = trkl.getSlope();
 
-      int t0 = mTrapConfig->getTrapReg(TrapConfig::kTPFS, mDetector, mRobPos, mMcmPos);
-      int t1 = mTrapConfig->getTrapReg(TrapConfig::kTPFE, mDetector, mRobPos, mMcmPos);
+      int t0 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFS, mDetector, mRobPos, mMcmPos);
+      int t1 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFE, mDetector, mRobPos, mMcmPos);
 
       trklLines[iTrkl].SetX1(position - slope * t0);
       trklLines[iTrkl].SetY1(t0);
@@ -644,7 +599,7 @@ void TrapSimulator::draw(int choice, int index)
       trklLines[iTrkl].SetLineWidth(2);
       LOG(debug) << "Tracklet " << iTrkl << ": y = " << trkl.getPosition() << ", slope = " << (float)trkl.getSlope() << "for a det:rob:mcm combo of : " << mDetector << ":" << mRobPos << ":" << mMcmPos;
       LOG(debug) << "Tracklet " << iTrkl << ": x1,y1,x2,y2 :: " << trklLines[iTrkl].GetX1() << "," << trklLines[iTrkl].GetY1() << "," << trklLines[iTrkl].GetX2() << "," << trklLines[iTrkl].GetY2();
-      LOG(debug) << "Tracklet " << iTrkl << ": t0 : " << t0 << ", t1 " << t1 << ", slope:" << slope << ",  which comes from : " << mTrapConfig->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos) << " shifted 5 to the right ";
+      LOG(debug) << "Tracklet " << iTrkl << ": t0 : " << t0 << ", t1 " << t1 << ", slope:" << slope << ",  which comes from : " << mTrapConfigEvent->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos) << " shifted 5 to the right ";
       trklLines[iTrkl].Draw();
     }
     LOG(debug) << "Tracklet end ...";
@@ -696,8 +651,8 @@ void TrapSimulator::setBaselines()
     if ((mADCFilled & (1 << adc)) == 0) { // adc is empty by construction of mADCFilled.
       for (int timebin = 0; timebin < mNTimeBin; timebin++) {
         // kFPNP = 32 = 8 << 2 (pedestal correction additive) and kTPFP = 40 = 10 << 2 (filtered pedestal)
-        mADCR[adc * mNTimeBin + timebin] = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos); // OS: not using FPNP here, since in filter() the ADC values from the 'raw' array will be copied into the filtered array
-        mADCF[adc * mNTimeBin + timebin] = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos);
+        mADCR[adc * mNTimeBin + timebin] = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFP, mDetector, mRobPos, mMcmPos); // OS: not using FPNP here, since in filter() the ADC values from the 'raw' array will be copied into the filtered array
+        mADCF[adc * mNTimeBin + timebin] = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFP, mDetector, mRobPos, mMcmPos);
       }
     }
   }
@@ -718,8 +673,8 @@ void TrapSimulator::setDataPedestal(int adc)
   }
 
   for (int it = 0; it < mNTimeBin; it++) {
-    mADCR[adc * mNTimeBin + it] = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos);
-    mADCF[adc * mNTimeBin + it] = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos);
+    mADCR[adc * mNTimeBin + it] = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFPNP, mDetector, mRobPos, mMcmPos);
+    mADCF[adc * mNTimeBin + it] = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFP, mDetector, mRobPos, mMcmPos);
   }
 }
 
@@ -814,7 +769,7 @@ void TrapSimulator::filter()
 {
   //
   // Filter the raw ADC values. The active filter stages and their
-  // parameters are taken from TrapConfig.
+  // parameters are taken from TrapConfigEvent.
   // The raw data is stored separate from the filtered data. Thus,
   // it is possible to run the filters on a set of raw values
   // sequentially for parameter tuning.
@@ -845,7 +800,7 @@ void TrapSimulator::filterPedestalInit(int baseline)
   // been constant for a long time (compared to the time constant).
   //  LOG(debug) << "BEGIN: " << __FILE__ << ":" << __func__ << ":" << __LINE__ ;
 
-  unsigned short fptc = mTrapConfig->getTrapReg(TrapConfig::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
+  unsigned short fptc = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
 
   for (int adc = 0; adc < NADCMCM; adc++) {
     mInternalFilterRegisters[adc].mPedAcc = (baseline << 2) * (1 << mgkFPshifts[fptc]);
@@ -860,9 +815,9 @@ unsigned short TrapSimulator::filterPedestalNextSample(int adc, int timebin, uns
   // history of the filter.
   LOG(debug) << "BEGIN: " << __FILE__ << ":" << __func__ << ":" << __LINE__;
 
-  unsigned short fpnp = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos); // 0..511 -> 0..127.75, pedestal at the output
-  unsigned short fptc = mTrapConfig->getTrapReg(TrapConfig::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
-  unsigned short fpby = mTrapConfig->getTrapReg(TrapConfig::kFPBY, mDetector, mRobPos, mMcmPos); // 0..1 bypass, active low
+  unsigned short fpnp = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFPNP, mDetector, mRobPos, mMcmPos); // 0..511 -> 0..127.75, pedestal at the output
+  unsigned short fptc = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
+  unsigned short fpby = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFPBY, mDetector, mRobPos, mMcmPos); // 0..1 bypass, active low
 
   unsigned short accumulatorShifted;
   unsigned short inpAdd;
@@ -938,11 +893,11 @@ unsigned short TrapSimulator::filterGainNextSample(int adc, unsigned short value
   // history of the filter.
   //  if(mDetector==75&& mRobPos==5 && mMcmPos==15) LOG(debug) << "ENTER: " << __FILE__ << ":" << __func__ << ":" << __LINE__ << " with adc = " << adc << " value = " << value;
 
-  unsigned short mgby = mTrapConfig->getTrapReg(TrapConfig::kFGBY, mDetector, mRobPos, mMcmPos);                             // bypass, active low
-  unsigned short mgf = mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGF0 + adc), mDetector, mRobPos, mMcmPos); // 0x700 + (0 & 0x1ff);
-  unsigned short mga = mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGA0 + adc), mDetector, mRobPos, mMcmPos); // 40;
-  unsigned short mgta = mTrapConfig->getTrapReg(TrapConfig::kFGTA, mDetector, mRobPos, mMcmPos);                             // 20;
-  unsigned short mgtb = mTrapConfig->getTrapReg(TrapConfig::kFGTB, mDetector, mRobPos, mMcmPos);                             // 2060;
+  unsigned short mgby = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGBY, mDetector, mRobPos, mMcmPos);      // bypass, active low
+  unsigned short mgf = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGF0 + adc, mDetector, mRobPos, mMcmPos); // 0x700 + (0 & 0x1ff);
+  unsigned short mga = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGA0 + adc, mDetector, mRobPos, mMcmPos); // 40;
+  unsigned short mgta = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGTA, mDetector, mRobPos, mMcmPos);      // 20;
+  unsigned short mgtb = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGTB, mDetector, mRobPos, mMcmPos);      // 2060;
   //  mgf=256;
   //  mga=8;
   //  mgta=20;
@@ -1000,9 +955,9 @@ void TrapSimulator::filterTailInit(int baseline)
   // sufficiently long time.
 
   // exponents and weight calculated from configuration
-  unsigned short alphaLong = 0x3ff & mTrapConfig->getTrapReg(TrapConfig::kFTAL, mDetector, mRobPos, mMcmPos);                            // the weight of the long component
-  unsigned short lambdaLong = (1 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLL, mDetector, mRobPos, mMcmPos) & 0x1FF);  // the multiplier
-  unsigned short lambdaShort = (0 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLS, mDetector, mRobPos, mMcmPos) & 0x1FF); // the multiplier
+  unsigned short alphaLong = 0x3ff & mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTAL, mDetector, mRobPos, mMcmPos);                            // the weight of the long component
+  unsigned short lambdaLong = (1 << 10) | (1 << 9) | (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTLL, mDetector, mRobPos, mMcmPos) & 0x1FF);  // the multiplier
+  unsigned short lambdaShort = (0 << 10) | (1 << 9) | (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTLS, mDetector, mRobPos, mMcmPos) & 0x1FF); // the multiplier
 
   float lambdaL = lambdaLong * 1.0 / (1 << 11);
   float lambdaS = lambdaShort * 1.0 / (1 << 11);
@@ -1015,7 +970,7 @@ void TrapSimulator::filterTailInit(int baseline)
   float ql, qs;
 
   if (baseline < 0) {
-    baseline = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos);
+    baseline = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFPNP, mDetector, mRobPos, mMcmPos);
   }
 
   ql = lambdaL * (1 - lambdaS) * alphaL;
@@ -1023,9 +978,9 @@ void TrapSimulator::filterTailInit(int baseline)
 
   for (int adc = 0; adc < NADCMCM; adc++) {
     int value = baseline & 0xFFF;
-    int corr = (value * mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGF0 + adc), mDetector, mRobPos, mMcmPos)) >> 11;
+    int corr = (value * mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGF0 + adc, mDetector, mRobPos, mMcmPos)) >> 11;
     corr = corr > 0xfff ? 0xfff : corr;
-    corr = addUintClipping(corr, mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGA0 + adc), mDetector, mRobPos, mMcmPos), 12);
+    corr = addUintClipping(corr, mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFGA0 + adc, mDetector, mRobPos, mMcmPos), 12);
 
     float kt = kdc * baseline;
     unsigned short aout = baseline - (unsigned short)kt;
@@ -1042,9 +997,9 @@ unsigned short TrapSimulator::filterTailNextSample(int adc, unsigned short value
   // history of the filter.
 
   // exponents and weight calculated from configuration
-  unsigned short alphaLong = 0x3ff & mTrapConfig->getTrapReg(TrapConfig::kFTAL, mDetector, mRobPos, mMcmPos);                            // the weight of the long component
-  unsigned short lambdaLong = (1 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLL, mDetector, mRobPos, mMcmPos) & 0x1FF);  // the multiplier of the long component
-  unsigned short lambdaShort = (0 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLS, mDetector, mRobPos, mMcmPos) & 0x1FF); // the multiplier of the short component
+  unsigned short alphaLong = 0x3ff & mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTAL, mDetector, mRobPos, mMcmPos);                            // the weight of the long component
+  unsigned short lambdaLong = (1 << 10) | (1 << 9) | (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTLL, mDetector, mRobPos, mMcmPos) & 0x1FF);  // the multiplier of the long component
+  unsigned short lambdaShort = (0 << 10) | (1 << 9) | (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTLS, mDetector, mRobPos, mMcmPos) & 0x1FF); // the multiplier of the short component
 
   // intermediate signals
   unsigned int aDiff;
@@ -1078,7 +1033,7 @@ unsigned short TrapSimulator::filterTailNextSample(int adc, unsigned short value
   mInternalFilterRegisters[adc].mTailAmplShort = tmp & 0xFFF;
 
   // the output of the filter
-  if (mTrapConfig->getTrapReg(TrapConfig::kFTBY, mDetector, mRobPos, mMcmPos) == 0) { // bypass mode, active low
+  if (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kFTBY, mDetector, mRobPos, mMcmPos) == 0) { // bypass mode, active low
     return value;
   } else {
     return aDiff;
@@ -1110,10 +1065,10 @@ void TrapSimulator::zeroSupressionMapping()
     return;
   }
 
-  int eBIS = mTrapConfig->getTrapReg(TrapConfig::kEBIS, mDetector, mRobPos, mMcmPos);
-  int eBIT = mTrapConfig->getTrapReg(TrapConfig::kEBIT, mDetector, mRobPos, mMcmPos);
-  int eBIL = mTrapConfig->getTrapReg(TrapConfig::kEBIL, mDetector, mRobPos, mMcmPos);
-  int eBIN = mTrapConfig->getTrapReg(TrapConfig::kEBIN, mDetector, mRobPos, mMcmPos);
+  int eBIS = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kEBIS, mDetector, mRobPos, mMcmPos);
+  int eBIT = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kEBIT, mDetector, mRobPos, mMcmPos);
+  int eBIL = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kEBIL, mDetector, mRobPos, mMcmPos);
+  int eBIN = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kEBIN, mDetector, mRobPos, mMcmPos);
 
   for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
     mZSMap[iAdc] = -1;
@@ -1191,13 +1146,13 @@ void TrapSimulator::addHitToFitreg(int adc, unsigned short timebin, unsigned sho
   // In addition to the fit sums in the fit register
   //
   /*
-    if ((timebin >= mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos)) &&
-        (timebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos))) {
+    if ((timebin >= mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQS0, mDetector, mRobPos, mMcmPos)) &&
+        (timebin < mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQE0, mDetector, mRobPos, mMcmPos))) {
       mFitReg[adc].q0 += qtot;
     }
 
-    if ((timebin >= mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos)) &&
-        (timebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos))) {
+    if ((timebin >= mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQS1, mDetector, mRobPos, mMcmPos)) &&
+        (timebin < mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQE1, mDetector, mRobPos, mMcmPos))) {
       mFitReg[adc].q1 += qtot;
     }
   */
@@ -1231,21 +1186,21 @@ void TrapSimulator::calcFitreg()
   //??? to be clarified:
 
   // find first timebin to be looked at
-  unsigned short timebin1 = mTrapConfig->getTrapReg(TrapConfig::kTPFS, mDetector, mRobPos, mMcmPos);
-  if (mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos) < timebin1) {
-    timebin1 = mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos);
+  unsigned short timebin1 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFS, mDetector, mRobPos, mMcmPos);
+  if (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQS0, mDetector, mRobPos, mMcmPos) < timebin1) {
+    timebin1 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQS0, mDetector, mRobPos, mMcmPos);
   }
-  if (mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos) < timebin1) {
-    timebin1 = mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos);
+  if (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQS1, mDetector, mRobPos, mMcmPos) < timebin1) {
+    timebin1 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQS1, mDetector, mRobPos, mMcmPos);
   }
 
   // find last timebin to be looked at
-  unsigned short timebin2 = mTrapConfig->getTrapReg(TrapConfig::kTPFE, mDetector, mRobPos, mMcmPos);
-  if (mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos) > timebin2) {
-    timebin2 = mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos);
+  unsigned short timebin2 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFE, mDetector, mRobPos, mMcmPos);
+  if (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQE0, mDetector, mRobPos, mMcmPos) > timebin2) {
+    timebin2 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQE0, mDetector, mRobPos, mMcmPos);
   }
-  if (mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos) > timebin2) {
-    timebin2 = mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos);
+  if (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQE1, mDetector, mRobPos, mMcmPos) > timebin2) {
+    timebin2 = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPQE1, mDetector, mRobPos, mMcmPos);
   }
 
   // FIXME: overwrite fit start with values as in Venelin's simulation:
@@ -1267,16 +1222,16 @@ void TrapSimulator::calcFitreg()
       adcCentral = mADCF[(adcch + 1) * mNTimeBin + timebin];
       adcRight = mADCF[(adcch + 2) * mNTimeBin + timebin];
       bool hitQual = false;
-      if (mTrapConfig->getTrapReg(TrapConfig::kTPVBY, mDetector, mRobPos, mMcmPos) == 0) {
+      if (mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPVBY, mDetector, mRobPos, mMcmPos) == 0) {
         // bypass the cluster verification
         hitQual = true;
       } else {
         hitQual = ((adcLeft * adcRight) <
-                   ((mTrapConfig->getTrapReg(TrapConfig::kTPVT, mDetector, mRobPos, mMcmPos) * adcCentral * adcCentral) >> 10));
+                   ((mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPVT, mDetector, mRobPos, mMcmPos) * adcCentral * adcCentral) >> 10));
         if (hitQual) {
           LOG(debug) << "cluster quality cut passed with " << adcLeft << ", " << adcCentral << ", "
-                     << adcRight << " - threshold " << mTrapConfig->getTrapReg(TrapConfig::kTPVT, mDetector, mRobPos, mMcmPos)
-                     << " -> " << mTrapConfig->getTrapReg(TrapConfig::kTPVT, mDetector, mRobPos, mMcmPos) * adcCentral * adcCentral;
+                     << adcRight << " - threshold " << mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPVT, mDetector, mRobPos, mMcmPos)
+                     << " -> " << mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPVT, mDetector, mRobPos, mMcmPos) * adcCentral * adcCentral;
         }
       }
 
@@ -1284,7 +1239,7 @@ void TrapSimulator::calcFitreg()
       int qtotTemp = adcLeft + adcCentral + adcRight;
 
       if ((hitQual) &&
-          (qtotTemp >= mTrapConfig->getTrapReg(TrapConfig::kTPHT, mDetector, mRobPos, mMcmPos)) &&
+          (qtotTemp >= mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPHT, mDetector, mRobPos, mMcmPos)) &&
           (adcLeft <= adcCentral) &&
           (adcCentral > adcRight)) {
         qTotal[adcch] = qtotTemp;
@@ -1373,10 +1328,10 @@ void TrapSimulator::calcFitreg()
         //  hit detected, in TRAP we have 4 units and a hit-selection, here we proceed all channels!
         //  subtract the pedestal TPFP, clipping instead of wrapping
 
-        int regTPFP = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos); //TODO put this together with the others as members of trapsim, which is initiliased by det,rob,mcm.
+        int regTPFP = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFP, mDetector, mRobPos, mMcmPos); //TODO put this together with the others as members of trapsim, which is initiliased by det,rob,mcm.
         LOG(debug) << "Hit found, time=" << timebin << ", adcch=" << adcch << "/" << adcch + 1 << "/"
                    << adcch + 2 << ", adc values=" << adcLeft << "/" << adcCentral << "/"
-                   << adcRight << ", regTPFP=" << regTPFP << ", TPHT=" << mTrapConfig->getTrapReg(TrapConfig::kTPHT, mDetector, mRobPos, mMcmPos);
+                   << adcRight << ", regTPFP=" << regTPFP << ", TPHT=" << mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPHT, mDetector, mRobPos, mMcmPos);
         // regTPFP >>= 2; // OS: this line should be commented out when checking real data. It's only needed for comparison with Venelin's simulation if in addition mgkAddDigits == 0
         if (adcLeft < regTPFP) {
           adcLeft = 0;
@@ -1408,8 +1363,8 @@ void TrapSimulator::calcFitreg()
         //  make the correction using the position LUT
         // LOG(info) << "ypos raw is " << ypos << "  adcrigh-adcleft/adccentral " << adcRight << "-" << adcLeft << "/" << adcCentral << "==" << (adcRight - adcLeft) / adcCentral << " 128 * numerator : " << 128 * (adcRight - adcLeft) / adcCentral;
         // LOG(info) << "ypos before lut correction : " << ypos;
-        ypos = ypos + mTrapConfig->getTrapReg((TrapConfig::TrapReg_t)(TrapConfig::kTPL00 + (ypos & 0x7F)),
-                                              mDetector, mRobPos, mMcmPos);
+        ypos = ypos + mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPL00 + (ypos & 0x7F),
+                                                   mDetector, mRobPos, mMcmPos);
         // ypos += LUT_POS[ypos & 0x7f]; // FIXME use this LUT to obtain the same results as Venelin
         //   LOG(info) << "ypos after lut correction : " << ypos;
         if (adcLeft > adcRight) {
@@ -1431,10 +1386,10 @@ void TrapSimulator::trackletSelection()
   std::array<unsigned short, 18> trackletCandhits{}; // store the number of hits for all tracklet candidates
 
   ntracks = 0;
-  // LOG(info) << "kTPCL: " << mTrapConfig->getTrapReg(TrapConfig::kTPCL, mDetector, mRobPos, mMcmPos);
-  // LOG(info) << "kTPCT: " << mTrapConfig->getTrapReg(TrapConfig::kTPCT, mDetector, mRobPos, mMcmPos);
+  // LOG(info) << "kTPCL: " << mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPCL, mDetector, mRobPos, mMcmPos);
+  // LOG(info) << "kTPCT: " << mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPCT, mDetector, mRobPos, mMcmPos);
   for (adcIdx = 0; adcIdx < 18; adcIdx++) { // ADCs
-    if ((mFitReg[adcIdx].nHits >= mTrapConfig->getTrapReg(TrapConfig::kTPCL, mDetector, mRobPos, mMcmPos)) &&
+    if ((mFitReg[adcIdx].nHits >= mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPCL, mDetector, mRobPos, mMcmPos)) &&
         (mFitReg[adcIdx].nHits + mFitReg[adcIdx + 1].nHits >= 8)) { // FIXME was 10 otherwise
       trackletCandch[ntracks] = adcIdx;
       trackletCandhits[ntracks] = mFitReg[adcIdx].nHits + mFitReg[adcIdx + 1].nHits;
@@ -1596,7 +1551,7 @@ void TrapSimulator::fitTracklet()
     // add corrections for mis-alignment
     if (FeeParam::instance()->getUseMisalignCorr()) {
       LOG(debug) << "using mis-alignment correction";
-      yoffs += (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrYcorr, mDetector, mRobPos, mMcmPos);
+      yoffs += (int)mTrapConfigEvent->getDmemUnsigned(mgkDmemAddrYcorr, mDetector, mRobPos, mMcmPos);
     }
 
     uint64_t shift = 1UL << 32;
@@ -1613,7 +1568,7 @@ void TrapSimulator::fitTracklet()
         int64_t mult64 = 1L << (32 + decPlaces);
 
         // time offset for fit sums
-        const int t0 = FeeParam::instance()->getUseTimeOffset() ? (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrTimeOffset, mDetector, mRobPos, mMcmPos) : 0;
+        const int t0 = FeeParam::instance()->getUseTimeOffset() ? (int)mTrapConfigEvent->getDmemUnsigned(mgkDmemAddrTimeOffset, mDetector, mRobPos, mMcmPos) : 0;
 
         LOG(debug) << "using time offset of t0 = " << t0;
 
@@ -2021,146 +1976,4 @@ void TrapSimulator::sort6To2Worst(uint16_t idx1i, uint16_t idx2i, uint16_t idx3i
   sort3(idx21s, idx22s, idx23s, val21s, val22s, val23s,
         &dummy1, &dummy2, idx6o,
         &dummy3, &dummy4, &dummy5);
-}
-
-bool TrapSimulator::readPackedConfig(TrapConfig* cfg, int hc, unsigned int* data, int size)
-{
-  // Read the packed configuration from the passed memory block
-  //
-  // To be used to retrieve the TRAP configuration from the
-  // configuration as sent in the raw data.
-
-  LOG(debug) << "Reading packed configuration";
-
-  int det = hc / 2;
-
-  int idx = 0;
-  int err = 0;
-  int step, bwidth, nwords, exitFlag, bitcnt;
-
-  unsigned short caddr;
-  unsigned int dat, msk, header, dataHi;
-
-  while (idx < size && *data != 0x00000000) {
-
-    int rob = (*data >> 28) & 0x7;
-    int mcm = (*data >> 24) & 0xf;
-
-    LOG(debug) << "Config of det. " << det << " MCM " << rob << ":" << mcm << " (0x" << std::hex << *data << ")";
-    data++;
-
-    while (idx < size && *data != 0x00000000) {
-
-      header = *data;
-      data++;
-      idx++;
-
-      LOG(debug) << "read: 0x" << hex << header;
-
-      if (header & 0x01) // single data
-      {
-        dat = (header >> 2) & 0xFFFF;    // 16 bit data
-        caddr = (header >> 18) & 0x3FFF; // 14 bit address
-
-        if (caddr != 0x1FFF) // temp!!! because the end marker was wrong
-        {
-          if (header & 0x02) // check if > 16 bits
-          {
-            dataHi = *data;
-            LOG(debug) << "read: 0x" << hex << dataHi;
-            data++;
-            idx++;
-            err += ((dataHi ^ (dat | 1)) & 0xFFFF) != 0;
-            dat = (dataHi & 0xFFFF0000) | dat;
-          }
-          LOG(debug) << "addr=0x" << hex << caddr << "(" << cfg->getRegName(cfg->getRegByAddress(caddr)) << ") data=0x" << hex << dat;
-          if (!cfg->poke(caddr, dat, det, rob, mcm)) {
-            LOG(debug) << "(single-write): non-existing address 0x" << std::hex << caddr << " containing 0x" << std::hex << header;
-          }
-          if (idx > size) {
-            LOG(debug) << "(single-write): no more data, missing end marker";
-            return -err;
-          }
-        } else {
-          LOG(debug) << "(single-write): address 0x" << setw(4) << std::hex << caddr << " => old endmarker?" << std::dec;
-          return err;
-        }
-      }
-
-      else // block of data
-      {
-        step = (header >> 1) & 0x0003;
-        bwidth = ((header >> 3) & 0x001F) + 1;
-        nwords = (header >> 8) & 0x00FF;
-        caddr = (header >> 16) & 0xFFFF;
-        exitFlag = (step == 0) || (step == 3) || (nwords == 0);
-
-        if (exitFlag) {
-          break;
-        }
-
-        switch (bwidth) {
-          case 15:
-          case 10:
-          case 7:
-          case 6:
-          case 5: {
-            msk = (1 << bwidth) - 1;
-            bitcnt = 0;
-            while (nwords > 0) {
-              nwords--;
-              bitcnt -= bwidth;
-              if (bitcnt < 0) {
-                header = *data;
-                LOG(debug) << "read 0x" << setw(8) << std::hex << header << std::dec;
-                data++;
-                idx++;
-                err += (header & 1);
-                header = header >> 1;
-                bitcnt = 31 - bwidth;
-              }
-              LOG(debug) << "addr=0x" << setw(4) << std::hex << caddr << "(" << cfg->getRegName(cfg->getRegByAddress(caddr)) << ") data=0x" << setw(8) << std::hex << (header & msk);
-              if (!cfg->poke(caddr, header & msk, det, rob, mcm)) {
-                LOG(debug) << "(single-write): non-existing address 0x" << setw(4) << std::hex << caddr << " containing 0x" << setw(8) << std::hex << header << std::dec;
-              }
-
-              caddr += step;
-              header = header >> bwidth;
-              if (idx >= size) {
-                LOG(debug) << "(block-write): no end marker! " << idx << " words read";
-                return -err;
-              }
-            }
-            break;
-          } // end case 5-15
-          case 31: {
-            while (nwords > 0) {
-              header = *data;
-              LOG(debug) << "read 0x" << setw(8) << std::hex << header;
-              data++;
-              idx++;
-              nwords--;
-              err += (header & 1);
-
-              LOG(debug) << "addr=0x" << hex << setw(4) << caddr << " (" << cfg->getRegName(cfg->getRegByAddress(caddr)) << ")  data=0x" << hex << setw(8) << (header >> 1);
-              if (!cfg->poke(caddr, header >> 1, det, rob, mcm)) {
-                LOG(debug) << "(single-write): non-existing address 0x" << setw(4) << std::hex << " containing 0x" << setw(8) << std::hex << header << std::dec;
-              }
-
-              caddr += step;
-              if (idx >= size) {
-                LOG(debug) << "no end marker! " << idx << " words read";
-                return -err;
-              }
-            }
-            break;
-          }
-          default:
-            return err;
-        } // end switch
-      }   // end block case
-    }
-  } // end while
-  LOG(debug) << "no end marker! " << idx << " words read";
-  return -err; // only if the max length of the block reached!
 }

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -1328,7 +1328,7 @@ void TrapSimulator::calcFitreg()
         //  hit detected, in TRAP we have 4 units and a hit-selection, here we proceed all channels!
         //  subtract the pedestal TPFP, clipping instead of wrapping
 
-        int regTPFP = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFP, mDetector, mRobPos, mMcmPos); //TODO put this together with the others as members of trapsim, which is initiliased by det,rob,mcm.
+        int regTPFP = mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPFP, mDetector, mRobPos, mMcmPos); // TODO put this together with the others as members of trapsim, which is initiliased by det,rob,mcm.
         LOG(debug) << "Hit found, time=" << timebin << ", adcch=" << adcch << "/" << adcch + 1 << "/"
                    << adcch + 2 << ", adc values=" << adcLeft << "/" << adcCentral << "/"
                    << adcRight << ", regTPFP=" << regTPFP << ", TPHT=" << mTrapConfigEvent->getTrapReg(TrapConfigEvent::kTPHT, mDetector, mRobPos, mMcmPos);

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -22,9 +22,12 @@ o2_add_library(TRDWorkflow
                        src/EntropyEncoderSpec.cxx
                        src/TrackBasedCalibSpec.cxx
                        src/KrClustererSpec.cxx
+                       src/TrapConfigEventSpec.cxx
                        include/TRDWorkflow/VdAndExBCalibSpec.h
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
+                       include/TRDWorkflow/TrapConfigEventSpec.h
+                       include/TRDWorkflow/CalibratorConfigEvents.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils
                                      O2::Steer
                                      O2::Algorithm
@@ -86,6 +89,11 @@ o2_add_executable(kr-clusterer
                   COMPONENT_NAME trd
                   SOURCES src/trd-kr-clusterer.cxx
                   PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
+
+o2_add_executable(configevent-workflow
+                  COMPONENT_NAME trd
+                  SOURCES src/trd-configevent-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflow O2::DataFormatsTRD O2::TRDReconstruction)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -27,7 +27,7 @@ o2_add_library(TRDWorkflow
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
                        include/TRDWorkflow/TrapConfigEventSpec.h
-                       include/TRDWorkflow/CalibratorConfigEvents.h
+                       include/TRDWorkflow/ConfigEventCalibSpec.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils
                                      O2::Steer
                                      O2::Algorithm

--- a/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibDevice.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibDevice.h
@@ -1,0 +1,163 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_CONFIGEVENTCALIBSPEC_H
+#define O2_TRD_CONFIGEVENTCALIBSPEC_H
+
+/// \file   VdAndExBCalibSpec.h
+/// \brief DPL device for steering the TRD vD and ExB time slot based calibration
+/// \author Ole Schmidt
+
+#include "TRDCalibration/CalibratorConfigEvents.h"
+#include "DetectorsCalibration/Utils.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "Framework/CCDBParamSpec.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include <chrono>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace calibration
+{
+
+class ConfigEventCalibDevice : public o2::framework::Task
+{
+ public:
+  ConfigEventCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  void init(o2::framework::InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    auto delay = ic.options().get<uint32_t>("max-delay");
+    mCalibrator = std::make_unique<o2::trd::CalibratorConfigEvents>();
+    if (ic.options().get<bool>("enable-root-output")) {
+      mCalibrator->createFile();
+    }
+  }
+
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
+  {
+    o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+    if (tinfo.globalRunNumberChanged) { // new run is starting
+      mRunStopRequested = false;
+      mCalibrator->retrievePrev(pc); // SOR initialization is performed here
+    }
+    if (mRunStopRequested) {
+      return;
+    }
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+    auto dataAngRes = pc.inputs().get<o2::trd::AngularResidHistos>("input");
+    o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
+    LOG(detail) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << dataAngRes.getNEntries() << " AngularResidHistos entries";
+    mCalibrator->process(dataAngRes);
+    if (pc.transitionState() == TransitionHandlingState::Requested) {
+      LOG(info) << "Run stop requested, finalizing";
+      mRunStopRequested = true;
+      mCalibrator->checkSlotsToFinalize(o2::calibration::INFINITE_TF);
+      mCalibrator->closeFile();
+    }
+    sendOutput(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    if (mRunStopRequested) {
+      return;
+    }
+    mCalibrator->checkSlotsToFinalize(o2::calibration::INFINITE_TF);
+    mCalibrator->closeOutputFile();
+    sendOutput(ec.outputs());
+  }
+
+  void stop() final
+  {
+    mCalibrator->closeOutputFile();
+  }
+
+ private:
+  std::unique_ptr<o2::trd::CalibratorConfigEvents> mCalibrator;
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  bool mRunStopRequested = false; // flag that run was stopped (and the last output is sent)
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // TODO in principle, this routine is generic, can be moved to Utils.h
+
+    using clbUtils = o2::calibration::Utils;
+    const auto& payloadVec = mCalibrator->getCcdbObjectVector();
+    auto& infoVec = mCalibrator->getCcdbObjectInfoVector(); // use non-const version as we update it
+    assert(payloadVec.size() == infoVec.size());
+
+    for (uint32_t i = 0; i < payloadVec.size(); i++) {
+      auto& w = infoVec[i];
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
+      LOG(info) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
+
+      output.snapshot(Output{clbUtils::gDataOriginCDBPayload, "VDRIFTEXB", i}, *image.get()); // vector<char>
+      output.snapshot(Output{clbUtils::gDataOriginCDBWrapper, "VDRIFTEXB", i}, w);            // root-serialized
+    }
+    if (payloadVec.size()) {
+      mCalibrator->initOutput(); // reset the outputs once they are already sent
+    }
+  }
+};
+
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getTRDConfigEventCalibSpec()
+{
+  using device = o2::calibration::ConfigEventCalibDevice;
+  using clbUtils = o2::calibration::Utils;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CONFEVT"}, Lifetime::Sporadic);
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("input", "TRD", "TRDCFG");
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                                true,                           // GRPECS=true
+                                                                false,                          // GRPLHCIF
+                                                                false,                          // GRPMagField
+                                                                false,                          // askMatLUT
+                                                                o2::base::GRPGeomRequest::None, // geometry
+                                                                inputs);
+  return DataProcessorSpec{
+    "calib-confevt-calibration",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>(ccdbRequest)},
+    Options{
+      {"sec-per-slot", VariantType::UInt32, 900u, {"number of seconds per calibration time slot"}},
+      {"max-delay", VariantType::UInt32, 2u, {"number of slots in past to consider"}},
+      {"enable-root-output", VariantType::Bool, false, {"output tprofiles and fits to root file"}},
+    }};
+}
+} // namespace framework
+} // namespace o2
+
+#endif //O2_TRD_CONFIGEVENTCALIBSPEC_H

--- a/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibDevice.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibDevice.h
@@ -160,4 +160,4 @@ DataProcessorSpec getTRDConfigEventCalibSpec()
 } // namespace framework
 } // namespace o2
 
-#endif //O2_TRD_CONFIGEVENTCALIBSPEC_H
+#endif // O2_TRD_CONFIGEVENTCALIBSPEC_H

--- a/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibSpec.h
@@ -71,7 +71,7 @@ class ConfigEventCalibDevice : public o2::framework::Task
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
     auto /*trd::TrapConfigEvent*/ trapConfigEvent = pc.inputs().get<gsl::span<o2::trd::TrapConfigEvent>>("input");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
-    LOG(detail) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << trapConfigEvent.getNEntries() << " ConfigEventSlot entries";
+    LOG(detail) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with ";// << trapConfigEvent.getNEntries() << " ConfigEventSlot entries";
     trd::TrapConfigEventTimeSlot mtrapconfigeventtimeslot;
     mCalibrator->process(mtrapconfigeventtimeslot);
     if (pc.transitionState() == TransitionHandlingState::Requested) {

--- a/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibSpec.h
@@ -120,7 +120,7 @@ class ConfigEventCalibDevice : public o2::framework::Task
                 << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
 
       output.snapshot(Output{clbUtils::gDataOriginCDBPayload, "TRAPEVT", i}, *image.get()); // vector<char>
-      output.snapshot(Output{clbUtils::gDataOriginCDBWrapper, "TRAPEVTI", i}, w);            // root-serialized
+      output.snapshot(Output{clbUtils::gDataOriginCDBWrapper, "TRAPEVTI", i}, w);           // root-serialized
     }
     if (payloadVec.size()) {
       mCalibrator->initOutput(); // reset the outputs once they are already sent

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -29,6 +29,7 @@ namespace trd
 {
 
 class TrapConfig;
+class TrapConfigEvent;
 
 class TRDDPLTrapSimulatorTask : public o2::framework::Task
 {
@@ -41,7 +42,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
 
 
  private:
-  TrapConfig* mTrapConfig{nullptr};
+  TrapConfigEvent* mTrapConfigEvent{nullptr};
   int mRunNumber{297595}; // run number to anchor simulation to.
   int mDigitDownscaling{1}; // only digits of every mDigitDownscaling-th trigger will be kept
   int mChargeScalingFactor{-1}; // can be overwritten to set custom charge scaling factor for tracklets
@@ -52,11 +53,11 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mInitCcdbObjectsDone{false}; // flag whether one time download of CCDB objects has been done
   int mNumThreads{-1};              // number of threads used for parallel processing
   std::string mTrapConfigName;      // the name of the config to be used.
-  std::string mOnlineGainTableName;
-  std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
+                                    //  std::string mOnlineGainTableName;
+                                    //  std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
 
   void initTrapConfig(long timeStamp);
-  void setOnlineGainTables();
+  // void setOnlineGainTables();
   void processTRAPchips(int& nTracklets, std::vector<Tracklet64>& trackletsAccum, std::array<TrapSimulator, constants::NMCMHCMAX>& trapSimulators, std::vector<short>& digitCounts, std::vector<int>& digitIndices);
 };
 

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TrapConfigEventSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TrapConfigEventSpec.h
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRAPCONFIGEVENTSPEC_H
+#define O2_TRD_TRAPCONFIGEVENTSPEC_H
+
+/// \file  TrapConfigEventSpec.h
+/// \brief Steers TrapConfigEvent comparison and parsing.
+/// \author Sean Murray
+
+// input TRD config events, current config from ccdb
+// output new ccdb config if required
+
+#include <vector>
+#include <array>
+#include <string>
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#include "TRDReconstruction/TrapConfigEventParser.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getTrapConfigEventSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRD_TRAPCONFIGSPEC

--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -21,6 +21,8 @@ o2_add_library(TRDWorkflowIO
                        src/TRDTrackReaderSpec.cxx
                        src/TRDCalibWriterSpec.cxx
                        src/KrClusterWriterSpec.cxx
+                       src/TRDConfigEventWriterSpec.cxx
+                       src/TRDConfigEventReaderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD O2::SimulationDataFormat O2::DPLUtils O2::GPUDataTypeHeaders O2::DataFormatsTPC)
 
 
@@ -35,4 +37,12 @@ o2_add_executable(track-reader
 o2_add_executable(digittracklet-writer
                  COMPONENT_NAME trd
                  SOURCES src/trd-digittracklet-writer-workflow.cxx
+                 PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
+o2_add_executable(configevent-reader-workflow
+                 COMPONENT_NAME trd
+                 SOURCES src/trd-configevent-reader-workflow.cxx
+                 PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
+o2_add_executable(configevent-writer-workflow
+                 COMPONENT_NAME trd
+                 SOURCES src/trd-configevent-writer-workflow.cxx
                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventReaderSpec.h
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDCONFIGEVENTREADERSPEC_H
+#define O2_TRDCONFIGEVENTREADERSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include <memory>
+#include <string>
+
+namespace o2::trd
+{
+
+class TRDConfigEventReaderSpec : public o2::framework::Task
+{
+ public:
+  TRDConfigEventReaderSpec() = default;
+  ~TRDConfigEventReaderSpec() override = default;
+  void init(o2::framework::InitContext& ic) override;
+  void run(o2::framework::ProcessingContext& pc) override;
+
+ private:
+  void connectTree();
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTreeConfigEvent;
+  std::string mFileName = "trdconfigevent.root";
+  std::string mConfigEventTreeName = "o2sim";
+  std::string mConfigEventBranchName = "TRDConfigEvent";
+  std::vector<o2::trd::TrapConfigEvent> mTrapConfigEvent, *mTrapConfigEventPtr = &mTrapConfigEvent;
+};
+
+o2::framework::DataProcessorSpec getTRDConfigEventReaderSpec();
+
+} // end namespace o2::trd
+
+#endif // O2_TRDCONFIGEVENTREADERSPEC_H

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventWriterSpec.h
@@ -1,0 +1,30 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef TRDWORKFLOW_SRC_TRDCONFIGEVENTSPEC_H_
+#define TRDWORKFLOW_SRC_TRDCONFIGEVENTSPEC_H_
+
+namespace o2
+{
+namespace framework
+{
+struct DataProcessorSpec;
+} // end namespace framework
+
+namespace trd
+{
+
+o2::framework::DataProcessorSpec getTRDConfigEventWriterSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif /* TRDWORKFLOW_SRC_TRDCONFIGEVENTSPEC_H_ */

--- a/Detectors/TRD/workflow/io/src/TRDConfigEventReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDConfigEventReaderSpec.cxx
@@ -66,4 +66,4 @@ DataProcessorSpec getTRDConfigEventReaderSpec()
                              {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 };
 
-} //end namespace o2::trd
+} // end namespace o2::trd

--- a/Detectors/TRD/workflow/io/src/TRDConfigEventReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDConfigEventReaderSpec.cxx
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "CommonUtils/StringUtils.h"
+#include "fairlogger/Logger.h"
+
+using namespace o2::framework;
+
+namespace o2::trd
+{
+
+void TRDConfigEventReaderSpec::init(InitContext& ic)
+{
+
+  mFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                            ic.options().get<std::string>("configeventsfile"));
+  connectTree();
+}
+
+void TRDConfigEventReaderSpec::connectTree()
+{
+  mTreeConfigEvent.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(mFileName.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTreeConfigEvent.reset((TTree*)mFile->Get(mConfigEventTreeName.c_str()));
+  assert(mTreeConfigEvent);
+  mTreeConfigEvent->SetBranchAddress(mConfigEventBranchName.c_str(), &mTrapConfigEventPtr);
+  LOG(info) << "Loaded tree from " << mFileName << " with a trapconfig";
+}
+
+void TRDConfigEventReaderSpec::run(ProcessingContext& pc)
+{
+  auto currEntry = mTreeConfigEvent->GetReadEntry() + 1;
+  assert(currEntry < mTreeConfigEvent->GetEntries()); // this should not happen
+  mTreeConfigEvent->GetEntry(currEntry);
+  LOG(info) << "Pushing Trapconfig to file ";
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "CONFEVT", 1, Lifetime::Sporadic}, mTrapConfigEvent);
+  if (mTreeConfigEvent->GetReadEntry() + 1 >= mTreeConfigEvent->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+DataProcessorSpec getTRDConfigEventReaderSpec()
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("TRD", "CFGEVT", 1, Lifetime::Timeframe);
+  return DataProcessorSpec{"TRDCONFIGEVENTREADER",
+                           Inputs{},
+                           outputs,
+                           AlgorithmSpec{adaptFromTask<TRDConfigEventReaderSpec>()},
+                           Options{
+                             {"configeventfile", VariantType::String, "trdconfigevent.root", {"Input Configuration event"}},
+                             {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+};
+
+} //end namespace o2::trd

--- a/Detectors/TRD/workflow/io/src/TRDConfigEventWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDConfigEventWriterSpec.cxx
@@ -16,6 +16,7 @@
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Framework/InputSpec.h"
 #include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/Digit.h"
 #include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
 
 namespace o2
@@ -37,7 +38,7 @@ o2::framework::DataProcessorSpec getTRDConfigEventWriterSpec()
                                 "trdconfigevents.root",
                                 "o2sim",
                                 // setting a custom callback for closing the writer
-                                BranchDefinition<o2::trd::TrapConfigEvent>{InputSpec{"trapconfig", o2::header::gDataOriginTRD, "TRDCFG"}, "ConfigEvent"})();
+                                BranchDefinition<o2::trd::Digit>{InputSpec{"trapconfig", o2::header::gDataOriginTRD, "TRDCFG"}, "ConfigEvent"})();
 }
 
 } // end namespace trd

--- a/Detectors/TRD/workflow/io/src/TRDConfigEventWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDConfigEventWriterSpec.cxx
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef CONFIGEVENT_SRC_TRDDIGITWRITERSPEC_H_
+#define CONFIGEVENT_SRC_TRDDIGITWRITERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getTRDConfigEventWriterSpec()
+{
+  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  using DataRef = framework::DataRef;
+  LOGP(info, " ZZZ writing config event to root file");
+
+  return MakeRootTreeWriterSpec("TRDConfigEventWriter",
+                                "trdconfigevents.root",
+                                "o2sim",
+                                // setting a custom callback for closing the writer
+                                BranchDefinition<o2::trd::TrapConfigEvent>{InputSpec{"trapconfig", o2::header::gDataOriginTRD, "TRDCFG"}, "ConfigEvent"})();
+}
+
+} // end namespace trd
+} // end namespace o2
+
+#endif /* CONFIGEVENT_SRC_TRDDIGITWRITERSPEC_H_ */

--- a/Detectors/TRD/workflow/io/src/trd-configevent-reader-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-configevent-reader-workflow.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDConfigEventReaderSpec());
+  return specs;
+}

--- a/Detectors/TRD/workflow/io/src/trd-configevent-writer-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-configevent-writer-workflow.cxx
@@ -1,0 +1,52 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+// this is simply to enable one to write out the tracklet and digits and triggers after reading in the ctf
+// to do a comparison pre and post ctf. Use case is probably only unit tests.
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDConfigEventWriterSpec());
+  return specs;
+}

--- a/Detectors/TRD/workflow/src/TrapConfigEventSpec.cxx
+++ b/Detectors/TRD/workflow/src/TrapConfigEventSpec.cxx
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   TrapConfigEventSpec.cxx
+/// \brief  DPL device for handling the trap configuration events
+/// \author Sean Murray
+
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include <fairlogger/Logger.h>
+
+#include "TRDReconstruction/TrapConfigEventParser.h"
+#include "TRDWorkflow/TrapConfigEventSpec.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+
+#include "TStopwatch.h"
+#include "TFile.h"
+
+using namespace o2::framework;
+
+namespace o2::trd
+{
+
+class TrapConfigEventDevice : public Task
+{
+ public:
+  TrapConfigEventDevice() = default;
+  ~TrapConfigEventDevice() = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::trd::TrapConfigEventParser mTrapConfigEventParser;
+  std::bitset<constants::MAXHALFCHAMBER> mOldHalfChamberPresent; // keep a store of which half chambers have been seen so far.
+  uint32_t mConfigCounter = 0;
+};
+
+void TrapConfigEventDevice::init(InitContext& ic)
+{
+  mTrapConfigEventParser.init();
+  mOldHalfChamberPresent.set(0);
+  mConfigCounter = 0;
+}
+
+void TrapConfigEventDevice::run(ProcessingContext& pc)
+{
+  TStopwatch timer;
+
+  std::vector<uint32_t> configdata = pc.inputs().get<std::vector<uint32_t>>("trapconfigs");
+
+  LOGP(info, " Config event coming in with size : {}", configdata.size());
+  timer.Start();
+  mTrapConfigEventParser.parse(configdata);
+  timer.Stop();
+
+  LOGP(info, "TRD config event took:  Cpu: {:.3} s Real: {:.3} s halfchambers with data : {}, and a datasize of {}MB", timer.CpuTime(), timer.RealTime(),  mTrapConfigEventParser.countHCIDPresent(), ((float)configdata.size()) / 1025. / 1024.);
+  timer.Start();
+  mTrapConfigEventParser.isNewConfig();
+  timer.Stop();
+  LOGF(info, "Comparison to previous one config in ccdb took : Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
+  mOldHalfChamberPresent = mTrapConfigEventParser.countHCIDPresent();
+//  if (mConfigCounter % 5 == 0) {
+    //send the config message
+    LOGP(info, "We have a new config and sending ....");
+    // LOGP(info,"first value of tpl00 : {}",mTrapConfigEventParser.getNewConfig().getRegisterValue(0,31361));
+    //TrapConfigEvent a;
+    // auto a=mTrapConfigEventParser.getNewConfig();
+    // LOGP(info,"first value of copied trapconfigevent A is tpl00 : {}",a.getRegisterValue(0,31361));
+    LOGP(info, "Trap config is size : {}", mTrapConfigEventParser.getConfigSize());
+    mTrapConfigEventParser.sendTrapConfigEvent(pc);
+    LOGP(info, "Trap config has been sent : {}", mTrapConfigEventParser.getConfigSize());
+//  }
+  mConfigCounter++;
+  if (mConfigCounter == 20)
+    exit(1);
+}
+
+void TrapConfigEventDevice::endOfStream(EndOfStreamContext& ec)
+{
+  LOG(info) << "Finished with TRD Trap Config event (EoS received)";
+}
+
+DataProcessorSpec getTrapConfigEventSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("trapconfigs", ConcreteDataTypeMatcher{o2::header::gDataOriginTRD, "CONFEVT"}, Lifetime::Sporadic);
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRDCFG", 0, Lifetime::Condition);
+
+  return DataProcessorSpec{
+    "trd-configevents",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TrapConfigEventDevice>()},
+    Options{}};
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/workflow/src/TrapConfigEventSpec.cxx
+++ b/Detectors/TRD/workflow/src/TrapConfigEventSpec.cxx
@@ -62,23 +62,23 @@ void TrapConfigEventDevice::run(ProcessingContext& pc)
   mTrapConfigEventParser.parse(configdata);
   timer.Stop();
 
-  LOGP(info, "TRD config event took:  Cpu: {:.3} s Real: {:.3} s halfchambers with data : {}, and a datasize of {}MB", timer.CpuTime(), timer.RealTime(),  mTrapConfigEventParser.countHCIDPresent(), ((float)configdata.size()) / 1025. / 1024.);
+  LOGP(info, "TRD config event took:  Cpu: {:.3} s Real: {:.3} s halfchambers with data : {}, and a datasize of {}MB", timer.CpuTime(), timer.RealTime(), mTrapConfigEventParser.countHCIDPresent(), ((float)configdata.size()) / 1025. / 1024.);
   timer.Start();
   mTrapConfigEventParser.isNewConfig();
   timer.Stop();
   LOGF(info, "Comparison to previous one config in ccdb took : Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
   mOldHalfChamberPresent = mTrapConfigEventParser.countHCIDPresent();
-//  if (mConfigCounter % 5 == 0) {
-    //send the config message
-    LOGP(info, "We have a new config and sending ....");
-    // LOGP(info,"first value of tpl00 : {}",mTrapConfigEventParser.getNewConfig().getRegisterValue(0,31361));
-    //TrapConfigEvent a;
-    // auto a=mTrapConfigEventParser.getNewConfig();
-    // LOGP(info,"first value of copied trapconfigevent A is tpl00 : {}",a.getRegisterValue(0,31361));
-    LOGP(info, "Trap config is size : {}", mTrapConfigEventParser.getConfigSize());
-    mTrapConfigEventParser.sendTrapConfigEvent(pc);
-    LOGP(info, "Trap config has been sent : {}", mTrapConfigEventParser.getConfigSize());
-//  }
+  //  if (mConfigCounter % 5 == 0) {
+  // send the config message
+  LOGP(info, "We have a new config and sending ....");
+  // LOGP(info,"first value of tpl00 : {}",mTrapConfigEventParser.getNewConfig().getRegisterValue(0,31361));
+  // TrapConfigEvent a;
+  // auto a=mTrapConfigEventParser.getNewConfig();
+  // LOGP(info,"first value of copied trapconfigevent A is tpl00 : {}",a.getRegisterValue(0,31361));
+  LOGP(info, "Trap config is size : {}", mTrapConfigEventParser.getConfigSize());
+  mTrapConfigEventParser.sendTrapConfigEvent(pc);
+  LOGP(info, "Trap config has been sent : {}", mTrapConfigEventParser.getConfigSize());
+  //  }
   mConfigCounter++;
   if (mConfigCounter == 20)
     exit(1);

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -12,8 +12,10 @@
 #include "Framework/DataProcessorSpec.h"
 #include "TRDWorkflowIO/TRDCalibReaderSpec.h"
 #include "TRDWorkflowIO/TRDDigitReaderSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
 #include "TRDWorkflow/VdAndExBCalibSpec.h"
 #include "TRDWorkflow/NoiseCalibSpec.h"
+#include "TRDWorkflow/ConfigEventDevice.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
@@ -54,6 +56,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       specs.emplace_back(o2::trd::getTRDDigitReaderSpec(false));
     }
     specs.emplace_back(o2::trd::getTRDNoiseCalibSpec());
+  }
+  if (configcontext.options().get<bool>("configevent")) {
+    if (enableRootInp) {
+      specs.emplace_back(o2::trd::getTRDConfigEventReaderSpec());
+    }
+    specs.emplace_back(o2::trd::getTRDConfigEventCalibSpec());
   }
 
   return specs;

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -29,6 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-root-input", o2::framework::VariantType::Bool, false, {"enable root-files input readers"}},
     {"vDriftAndExB", o2::framework::VariantType::Bool, false, {"enable vDrift and ExB calibration"}},
     {"noise", o2::framework::VariantType::Bool, false, {"enable noise and pad status calibration"}},
+    {"configevents", o2::framework::VariantType::Bool, false, {"enable noise and pad status calibration"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
   };
@@ -60,10 +61,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
     specs.emplace_back(o2::trd::getTRDNoiseCalibSpec());
   }
-  if (configcontext.options().get<bool>("configevent")) {
+  if (configcontext.options().get<bool>("configevents")) {
     if (enableRootInp) {
       specs.emplace_back(o2::trd::getTRDConfigEventReaderSpec());
     }
+    LOGP(info," about to emplace getTrapConfigEventSpec");
     specs.emplace_back(o2::trd::getTrapConfigEventSpec());
   }
 

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -13,9 +13,10 @@
 #include "TRDWorkflowIO/TRDCalibReaderSpec.h"
 #include "TRDWorkflowIO/TRDDigitReaderSpec.h"
 #include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
+#include "TRDWorkflow/TrapConfigEventSpec.h"
 #include "TRDWorkflow/VdAndExBCalibSpec.h"
 #include "TRDWorkflow/NoiseCalibSpec.h"
-#include "TRDWorkflow/ConfigEventDevice.h"
+#include "TRDWorkflow/ConfigEventCalibSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
@@ -28,7 +29,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-root-input", o2::framework::VariantType::Bool, false, {"enable root-files input readers"}},
     {"vDriftAndExB", o2::framework::VariantType::Bool, false, {"enable vDrift and ExB calibration"}},
     {"noise", o2::framework::VariantType::Bool, false, {"enable noise and pad status calibration"}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+  };
 
   std::swap(workflowOptions, options);
 }
@@ -61,7 +64,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     if (enableRootInp) {
       specs.emplace_back(o2::trd::getTRDConfigEventReaderSpec());
     }
-    specs.emplace_back(o2::trd::getTRDConfigEventCalibSpec());
+    specs.emplace_back(o2::trd::getTrapConfigEventSpec());
   }
 
   return specs;

--- a/Detectors/TRD/workflow/src/trd-configevent-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-configevent-workflow.cxx
@@ -57,10 +57,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   */
   // processing devices
   specs.emplace_back(o2::trd::getTrapConfigEventSpec());
- 
-    if (!configcontext.options().get<bool>("disable-root-output")) {
-      specs.emplace_back(o2::trd::getTRDConfigEventWriterSpec());
-    }
-  
+
+  if (!configcontext.options().get<bool>("disable-root-output")) {
+    specs.emplace_back(o2::trd::getTRDConfigEventWriterSpec());
+  }
+
   return specs;
 }

--- a/Detectors/TRD/workflow/src/trd-configevent-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-configevent-workflow.cxx
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "TRDWorkflow/TrapConfigEventSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
+#include "TRDReconstruction/TrapConfigEventParser.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+/*void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}*/
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  // o2::conf::ConfigurableParam::writeINI("o2trapconfig_workflow_configuration.ini");
+
+  o2::framework::WorkflowSpec specs;
+  /*
+    // input
+    if (!configcontext.options().get<bool>("disable-root-input")) {
+      specs.emplace_back(o2::trd::getTRDTrapConfigRawReaderReaderSpec(false));
+    }
+  */
+  // processing devices
+  specs.emplace_back(o2::trd::getTrapConfigEventSpec());
+ 
+    if (!configcontext.options().get<bool>("disable-root-output")) {
+      specs.emplace_back(o2::trd::getTRDConfigEventWriterSpec());
+    }
+  
+  return specs;
+}

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -30,6 +30,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             Detectors/TRD/base/macros/PrintTrapConfig.C
             Detectors/TRD/base/macros/TestTrapSim.C
             Detectors/TRD/macros/convertRun2ToRun3Digits.C
+            Detectors/TRD/macros/CheckConfigEvent.C
             Detectors/TRD/simulation/macros/CheckTRDFST.C
             Detectors/TRD/reconstruction/macros/checkTrackletCharges.C
             Detectors/TRD/reconstruction/macros/CompareDigitsAndTracklets.C


### PR DESCRIPTION
Handle configuration events.

epn device to Parse, send
aggregator accumulates all the above, every 15 minutes check against ccdb current values, save if different, else do nothing.
aggregator accumulates values, stores the various values, and saves the most prevalent value.

Dont look at the moment, its being cleaned up and seperated, so will change quite a lot. The basic organisation will stay though.