### PR TITLE
Removing thread safety breaches from CCDBDownloader

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -218,6 +218,16 @@ class CCDBDownloader
   std::mutex mHandlesQueueLock;
 
   /**
+   * Blocks the constructor from returning before the uv_loop has started running
+   */
+  std::condition_variable* mConstructorCV;
+
+  /**
+   * Prevents the mConstructorCV from being notified after the constructor returned
+   */
+  bool mLoopRunning = false;
+
+  /**
    * Thread on which the thread with uv_loop runs.
    */
   std::thread* mLoopThread;

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -64,7 +64,7 @@ CCDBDownloader::CCDBDownloader(uv_loop_t* uv_loop)
   mConstructorCV = new std::condition_variable();
   std::mutex cv_m;
   std::unique_lock<std::mutex> lk(cv_m);
-  
+
   if (!mIsExternalLoop) {
     mLoopThread = new std::thread(&CCDBDownloader::runLoop, this);
   }

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -274,33 +274,5 @@ BOOST_AUTO_TEST_CASE(asynch_batch_callback)
   curl_global_cleanup();
 }
 
-BOOST_AUTO_TEST_CASE(external_loop_test)
-{
-  if (curl_global_init(CURL_GLOBAL_ALL)) {
-    fprintf(stderr, "Could not init curl\n");
-    return;
-  }
-
-  uv_loop_t loop;
-
-  CCDBDownloader downloader(&loop);
-  std::string dst = "";
-  CURL* handle = createTestHandle(&dst);
-
-  CURLcode curlCode = downloader.perform(handle);
-
-  BOOST_CHECK(curlCode == CURLE_OK);
-  std::cout << "CURL code: " << curlCode << "\n";
-
-  long httpCode;
-  curl_easy_getinfo(handle, CURLINFO_HTTP_CODE, &httpCode);
-  BOOST_CHECK(httpCode == 200);
-  std::cout << "HTTP code: " << httpCode << "\n";
-
-  curl_easy_cleanup(handle);
-
-  curl_global_cleanup();
-}
-
 } // namespace ccdb
 } // namespace o2


### PR DESCRIPTION
Creating and initializing uv_handles has been moved from the constructor into the uv_loop thread, so to avoid the existing thread safety violations.

Additionally a lock was added as to prevent the constructor from returning before the uv_loop started. This protects the uv_loop from receiving asynchronous handles before it was initialized, which would cause it to crash.

Moreover, the current mechanism for reusing an existing uv_loop (which can be passed via constructor) is not thread safe, and will be removed and reworked in following PRs.