### PR TITLE
Some work for TRD

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -43,6 +43,7 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/KrCluster.h
                        include/DataFormatsTRD/KrClusterTriggerRecord.h
                        include/DataFormatsTRD/NoiseCalibration.h
+                        include/DataFormatsTRD/PHData.h
                        include/DataFormatsTRD/CTF.h
                        include/DataFormatsTRD/CalVdriftExB.h
                        include/DataFormatsTRD/CalGain.h
@@ -66,4 +67,3 @@ o2_add_test(RawData
             ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
             LABELS trd
             )
-

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
@@ -85,6 +85,7 @@ class Digit
   int getChannel() const { return mChannel; }
   int getPreTrigPhase() const { return ((mDetector >> 12) & 0xf); }
   bool isSharedDigit() const;
+  bool isNeighbour(const Digit& other) const;
 
   ArrayADC const& getADC() const { return mADC; }
   ADC_t getADCsum() const { return std::accumulate(mADC.begin(), mADC.end(), (ADC_t)0); }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/PHData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/PHData.h
@@ -1,0 +1,65 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_PHDATA_H_
+#define ALICEO2_TRD_PHDATA_H_
+
+#include <cstdint>
+
+namespace o2::trd
+{
+
+/*
+  This data type is used to send around the information required to fill PH plots per chamber
+
+  |31|30|29|28|27|26|25|24|23|22|21|20|19|18|17|16|15|14|13|12|11|10|09|08|07|06|05|04|03|02|01|00|
+  -------------------------------------------------------------------------------------------------
+  |type |nNeighb |   time bin   |        detector number      |     ADC sum for all neigbours     |
+  -------------------------------------------------------------------------------------------------
+*/
+
+class PHData
+{
+ public:
+  enum Origin : uint8_t {
+    ITSTPCTRD,
+    TPCTRD,
+    TRACKLET,
+    OTHER
+  };
+
+  PHData() = default;
+  PHData(int adc, int det, int tb, int nb, int type) { set(adc, det, tb, nb, type); }
+
+  void set(int adc, int det, int tb, int nb, int type)
+  {
+    mData = (type << 30) | (nb << 27) | (tb << 22) | (det << 12) | adc;
+  }
+
+  // the ADC sum for given time bin for up to three neighbours
+  int getADC() const { return mData & 0xfff; }
+  // the TRD detector number
+  int getDetector() const { return (mData >> 12) & 0x3ff; }
+  // the given time bin
+  int getTimebin() const { return (mData >> 22) & 0x1f; }
+  // number of neighbouring digits for which the ADC is accumulated
+  int getNneighbours() const { return (mData >> 27) & 0x7; }
+  // the origin of this point: digit on ITS-TPC-TRD track, ... (see enum Origin above)
+  int getType() const { return (mData >> 30) & 0x3; }
+
+ private:
+  uint32_t mData{0}; // see comment above for data content
+
+  ClassDefNV(PHData, 1);
+};
+} // namespace o2::trd
+
+#endif // ALICEO2_TRD_PHDATA_H_

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -119,7 +119,8 @@ enum OptionBits {
   TRDVerboseErrorsBit,
   TRDIgnore2StageTrigger,
   TRDGenerateStats,
-  TRDOnlyCalibrationTriggerBit
+  TRDOnlyCalibrationTriggerBit,
+  TRDSortDigits
 }; // this is currently 16 options, the array is 16, if you add here you need to change the 16;
 
 //Data to be stored and accumulated on an event basis.

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -41,6 +41,7 @@
 #pragma link C++ class o2::trd::LinkToHCIDMapping + ;
 #pragma link C++ class o2::trd::ChannelInfo + ;
 #pragma link C++ class o2::trd::ChannelInfoContainer + ;
+#pragma link C++ struct o2::trd::PHData + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TrackTriggerRecord> + ;
@@ -50,6 +51,7 @@
 #pragma link C++ class std::vector < o2::trd::Digit> + ;
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class std::vector < o2::trd::GainCalibHistos> + ;
+#pragma link C++ class std::vector < o2::trd::PHData> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 

--- a/DataFormats/Detectors/TRD/src/Digit.cxx
+++ b/DataFormats/Detectors/TRD/src/Digit.cxx
@@ -63,6 +63,11 @@ bool Digit::isSharedDigit() const
   }
 }
 
