### PR TITLE
Introducing iCell selections

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cu
@@ -434,8 +434,7 @@ GPUg() void computeLayerCellsKernel(
           new (cells + cellsLUT[iCurrentTrackletIndex] + foundCells) Cell{currentTracklet.firstClusterIndex, nextTracklet.firstClusterIndex,
                                                                           nextTracklet.secondClusterIndex,
                                                                           iCurrentTrackletIndex,
-                                                                          iNextTrackletIndex,
-                                                                          tanLambda};
+                                                                          iNextTrackletIndex};
         }
         ++foundCells;
       }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -32,14 +32,13 @@ class Cell final
 {
  public:
   GPUhd() Cell();
-  GPUd() Cell(const int, const int, const int, const int, const int, const float);
+  GPUd() Cell(const int, const int, const int, const int, const int);
 
   GPUhd() int getFirstClusterIndex() const { return mFirstClusterIndex; };
   GPUhd() int getSecondClusterIndex() const { return mSecondClusterIndex; };
   GPUhd() int getThirdClusterIndex() const { return mThirdClusterIndex; };
   GPUhd() int getFirstTrackletIndex() const { return mFirstTrackletIndex; };
   GPUhd() int getSecondTrackletIndex() const { return mSecondTrackletIndex; };
-  GPUhd() float getTanLambda() const { return mTanLambda; };
   GPUhd() int getLevel() const { return mLevel; };
   GPUhd() void setLevel(const int level) { mLevel = level; };
   GPUhd() int* getLevelPtr() { return &mLevel; }
@@ -50,7 +49,6 @@ class Cell final
   const int mThirdClusterIndex;
   const int mFirstTrackletIndex;
   const int mSecondTrackletIndex;
-  const float mTanLambda;
   int mLevel;
 };
 
@@ -60,20 +58,18 @@ GPUhdi() Cell::Cell()
     mThirdClusterIndex{0},
     mFirstTrackletIndex{0},
     mSecondTrackletIndex{0},
-    mTanLambda{0},
     mLevel{0}
 {
   // Nothing to do
 }
 
 GPUdi() Cell::Cell(const int firstClusterIndex, const int secondClusterIndex, const int thirdClusterIndex,
-                   const int firstTrackletIndex, const int secondTrackletIndex, const float tanL)
+                   const int firstTrackletIndex, const int secondTrackletIndex)
   : mFirstClusterIndex{firstClusterIndex},
     mSecondClusterIndex{secondClusterIndex},
     mThirdClusterIndex{thirdClusterIndex},
     mFirstTrackletIndex{firstTrackletIndex},
     mSecondTrackletIndex{secondTrackletIndex},
-    mTanLambda{tanL},
     mLevel{1}
 {
   // Nothing to do

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -151,6 +151,9 @@ class TimeFrame
   std::vector<std::vector<Cluster>>& getUnsortedClusters();
   int getClusterROF(int iLayer, int iCluster);
   std::vector<std::vector<Cell>>& getCells();
+  std::vector<std::vector<o2::track::TrackParCovF>>& getCellSeeds();
+  std::vector<std::vector<float>>& getCellSeedsChi2() { return mCellSeedsChi2; }
+
   std::vector<std::vector<int>>& getCellsLookupTable();
   std::vector<std::vector<std::vector<int>>>& getCellsNeighbours();
   std::vector<Road<5>>& getRoads();
@@ -247,6 +250,8 @@ class TimeFrame
   std::vector<std::vector<MCCompLabel>> mTrackletLabels;
   std::vector<std::vector<MCCompLabel>> mCellLabels;
   std::vector<std::vector<Cell>> mCells;
+  std::vector<std::vector<o2::track::TrackParCovF>> mCellSeeds;
+  std::vector<std::vector<float>> mCellSeedsChi2;
   std::vector<std::vector<int>> mCellsLookupTable;
   std::vector<std::vector<std::vector<int>>> mCellsNeighbours;
   std::vector<Road<5>> mRoads;
@@ -529,6 +534,8 @@ inline std::vector<std::vector<Cluster>>& TimeFrame::getUnsortedClusters()
 }
 
 inline std::vector<std::vector<Cell>>& TimeFrame::getCells() { return mCells; }
+
+inline std::vector<std::vector<o2::track::TrackParCovF>>& TimeFrame::getCellSeeds() { return mCellSeeds; }
 
 inline std::vector<std::vector<int>>& TimeFrame::getCellsLookupTable()
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -98,7 +98,7 @@ class TrackerTraits
  private:
   void traverseCellsTree(const int, const int);
   track::TrackParCov buildTrackSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster3, const TrackingFrameInfo& tf3);
