### PR TITLE
TRD new structure for Tracklet64

### DIFF
--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -10,37 +10,19 @@
 // or submit itself to any jurisdiction.
 
 #include "DataFormatsTRD/Tracklet64.h"
-#include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/HelperMethods.h"
-#include "GPUCommonMath.h"
-
 #include "fairlogger/Logger.h"
 #include <iostream>
 
-using namespace GPUCA_NAMESPACE::gpu;
-
 namespace o2
 {
-
 namespace trd
 {
-
-using namespace constants;
 
 void Tracklet64::print() const
 {
   LOGF(info, "%02i_%i_%i, ROB(%i), MCM(%i), row(%i), col(%i), position(%i), slope(%i), pid(%i), q0(%i), q1(%i), q2(%i). Format(%i)",
        HelperMethods::getSector(getDetector()), HelperMethods::getStack(getDetector()), HelperMethods::getLayer(getDetector()), getROB(), getMCM(), getPadRow(), getColumn(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2(), getFormat());
-}
-
-GPUd() int Tracklet64::getPadCol() const
-{
-  // obtain pad number relative to MCM center
-  int padLocal = getPositionBinSigned() * GRANULARITYTRKLPOS;
-  // MCM number in column direction (0..7)
-  int mcmCol = (getMCM() % NMCMROBINCOL) + NMCMROBINCOL * (getROB() % 2);
-  // FIXME: understand why the offset seems to be 8 pads and not nChannels / 2 = 10.5
-  return CAMath::Nint(8.f + mcmCol * ((float)NCOLMCM) + padLocal);
 }
 
 #ifndef GPUCA_GPUCODE_DEVICE


### PR DESCRIPTION
@tdietel and @pestratm I tried to restructure a bit the Tracklet64 class. It should contain now all the functionality needed also for the raw data display. Most of the methods are simple one liners re-using the other methods which are already there.

Concerning the shift of 2 pads in `getPadCol()` this we should also discuss together. What I did was to change the PH class a bit to search for each tracklet which was matched to a tracklet for the closest digit which is a local maximum. For that I found an offset of +2.2 pads wrt my expectation.

But this was already implemented before, so this PR only adds some helper methods. All the previously implemented methods remain the same.

![trackletPadOffset](https://github.com/AliceO2Group/AliceO2/assets/26281793/4a6c84f5-f038-417f-a4fc-0247ab0973e2)