### PR TITLE
[O2-1787] Implementation of the Beam Pipe Support inside the ITS Cage on the A Side

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
@@ -91,23 +91,23 @@ class V3Cage : public V11Geometry
 
   /// Creates the Titanium lower part of the collar supporting the beam pipe
   /// \param mgr  The GeoManager (used only to get the proper material)
-  TGeoCompositeShape* createBPSuppLowerCollar(const TGeoManager* mgr = gGeoManager);
+  TGeoCompositeShape* createBPSuppLowerCollar(void);
 
   /// Creates the Titanium upper part of the collar supporting the beam pipe
   /// \param mgr  The GeoManager (used only to get the proper material)
-  TGeoCompositeShape* createBPSuppUpperCollar(const TGeoManager* mgr = gGeoManager);
+  TGeoCompositeShape* createBPSuppUpperCollar(void);
 
   /// Creates the CF lateral bar of the beam pipe support (aka collar beam)
   /// \param mgr  The GeoManager (used only to get the proper material)
-  TGeoCompositeShape* createBPSuppCollarBeam(const TGeoManager* mgr = gGeoManager);
+  TGeoCompositeShape* createBPSuppCollarBeam(void);
 
   /// Creates the Titanium lateral bracket of the beam pipe support
   /// \param mgr  The GeoManager (used only to get the proper material)
-  TGeoCompositeShape* createBPSuppBracket(const TGeoManager* mgr = gGeoManager);
+  TGeoCompositeShape* createBPSuppBracket(void);
 
   /// Creates the lateral clamps holding the beam pipe support to the Cage
   /// \param mgr  The GeoManager (used only to get the proper material)
-  TGeoCompositeShape* createBPSuppClamp(const TGeoManager* mgr = gGeoManager);
+  TGeoCompositeShape* createBPSuppClamp(void);
 
   /// Creates the Cage Closing Cross element
   /// \param mgr  The GeoManager (used only to get the proper material)

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
@@ -85,6 +85,30 @@ class V3Cage : public V11Geometry
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoCompositeShape* createCageEndCapCableCross(const TGeoManager* mgr = gGeoManager);
 
+  /// Creates the Beam Pipe Support inside the Cage on the A side
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoVolume* createBeamPipeSupport(const TGeoManager* mgr = gGeoManager);
+
+  /// Creates the Titanium lower part of the collar supporting the beam pipe
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoCompositeShape* createBPSuppLowerCollar(const TGeoManager* mgr = gGeoManager);
+
+  /// Creates the Titanium upper part of the collar supporting the beam pipe
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoCompositeShape* createBPSuppUpperCollar(const TGeoManager* mgr = gGeoManager);
+
+  /// Creates the CF lateral bar of the beam pipe support (aka collar beam)
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoCompositeShape* createBPSuppCollarBeam(const TGeoManager* mgr = gGeoManager);
+
+  /// Creates the Titanium lateral bracket of the beam pipe support
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoCompositeShape* createBPSuppBracket(const TGeoManager* mgr = gGeoManager);
+
+  /// Creates the lateral clamps holding the beam pipe support to the Cage
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoCompositeShape* createBPSuppClamp(const TGeoManager* mgr = gGeoManager);
+
   /// Creates the Cage Closing Cross element
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoVolume* createCageClosingCross(const TGeoManager* mgr = gGeoManager);
@@ -111,6 +135,7 @@ class V3Cage : public V11Geometry
   static const Double_t sCageCoverRibYBaseHi;  ///< Cover rib Base Height on Y
   static const Double_t sCageCoverRibFoldHi;   ///< Cover rib Fold Height
 
+  // Cage Side Panels and Rails
   static const Double_t sCageSidePanelLength;    ///< Side panel length along Z
   static const Double_t sCageSidePanelWidth;     ///< Side panel width along Y
   static const Double_t sCageSidePanelFoilThick; ///< Side panel foil thickness
@@ -135,6 +160,7 @@ class V3Cage : public V11Geometry
   static const Double_t sCageSidePanelRail2Ypos;    ///< Side panel rail 2 Y pos
   static const Double_t sCageSidePanelRail3Ypos[3]; ///< Side panel rail 3 Y pos
 
+  // Cage End Cap
   static const Double_t sCageEndCapDext;        ///< End Cap ext diameter
   static const Double_t sCageEndCapDint;        ///< End Cap int diameter
   static const Double_t sCageEndCapFoamThick;   ///< End Cap foam thickness
@@ -157,6 +183,57 @@ class V3Cage : public V11Geometry
   static const Double_t sCageECCableCrosInZLen; ///< EC Cable Cut inner length
   static const Double_t sCageECCableCrosSidWid; ///< EC Cable Cut Y side len
 
