### PR TITLE
TRD fix pad coordinate test

### DIFF
--- a/Detectors/TRD/base/src/PadPlane.cxx
+++ b/Detectors/TRD/base/src/PadPlane.cxx
@@ -176,7 +176,11 @@ double PadPlane::getPad(double y, double z) const
     pad += tiltOffsetPad;
   }
 
-  assert(!(pad < 0.0 || pad > double(mNcols)));
-
-  return pad;
+  if (pad < 0) {
+    return 0.;
+  } else if (pad > mNcols) {
+    return mNcols;
+  } else {
+    return pad;
+  }
 }

--- a/Detectors/TRD/base/test/testCoordinateTransforms.cxx
+++ b/Detectors/TRD/base/test/testCoordinateTransforms.cxx
@@ -45,7 +45,6 @@ BOOST_AUTO_TEST_CASE(LocaltoRCTest)
 {
   auto mGeo = o2::trd::Geometry::instance();
   mGeo->createPadPlaneArray();
-  mGeo->createClusterMatrixArray();
 
   int hcid = 776;
   // This C1 chamber has 16 pad rows with I pad length = 90mm and O pad length = 75mm


### PR DESCRIPTION
There are some borderline test cases which expect extremely small values and compare them to zero or values exactly equal to the number of columns. Depending on the precision this can lead to the assert triggered. See p5 (which is 4.4408921e-16 for example), p6, p18 and p19.
I assume the assert is normaly ignored, but not on arm. See comment in https://github.com/AliceO2Group/AliceO2/pull/11562#issuecomment-1609306469
In any case I don't see why we would want to have the assert there in any case so I would remove it.