-  bool fitTrack(TrackITSExt& track, int start, int end, int step, const float chi2clcut = o2::constants::math::VeryBig, const float chi2ndfcut = o2::constants::math::VeryBig, const float maxQoverPt = o2::constants::math::VeryBig);
+  bool fitTrack(TrackITSExt& track, int start, int end, int step, float chi2clcut = o2::constants::math::VeryBig, float chi2ndfcut = o2::constants::math::VeryBig, float maxQoverPt = o2::constants::math::VeryBig, int nCl = 0);
 
   int mNThreads = 1;
   bool mApplySmoothing = false;

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -251,6 +251,8 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     mTracksLabel.resize(mNrof);
     mLinesLabels.resize(mNrof);
     mCells.resize(trkParam.CellsPerRoad());
+    mCellSeeds.resize(trkParam.CellsPerRoad());
+    mCellSeedsChi2.resize(trkParam.CellsPerRoad());
     mCellsLookupTable.resize(trkParam.CellsPerRoad() - 1);
     mCellsNeighbours.resize(trkParam.CellsPerRoad() - 1);
     mCellLabels.resize(trkParam.CellsPerRoad());
@@ -383,6 +385,8 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     mTrackletLabels[iLayer].clear();
     if (iLayer < (int)mCells.size()) {
       mCells[iLayer].clear();
+      mCellSeeds[iLayer].clear();
+      mCellSeedsChi2[iLayer].clear();
       mTrackletsLookupTable[iLayer].clear();
       mTrackletsLookupTable[iLayer].resize(mClusters[iLayer + 1].size(), 0);
       mCellLabels[iLayer].clear();

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -291,7 +291,6 @@ void TrackerTraits::computeLayerCells(const int iteration)
         }
         const Tracklet& nextTracklet{tf->getTracklets()[iLayer + 1][iNextTracklet]};
         const float deltaTanLambda{std::abs(currentTracklet.tanLambda - nextTracklet.tanLambda)};
-        const float tanLambda{(currentTracklet.tanLambda + nextTracklet.tanLambda) * 0.5f};
 
 #ifdef OPTIMISATION_OUTPUT
         bool good{tf->getTrackletsLabel(iLayer)[iTracklet] == tf->getTrackletsLabel(iLayer + 1)[iNextTracklet]};
@@ -305,9 +304,54 @@ void TrackerTraits::computeLayerCells(const int iteration)
             tf->getCellsLookupTable()[iLayer - 1].resize(iTracklet + 1, tf->getCells()[iLayer].size());
           }
 
+          /// Track seed preparation. Clusters are numbered progressively from the innermost going outward.
+          const int clusId[3]{
+            mTimeFrame->getClusters()[iLayer][currentTracklet.firstClusterIndex].clusterId,
+            mTimeFrame->getClusters()[iLayer + 1][nextTracklet.firstClusterIndex].clusterId,
+            mTimeFrame->getClusters()[iLayer + 2][nextTracklet.secondClusterIndex].clusterId};
+          const auto& cluster1_glo = mTimeFrame->getUnsortedClusters()[iLayer].at(clusId[0]);
+          const auto& cluster2_glo = mTimeFrame->getUnsortedClusters()[iLayer + 1].at(clusId[1]);
+          const auto& cluster3_glo = mTimeFrame->getUnsortedClusters()[iLayer + 2].at(clusId[2]);
+          const auto& cluster3_tf = mTimeFrame->getTrackingFrameInfoOnLayer(iLayer + 2).at(clusId[2]);
+          auto track{buildTrackSeed(cluster1_glo, cluster2_glo, cluster3_glo, cluster3_tf)};
+
+          float chi2{0.f};
+          bool good{false};
+          for (int iC{2}; iC--;) {
+            const TrackingFrameInfo& trackingHit = mTimeFrame->getTrackingFrameInfoOnLayer(iLayer + iC).at(clusId[iC]);
+
+            if (!track.rotate(trackingHit.alphaTrackingFrame)) {
+              break;
+            }
+
+            if (!track.propagateTo(trackingHit.xTrackingFrame, getBz())) {
+              break;
+            }
+
+            constexpr float radl = 9.36f; // Radiation length of Si [cm]
+            constexpr float rho = 2.33f;  // Density of Si [g/cm^3]
+            if (!track.correctForMaterial(mTrkParams[0].LayerxX0[iLayer + iC], mTrkParams[0].LayerxX0[iLayer] * radl * rho, true)) {
+              break;
+            }
+
+            auto predChi2{track.getPredictedChi2(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
+            if (!track.o2::track::TrackParCov::update(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)) {
+              break;
+            }
+            if (!iC && predChi2 > mTrkParams[iteration].MaxChi2ClusterAttachment) {
+              break;
+            }
+            good = !iC;
+            chi2 += predChi2;
+          }
+          if (!good) {
+            continue;
+          }
           tf->getCells()[iLayer].emplace_back(
             currentTracklet.firstClusterIndex, nextTracklet.firstClusterIndex, nextTracklet.secondClusterIndex,
-            iTracklet, iNextTracklet, tanLambda);
+            iTracklet, iNextTracklet);
+          tf->getCellSeeds()[iLayer].emplace_back(track);
+          tf->getCellSeedsChi2()[iLayer].emplace_back(chi2);
         }
       }
     }
