### PR TITLE
Introduce proper generator IDs

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -84,3 +84,8 @@ o2_add_test(MCGenStatus
             SOURCES test/testMCGenStatus.cxx
             COMPONENT_NAME SimulationDataFormat
             PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat)
+
+o2_add_test(MCGenId
+            SOURCES test/testMCGenId.cxx
+            COMPONENT_NAME SimulationDataFormat
+            PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat)

--- a/DataFormats/simulation/include/SimulationDataFormat/MCGenProperties.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCGenProperties.h
@@ -86,8 +86,8 @@ class GeneratorProperty
   typedef const char* Property;
   static constexpr Property GENERATORID{"generator_id"};
   static constexpr Property GENERATORDESCRIPTION{"generator_description"};
-  static constexpr Property COCKTAILID{"cocktail_id"};
-  static constexpr Property COCKTAILDESCRIPTIONMAP{"gcocktail_description_map"};
+  static constexpr Property SUBGENERATORID{"subgenerator_id"};
+  static constexpr Property SUBGENERATORDESCRIPTIONMAP{"subgenerator_description_map"};
 };
 
 // internal structure to allow convenient manipulation of properties as bits on an int to (dis)entangle HepMC and specific generator status codes
@@ -95,18 +95,18 @@ union MCGenIdEncoding {
   MCGenIdEncoding() : fullEncoding(0) {}
   MCGenIdEncoding(int enc) : fullEncoding(enc) {}
   // To be backward-compatible, only set transport to 1 if hepmc status is 1
-  MCGenIdEncoding(int generatorId, int sourceId, int cocktailId = -1) : generatorId(generatorId), sourceId(sourceId), cocktailId(cocktailId) {}
+  MCGenIdEncoding(int generatorId, int sourceId, int subGeneratorId = -1) : generatorId(generatorId), sourceId(sourceId), subGeneratorId(subGeneratorId) {}
   short fullEncoding;
   struct {
-    short generatorId : 5; // an additional identifier for a generator which can be set by the user
-    short sourceId : 5;    // ID used in embedding scenarios
-    short cocktailId : 6;  // reserved bits for future encodings, for instance to identify single cocktail constituents of a generator
+    short generatorId : 7;    // an additional identifier for a generator which can be set by the user
+    short sourceId : 4;       // ID used in embedding scenarios
+    short subGeneratorId : 5; // sub generator ID in case a generator implements some additional logic
   };
 };
 
-inline short getEncodedGenId(int generatorId, int sourceId, int cocktailId = -1)
+inline short getEncodedGenId(int generatorId, int sourceId, int subGeneratorId = -1)
 {
-  return MCGenIdEncoding(generatorId, sourceId, cocktailId).fullEncoding;
+  return MCGenIdEncoding(generatorId, sourceId, subGeneratorId).fullEncoding;
 }
 
 inline int getGeneratorId(short encoded)
@@ -119,9 +119,9 @@ inline int getSourceId(short encoded)
   return static_cast<int>(MCGenIdEncoding(encoded).sourceId);
 }
 
-inline int getCocktailId(short encoded)
+inline int getSubGeneratorId(short encoded)
 {
-  return static_cast<int>(MCGenIdEncoding(encoded).cocktailId);
+  return static_cast<int>(MCGenIdEncoding(encoded).subGeneratorId);
 }
 
 } // namespace mcgenid

--- a/DataFormats/simulation/include/SimulationDataFormat/MCGenProperties.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCGenProperties.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef ALICEO2_SIMDATA_MCGENSTATUS_H_
-#define ALICEO2_SIMDATA_MCGENSTATUS_H_
+#ifndef ALICEO2_SIMDATA_MCGENPROPERTIES_H_
+#define ALICEO2_SIMDATA_MCGENPROPERTIES_H_
 
 namespace o2
 {
@@ -75,6 +75,56 @@ inline int getGenStatusCode(int encoded)
 }
 
 } // namespace mcgenstatus
+
+namespace mcgenid
+{
+
+// Define some common properties that can be set for Generators
+class GeneratorProperty
+{
+ public:
+  typedef const char* Property;
+  static constexpr Property GENERATORID{"generator_id"};
+  static constexpr Property GENERATORDESCRIPTION{"generator_description"};
+  static constexpr Property COCKTAILID{"cocktail_id"};
+  static constexpr Property COCKTAILDESCRIPTIONMAP{"gcocktail_description_map"};
+};
+
+// internal structure to allow convenient manipulation of properties as bits on an int to (dis)entangle HepMC and specific generator status codes
+union MCGenIdEncoding {
+  MCGenIdEncoding() : fullEncoding(0) {}
+  MCGenIdEncoding(int enc) : fullEncoding(enc) {}
+  // To be backward-compatible, only set transport to 1 if hepmc status is 1
+  MCGenIdEncoding(int generatorId, int sourceId, int cocktailId = -1) : generatorId(generatorId), sourceId(sourceId), cocktailId(cocktailId) {}
+  short fullEncoding;
+  struct {
+    short generatorId : 5; // an additional identifier for a generator which can be set by the user
+    short sourceId : 5;    // ID used in embedding scenarios
+    short cocktailId : 6;  // reserved bits for future encodings, for instance to identify single cocktail constituents of a generator
+  };
+};
+
+inline short getEncodedGenId(int generatorId, int sourceId, int cocktailId = -1)
+{
+  return MCGenIdEncoding(generatorId, sourceId, cocktailId).fullEncoding;
+}
+
+inline int getGeneratorId(short encoded)
+{
+  return static_cast<int>(MCGenIdEncoding(encoded).generatorId);
+}
+
+inline int getSourceId(short encoded)
+{
+  return static_cast<int>(MCGenIdEncoding(encoded).sourceId);
+}
+
+inline int getCocktailId(short encoded)
+{
+  return static_cast<int>(MCGenIdEncoding(encoded).cocktailId);
+}
+
+} // namespace mcgenid
 
 } // namespace o2
 

