### PR TITLE
DPL: Create consumeWhenAnyWithAllConditions completion policy, and revert consumeWhenAny to original behavior

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -51,6 +51,15 @@ struct CompletionPolicyHelpers {
   }
   static CompletionPolicy consumeWhenAny(std::string matchName);
 
+  /// When any of the parts of the record have been received, consume them.
+  static CompletionPolicy consumeWhenAnyWithAllConditions(const char* name, CompletionPolicy::Matcher matcher);
+  /// Default matcher applies for all devices
+  static CompletionPolicy consumeWhenAnyWithAllConditions(CompletionPolicy::Matcher matcher = [](auto const&) -> bool { return true; })
+  {
+    return consumeWhenAnyWithAllConditions("consume-any-all-conditions", matcher);
+  }
+  static CompletionPolicy consumeWhenAnyWithAllConditions(std::string matchName);
+
   /// When any of the parts of the record have been received, process the existing and free the associated payloads.
   /// This allows freeing things as early as possible, while still being able to wait
   /// all the parts before disposing the timeslice completely


### PR DESCRIPTION
@ktf : For now this does what we quickly discussed, revert to the original policy, and create a clone that takes into account conditions. We can discuss in more details on Monday.

For reference, outcome from the tests after my fix was:
- My patch fixed the data dropping fully, but apparently the qc dispatcher got still stuck.
- Weirdly, the timing then the dispatcher gets stuck changes somewhat, so it seems somehow related. But not fully clear. In synthetic runs at P2, it took ~75 minutes - 90 minutes for the EPNs to fail.