### PR TITLE
Several stability fixes for "simulation-as-as" service

### DIFF
--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -295,7 +295,7 @@ o2_add_test_command(NAME o2sim_G4_checklogs
                     LABELS long sim
 )
 
-set_tests_properties(o2sim_G3_checklogs
+set_tests_properties(o2sim_G4_checklogs
                      PROPERTIES FIXTURES_REQUIRED G4)
 endif()
 

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -235,6 +235,7 @@ class O2HitMerger : public fair::mq::Device
     mTrackRefBuffer.clear();
     mSubEventInfoBuffer.clear();
     mFlushableEvents.clear();
+    mNextFlushID = 1;
 
     return true;
   }

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -164,7 +164,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
   // function generating one event
   void generateEvent(/*bool changeState = false*/)
   {
-    bool changeState = false;
+    bool changeState = true; // false;
     LOG(info) << "Event generation started ";
     if (changeState) {
       stateTransition(O2PrimaryServerState::WaitingEvent, "GENEVENT");
@@ -185,7 +185,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
       }
       mPrimGen->GenerateEvent(mStack);
     } catch (std::exception const& e) {
-      LOG(error) << " Exception occurred during event gen ";
+      LOG(error) << " Exception occurred during event gen " << e.what();
     }
     timer.Stop();
     LOG(info) << "Event generation took " << timer.CpuTime() << "s"
@@ -288,7 +288,11 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     // and do not block here
     mGeneratorThread = std::thread(&O2PrimaryServerDevice::initGenerator, this);
     if (mGeneratorThread.joinable()) {
-      mGeneratorThread.join();
+      try {
+        mGeneratorThread.join();
+      } catch (std::exception const& e) {
+        LOG(warn) << "Exception during thread join ..ignoring";
+      }
     }
 
     // init pipe
@@ -301,6 +305,15 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     }
 
     mAsService = vm["asservice"].as<bool>();
