### PR TITLE
DPL: move the nextTimeslice to the decongestion service

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -13,6 +13,7 @@
 
 #include "Framework/DataRef.h"
 #include "Framework/InputSpec.h"
+#include "Framework/ServiceRegistryRef.h"
 
 #include <functional>
 #include <string>
@@ -64,7 +65,7 @@ struct CompletionPolicy {
   using Matcher = std::function<bool(DeviceSpec const& device)>;
   using InputSetElement = DataRef;
   using Callback = std::function<CompletionOp(InputSpan const&)>;
-  using CallbackFull = std::function<CompletionOp(InputSpan const&, std::vector<InputSpec> const&)>;
+  using CallbackFull = std::function<CompletionOp(InputSpan const&, std::vector<InputSpec> const&, ServiceRegistryRef&)>;
   using CallbackConfigureRelayer = std::function<void(DataRelayer&)>;
 
   /// Constructor

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -684,7 +684,7 @@ void DataRelayer::getReadyToProcess(std::vector<DataRelayer::RecordAction>& comp
     if (mCompletionPolicy.callback) {
       action = mCompletionPolicy.callback(span);
     } else if (mCompletionPolicy.callbackFull) {
-      action = mCompletionPolicy.callbackFull(span, mInputs);
+      action = mCompletionPolicy.callbackFull(span, mInputs, mContext);
     } else {
       throw runtime_error_f("Completion police %s has no callback set", mCompletionPolicy.name.c_str());
     }

--- a/Framework/Core/src/DecongestionService.h
+++ b/Framework/Core/src/DecongestionService.h
@@ -20,6 +20,8 @@ struct DecongestionService {
   bool isFirstInTopology = true;
   /// Last timeslice we communicated. Notice this should never go backwards.
   int64_t lastTimeslice = 0;
+  /// The next timeslice we should consume, when running in order
+  int64_t nextTimeslice = 0;
   // Task to enqueue the oldest possible timeslice propagation
   // at the end of any processing chain.
   o2::framework::AsyncTaskId oldestPossibleTimesliceTask = {0};


### PR DESCRIPTION
While for the moment this is just reshuffling, it will allow handling the case in which a Lifetime::Timeframe is dropped.