### PR TITLE
O2sim: Aggregating mode for mctracks proxy

### DIFF
--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -104,7 +104,8 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* label,
                                                    std::vector<OutputSpec> const& outputs,
                                                    const char* defaultChannelConfig,
                                                    InjectorFunction converter,
-                                                   uint64_t minSHM = 0);
+                                                   uint64_t minSHM = 0,
+                                                   bool sendTFcounter = false);
 
 DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* label,
                                                  Inputs const& inputSpecs,

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -13,7 +13,6 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/OutputSpec.h"
-#include "Framework/DataAllocator.h"
 #include <fairmq/FwdDecls.h>
 #include <vector>
 #include <functional>
@@ -42,6 +41,10 @@ std::string formatExternalChannelConfiguration(OutputChannelSpec const&);
 void sendOnChannel(fair::mq::Device& device, o2::header::Stack&& headerStack, fair::mq::MessagePtr&& payloadMessage, OutputSpec const& spec, ChannelRetriever& channelRetriever);
 
 void sendOnChannel(fair::mq::Device& device, fair::mq::Parts& messages, std::string const& channel, size_t timeSlice);
+
+/// append a header/payload part to multipart message for aggregate sending, a channel retriever
+/// callback is required to get the associated fair::mq::Channel
+void appendForSending(fair::mq::Device& device, o2::header::Stack&& headerStack, size_t timeSliceID, fair::mq::MessagePtr&& payloadMessage, OutputSpec const& spec, fair::mq::Parts& messageCache, ChannelRetriever& channelRetriever);
 
 /// Helper function which takes a set of inputs coming from a device,
 /// massages them so that they are valid DPL messages using @param spec as header

--- a/run/SimExamples/McTracksToAOD/run.sh
+++ b/run/SimExamples/McTracksToAOD/run.sh
@@ -13,7 +13,7 @@ SIMPROC=$!
 
 # --aggregate-timeframe 200 is used to combine 200 generated events into a timeframe that is then converted to AOD tables
 # note that if you need special configuration for the analysis tasks, it needs to be passed to proxy and converter as well
-o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} --aggregate-timeframe 200 |\ 
+o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} --aggregate-timeframe 200 |\
 o2-sim-mctracks-to-aod -b |\
 o2-analysis-mctracks-to-aod-simple-task -b &
 TRACKANAPROC=$!

--- a/run/SimExamples/McTracksToAOD/run.sh
+++ b/run/SimExamples/McTracksToAOD/run.sh
@@ -2,16 +2,20 @@
 
 set -x
 
-NEVENTS=100
-# launch generator process (for 100 min bias Pythia8 events; no Geant; no geometry)
-o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant -m CAVE -e TGeant3 &> sim.log &
+NEVENTS=10000
+# launch generator process (for 10000 min bias Pythia8 events; no Geant; no geometry)
+o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant &> sim.log &
 SIMPROC=$!
 
 # launch a DPL process (having the right proxy configuration)
 # (Note that the option --o2sim-pid is not strictly necessary when only one o2-sim process is running.
 #  The socket will than be auto-determined.)
 
-o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} | o2-sim-mctracks-to-aod -b | o2-analysis-mctracks-to-aod-simple-task -b &
+# --aggregate-timeframe 200 is used to combine 200 generated events into a timeframe that is then converted to AOD tables
+# note that if you need special configuration for the analysis tasks, it needs to be passed to proxy and converter as well
+o2-sim-mctracks-proxy -b --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} --aggregate-timeframe 200 |\ 
+o2-sim-mctracks-to-aod -b |\
+o2-analysis-mctracks-to-aod-simple-task -b &
 TRACKANAPROC=$!
 
 wait ${SIMPROC}

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -146,6 +146,14 @@ InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, 
     }
 
     if (*totalEventCounter == static_cast<size_t>(nevents)) {
+      if (nPerTF > 0) {
+        // send accumulated messages if the limit is reached
+        ++(*TFcounter);
+        sendOnChannel(device, *MCHeadersMessageCache.get(), channelRetriever(specs[0], *TFcounter), *TFcounter);
+        sendOnChannel(device, *MCTracksMessageCache.get(), channelRetriever(specs[1], *TFcounter), *TFcounter);
+        MCHeadersMessageCache->Clear();
+        MCTracksMessageCache->Clear();
+      }
       // I am done (I don't expect more events to convert); so tell the proxy device to shut-down
       stop = true;
     }

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -11,9 +11,9 @@
 
 #include <boost/program_options.hpp>
 
