### PR TITLE
o2-sim: Avoid hang for on-the-fly injection into DPL

### DIFF
--- a/run/SimExamples/MCTrackToDPL/run.sh
+++ b/run/SimExamples/MCTrackToDPL/run.sh
@@ -5,7 +5,7 @@ set -x
 NEVENTS=100
 RATELIMIT=1
 # launch generator process (for 100 min bias Pythia8 events; no Geant; no geometry)
-o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant -m CAVE -e TGeant3 &> sim.log &
+o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant &> sim.log &
 SIMPROC=$!
 
 # launch a DPL process (having the right proxy configuration)


### PR DESCRIPTION
+ minor cleanup of example file