+  // Beam Pipe Support (A Side)
+  static const Double_t sBPSuppCollarIntD;     ///< BP support collar int diam
+  static const Double_t sBPSuppCollarExtD;     ///< BP support collar ext diam
+  static const Double_t sBPSuppCollarBushD;    ///< BP support collar bushing diam
+  static const Double_t sBPSuppUpperCollarLen; ///< BP support upper collar len
+  static const Double_t sBPSuppUpperCollarHei; ///< BP support upper collar high
+  static const Double_t sBPSuppLowerCollarLen; ///< BP support lower collar len
+  static const Double_t sBPSuppLowerCollarTlX; ///< BP support lower collar tail X
+  static const Double_t sBPSuppLowCollHolDist; ///< BP support lower collar hole dist
+  static const Double_t sBPSuppLowCollTailHei; ///< BP support lower collar tail hei
+  static const Double_t sBPSuppCollarBeamLen;  ///< BP support collar beam len
+  static const Double_t sBPSuppCollarBeamWid;  ///< BP support collar beam wide
+  static const Double_t sBPSuppCollarBeamHei;  ///< BP support collar beam high
+  static const Double_t sBPSuppBracketTotLen;  ///< BP support bracket total len
+  static const Double_t sBPSuppBracketWidth;   ///< BP support bracket width
+  static const Double_t sBPSuppBracketInLen;   ///< BP support bracket internal len
+  static const Double_t sBPSuppBracketInHei;   ///< BP support bracket internal height
+  static const Double_t sBPSuppBracketTailLen; ///< BP support bracket tail len
+  static const Double_t sBPSuppBracketTailHei; ///< BP support bracket tail hei
+  static const Double_t sBPSuppBrktCentHoleX;  ///< BP support bracket central hole X pos
+  static const Double_t sBPSuppBrktCentHoleD;  ///< BP support bracket central hole diameter
+  static const Double_t sBPSuppBrktLatHoleX;   ///< BP support bracket lateral hole X pos
+  static const Double_t sBPSuppBrktLatHoleD;   ///< BP support bracket lateral hole diameter
+  static const Double_t sBPSuppBrktLatHoleW;   ///< BP support bracket lateral hole width
+  static const Double_t sBPSuppBrktLatHoleH;   ///< BP support bracket lateral hole height
+  static const Double_t sBPSuppBrktHolesY;     ///< BP support bracket holes Y pos
+  static const Double_t sBPSuppCollarM4High;   ///< BP support collar screw head height
+  static const Double_t sBPSuppCollarM4Diam;   ///< BP support collar screw head diameter
+  static const Double_t sBPSuppCollarM4XDist;  ///< BP support collar screw X dist
+  static const Double_t sBPSuppCollarM4ZPos;   ///< BP support collar screw Z pos
+  static const Double_t sBPSuppClampTotLen;    ///< BP support clamp length
+  static const Double_t sBPSuppClampTotWid;    ///< BP support clamp width
+  static const Double_t sBPSuppClampTotHei;    ///< BP support clamp height
+  static const Double_t sBPSuppClampLatThick;  ///< BP support clamp lateral thick
+  static const Double_t sBPSuppClampShelfLen;  ///< BP support clamp shelf len
+  static const Double_t sBPSuppClampShelfHei;  ///< BP support clamp shelf hei
+  static const Double_t sBPSuppClampsXDist;    ///< BP support clamps X distance
+  static const Double_t sBPSuppClampInsDmin;   ///< BP support clamp insert Dmin
+  static const Double_t sBPSuppClampInsDmax;   ///< BP support clamp insert Dmax
+  static const Double_t sBPSuppClampInsH;      ///< BP support clamp insert H
+  static const Double_t sBPSuppClampInsXPos;   ///< BP support clamp insert X
+  static const Double_t sBPSuppClampInsZPos;   ///< BP support clamp insert Z
+  static const Double_t sBPSuppClampShimLen;   ///< BP support clamp shim length
+  static const Double_t sBPSuppClampShimWid;   ///< BP support clamp shim width
+  static const Double_t sBPSuppClampShimThick; ///< BP support clamp shim thick
+  static const Double_t sBPSuppClampM5High;    ///< BP support clamp screw head height
+  static const Double_t sBPSuppClampM5Diam;    ///< BP support clamp screw head diameter
+  static const Double_t sBPSuppClampM5ZPos;    ///< BP support clamp screw Z pos
+  static const Double_t sBPSuppZPos;           ///< BP support global Z pos
+
+  // Closing Cross
   static const Double_t sCageCrossXWidthTot;  ///< Closing cross total X wid
   static const Double_t sCageCrossXWidthExt;  ///< Closing cross external X wid
   static const Double_t sCageCrossXWidthInt;  ///< Closing cross internal X wid

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -508,6 +508,12 @@ void Detector::createMaterials()
   Float_t wPoly[2] = {0.857, .143};
   Float_t dPoly = 0.9;
 
+  // Vespel for Beam Pipe Support (same definition of Polyimide in Pipe.cxx)
+  Float_t aVesp[4] = {16., 14., 12., 1.};
+  Float_t zVesp[4] = {8., 7., 6., 1.};
+  Float_t wVesp[4] = {5., 2., 22., 10.};
+  Float_t dVesp = 1.42;
+
   o2::base::Detector::Mixture(1, "AIR$", aAir, zAir, dAir, 4, wAir);
   o2::base::Detector::Medium(1, "AIR$", 1, 0, ifield, fieldm, tmaxfdAir, stemaxAir, deemaxAir, epsilAir, stminAir);
 
