### PR TITLE
[FOCAL-12] Fix operator==

### DIFF
--- a/Detectors/FOCAL/calib/include/FOCALCalib/PadPedestal.h
+++ b/Detectors/FOCAL/calib/include/FOCALCalib/PadPedestal.h
@@ -99,6 +99,7 @@ class PadPedestal
 
   TH1* getHistogramRepresentation(int layer) const;
   std::array<TH1*, 18> getLayerHistogramRepresentations() const;
+  int getNumberOfChannels() const { return mPedestalValues.size(); }
 
  private:
   std::unordered_map<ChannelID, double, ChannelIDHasher> mPedestalValues;

--- a/Detectors/FOCAL/calib/src/PadPedestal.cxx
+++ b/Detectors/FOCAL/calib/src/PadPedestal.cxx
@@ -56,7 +56,7 @@ bool PadPedestal::operator==(const PadPedestal& rhs) const
       }
     }
   }
-  return failure;
+  return !failure;
 }
 
 void PadPedestal::setPedestal(std::size_t layer, std::size_t channel, double pedestal)


### PR DESCRIPTION
Condition was inverted by accident,
for channel-by-channel check. In
addition adding getter for number
of channels.