### PR TITLE
Revert "Enable using CCDB VDrift in TPC Digitizer"

### DIFF
--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -246,7 +246,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     auto& cdb = o2::tpc::CDBInterface::instance();
     cdb.setUseDefaults(!mUseCalibrationsFromCCDB);
     // whatever are global settings for CCDB usage, we have to extract the TPC vdrift from CCDB for anchored simulations
-    mTPCVDriftHelper.extractCCDBInputs(pc);
+    //    mTPCVDriftHelper.extractCCDBInputs(pc);
     if (mTPCVDriftHelper.isUpdated()) {
       const auto& vd = mTPCVDriftHelper.getVDriftObject();
       LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",


### PR DESCRIPTION
TPCDigitizer should be switched to consumeWhenAnyWithAllConditions but the latter needs some extra stuff.

This reverts commit 74ef0705c240e5818f17fe19af4f4b26e9bc94e2.