### PR TITLE
[EMCAL-565, EMCAL-566] Add gain calib factors to online calibration

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -47,7 +47,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool UpdateAtEndOfRunOnly_bc = false; ///< switch to enable trigger of calibration only at end of run
   float minNHitsForMeanEnergyCut = 100; ///< mean number of hits per cell that is needed to cut on the mean energy per hit. Needed for high energy intervals as outliers can distort the distribution
   float minNHitsForNHitCut = 1;         ///< mean number of hits per cell that is needed to cut on the mean number of hits. Needed for high energy intervals as outliers can distort the distribution
-  float minCellEnergy_bc = 0.075;       ///< minimum cell energy considered for filling the histograms for bad channel calib. Should speedup the filling of the histogram to suppress noise
+  float minCellEnergy_bc = 0.1;         ///< minimum cell energy considered for filling the histograms for bad channel calib. Should speedup the filling of the histogram to suppress noise
 
   // parameters for time calibration
   unsigned int minNEvents_tc = 1e7;      ///< minimum number of events to trigger the calibration

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -22,6 +22,7 @@
 #include "EMCALCalibration/EMCALChannelData.h"
 #include "EMCALCalibration/EMCALCalibExtractor.h"
 #include "EMCALCalibration/EMCALCalibParams.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 #include "DataFormatsEMCAL/Cell.h"
@@ -95,6 +96,8 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<DataI
   std::shared_ptr<EMCALCalibExtractor> getCalibExtractor() { return mCalibrator; } // return shared pointer!
   /// \brief setter for mCalibrator
   void SetCalibExtractor(std::shared_ptr<EMCALCalibExtractor> extr) { mCalibrator = extr; };
+
+  bool setGainCalibrationFactors(o2::emcal::GainCalibrationFactors* gainCalibFactors);
 
  private:
   int mNBins = 0;          ///< bins of the histogram for passing
@@ -317,6 +320,22 @@ bool EMCALChannelCalibrator<DataInput, DataOutput>::adoptSavedData(const o2::cal
     return false;
   }
   c->setNEvents(hEvents->GetBinContent(1));
+
+  return true;
+}
+
+template <typename DataInput, typename DataOutput>
+bool EMCALChannelCalibrator<DataInput, DataOutput>::setGainCalibrationFactors(o2::emcal::GainCalibrationFactors* gainCalibFactors)
+{
+
+  auto& cont = o2::calibration::TimeSlotCalibration<DataInput>::getSlots();
+  if (cont.size() == 0) {
+    return false; // time slot object not yet there
+  }
+
+  auto& slot = cont.at(0);
+  DataInput* c = slot.getContainer();
+  c->setGainCalibFactors(gainCalibFactors);
 
   return true;
 }

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -23,6 +23,7 @@
 // #include "CommonUtils/BoostHistogramUtils.h"
 // #include "EMCALCalib/BadChannelMap.h"
 // #include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
 #include "EMCALCalib/EMCALChannelScaleFactors.h"
 #include "EMCALCalibration/EMCALCalibExtractor.h"
 #include "EMCALCalibration/EMCALCalibParams.h"
@@ -132,6 +133,12 @@ class EMCALChannelData
   long unsigned int getNEntriesInHisto() const { return mNEntriesInHisto; }
   void setNEntriesInHisto(long unsigned int n) { mNEntriesInHisto = n; }
 
+  void setGainCalibFactors(o2::emcal::GainCalibrationFactors* calibFactors)
+  {
+    mGainCalibFactors = calibFactors;
+    mApplyGainCalib = true;
+  }
+
  private:
   float mRange = 10;                                    ///< Maximum energy range of boost histogram (will be overwritten by values in the EMCALCalibParams)
   int mNBins = 1000;                                    ///< Number of bins in the boost histogram (will be overwritten by values in the EMCALCalibParams)
@@ -147,6 +154,8 @@ class EMCALChannelData
   boostHisto mCellAmplitude;                            ///< is the input for the calibration, hist of cell E vs. ID
   bool mTest = false;                                   ///< flag to be used when running in test mode: it simplify the processing
   BadChannelMap mOutputBCM;                             ///< output bad channel map for the calibration
+  bool mApplyGainCalib = false;                         ///< Switch if gain calibration is applied or not
+  o2::emcal::GainCalibrationFactors* mGainCalibFactors; ///< Gain calibration factors applied to the data before filling the histograms
   std::shared_ptr<EMCALCalibExtractor> mCalibExtractor; ///< calib extractor
 
   ClassDefNV(EMCALChannelData, 1);

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -24,6 +24,7 @@
 #include "EMCALBase/Geometry.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
 #include "EMCALCalibration/EMCALCalibParams.h"
 
 #include "Framework/Logger.h"
