### PR TITLE
O2sim: Add rate limiting to mctracks proxy

### DIFF
--- a/run/SimExamples/MCTrackToDPL/run.sh
+++ b/run/SimExamples/MCTrackToDPL/run.sh
@@ -3,6 +3,7 @@
 set -x
 
 NEVENTS=100
+RATELIMIT=1
 # launch generator process (for 100 min bias Pythia8 events; no Geant; no geometry)
 o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant -m CAVE -e TGeant3 &> sim.log &
 SIMPROC=$!
@@ -10,7 +11,7 @@ SIMPROC=$!
 # launch a DPL process (having the right proxy configuration)
 # (Note that the option --o2sim-pid is not strictly necessary when only one o2-sim process is running.
 #  The socket will than be auto-determined.)
-o2-sim-mctracks-proxy -b --enable-test-consumer --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} &
+o2-sim-mctracks-proxy -b --enable-test-consumer --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} --timeframes-rate-limit ${RATELIMIT} &
 TRACKANAPROC=$!
 
 wait ${SIMPROC}

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -48,7 +48,6 @@ class ConsumerTask
   {
     LOG(debug) << "Running simple kinematics consumer client";
     for (const DataRef& ref : InputRecordWalker(pc.inputs())) {
-
       auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       LOG(debug) << "Payload size " << dh->payloadSize << " method " << dh->payloadSerializationMethod.as<std::string>();
     }

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -13,9 +13,7 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
-#include "Framework/CompletionPolicy.h"
-#include "Framework/CompletionPolicyHelpers.h"
-#include "Framework/DeviceSpec.h"
+#include "Framework/CommonDataProcessors.h"
 #include "Framework/ExternalFairMQDeviceProxy.h"
 #include "Framework/Task.h"
 #include "Framework/DataRef.h"
@@ -139,9 +137,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     channelspec = channelbase + socketlist[0] + ",rateLogging=100";
   }
 
-  specs.emplace_back(specifyExternalFairMQDeviceProxy("o2sim-mctrack-proxy",
-                                                      outputs,
-                                                      channelspec.c_str(), f));
+  auto proxy = specifyExternalFairMQDeviceProxy("o2sim-mctrack-proxy",
+                                                outputs,
+                                                channelspec.c_str(), f);
+  proxy.algorithm = CommonDataProcessors::wrapWithRateLimiting(proxy.algorithm);
+  specs.push_back(proxy);
 
   if (configcontext.options().get<bool>("enable-test-consumer")) {
     // connect a test consumer

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -117,7 +117,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // use given pid
   // TODO: this could go away with a proper pipeline implementation
   std::string channelspec;
-  std::string channelbase = "type=sub,method=connect,address=ipc://";
+  std::string channelbase = "type=pair,method=connect,address=ipc://";
   if (configcontext.options().get<int>("o2sim-pid") != -1) {
     std::stringstream channelstr;
     channelstr << channelbase << "/tmp/o2sim-hitmerger-kineforward-" << configcontext.options().get<int>("o2sim-pid") << ",rateLogging=100";

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -48,13 +48,17 @@ class ConsumerTask
   {
     LOG(debug) << "Running simple kinematics consumer client";
     for (const DataRef& ref : InputRecordWalker(pc.inputs())) {
+
       auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       LOG(debug) << "Payload size " << dh->payloadSize << " method " << dh->payloadSerializationMethod.as<std::string>();
     }
-    auto tracks = pc.inputs().get<std::vector<o2::MCTrack>>("mctracks");
-    auto eventheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader");
-    LOG(info) << "Got " << tracks.size() << " tracks";
-    LOG(info) << "Got " << eventheader->GetB() << " as impact parameter in the event header";
+    try {
+      auto tracks = pc.inputs().get<std::vector<o2::MCTrack>>("mctracks");
+      auto eventheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader");
+      LOG(info) << "Got " << tracks.size() << " tracks";
+      LOG(info) << "Got " << eventheader->GetB() << " as impact parameter in the event header";
+    } catch (...) {
+    }
   }
 };
 

--- a/run/o2simtopology_template.json
+++ b/run/o2simtopology_template.json
@@ -135,7 +135,7 @@
             "name": "kineforward",
             "sockets": [
               {
-                "type": "pub",
+                "type": "pair",
                 "method": "bind",
                 "address": "ipc:///tmp/o2sim-hitmerger-kineforward-#PID#",
                 "sndBufSize": 1000,


### PR DESCRIPTION
Adds rate limiting to mctracks-proxy. Adds sending EoS to forwarding channel if o2sim quits earlier. Kine forward channel configuration is changed to `pair` to avoid dropping events. Note that proxy sends a single event per "timeframe". Rate limiting needs to be set in terms of number of events that are to be kept in memory by the proxy. 