### PR TITLE
DPL: signpost update

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -646,14 +646,16 @@ auto flushStates(ServiceRegistryRef registry, DataProcessingStates& states) -> v
   });
 }
 
+O2_DECLARE_DYNAMIC_LOG(monitoring_service);
+
 /// This will flush metrics only once every second.
 auto flushMetrics(ServiceRegistryRef registry, DataProcessingStats& stats) -> void
 {
-  ZoneScopedN("flush metrics");
+  O2_SIGNPOST_ID_GENERATE(sid, monitoring_service);
+  O2_SIGNPOST_START(monitoring_service, sid, "flush", "flushing metrics");
   auto& monitoring = registry.get<Monitoring>();
   auto& relayer = registry.get<DataRelayer>();
 
-  O2_SIGNPOST_START(MonitoringStatus::ID, MonitoringStatus::FLUSH, 0, 0, O2_SIGNPOST_RED);
   // Send all the relevant metrics for the relayer to update the GUI
   stats.flushChangedMetrics([&monitoring](DataProcessingStats::MetricSpec const& spec, int64_t timestamp, int64_t value) mutable -> void {
     // convert timestamp to a time_point
@@ -683,7 +685,7 @@ auto flushMetrics(ServiceRegistryRef registry, DataProcessingStats& stats) -> vo
   });
   relayer.sendContextState();
   monitoring.flushBuffer();
-  O2_SIGNPOST_END(MonitoringStatus::ID, MonitoringStatus::FLUSH, 0, 0, O2_SIGNPOST_RED);
+  O2_SIGNPOST_END(monitoring_service, sid, "flush", "done flushing metrics");
 };
 } // namespace
 

--- a/Framework/Core/src/DataProcessingStatus.h
+++ b/Framework/Core/src/DataProcessingStatus.h
@@ -23,9 +23,9 @@ namespace o2::framework
 /// Describe the possible states for DataProcessing
 enum struct DataProcessingStatus : uint32_t {
   ID = 0,
-  IN_DPL_OVERHEAD = O2_SIGNPOST_RED,
-  IN_DPL_USER_CALLBACK = O2_SIGNPOST_GREEN,
-  IN_DPL_ERROR_CALLBACK = O2_SIGNPOST_PURPLE
+  IN_DPL_OVERHEAD,
+  IN_DPL_USER_CALLBACK,
+  IN_DPL_ERROR_CALLBACK
 };
 
 /// Describe the possible states for Monitoring

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -24,7 +24,6 @@
 #include "Framework/Logger.h"
 #include "Framework/PartRef.h"
 #include "Framework/TimesliceIndex.h"
-#include "Framework/Signpost.h"
 #include "Framework/RoutingIndices.h"
 #include "Framework/VariableContextHelpers.h"
 #include "Framework/FairMQDeviceProxy.h"