--- a/DataFormats/simulation/include/SimulationDataFormat/MCGenProperties.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCGenProperties.h
@@ -90,27 +90,28 @@ class GeneratorProperty
   static constexpr Property SUBGENERATORDESCRIPTIONMAP{"subgenerator_description_map"};
 };
 
-// internal structure to allow convenient manipulation of properties as bits on an int to (dis)entangle HepMC and specific generator status codes
+// internal structure to allow encoding of generator IDs and map different numbers to a single short
 union MCGenIdEncoding {
   MCGenIdEncoding() : fullEncoding(0) {}
   MCGenIdEncoding(int enc) : fullEncoding(enc) {}
-  // To be backward-compatible, only set transport to 1 if hepmc status is 1
-  MCGenIdEncoding(int generatorId, int sourceId, int subGeneratorId = -1) : generatorId(generatorId), sourceId(sourceId), subGeneratorId(subGeneratorId) {}
+  MCGenIdEncoding(int generatorId, int sourceId, int subGeneratorId) : generatorId(generatorId), sourceId(sourceId), subGeneratorId(subGeneratorId) {}
   short fullEncoding;
   struct {
-    short generatorId : 7;    // an additional identifier for a generator which can be set by the user
-    short sourceId : 4;       // ID used in embedding scenarios
-    short subGeneratorId : 5; // sub generator ID in case a generator implements some additional logic
+    unsigned short generatorId : 7;    // an additional identifier for a generator which can be set by the user
+    unsigned short sourceId : 4;       // ID used in embedding scenarios
+    unsigned short subGeneratorId : 5; // sub generator ID in case a generator implements some additional logic
   };
 };
 
 inline short getEncodedGenId(int generatorId, int sourceId, int subGeneratorId = -1)
 {
-  return MCGenIdEncoding(generatorId, sourceId, subGeneratorId).fullEncoding;
+
+  return MCGenIdEncoding(generatorId, sourceId, subGeneratorId + 1).fullEncoding;
 }
 
 inline int getGeneratorId(short encoded)
 {
+
   return static_cast<int>(MCGenIdEncoding(encoded).generatorId);
 }
 
@@ -121,7 +122,7 @@ inline int getSourceId(short encoded)
 
 inline int getSubGeneratorId(short encoded)
 {
-  return static_cast<int>(MCGenIdEncoding(encoded).subGeneratorId);
+  return static_cast<int>(MCGenIdEncoding(encoded).subGeneratorId) - 1;
 }
 
 } // namespace mcgenid

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -17,7 +17,7 @@
 #define ALICEO2_DATA_MCTRACK_H_
 
 #include "SimulationDataFormat/ParticleStatus.h"
-#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "Rtypes.h"
 #include "SimulationDataFormat/O2DatabasePDG.h"

--- a/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
@@ -16,8 +16,8 @@
 #ifndef O2_MCUTILS_H
 #define O2_MCUTILS_H
 
+#include <string>
 #include <SimulationDataFormat/MCTrack.h>
-#include <SimulationDataFormat/MCGenStatus.h>
 #include <SimulationDataFormat/ParticleStatus.h>
 #include "TPDGCode.h"
 #include "TParticle.h"
