### PR TITLE
Improved thread safety in construtor and destructor of the downloader

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -114,8 +114,7 @@ class CCDBDownloader
    */
   int mMaxHandlesInUse = 3;
 
-  // CCDBDownloader(uv_loop_t uv_loop);
-  CCDBDownloader(uv_loop_t* uv_loop = nullptr);
+  CCDBDownloader();
   ~CCDBDownloader();
 
   /**
@@ -144,6 +143,9 @@ class CCDBDownloader
    * @param completionFlag Should be set to false before passing it to this function. Will be set to true after all transfers finish.
    */
   std::vector<CURLcode> batchAsynchPerform(std::vector<CURL*> const& handleVector, bool* completionFlag);
+
+  void sendCloseLoopHandle();
+  static void closeLoop(uv_async_t* handle);
 
   /**
    * Limits the number of parallel connections. Should be used only if no transfers are happening.
@@ -182,12 +184,6 @@ class CCDBDownloader
 
  private:
   /**
-   * Indicates whether the loop that the downloader is running on has been created by it or provided externally.
-   * In case of external loop, the loop will not be closed after downloader is deleted.
-   */
-  bool mIsExternalLoop;
-
-  /**
    * Used in debug to detect whether uv loop closed prematurely.
    */
   bool mIsClosing = false;
@@ -218,6 +214,16 @@ class CCDBDownloader
   std::mutex mHandlesQueueLock;
 
   /**
+   * Blocks the constructor from returning before the uv_loop has started running
+   */
+  std::condition_variable* mConstructorCV;
+
+  /**
+   * Prevents the mConstructorCV from being notified after the constructor returned
+   */
+  bool mLoopRunning = false;
+
+  /**
    * Thread on which the thread with uv_loop runs.
    */
   std::thread* mLoopThread;
@@ -226,11 +232,6 @@ class CCDBDownloader
    * Vector with reference to callback threads with a flag marking whether they finished running.
    */
   std::vector<std::pair<std::thread*, bool*>> mThreadFlagPairVector;
-
-  /**
-   * Flag used to signall the loop to close.
-   */
-  bool mCloseLoop = false;
 
   /**
    * Types of requests.
@@ -293,11 +294,11 @@ class CCDBDownloader
   static void curlPerform(uv_poll_t* handle, int status, int events);
 
   /**
-   * Check if loop was signalled to close. The handle connected with this callbacks is always active as to prevent the uv_loop from stopping.
+   * This handle should be always running to keep the uv_loop from closing.
    *
    * @param handle uv_handle to which this callbacks is assigned
    */
-  static void checkStopSignal(uv_timer_t* handle);
+  static void upkeepTimerFunction(uv_timer_t* handle);
 
   /**
    * Used by CURL to react to action happening on a socket.
@@ -333,6 +334,13 @@ class CCDBDownloader
   static void curlCloseCB(uv_handle_t* handle);
 
   /**
+   * Callback for the asynchronous handle that closes the uv_loop
+   *
+   * @param handle Handle assigned to this callback.
+   */
+  static void uvCloseCallback(uv_async_t* handle);
+
+  /**
    * Close poll handle assigned to the socket contained in the context and free data within the handle.
    *
    * @param context Structure containing information about socket and handle to be closed.
@@ -347,6 +355,11 @@ class CCDBDownloader
    * @param userp Pointer to the uv_timer_t handle that is used for timeout.
    */
   static int startTimeout(CURLM* multi, long timeout_ms, void* userp);
