### PR TITLE
[WIP] Add TRD Pulse Height

### DIFF
--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -51,7 +51,7 @@ CURL* createTestHandle(std::string* dst)
   CURL* handle = curl_easy_init();
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, CurlWrite_CallbackFunc_StdString2);
   curl_easy_setopt(handle, CURLOPT_WRITEDATA, dst);
-  curl_easy_setopt(handle, CURLOPT_URL, "http://ccdb-test.cern.ch:8080/");
+  curl_easy_setopt(handle, CURLOPT_URL, "http://ccdb-test.cern.ch:8080/latest/");
   return handle;
 }
 

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -127,7 +127,7 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
   /** add track **/
 
   // check the status encoding
-  if (!mcgenstatus::isEncoded(generatorStatus) && proc == TMCProcess::kPPrimary) {
+  if (!mcgenstatus::isEncoded(generatorStatus)) {
     LOG(fatal) << "Generatror status " << generatorStatus << " of particle is not encoded properly.";
   }
 

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -192,7 +192,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"ccdb-tof-sa", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects via CCDBManager (obsolete remap to use-ccdb-tof)"}});
 
   // option to use/not use CCDB for FT0
-  workflowOptions.push_back(ConfigParamSpec{"use-ccdb-ft0", o2::framework::VariantType::Bool, false, {"enable access to ccdb ft0 calibration objects"}});
+  workflowOptions.push_back(ConfigParamSpec{"use-ccdb-ft0", o2::framework::VariantType::Bool, true, {"enable access to ccdb ft0 calibration objects"}});
 
   // option to use/not use CCDB for EMCAL
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-emc", o2::framework::VariantType::Bool, false, {"enable access to ccdb EMCAL simulation objects"}});


### PR DESCRIPTION
Moving  creation of the pulse height spectra from QC into O2, such that
a) we avoid the sampling of digits and get more statistics in the plots
b) the PH plots can be used downstream for example for the T0 calibration
This is  a work in progress on top of the basic structure https://github.com/martenole/AliceO2/tree/trd-ph created by @martenole 

- [x] move the algorithm for creating the PH plot from QC into PulseHeight::process()
- [ ] add a writer to write the output to a file
- [ ] initialization and reset methods (if needed, depending on the output type chosen)