+#include "../Framework/Core/src/ArrowSupport.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
-#include "Framework/CommonDataProcessors.h"
 #include "Framework/ExternalFairMQDeviceProxy.h"
 #include "Framework/Task.h"
 #include "Framework/DataRef.h"
@@ -34,6 +34,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"enable-test-consumer", o2::framework::VariantType::Bool, false, {"enable a simple test consumer for injected MC tracks"}});
   workflowOptions.push_back(ConfigParamSpec{"o2sim-pid", o2::framework::VariantType::Int, -1, {"The process id of the source o2-sim"}});
   workflowOptions.push_back(ConfigParamSpec{"nevents", o2::framework::VariantType::Int, -1, {"The number of events expected to arrive on the proxy"}});
+  workflowOptions.push_back(ConfigParamSpec{"aggregate-timeframe", o2::framework::VariantType::Int, -1, {"The number of events to aggregate per timeframe"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -43,7 +44,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 class ConsumerTask
 {
  public:
-  void init(o2::framework::InitContext& ic) {}
+  void init(o2::framework::InitContext& /*ic*/) {}
   void run(o2::framework::ProcessingContext& pc)
   {
     LOG(debug) << "Running simple kinematics consumer client";
@@ -63,38 +64,88 @@ class ConsumerTask
 
 /// Function converting raw input data to DPL data format. Uses knowledge of how MCTracks and MCEventHeaders
 /// are sent from the o2sim side.
-InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, uint64_t startTime, uint64_t step, int nevents)
+/// If aggregate-timeframe is set to non-negative value N, this number of events is accumulated and then sent
+/// as a multipart message, which is useful for AOD creation
+InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, uint64_t startTime, uint64_t step, int nevents, int nPerTF)
 {
   auto timesliceId = std::make_shared<size_t>(startTime);
+  auto totalEventCounter = std::make_shared<size_t>(0);
+  auto eventCounter = std::make_shared<size_t>(0);
+  auto TFcounter = std::make_shared<size_t>(startTime);
+  auto MCHeadersMessageCache = std::make_shared<fair::mq::Parts>();
+  auto MCTracksMessageCache = std::make_shared<fair::mq::Parts>();
 
-  return [timesliceId, specs, step, nevents](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
+  return [timesliceId, specs, step, nevents, nPerTF, totalEventCounter, eventCounter, TFcounter, MCHeadersMessageCache = MCHeadersMessageCache, MCTracksMessageCache = MCTracksMessageCache](TimingInfo& ti, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) mutable {
     // We iterate on all the parts and we send them two by two,
     // adding the appropriate O2 header.
-    static int eventcounter = 0;
-
-    for (int i = 0; i < parts.Size(); ++i) {
-      DataHeader dh;
-      ConcreteDataMatcher matcher = DataSpecUtils::asConcreteDataMatcher(specs[i]);
-      dh.dataOrigin = matcher.origin;
-      dh.dataDescription = matcher.description;
-      dh.subSpecification = matcher.subSpec;
-      dh.payloadSize = parts.At(i)->GetSize();
-      if (i == 0) {
-        dh.payloadSerializationMethod = gSerializationMethodROOT;
-      } else if (i == 1) {
-        dh.payloadSerializationMethod = gSerializationMethodROOT;
-      }
+    if (nPerTF < 0) {
+      // if no aggregation requested, forward each message with the DPL header
       if (*timesliceId != newTimesliceId) {
         LOG(fatal) << "Time slice ID provided from oldestPossible mechanism " << newTimesliceId << " is out of sync with expected value " << *timesliceId;
       }
-      DataProcessingHeader dph{newTimesliceId, 0};
-      // we have to move the incoming data
-      o2::header::Stack headerStack{dh, dph};
-      sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), specs[i], channelRetriever);
+      for (auto i = 0U; i < parts.Size(); ++i) {
+        DataHeader dh;
+        ConcreteDataMatcher matcher = DataSpecUtils::asConcreteDataMatcher(specs[i]);
+        dh.dataOrigin = matcher.origin;
+        dh.dataDescription = matcher.description;
+        dh.subSpecification = matcher.subSpec;
+        dh.payloadSize = parts.At(i)->GetSize();
+        dh.payloadSerializationMethod = gSerializationMethodROOT;
+        DataProcessingHeader dph{newTimesliceId, 0};
+        // we have to move the incoming data
+        o2::header::Stack headerStack{dh, dph};
+        sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), specs[i], channelRetriever);
+      }
+      *timesliceId += step;
+    } else {
+      // if aggregation is requested, colelct the payloads into a multipart message
+      ti.timeslice = *TFcounter;
+      ti.tfCounter = *TFcounter;
+      DataHeader headerDH;
+      DataHeader tracksDH;
+      auto headerSize = parts.At(0)->GetSize();
+      auto tracksSize = parts.At(1)->GetSize();
+
+      DataProcessingHeader hdph{*TFcounter, 0};
+      ConcreteDataMatcher headerMatcher = DataSpecUtils::asConcreteDataMatcher(specs[0]);
+      headerDH.dataOrigin = headerMatcher.origin;
+      headerDH.dataDescription = headerMatcher.description;
+      headerDH.subSpecification = headerMatcher.subSpec;
+      headerDH.payloadSize = headerSize;
+      headerDH.payloadSerializationMethod = gSerializationMethodROOT;
+      headerDH.splitPayloadParts = nPerTF;
+      headerDH.splitPayloadIndex = *eventCounter;
+      o2::header::Stack hhs{headerDH, hdph};
+
+      DataProcessingHeader tdph{*TFcounter, 0};
+      ConcreteDataMatcher tracksMatcher = DataSpecUtils::asConcreteDataMatcher(specs[1]);
+      tracksDH.dataOrigin = tracksMatcher.origin;
+      tracksDH.dataDescription = tracksMatcher.description;
+      tracksDH.subSpecification = tracksMatcher.subSpec;
+      tracksDH.payloadSize = tracksSize;
+      tracksDH.payloadSerializationMethod = gSerializationMethodROOT;
+      tracksDH.splitPayloadParts = nPerTF;
+      tracksDH.splitPayloadIndex = *eventCounter;
+      o2::header::Stack ths{tracksDH, tdph};
+
+      appendForSending(device, std::move(hhs), *TFcounter, std::move(parts.At(0)), specs[0], *MCHeadersMessageCache.get(), channelRetriever);
+      appendForSending(device, std::move(ths), *TFcounter, std::move(parts.At(1)), specs[1], *MCTracksMessageCache.get(), channelRetriever);
+      ++(*eventCounter);
     }
-    *timesliceId += step;
-    eventcounter++;
-    if (eventcounter == nevents) {
+
+    ++(*totalEventCounter);
+    if (nPerTF > 0 && *eventCounter == static_cast<size_t>(nPerTF)) {
+      // if aggregation is requested, only send the accumulated vectors
+      LOGP(info, ">> Events: {}; TF counter: {}", *eventCounter, *TFcounter);
+      *eventCounter = 0;
+      ++(*TFcounter);
+      sendOnChannel(device, *MCHeadersMessageCache.get(), channelRetriever(specs[0], *TFcounter), *TFcounter);
+      sendOnChannel(device, *MCTracksMessageCache.get(), channelRetriever(specs[1], *TFcounter), *TFcounter);
+      MCHeadersMessageCache->Clear();
+      MCTracksMessageCache->Clear();
+    }
+
+    if (*totalEventCounter == static_cast<size_t>(nevents)) {
       // I am done (I don't expect more events to convert); so tell the proxy device to shut-down
       stop = true;
     }
@@ -114,7 +165,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // fetch the number of events to expect
   auto nevents = configcontext.options().get<int>("nevents");
-  o2::framework::InjectorFunction f = o2simKinematicsConverter(outputs, 0, 1, nevents);
+  auto nEventsPerTF = configcontext.options().get<int>("aggregate-timeframe");
+  o2::framework::InjectorFunction f = o2simKinematicsConverter(outputs, 0, 1, nevents, nEventsPerTF);
 
   // construct the input channel to listen on
   // use given pid
@@ -143,10 +195,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto proxy = specifyExternalFairMQDeviceProxy("o2sim-mctrack-proxy",
                                                 outputs,
                                                 channelspec.c_str(), f);
-  proxy.algorithm = CommonDataProcessors::wrapWithRateLimiting(proxy.algorithm);
+  // add monitoring service to be able to report number of timeframes sent for the rate limiting to work
+  proxy.requiredServices.push_back(o2::framework::ArrowSupport::arrowBackendSpec());
+  // if aggregation is requested, set the enumeration repetitions to aggregation size
+  if (nEventsPerTF > 0) {
+    proxy.inputs.emplace_back(InputSpec{"clock", "enum", "DPL", 0, Lifetime::Enumeration, {ConfigParamSpec{"repetitions", VariantType::Int64, static_cast<int64_t>(nEventsPerTF), {"merged events"}}}});
+  }
   specs.push_back(proxy);
 
-  if (configcontext.options().get<bool>("enable-test-consumer")) {
+  if (configcontext.options().get<bool>("enable-test-consumer") && (nEventsPerTF < 0)) {
     // connect a test consumer
     std::vector<InputSpec> inputs;
     inputs.emplace_back("mctracks", "MC", "MCTRACKS", 0., Lifetime::Timeframe);

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -202,7 +202,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   auto proxy = specifyExternalFairMQDeviceProxy("o2sim-mctrack-proxy",
                                                 outputs,
-                                                channelspec.c_str(), f);
+                                                channelspec.c_str(), f, 0, true);
   // add monitoring service to be able to report number of timeframes sent for the rate limiting to work
   proxy.requiredServices.push_back(o2::framework::ArrowSupport::arrowBackendSpec());
   // if aggregation is requested, set the enumeration repetitions to aggregation size

--- a/run/o2sim_mctracks_to_aod.cxx
+++ b/run/o2sim_mctracks_to_aod.cxx
@@ -11,103 +11,92 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/Task.h"
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCEventHeader.h"
 #include "Framework/AnalysisDataModel.h"
 
 using namespace o2::framework;
 
-struct McTracksToAODSpawner {
-  Spawns<o2::aod::McParticles> mcparticlesExt;
-
-  void init(o2::framework::InitContext& ic) {}
-
-  void run(o2::framework::ProcessingContext& pc) {}
-};
-
 struct McTracksToAOD {
-
+  size_t bcCounter = 0;
   Produces<o2::aod::McCollisions> mcollisions;
   Produces<o2::aod::StoredMcParticles_001> mcparticles;
 
-  Configurable<int> collisionsPerTimeFfame{"collisionsPerTimeframe", 200, "Number of McCollisions per timeframe"};
-
-  int collisionId = 0;
   long timeframe = 0;
 
-  void init(o2::framework::InitContext& ic) {}
+  void init(o2::framework::InitContext& /*ic*/) {}
 
   void run(o2::framework::ProcessingContext& pc)
   {
-    auto mcheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader");
-    auto mctracks = pc.inputs().get<std::vector<o2::MCTrack>>("mctracks");
-
-    mcollisions(0, // bc
-                0, // generatorId
-                mcheader->GetX(),
-                mcheader->GetY(),
-                mcheader->GetZ(),
-                mcheader->GetT(),
-                1., // weight
-                mcheader->GetB());
-    for (auto& mctrack : mctracks) {
-      int mothers_size = 0;
-      std::vector<int> mothers;
-      int daughters[2];
-
-      if (mctrack.getMotherTrackId() >= 0) {
-        mothers.push_back(mctrack.getMotherTrackId());
-        mothers_size++;
-      }
-      if (mctrack.getSecondMotherTrackId() >= 0) {
-        mothers.push_back(mctrack.getSecondMotherTrackId());
-        mothers_size++;
-      }
-      daughters[0] = -1;
-      daughters[1] = -1;
-      if (mctrack.getFirstDaughterTrackId() >= 0 && mctrack.getLastDaughterTrackId() >= 0) {
-        daughters[0] = mctrack.getFirstDaughterTrackId();
-        daughters[1] = mctrack.getLastDaughterTrackId();
-      } else if (mctrack.getFirstDaughterTrackId() >= 0) {
-        daughters[0] = mctrack.getFirstDaughterTrackId();
-        daughters[1] = mctrack.getLastDaughterTrackId();
-      }
-      int PdgCode = mctrack.GetPdgCode();
-      int statusCode = mctrack.getStatusCode().fullEncoding;
-      float weight = mctrack.getWeight();
-      float px = mctrack.Px();
-      float py = mctrack.Py();
-      float pz = mctrack.Pz();
-      float e = mctrack.GetEnergy();
-      float x = mctrack.GetStartVertexCoordinatesX();
-      float y = mctrack.GetStartVertexCoordinatesY();
-      float z = mctrack.GetStartVertexCoordinatesZ();
-      float t = mctrack.GetStartVertexCoordinatesT();
-      int flags = 0;
-      mcparticles(0, // collisionId,
-                  PdgCode,
-                  statusCode,
-                  flags,
-                  mothers,
-                  daughters,
-                  weight,
-                  px,
-                  py,
-                  pz,
-                  e,
-                  x,
-                  y,
-                  z,
-                  t);
+    auto Nparts = pc.inputs().getNofParts(0);
+    auto Nparts_verify = pc.inputs().getNofParts(1);
+    if (Nparts != Nparts_verify) {
+      LOG(warn) << "Mismatch between number of MC headers and number of track vectors: " << Nparts << " != " << Nparts_verify << ", shipping the empty timeframe";
+      return;
     }
-    collisionId++;
+    for (auto i = 0U; i < Nparts; ++i) {
+      auto mcheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader", i);
+      auto mctracks = pc.inputs().get<std::vector<o2::MCTrack>>("mctracks", i);
+
+      mcollisions(bcCounter++, // bc
+                  0,           // generatorId
+                  mcheader->GetX(),
+                  mcheader->GetY(),
+                  mcheader->GetZ(),
+                  mcheader->GetT(),
+                  1., // weight
+                  mcheader->GetB());
+      for (auto& mctrack : mctracks) {
+        std::vector<int> mothers;
+        int daughters[2];
+
+        if (mctrack.getMotherTrackId() >= 0) {
+          mothers.push_back(mctrack.getMotherTrackId());
+        }
+        if (mctrack.getSecondMotherTrackId() >= 0) {
+          mothers.push_back(mctrack.getSecondMotherTrackId());
+        }
+        daughters[0] = -1;
+        daughters[1] = -1;
+        if (mctrack.getFirstDaughterTrackId() >= 0 && mctrack.getLastDaughterTrackId() >= 0) {
+          daughters[0] = mctrack.getFirstDaughterTrackId();
+          daughters[1] = mctrack.getLastDaughterTrackId();
+        } else if (mctrack.getFirstDaughterTrackId() >= 0) {
+          daughters[0] = mctrack.getFirstDaughterTrackId();
+          daughters[1] = mctrack.getLastDaughterTrackId();
+        }
+        int PdgCode = mctrack.GetPdgCode();
+        int statusCode = mctrack.getStatusCode().fullEncoding;
+        float weight = mctrack.getWeight();
+        float px = mctrack.Px();
+        float py = mctrack.Py();
+        float pz = mctrack.Pz();
+        float e = mctrack.GetEnergy();
+        float x = mctrack.GetStartVertexCoordinatesX();
+        float y = mctrack.GetStartVertexCoordinatesY();
+        float z = mctrack.GetStartVertexCoordinatesZ();
+        float t = mctrack.GetStartVertexCoordinatesT();
+        int flags = 0;
+        mcparticles(i, // collisionId,
+                    PdgCode,
+                    statusCode,
+                    flags,
+                    mothers,
+                    daughters,
+                    weight,
+                    px,
+                    py,
+                    pz,
+                    e,
+                    x,
+                    y,
+                    z,
+                    t);
+      }
+    }
+    ++timeframe;
     pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
     pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, timeframe);
-    if (collisionId == collisionsPerTimeFfame) {
-      collisionId = 0;
-      timeframe++;
-    }
   }
 };
 
@@ -122,9 +111,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   dSpec.outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
   dSpec.outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
   specs.emplace_back(dSpec);
-
-  DataProcessorSpec dSpec2 = adaptAnalysisTask<McTracksToAODSpawner>(cfgc, TaskName{"mctracks-to-aod-spawner"});
-  specs.emplace_back(dSpec2);
 
   return specs;
 }


### PR DESCRIPTION
* FairMQDeviceProxy: send TF counter metrics if Monitoring service is available
* FairMQDeviceProxy: message aggregation function added
* mctracks-proxy: added `--aggregate-timeframe <number>` option to combine `<number>` of incoming events into a single multipart message and require a Monitoring service so that TF counter can be sent and TF-based rate limiting works
* mctracks-to-aod: updated to handle the aggregated messages
* mctracks-to-aod: removed the redundant spawner task (analysis workflows add aod-spawner automatically)
* example script: updated to use `--aggregate-timeframe`

@sawenzel @mconcas 