### PR TITLE
Optimizing tests in the CCDBDownloader

### DIFF
--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -51,7 +51,7 @@ CURL* createTestHandle(std::string* dst)
   CURL* handle = curl_easy_init();
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, CurlWrite_CallbackFunc_StdString2);
   curl_easy_setopt(handle, CURLOPT_WRITEDATA, dst);
-  curl_easy_setopt(handle, CURLOPT_URL, "http://ccdb-test.cern.ch:8080/latest/");
+  curl_easy_setopt(handle, CURLOPT_URL, "http://ccdb-test.cern.ch:8080/");
   return handle;
 }
 


### PR DESCRIPTION
This change will lighten the load on the test server, while providing the same results.