### PR TITLE
Use SHM in hit allocators only in compiled mode

### DIFF
--- a/Common/Utils/include/CommonUtils/ShmManager.h
+++ b/Common/Utils/include/CommonUtils/ShmManager.h
@@ -26,7 +26,10 @@
 #include <boost/interprocess/managed_external_buffer.hpp>
 #include <boost/interprocess/allocators/allocator.hpp>
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
+// this shared mem mode is meant for compiled stuff in o2-sim; not for ROOT sessions
 #define USESHM 1
+#endif
 
 namespace o2
 {


### PR DESCRIPTION
No need to use special shm allocators for detector hits when reading hits in an interactive ROOT macro. (We had problems reading MID/MCH hits and this is an easy fix.)