+bool Digit::isNeighbour(const Digit& other) const
+{
+  return (getDetector() == other.getDetector() && getROB() == other.getROB() && getMCM() == other.getMCM() && std::abs(getChannel() - other.getChannel()) == 1);
+}
+
 ADC_t Digit::getADCmax(int& idx) const
 {
   auto itMax = std::max_element(mADC.begin(), mADC.end());

--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -29,8 +29,8 @@ using namespace constants;
 
 void Tracklet64::print() const
 {
-  LOGF(info, "%02i_%i_%i, row(%i), col(%i), position(%i), slope(%i), pid(%i), q0(%i), q1(%i), q2(%i). Format(%i)",
-       HelperMethods::getSector(getDetector()), HelperMethods::getStack(getDetector()), HelperMethods::getLayer(getDetector()), getPadRow(), getColumn(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2(), getFormat());
+  LOGF(info, "%02i_%i_%i, ROB(%i), MCM(%i), row(%i), col(%i), position(%i), slope(%i), pid(%i), q0(%i), q1(%i), q2(%i). Format(%i)",
+       HelperMethods::getSector(getDetector()), HelperMethods::getStack(getDetector()), HelperMethods::getLayer(getDetector()), getROB(), getMCM(), getPadRow(), getColumn(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2(), getFormat());
 }
 
 GPUd() int Tracklet64::getPadCol() const
@@ -39,8 +39,8 @@ GPUd() int Tracklet64::getPadCol() const
   int padLocal = getPositionBinSigned() * GRANULARITYTRKLPOS;
   // MCM number in column direction (0..7)
   int mcmCol = (getMCM() % NMCMROBINCOL) + NMCMROBINCOL * (getROB() % 2);
-  // FIXME: understand why the offset seems to be 6 pads and not nChannels / 2 = 10.5
-  return CAMath::Nint(6.f + mcmCol * ((float)NCOLMCM) + padLocal);
+  // FIXME: understand why the offset seems to be 8 pads and not nChannels / 2 = 10.5
+  return CAMath::Nint(8.f + mcmCol * ((float)NCOLMCM) + padLocal);
 }
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -39,6 +39,9 @@ struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams>
   float dEdxTPCMin = 30.;
   float dEdxTPCMax = 70.;
 
+  // Creation of PH plots
+  float pileupCut = 0.7;
+
   // parameters related to noise calibration
   size_t minNumberOfDigits = 1'000'000'000UL; ///< when reached, noise calibration will be finalized
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
@@ -20,6 +20,10 @@
 #include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "DataFormatsTRD/PHData.h"
+#include "TRDCalibration/CalibrationParams.h"
+#include "TFile.h"
+#include "TTree.h"
 
 namespace o2
 {
@@ -50,6 +54,15 @@ class PulseHeight
   /// Main processing function
   void process();
 
+  /// Search for up to 3 neighbouring digits matching given tracklet and fill the PH values
+  void findDigitsForTracklet(const Tracklet64& trklt, const TriggerRecord& trig, int type);
+
+  /// Access to output
+  const std::vector<PHData>& getPHData() { return mPHValues; }
+
+  void createOutputFile();
+  void closeOutputFile();
+
  private:
   // input arrays which should not be modified since they are provided externally
   gsl::span<const TrackTRD> mTracksInITSTPCTRD;                      ///< TRD tracks reconstructed from TPC or ITS-TPC seeds
@@ -59,6 +72,16 @@ class PulseHeight
   gsl::span<const TriggerRecord> mTriggerRecords;                    ///< array of trigger records
   gsl::span<const TrackTriggerRecord> mTrackTriggerRecordsTPCTRD;    ///< array of track trigger records
   gsl::span<const TrackTriggerRecord> mTrackTriggerRecordsITSTPCTRD; ///< array of track trigger records
+
+  // output
+  std::vector<PHData> mPHValues, *mPHValuesPtr{&mPHValues}; ///< vector of values used to fill the PH spectra per detector
+  std::vector<int> mDistances, *mDistancesPtr{&mDistances}; ///< pad distance between tracklet column and digit ADC maximum
+  std::unique_ptr<TFile> mOutFile{nullptr};                 ///< output file
+  std::unique_ptr<TTree> mOutTree{nullptr};                 ///< output tree
+
+  // settings
+  const TRDCalibParams& mParams{TRDCalibParams::Instance()}; ///< reference to calibration parameters
+  bool mWriteOutput{false};                                  ///< will be set to true in case createOutputFile() is called
 
   ClassDefNV(PulseHeight, 1);
 };

--- a/Detectors/TRD/calibration/src/PulseHeight.cxx
+++ b/Detectors/TRD/calibration/src/PulseHeight.cxx
@@ -22,10 +22,43 @@ using namespace o2::trd::constants;
 
 void PulseHeight::reset()
 {
+  mPHValues.clear();
+  mDistances.clear();
 }
 
 void PulseHeight::init()
 {
+}
+
+void PulseHeight::createOutputFile()
+{
+  mOutFile = std::make_unique<TFile>("trd_PH.root", "RECREATE");
+  if (mOutFile->IsZombie()) {
+    LOG(error) << "Failed to create output file!";
+    return;
+  }
+  mOutTree = std::make_unique<TTree>("ph", "Data points for PH histograms");
+  mOutTree->Branch("values", &mPHValuesPtr);
+  mOutTree->Branch("dist", &mDistancesPtr);
+  mWriteOutput = true;
+  LOG(info) << "Writing PH data points to local file trd_PH.root";
+}
+
+void PulseHeight::closeOutputFile()
+{
+  if (!mWriteOutput) {
+    return;
+  }
+  try {
+    mOutFile->cd();
+    mOutTree->Write();
+    mOutTree.reset();
+    mOutFile->Close();
+    mOutFile.reset();
+  } catch (std::exception const& e) {
+    LOG(error) << "Failed to write output file, reason: " << e.what();
+  }
+  mWriteOutput = false;
 }
 
 void PulseHeight::setInput(const o2::globaltracking::RecoContainer& input, gsl::span<const Digit>* digits)
@@ -41,6 +74,101 @@ void PulseHeight::setInput(const o2::globaltracking::RecoContainer& input, gsl::
 
 void PulseHeight::process()
 {
-  LOGP(info, "Processing {} tracklets and {} digits from {} triggers and {} ITS-TPC-TRD tracks and {} TPC-TRD tracks",
+  LOGP(debug, "Processing {} tracklets and {} digits from {} triggers and {} ITS-TPC-TRD tracks and {} TPC-TRD tracks",
        mTrackletsRaw.size(), mDigits->size(), mTriggerRecords.size(), mTracksInITSTPCTRD.size(), mTracksInTPCTRD.size());
+  if (mDigits->size() == 0) {
+    return;
+  }
+  size_t nTrkTrig[2] = {mTrackTriggerRecordsITSTPCTRD.size(), mTrackTriggerRecordsTPCTRD.size()};
+  int lastTrkTrig[2] = {0};
+  for (const auto& trig : mTriggerRecords) {
+    if (trig.getNumberOfDigits() == 0) {
+      continue;
+    }
+    for (int iTrackType = 0; iTrackType <= 1; ++iTrackType) {
+      const gsl::span<const TrackTRD>* tracks = (iTrackType == 0) ? &mTracksInITSTPCTRD : &mTracksInTPCTRD;
+      const gsl::span<const TrackTriggerRecord>* trackTriggers = (iTrackType == 0) ? &mTrackTriggerRecordsITSTPCTRD : &mTrackTriggerRecordsTPCTRD;
+      for (int iTrigTrack = lastTrkTrig[iTrackType]; iTrigTrack < nTrkTrig[iTrackType]; ++iTrigTrack) {
+        const auto& trigTrack = (*trackTriggers)[iTrigTrack];
+        if (trigTrack.getBCData().differenceInBC(trig.getBCData()) > 0) {
+          // aborting, since track trigger is later than digit trigger";
+          break;
+        }
+        if (trigTrack.getBCData() != trig.getBCData()) {
+          // skipping, since track trigger earlier than digit trigger";
+          ++lastTrkTrig[iTrackType];
+          continue;
+        }
+        if ((*tracks)[trigTrack.getFirstTrack()].hasPileUpInfo() && (*tracks)[trigTrack.getFirstTrack()].getPileUpTimeShiftMUS() < mParams.pileupCut) {
+          // rejecting triggers which are close to other collisions (avoid pile-up)
+          ++lastTrkTrig[iTrackType];
+          break;
+        }
+        for (int iTrk = trigTrack.getFirstTrack(); iTrk < trigTrack.getFirstTrack() + trigTrack.getNumberOfTracks(); iTrk++) {
+          const auto& trk = (*tracks)[iTrk];
+          for (int iLayer = 0; iLayer < 6; iLayer++) {
+            int trkltIdx = trk.getTrackletIndex(iLayer);
+            if (trkltIdx < 0) {
+              continue;
+            }
+            findDigitsForTracklet(mTrackletsRaw[trkltIdx], trig, iTrackType);
+          }
+        }
+      }
+    }
+  }
+  if (mWriteOutput) {
+    mOutTree->Fill();
+  }
+}
+
+void PulseHeight::findDigitsForTracklet(const Tracklet64& trklt, const TriggerRecord& trig, int type)
+{
+  auto trkltDet = trklt.getDetector();
+  for (int iDigit = trig.getFirstDigit() + 1; iDigit < trig.getFirstDigit() + trig.getNumberOfDigits() - 1; ++iDigit) {
+    const auto& digit = (*mDigits)[iDigit];
+    if (digit.getDetector() != trkltDet || digit.getPadRow() != trklt.getPadRow() || digit.getPadCol() != trklt.getPadCol()) {
+      // for now we loose charge information from padrow-crossing tracklets (~15% of all tracklets)
+      continue;
+    }
+    int nNeighbours = 0;
+    bool left = false;
+    bool right = false;
+    const auto& digitLeft = (*mDigits)[iDigit - 1];
+    const auto& digitRight = (*mDigits)[iDigit + 1];
+    LOG(debug) << "Central digit: " << digit;
+    LOG(debug) << "Left digit: " << digitLeft;
+    LOG(debug) << "Right digit: " << digitRight;
+    if (digitLeft.isNeighbour(digit) && digitLeft.getChannel() < digit.getChannel()) {
+      ++nNeighbours;
+      left = true;
+    }
+    if (digitRight.isNeighbour(digit) && digitRight.getChannel() > digit.getChannel()) {
+      ++nNeighbours;
+      right = true;
+    }
+    if (nNeighbours > 0) {
+      int digitTrackletDistance = 0;
+      auto adcSumMax = digit.getADCsum();
+      if (left && digitLeft.getADCsum() > adcSumMax) {
+        adcSumMax = digitLeft.getADCsum();
+        digitTrackletDistance = 1;
+      }
+      if (right && digitRight.getADCsum() > adcSumMax) {
+        adcSumMax = digitRight.getADCsum();
+        digitTrackletDistance = -1;
+      }
+      mDistances.push_back(digitTrackletDistance);
+      for (int iTb = 0; iTb < TIMEBINS; ++iTb) {
+        uint16_t phVal = digit.getADC()[iTb];
+        if (left) {
+          phVal += digitLeft.getADC()[iTb];
+        }
+        if (right) {
+          phVal += digitRight.getADC()[iTb];
+        }
+        mPHValues.emplace_back(phVal, trkltDet, iTb, nNeighbours, type);
+      }
+    }
+  }
 }

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
@@ -50,9 +50,8 @@ class EventRecord
   // needed, in order to check if a trigger already exist for this bunch crossing
   bool operator==(const EventRecord& o) const { return mBCData == o.mBCData; }
 
-  // only the tracklets are sorted by detector ID
-  // TODO: maybe at some point a finer sorting might be helpful (padrow, padcolumn?)
-  void sortTrackletsByDetector();
+  // sort the tracklets (and optionally digits) by detector, pad row, pad column
+  void sortData(bool sortDigits);
 
   //statistics stuff these get passed to the per tf data at the end of the timeframe,
   //but as we read in per link, events are seperated hence these counters
@@ -83,7 +82,7 @@ class EventRecordContainer
   EventRecordContainer() = default;
   ~EventRecordContainer() = default;
 
-  void sendData(o2::framework::ProcessingContext& pc, bool generatestats);
+  void sendData(o2::framework::ProcessingContext& pc, bool generatestats, bool sortDigits);
 
   void setCurrentEventRecord(const InteractionRecord& ir);
   EventRecord& getCurrentEventRecord() { return mEventRecords.at(mCurrEventRecord); }

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -1125,7 +1125,7 @@ void CruRawReader::printHalfChamberHeaderReport() const
 //write the output data directly to the given DataAllocator from the datareader task.
 void CruRawReader::buildDPLOutputs(o2::framework::ProcessingContext& pc)
 {
-  mEventRecords.sendData(pc, mOptions[TRDGenerateStats]);
+  mEventRecords.sendData(pc, mOptions[TRDGenerateStats], mOptions[TRDSortDigits]);
 }
 
 void CruRawReader::reset()

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -40,6 +40,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"halfchambermajor", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of major version, ignored if version is not 0.0"}},
     {"fixforoldtrigger", VariantType::Bool, false, {"Fix for the old data not having a 2 stage trigger stored in the cru header."}},
     {"onlycalibrationtrigger", VariantType::Bool, false, {"Only permit calibration triggers, used for debugging traclets and their digits, maybe other uses."}},
+    {"sortDigits", VariantType::Bool, false, {"Sort the digits in det/row/col (tracklets are always sorted)"}},
     {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"disable-stats", VariantType::Bool, false, {"Do not generate stat messages for qc"}},
     {"disable-root-output", VariantType::Bool, false, {"Do not write the digits and tracklets to file"}},
@@ -73,6 +74,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
   binaryoptions[o2::trd::TRDGenerateStats] = !cfgc.options().get<bool>("disable-stats");
   binaryoptions[o2::trd::TRDOnlyCalibrationTriggerBit] = cfgc.options().get<bool>("onlycalibrationtrigger");
+  binaryoptions[o2::trd::TRDSortDigits] = cfgc.options().get<bool>("sortDigits");
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, binaryoptions)};
 

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibWriterSpec.h
@@ -25,7 +25,7 @@ namespace o2
 namespace trd
 {
 
-o2::framework::DataProcessorSpec getTRDCalibWriterSpec(bool vdexb, bool gain);
+o2::framework::DataProcessorSpec getTRDCalibWriterSpec(bool vdexb, bool gain, bool ph);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDCalibWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibWriterSpec.cxx
@@ -15,6 +15,7 @@
 #include "TRDWorkflowIO/TRDCalibWriterSpec.h"
 #include "DataFormatsTRD/AngularResidHistos.h"
 #include "DataFormatsTRD/GainCalibHistos.h"
+#include "DataFormatsTRD/PHData.h"
 
 using namespace o2::framework;
 
@@ -26,13 +27,14 @@ namespace trd
 template <typename T>
 using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-o2::framework::DataProcessorSpec getTRDCalibWriterSpec(bool vdexb, bool gain)
+o2::framework::DataProcessorSpec getTRDCalibWriterSpec(bool vdexb, bool gain, bool ph)
 {
   using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
   return MakeRootTreeWriterSpec("TRDCalibWriter",
                                 "trdcaliboutput.root",
                                 "calibdata",
                                 BranchDefinition<o2::trd::AngularResidHistos>{InputSpec{"calibdata", "TRD", "ANGRESHISTS"}, "AngularResids", (vdexb ? 1 : 0)},
+                                BranchDefinition<std::vector<o2::trd::PHData>>{InputSpec{"phValues", "TRD", "PULSEHEIGHT"}, "PulseHeight", (ph ? 1 : 0)},
                                 BranchDefinition<o2::trd::GainCalibHistos>{InputSpec{"calibdatagain", "TRD", "GAINCALIBHISTS"}, "GainHistograms", (gain ? 1 : 0)})();
 };
 

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -82,6 +82,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto requireCTPLumi = configcontext.options().get<bool>("require-ctp-lumi");
   auto vdexb = configcontext.options().get<bool>("enable-vdexb-calib");
   auto gain = configcontext.options().get<bool>("enable-gain-calib");
+  auto pulseHeight = configcontext.options().get<bool>("enable-ph");
   bool rootInput = !configcontext.options().get<bool>("disable-root-input");
   GTrackID::mask_t srcTRD = allowedSources & GTrackID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
   if (strict && (srcTRD & ~GTrackID::getSourcesMask("TPC")).any()) {
@@ -115,7 +116,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (configcontext.options().get<bool>("enable-qc")) {
     specs.emplace_back(o2::trd::getTRDGlobalTrackingQCSpec(srcTRD));
   }
-  if (configcontext.options().get<bool>("enable-ph")) {
+  if (pulseHeight) {
     if (rootInput) {
       specs.emplace_back(o2::trd::getTRDDigitReaderSpec(useMC));
     }
@@ -130,8 +131,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     if (GTrackID::includesSource(GTrackID::Source::TPC, srcTRD)) {
       specs.emplace_back(o2::trd::getTRDTPCTrackWriterSpec(useMC, strict));
     }
-    if (vdexb || gain) {
-      specs.emplace_back(o2::trd::getTRDCalibWriterSpec(vdexb, gain));
+    if (vdexb || gain || pulseHeight) {
+      specs.emplace_back(o2::trd::getTRDCalibWriterSpec(vdexb, gain, pulseHeight));
     }
     if (configcontext.options().get<bool>("enable-qc")) {
       specs.emplace_back(o2::trd::getTRDTrackingQCWriterSpec());


### PR DESCRIPTION
- allow filling of PH plots in O2 both from ITS-TPC-TRD and from TPC-TRD tracks. In the future one could also add a spectrum based on digits on tracklets without much additional work
- raw reader optionally sorts the digits. In the worst case (noise runs) this increases the raw parsing time by 50%. In real data I have seen an increase of 5-10% in compute time, so not very large, but also not fully negligible. It would allow to more easily match tracklets and digits together
- some unrelated additions to macros (check for noisy MCMs and pad noise macro)