### PR TITLE
Use pageCounter instead of packetCounter to detect packet loss

### DIFF
--- a/Framework/Utils/test/RawPageTestData.cxx
+++ b/Framework/Utils/test/RawPageTestData.cxx
@@ -48,6 +48,9 @@ DataSet createData(std::vector<InputSpec> const& inputspecs, std::vector<DataHea
   unsigned char packetCounter = 0;
 
   auto initRawPage = [&checkValues, &amendRdh, &packetCounter](char* buffer, size_t size, auto value) {
+    int pageCounter = 0;
+    unsigned int lastFEEID = 0;
+    unsigned int lastOrbit = 0;
     char* wrtptr = buffer;
     while (wrtptr < buffer + size) {
       auto* header = reinterpret_cast<RAWDataHeader*>(wrtptr);
@@ -55,8 +58,14 @@ DataSet createData(std::vector<InputSpec> const& inputspecs, std::vector<DataHea
       if (amendRdh) {
         amendRdh(*header);
       }
+      if (wrtptr == buffer || header->feeId != lastFEEID || header->orbit != lastOrbit) {
+        pageCounter = 0;
+      }
+      lastFEEID = header->feeId;
+      lastOrbit = header->orbit;
       header->memorySize = PAGESIZE;
       header->offsetToNext = PAGESIZE;
+      header->pageCnt = pageCounter++;
       header->packetCounter = packetCounter++;
       *reinterpret_cast<decltype(value)*>(wrtptr + header->headerSize) = value;
       wrtptr += PAGESIZE;

--- a/Framework/Utils/test/test_RawParser.cxx
+++ b/Framework/Utils/test/test_RawParser.cxx
@@ -33,7 +33,7 @@ void fillPages(Container& buffer)
     rdh->headerSize = sizeof(RDH);
     rdh->offsetToNext = PageSize;
     rdh->memorySize = PageSize;
-    rdh->pageCnt = NofPages;
+    rdh->pageCnt = pageNo;
     rdh->packetCounter = pageNo;
     rdh->stop = pageNo + 1 == NofPages;
     auto* data = reinterpret_cast<size_t*>(buffer.data() + pageNo * PageSize + rdh->headerSize);

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -145,10 +145,6 @@ int GPUO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutp
   if (retVal == 2) {
     retVal = 0; // 2 signals end of event display, ignore
   }
-  if (retVal) {
-    mRec->ClearAllocatedMemory();
-    return retVal;
-  }
   if (mConfig->configQA.shipToQC && mChain->QARanForTF()) {
     outputs->qa.hist1 = &mChain->GetQA()->getHistograms1D();
     outputs->qa.hist2 = &mChain->GetQA()->getHistograms2D();
@@ -158,7 +154,7 @@ int GPUO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutp
   }
   *data = mChain->mIOPtrs;
 
-  return 0;
+  return retVal;
 }
 
 void GPUO2Interface::Clear(bool clearOutputs) { mRec->ClearAllocatedMemory(clearOutputs); }

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
@@ -623,13 +623,13 @@ GPUd() uint32_t GPUTPCCFDecodeZSDenseLink::DecodePage(GPUSharedMemory& smem, pro
     if (i == decHeader->nTimebinHeaders - 1 && decHeader->flags & o2::tpc::TPCZSHDRV2::ZSFlags::payloadExtendsToNextPage) {
       assert(o2::raw::RDHUtils::getMemorySize(*rawDataHeader) == TPCZSHDR::TPC_ZS_PAGE_SIZE);
       // Disable check for dropped pages temporarily, decoding fails on large dataset when enabled...
-      if ((unsigned char)(raw::RDHUtils::getPacketCounter(rawDataHeader) + 1) == raw::RDHUtils::getPacketCounter(nextPage)) {
+      if ((unsigned char)(raw::RDHUtils::getPageCounter(rawDataHeader) + 1) == raw::RDHUtils::getPageCounter(nextPage)) {
         nSamplesWrittenTB = DecodeTB<DecodeInParallel, true>(clusterer, smem, iThread, page, pageDigitOffset, rawDataHeader, firstHBF, decHeader->cruID, payloadEnd, nextPage);
       } else {
         nSamplesWrittenTB = FillWithInvalid(clusterer, iThread, nThreads, pageDigitOffset, nSamplesInPage - nSamplesWritten);
 #ifdef GPUCA_CHECK_TPCZS_CORRUPTION
         if (iThread == 0) {
-          clusterer.raiseError(GPUErrors::ERROR_TPCZS_INCOMPLETE_HBF, clusterer.mISlice, raw::RDHUtils::getPacketCounter(rawDataHeader), raw::RDHUtils::getPacketCounter(nextPage));
+          clusterer.raiseError(GPUErrors::ERROR_TPCZS_INCOMPLETE_HBF, clusterer.mISlice, raw::RDHUtils::getPageCounter(rawDataHeader), raw::RDHUtils::getPageCounter(nextPage));
         }
 #endif
       }

--- a/GPU/GPUTracking/display/GPUDisplay.h
+++ b/GPU/GPUTracking/display/GPUDisplay.h
@@ -160,7 +160,10 @@ class GPUDisplay : public GPUDisplayInterface
   template <typename... Args>
   void SetInfo(Args... args)
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     snprintf(mInfoText2, 1024, args...);
+#pragma GCC diagnostic pop
     GPUInfo("%s", mInfoText2);
     mInfoText2Timer.ResetStart();
   }


### PR DESCRIPTION
There is a problem that on the CRU when the user logic is active, and data is written to multiple links, a global packetCounter is used, so the packetCounter per link is not incremental. This is worked around by this change.