@@ -509,7 +508,6 @@ DataRelayer::RelayChoice
   auto& stats = mContext.get<DataProcessingStats>();
   /// If we get a valid result, we can store the message in cache.
   if (input != INVALID_INPUT && TimesliceId::isValid(timeslice) && TimesliceSlot::isValid(slot)) {
-    O2_SIGNPOST(O2_PROBE_DATARELAYER, timeslice.value, 0, 0, 0);
     if (needsCleaning) {
       this->pruneCache(slot, onDrop);
       mPruneOps.erase(std::remove_if(mPruneOps.begin(), mPruneOps.end(), [slot](const auto& x) { return x.slot == slot; }), mPruneOps.end());

--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -35,8 +35,13 @@ add_executable(o2-test-framework-foundation
 target_link_libraries(o2-test-framework-foundation PRIVATE O2::FrameworkFoundation)
 target_link_libraries(o2-test-framework-foundation PRIVATE O2::Catch2)
 
+add_executable(o2-test-framework-Signpost
+               test/test_Signpost.cxx)
+target_link_libraries(o2-test-framework-Signpost PRIVATE O2::FrameworkFoundation)
+
 get_filename_component(outdir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../tests ABSOLUTE)
 set_property(TARGET o2-test-framework-foundation PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
+set_property(TARGET o2-test-framework-Signpost PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
 
 add_test(NAME framework:foundation COMMAND o2-test-framework-foundation)
 

--- a/Framework/Foundation/include/Framework/Signpost.h
+++ b/Framework/Foundation/include/Framework/Signpost.h
@@ -11,108 +11,346 @@
 #ifndef O2_FRAMEWORK_SIGNPOST_H_
 #define O2_FRAMEWORK_SIGNPOST_H_
 
-#include <cstdint>
-
-/// Signpost API implemented using different techonologies:
-///
-/// * macOS 10.15 onwards os_signpost
-/// * macOS 10.14 and below (either kdebug_signpost or kdebug)
-/// * linux SystemTap
-///
-/// Supported systems will have O2_SIGNPOST_API_AVAILABLE defined.
-///
-/// In order to use it, one must define O2_SIGNPOST_DEFINE_CONTEXT in at least one cxx file,
-/// include "Framework/Signpost.h" and invoke O2_SIGNPOST_INIT().
-#if defined(__APPLE__) && __has_include(<os/signpost.h>) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_15)
-#include <os/signpost.h>
+#if !defined(O2_FORCE_LOGGER_SIGNPOST) && defined(__APPLE__) && !defined(NDEBUG)
 #include <os/log.h>
-#if defined(OS_LOG_TARGET_HAS_10_15_FEATURES) && defined(OS_LOG_CATEGORY_DYNAMIC_TRACING)
-#define O2_SIGNPOST_TYPE OS_LOG_CATEGORY_DYNAMIC_TRACING
+#include <os/signpost.h>
+#define O2_DECLARE_DYNAMIC_LOG(x) static os_log_t private_o2_log_##x = os_log_create("ch.cern.aliceo2." #x, OS_LOG_CATEGORY_DYNAMIC_TRACING)
+#define O2_DECLARE_DYNAMIC_STACKTRACE_LOG(x) static os_log_t private_o2_log_##x = os_log_create("ch.cern.aliceo2." #x, OS_LOG_CATEGORY_DYNAMIC_STACK_TRACING)
+// This is a no-op on macOS using the os_signpost API because only external instruments can enable/disable dynamic signposts
+#define O2_LOG_ENABLE_DYNAMIC(log)
+// This is a no-op on macOS using the os_signpost API because only external instruments can enable/disable dynamic signposts
+#define O2_LOG_ENABLE_STACKTRACE(log)
+#define O2_DECLARE_LOG(x, category) static os_log_t private_o2_log_##x = os_log_create("ch.cern.aliceo2." #x, #category)
+#define O2_LOG_DEBUG(log, ...) os_log_debug(private_o2_log_##log, __VA_ARGS__)
+#define O2_SIGNPOST_ID_FROM_POINTER(name, log, pointer) os_signpost_id_t name = os_signpost_id_make_with_pointer(private_o2_log_##log, pointer)
+#define O2_SIGNPOST_ID_GENERATE(name, log) os_signpost_id_t name = os_signpost_id_generate(private_o2_log_##log)
+#define O2_SIGNPOST_EVENT_EMIT(log, id, name, ...) os_signpost_event_emit(private_o2_log_##log, id, name, __VA_ARGS__)
+#define O2_SIGNPOST_START(log, id, name, ...) os_signpost_interval_begin(private_o2_log_##log, id, name, __VA_ARGS__)
+#define O2_SIGNPOST_END(log, id, name, ...) os_signpost_interval_end(private_o2_log_##log, id, name, __VA_ARGS__)
+#define O2_ENG_TYPE(x, what) "%{xcode:" #x "}" what
+#elif !defined(NDEBUG) || defined(O2_FORCE_LOGGER_SIGNPOST)
+
+#ifndef O2_LOG_MACRO
+#if __has_include("Framework/Logger.h")
+#include "Framework/Logger.h"
+// If NDEBUG is not defined, we use the logger to print out the signposts at the debug level.
+#if !defined(NDEBUG)
+#define O2_LOG_MACRO(...) LOGF(debug, __VA_ARGS__)
+#elif defined(O2_FORCE_LOGGER_SIGNPOST)
+// If we force the presence of the logger, we use it to print out the signposts at the detail level, which is not optimized out.
+#define O2_LOG_MACRO(...) LOGF(info, __VA_ARGS__)
+#endif
 #else
-#define O2_SIGNPOST_TYPE OS_LOG_CATEGORY_POINTS_OF_INTEREST
+// If we do not have the fairlogger, we simply print out the signposts to the console.
+// This is useful for things like the tests, which this way do not need to depend on the FairLogger.
+#define O2_LOG_MACRO(...) \
+  do {                    \
+    printf(__VA_ARGS__);  \
+    printf("\n");         \
+  } while (0)
 #endif
-#ifdef O2_SIGNPOST_DEFINE_CONTEXT
-os_log_t gDPLLog = 0;
-#else
-static os_log_t gDPLLog;
-#endif
-#define O2_SIGNPOST_INIT() gDPLLog = os_log_create("ch.cern.alice.dpl", O2_SIGNPOST_TYPE);
-#define O2_SIGNPOST(code, arg1, arg2, arg3, color) os_signpost_event_emit(gDPLLog, OS_SIGNPOST_ID_EXCLUSIVE, "##code", "%lu %lu %lu %lu", (uintptr_t)arg1, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)color)
-#define O2_SIGNPOST_START(code, interval_id, arg2, arg3, color) os_signpost_interval_begin(gDPLLog, (os_signpost_id_t)interval_id, "##code", "%lu %lu %lu", (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)color)
-#define O2_SIGNPOST_END(code, interval_id, arg2, arg3, color) os_signpost_interval_end(gDPLLog, (os_signpost_id_t)interval_id, "##code", "%lu %lu %lu", (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)color)
-#define O2_SIGNPOST_API_AVAILABLE
-#elif defined(__APPLE__) && __has_include(<sys/kdebug_signpost.h>) && (__MAC_OS_X_VERSION_MAX_ALLOWED < __MAC_10_15) // Deprecated in Catalina
-#include <sys/kdebug_signpost.h>
-#define O2_SIGNPOST_INIT()
-#define O2_SIGNPOST(code, arg1, arg2, arg3, color) kdebug_signpost((uint32_t)code, (uintptr_t)arg1, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)color)
-#define O2_SIGNPOST_START(code, interval_id, arg2, arg3, color) kdebug_signpost_start((uint32_t)code, (uintptr_t)interval_id, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)color)
-#define O2_SIGNPOST_END(code, interval_id, arg2, arg3, color) kdebug_signpost_end((uint32_t)code, (uintptr_t)interval_id, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)color)
-#define O2_SIGNPOST_API_AVAILABLE
-#elif defined(__APPLE__) && __has_include(<sys/kdebug.h>) && (__MAC_OS_X_VERSION_MAX_ALLOWED < __MAC_10_15) // Compatibility with old API
-#include <sys/kdebug.h>
-#include <sys/syscall.h>
-#include <unistd.h>
-#ifndef SYS_kdebug_trace
-#define SYS_kdebug_trace 180
-#endif
-#define O2_SIGNPOST_INIT()
-#define O2_SIGNPOST(code, arg1, arg2, arg3, arg4) syscall(SYS_kdebug_trace, APPSDBG_CODE(DBG_MACH_CHUD, (uint32_t)code) | DBG_FUNC_NONE, (uintptr_t)arg1, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)arg4);
-#define O2_SIGNPOST_START(code, arg1, arg2, arg3, arg4) syscall(SYS_kdebug_trace, APPSDBG_CODE(DBG_MACH_CHUD, (uint32_t)code) | DBG_FUNC_START, (uintptr_t)arg1, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)arg4);
-#define O2_SIGNPOST_END(code, arg1, arg2, arg3, arg4) syscall(SYS_kdebug_trace, APPSDBG_CODE(DBG_MACH_CHUD, (uintptr_t)code) | DBG_FUNC_END, (uintptr_t)arg1, (uintptr_t)arg2, (uintptr_t)arg3, (uintptr_t)arg4);
-#define O2_SIGNPOST_API_AVAILABLE
-#elif (!defined(__APPLE__)) && __has_include(<sys/sdt.h>) // Dtrace support is being dropped by Apple
-#include <sys/sdt.h>
-#define O2_SIGNPOST_INIT()
-#define O2_SIGNPOST(code, arg1, arg2, arg3, arg4) STAP_PROBE4(dpl, probe##code, arg1, arg2, arg3, arg4)
-#define O2_SIGNPOST_START(code, arg1, arg2, arg3, arg4) STAP_PROBE4(dpl, start_probe##code, arg1, arg2, arg3, arg4)
-#define O2_SIGNPOST_END(code, arg1, arg2, arg3, arg4) STAP_PROBE4(dpl, stop_probe##code, arg1, arg2, arg3, arg4)
-#define O2_SIGNPOST_API_AVAILABLE
-#else // by default we do not do anything
-#define O2_SIGNPOST_INIT()
-#define O2_SIGNPOST(code, arg1, arg2, arg3, arg4)
-#define O2_SIGNPOST_START(code, arg1, arg2, arg3, arg4)
-#define O2_SIGNPOST_END(code, arg1, arg2, arg3, arg4)
 #endif
 
-/// Colors for the signpost while shown in instruments.
-/// Notice we use defines and not enums becasue STAP / DTRACE seems not
-/// to play well with it, due to macro expansion tricks.
-///
-/// FIXME: we should have sensible defaults also for some DTrace / STAP
-/// GUI.
-#define O2_SIGNPOST_BLUE 0
-#define O2_SIGNPOST_GREEN 1
-#define O2_SIGNPOST_PURPLE 2
-#define O2_SIGNPOST_ORANGE 3
-#define O2_SIGNPOST_RED 4
+// This is the linux implementation, it is not as nice as the apple one and simply prints out
+// the signpost information to the log.
+#include <atomic>
+#include <array>
+#include <cstdio>
+#include "Framework/RuntimeError.h"
 
-/// Helper class which allows the user to track
-template <typename S>
-struct StateMonitoring {
- public:
-  static void start()
-  {
-    O2_SIGNPOST_START(S::ID, StateMonitoring<S>::count, 0, 0, StateMonitoring<S>::level);
-  }
+#include <cassert>
+#include <atomic>
+#include <cstdarg>
+#include <cinttypes>
 
-  static void moveTo(S newLevel)
-  {
-    if ((uint32_t)newLevel == StateMonitoring<S>::level) {
-      return;
-    }
-    O2_SIGNPOST_END(S::ID, StateMonitoring<S>::count, 0, 0, StateMonitoring<S>::level);
-    StateMonitoring<S>::count++;
-    StateMonitoring<S>::level = (uint32_t)newLevel;
-    O2_SIGNPOST_START(S::ID, StateMonitoring<S>::count, 0, 0, StateMonitoring<S>::level);
-  }
-
-  static void end()
-  {
-    O2_SIGNPOST_END(S::ID, StateMonitoring<S>::count, 0, 0, 0);
-  }
-
-  inline static uint32_t count = 0;
-  inline static uint32_t level = 0;
+namespace {
+struct _o2_lock_free_stack {
+  static constexpr size_t N = 1024;
+  std::atomic<size_t> top = 0;
+  int stack[N];
 };
+
+// returns true if the push was successful, false if the stack was full
+// @param spin if true, will spin until the stack is not full
+bool _o2_lock_free_stack_push(_o2_lock_free_stack& stack, const int& value, bool spin = false)
+{
+  size_t currentTop = stack.top.load(std::memory_order_relaxed);
+  while (true) {
+    if (currentTop == _o2_lock_free_stack::N && spin == false) {
+      return false;
+    } else if (currentTop == _o2_lock_free_stack::N) {
+// Avoid consuming too much CPU time if we are spinning.
+#if defined(__x86_64__) || defined(__i386__)
+      __asm__ __volatile__("pause" ::
+                             : "memory");
+#elif defined(__aarch64__)
+      __asm__ __volatile__("yield" ::
+                             : "memory");
+#endif
+      continue;
+    }
+
+    if (stack.top.compare_exchange_weak(currentTop, currentTop + 1,
+                                        std::memory_order_release,
+                                        std::memory_order_relaxed)) {
+      stack.stack[currentTop] = value;
+      return true;
+    }
+  }
+}
+
+bool _o2_lock_free_stack_pop(_o2_lock_free_stack& stack, int& value, bool spin = false)
+{
+  size_t currentTop = stack.top.load(std::memory_order_relaxed);
+  while (true) {
+    if (currentTop == 0 && spin == false) {
+      return false;
+    } else if (currentTop == 0) {
+// Avoid consuming too much CPU time if we are spinning.
+#if defined(__x86_64__) || defined(__i386__)
+      __asm__ __volatile__("pause" ::
+                             : "memory");
+#elif defined(__aarch64__)
+      __asm__ __volatile__("yield" ::
+                             : "memory");
+#endif
+      continue;
+    }
+
+    if (stack.top.compare_exchange_weak(currentTop, currentTop - 1,
+                                        std::memory_order_acquire,
+                                        std::memory_order_relaxed)) {
+      value = stack.stack[currentTop - 1];
+      return true;
+    }
+  }
+}
+
+// A log is simply an inbox which keeps track of the available id, so that we can print out different signposts
+// with different indentation levels.
+// supports up to 1024 paralle signposts before it spinlocks.
+typedef int _o2_signpost_index_t;
+
+struct _o2_activity_t {
+  // How much the activity is indented in the output log.
+  unsigned char indentation = 0;
+  char const* name = nullptr;
+};
+
+struct _o2_signpost_id_t {
+  // The id of the activity.
+  int64_t id = -1;
+};
+
+struct _o2_log_t {
+  // A circular buffer of available slots. Each unique interval pulls an id from this buffer.
+  _o2_lock_free_stack slots;
+  // Up to 256 activities can be active at the same time.
+  std::array<_o2_signpost_id_t, 256> ids = {};
+  // The intervals associated with each slot.
+  // We use this to keep track of the indentation level for messages associated to it
+  std::array<_o2_activity_t, 256> activities = {};
+  std::atomic<int64_t> current_indentation = 0;
+  // Each thread needs to maintain a stack for the intervals, so that
+  // you can have nested intervals.
+  std::atomic<int64_t> unique_signpost = 1;
+
+  // how many stacktrace levels print per log.
+  // 0 means the log is disabled.
+  // 1 means only the current signpost is printed.
+  // >1 means the current signpost and n levels of the stacktrace are printed.
+  std::atomic<int> stacktrace = 1;
+};
+
+// This generates a unique id for a signpost. Do not use this directly, use O2_SIGNPOST_ID_GENERATE instead.
+// Notice that this is only valid on a given computer.
+// This is guaranteed to be unique at 5 GHz for at least 63 years, if my math is correct.
+// I doubt we will have a job running for that long or that CPU scaling will shorten that period too much.
+// If you want to use this on the Nostromo, please think twice about it.
+// We use odd numbers so that pointers to things which are not bytes are not confused with
+// the generated ones.
+inline _o2_signpost_id_t _o2_signpost_id_generate_local(_o2_log_t* log)
+{
+  return {(log->unique_signpost++ * 2) + 1};
+}
+
+// Generate a unique id for a signpost. Do not use this directly, use O2_SIGNPOST_ID_FROM_POINTER instead.
+// Notice that this will fail for pointers to bytes as it might overlap with the id above.
+inline _o2_signpost_id_t _o2_signpost_id_make_with_pointer(_o2_log_t* log, void* pointer)
+{
+  assert(((int64_t)pointer & 1) != 1);
+  _o2_signpost_id_t uniqueId{(int64_t)pointer};
+  return uniqueId;
+}
+
+inline _o2_signpost_index_t o2_signpost_id_make_with_pointer(_o2_log_t* log, void* pointer)
+{
+  _o2_signpost_index_t signpost_index;
+  _o2_lock_free_stack_pop(log->slots, signpost_index, true);
+  log->ids[signpost_index].id = (int64_t)pointer;
+  return signpost_index;
+}
+
+_o2_log_t* _o2_log_create(char const* name, int stacktrace)
+{
+  _o2_log_t* log = new _o2_log_t();
+  // Write the initial 256 ids to the inbox, in reverse, so that the
+  // linear search below is just for an handful of elements.
+  int n = _o2_lock_free_stack::N;
+  for (int i = 0; i < n; i++) {
+    _o2_signpost_index_t signpost_index{n - 1 - i};
+    _o2_lock_free_stack_push(log->slots, signpost_index, true);
+  }
+  log->stacktrace = stacktrace;
+  return log;
+}
+
+// This will look at the slot in the log associated to the ID.
+// If the slot is empty, it will return the id and increment the indentation level.
+void _o2_signpost_event_emit(_o2_log_t* log, _o2_signpost_id_t id, char const* name, char const* const format, ...)
+{
+  // Nothing to be done
+  if (log->stacktrace == 0) {
+    return;
+  }
+  va_list args;
+  va_start(args, format);
+
+  // Find the index of the activity
+  int leading = 0;
+
+  // This is the equivalent of exclusive
+  if (id.id != 0) {
+    int i = 0;
+    for (i = 0; i < log->ids.size(); ++i) {
+      if (log->ids[i].id == id.id) {
+        break;
+      }
+    }
+    // If the id is not in the list, then we consider it as a standalone event and we print
+    // it at toplevel.
+    if (i != log->ids.size()) {
+      // we found an interval associated to this id.
+      _o2_activity_t* activity = &log->activities[i];
+      leading = activity->indentation * 2;
+    }
+  }
+
+  char prebuffer[4096];
+  int s = snprintf(prebuffer, 4096, "id%.16llx:%-16s*>%*c", id.id, name, leading, ' ');
+  vsnprintf(prebuffer + s, 4096 - s, format, args);
+  va_end(args);
+  O2_LOG_MACRO("%s", prebuffer);
+}
+
+// This will look at the slot in the log associated to the ID.
+// If the slot is empty, it will return the id and increment the indentation level.
+void _o2_signpost_interval_begin(_o2_log_t* log, _o2_signpost_id_t id, char const* name, char const* const format, ...)
+{
+  if (log->stacktrace == 0) {
+    return;
+  }
+  va_list args;
+  va_start(args, format);
+  // This is a unique slot for this interval.
+  _o2_signpost_index_t signpost_index;
+  _o2_lock_free_stack_pop(log->slots, signpost_index, true);
+  // Put the id in the slot, to close things or to attach signposts to a given interval
+  log->ids[signpost_index].id = id.id;
+  auto* activity = &log->activities[signpost_index];
+  activity->indentation = log->current_indentation++;
+  activity->name = name;
+  int leading = activity->indentation * 2;
+  char prebuffer[4096];
+  int s = snprintf(prebuffer, 4096, "id%.16llx:%-16sS>%*c", id.id, name, leading, ' ');
+  vsnprintf(prebuffer + s, 4096 - s, format, args);
+  va_end(args);
+  O2_LOG_MACRO("%s", prebuffer);
+}
+
+void _o2_signpost_interval_end_v(_o2_log_t* log, _o2_signpost_id_t id, char const* name, char const* const format, va_list args)
+{
+  if (log->stacktrace == 0) {
+    return;
+  }
+  // Find the index of the activity
+  int i = 0;
+  for (i = 0; i < log->ids.size(); ++i) {
+    if (log->ids[i].id == id.id) {
+      break;
+    }
+  }
+  // If we do not find a matching id, then we just emit this as an event in then log.
+  // We should not make this an error because one could have enabled the log after the interval
+  // was started.
+  if (i == log->ids.size()) {
+    _o2_signpost_event_emit(log, id, name, format, args);
+    return;
+  }
+  // i is the slot index
+  _o2_activity_t* activity = &log->activities[i];
+  int leading = activity->indentation * 2;
+  char prebuffer[4096];
+  int s = snprintf(prebuffer, 4096, "id%.16llx:%-16sE>%*c", id.id, name, leading, ' ');
+  vsnprintf(prebuffer + s, 4096 - s, format, args);
+  O2_LOG_MACRO("%s", prebuffer);
+  // Clear the slot
+  activity->indentation = -1;
+  activity->name = nullptr;
+  log->ids[i].id = -1;
+  // Put back the slot
+  log->current_indentation--;
+  _o2_signpost_index_t signpost_index{i};
+  _o2_lock_free_stack_push(log->slots, signpost_index, true);
+}
+
+// We separate this so that we can still emit the end signpost when the log is not enabled.
+void _o2_signpost_interval_end(_o2_log_t* log, _o2_signpost_id_t id, char const* name, char const* const format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  _o2_signpost_interval_end_v(log, id, name, format, args);
+  va_end(args);
+  return;
+}
+
+void _o2_log_set_stacktrace(_o2_log_t* log, int stacktrace)
+{
+  log->stacktrace = stacktrace;
+}
+}
+
+/// Dynamic logs need to be enabled via the O2_LOG_ENABLE_DYNAMIC macro. Notice this will only work
+/// for the logger based logging, since the Apple version needs instruments to enable them.
+#define O2_DECLARE_DYNAMIC_LOG(name) static _o2_log_t* private_o2_log_##name = _o2_log_create("ch.cern.aliceo2." #name, 0)
+/// For the moment we do not support logs with a stacktrace.
+#define O2_DECLARE_DYNAMIC_STACKTRACE_LOG(name) static _o2_log_t* private_o2_log_##name = _o2_log_create("ch.cern.aliceo2." #name, 0)
+#define O2_DECLARE_LOG(name, category) static _o2_log_t* private_o2_log_##name = _o2_log_create("ch.cern.aliceo2." #name, 1)
+#define O2_LOG_ENABLE_DYNAMIC(log) _o2_log_set_stacktrace(private_o2_log_##log, 1)
+// We print out only the first 64 frames.
+#define O2_LOG_ENABLE_STACKTRACE(log) _o2_log_set_stacktrace(private_o2_log_##log, 64)
+// For the moment we simply use LOG DEBUG. We should have proper activities so that we can
+// turn on and off the printing.
+#define O2_LOG_DEBUG(log, ...) O2_LOG_MACRO(__VA_ARGS__)
+#define O2_SIGNPOST_ID_FROM_POINTER(name, log, pointer) _o2_signpost_id_t name = _o2_signpost_id_make_with_pointer(private_o2_log_##log, pointer)
+#define O2_SIGNPOST_ID_GENERATE(name, log) _o2_signpost_id_t name = _o2_signpost_id_generate_local(private_o2_log_##log)
+#define O2_SIGNPOST_EVENT_EMIT(log, id, name, ...) _o2_signpost_event_emit(private_o2_log_##log, id, name, __VA_ARGS__)
+#define O2_SIGNPOST_START(log, id, name, ...) _o2_signpost_interval_begin(private_o2_log_##log, id, name, __VA_ARGS__)
+#define O2_SIGNPOST_END(log, id, name, ...) _o2_signpost_interval_end(private_o2_log_##log, id, name, __VA_ARGS__)
+#define O2_ENG_TYPE(x, what) "%" what
+#else // This is the release implementation, it does nothing.
+#define O2_DECLARE_DYNAMIC_LOG(x)
+#define O2_DECLARE_DYNAMIC_STACKTRACE_LOG(x)
+#define O2_DECLARE_LOG(x, category)
+#define O2_LOG_ENABLE_DYNAMIC(log)
+#define O2_LOG_ENABLE_STACKTRACE(log)
+#define O2_LOG_DEBUG(log, ...)
+#define O2_SIGNPOST_ID_FROM_POINTER(name, log, pointer)
+#define O2_SIGNPOST_ID_GENERATE(name, log)
+#define O2_SIGNPOST_EVENT_EMIT(log, id, name, ...)
+#define O2_SIGNPOST_START(log, id, name, ...)
+#define O2_SIGNPOST_END(log, id, name, ...)
+#define O2_ENG_TYPE(x)
+#endif
 
 #endif // O2_FRAMEWORK_SIGNPOST_H_

--- a/Framework/Foundation/test/test_Signpost.cxx
+++ b/Framework/Foundation/test/test_Signpost.cxx
@@ -9,16 +9,38 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <iostream>
-#define O2_SIGNPOST_DEFINE_CONTEXT
+#define O2_FORCE_LOGGER_SIGNPOST 1
 #include "Framework/Signpost.h"
+#include <iostream>
 
 int main(int argc, char** argv)
 {
-  // To be run inside some profiler (e.g. instruments) to make sure it actually
-  // works.
-  O2_SIGNPOST_INIT();
-  O2_SIGNPOST(dpl, 1000, 0, 0, 0);
-  O2_SIGNPOST_START(dpl, 1, 0, 0, 0);
-  O2_SIGNPOST_END(dpl, 1, 0, 0, 0);
+  O2_DECLARE_LOG(test_Signpost, "my category");
+  O2_DECLARE_DYNAMIC_LOG(test_SignpostDynamic);
+
+  O2_LOG_DEBUG(test_Signpost, "%s %d", "test_Signpost", 1);
+  O2_SIGNPOST_ID_GENERATE(id, test_Signpost);
+  O2_SIGNPOST_ID_GENERATE(id2, test_Signpost);
+  O2_SIGNPOST_START(test_Signpost, id, "Test category", "This is a test signpost");
+  O2_SIGNPOST_START(test_Signpost, id2, "Test category", "A sepaarate interval");
+  O2_SIGNPOST_EVENT_EMIT(test_Signpost, id, "Test category", "An event in an interval");
+  O2_SIGNPOST_END(test_Signpost, id, "Test category", "End of the first interval");
+  O2_SIGNPOST_END(test_Signpost, id2, "Test category", "A sepaarate interval");
+  O2_SIGNPOST_ID_FROM_POINTER(id3, test_Signpost, &id2);
+  O2_SIGNPOST_START(test_Signpost, id3, "Test category", "A signpost interval from a pointer");
+  O2_SIGNPOST_END(test_Signpost, id3, "Test category", "A signpost interval from a pointer");
+
+  // This has an engineering type, which we will not use on Linux / FairLogger
+  O2_SIGNPOST_ID_FROM_POINTER(id4, test_Signpost, &id3);
+  O2_SIGNPOST_START(test_Signpost, id4, "Test category", "A signpost with an engineering type formatter " O2_ENG_TYPE(size - in - bytes, "d"), 1);
+  O2_SIGNPOST_END(test_Signpost, id4, "Test category", "A signpost interval from a pointer");
+
+  O2_SIGNPOST_START(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will not see, because they are off by default");
+  O2_SIGNPOST_END(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will not see, because they are off by default");
+  O2_LOG_ENABLE_DYNAMIC(test_SignpostDynamic);
+#ifdef __APPLE__
+  // On Apple there is no way to turn on signposts in the logger, so we do not display this message
+  O2_SIGNPOST_START(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will see, because we turned them on");
+  O2_SIGNPOST_END(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will see, because we turned them on");
+#endif
 }

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -1060,7 +1060,7 @@ void displayDriverInfo(DriverInfo const& driverInfo, DriverControl& driverContro
       "osascript -e 'tell application \"Terminal\"'"
       " -e 'activate'"
       " -e 'do script \"xcrun xctrace record --output dpl-profile-{0}.trace"
-      " --time-limit 30s --template Time\\\\ Profiler --attach {0} "
+      " --instrument os_signpost --time-limit 30s --template Time\\\\ Profiler --attach {0} "
       " && open dpl-profile-{0}.trace && exit\"'"
       " -e 'end tell'",
       pid);
@@ -1082,7 +1082,7 @@ void displayDriverInfo(DriverInfo const& driverInfo, DriverControl& driverContro
       "osascript -e 'tell application \"Terminal\"'"
       " -e 'activate'"
       " -e 'do script \"xcrun xctrace record --output dpl-profile-{0}.trace"
-      " --time-limit 30s --template Allocations --attach {0} "
+      " --instrument os_signpost --time-limit 30s --template Allocations --attach {0} "
       " && open dpl-profile-{0}.trace && exit\"'"
       " -e 'end tell'",
       pid);


### PR DESCRIPTION
This is a revamped version of the Signpost tracing support. It's actually now quite usable to either investigate cases in which there are nested debug intervals.

On macOS by default is produces the os_signposts which can then be visualised in instruments. For example single stepping in the test_Signpost results in:

![image](https://github.com/AliceO2Group/AliceO2/assets/10544/b5e7789b-fa3c-4ff9-a2e7-93cf93c68dec)

While on linux / if defined(O2_FORCE_LOGGER_SIGNPOST) one will get properly indented (according to the number of parallel intervals) printout:

```
test_Signpost 1
id0000000000000003:Test category   S> This is a test signpost
id0000000000000005:Test category   S>  A sepaarate interval
id0000000000000003:Test category   *> An event in an interval
id0000000000000003:Test category   E> End of the first interval
id0000000000000005:Test category   E>  A sepaarate interval
id000000016ba59040:Test category   S> A signpost interval from a pointer
id000000016ba59040:Test category   E> A signpost interval from a pointer
id000000016ba59010:Test category   S> A signpost with an engineering type formatter "d"
id000000016ba59010:Test category   E> A signpost interval from a pointer
id0000000000000003:Test category   S> This is dynamic signpost which you will see, because we turned them on
id0000000000000003:Test category   E> This is dynamic signpost which you will see, because we turned them on
```

Notice how the `DYNAMIC` loggers must be enabled explicitly, either via the associated macro, or in instruments. The STACKTRACE will also attach a stacktrace to each event, but for the moment it only works in instruments.