### PR TITLE
[QC-889] Retry curl call in case of failure

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -556,7 +556,7 @@ class CcdbApi //: public DatabaseInterface
   mutable TGrid* mAlienInstance = nullptr;                       // a cached connection to TGrid (needed for Alien locations)
   bool mNeedAlienToken = true;                                   // On EPN and FLP we use a local cache and don't need the alien token
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
-  int mCurlRetries = 1;
+  int mCurlRetries = 3;
   int mCurlDelayRetries = 100000; // in microseconds
 
   ClassDefNV(CcdbApi, 1);

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -451,6 +451,17 @@ class CcdbApi //: public DatabaseInterface
                           long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",
                           const std::string& createdNotAfter = "", const std::string& createdNotBefore = "") const;
 
+  /**
+   * Set the number of times curl should retry in case of failure and the delay between thte attempts.
+   * @param numberRetries
+   * @param delay
+   */
+  void setCurlRetriesParameters(int numberRetries, int delay = 100000 /* microseconds */)
+  {
+    mCurlRetries = numberRetries;
+    mCurlDelayRetries = delay;
+  }
+
  private:
   /**
    * A helper function to extract object from a local ROOT file
@@ -545,6 +556,8 @@ class CcdbApi //: public DatabaseInterface
   mutable TGrid* mAlienInstance = nullptr;                       // a cached connection to TGrid (needed for Alien locations)
   bool mNeedAlienToken = true;                                   // On EPN and FLP we use a local cache and don't need the alien token
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
+  int mCurlRetries = 1;
+  int mCurlDelayRetries = 100000; // in microseconds
 
   ClassDefNV(CcdbApi, 1);
 };

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1790,7 +1790,6 @@ CURLcode CcdbApi::CURL_perform(CURL* handle) const
   }
   CURLcode result;
   for (int i = 1; i <= mCurlRetries && (result = curl_easy_perform(handle)) != CURLE_OK; i++) {
-    std::cout << "failed, new attempt" << std::endl;
     usleep(mCurlDelayRetries);
   }
   return result;

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1790,7 +1790,7 @@ CURLcode CcdbApi::CURL_perform(CURL* handle) const
   }
   CURLcode result;
   for (int i = 1; i <= mCurlRetries && (result = curl_easy_perform(handle)) != CURLE_OK; i++) {
-    usleep(mCurlDelayRetries);
+    usleep(mCurlDelayRetries * i);
   }
   return result;
 }

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1788,7 +1788,12 @@ CURLcode CcdbApi::CURL_perform(CURL* handle) const
   if (mIsCCDBDownloaderEnabled) {
     return mDownloader->perform(handle);
   }
-  return curl_easy_perform(handle);
+  CURLcode result;
+  for (int i = 1; i <= mCurlRetries && (result = curl_easy_perform(handle)) != CURLE_OK; i++) {
+    std::cout << "failed, new attempt" << std::endl;
+    usleep(mCurlDelayRetries);
+  }
+  return result;
 }
 
 } // namespace o2


### PR DESCRIPTION
Configurable. Off by default. The delay, in microseconds, can also be specified. 

We will use it in QC. 