### PR TITLE
Stability improvements for sim-as-service

### DIFF
--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -355,10 +355,6 @@ class O2PrimaryServerDevice final : public fair::mq::Device
       mGeneratorThread.join();
     }
     mGeneratorThread = std::thread(&O2PrimaryServerDevice::initGenerator, this);
-    // initGenerator();
-    if (mGeneratorThread.joinable()) {
-      mGeneratorThread.join();
-    }
 
     return true;
   }

--- a/run/SimExamples/SimAsService_biasing1/run.sh
+++ b/run/SimExamples/SimAsService_biasing1/run.sh
@@ -32,7 +32,7 @@ rname1=$(hexdump -n 16 -v -e '/1 "%02X"' -e '/16 "\n"' /dev/urandom | head -c 6)
 set -x
 ### step 1: Startup the 1st service with a partial detector config
 
-( o2-sim-client.py --startup "-j ${NWORKERS} -n 0 -g pythia8 -m ${MODULES} -o simservice --configFile sim_step1.ini" \
+( o2-sim-client.py --startup "-j ${NWORKERS} -n 0 -g pythia8pp -m ${MODULES} -o simservice --configFile sim_step1.ini" \
                    --block ) | tee /tmp/${rname1}  # <--- return when everything is fully initialized
 SERVICE1_PID=$(grep "detached as pid" /tmp/${rname1} | awk '//{print $4}')
 
@@ -50,7 +50,7 @@ batch=0
 trialevents=0
 while (( biasedcount < ${NTRIGGEREDEVENTS} )); do
   ### simulate some events with service 1
-  o2-sim-client.py --pid ${SERVICE1_PID} --command "-g pythia8 -n ${NTRIALEVENTS} --configFile sim_step1.ini -o batch${batch}" --block
+  o2-sim-client.py --pid ${SERVICE1_PID} --command "-g pythia8pp -n ${NTRIALEVENTS} --configFile sim_step1.ini -o batch${batch}" --block
 
   ### filter out good events
   ln -nsf simservice_grp.root batch${batch}_grp.root

--- a/run/o2-sim-client.py
+++ b/run/o2-sim-client.py
@@ -91,18 +91,18 @@ if args.command:
 
    if code == 0:
      print ("Submission successful.")
-   if args.block:
-      # blocking means we wait until the operation (simulation) is done serverside
-      print ("Waiting for DONE message from server")
-      batchdone = False
-      while not batchdone:
-        notification = incomingsocket.recv_string()  #
-        print (notification)
-        if re.match('O2SIM.*DONE', notification) != None:
+     if args.block:
+       # blocking means we wait until the operation (simulation) is done serverside
+       print ("... waiting for DONE message from server")
+       batchdone = False
+       while not batchdone:
+         notification = incomingsocket.recv_string()  #
+         print (notification)
+         if re.match('O2SIM.*DONE', notification) != None:
             print ("Received DONE notification from server ... quitting", notification)
             batchdone = True
 
-      exit (0)
+     exit (0)
 
    elif code == 1:
       print ("Server busy; Cannot take commands.")
@@ -110,7 +110,7 @@ if args.command:
       print ("Command string faulty (Parsing failed on serverside).")
       exit (code)
    else:
-      print ("Unknown return code.")
+      print ("Unknown return code " + str(code) + ".")
       exit (1)
 
 # in case of startup we might also want to block until system is ready


### PR DESCRIPTION
* taking away a (hopefully useless) thread.join(); Apparently there was another thread.join() in a different thread ... which according to the C++ standard can result in undefined behaviour.

  This removed a hang observed in local testing of

  O2/run/SimExamples/SimAsService_basic

* fix generator setting in SimAsService_biasing1 example (was crashing)

* fix a wrong exit logic in `o2-sim-client.py`