### PR TITLE
DPL: runNumber can never change to zero

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1954,6 +1954,8 @@ bool DataProcessingDevice::tryDispatchComputation(ServiceRegistryRef ref, std::v
     timingInfo.runNumber = relayer.getRunNumberForSlot(i);
     timingInfo.creation = relayer.getCreationTimeForSlot(i);
     timingInfo.globalRunNumberChanged = !TimingInfo::timesliceIsTimer(timeslice.value) && dataProcessorContext.lastRunNumberProcessed != timingInfo.runNumber;
+    // A switch to runNumber=0 should not appear and thus does not set globalRunNumberChanged, unless it is seen in the first processed timeslice
+    timingInfo.globalRunNumberChanged &= (dataProcessorContext.lastRunNumberProcessed == -1 || timingInfo.runNumber != 0);
     // We report wether or not this timing info refers to a new Run.
     if (timingInfo.globalRunNumberChanged) {
       dataProcessorContext.lastRunNumberProcessed = timingInfo.runNumber;


### PR DESCRIPTION
In the end of run sequence it can happen that we receive a message with runNumber = 0. For some devices this can trigger a call which is only meant to happen in case a real new run is started. So for runNumber=0 the globalRunNumberChanged should not be set to true

```
[15:29:01][INFO] Processing timeslice:40260, tfCounter:40446, firstTForbit:32, runNumber:538056, creation:1547590800002, action:0
[15:29:01][INFO] Done processing timeslice:40260, tfCounter:40446, firstTForbit:32, runNumber:538056, creation:1547590800002, action:0, wall:1440
[15:29:01][INFO] Processing timeslice:40261, tfCounter:169, firstTForbit:0, runNumber:0, creation:1547590800000, action:0

```

Related to https://alice.its.cern.ch/jira/browse/O2-3859