@@ -95,6 +96,12 @@ class EMCALTimeCalibData
   boostHisto& getHisto() { return mTimeHisto; }
   const boostHisto& getHisto() const { return mTimeHisto; }
 
+  void setGainCalibFactors(o2::emcal::GainCalibrationFactors* calibFactors)
+  {
+    mGainCalibFactors = calibFactors;
+    mApplyGainCalib = true;
+  }
+
   /// \brief Set new calibration histogram
   void setHisto(boostHisto hist) { mTimeHisto = hist; }
 
@@ -106,8 +113,10 @@ class EMCALTimeCalibData
  private:
   boostHisto mTimeHisto; ///< histogram with cell time vs. cell ID
 
-  int mEvents = 0;                        ///< current number of events
-  long unsigned int mNEntriesInHisto = 0; ///< number of entries in histogram
+  int mEvents = 0;                                      ///< current number of events
+  long unsigned int mNEntriesInHisto = 0;               ///< number of entries in histogram
+  bool mApplyGainCalib = false;                         ///< Switch if gain calibration is applied or not
+  o2::emcal::GainCalibrationFactors* mGainCalibFactors; ///< Gain calibration factors applied to the data before filling the histograms
 
   ClassDefNV(EMCALTimeCalibData, 1);
 };

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -50,12 +50,19 @@ void EMCALChannelData::fill(const gsl::span<const o2::emcal::Cell> data)
   //the fill function is called once per event
   mEvents++;
   for (auto cell : data) {
+    int id = cell.getTower();
     double cellEnergy = cell.getEnergy();
+
+    if (mApplyGainCalib) {
+      LOG(debug) << " gain calib factor for cell " << cell.getTower() << " = " << mGainCalibFactors->getGainCalibFactors(cell.getTower());
+      cellEnergy *= mGainCalibFactors->getGainCalibFactors(id);
+    }
+
     if (cellEnergy < o2::emcal::EMCALCalibParams::Instance().minCellEnergy_bc) {
       LOG(debug) << "skipping cell ID " << cell.getTower() << ": with energy = " << cellEnergy << " below  threshold of " << o2::emcal::EMCALCalibParams::Instance().minCellEnergy_bc;
       continue;
     }
-    int id = cell.getTower();
+
     LOG(debug) << "inserting in cell ID " << id << ": energy = " << cellEnergy;
     mHisto(cellEnergy, id);
     mNEntriesInHisto++;

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -83,6 +83,10 @@ void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
     double cellEnergy = cell.getEnergy();
     double cellTime = cell.getTimeStamp();
     int id = cell.getTower();
+    if (mApplyGainCalib) {
+      LOG(debug) << " gain calib factor for cell " << id << " = " << mGainCalibFactors->getGainCalibFactors(id);
+      cellEnergy *= mGainCalibFactors->getGainCalibFactors(id);
+    }
     if (cellEnergy > EMCALCalibParams::Instance().minCellEnergy_tc) {
       LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
       mTimeHisto(cellTime, id);

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -41,6 +41,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"no-loadCalibParamsFromCCDB", VariantType::Bool, false, {"disabled by default such that calib params are taken from the ccdb. If enabled, calib params are taken from EMCALCalibParams.h directly"}},
     {"no-rejectCalibTrigger", VariantType::Bool, false, {"disabled by default such that calib triggers are rejected. If enabled, calibration triggers (LED events etc.) also enter the calibration"}},
     {"no-rejectL0Trigger", VariantType::Bool, false, {"disabled by default such that L0 triggers are rejected. If enabled, L0 triggers (Gamma trigger and jet trigger) also enter the calibration"}},
+    {"no-applyGainCalib", VariantType::Bool, false, {"if appplication of gain calibration should be disabled"}},
     {"ctpconfig-per-run", VariantType::Bool, false, {"Use CTP config per run. 1 -- on (Data), 0 -- off (MC)"}}};
 
   std::swap(workflowOptions, options);
@@ -57,9 +58,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool rejectCalibTrigger = !cfgc.options().get<bool>("no-rejectCalibTrigger");
   bool rejectL0Trigger = !cfgc.options().get<bool>("no-rejectL0Trigger");
   bool ctpcfgperrun = cfgc.options().get<bool>("ctpconfig-per-run");
+  bool applyGainCalib = !cfgc.options().get<bool>("no-applyGainCalib");
 
   WorkflowSpec specs;
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger, rejectL0Trigger, ctpcfgperrun));
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger, rejectL0Trigger, ctpcfgperrun, applyGainCalib));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   // o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
- Gain calibration influences the cell energy. Hence the bad channel calibration can be influenced by the gain calibration factors
- Gain calib factors are read from ccdb and then passed to the calib data
- Application can be switched off with the workflow argument no-applyGainCalib
- cell energy is increased to 100 MeV for filling of the bad channel histograms as default to speedup the filling (before was 75 MeV)