@@ -356,21 +400,33 @@ void TrackerTraits::findCellsNeighbours(const int iteration)
     for (int iCell{0}; iCell < layerCellsNum; ++iCell) {
 
       const Cell& currentCell{mTimeFrame->getCells()[iLayer][iCell]};
+      const auto& currentCellSeed{mTimeFrame->getCellSeeds()[iLayer][iCell]};
       const int nextLayerTrackletIndex{currentCell.getSecondTrackletIndex()};
       const int nextLayerFirstCellIndex{mTimeFrame->getCellsLookupTable()[iLayer][nextLayerTrackletIndex]};
       const int nextLayerLastCellIndex{mTimeFrame->getCellsLookupTable()[iLayer][nextLayerTrackletIndex + 1]};
       for (int iNextCell{nextLayerFirstCellIndex}; iNextCell < nextLayerLastCellIndex; ++iNextCell) {
 
         Cell& nextCell{mTimeFrame->getCells()[iLayer + 1][iNextCell]};
+        auto nextCellSeed{mTimeFrame->getCellSeeds()[iLayer + 1][iNextCell]}; /// copy
         if (nextCell.getFirstTrackletIndex() != nextLayerTrackletIndex) {
           break;
         }
 
+        if (!nextCellSeed.rotate(currentCellSeed.getAlpha()) ||
+            !nextCellSeed.propagateTo(currentCellSeed.getX(), getBz())) {
+          continue;
+        }
+        float chi2 = currentCellSeed.getPredictedChi2(nextCellSeed);
+
 #ifdef OPTIMISATION_OUTPUT
         bool good{mTimeFrame->getCellsLabel(iLayer)[iCell] == mTimeFrame->getCellsLabel(iLayer + 1)[iNextCell]};
-        float signedDelta{currentCell.getTanLambda() - nextCell.getTanLambda()};
-        off << fmt::format("{}\t{:d}\t{}\t{}", iLayer, good, signedDelta, signedDelta / mTrkParams[iteration].CellDeltaTanLambdaSigma) << std::endl;
+        off << fmt::format("{}\t{:d}\t{}", iLayer, good, chi2) << std::endl;
 #endif
+
+        if (chi2 > mTrkParams[iteration].MaxChi2ClusterAttachment) {
+          continue;
+        }
+
         mTimeFrame->getCellsNeighbours()[iLayer][iNextCell].push_back(iCell);
 
         const int currentCellLevel{currentCell.getLevel()};
@@ -457,6 +513,7 @@ void TrackerTraits::findTracks()
     auto& road = mTimeFrame->getRoads()[ri];
     std::vector<int> clusters(mTrkParams[0].NLayers, constants::its::UnusedIndex);
     int lastCellLevel = constants::its::UnusedIndex;
+    int lastCellIndex{-1};
     CA_DEBUGGER(int nClusters = 2);
     int firstTracklet{constants::its::UnusedIndex};
     std::vector<int> tracklets(mTrkParams[0].TrackletsPerRoad(), constants::its::UnusedIndex);
@@ -478,6 +535,7 @@ void TrackerTraits::findTracks()
                clusters[iCell + 1] != constants::its::UnusedIndex &&
                clusters[iCell + 2] != constants::its::UnusedIndex);
         lastCellLevel = iCell;
+        lastCellIndex = cellIndex;
         CA_DEBUGGER(nClusters++);
       }
     }
