### PR TITLE
O2sim: add timeframe aggregation to kine-publisher

### DIFF
--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -24,6 +24,7 @@
 #include "Framework/ChannelInfo.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/RateLimiter.h"
+#include "Framework/TimesliceIndex.h"
 #include "Framework/TimingInfo.h"
 #include "Framework/DeviceState.h"
 #include "Headers/DataHeader.h"
@@ -31,7 +32,7 @@
 #include "CommonConstants/LHCConstants.h"
 
 #include "./DeviceSpecHelpers.h"
-#include "Framework/DataProcessingHelpers.h"
+#include "Monitoring/Monitoring.h"
 
 #include <fairmq/Parts.h>
 #include <fairmq/Device.h>


### PR DESCRIPTION
Similar treatment as in #11608 for kine-publisher, so it can be used with updated mctracks-to-aod. 