### PR TITLE
DPL: attempt at supporting multiple output proxies

### DIFF
--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -55,7 +55,7 @@ class FairMQDeviceProxy
   /// Retrieve the channel index from a given OutputSpec and the associated timeslice
   [[nodiscard]] ChannelIndex getOutputChannelIndex(OutputSpec const& spec, size_t timeslice) const;
   /// Retrieve the channel index from a given OutputSpec and the associated timeslice
-  [[nodiscard]] ChannelIndex getForwardChannelIndex(header::DataHeader const& header, size_t timeslice) const;
+  void getMatchingForwardChannelIndexes(std::vector<ChannelIndex>& result, header::DataHeader const& header, size_t timeslice) const;
   /// ChannelIndex from a RouteIndex
   [[nodiscard]] ChannelIndex getOutputChannelIndex(RouteIndex routeIndex) const;
   [[nodiscard]] ChannelIndex getInputChannelIndex(RouteIndex routeIndex) const;

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -711,12 +711,6 @@ DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* name,
     callbacks.set<CallbackService::Id::Start>(channelConfigurationChecker);
     auto lastDataProcessingHeader = std::make_shared<DataProcessingHeader>(0, 0);
 
-    if (deviceSpec.forwards.size() > 0) {
-      // check that no internal forwards are existing, i.e. that proxy is at the end of the workflow
-      // in principle we can be less strict here if we check only for the defined input specs that there
-      // are no internal forwards
-      throw std::runtime_error("can not add forward targets outside DPL if internal forwards are existing, the proxy must be at the end of the workflow");
-    }
     auto& spec = const_cast<DeviceSpec&>(deviceSpec);
     for (auto const& inputSpec : inputSpecs) {
       // this is a prototype, in principle we want to have all spec objects const
@@ -798,12 +792,6 @@ DataProcessorSpec specifyFairMQDeviceMultiOutputProxy(char const* name,
     // also we set forwards for all input specs and keep a list of all channels so we can send EOS on them
     auto channelNames = std::make_shared<std::vector<std::string>>();
     auto channelConfigurationInitializer = [&proxy, inputSpecs = std::move(inputSpecs), device, channelSelector, &deviceSpec, channelNames]() {
-      if (deviceSpec.forwards.size() > 0) {
-        // check that no internal forwards are existing, i.e. that proxy is at the end of the workflow
-        // in principle we can be less strict here if we check only for the defined input specs that there
-        // are no internal forwards
-        throw std::runtime_error("can not add forward targets outside DPL if internal forwards are existing, the proxy must be at the end of the workflow");
-      }
       channelNames->clear();
       auto& mutableDeviceSpec = const_cast<DeviceSpec&>(deviceSpec);
       for (auto const& spec : inputSpecs) {

--- a/Framework/Core/src/FairMQDeviceProxy.cxx
+++ b/Framework/Core/src/FairMQDeviceProxy.cxx
@@ -21,6 +21,8 @@
 #include <fairmq/Message.h>
 #include <fairmq/TransportFactory.h>
 
+#include <unordered_set>
+
 namespace o2::framework
 {
 
@@ -117,21 +119,37 @@ ChannelIndex FairMQDeviceProxy::getOutputChannelIndex(OutputSpec const& query, s
   return ChannelIndex{ChannelIndex::INVALID};
 }
 
-ChannelIndex FairMQDeviceProxy::getForwardChannelIndex(header::DataHeader const& dh, size_t timeslice) const
+void FairMQDeviceProxy::getMatchingForwardChannelIndexes(std::vector<ChannelIndex>& result, header::DataHeader const& dh, size_t timeslice) const
 {
   assert(mForwardRoutes.size() == mForwards.size());
   // Notice we need to match against a data header and not against
   // the InputMatcher, because an input might match something which
   // is then rerouted to two different output routes, depending on the content.
+  // Also notice that we need to match against all the routes, because we
+  // might have multiple outputs routes (e.g. in the output proxy) with the same matcher.
+  bool dplChannelMatched = false;
   for (size_t ri = 0; ri < mForwards.size(); ++ri) {
     auto& route = mForwards[ri];
 
     LOGP(debug, "matching: {} to route {}", dh, DataSpecUtils::describe(route.matcher));
     if (DataSpecUtils::match(route.matcher, dh.dataOrigin, dh.dataDescription, dh.subSpecification) && ((timeslice % route.maxTimeslices) == route.timeslice)) {
-      return mForwardRoutes[ri].channel;
+      auto channelInfoIndex = mForwardRoutes[ri].channel;
+      auto& info = mForwardChannelInfos[channelInfoIndex.value];
+      // We need to make sure that we forward the same payload only once per channel.
+      if (info.channelType == ChannelAccountingType::DPL) {
+        if (dplChannelMatched) {
+          continue;
+        }
+        dplChannelMatched = true;
+      }
+      result.emplace_back(channelInfoIndex);
     }
   }
-  return ChannelIndex{ChannelIndex::INVALID};
+  // Remove duplicates, keeping the order of the channels.
+  std::unordered_set<int> numSet;
+  auto iter = std::stable_partition(result.begin(), result.end(),
+                                    [&](ChannelIndex n) { bool ret = !numSet.count(n.value); numSet.insert(n.value); return ret; }); // returns true if the item has not been "seen"
+  result.erase(iter, result.end());
 }
 
 ChannelIndex FairMQDeviceProxy::getOutputChannelIndexByName(std::string const& name) const


### PR DESCRIPTION
The basic idea is that now that we can do early forwarding, we can just use that in the output proxy, and multiple routes matching the same input will simply be shallow copied (if in the same transport) or deep copied (when the transport is different).