@@ -520,16 +578,18 @@ void TrackerTraits::findTracks()
     const auto& cluster3_glo = mTimeFrame->getUnsortedClusters()[lastCellLevel + 2].at(clusters[lastCellLevel + 2]);
     const auto& cluster3_tf = mTimeFrame->getTrackingFrameInfoOnLayer(lastCellLevel + 2).at(clusters[lastCellLevel + 2]);
 
-    TrackITSExt temporaryTrack{buildTrackSeed(cluster1_glo, cluster2_glo, cluster3_glo, cluster3_tf)};
+    TrackITSExt temporaryTrack{mTimeFrame->getCellSeeds()[lastCellLevel][lastCellIndex]};
+    temporaryTrack.setChi2(mTimeFrame->getCellSeedsChi2()[lastCellLevel][lastCellIndex]);
     for (size_t iC = 0; iC < clusters.size(); ++iC) {
       temporaryTrack.setExternalClusterIndex(iC, clusters[iC], clusters[iC] != constants::its::UnusedIndex);
     }
-    bool fitSuccess = fitTrack(temporaryTrack, lastCellLevel + 1, -1, -1);
+    bool fitSuccess = fitTrack(temporaryTrack, lastCellLevel - 1, -1, -1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF, 1.e3, 3);
     if (!fitSuccess) {
       continue;
     }
     CA_DEBUGGER(fitCounters[nClusters - 4]++);
     temporaryTrack.resetCovariance();
+    temporaryTrack.setChi2(0);
     fitSuccess = fitTrack(temporaryTrack, 0, mTrkParams[0].NLayers, 1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF);
     if (!fitSuccess) {
       continue;
@@ -537,6 +597,7 @@ void TrackerTraits::findTracks()
     CA_DEBUGGER(backpropagatedCounters[nClusters - 4]++);
     temporaryTrack.getParamOut() = temporaryTrack;
     temporaryTrack.resetCovariance();
+    temporaryTrack.setChi2(0);
     fitSuccess = fitTrack(temporaryTrack, mTrkParams[0].NLayers - 1, -1, -1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF, 50.);
     if (!fitSuccess) {
       continue;
@@ -619,6 +680,7 @@ void TrackerTraits::extendTracks(const int iteration)
       if (success) {
         /// We have to refit the track
         track.resetCovariance();
+        track.setChi2(0);
         bool fitSuccess = fitTrack(track, 0, mTrkParams[0].NLayers, 1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF);
         if (!fitSuccess) {
           track = backup;
@@ -626,6 +688,7 @@ void TrackerTraits::extendTracks(const int iteration)
         }
         track.getParamOut() = track;
         track.resetCovariance();
+        track.setChi2(0);
         fitSuccess = fitTrack(track, mTrkParams[0].NLayers - 1, -1, -1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF, 50.);
         if (!fitSuccess) {
           track = backup;
@@ -715,12 +778,14 @@ void TrackerTraits::findShortPrimaries()
     }
 
     bestTrack.resetCovariance();
+    bestTrack.setChi2(0.f);
     fitSuccess = fitTrack(bestTrack, 0, mTrkParams[0].NLayers, 1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF);
     if (!fitSuccess) {
       continue;
     }
     bestTrack.getParamOut() = bestTrack;
     bestTrack.resetCovariance();
+    bestTrack.setChi2(0.f);
     fitSuccess = fitTrack(bestTrack, mTrkParams[0].NLayers - 1, -1, -1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF, 50.);
     if (!fitSuccess) {
       continue;
@@ -732,11 +797,10 @@ void TrackerTraits::findShortPrimaries()
   }
 }
 
-bool TrackerTraits::fitTrack(TrackITSExt& track, int start, int end, int step, const float chi2clcut, const float chi2ndfcut, const float maxQoverPt)
+bool TrackerTraits::fitTrack(TrackITSExt& track, int start, int end, int step, float chi2clcut, float chi2ndfcut, float maxQoverPt, int nCl)
 {
   auto propInstance = o2::base::Propagator::Instance();
-  track.setChi2(0);
-  int nCl{0};
+
   for (int iLayer{start}; iLayer != end; iLayer += step) {
     if (track.getClusterIndex(iLayer) == constants::its::UnusedIndex) {
       continue;


### PR DESCRIPTION
Remove cells as early as possible in the ITS tracking, reducing the
number of candidate tracks to be fitted