+
+  /**
+   * Sends an asynchronous handle that signalls the uvloop to close.
+   */
+  void signalToClose();
 
   /**
    * Check if any of the callback threads have finished running and approprietly join them.

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -52,35 +52,19 @@ void curlMultiErrorCheck(CURLMcode code)
   }
 }
 
-CCDBDownloader::CCDBDownloader(uv_loop_t* uv_loop)
+CCDBDownloader::CCDBDownloader()
 {
-  if (uv_loop) {
-    mUVLoop = uv_loop;
-    mIsExternalLoop = true;
-  } else {
-    mUVLoop = new uv_loop_t();
-    mIsExternalLoop = false;
-  }
-
-  // Preparing timer to be used by curl
-  mTimeoutTimer = new uv_timer_t();
-  mTimeoutTimer->data = this;
-  uvErrorCheck(uv_loop_init(mUVLoop));
-  uvErrorCheck(uv_timer_init(mUVLoop, mTimeoutTimer));
-  mHandleMap[(uv_handle_t*)mTimeoutTimer] = true;
-
-  // Preparing curl handle
-  initializeMultiHandle();
-
-  // Global timer
-  // uv_loop runs only when there are active handles, this handle guarantees the loop won't close immedietly after starting
-  auto timerCheckQueueHandle = new uv_timer_t();
-  timerCheckQueueHandle->data = this;
-  uvErrorCheck(uv_timer_init(mUVLoop, timerCheckQueueHandle));
-  mHandleMap[(uv_handle_t*)timerCheckQueueHandle] = true;
-  uvErrorCheck(uv_timer_start(timerCheckQueueHandle, checkStopSignal, 100, 100));
+  mConstructorCV = new std::condition_variable();
+  std::mutex cv_m;
+  std::unique_lock<std::mutex> lk(cv_m);
 
   mLoopThread = new std::thread(&CCDBDownloader::runLoop, this);
+
+  // Don't allow constructor to return unless the uv_loop started running.
+  // This protects the loop from receiving handles before it was initialized.
+  mConstructorCV->wait(lk);
+  mLoopRunning = true;
+  delete mConstructorCV;
 }
 
 void CCDBDownloader::initializeMultiHandle()
@@ -98,49 +82,36 @@ void CCDBDownloader::initializeMultiHandle()
 
 CCDBDownloader::~CCDBDownloader()
 {
+  // Flag used for debug. Indicates that the uv_loop is supposed to close.
   mIsClosing = true;
-  // Cleanup and close all socket timers (curl_multi_cleanup will take care of the sockets)
-  for (auto socketTimerPair : mSocketTimerMap) {
-    auto timer = socketTimerPair.second;
-    if (timer->data) {
-      delete (DataForClosingSocket*)timer->data;
-    }
-    uvErrorCheck(uv_timer_stop(socketTimerPair.second));
-    uv_close((uv_handle_t*)socketTimerPair.second, onUVClose);
-  }
-  // all timers have been closed --> so clear this map (otherwise it may get accessed in different callbacks again
-  // ... for instance when called from within curl_multi_cleanup)
-  mSocketTimerMap.clear();
 
-  // Close loop thread
-  mCloseLoop = true;
+  // Send asynchronous signal to close the loop
+  signalToClose();
   mLoopThread->join();
+
   delete mLoopThread;
+  delete mUVLoop;
+}
 
-  // Close the loop and if any handles are running then signal to close, and run loop once to close them
-  // This may take more then one iteration of loop - hence the "while"
-  if (mIsExternalLoop) {
-    uv_walk(mUVLoop, closeHandles, this);
-  } else {
-    while (UV_EBUSY == uv_loop_close(mUVLoop)) {
-      mCloseLoop = false;
-      uv_walk(mUVLoop, closeHandles, this);
-      uvErrorCheck(uv_run(mUVLoop, UV_RUN_ONCE));
-    }
-    delete mUVLoop;
-  }
+void CCDBDownloader::signalToClose()
+{
+  auto asyncHandle = new uv_async_t();
+  asyncHandle->data = this;
+  uvErrorCheck(uv_async_init(mUVLoop, asyncHandle, uvCloseCallback));
+  uvErrorCheck(uv_async_send(asyncHandle));
+}
 
-  // delete timer
-  // delete mTimeoutTimer; ---> not necessay (done elsewhere??)
-
-  curlMultiErrorCheck(curl_multi_cleanup(mCurlMultiHandle));
+void CCDBDownloader::uvCloseCallback(uv_async_t* handle)
+{
+  auto CD = (CCDBDownloader*)handle->data;
+  uv_close((uv_handle_t*)handle, onUVClose);
+  uv_stop(CD->mUVLoop);
 }
 
 void closeHandles(uv_handle_t* handle, void* arg)
 {
   auto CD = (CCDBDownloader*)arg;
-  if (!uv_is_closing(handle) && CD->mHandleMap.find(handle) != CD->mHandleMap.end()) {
-    CD->mHandleMap.erase(handle);
+  if (!uv_is_closing(handle)) {
     uv_close(handle, onUVClose);
   }
 }
@@ -152,13 +123,13 @@ void onUVClose(uv_handle_t* handle)
   }
 }
 
-void CCDBDownloader::checkStopSignal(uv_timer_t* handle)
+void CCDBDownloader::upkeepTimerFunction(uv_timer_t* handle)
 {
-  // Check for closing signal
   auto CD = (CCDBDownloader*)handle->data;
-  if (CD->mCloseLoop) {
-    uvErrorCheck(uv_timer_stop(handle));
-    uv_stop(CD->mUVLoop);
+  if (!CD->mLoopRunning) {
+    // The fact that this callback is executed means the uv_loop is running.
+    // Notify the constructor if it hasn't been already.
+    CD->mConstructorCV->notify_all();
   }
   CD->checkForThreadsToJoin();
 }
@@ -482,7 +453,39 @@ void CCDBDownloader::checkHandleQueue()
 
 void CCDBDownloader::runLoop()
 {
-  uvErrorCheck(uv_run(mUVLoop, UV_RUN_DEFAULT));
+  // Only runLoop() function and functions called by it are allowed to interact with the uv_loop via non asynchronous handles.
+  mUVLoop = new uv_loop_t();
+  uvErrorCheck(uv_loop_init(mUVLoop));
+
+  // Preparing timer to be used by curl
+  mTimeoutTimer = new uv_timer_t();
+  mTimeoutTimer->data = this;
+  uvErrorCheck(uv_timer_init(mUVLoop, mTimeoutTimer));
+  mHandleMap[(uv_handle_t*)mTimeoutTimer] = true;
+
+  // Preparing curl handle
+  initializeMultiHandle();
+
+  // Global timer
+  // uv_loop runs only when there are active handles, this handle guarantees the loop won't close immedietly after starting
+  auto timerCheckQueueHandle = new uv_timer_t();
+  timerCheckQueueHandle->data = this;
+  uvErrorCheck(uv_timer_init(mUVLoop, timerCheckQueueHandle));
+  mHandleMap[(uv_handle_t*)timerCheckQueueHandle] = true;
+  uvErrorCheck(uv_timer_start(timerCheckQueueHandle, upkeepTimerFunction, 1, 100));
+
+  // Start the loop
+  uv_run(mUVLoop, UV_RUN_DEFAULT);
+
+  // Loop has been ordered to stop via signalToClose()
+  curlMultiErrorCheck(curl_multi_cleanup(mCurlMultiHandle));
+
+  // Schedule all handles to close. Execute loop once to allow them to execute their destructors.
+  while (uv_loop_alive(mUVLoop) && uv_loop_close(mUVLoop) == UV_EBUSY) {
+    uv_walk(mUVLoop, closeHandles, this);
+    uv_run(mUVLoop, UV_RUN_ONCE);
+  }
+
   if (!mIsClosing) {
     LOG(error) << "CCDBDownloader: uvloop closed prematurely";
   }

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -274,33 +274,5 @@ BOOST_AUTO_TEST_CASE(asynch_batch_callback)
   curl_global_cleanup();
 }
 
-BOOST_AUTO_TEST_CASE(external_loop_test)
-{
-  if (curl_global_init(CURL_GLOBAL_ALL)) {
-    fprintf(stderr, "Could not init curl\n");
-    return;
-  }
-
-  uv_loop_t loop;
-
-  CCDBDownloader downloader(&loop);
-  std::string dst = "";
-  CURL* handle = createTestHandle(&dst);
-
-  CURLcode curlCode = downloader.perform(handle);
-
-  BOOST_CHECK(curlCode == CURLE_OK);
-  std::cout << "CURL code: " << curlCode << "\n";
-
-  long httpCode;
-  curl_easy_getinfo(handle, CURLINFO_HTTP_CODE, &httpCode);
-  BOOST_CHECK(httpCode == 200);
-  std::cout << "HTTP code: " << httpCode << "\n";
-
-  curl_easy_cleanup(handle);
-
-  curl_global_cleanup();
-}
-
 } // namespace ccdb
 } // namespace o2


### PR DESCRIPTION
All handle and loop initialization and deletion has been moved from the constructor and destructor to the loop thread.

Additionally, all mechanisms regarding the use of an external uv_loop have been removed, as their use would cause more thread safety violations.