### PR TITLE
[EMCAL-742] Add rejection of EMCal L0 triggered events in calib histo exporter

### DIFF
--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -26,7 +26,7 @@ o2_add_library(EMCALWorkflow
         src/EntropyDecoderSpec.cxx
         src/StandaloneAODProducerSpec.cxx
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsCTP O2::DataFormatsEMCAL O2::EMCALSimulation O2::Steer
-        O2::DPLUtils O2::EMCALBase O2::EMCALCalib O2::EMCALReconstruction O2::Algorithm O2::MathUtils)
+        O2::DPLUtils O2::EMCALBase O2::EMCALCalib O2::EMCALCalibration O2::EMCALReconstruction O2::Algorithm O2::MathUtils)
 
 o2_add_executable(reco-workflow
         COMPONENT_NAME emcal

--- a/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
@@ -25,6 +25,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
                                        {"no-rejectCalibTrigg", VariantType::Bool, false, {"if set to true, all events, including calibration triggered events, will be accepted"}},
                                        {"input-subspec", VariantType::UInt32, 0U, {"Subspecification for input objects"}},
                                        {"applyGainCalib", VariantType::Bool, false, {"Apply the gain calibration parameters for the bad channel calibration"}},
+                                       {"rejectL0Trigger", VariantType::Bool, false, {"Reject all emcal triggers except the minimum bias trigger"}},
+                                       {"ctpconfig-per-run", VariantType::Bool, false, {"Use CTP config per run. 1 -- on (Data), 0 -- off (MC)"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -40,11 +42,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool makeCellIDTimeEnergy = cfgc.options().get<bool>("makeCellIDTimeEnergy");
   bool rejectCalibTrigg = !cfgc.options().get<bool>("no-rejectCalibTrigg");
   bool doApplyGainCalib = cfgc.options().get<bool>("applyGainCalib");
+  bool doRejectL0Trigger = cfgc.options().get<bool>("rejectL0Trigger");
+  bool ctpcfgperrun = cfgc.options().get<bool>("ctpconfig-per-run");
 
   // subpsecs for input
   auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec");
 
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg, inputsubspec, doApplyGainCalib));
+  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg, inputsubspec, doApplyGainCalib, doRejectL0Trigger, ctpcfgperrun));
   return wf;
 }


### PR DESCRIPTION
- For bad channel and time calibration, only minimum bias triggered data should be used
- As the EMCal started taking data with L0 triggers in 2023, L0 triggered events have to be rejected
- Information taken from CTP input (CTPDigits)
- Selected trigger names are settable in the calib params
- This does not effect the online calibration!