### PR TITLE
DPL: Remove nOrbitsPerTF from DataTakingContext

### DIFF
--- a/Framework/Core/include/Framework/DataTakingContext.h
+++ b/Framework/Core/include/Framework/DataTakingContext.h
@@ -32,8 +32,6 @@ struct DataTakingContext {
   static constexpr const char* UNKNOWN = "unknown";
   /// The current run number
   std::string runNumber{UNKNOWN};
-  /// How many orbits in a timeframe
-  uint64_t nOrbitsPerTF = 128;
   /// The start time of the first orbit in microseconds(!)
   long orbitResetTimeMUS = 0;
   /// The current lhc period

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -213,9 +213,7 @@ o2::framework::ServiceSpec CommonServices::datatakingContextSpec()
         context.detectors = extDetectors;
       }
       auto forcedRaw = services.get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("force_run_as_raw", "false");
-      context.forcedRaw = forcedRaw == "true";
-
-      context.nOrbitsPerTF = services.get<RawDeviceService>().device()->fConfig->GetProperty<uint64_t>("Norbits_per_TF", 128); },
+      context.forcedRaw = forcedRaw == "true"; },
     .kind = ServiceKind::Stream};
 }
 


### PR DESCRIPTION
as agreed in https://github.com/AliceO2Group/AliceO2/pull/11616, the field is removed since it is not actually set and the recommended way is to get it from GRP Helper or CCDB directly

will fail in QC until this is merged and propagated to a version in alidist: https://github.com/AliceO2Group/QualityControl/pull/1873