+    if (mAsService) {
+      mControlChannel = fair::mq::Channel{"o2sim-control", "sub", fTransportFactory};
+      auto controlsocketname = getenv("ALICE_O2SIMCONTROL");
+      if (!controlsocketname) {
+        LOG(fatal) << "Internal error: Socketname for control input missing";
+      }
+      mControlChannel.Connect(std::string(controlsocketname));
+      mControlChannel.Validate();
+    }
 
     if (mMaxEvents <= 0) {
       if (mAsService) {
@@ -352,9 +365,14 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     mNeedNewEvent = true;
     // reinit generator and start generation of a new event
     if (mGeneratorThread.joinable()) {
-      mGeneratorThread.join();
+      try {
+        mGeneratorThread.join();
+      } catch (std::exception const& e) {
+        LOG(warn) << "Exception during thread join ..ignoring";
+      }
     }
-    mGeneratorThread = std::thread(&O2PrimaryServerDevice::initGenerator, this);
+    // mGeneratorThread = std::thread(&O2PrimaryServerDevice::initGenerator, this);
+    initGenerator();
 
     return true;
   }
@@ -385,7 +403,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
   bool ConditionalRun() override
   {
     // we might come here in IDLE mode
-    if (mState == O2PrimaryServerState::Idle) {
+    if (mState.load() == O2PrimaryServerState::Idle) {
       if (mWaitingControlInput.load() == 0) {
         if (mControlThread.joinable()) {
           mControlThread.join();
@@ -459,40 +477,46 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     reply.AddPart(std::move(headermsg));
 
     LOG(debug) << "Received request for work " << mEventCounter << " " << mMaxEvents << " " << mNeedNewEvent << " available " << workavailable;
-    if (mNeedNewEvent) {
-      // we need a newly generated event now
-      if (mGeneratorThread.joinable()) {
-        try {
-          mGeneratorThread.join();
-        } catch (std::exception const& e) {
-          LOG(warn) << "Exception during thread join ..ignoring";
-        }
-      }
-      mNeedNewEvent = false;
-      mPartCounter = 0;
-      mEventCounter++;
-    }
-
-    auto& prims = mStack->getPrimaries();
-    auto numberofparts = (int)std::ceil(prims.size() / (1. * mChunkGranularity));
-    // number of parts should be at least 1 (even if empty)
-    numberofparts = std::max(1, numberofparts);
-
-    LOG(debug) << "Have " << prims.size() << " " << numberofparts;
-
-    o2::data::PrimaryChunk m;
-    o2::data::SubEventInfo i;
-    i.eventID = workavailable ? mEventCounter : -1;
-    i.maxEvents = mMaxEvents;
-    i.part = mPartCounter + 1;
-    i.nparts = numberofparts;
-
-    i.seed = mUseFixedChunkSeed ? mFixedChunkSeed : mEventCounter + mInitialSeed;
-    i.index = m.mParticles.size();
-    i.mMCEventHeader = mEventHeader;
-    m.mSubEventInfo = i;
-
     if (workavailable) {
+
+      if (mNeedNewEvent) {
+        // we need a newly generated event now
+        if (mGeneratorThread.joinable()) {
+          try {
+            mGeneratorThread.join();
+          } catch (std::exception const& e) {
+            LOG(warn) << "Exception during thread join ..ignoring";
+          }
+        }
+        // also if we are still in event waiting stage (doing some busy sleep)
+        while (mState.load() == O2PrimaryServerState::WaitingEvent) {
+          LOG(info) << "Waiting for event generation do become fully available";
+          usleep(100);
+        }
+        mNeedNewEvent = false;
+        mPartCounter = 0;
+        mEventCounter++;
+      }
+
+      auto& prims = mStack->getPrimaries();
+      auto numberofparts = (int)std::ceil(prims.size() / (1. * mChunkGranularity));
+      // number of parts should be at least 1 (even if empty)
+      numberofparts = std::max(1, numberofparts);
+
+      LOG(debug) << "Have " << prims.size() << " " << numberofparts;
+
+      o2::data::PrimaryChunk m;
+      o2::data::SubEventInfo i;
+      i.eventID = workavailable ? mEventCounter : -1;
+      i.maxEvents = mMaxEvents;
+      i.part = mPartCounter + 1;
+      i.nparts = numberofparts;
+
+      i.seed = mUseFixedChunkSeed ? mFixedChunkSeed : mEventCounter + mInitialSeed;
+      i.index = m.mParticles.size();
+      i.mMCEventHeader = mEventHeader;
+      m.mSubEventInfo = i;
+
       int endindex = prims.size() - mPartCounter * mChunkGranularity;
       int startindex = prims.size() - (mPartCounter + 1) * mChunkGranularity;
       LOG(debug) << "indices " << startindex << " " << endindex;
@@ -560,22 +584,20 @@ class O2PrimaryServerDevice final : public fair::mq::Device
   void waitForControlInput()
   {
     mWaitingControlInput.store(1);
-    stateTransition(O2PrimaryServerState::Idle, "CONTROL");
+    if (mState.load() != O2PrimaryServerState::Idle) {
+      mWaitingControlInput.store(0);
+      return;
+    }
 
     o2::simpubsub::publishMessage(fChannels["primary-notifications"].at(0), o2::simpubsub::simStatusString("PRIMSERVER", "STATUS", "AWAITING INPUT"));
     // this means we are idling
 
-    auto factory = fair::mq::TransportFactory::CreateTransportFactory("zeromq");
-    auto channel = fair::mq::Channel{"o2sim-control", "sub", factory};
-    auto controlsocketname = getenv("ALICE_O2SIMCONTROL");
-    channel.Connect(std::string(controlsocketname));
-    channel.Validate();
-    std::unique_ptr<fair::mq::Message> reply(channel.NewMessage());
+    std::unique_ptr<fair::mq::Message> reply(mControlChannel.NewMessage());
 
     bool ok = false;
 
     LOG(info) << "WAITING FOR CONTROL INPUT";
-    if (channel.Receive(reply) > 0) {
+    if (mControlChannel.Receive(reply) > 0) {
       stateTransition(O2PrimaryServerState::Initializing, "CONTROL");
       auto data = reply->GetData();
       auto size = reply->GetSize();
@@ -597,7 +619,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
       LOG(info) << "NOTHING RECEIVED";
     }
     if (ok) {
-      stateTransition(O2PrimaryServerState::ReadyToServe, "CONTROL");
+      // stateTransition(O2PrimaryServerState::ReadyToServe, "CONTROL"); --> SHOULD BE DONE FROM EVENT GENERATOR (which get's however called only when mEvents>0)
     } else {
       stateTransition(O2PrimaryServerState::Stopped, "CONTROL");
     }
@@ -636,6 +658,9 @@ class O2PrimaryServerDevice final : public fair::mq::Device
   std::atomic<bool> mInfoThreadStopped{false};
 
   bool mAsService = false;
+
+  // a dedicate (on-the-fly channel) for control messages
+  fair::mq::Channel mControlChannel;
 
   // some information specific to use case when we have a collision context
   o2::steer::DigitizationContext* mCollissionContext = nullptr; //!

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -29,6 +29,12 @@
 #include <cstring>
 #include "PrimaryServerState.h"
 
+// a helper for logging with worker index prefixed
+void doLogInfo(int workerID, std::string const& message)
+{
+  LOG(info) << "[W" << workerID << "] " << message;
+}
+
 namespace o2
 {
 namespace devices
@@ -206,25 +212,26 @@ class O2SimDevice final : public fair::mq::Device
       return str.str();
     };
 
-    LOG(info) << workerStr() << " Requesting work chunk";
+    doLogInfo(workerID, "Requesting work chunk");
     int timeoutinMS = 2000;
     auto sendcode = requestchannel.Send(request, timeoutinMS);
     if (sendcode > 0) {
-      LOG(info) << workerStr() << " Waiting for answer";
+      doLogInfo(workerID, "Waiting for answer");
       // asking for primary generation
 
       auto code = requestchannel.Receive(reply);
       if (code > 0) {
-        LOG(info) << workerStr() << " Primary chunk received";
+        doLogInfo(workerID, "Primary chunk received");
         auto rawmessage = std::move(reply.At(0));
         auto header = *(o2::PrimaryChunkAnswer*)(rawmessage->GetData());
         if (!header.payload_attached) {
-          LOG(info) << "No payload; Server in state " << PrimStateToString[(int)header.serverstate];
+          doLogInfo(workerID, "No payload; Server in stage " + std::string(PrimStateToString[(int)header.serverstate]));
           // if no payload attached we inspect the server state, to see what to do
           if (header.serverstate == O2PrimaryServerState::Initializing || header.serverstate == O2PrimaryServerState::WaitingEvent) {
             sleep(1); // back-off and retry
             return true;
           }
+          // we need to decide what to do when the server is idle ---> if this happens immediately after a new batch request it means that the server might just lag a bit behind
           return false;
         } else {
           auto payload = std::move(reply.At(1));
@@ -235,7 +242,7 @@ class O2SimDevice final : public fair::mq::Device
           bool goon = true;
           // no particles and eventID == -1 --> indication for no more work
           if (chunk->mParticles.size() == 0 && chunk->mSubEventInfo.eventID == -1) {
-            LOG(info) << workerStr() << " No particles in reply : quitting kernel";
+            doLogInfo(workerID, "No particles in reply : quitting kernel");
             goon = false;
           }
 
@@ -248,7 +255,7 @@ class O2SimDevice final : public fair::mq::Device
             LOG(info) << workerStr() << " Processing " << chunk->mParticles.size() << " primary particles "
                       << "for event " << info.eventID << "/" << info.maxEvents << " "
                       << "part " << info.part << "/" << info.nparts;
-            LOG(info) << "Setting seed for this sub-event to " << chunk->mSubEventInfo.seed;
+            LOG(info) << workerStr() << " Setting seed for this sub-event to " << chunk->mSubEventInfo.seed;
             gRandom->SetSeed(chunk->mSubEventInfo.seed);
 
             // Process one event

--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -176,7 +176,7 @@ int runSim(KernelSetup setup)
   // the simplified runloop
   while (setup.sim->Kernel(setup.workerID, *setup.primchannel, *setup.datachannel, setup.primstatuschannel)) {
   }
-  LOG(info) << "[W" << setup.workerID << "] simulation is done";
+  doLogInfo(setup.workerID, "simulation is done");
   return 0;
 }
 
@@ -217,33 +217,39 @@ void pinToCPU(unsigned int cpuid)
   }
 }
 
-bool waitForControlInput()
+bool waitForControlInput(int workerID)
 {
-  auto factory = fair::mq::TransportFactory::CreateTransportFactory("zeromq");
-  auto channel = fair::mq::Channel{"o2sim-control", "sub", factory};
-  auto controlsocketname = getenv("ALICE_O2SIMCONTROL");
-  LOG(debug) << "AWAITING CONTROL ON SOCKETNAME " << controlsocketname;
-  channel.Connect(std::string(controlsocketname));
-  channel.Validate();
+  static bool initialized = false;
+  static FairMQChannel channel;
+  if (!initialized) {
+    // we do the channel connect and initialization only once
+    // (reducing the chances that we might miss a control message from the master)
+    static auto factory = fair::mq::TransportFactory::CreateTransportFactory("zeromq");
+    channel = fair::mq::Channel{"o2sim-control", "sub", factory};
+    auto controlsocketname = getenv("ALICE_O2SIMCONTROL");
+    channel.Connect(std::string(controlsocketname));
+    channel.Validate();
+    initialized = true;
+  }
   std::unique_ptr<fair::mq::Message> reply(channel.NewMessage());
 
-  LOG(debug) << "WAITING FOR INPUT";
+  doLogInfo(workerID, "Listening for master control input");
   if (channel.Receive(reply) > 0) {
     auto data = reply->GetData();
     auto size = reply->GetSize();
 
     std::string command(reinterpret_cast<char const*>(data), size);
-    LOG(info) << "message: " << command;
+    doLogInfo(workerID, "Received control message: " + command);
 
     o2::conf::SimReconfigData reconfig;
     o2::conf::parseSimReconfigFromString(command, reconfig);
     if (reconfig.stop) {
-      LOG(info) << "Stop asked, shutting down";
+      doLogInfo(workerID, "Stop asked, shutting down");
       return false;
     }
-    LOG(info) << "Processing " << reconfig.nEvents << " new events";
+    doLogInfo(workerID, "Asked to process " + std::to_string(reconfig.nEvents) + std::string(" new events"));
   } else {
-    LOG(info) << "NOTHING RECEIVED";
+    doLogInfo(workerID, "No control input received ");
   }
   return true;
 }
@@ -426,8 +432,8 @@ int main(int argc, char* argv[])
           if (conf.asService()) {
             LOG(info) << "IN SERVICE MODE WAITING";
             o2::simpubsub::publishMessage(pushchannel, o2::simpubsub::simStatusString(worker.str(), "STATUS", "AWAITING INPUT"));
-            more = waitForControlInput();
-            usleep(100); // --> why?
+            more = waitForControlInput(kernelSetup.workerID);
+            usleep(100); // --> why? (probably to give the server some chance to come to a "serving" state)
           } else {
             o2::simpubsub::publishMessage(pushchannel, o2::simpubsub::simStatusString(worker.str(), "STATUS", "TERMINATING"));
 

--- a/run/SimExamples/SimAsService_biasing1/run.sh
+++ b/run/SimExamples/SimAsService_biasing1/run.sh
@@ -32,7 +32,7 @@ rname1=$(hexdump -n 16 -v -e '/1 "%02X"' -e '/16 "\n"' /dev/urandom | head -c 6)
 set -x
 ### step 1: Startup the 1st service with a partial detector config
 
-( o2-sim-client.py --startup "-j ${NWORKERS} -n 0 -g pythia8pp -m ${MODULES} -o simservice --configFile sim_step1.ini" \
+( o2-sim-client.py --startup "-j ${NWORKERS} -n 0 -m ${MODULES} -o simservice --configFile sim_step1.ini" \
                    --block ) | tee /tmp/${rname1}  # <--- return when everything is fully initialized
 SERVICE1_PID=$(grep "detached as pid" /tmp/${rname1} | awk '//{print $4}')
 

--- a/run/o2-sim-client.py
+++ b/run/o2-sim-client.py
@@ -44,8 +44,11 @@ if args.pid:
 if args.startup:
     commandtokens=args.startup.split()
     commandtokens+="--asservice 1".split()
+    commandtokens=['o2-sim'] + commandtokens
+    # if we do valgrind
+    # commandtokens=['valgrind','--tool=helgrind','--trace-children=yes'] + commandtokens
     with open("simservice.out","wb") as out, open("simservice.err","wb") as err:
-        pid = psutil.Popen(['o2-sim'] + commandtokens, close_fds=True, stderr=err, stdout=out)
+        pid = psutil.Popen(commandtokens, close_fds=True, stderr=err, stdout=out)
         service_pid = pid.pid
         print ("detached as pid", pid.pid)
 

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -199,12 +199,14 @@ void launchControlThread()
   auto lambda = [controladdress, internalcontroladdress]() {
     auto factory = fair::mq::TransportFactory::CreateTransportFactory("zeromq");
 
-    auto internalchannel = fair::mq::Channel{"o2sim-control", "pub", factory};
+    // used for internal distribution of control commands
+    auto internalchannel = fair::mq::Channel{"o2sim-internal", "pub", factory};
     internalchannel.Bind(internalcontroladdress);
     internalchannel.Validate();
     std::unique_ptr<fair::mq::Message> message(internalchannel.NewMessage());
 
-    auto outsidechannel = fair::mq::Channel{"o2sim-outside-exchange", "rep", factory};
+    // the channel with which outside entities can control this simulator
+    auto outsidechannel = fair::mq::Channel{"o2sim-control", "rep", factory};
     outsidechannel.Bind(controladdress);
     outsidechannel.Validate();
     std::unique_ptr<fair::mq::Message> request(outsidechannel.NewMessage());
@@ -216,7 +218,7 @@ void launchControlThread()
       outsidechannel.Validate();
       if (outsidechannel.Receive(request) > 0) {
         std::string command(reinterpret_cast<char const*>(request->GetData()), request->GetSize());
-        LOG(info) << "Control message: " << command;
+        LOG(info) << "Control message: " << command << " received ";
         int code = -1;
         if (isBusy()) {
           code = 1; // code = 1 --> busy


### PR DESCRIPTION
* fix counter in merger (otherwise no flush)
* make state transition logic in particle server more robust
* reusing fair::mq::Channels instead of creating new ones each time
* some improved logging in Geant worker devices

These changes make the example for event biasing run correctly again (apart from an issue with generator states which will be fixed separately).