@@ -632,6 +638,14 @@ void Detector::createMaterials()
   // Titanium
   o2::base::Detector::Material(35, "TITANIUM$", 47.867, 22, 4.506, 999, 999);
   o2::base::Detector::Medium(35, "TITANIUM$", 35, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
+
+  // Carbon-Fiber-Reinforced Polymer
+  o2::base::Detector::Material(43, "CFRP$", 12.01, 6, 1.55, 999, 999);
+  o2::base::Detector::Medium(43, "CFRP$", 43, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
+
+  // Vespel for Beam Pipe Support
+  o2::base::Detector::Mixture(44, "VESPEL$", aVesp, zVesp, dVesp, -4, wVesp);
+  o2::base::Detector::Medium(44, "VESPEL$", 44, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
 
   // Carbon for ITS services
   o2::base::Detector::Material(41, "C4SERVICES$", 12.01, 6, 1.75, 999, 999);

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
@@ -1055,19 +1055,19 @@ TGeoVolume* V3Cage::createBeamPipeSupport(const TGeoManager* mgr)
   TGeoVolumeAssembly* bpSuppVol = new TGeoVolumeAssembly("CageBeamPipeSupport");
 
   // The lower collar
-  TGeoCompositeShape* lowCollarSh = createBPSuppLowerCollar(mgr);
+  TGeoCompositeShape* lowCollarSh = createBPSuppLowerCollar();
 
   // The upper collar
-  TGeoCompositeShape* upCollarSh = createBPSuppUpperCollar(mgr);
+  TGeoCompositeShape* upCollarSh = createBPSuppUpperCollar();
 
   // Each one of the collar beams
-  TGeoCompositeShape* collarBeamSh = createBPSuppCollarBeam(mgr);
+  TGeoCompositeShape* collarBeamSh = createBPSuppCollarBeam();
 
   // Each one of the lateral brackets
-  TGeoCompositeShape* bracketSh = createBPSuppBracket(mgr);
+  TGeoCompositeShape* bracketSh = createBPSuppBracket();
 
   // Each one of the lateral clamps
-  TGeoCompositeShape* clampSh = createBPSuppClamp(mgr);
+  TGeoCompositeShape* clampSh = createBPSuppClamp();
 
   // The Vespel bushing: a Tube
   TGeoTube* bushSh = new TGeoTube(0.5 * sBPSuppCollarBushD, 0.5 * sBPSuppCollarIntD, 0.5 * sBPSuppBracketWidth);
@@ -1187,14 +1187,13 @@ TGeoVolume* V3Cage::createBeamPipeSupport(const TGeoManager* mgr)
   return bpSuppVol;
 }
 
-TGeoCompositeShape* V3Cage::createBPSuppLowerCollar(const TGeoManager* mgr)
+TGeoCompositeShape* V3Cage::createBPSuppLowerCollar(void)
 {
   //
   // Creates the lower collar which actually supports the Beam Pipe
   // (ALIITSUP1056)
   //
   // Input:
-  //         mgr : the GeoManager (used only to get the proper material)
   //
   // Output:
   //
@@ -1308,13 +1307,12 @@ TGeoCompositeShape* V3Cage::createBPSuppLowerCollar(const TGeoManager* mgr)
   return collarShape;
 }
 
-TGeoCompositeShape* V3Cage::createBPSuppUpperCollar(const TGeoManager* mgr)
+TGeoCompositeShape* V3Cage::createBPSuppUpperCollar(void)
 {
   //
   // Creates the upper collar of the Beam Pipe Support (ALIITSUP0823)
   //
   // Input:
-  //         mgr : the GeoManager (used only to get the proper material)
   //
   // Output:
   //
@@ -1354,14 +1352,13 @@ TGeoCompositeShape* V3Cage::createBPSuppUpperCollar(const TGeoManager* mgr)
   return collarShape;
 }
 
-TGeoCompositeShape* V3Cage::createBPSuppCollarBeam(const TGeoManager* mgr)
+TGeoCompositeShape* V3Cage::createBPSuppCollarBeam(void)
 {
   //
   // Creates the collar beam (i.e. the lateral support bar) of the
   // Beam Pipe Support (ALIITSUP1057)
   //
   // Input:
-  //         mgr : the GeoManager (used only to get the proper material)
   //
   // Output:
   //
@@ -1422,14 +1419,13 @@ TGeoCompositeShape* V3Cage::createBPSuppCollarBeam(const TGeoManager* mgr)
   return beamShape;
 }
 
-TGeoCompositeShape* V3Cage::createBPSuppBracket(const TGeoManager* mgr)
+TGeoCompositeShape* V3Cage::createBPSuppBracket(void)
 {
   //
   // Creates the lateral Titanium bracket of the Beam Pipe Support
   // (ALIITSUP1058)
   //
   // Input:
-  //         mgr : the GeoManager (used only to get the proper material)
   //
   // Output:
   //
@@ -1504,14 +1500,13 @@ TGeoCompositeShape* V3Cage::createBPSuppBracket(const TGeoManager* mgr)
   return bracketShape;
 }
 
-TGeoCompositeShape* V3Cage::createBPSuppClamp(const TGeoManager* mgr)
+TGeoCompositeShape* V3Cage::createBPSuppClamp(void)
 {
   //
   // Creates the lateral Titanium clamp holding the Beam Pipe Support
   // to the ITS Cage (ALIITSUP1060)
   //
   // Input:
-  //         mgr : the GeoManager (used only to get the proper material)
   //
   // Output:
   //

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
@@ -19,9 +19,9 @@
 
 #include <fairlogger/Logger.h> // for LOG
 
-// #include <TGeoArb8.h>           // for TGeoArb8
-// #include <TGeoBBox.h>    // for TGeoBBox
-// #include <TGeoCone.h>    // for TGeoConeSeg, TGeoCone
+#include <TGeoArb8.h>    // for TGeoArb8
+#include <TGeoBBox.h>    // for TGeoBBox
+#include <TGeoCone.h>    // for TGeoConeSeg, TGeoCone
 #include <TGeoPcon.h>    // for TGeoPcon
 #include <TGeoManager.h> // for TGeoManager, gGeoManager
 #include <TGeoMatrix.h>  // for TGeoCombiTrans, TGeoRotation, etc
@@ -108,6 +108,55 @@ const Double_t V3Cage::sCageECCableCrosInThik = 4 * sMm;
 const Double_t V3Cage::sCageECCableCrosInZLen = 10.2 * sMm;
 const Double_t V3Cage::sCageECCableCrosSidWid = 8 * sMm;
 
+const Double_t V3Cage::sBPSuppCollarIntD = 53 * sMm;
+const Double_t V3Cage::sBPSuppCollarExtD = 57 * sMm;
+const Double_t V3Cage::sBPSuppCollarBushD = 52 * sMm;
+const Double_t V3Cage::sBPSuppUpperCollarLen = 78 * sMm;
+const Double_t V3Cage::sBPSuppUpperCollarHei = 4 * sMm;
+const Double_t V3Cage::sBPSuppLowerCollarLen = 151 * sMm;
+const Double_t V3Cage::sBPSuppLowerCollarTlX = 40.5 * sMm;
+const Double_t V3Cage::sBPSuppLowCollHolDist = 100 * sMm;
+const Double_t V3Cage::sBPSuppLowCollTailHei = 6 * sMm;
+const Double_t V3Cage::sBPSuppCollarBeamLen = 370 * sMm;
+const Double_t V3Cage::sBPSuppCollarBeamWid = 40 * sMm;
+const Double_t V3Cage::sBPSuppCollarBeamHei = 12 * sMm;
+const Double_t V3Cage::sBPSuppBracketTotLen = 57 * sMm;
+const Double_t V3Cage::sBPSuppBracketWidth = 25 * sMm;
+const Double_t V3Cage::sBPSuppBracketInLen = 20 * sMm;
+const Double_t V3Cage::sBPSuppBracketInHei = 8 * sMm;
+const Double_t V3Cage::sBPSuppBracketTailLen = 18.5 * sMm;
+const Double_t V3Cage::sBPSuppBracketTailHei = 3 * sMm;
+const Double_t V3Cage::sBPSuppBrktCentHoleX = 31.5 * sMm;
+const Double_t V3Cage::sBPSuppBrktCentHoleD = 6 * sMm;
+const Double_t V3Cage::sBPSuppBrktLatHoleX = 24.5 * sMm;
+const Double_t V3Cage::sBPSuppBrktLatHoleD = 3.2 * sMm;
+const Double_t V3Cage::sBPSuppBrktLatHoleW = 4 * sMm;
+const Double_t V3Cage::sBPSuppBrktLatHoleH = 2.5 * sMm;
+const Double_t V3Cage::sBPSuppBrktHolesY = 0.5 * sMm;
+const Double_t V3Cage::sBPSuppCollarM4High = 2.2 * sMm;
+const Double_t V3Cage::sBPSuppCollarM4Diam = 7.5 * sMm;
+const Double_t V3Cage::sBPSuppCollarM4XDist = 68 * sMm;
+const Double_t V3Cage::sBPSuppCollarM4ZPos = 7 * sMm;
+const Double_t V3Cage::sBPSuppClampTotLen = 55 * sMm;
+const Double_t V3Cage::sBPSuppClampTotWid = 23 * sMm;
+const Double_t V3Cage::sBPSuppClampTotHei = 13 * sMm;
+const Double_t V3Cage::sBPSuppClampLatThick = 5 * sMm;
+const Double_t V3Cage::sBPSuppClampShelfLen = 25 * sMm;
+const Double_t V3Cage::sBPSuppClampShelfHei = 4.5 * sMm;
+const Double_t V3Cage::sBPSuppClampsXDist = 944 * sMm;
+const Double_t V3Cage::sBPSuppClampInsDmin = 7 * sMm;
+const Double_t V3Cage::sBPSuppClampInsDmax = 11 * sMm;
+const Double_t V3Cage::sBPSuppClampInsH = 2.9 * sMm;
+const Double_t V3Cage::sBPSuppClampInsXPos = 15 * sMm;
+const Double_t V3Cage::sBPSuppClampInsZPos = 7 * sMm;
+const Double_t V3Cage::sBPSuppClampShimLen = 26 * sMm;
+const Double_t V3Cage::sBPSuppClampShimWid = 15 * sMm;
+const Double_t V3Cage::sBPSuppClampShimThick = 2.5 * sMm;
+const Double_t V3Cage::sBPSuppClampM5High = 2.7 * sMm;
+const Double_t V3Cage::sBPSuppClampM5Diam = 8.5 * sMm;
+const Double_t V3Cage::sBPSuppClampM5ZPos = 20 * sMm;
+const Double_t V3Cage::sBPSuppZPos = 1801 * sMm;
+
 const Double_t V3Cage::sCageCrossXWidthTot = 973 * sMm;
 const Double_t V3Cage::sCageCrossXWidthExt = 944 * sMm;
 const Double_t V3Cage::sCageCrossXWidthInt = 904 * sMm;
@@ -149,13 +198,14 @@ void V3Cage::createAndPlaceCage(TGeoVolume* mother, const TGeoManager* mgr)
   //
 
   // Local variables
-  Double_t zunit, xpos, zpos;
+  Double_t zunit, xpos, ypos, zpos;
 
   // Create the cover elements
   TGeoVolume* cageCover = createCageCover(mgr);
   TGeoVolume* cageCoverRib = createCageCoverRib(mgr);
   TGeoVolume* cageEndCap = createCageEndCap(mgr);
   TGeoVolume* cageSidePanel = createCageSidePanel(mgr);
+  TGeoVolume* cageBPSupport = createBeamPipeSupport(mgr);
   TGeoVolume* cageClosingCross = createCageClosingCross(mgr);
 
   // Now place all elements
@@ -195,6 +245,11 @@ void V3Cage::createAndPlaceCage(TGeoVolume* mother, const TGeoManager* mgr)
   zpos = 3 * zunit;
   mother->AddNode(cageCoverRib, 5, new TGeoTranslation(0, sCageYInBarrel, zpos));
   mother->AddNode(cageCoverRib, 6, new TGeoCombiTrans(0, sCageYInBarrel, zpos, new TGeoRotation("", 180, 0, 0)));
+
+  // The Beam Pipe Support on A side
+  ypos = sCageYInBarrel - sBPSuppLowCollTailHei / 2;
+  zpos = sBPSuppZPos + sBPSuppCollarBeamWid / 2;
+  mother->AddNode(cageBPSupport, 1, new TGeoTranslation(0, ypos, zpos));
 
   return;
 }
@@ -971,6 +1026,537 @@ TGeoCompositeShape* V3Cage::createCageEndCapCableCross(const TGeoManager* mgr)
   TGeoCompositeShape* cableCross = new TGeoCompositeShape(crossShape.Data());
 
   return cableCross;
+}
+
+TGeoVolume* V3Cage::createBeamPipeSupport(const TGeoManager* mgr)
+{
+  //
+  // Creates the Beam Pipe Support inside the Cage on the A side
+  // (from drawings ALIITSUP1064, ALIITSUP1059, ALIITSUP1057, ALIITSUP1058,
+  // ALIITSUP1056, ALIITSUP0823, ALIITSUP0273, ALIITSUP1060, ALIITSUP1062)
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         The beam pipe support as a TGeoVolumeAssembly
+  //
+  // Created:      03 Jun 2023  Mario Sitta
+  //
+
+  // Local variables
+  const Int_t nv = 8;
+  Double_t xv[nv], yv[nv];
+  Double_t xpos, ypos, zpos;
+
+  // The TGeoVolumeAssembly holding all elements
+  TGeoVolumeAssembly* bpSuppVol = new TGeoVolumeAssembly("CageBeamPipeSupport");
+
+  // The lower collar
+  TGeoCompositeShape* lowCollarSh = createBPSuppLowerCollar(mgr);
+
+  // The upper collar
+  TGeoCompositeShape* upCollarSh = createBPSuppUpperCollar(mgr);
+
+  // Each one of the collar beams
+  TGeoCompositeShape* collarBeamSh = createBPSuppCollarBeam(mgr);
+
+  // Each one of the lateral brackets
+  TGeoCompositeShape* bracketSh = createBPSuppBracket(mgr);
+
+  // Each one of the lateral clamps
+  TGeoCompositeShape* clampSh = createBPSuppClamp(mgr);
+
+  // The Vespel bushing: a Tube
+  TGeoTube* bushSh = new TGeoTube(0.5 * sBPSuppCollarBushD, 0.5 * sBPSuppCollarIntD, 0.5 * sBPSuppBracketWidth);
+
+  // The clamp shim: a BBox
+  TGeoBBox* shimSh = new TGeoBBox(0.5 * sBPSuppClampShimWid, 0.5 * sBPSuppClampShimThick, 0.5 * sBPSuppClampShimLen);
+
+  // The M4 screw head: a Tube
+  TGeoTube* m4ScrewSh = new TGeoTube(0, 0.5 * sBPSuppCollarM4Diam, 0.5 * sBPSuppCollarM4High);
+
+  // The M5 screw head: a Tube
+  TGeoTube* m5ScrewSh = new TGeoTube(0, 0.5 * sBPSuppClampM5Diam, 0.5 * sBPSuppClampM5High);
+
+  // The threaded insert head: a Cone
+  TGeoCone* insHeadSh = new TGeoCone(0.5 * sBPSuppClampInsH, 0, 0.5 * sBPSuppClampInsDmin, 0, 0.5 * sBPSuppClampInsDmax);
+
+  // We have all the shapes: now create the real volumes
+  TGeoMedium* medCFRP = mgr->GetMedium(Form("%s_CFRP$", GetDetName()));
+  TGeoMedium* medTitanium = mgr->GetMedium(Form("%s_TITANIUM$", GetDetName()));
+  TGeoMedium* medSteel = mgr->GetMedium(Form("%s_INOX304$", GetDetName()));
+  TGeoMedium* medBrass = mgr->GetMedium(Form("%s_BRASS$", GetDetName()));
+  TGeoMedium* medVespel = mgr->GetMedium(Form("%s_VESPEL$", GetDetName()));
+
+  Color_t kTitanium = kGray + 1; // Darker gray
+
+  TGeoVolume* lowCollarVol = new TGeoVolume("BPSupportLowerCollar", lowCollarSh, medTitanium);
+  lowCollarVol->SetFillColor(kTitanium);
+  lowCollarVol->SetLineColor(kTitanium);
+
+  TGeoVolume* upCollarVol = new TGeoVolume("BPSupportUpperCollar", upCollarSh, medTitanium);
+  upCollarVol->SetFillColor(kTitanium);
+  upCollarVol->SetLineColor(kTitanium);
+
+  TGeoVolume* bushVol = new TGeoVolume("BPSupportCollarBushing", bushSh, medVespel);
+  bushVol->SetFillColor(kGreen);
+  bushVol->SetLineColor(kGreen);
+
+  TGeoVolume* collarBeamVol = new TGeoVolume("BPSupportCollarBeam", collarBeamSh, medCFRP);
+  collarBeamVol->SetFillColor(kBlue);
+  collarBeamVol->SetLineColor(kBlue);
+
+  TGeoVolume* bracketVol = new TGeoVolume("BPSupportBracket", bracketSh, medTitanium);
+  bracketVol->SetFillColor(kTitanium);
+  bracketVol->SetLineColor(kTitanium);
+
+  TGeoVolume* clampVol = new TGeoVolume("BPSupportClamp", clampSh, medTitanium);
+  clampVol->SetFillColor(kTitanium);
+  clampVol->SetLineColor(kTitanium);
+
+  TGeoVolume* shimVol = new TGeoVolume("BPSupportClampShim", shimSh, medBrass);
+  shimVol->SetFillColor(kOrange - 4); // Brownish
+  shimVol->SetLineColor(kOrange - 4);
+
+  TGeoVolume* m4ScrewVol = new TGeoVolume("BPSupportCollarScrew", m4ScrewSh, medTitanium);
+  m4ScrewVol->SetFillColor(kTitanium);
+  m4ScrewVol->SetLineColor(kTitanium);
+
+  TGeoVolume* m5ScrewVol = new TGeoVolume("BPSupportClampScrew", m5ScrewSh, medSteel);
+  m5ScrewVol->SetFillColor(kGray);
+  m5ScrewVol->SetLineColor(kGray);
+
+  TGeoVolume* insHeadVol = new TGeoVolume("BPSupportClampInsert", insHeadSh, medSteel);
+  insHeadVol->SetFillColor(kGray);
+  insHeadVol->SetLineColor(kGray);
+
+  // Then build up the beam support
+  bpSuppVol->AddNode(lowCollarVol, 1, nullptr);
+
+  ypos = sBPSuppLowCollTailHei / 2;
+  bpSuppVol->AddNode(upCollarVol, 1, new TGeoTranslation(0, ypos, 0));
+
+  bpSuppVol->AddNode(bushVol, 1, new TGeoTranslation(0, ypos, 0));
+
+  xpos = sBPSuppCollarM4XDist / 2;
+  ypos += (sBPSuppUpperCollarHei + m4ScrewSh->GetDz());
+  zpos = sBPSuppCollarM4ZPos;
+  bpSuppVol->AddNode(m4ScrewVol, 1, new TGeoCombiTrans(xpos, ypos, zpos, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(m4ScrewVol, 2, new TGeoCombiTrans(-xpos, ypos, zpos, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(m4ScrewVol, 3, new TGeoCombiTrans(xpos, ypos, -zpos, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(m4ScrewVol, 4, new TGeoCombiTrans(-xpos, ypos, -zpos, new TGeoRotation("", 0, 90, 0)));
+
+  xpos = sBPSuppLowerCollarLen / 2 - sBPSuppBracketInLen + sBPSuppCollarBeamLen / 2;
+  bpSuppVol->AddNode(collarBeamVol, 1, new TGeoCombiTrans(xpos, 0, 0, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(collarBeamVol, 2, new TGeoCombiTrans(-xpos, 0, 0, new TGeoRotation("", 0, 90, 0)));
+
+  xpos += (sBPSuppCollarBeamLen / 2 - sBPSuppBracketInLen);
+  bpSuppVol->AddNode(bracketVol, 1, new TGeoTranslation(xpos, 0, 0));
+  bpSuppVol->AddNode(bracketVol, 2, new TGeoCombiTrans(-xpos, 0, 0, new TGeoRotation("", 90, 180, -90)));
+
+  xpos = 0.5 * sBPSuppClampsXDist - sBPSuppClampTotWid + shimSh->GetDX();
+  ypos = -shimSh->GetDY();
+  bpSuppVol->AddNode(shimVol, 1, new TGeoTranslation(xpos, ypos, 0));
+  bpSuppVol->AddNode(shimVol, 2, new TGeoTranslation(-xpos, ypos, 0));
+
+  xpos = 0.5 * sBPSuppClampsXDist - sBPSuppClampLatThick;
+  ypos -= shimSh->GetDY();
+  bpSuppVol->AddNode(clampVol, 1, new TGeoTranslation(-xpos, ypos, 0));
+  bpSuppVol->AddNode(clampVol, 2, new TGeoCombiTrans(xpos, ypos, 0, new TGeoRotation("", 90, 180, -90)));
+
+  xpos -= m5ScrewSh->GetDz();
+  ypos += (0.5 * sBPSuppClampTotHei - sBPSuppClampShelfHei);
+  zpos = sBPSuppClampM5ZPos;
+  bpSuppVol->AddNode(m5ScrewVol, 1, new TGeoCombiTrans(xpos, ypos, zpos, new TGeoRotation("", 90, 90, -90)));
+  bpSuppVol->AddNode(m5ScrewVol, 2, new TGeoCombiTrans(xpos, ypos, -zpos, new TGeoRotation("", 90, 90, -90)));
+  bpSuppVol->AddNode(m5ScrewVol, 3, new TGeoCombiTrans(-xpos, ypos, zpos, new TGeoRotation("", 90, 90, -90)));
+  bpSuppVol->AddNode(m5ScrewVol, 4, new TGeoCombiTrans(-xpos, ypos, -zpos, new TGeoRotation("", 90, 90, -90)));
+
+  xpos = 0.5 * sBPSuppClampsXDist - sBPSuppClampInsXPos;
+  ypos = sBPSuppBracketTailHei + insHeadSh->GetDz();
+  zpos = sBPSuppClampInsZPos;
+  bpSuppVol->AddNode(insHeadVol, 1, new TGeoCombiTrans(xpos, ypos, zpos, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(insHeadVol, 2, new TGeoCombiTrans(-xpos, ypos, zpos, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(insHeadVol, 3, new TGeoCombiTrans(xpos, ypos, -zpos, new TGeoRotation("", 0, 90, 0)));
+  bpSuppVol->AddNode(insHeadVol, 4, new TGeoCombiTrans(-xpos, ypos, -zpos, new TGeoRotation("", 0, 90, 0)));
+
+  // Finally return the beam pipe support volume
+  return bpSuppVol;
+}
+
+TGeoCompositeShape* V3Cage::createBPSuppLowerCollar(const TGeoManager* mgr)
+{
+  //
+  // Creates the lower collar which actually supports the Beam Pipe
+  // (ALIITSUP1056)
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         The lower collar as a TGeoCompositeShape
+  //
+  // Created:      06 Jun 2023  Mario Sitta
+  //
+
+  // Local variables
+  const Int_t nv = 12;
+  Double_t xv[nv], yv[nv], xy8[16];
+  Double_t zlen;
+  Double_t xpos, ypos;
+
+  // The lateral bracket: a Xtru
+  Double_t totlen = (sBPSuppLowerCollarLen - sBPSuppCollarIntD) / 2;
+  Double_t xtail = (sBPSuppLowCollHolDist - sBPSuppCollarIntD) / 2;
+  Double_t taillen = sBPSuppLowerCollarTlX - sBPSuppCollarIntD / 2;
+
+  xv[0] = 0;
+  yv[0] = -sBPSuppCollarBeamHei / 2;
+  xv[1] = totlen - xtail;
+  yv[1] = yv[0];
+  xv[2] = totlen - taillen;
+  yv[2] = -sBPSuppLowCollTailHei / 2;
+  xv[3] = totlen;
+  yv[3] = yv[2];
+  xv[4] = xv[3];
+  yv[4] = sBPSuppLowCollTailHei / 2;
+  xv[5] = xv[2];
+  yv[5] = yv[4];
+  xv[6] = xv[1];
+  yv[6] = -yv[1];
+  xv[7] = xv[0];
+  yv[7] = yv[6];
+  xv[8] = xv[7];
+  yv[8] = sBPSuppBracketInHei / 2;
+  xv[9] = sBPSuppBracketInLen;
+  yv[9] = yv[8];
+  xv[10] = xv[9];
+  yv[10] = -yv[9];
+  xv[11] = xv[0];
+  yv[11] = yv[10];
+
+  zlen = sBPSuppBracketWidth / 2;
+  TGeoXtru* brktlat = new TGeoXtru(2);
+  brktlat->DefinePolygon(nv, xv, yv);
+  brktlat->DefineSection(0, -zlen);
+  brktlat->DefineSection(1, zlen);
+  brktlat->SetName("latBrackBody");
+
+  // The central hole in lateral bracket: a Tube
+  zlen = sBPSuppBracketWidth / 2 + 0.001;
+  TGeoTube* brktcenthole = new TGeoTube(0, sBPSuppBrktCentHoleD / 2, zlen);
+  brktcenthole->SetName("latBrackCentHole");
+
+  xpos = totlen - xtail;
+  TGeoTranslation* brktcenthmat = new TGeoTranslation(xpos, 0, 0);
+  brktcenthmat->SetName("latCentHoleMat");
+  brktcenthmat->RegisterYourself();
+
+  // The lateral hole in lateral bracket: an Arb8
+  // (array of vertices is in the form (x0, y0, x1, y1, ..., x7, y7) )
+  xy8[0] = 0;
+  xy8[1] = 0;
+  xy8[2] = -sBPSuppBrktLatHoleW;
+  xy8[3] = -sBPSuppBrktLatHoleH / 2;
+  xy8[4] = xy8[2];
+  xy8[5] = -xy8[3];
+  xy8[6] = xy8[0];
+  xy8[7] = xy8[1];
+  for (Int_t i = 0; i < 8; i++) { // The opposite face
+    xy8[8 + i] = xy8[i];
+  }
+  TGeoArb8* brktlathole = new TGeoArb8(zlen, xy8);
+  brktlathole->SetName("latBrackLatHole");
+
+  xpos = totlen - taillen;
+  TGeoTranslation* brktlathmat = new TGeoTranslation(xpos, 0, 0);
+  brktlathmat->SetName("latLatHoleMat");
+  brktlathmat->RegisterYourself();
+
+  // The lateral bracket: a CompositeShape
+  TGeoCompositeShape* latbrkt = new TGeoCompositeShape("latBrackBody-latBrackCentHole:latCentHoleMat-latBrackLatHole:latLatHoleMat");
+  latbrkt->SetName("lateralBracket");
+
+  // The lateral bracket matrices
+  xpos = sBPSuppLowerCollarLen / 2;
+  TGeoTranslation* latmat1 = new TGeoTranslation(-xpos, 0, 0);
+  latmat1->SetName("latBrackMat1");
+  latmat1->RegisterYourself();
+
+  TGeoCombiTrans* latmat2 = new TGeoCombiTrans(xpos, 0, 0, new TGeoRotation("", 90, 180, -90));
+  latmat2->SetName("latBrackMat2");
+  latmat2->RegisterYourself();
+
+  // The collar: a TubeSeg
+  TGeoTubeSeg* collar = new TGeoTubeSeg(0.5 * sBPSuppCollarIntD, 0.5 * sBPSuppCollarExtD, 0.5 * sBPSuppBracketWidth, 180, 360);
+  collar->SetName("lowerCollar");
+
+  ypos = brktlat->GetY(4); // The upper face of the tail
+  TGeoTranslation* collmat = new TGeoTranslation(0, ypos, 0);
+  collmat->SetName("lowerCollMat");
+  collmat->RegisterYourself();
+
+  // Finally create and return the lower collar
+  // (the origin of its reference system is at its center)
+  TGeoCompositeShape* collarShape = new TGeoCompositeShape("lowerCollar:lowerCollMat+lateralBracket:latBrackMat1+lateralBracket:latBrackMat2");
+
+  return collarShape;
+}
+
+TGeoCompositeShape* V3Cage::createBPSuppUpperCollar(const TGeoManager* mgr)
+{
+  //
+  // Creates the upper collar of the Beam Pipe Support (ALIITSUP0823)
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         The upper collar as a TGeoCompositeShape
+  //
+  // Created:      07 Jun 2023  Mario Sitta
+  //
+
+  // Local variables
+  Double_t xlen;
+  Double_t xpos, ypos;
+
+  // The lateral plate: a BBox
+  xlen = (sBPSuppUpperCollarLen - sBPSuppCollarIntD) / 2;
+  TGeoBBox* plate = new TGeoBBox(0.5 * xlen, 0.5 * sBPSuppUpperCollarHei, 0.5 * sBPSuppBracketWidth);
+  plate->SetName("lateralPlate");
+
+  xpos = sBPSuppUpperCollarLen / 2 - plate->GetDX();
+  ypos = plate->GetDY();
+  TGeoTranslation* latplmat1 = new TGeoTranslation(xpos, ypos, 0);
+  latplmat1->SetName("lateralPlateMat1");
+  latplmat1->RegisterYourself();
+
+  TGeoTranslation* latplmat2 = new TGeoTranslation(-xpos, ypos, 0);
+  latplmat2->SetName("lateralPlateMat2");
+  latplmat2->RegisterYourself();
+
+  // The collar: a TubeSeg
+  TGeoTubeSeg* collar = new TGeoTubeSeg(0.5 * sBPSuppCollarIntD, 0.5 * sBPSuppCollarExtD, 0.5 * sBPSuppBracketWidth, 0, 180);
+  collar->SetName("upperCollar");
+
+  // Finally create and return the upper collar
+  // (the origin of its reference system is at its center)
+  TGeoCompositeShape* collarShape = new TGeoCompositeShape("upperCollar+lateralPlate:lateralPlateMat1+lateralPlate:lateralPlateMat2");
+
+  return collarShape;
+}
+
+TGeoCompositeShape* V3Cage::createBPSuppCollarBeam(const TGeoManager* mgr)
+{
+  //
+  // Creates the collar beam (i.e. the lateral support bar) of the
+  // Beam Pipe Support (ALIITSUP1057)
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         The collar beam as a TGeoCompositeShape
+  //
+  // Created:      03 Jun 2023  Mario Sitta
+  //
+
+  // Local variables
+  const Int_t nv = 8;
+  Double_t xv[nv], yv[nv];
+  Double_t xlen, xwid, ylen, zlen;
+  Double_t xpos;
+
+  // The central part: a Xtru
+  xlen = (sBPSuppCollarBeamLen - 2 * sBPSuppBracketInLen) / 2;
+  xwid = (sBPSuppCollarBeamWid - sBPSuppBracketWidth) / 2;
+  xv[0] = -xlen;
+  yv[0] = -sBPSuppBracketWidth / 2;
+  xv[1] = xv[0] + xwid;
+  yv[1] = -sBPSuppCollarBeamWid / 2;
+  xv[2] = -xv[1];
+  yv[2] = yv[1];
+  xv[3] = -xv[0];
+  yv[3] = yv[0];
+  for (Int_t i = 0; i < 4; i++) { // Reflect the lower half to the upper half
+    xv[4 + i] = xv[3 - i];
+    yv[4 + i] = -yv[3 - i];
+  }
+
+  zlen = sBPSuppCollarBeamHei / 2;
+  TGeoXtru* colcent = new TGeoXtru(2);
+  colcent->SetName("collarCentral");
+  colcent->DefinePolygon(nv, xv, yv);
+  colcent->DefineSection(0, -zlen);
+  colcent->DefineSection(1, zlen);
+
+  // Each bracket insert: a BBox
+  xlen = sBPSuppBracketInLen / 2;
+  ylen = sBPSuppBracketWidth / 2;
+  zlen = sBPSuppBracketInHei / 2;
+  TGeoBBox* colins = new TGeoBBox("collarInsert", xlen, ylen, zlen);
+
+  xpos = colcent->GetX(0) - colins->GetDX();
+  TGeoTranslation* insmat1 = new TGeoTranslation(-xpos, 0, 0);
+  insmat1->SetName("colInsMat1");
+  insmat1->RegisterYourself();
+
+  TGeoTranslation* insmat2 = new TGeoTranslation(xpos, 0, 0);
+  insmat2->SetName("colInsMat2");
+  insmat2->RegisterYourself();
+
+  // Finally create and return the collar beam
+  // (the origin of its reference system is at its center)
+  TGeoCompositeShape* beamShape = new TGeoCompositeShape("collarCentral+collarInsert:colInsMat1+collarInsert:colInsMat2");
+
+  return beamShape;
+}
+
+TGeoCompositeShape* V3Cage::createBPSuppBracket(const TGeoManager* mgr)
+{
+  //
+  // Creates the lateral Titanium bracket of the Beam Pipe Support
+  // (ALIITSUP1058)
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         The bracket as a TGeoCompositeShape
+  //
+  // Created:      04 Jun 2023  Mario Sitta
+  //
+
+  // Local variables
+  const Int_t nv = 12;
+  Double_t xv[nv], yv[nv];
+  Double_t zlen;
+  Double_t xpos;
+
+  // The main body: a Xtru
+  xv[0] = 0;
+  yv[0] = -sBPSuppCollarBeamHei / 2;
+  xv[1] = sBPSuppBracketTotLen - sBPSuppBrktCentHoleX;
+  yv[1] = yv[0];
+  xv[2] = sBPSuppBracketTotLen - sBPSuppBracketTailLen;
+  yv[2] = 0;
+  xv[3] = sBPSuppBracketTotLen;
+  yv[3] = yv[2];
+  xv[4] = xv[3];
+  yv[4] = sBPSuppBracketTailHei;
+  xv[5] = xv[2];
+  yv[5] = yv[4];
+  xv[6] = xv[1];
+  yv[6] = -yv[1];
+  xv[7] = xv[0];
+  yv[7] = yv[6];
+  xv[8] = xv[7];
+  yv[8] = sBPSuppBracketInHei / 2;
+  xv[9] = sBPSuppBracketInLen;
+  yv[9] = yv[8];
+  xv[10] = xv[9];
+  yv[10] = -yv[9];
+  xv[11] = xv[0];
+  yv[11] = yv[10];
+
+  zlen = sBPSuppBracketWidth / 2;
+  TGeoXtru* brktbody = new TGeoXtru(2);
+  brktbody->DefinePolygon(nv, xv, yv);
+  brktbody->DefineSection(0, -zlen);
+  brktbody->DefineSection(1, zlen);
+  brktbody->SetName("bracketBody");
+
+  // The central hole: a Tube
+  zlen = sBPSuppBracketWidth / 2 + 0.001;
+  TGeoTube* brktcenthole = new TGeoTube(0, sBPSuppBrktCentHoleD / 2, zlen);
+  brktcenthole->SetName("bracketCentHole");
+
+  xpos = sBPSuppBracketTotLen - sBPSuppBrktCentHoleX;
+  TGeoTranslation* brktcenthmat = new TGeoTranslation(xpos, -sBPSuppBrktHolesY, 0);
+  brktcenthmat->SetName("bracketCentHMat");
+  brktcenthmat->RegisterYourself();
+
+  // The lateral hole: a Tube
+  TGeoTube* brktlathole = new TGeoTube(0, sBPSuppBrktLatHoleD / 2, zlen);
+  brktlathole->SetName("bracketLatHole");
+
+  xpos = sBPSuppBracketTotLen - sBPSuppBrktLatHoleX;
+  TGeoTranslation* brktlathmat = new TGeoTranslation(xpos, sBPSuppBrktHolesY, 0);
+  brktlathmat->SetName("bracketLatHMat");
+  brktlathmat->RegisterYourself();
+
+  // Finally create and return the bracket
+  // (the origin of its reference system is opposite to its tail)
+  TGeoCompositeShape* bracketShape = new TGeoCompositeShape("bracketBody-bracketCentHole:bracketCentHMat-bracketLatHole:bracketLatHMat");
+
+  return bracketShape;
+}
+
+TGeoCompositeShape* V3Cage::createBPSuppClamp(const TGeoManager* mgr)
+{
+  //
+  // Creates the lateral Titanium clamp holding the Beam Pipe Support
+  // to the ITS Cage (ALIITSUP1060)
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         The clamp as a TGeoCompositeShape
+  //
+  // Created:      08 Jun 2023  Mario Sitta
+  //
+
+  // Local variables
+  Double_t xlen, ylen, zlen;
+  Double_t xpos, ypos;
+
+  // The vertical wall: a BBox
+  xlen = sBPSuppClampLatThick / 2;
+  ylen = sBPSuppClampTotHei / 2;
+  zlen = sBPSuppClampTotLen / 2;
+  TGeoBBox* clampwall = new TGeoBBox(xlen, ylen, zlen);
+  clampwall->SetName("clampWall");
+
+  xpos = -clampwall->GetDX();
+  ypos = clampwall->GetDY() - sBPSuppClampShelfHei;
+  TGeoTranslation* clampwallmat = new TGeoTranslation(xpos, ypos, 0);
+  clampwallmat->SetName("clampWallMat");
+  clampwallmat->RegisterYourself();
+
+  // The horizontal shelf: a BBox
+  xlen = (sBPSuppClampTotWid - sBPSuppClampLatThick) / 2;
+  ylen = sBPSuppClampShelfHei / 2;
+  zlen = sBPSuppClampShelfLen / 2;
+  TGeoBBox* clampshelf = new TGeoBBox(xlen, ylen, zlen);
+  clampshelf->SetName("clampShelf");
+
+  xpos = clampshelf->GetDX();
+  ypos = -clampshelf->GetDY();
+  TGeoTranslation* clampshelfmat = new TGeoTranslation(xpos, ypos, 0);
+  clampshelfmat->SetName("clampShelfMat");
+  clampshelfmat->RegisterYourself();
+
+  // Finally create and return the clamp
+  // (the origin of its reference system is at the conjunction
+  // of the vertical wall with the horizontal shelf)
+  TGeoCompositeShape* clampShape = new TGeoCompositeShape("clampWall:clampWallMat+clampShelf:clampShelfMat");
+
+  return clampShape;
 }
 
 TGeoVolume* V3Cage::createCageClosingCross(const TGeoManager* mgr)


### PR DESCRIPTION
The Beam Pipe Support structure anchored to the ITS Cage and placed on the A Side was implemented following the blueprints with pretty a lot of details. The actual implementation is inside the V3Cage class. To avoid fake overlaps with the rough description of the ITS services (cables and the like) inside the Cage, these volumes were slightly modified (in the V3Services class): two holes were drilled on the sides of the service shapes through which the supporting bars can pass.