### PR TITLE
DPL: Online mode should use default pipeline size of 512, since it mitigates some hangs we are seeing (which are still to be understood)

### DIFF
--- a/Framework/Core/src/DefaultsHelpers.cxx
+++ b/Framework/Core/src/DefaultsHelpers.cxx
@@ -29,7 +29,7 @@ unsigned int DefaultsHelpers::pipelineLength()
   // just some reasonable numers
   // The number should really be tuned at runtime for each processor.
   if (deploymentMode == DeploymentMode::OnlineDDS || deploymentMode == DeploymentMode::OnlineECS || deploymentMode == DeploymentMode::FST) {
-    return 256;
+    return 512;
   } else {
     return 64;
   }


### PR DESCRIPTION
trivial and not tested anyway, merging