### PR TITLE
DPL: update the nextTimeslice correctly in case of dropped data

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -486,6 +486,7 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
         decongestion->nextTimeslice = std::max(decongestion->nextTimeslice, (int64_t)oldestPossibleOutput.timeslice.value);
         if (oldNextTimeslice != decongestion->nextTimeslice) {
           LOGP(error, "Some Lifetime::Timeframe data got dropped starting at {}", oldNextTimeslice);
+          timesliceIndex.rescan();
         }
       }
       DataProcessingHelpers::broadcastOldestPossibleTimeslice(proxy, oldestPossibleOutput.timeslice.value);

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -555,6 +555,7 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
             decongestion.nextTimeslice = std::max(decongestion.nextTimeslice, (int64_t)oldestPossibleOutput.timeslice.value);
             if (oldNextTimeslice != decongestion.nextTimeslice) {
               LOGP(error, "Some Lifetime::Timeframe data got dropped starting at {}", oldNextTimeslice);
+              timesliceIndex.rescan();
             }
           }
         },

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -481,6 +481,13 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       LOGP(debug, "Broadcasting oldest possible output {} due to {} ({})", oldestPossibleOutput.timeslice.value,
            oldestPossibleOutput.slot.index == -1 ? "channel" : "slot",
            oldestPossibleOutput.slot.index == -1 ? oldestPossibleOutput.channel.value : oldestPossibleOutput.slot.index);
+      if (decongestion->orderedCompletionPolicyActive) {
+        auto oldNextTimeslice = decongestion->nextTimeslice;
+        decongestion->nextTimeslice = std::max(decongestion->nextTimeslice, (int64_t)oldestPossibleOutput.timeslice.value);
+        if (oldNextTimeslice != decongestion->nextTimeslice) {
+          LOGP(error, "Some Lifetime::Timeframe data got dropped starting at {}", oldNextTimeslice);
+        }
+      }
       DataProcessingHelpers::broadcastOldestPossibleTimeslice(proxy, oldestPossibleOutput.timeslice.value);
 
       for (int fi = 0; fi < proxy.getNumForwardChannels(); fi++) {
@@ -543,6 +550,13 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
             }
           }
           decongestion.lastTimeslice = oldestPossibleOutput.timeslice.value;
+          if (decongestion.orderedCompletionPolicyActive) {
+            int64_t oldNextTimeslice = decongestion.nextTimeslice;
+            decongestion.nextTimeslice = std::max(decongestion.nextTimeslice, (int64_t)oldestPossibleOutput.timeslice.value);
+            if (oldNextTimeslice != decongestion.nextTimeslice) {
+              LOGP(error, "Some Lifetime::Timeframe data got dropped starting at {}", oldNextTimeslice);
+            }
+          }
         },
         TimesliceId{oldestPossibleTimeslice}, -1); },
     .kind = ServiceKind::Serial};
@@ -892,7 +906,7 @@ o2::framework::ServiceSpec CommonServices::dataProcessingStats()
     },
     .postProcessing = [](ProcessingContext& context, void* service) {
       auto* stats = (DataProcessingStats*)service;
-      stats->updateStats({(short)ProcessingStatsId::PERFORMED_COMPUTATIONS, DataProcessingStats::Op::Add, 1}); 
+      stats->updateStats({(short)ProcessingStatsId::PERFORMED_COMPUTATIONS, DataProcessingStats::Op::Add, 1});
       flushMetrics(context.services(), *stats); },
     .preDangling = [](DanglingContext& context, void* service) {
        auto* stats = (DataProcessingStats*)service;

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -123,6 +123,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAllOrdered(const char* name
 {
   auto callbackFull = [](InputSpan const& inputs, std::vector<InputSpec> const&, ServiceRegistryRef& ref) -> CompletionPolicy::CompletionOp {
     auto& decongestionService = ref.get<DecongestionService>();
+    decongestionService.orderedCompletionPolicyActive = 1;
     for (auto& input : inputs) {
       if (input.header == nullptr) {
         return CompletionPolicy::CompletionOp::Wait;

--- a/Framework/Core/src/DecongestionService.h
+++ b/Framework/Core/src/DecongestionService.h
@@ -20,8 +20,11 @@ struct DecongestionService {
   bool isFirstInTopology = true;
   /// Last timeslice we communicated. Notice this should never go backwards.
   int64_t lastTimeslice = 0;
-  /// The next timeslice we should consume, when running in order
+  /// The next timeslice we should consume, when running in order,
+  /// using an ordered completion policy.
   int64_t nextTimeslice = 0;
+  /// Ordered completion policy is active.
+  bool orderedCompletionPolicyActive = false;
   // Task to enqueue the oldest possible timeslice propagation
   // at the end of any processing chain.
   o2::framework::AsyncTaskId oldestPossibleTimesliceTask = {0};


### PR DESCRIPTION
This should not happen, but in case it does, it will not stop data taking.