### PR TITLE
FT0 calibration: protection from empty slots and EOV issue

### DIFF
--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0TimeOffsetSlotContainer.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0TimeOffsetSlotContainer.h
@@ -55,7 +55,8 @@ class FT0TimeOffsetSlotContainer final
   bool mIsReady{false};
   // Once it is upper than max entry threshold it stops increasing
   std::array<std::size_t, sNCHANNELS> mArrEntries{};
-
+  //Total number of events
+  uint64_t mTotalNevents{0};
   // Contains all information about time spectra
   FlatHisto2D_t mHistogram;
   ClassDefNV(FT0TimeOffsetSlotContainer, 1);

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0TimeOffsetSlotContainer.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0TimeOffsetSlotContainer.h
@@ -55,7 +55,7 @@ class FT0TimeOffsetSlotContainer final
   bool mIsReady{false};
   // Once it is upper than max entry threshold it stops increasing
   std::array<std::size_t, sNCHANNELS> mArrEntries{};
-  //Total number of events
+  // Total number of events
   uint64_t mTotalNevents{0};
   // Contains all information about time spectra
   FlatHisto2D_t mHistogram;

--- a/Detectors/FIT/FT0/calibration/src/FT0TimeOffsetSlotContainer.cxx
+++ b/Detectors/FIT/FT0/calibration/src/FT0TimeOffsetSlotContainer.cxx
@@ -25,12 +25,11 @@ FT0TimeOffsetSlotContainer::FT0TimeOffsetSlotContainer(std::size_t minEntries) {
 
 bool FT0TimeOffsetSlotContainer::hasEnoughEntries() const
 {
-  if (mTotalNevents==0) {
-    //Dummy slot, should be ignored for protection
+  if (mTotalNevents == 0) {
+    // Dummy slot, should be ignored for protection
     LOG(warning) << "RESULT: Empty slot, ignoring";
     return false;
-  }
-  else if (mIsReady) {
+  } else if (mIsReady) {
     // ready : bad+good == NChannels (i.e. no pending channel)
     LOG(info) << "RESULT: ready";
     print();
@@ -83,7 +82,7 @@ void FT0TimeOffsetSlotContainer::fill(const gsl::span<const float>& data)
       nEntries += en;
     }
     mArrEntries[iCh] = nEntries;
-    mTotalNevents+=nEntries;
+    mTotalNevents += nEntries;
     if (nEntries >= CalibParam::Instance().mMaxEntriesThreshold) {
       mBitsetGoodChIDs.set(iCh);
     }

--- a/Detectors/FIT/FT0/calibration/src/FT0TimeOffsetSlotContainer.cxx
+++ b/Detectors/FIT/FT0/calibration/src/FT0TimeOffsetSlotContainer.cxx
@@ -25,7 +25,12 @@ FT0TimeOffsetSlotContainer::FT0TimeOffsetSlotContainer(std::size_t minEntries) {
 
 bool FT0TimeOffsetSlotContainer::hasEnoughEntries() const
 {
-  if (mIsReady) {
+  if (mTotalNevents==0) {
+    //Dummy slot, should be ignored for protection
+    LOG(warning) << "RESULT: Empty slot, ignoring";
+    return false;
+  }
+  else if (mIsReady) {
     // ready : bad+good == NChannels (i.e. no pending channel)
     LOG(info) << "RESULT: ready";
     print();
@@ -78,6 +83,7 @@ void FT0TimeOffsetSlotContainer::fill(const gsl::span<const float>& data)
       nEntries += en;
     }
     mArrEntries[iCh] = nEntries;
+    mTotalNevents+=nEntries;
     if (nEntries >= CalibParam::Instance().mMaxEntriesThreshold) {
       mBitsetGoodChIDs.set(iCh);
     }

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
@@ -63,7 +63,7 @@ class FITCalibrator final : public o2::calibration::TimeSlotCalibration<TimeSlot
   {
     static std::map<std::string, std::string> md;
     auto* container = slot.getContainer();
-    const auto startValidity = slot.getStartTimeMS();
+    const auto startValidity = slot.getStartTimeMS() - o2::ccdb::CcdbObjectInfo::SECOND * 10;
     const auto endValidity = slot.getEndTimeMS() + o2::ccdb::CcdbObjectInfo::MONTH;
     LOGP(info, "!!!! {}<=TF<={}, startValidity: {} endValidity: {}", slot.getTFStart(), slot.getTFEnd(), startValidity, endValidity);
     auto calibrationObject = container->generateCalibrationObject(startValidity, endValidity, mExtraInfo);

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
@@ -63,13 +63,12 @@ class FITCalibrator final : public o2::calibration::TimeSlotCalibration<TimeSlot
   {
     static std::map<std::string, std::string> md;
     auto* container = slot.getContainer();
-    static const double TFlength = 1E-3 * o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCOrbitMUS; // in ms
-    auto starting = slot.getStartTimeMS();
-    auto stopping = slot.getEndTimeMS();
-    LOGP(info, "!!!! {}({})<=TF<={}({}), starting: {} stopping {}", slot.getTFStart(), slot.getStartTimeMS(), slot.getTFEnd(), slot.getEndTimeMS(), starting, stopping);
-    auto calibrationObject = container->generateCalibrationObject(slot.getStartTimeMS(), slot.getEndTimeMS(), mExtraInfo);
+    const auto startValidity = slot.getStartTimeMS();
+    const auto endValidity = slot.getEndTimeMS() + o2::ccdb::CcdbObjectInfo::MONTH;
+    LOGP(info, "!!!! {}<=TF<={}, startValidity: {} endValidity: {}", slot.getTFStart(), slot.getTFEnd(), startValidity, endValidity);
+    auto calibrationObject = container->generateCalibrationObject(startValidity, endValidity, mExtraInfo);
     std::vector<CalibObjWithInfoType> preparedCalibObjects;
-    preparedCalibObjects.emplace_back(doSerializationAndPrepareObjectInfo(calibrationObject, starting, stopping));
+    preparedCalibObjects.emplace_back(doSerializationAndPrepareObjectInfo(calibrationObject, startValidity, endValidity));
     mStoredCalibrationObjects.insert(mStoredCalibrationObjects.end(),
                                      std::make_move_iterator(preparedCalibObjects.begin()),
                                      std::make_move_iterator(preparedCalibObjects.end()));


### PR DESCRIPTION
Special bugfix for validity range:
1. Empty slots will be discarded
2. EOV has + 1 month