@@ -26,6 +26,7 @@ namespace o2
 {
 namespace mcutils
 {
+
 /// A couple of functions to query on MC tracks ( that needs navigation within the global container
 /// of available tracks. It is a class so as to make it available for interactive ROOT more easily.
 class MCTrackNavigator
@@ -79,7 +80,6 @@ class MCGenHelper
   // Has to be in a class as a static methid. Just in a namespace it doesn't work to use this function in ROOT macros.
   static void encodeParticleStatusAndTracking(TParticle& particle, bool wanttracking = true);
   static void encodeParticleStatusAndTracking(TParticle& particle, int hepmcStatus, int genStatus, bool wanttracking = true);
-
   ClassDefNV(MCGenHelper, 1)
 };
 

--- a/DataFormats/simulation/src/MCUtils.cxx
+++ b/DataFormats/simulation/src/MCUtils.cxx
@@ -14,7 +14,7 @@
 //
 
 #include <SimulationDataFormat/MCUtils.h>
-#include <SimulationDataFormat/MCGenStatus.h>
+#include <SimulationDataFormat/MCGenProperties.h>
 
 namespace o2::mcutils
 {

--- a/DataFormats/simulation/test/testMCGenId.cxx
+++ b/DataFormats/simulation/test/testMCGenId.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#define BOOST_TEST_MODULE Test MCGenStatus class
+#define BOOST_TEST_MODULE Test MCGenId class
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -19,16 +19,17 @@ using namespace o2::mcgenid;
 
 BOOST_AUTO_TEST_CASE(MCGenId_test)
 {
-  // create 2 vectors each with some random integers
-  constexpr size_t length{100};
-  constexpr int low{-2};
-  constexpr int highGenerator{64};
-  constexpr int highSubGenerator{16};
-  constexpr int highSource{8};
+  // possible generator IDs range from 0 to 127 (included)
+  constexpr int highGenerator{128};
+  // possible sub-generator IDs range from -1 to 30 (included)
+  constexpr int highSubGenerator{31};
+  // possible soufce IDs range from 0 to 15 (included)
+  constexpr int highSource{16};
 
+  // test all combinations
   for (int sourceId = 0; sourceId < highSource; sourceId++) {
     for (int generatorId = 0; generatorId < highGenerator; generatorId++) {
-      for (int subGeneratorId = 0; subGeneratorId < highSubGenerator; subGeneratorId++) {
+      for (int subGeneratorId = -1; subGeneratorId < highSubGenerator; subGeneratorId++) {
         auto encoded = getEncodedGenId(generatorId, sourceId, subGeneratorId);
         // decode them
         auto sourceIdAfter = getSourceId(encoded);

--- a/DataFormats/simulation/test/testMCGenId.cxx
+++ b/DataFormats/simulation/test/testMCGenId.cxx
@@ -1,0 +1,54 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCGenStatus class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "SimulationDataFormat/MCGenProperties.h"
+#include "TRandom.h"
+
+using namespace o2::mcgenid;
+
+BOOST_AUTO_TEST_CASE(MCGenId_test)
+{
+  // create 2 vectors each with some random integers
+  constexpr size_t length{100};
+  constexpr int low{-2};
+  constexpr int high{16};
+
+  // initialise the seed (could be anything)
+  gRandom->SetSeed();
+
+  for (size_t i = 0; i < length; i++) {
+    // draw random integers
+    auto sourceId = static_cast<int>(gRandom->Uniform(low, high));
+    auto generatorId = static_cast<int>(gRandom->Uniform(low, high));
+    auto cocktailId = static_cast<int>(gRandom->Uniform(low, high));
+
+    // encode them
+    auto encoded = getEncodedGenId(generatorId, sourceId, cocktailId);
+
+    // decode them
+    auto sourceIdAfter = getSourceId(encoded);
+    auto generatorIdAfter = getGeneratorId(encoded);
+    auto cocktailIdAfter = getCocktailId(encoded);
+
+    std::cout << "SourceID: " << sourceId << " ==> " << sourceIdAfter << "\n"
+              << "generatorId: " << generatorId << " ==> " << generatorIdAfter << "\n"
+              << "cocktailId: " << cocktailId << " ==> " << cocktailIdAfter << "\n";
+
+    // check if original and decoded numbers are the same
+    BOOST_CHECK(sourceIdAfter == sourceId);
+    BOOST_CHECK(generatorIdAfter == generatorId);
+    BOOST_CHECK(cocktailId == cocktailIdAfter);
+  }
+}

--- a/DataFormats/simulation/test/testMCGenId.cxx
+++ b/DataFormats/simulation/test/testMCGenId.cxx
@@ -14,7 +14,6 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 #include "SimulationDataFormat/MCGenProperties.h"
-#include "TRandom.h"
 
 using namespace o2::mcgenid;
 
@@ -23,32 +22,28 @@ BOOST_AUTO_TEST_CASE(MCGenId_test)
   // create 2 vectors each with some random integers
   constexpr size_t length{100};
   constexpr int low{-2};
-  constexpr int high{16};
+  constexpr int highGenerator{64};
+  constexpr int highSubGenerator{16};
+  constexpr int highSource{8};
 
-  // initialise the seed (could be anything)
-  gRandom->SetSeed();
+  for (int sourceId = 0; sourceId < highSource; sourceId++) {
+    for (int generatorId = 0; generatorId < highGenerator; generatorId++) {
+      for (int subGeneratorId = 0; subGeneratorId < highSubGenerator; subGeneratorId++) {
+        auto encoded = getEncodedGenId(generatorId, sourceId, subGeneratorId);
+        // decode them
+        auto sourceIdAfter = getSourceId(encoded);
+        auto generatorIdAfter = getGeneratorId(encoded);
+        auto subGeneratorIdAfter = getSubGeneratorId(encoded);
 
-  for (size_t i = 0; i < length; i++) {
-    // draw random integers
-    auto sourceId = static_cast<int>(gRandom->Uniform(low, high));
-    auto generatorId = static_cast<int>(gRandom->Uniform(low, high));
-    auto cocktailId = static_cast<int>(gRandom->Uniform(low, high));
+        std::cout << "SourceID: " << sourceId << " ==> " << sourceIdAfter << "\n"
+                  << "generatorId: " << generatorId << " ==> " << generatorIdAfter << "\n"
+                  << "subGeneratorId: " << subGeneratorId << " ==> " << subGeneratorIdAfter << "\n";
 
-    // encode them
-    auto encoded = getEncodedGenId(generatorId, sourceId, cocktailId);
-
-    // decode them
-    auto sourceIdAfter = getSourceId(encoded);
-    auto generatorIdAfter = getGeneratorId(encoded);
-    auto cocktailIdAfter = getCocktailId(encoded);
-
-    std::cout << "SourceID: " << sourceId << " ==> " << sourceIdAfter << "\n"
-              << "generatorId: " << generatorId << " ==> " << generatorIdAfter << "\n"
-              << "cocktailId: " << cocktailId << " ==> " << cocktailIdAfter << "\n";
-
-    // check if original and decoded numbers are the same
-    BOOST_CHECK(sourceIdAfter == sourceId);
-    BOOST_CHECK(generatorIdAfter == generatorId);
-    BOOST_CHECK(cocktailId == cocktailIdAfter);
+        // check if original and decoded numbers are the same
+        BOOST_CHECK(sourceIdAfter == sourceId);
+        BOOST_CHECK(generatorIdAfter == generatorId);
+        BOOST_CHECK(subGeneratorId == subGeneratorIdAfter);
+      }
+    }
   }
 }

--- a/DataFormats/simulation/test/testMCGenStatus.cxx
+++ b/DataFormats/simulation/test/testMCGenStatus.cxx
@@ -15,7 +15,7 @@
 #include <boost/test/unit_test.hpp>
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/ParticleStatus.h"
-#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "SimulationDataFormat/MCUtils.h"
 #include "TFile.h"
 #include "TParticle.h"

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1842,7 +1842,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
           auto& header = mcReader->getMCEventHeader(sourceID, eventID);
           bool isValid{};
           mcCollisionsCursor(bcID,
-                             o2::mcgenid::getEncodedGenId(header.getInfo<int>(o2::mcgenid::GeneratorProperty::GENERATORID, isValid), header.getInfo<int>(o2::mcgenid::GeneratorProperty::COCKTAILID, isValid), sourceID),
+                             o2::mcgenid::getEncodedGenId(header.getInfo<int>(o2::mcgenid::GeneratorProperty::GENERATORID, isValid), sourceID, header.getInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, isValid)),
                              truncateFloatFraction(header.GetX(), mCollisionPosition),
                              truncateFloatFraction(header.GetY(), mCollisionPosition),
                              truncateFloatFraction(header.GetZ(), mCollisionPosition),

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -72,6 +72,7 @@
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCUtils.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "ZDCBase/Constants.h"
 #include "TPCBase/ParameterElectronics.h"
 #include "GPUTPCGMMergedTrackHit.h"
@@ -1838,10 +1839,10 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
         if (nParts == 1 || sourceID == 0) {
           // FIXME:
           // use generators' names for generatorIDs (?)
-          short generatorID = sourceID;
           auto& header = mcReader->getMCEventHeader(sourceID, eventID);
+          bool isValid{};
           mcCollisionsCursor(bcID,
-                             generatorID,
+                             o2::mcgenid::getEncodedGenId(header.getInfo<int>(o2::mcgenid::GeneratorProperty::GENERATORID, isValid), header.getInfo<int>(o2::mcgenid::GeneratorProperty::COCKTAILID, isValid), sourceID),
                              truncateFloatFraction(header.GetX(), mCollisionPosition),
                              truncateFloatFraction(header.GetY(), mCollisionPosition),
                              truncateFloatFraction(header.GetZ(), mCollisionPosition),

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -19,7 +19,7 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "CommonConstants/GeomConstants.h"
 #include "CommonConstants/ZDCConstants.h"
-#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 
 using namespace o2::constants::math;
 
@@ -1271,13 +1271,20 @@ namespace mccollision
 {
 DECLARE_SOA_INDEX_COLUMN(BC, bc); //! BC index
 // TODO enum to be added to O2
-DECLARE_SOA_COLUMN(GeneratorsID, generatorsID, short);       //!
+DECLARE_SOA_COLUMN(GeneratorsID, generatorsID, short);       //! disentangled generator IDs should be accessed from dynamic columns using getGenId, getCocktailId and getSourceId
 DECLARE_SOA_COLUMN(PosX, posX, float);                       //! X vertex position in cm
 DECLARE_SOA_COLUMN(PosY, posY, float);                       //! Y vertex position in cm
 DECLARE_SOA_COLUMN(PosZ, posZ, float);                       //! Z vertex position in cm
 DECLARE_SOA_COLUMN(T, t, float);                             //! Collision time relative to given bc in ns
 DECLARE_SOA_COLUMN(Weight, weight, float);                   //! MC weight
 DECLARE_SOA_COLUMN(ImpactParameter, impactParameter, float); //! Impact parameter for A-A
+DECLARE_SOA_DYNAMIC_COLUMN(GetGenId, getGenId,               //! The global generator ID which might have been assigned by the user
+                           [](short generatorsID) -> int { return o2::mcgenid::getGeneratorId(generatorsID); });
+DECLARE_SOA_DYNAMIC_COLUMN(GetCocktailId, getCocktailId, //! A specific cocktail ID in case the generator consisted of multiple cocktail constituents
+                           [](short generatorsID) -> int { return o2::mcgenid::getCocktailId(generatorsID); });
+DECLARE_SOA_DYNAMIC_COLUMN(GetSourceId, getSourceId, //! The source ID to differentiate between signals and background in an embedding simulation
+                           [](short generatorsID) -> int { return o2::mcgenid::getSourceId(generatorsID); });
+
 } // namespace mccollision
 
 DECLARE_SOA_TABLE(McCollisions, "AOD", "MCCOLLISION", //! MC collision table

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1270,7 +1270,6 @@ using Run2BCInfo = Run2BCInfos::iterator;
 namespace mccollision
 {
 DECLARE_SOA_INDEX_COLUMN(BC, bc); //! BC index
-// TODO enum to be added to O2
 DECLARE_SOA_COLUMN(GeneratorsID, generatorsID, short);       //! disentangled generator IDs should be accessed from dynamic columns using getGenId, getCocktailId and getSourceId
 DECLARE_SOA_COLUMN(PosX, posX, float);                       //! X vertex position in cm
 DECLARE_SOA_COLUMN(PosY, posY, float);                       //! Y vertex position in cm
@@ -1278,10 +1277,10 @@ DECLARE_SOA_COLUMN(PosZ, posZ, float);                       //! Z vertex positi
 DECLARE_SOA_COLUMN(T, t, float);                             //! Collision time relative to given bc in ns
 DECLARE_SOA_COLUMN(Weight, weight, float);                   //! MC weight
 DECLARE_SOA_COLUMN(ImpactParameter, impactParameter, float); //! Impact parameter for A-A
-DECLARE_SOA_DYNAMIC_COLUMN(GetGenId, getGenId,               //! The global generator ID which might have been assigned by the user
+DECLARE_SOA_DYNAMIC_COLUMN(GetGeneratorId, getGeneratorId,   //! The global generator ID which might have been assigned by the user
                            [](short generatorsID) -> int { return o2::mcgenid::getGeneratorId(generatorsID); });
-DECLARE_SOA_DYNAMIC_COLUMN(GetCocktailId, getCocktailId, //! A specific cocktail ID in case the generator consisted of multiple cocktail constituents
-                           [](short generatorsID) -> int { return o2::mcgenid::getCocktailId(generatorsID); });
+DECLARE_SOA_DYNAMIC_COLUMN(GetSubGeneratorId, getSubGeneratorId, //! A specific sub-generator ID in case the generator has some sub-generator logic
+                           [](short generatorsID) -> int { return o2::mcgenid::getSubGeneratorId(generatorsID); });
 DECLARE_SOA_DYNAMIC_COLUMN(GetSourceId, getSourceId, //! The source ID to differentiate between signals and background in an embedding simulation
                            [](short generatorsID) -> int { return o2::mcgenid::getSourceId(generatorsID); });
 

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_add_library(Generators
                        src/GeneratorFromFile.cxx
                        src/GeneratorFromO2KineParam.cxx
                        src/PrimaryGenerator.cxx
+                       src/PrimaryGeneratorParam.cxx
                        src/TriggerExternalParam.cxx
                        src/TriggerParticleParam.cxx
                        src/BoxGunParam.cxx
@@ -71,6 +72,7 @@ set(headers
     include/Generators/GeneratorFromFile.h
     include/Generators/GeneratorFromO2KineParam.h
     include/Generators/PrimaryGenerator.h
+    include/Generators/PrimaryGeneratorParam.h
     include/Generators/TriggerExternalParam.h
     include/Generators/TriggerParticleParam.h
     include/Generators/BoxGunParam.h
@@ -81,11 +83,11 @@ set(headers
 
 if (pythia6_FOUND)
    list(APPEND headers include/Generators/GeneratorPythia6.h
-   	       include/Generators/GeneratorPythia6Param.h)
+                       include/Generators/GeneratorPythia6Param.h)
 endif()
 
 if(pythia_FOUND)
-  list(APPEND headers 
+  list(APPEND headers
               include/Generators/GeneratorPythia8.h
               include/Generators/DecayerPythia8.h
               include/Generators/GeneratorPythia8Param.h
@@ -137,8 +139,8 @@ o2_add_test_root_macro(share/external/trigger_mpi.C
 o2_add_test_root_macro(share/egconfig/pythia8_userhooks_charm.C
         PUBLIC_LINK_LIBRARIES O2::Generators
                        LABELS generators)
-endif()		       
-		     
+endif()
+
 o2_data_file(COPY share/external DESTINATION Generators)
 o2_data_file(COPY share/egconfig DESTINATION Generators)
 o2_data_file(COPY share/pythia8 DESTINATION Generators)

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -111,10 +111,7 @@ class Generator : public FairGenerator
   Bool_t triggerEvent();
 
   /** to handle cocktail constituents **/
-  void addSubGenerator(int subGeneratorId, std::string const& subGeneratorDescription)
-  {
-    mSubGeneratorsIdToDesc.insert({subGeneratorId, subGeneratorDescription});
-  }
+  void addSubGenerator(int subGeneratorId, std::string const& subGeneratorDescription);
   void notifySubGenerator(int subGeneratorId) { mSubGeneratorId = subGeneratorId; }
 
   /** generator interface **/

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -19,6 +19,7 @@
 #include "Generators/Trigger.h"
 #include <functional>
 #include <vector>
+#include <unordered_map>
 
 namespace o2
 {
@@ -61,12 +62,12 @@ class Generator : public FairGenerator
   Bool_t Init() override;
 
   /** Abstract method ReadEvent must be implemented by any derived class.
-	It has to handle the generation of input tracks (reading from input
-	file) and the handing of the tracks to the FairPrimaryGenerator. I
-	t is called from FairMCApplication.
-	*@param pStack The stack
-	*@return kTRUE if successful, kFALSE if not
-	**/
+  has to handle the generation of input tracks (reading from input
+  file) and the handing of the tracks to the FairPrimaryGenerator. It is
+  called from FairMCApplication.
+  *@param pStack The stack
+  *@return kTRUE if successful, kFALSE if not
+  **/
   Bool_t ReadEvent(FairPrimaryGenerator* primGen) final;
 
   /** methods to override **/
@@ -109,6 +110,13 @@ class Generator : public FairGenerator
   Bool_t boostEvent();
   Bool_t triggerEvent();
 
+  /** to handle cocktail constituents **/
+  void addCocktailConstituent(int cocktailId, std::string const& cocktailDescription)
+  {
+    mCocktailIdToDesc.insert({cocktailId, cocktailDescription});
+  }
+  void notifyCocktailConstituent(int cocktailId) { mCocktailId = cocktailId; }
+
   /** generator interface **/
   void* mInterface = nullptr;
   std::string mInterfaceName;
@@ -136,7 +144,13 @@ class Generator : public FairGenerator
   /** lorentz boost data members **/
   Double_t mBoost;
 
-  ClassDefOverride(Generator, 1);
+ private:
+  void updateCocktailInformation(o2::dataformats::MCEventHeader* header) const;
+
+  std::unordered_map<int, std::string> mCocktailIdToDesc;
+  int mCocktailId = -1;
+
+  ClassDefOverride(Generator, 2);
 
 }; /** class Generator **/
 

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -111,11 +111,11 @@ class Generator : public FairGenerator
   Bool_t triggerEvent();
 
   /** to handle cocktail constituents **/
-  void addCocktailConstituent(int cocktailId, std::string const& cocktailDescription)
+  void addSubGenerator(int subGeneratorId, std::string const& subGeneratorDescription)
   {
-    mCocktailIdToDesc.insert({cocktailId, cocktailDescription});
+    mSubGeneratorsIdToDesc.insert({subGeneratorId, subGeneratorDescription});
   }
-  void notifyCocktailConstituent(int cocktailId) { mCocktailId = cocktailId; }
+  void notifySubGenerator(int subGeneratorId) { mSubGeneratorId = subGeneratorId; }
 
   /** generator interface **/
   void* mInterface = nullptr;
@@ -145,10 +145,12 @@ class Generator : public FairGenerator
   Double_t mBoost;
 
  private:
-  void updateCocktailInformation(o2::dataformats::MCEventHeader* header) const;
+  void updateSubGeneratorInformation(o2::dataformats::MCEventHeader* header) const;
 
-  std::unordered_map<int, std::string> mCocktailIdToDesc;
-  int mCocktailId = -1;
+  // collect an ID and a short description of sub-generator entities
+  std::unordered_map<int, std::string> mSubGeneratorsIdToDesc;
+  // the current ID of the sub-generator used in the current event (if applicable)
+  int mSubGeneratorId = -1;
 
   ClassDefOverride(Generator, 2);
 

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -85,6 +85,10 @@ class PrimaryGenerator : public FairPrimaryGenerator
   // sets the vertex mode; if mode is kCCDB, a valid MeanVertexObject pointer must be given at the same time
   void setVertexMode(o2::conf::VertexMode const& mode, o2::dataformats::MeanVertexObject const* obj = nullptr);
 
+  // set identifier and description
+  void setGeneratorId(int id) { mGeneratorId = id; }
+  void setGeneratorDescription(std::string const& desc) { mGeneratorDescription = desc; }
+
  protected:
   /** copy constructor **/
   // PrimaryGenerator(const PrimaryGenerator&) = default;
@@ -113,7 +117,13 @@ class PrimaryGenerator : public FairPrimaryGenerator
   o2::conf::VertexMode mVertexMode = o2::conf::VertexMode::kDiamondParam; // !vertex mode
   std::unique_ptr<o2::dataformats::MeanVertexObject> mMeanVertex;
 
-  ClassDefOverride(PrimaryGenerator, 2);
+ private:
+  void setGeneratorInformation();
+  // generator identifier and description
+  int mGeneratorId = -1;
+  std::string mGeneratorDescription;
+
+  ClassDefOverride(PrimaryGenerator, 3);
 
 }; /** class PrimaryGenerator **/
 

--- a/Generators/include/Generators/PrimaryGeneratorParam.h
+++ b/Generators/include/Generators/PrimaryGeneratorParam.h
@@ -9,10 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \author R+Preghenella - September 2020
-
-#ifndef ALICEO2_EVENTGEN_GENERATOREXTERNALPARAM_H_
-#define ALICEO2_EVENTGEN_GENERATOREXTERNALPARAM_H_
+#ifndef ALICEO2_EVENTGEN_PRIMARYGENERATORPARAM_H_
+#define ALICEO2_EVENTGEN_PRIMARYGENERATORPARAM_H_
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
@@ -24,16 +22,16 @@ namespace eventgen
 
 /**
  ** a parameter class/struct to keep the settings of
- ** the external event-generator and
+ ** the event-generator external trigger and
  ** allow the user to modify them
  **/
-struct GeneratorExternalParam : public o2::conf::ConfigurableParamHelper<GeneratorExternalParam> {
-  std::string fileName = "";
-  std::string funcName = "";
-  O2ParamDef(GeneratorExternalParam, "GeneratorExternal");
+struct PrimaryGeneratorParam : public o2::conf::ConfigurableParamHelper<PrimaryGeneratorParam> {
+  int id = -1;
+  std::string description = "";
+  O2ParamDef(PrimaryGeneratorParam, "PrimaryGenerator");
 };
 
 } // end namespace eventgen
 } // end namespace o2
 
-#endif // ALICEO2_EVENTGEN_GENERATOREXTERNALPARAM_H_
+#endif // ALICEO2_EVENTGEN_PRIMARYGENERATORPARAM_H_

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -220,6 +220,16 @@ Bool_t
 
 /*****************************************************************/
 
+void Generator::addSubGenerator(int subGeneratorId, std::string const& subGeneratorDescription)
+{
+  if (mSubGeneratorId < 0) {
+    LOG(fatal) << "Sub-generator IDs must be >= 0, instead, passed value is " << subGeneratorId;
+  }
+  mSubGeneratorsIdToDesc.insert({subGeneratorId, subGeneratorDescription});
+}
+
+/*****************************************************************/
+
 void Generator::updateSubGeneratorInformation(o2::dataformats::MCEventHeader* header) const
 {
   if (mSubGeneratorId < 0) {

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -16,7 +16,7 @@
 #include "Generators/PrimaryGenerator.h"
 #include "SimulationDataFormat/MCEventHeader.h"
 #include "SimulationDataFormat/ParticleStatus.h"
-#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "FairPrimaryGenerator.h"
 #include <fairlogger/Logger.h>
 #include <cmath>
@@ -70,6 +70,9 @@ Bool_t
     /** clear particle vector **/
     mParticles.clear();
 
+    /** reset the cocktail ID **/
+    mCocktailId = -1;
+
     /** generate event **/
     if (!generateEvent()) {
       return kFALSE;
@@ -77,6 +80,14 @@ Bool_t
 
     /** import particles **/
     if (!importParticles()) {
+      return kFALSE;
+    }
+
+    if (mCocktailIdToDesc.empty() && mCocktailId > -1) {
+      return kFALSE;
+    }
+
+    if (!mCocktailIdToDesc.empty() && mCocktailId < 0) {
       return kFALSE;
     }
 
@@ -102,6 +113,7 @@ Bool_t
     return kFALSE;
   }
   updateHeader(o2header);
+  updateCocktailInformation(o2header);
 
   /** success **/
   return kTRUE;
@@ -204,6 +216,17 @@ Bool_t
 
   /** return **/
   return triggered;
+}
+
+/*****************************************************************/
+
+void Generator::updateCocktailInformation(o2::dataformats::MCEventHeader* header) const
+{
+  if (mCocktailId < 0) {
+    return;
+  }
+  header->putInfo<int>(o2::mcgenid::GeneratorProperty::COCKTAILID, mCocktailId);
+  header->putInfo<std::unordered_map<int, std::string>>(o2::mcgenid::GeneratorProperty::COCKTAILDESCRIPTIONMAP, mCocktailIdToDesc);
 }
 
 /*****************************************************************/

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -70,8 +70,8 @@ Bool_t
     /** clear particle vector **/
     mParticles.clear();
 
-    /** reset the cocktail ID **/
-    mCocktailId = -1;
+    /** reset the sub-generator ID **/
+    mSubGeneratorId = -1;
 
     /** generate event **/
     if (!generateEvent()) {
@@ -83,11 +83,11 @@ Bool_t
       return kFALSE;
     }
 
-    if (mCocktailIdToDesc.empty() && mCocktailId > -1) {
+    if (mSubGeneratorsIdToDesc.empty() && mSubGeneratorId > -1) {
       return kFALSE;
     }
 
-    if (!mCocktailIdToDesc.empty() && mCocktailId < 0) {
+    if (!mSubGeneratorsIdToDesc.empty() && mSubGeneratorId < 0) {
       return kFALSE;
     }
 
@@ -113,7 +113,7 @@ Bool_t
     return kFALSE;
   }
   updateHeader(o2header);
-  updateCocktailInformation(o2header);
+  updateSubGeneratorInformation(o2header);
 
   /** success **/
   return kTRUE;
@@ -220,13 +220,13 @@ Bool_t
 
 /*****************************************************************/
 
-void Generator::updateCocktailInformation(o2::dataformats::MCEventHeader* header) const
+void Generator::updateSubGeneratorInformation(o2::dataformats::MCEventHeader* header) const
 {
-  if (mCocktailId < 0) {
+  if (mSubGeneratorId < 0) {
     return;
   }
-  header->putInfo<int>(o2::mcgenid::GeneratorProperty::COCKTAILID, mCocktailId);
-  header->putInfo<std::unordered_map<int, std::string>>(o2::mcgenid::GeneratorProperty::COCKTAILDESCRIPTIONMAP, mCocktailIdToDesc);
+  header->putInfo<int>(o2::mcgenid::GeneratorProperty::SUBGENERATORID, mSubGeneratorId);
+  header->putInfo<std::unordered_map<int, std::string>>(o2::mcgenid::GeneratorProperty::SUBGENERATORDESCRIPTIONMAP, mSubGeneratorsIdToDesc);
 }
 
 /*****************************************************************/

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -13,7 +13,6 @@
 
 #include <SimulationDataFormat/O2DatabasePDG.h>
 #include <Generators/GeneratorFactory.h>
-#include "FairPrimaryGenerator.h"
 #include "FairGenerator.h"
 #include "FairBoxGenerator.h"
 #include <fairlogger/Logger.h>
@@ -33,6 +32,7 @@
 #include <Generators/GeneratorHepMC.h>
 #include <Generators/GeneratorHepMCParam.h>
 #endif
+#include <Generators/PrimaryGenerator.h>
 #include <Generators/BoxGunParam.h>
 #include <Generators/TriggerParticle.h>
 #include <Generators/TriggerExternalParam.h>
@@ -54,6 +54,8 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     LOG(warning) << "No primary generator instance; Cannot setup";
     return;
   }
+
+  auto primGenO2 = dynamic_cast<PrimaryGenerator*>(primGen);
 
   auto makeBoxGen = [](int pdgid, int mult, double etamin, double etamax, double pmin, double pmax, double phimin, double phimax, bool debug = false) {
     auto gen = new FairBoxGenerator(pdgid, mult);

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -13,7 +13,6 @@
 #include "Generators/GeneratorFromO2KineParam.h"
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCEventHeader.h"
-#include "SimulationDataFormat/MCGenStatus.h"
 #include <fairlogger/Logger.h>
 #include <FairPrimaryGenerator.h>
 #include <TBranch.h>

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -19,7 +19,7 @@
 #include "TF1.h"
 #include "TRandom.h"
 #include "SimulationDataFormat/MCEventHeader.h"
-#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "SimulationDataFormat/ParticleStatus.h"
 #include "Pythia8/HIUserHooks.h"
 #include "TSystem.h"

--- a/Generators/src/GeneratorTGenerator.cxx
+++ b/Generators/src/GeneratorTGenerator.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "SimulationDataFormat/ParticleStatus.h"
 #include "Generators/GeneratorTGenerator.h"
 #include <fairlogger/Logger.h>

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -54,6 +54,7 @@
 #pragma link C++ class o2::eventgen::GeneratorFromO2KineParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorFromO2KineParam> + ;
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
+#pragma link C++ class o2::eventgen::PrimaryGeneratorParam + ;
 
 #pragma link C++ enum o2::eventgen::EVertexDistribution;
 #pragma link C++ class o2::eventgen::TriggerExternalParam + ;

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -12,9 +12,11 @@
 /// \author R+Preghenella - June 2017
 
 #include "Generators/PrimaryGenerator.h"
+#include <Generators/PrimaryGeneratorParam.h>
 #include "Generators/Generator.h"
 #include "SimConfig/InteractionDiamondParam.h"
 #include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/MCGenProperties.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
 #include "DetectorsBase/Stack.h"
 #include <fairlogger/Logger.h>
@@ -56,6 +58,11 @@ Bool_t PrimaryGenerator::Init()
 
   LOG(info) << "Initialising primary generator";
 
+  // set generator ID and description
+  auto& params = PrimaryGeneratorParam::Instance();
+  setGeneratorId(params.id);
+  setGeneratorDescription(params.description);
+
   /** embedding **/
   if (mEmbedTree) {
     LOG(info) << "Embedding into: " << mEmbedFile->GetName()
@@ -76,7 +83,11 @@ Bool_t PrimaryGenerator::GenerateEvent(FairGenericStack* pStack)
   /** normal generation if no embedding **/
   if (!mEmbedTree) {
     fixInteractionVertex(); // <-- always fixes vertex outside of FairROOT
-    return FairPrimaryGenerator::GenerateEvent(pStack);
+    auto ret = FairPrimaryGenerator::GenerateEvent(pStack);
+    if (ret) {
+      setGeneratorInformation();
+    }
+    return ret;
   }
 
   /** this is for embedding **/
@@ -105,6 +116,7 @@ Bool_t PrimaryGenerator::GenerateEvent(FairGenericStack* pStack)
     o2event->setEmbeddingFileName(mEmbedFile->GetName());
     o2event->setEmbeddingEventIndex(mEmbedIndex);
   }
+  setGeneratorInformation();
 
   /** increment embedding counter **/
   mEmbedIndex++;
@@ -335,6 +347,17 @@ Bool_t PrimaryGenerator::embedInto(TString fname)
 
   /** success **/
   return kTRUE;
+}
+
+/*****************************************************************/
+
+void PrimaryGenerator::setGeneratorInformation()
+{
+  auto o2event = dynamic_cast<MCEventHeader*>(fEvent);
+  if (o2event) {
+    o2event->putInfo<int>(o2::mcgenid::GeneratorProperty::GENERATORID, mGeneratorId);
+    o2event->putInfo<std::string>(o2::mcgenid::GeneratorProperty::GENERATORDESCRIPTION, mGeneratorDescription);
+  }
 }
 
 /*****************************************************************/

--- a/Generators/src/PrimaryGeneratorParam.cxx
+++ b/Generators/src/PrimaryGeneratorParam.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Generators/PrimaryGeneratorParam.h"
+O2ParamImpl(o2::eventgen::PrimaryGeneratorParam);


### PR DESCRIPTION
* 3 values forseen
  * global ID assigend to a o2::eventgen::PrimaryGenerator
  * cocktail constituent ID in case a o2::eventgen::Generator consists
    of multiple cocktail constituents. If a specific constituent is used
    for an event, that event will be flagged with that ID
  * source ID to mark source in emebdding scenarios

* all 3 values are encoded into a single short, passed to mcCollision
  table at the end

* provide decoding via helper functions

* Global ID (and short description)
  * can be set via
    o2-sim --confKeyValues \
     "PrimaryGenerator.id=3;PrimaryGenerator.description=a specific gen"

* Each cocktail constituent must first be registered via
  o2::eventgen::Generator::addCocktailConstituent(int, std::string)

  then, each egnerated event must set a valid ID during
  o2::eventgen::Generator::GenerateEvent
  or
  o2::eventgen::Generator::importParticles

  if cocktail constituents are set but no valid ID is given, no event
  will be generated