### PR TITLE
Apply MFT tracker high mult protection always in synch mode

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -103,9 +103,8 @@ if [[ $SYNCMODE == 1 ]]; then
   [[ ! -z ${CUT_RANDOM_FRACTION_ITS:-} ]] && ITS_CONFIG_KEY+="fastMultConfig.cutRandomFraction=$CUT_RANDOM_FRACTION_ITS;"
   if has_detector_reco ITS; then
     [[ $RUNTYPE == "COSMICS" ]] && MFT_CONFIG_KEY+="MFTTracking.irFramesOnly=1;"
-  else
-    MFT_CONFIG_KEY+="MFTTracking.cutMultClusLow=0;MFTTracking.cutMultClusHigh=2000;"
   fi
+  MFT_CONFIG_KEY+="MFTTracking.cutMultClusLow=0;MFTTracking.cutMultClusHigh=2000;"
 
   PVERTEXING_CONFIG_KEY+="pvertexer.meanVertexExtraErrConstraint=0.3;" # for calibration relax the constraint
   if [[ $SYNCRAWMODE == 1 ]]; then # add extra tolerance in sync mode to account for eventual time misalignment


### PR DESCRIPTION
We see from time to time the MFT tracking being too slow on individual TFs (up to 30 minutes) if it encounters a ROF with many clusters. Currently a protection is only added in case ITS is not included in the run. For the synch. reco I think the protection should always be there.
More details in https://alice.its.cern.ch/jira/browse/O2-3740

pinging @robincaron13

Since I am not sure if I am missing something (it is not clear to me why the protection was added like this in the first place) I'll wait for approval before merging