### PR TITLE
Revert "Condtion ctf*root.part -> ctf.root renaming by creation of me…

### DIFF
--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -601,6 +601,9 @@ void CTFWriterSpec::closeTFTreeAndFile()
       mCTFTreeOut.reset();
       mCTFFileOut->Close();
       mCTFFileOut.reset();
+      if (!TMPFileEnding.empty()) {
+        std::filesystem::rename(o2::utils::Str::concat_string(mCurrentCTFFileNameFull, TMPFileEnding), mCurrentCTFFileNameFull);
+      }
       // write CTF file metaFile data
       if (mStoreMetaFile) {
         o2::dataformats::FileMetaData ctfMetaData;
@@ -615,15 +618,10 @@ void CTFWriterSpec::closeTFTreeAndFile()
           std::ofstream metaFileOut(metaFileNameTmp);
           metaFileOut << ctfMetaData;
           metaFileOut.close();
-          if (!TMPFileEnding.empty()) {
-            std::filesystem::rename(o2::utils::Str::concat_string(mCurrentCTFFileNameFull, TMPFileEnding), mCurrentCTFFileNameFull);
-          }
           std::filesystem::rename(metaFileNameTmp, metaFileName);
         } catch (std::exception const& e) {
           LOG(error) << "Failed to store CTF meta data file " << metaFileName << ", reason: " << e.what();
         }
-      } else if (!TMPFileEnding.empty()) {
-        std::filesystem::rename(o2::utils::Str::concat_string(mCurrentCTFFileNameFull, TMPFileEnding), mCurrentCTFFileNameFull);
       }
     } catch (std::exception const& e) {
       LOG(error) << "Failed to finalize CTF file " << mCurrentCTFFileNameFull << ", reason: " << e.what();


### PR DESCRIPTION
…tafile"

This reverts commit 8a7d1ba4436b1b75d0e955dc99758c4cadd7a07d.

@shahor02 I thought about it and I don't think that it is possible to write the meta file before the file is available with its final name. Even with some tricks, we would not want the epn2eos tool to transfer the part file, so we can write the meta file only after the data file is final.

But please check if you have another idea.