### PR TITLE
TRD noise run fixes

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -51,6 +51,7 @@ class DataReaderTask : public Task
   bool mDataVerbose{false};      // verbose output of data unpacking
   bool mHeaderVerbose{false};    // verbose output of headers
   bool mCompressedData{false};   // are we dealing with the compressed data from the flp (send via option)
+  int mProcessEveryNthTF{1};     // to parse only every n-th TF and send empty output for the rest
   bool mInitOnceDone{false};     // flag for requesting new CCDB object upon global run number change
   std::bitset<16> mOptions;            // stores the incoming of the above bools, useful to be able to send this on instead of the individual ones above
                                        // the above bools make the code more readable hence still here.
@@ -64,6 +65,7 @@ class DataReaderTask : public Task
   uint64_t mWordsRejectedTotal{0};                                                        // accumulate the total number of words rejected
   uint64_t mDigitsTotal{0};                                                               // accumulate the total number of digits read
   uint64_t mTrackletsTotal{0};                                                            // accumulate the total number os tracklets read
+  size_t mNTFsProcessed{0};                                                               // keep track of the total number of TFs processed
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -94,7 +94,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     outputs,
     algoSpec,
     Options{{"log-max-errors", VariantType::Int, 20, {"maximum number of errors to log"}},
-            {"log-max-warnings", VariantType::Int, 20, {"maximum number of warnings to log"}}}});
+            {"log-max-warnings", VariantType::Int, 20, {"maximum number of warnings to log"}},
+            {"every-nth-tf", VariantType::Int, 1, {"process only every n-th TF"}}}});
 
   if (!cfgc.options().get<bool>("disable-root-output")) {
     workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, false));

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -33,6 +33,7 @@ void DataReaderTask::init(InitContext& ic)
 {
   mReader.setMaxErrWarnPrinted(ic.options().get<int>("log-max-errors"), ic.options().get<int>("log-max-warnings"));
   mReader.configure(mTrackletHCHeaderState, mHalfChamberWords, mHalfChamberMajor, mOptions);
+  mProcessEveryNthTF = ic.options().get<int>("every-nth-tf");
 }
 
 void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
@@ -98,7 +99,7 @@ void DataReaderTask::run(ProcessingContext& pc)
   updateTimeDependentParams(pc);
   auto dataReadStart = std::chrono::high_resolution_clock::now();
 
-  if (isTimeFrameEmpty(pc)) {
+  if ((mNTFsProcessed++ % mProcessEveryNthTF != 0) || isTimeFrameEmpty(pc)) {
     mReader.buildDPLOutputs(pc);
     mReader.reset();
     return;


### PR DESCRIPTION
Recent attempts to do a TRD noise run with all FLPs have failed. Apparently one EPN cannot handle the full input load and does not correctly drop a fraction of the input TFs. So this adds the possibility for two workarounds:
- use more than 1 EPN and do the actual noise calibration with CCDB upload only on a single EPN based on the DDS collection index
- optionally process only every nth TF by the raw reader and inject dummy output for all other TFs to increase the processing speed.
In any case the noise calibration does not require all available statistics.