### PR TITLE
PDG: Remove Lambda1520

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/O2DatabasePDG.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/O2DatabasePDG.h
@@ -233,9 +233,6 @@ inline void O2DatabasePDG::addALICEParticles(TDatabasePDG* db)
                   0, 0, "Special", kspe + 50);
   db->AddParticle("FeedbackPhoton", "FeedbackPhoton", 0, kFALSE,
                   0, 0, "Special", kspe + 51);
-  db->AddParticle("Lambda1520", "Lambda1520", 1.5195, kFALSE,
-                  0.0156, 0, "Resonance", 3124);
-  db->AddAntiParticle("Lambda1520bar", -3124);
 
   //Hyper nuclei and exotica
   ionCode = 1010010030;


### PR DESCRIPTION
Already exists with correct properties in ROOT's [`etc/pdg_table.txt`](https://github.com/root-project/root/blob/02274311acbc830a9119fac864310ac8d4f9a697/etc/pdg_table.txt#L3802).
Attempts to redefine it produce warnings:

```
*** TDatabasePDG::AddParticle: particle with PDGcode=3124 already defined
*** TDatabasePDG::AddAntiParticle: can't redefine parameters
```