### PR TITLE
wip: ITS-Studies: Add proto-MCKineReaderSpec task, TrackChecker skeleton

### DIFF
--- a/Detectors/ITSMFT/ITS/postprocessing/studies/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/CMakeLists.txt
@@ -12,6 +12,8 @@
 o2_add_library(ITSPostprocessing
                SOURCES src/ImpactParameter.cxx
                        src/K0sInvMass.cxx
+                       src/TrackCheck.cxx
+                       src/MCKinematicReaderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::GlobalTracking
                                      O2::GlobalTrackingWorkflowReaders
                                      O2::GlobalTrackingWorkflowHelpers

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/ImpactParameter.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/ImpactParameter.h
@@ -12,8 +12,8 @@
 #ifndef O2_IMPACT_PARAMETER_STUDY_H
 #define O2_IMPACT_PARAMETER_STUDY_H
 
-#include "ReconstructionDataFormats/GlobalTrackID.h"
-#include "Framework/DataProcessorSpec.h"
+#include <ReconstructionDataFormats/GlobalTrackID.h>
+#include <Framework/DataProcessorSpec.h>
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/MCKinematicReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/MCKinematicReaderSpec.h
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCKINEMATIC_READER_SPEC_H
+#define O2_MCKINEMATIC_READER_SPEC_H
+
+#include <Steer/MCKinematicsReader.h>
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace steer
+{
+using namespace o2::framework;
+class KinematicReader : public Task
+{
+ public:
+  KinematicReader() : mMCKinReader(std::make_unique<MCKinematicsReader>()), mCurrentEvent(0), mNEvents(0){};
+  ~KinematicReader() override = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+
+ protected:
+  std::unique_ptr<MCKinematicsReader> mMCKinReader;
+  std::string mKineFileName = "o2sim";
+  int mCurrentEvent;
+  int mNEvents;
+};
+
+DataProcessorSpec getMCKinematicReaderSpec();
+} // namespace steer
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/TrackCheck.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/TrackCheck.h
@@ -9,12 +9,21 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#ifndef O2_TRACK_CHECK_STUDY_H
+#define O2_TRACK_CHECK_STUDY_H
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include <Framework/DataProcessorSpec.h>
+#include <ReconstructionDataFormats/GlobalTrackID.h>
 
-// #pragma link C++ class ParticleInfo + ;
-
+namespace o2
+{
+namespace its
+{
+namespace study
+{
+using mask_t = o2::dataformats::GlobalTrackID::mask_t;
+o2::framework::DataProcessorSpec getTrackCheckStudy(mask_t srcTracksMask, mask_t srcClustersMask, bool useMC);
+} // namespace study
+} // namespace its
+} // namespace o2
 #endif

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
@@ -11,14 +11,13 @@
 
 // Skeleton derived from RS's code in ITSOffStudy
 
-#include "ITSStudies/ImpactParameter.h"
-
-#include "Framework/CCDBParamSpec.h"
-#include "Framework/Task.h"
-#include "DetectorsCommonDataFormats/DetID.h"
-#include "ReconstructionDataFormats/VtxTrackRef.h"
-#include "ReconstructionDataFormats/PrimaryVertex.h"
-#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include <ITSStudies/ImpactParameter.h>
+#include <Framework/CCDBParamSpec.h>
+#include <Framework/Task.h>
+#include <DetectorsCommonDataFormats/DetID.h>
+#include <ReconstructionDataFormats/VtxTrackRef.h>
+#include <ReconstructionDataFormats/PrimaryVertex.h>
+#include <DataFormatsGlobalTracking/RecoContainer.h>
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/MCKinematicReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/MCKinematicReaderSpec.cxx
@@ -1,0 +1,58 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <ITSStudies/MCKinematicReaderSpec.h>
+#include <Framework/ControlService.h>
+
+namespace o2
+{
+namespace steer
+{
+using namespace o2::framework;
+
+void KinematicReader::init(o2::framework::InitContext& ic)
+{
+  mMCKinReader->initFromKinematics(std::string(mKineFileName));
+  mNEvents = mMCKinReader->getNEvents(0);
+  LOGP(info, "Initialised KinematicReader");
+}
+
+void KinematicReader::run(ProcessingContext& pc)
+{
+  std::vector<o2::dataformats::MCEventHeader> tfMCHeaders;
+  std::vector<o2::MCTrack> tfMCTracks;
+  for (int iEvent{0}; iEvent < mNEvents; iEvent++) { // Single TF loaded from File, might extend it to use source
+    auto mcHeader = mMCKinReader->getMCEventHeader(0, iEvent);
+    auto mcTracks = mMCKinReader->getTracks(0, iEvent);
+    tfMCHeaders.push_back(mcHeader);
+    tfMCTracks.insert(tfMCTracks.end(), mcTracks.begin(), mcTracks.end());
+  }
+  // pc.outputs().snapshot(Output{"MC", "MCHEADER", 0, Lifetime::Timeframe}, tfMCHeaders); TODO: not messageable, what can we do?
+  pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0, Lifetime::Timeframe}, tfMCTracks);
+  pc.services().get<ControlService>().endOfStream();
+  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+}
+
+DataProcessorSpec getMCKinematicReaderSpec()
+{
+  std::vector<OutputSpec> outputSpec;
+  // outputSpec.emplace_back("MC", "MCHEADER", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("MC", "MCTRACKS", 0, Lifetime::Timeframe);
+  return DataProcessorSpec{
+    "mc-kinematic-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<KinematicReader>()},
+    Options{
+      {"kineFileName", VariantType::String, "o2sim", {"Name of the input Kine file"}}}};
+}
+} // namespace steer
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackCheck.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackCheck.cxx
@@ -1,0 +1,128 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <ITSStudies/TrackCheck.h>
+#include <Framework/Task.h>
+#include <SimulationDataFormat/MCEventHeader.h>
+#include <DataFormatsGlobalTracking/RecoContainer.h>
+
+#include <DataFormatsITS/TrackITS.h>
+#include <SimulationDataFormat/MCTrack.h>
+
+namespace o2
+{
+namespace its
+{
+namespace study
+{
+using namespace o2::framework;
+using namespace o2::globaltracking;
+
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+class TrackCheckStudy : public Task
+{
+  struct ParticleInfo {
+    int event;
+    int pdg;
+    float pt;
+    float eta;
+    float phi;
+    int mother;
+    int first;
+    unsigned short clusters = 0u;
+    unsigned char isReco = 0u;
+    unsigned char isFake = 0u;
+    bool isPrimary = 0u;
+    unsigned char storedStatus = 2; /// not stored = 2, fake = 1, good = 0
+    o2::its::TrackITS track;
+  };
+
+ public:
+  TrackCheckStudy(std::shared_ptr<DataRequest> dr, mask_t src) : mDataRequest(dr), mTracksSrc(src){};
+  ~TrackCheckStudy() final = default;
+  void run(ProcessingContext&) final;
+  void endOfStream(EndOfStreamContext&) final;
+  void finaliseCCDB(ConcreteDataMatcher&, void*) final;
+  void process(o2::globaltracking::RecoContainer&);
+
+ private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+
+  // Data
+  GTrackID::mask_t mTracksSrc{};
+  std::shared_ptr<DataRequest> mDataRequest;
+  gsl::span<const o2::dataformats::MCEventHeader> mHeader;
+  gsl::span<const o2::MCTrack> mMCTracks;
+};
+
+void TrackCheckStudy::run(ProcessingContext& pc)
+{
+  LOGP(info, "Called run function from trackcheckstudy");
+  o2::globaltracking::RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest.get());
+  // mHeader = pc.inputs().get<gsl::span<o2::dataformats::MCEventHeader>>("MCHeader"); TODO: header is not messageable, left unmanaged for now
+  mMCTracks = pc.inputs().get<gsl::span<o2::MCTrack>>("MCTracks");
+  updateTimeDependentParams(pc); // Make sure this is called after recoData.collectData, which may load some conditions
+  process(recoData);
+}
+
+void TrackCheckStudy::process(o2::globaltracking::RecoContainer& recoData)
+{
+  auto itsTracksROFRecords = recoData.getITSTracksROFRecords();
+  auto itsTracks = recoData.getITSTracks();
+  auto itsTracksMCLabels = recoData.getITSTracksMCLabels();
+
+  LOGP(info, "Got {} rofs", itsTracksROFRecords.size());
+  LOGP(info, "Got {} tracks", itsTracks.size());
+  LOGP(info, "Got {} labels", itsTracksMCLabels.size());
+  // LOGP(info, "Got {} MCHeaders", mHeader.size());
+  LOGP(info, "Got {} MCTracks", mMCTracks.size());
+}
+
+void TrackCheckStudy::updateTimeDependentParams(ProcessingContext& pc)
+{
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+  }
+}
+
+void TrackCheckStudy::endOfStream(EndOfStreamContext& ec)
+{
+}
+
+void TrackCheckStudy::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+}
+
+DataProcessorSpec getTrackCheckStudy(mask_t srcTracksMask, mask_t srcClustersMask, bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  auto dataRequest = std::make_shared<DataRequest>();
+  dataRequest->requestTracks(srcTracksMask, useMC);
+  dataRequest->requestClusters(srcClustersMask, useMC);
+
+  std::vector<InputSpec> inputs = dataRequest->inputs;
+  // inputs.emplace_back("MCHeader", "MC", "MCHEADER", 0, Lifetime::Timeframe);  TODO: Headers we cannot get them
+  inputs.emplace_back("MCTracks", "MC", "MCTRACKS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "its-study-check-tracks",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TrackCheckStudy>(dataRequest, srcTracksMask)},
+    Options{}};
+}
+
+} // namespace study
+} // namespace its
+} // namespace o2


### PR DESCRIPTION
This PR adds:

- Additional interface to read o2sim_Kine Files on a TF base rather than event one
- Skeleton for Reco/MCSim tracks comparison (i.e. CheckTracksCA.C idea)
- Fixes for unneeded requests such as HBInfos (for now)

This PR needs:

- Better understanding of how we can read MC Kine info and integrate in a DPL-TimeFrame-based approach
- Better understanding and treatment of non-messageable MCHeaders