### PR TITLE
Optionally override magnet currents

### DIFF
--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPMagField.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPMagField.h
@@ -34,8 +34,18 @@ class GRPMagField
   ~GRPMagField() = default;
 
   /// getters/setters for magnets currents
-  o2::units::Current_t getL3Current() const { return mL3Current; }
-  o2::units::Current_t getDipoleCurrent() const { return mDipoleCurrent; }
+  o2::units::Current_t getL3Current() const
+  {
+    static float v = checkL3Override();
+    return v == NOOVERRIDEVAL ? mL3Current : v;
+  }
+
+  o2::units::Current_t getDipoleCurrent() const
+  {
+    static float v = checkDipoleOverride();
+    return v == NOOVERRIDEVAL ? mDipoleCurrent : v;
+  }
+
   bool getFieldUniformity() const { return mUniformField; }
   int8_t getNominalL3Field();
   void setL3Current(o2::units::Current_t v) { mL3Current = v; }
@@ -54,6 +64,10 @@ class GRPMagField
   int8_t mNominalL3Field = 0;                //!< Nominal L3 field deduced from mL3Current
   bool mNominalL3FieldValid = false;         //!< Has the field been computed (for caching)
 
+  static constexpr float NOOVERRIDEVAL = 1e99;
+  static float checkL3Override();
+  static float checkDipoleOverride();
+
   ClassDefNV(GRPMagField, 2);
 };
 
@@ -62,7 +76,7 @@ inline int8_t GRPMagField::getNominalL3Field()
   // compute nominal L3 field in kG
 
   if (mNominalL3FieldValid == false) {
-    mNominalL3Field = std::lround(5.f * mL3Current / 30000.f);
+    mNominalL3Field = std::lround(5.f * getL3Current() / 30000.f);
     mNominalL3FieldValid = true;
   }
   return mNominalL3Field;

--- a/DataFormats/Parameters/src/GRPMagField.cxx
+++ b/DataFormats/Parameters/src/GRPMagField.cxx
@@ -41,3 +41,25 @@ void GRPMagField::print() const
 {
   printf("magnet currents (A) L3 = %.3f, Dipole = %.f; uniformity = %s\n", getL3Current(), getDipoleCurrent(), mUniformField ? "true" : "false");
 }
+
+o2::units::Current_t GRPMagField::checkDipoleOverride()
+{
+  static float v = getenv("O2_OVERRIDE_DIPOLE_CURRENT") ? atof(getenv("O2_OVERRIDE_DIPOLE_CURRENT")) : NOOVERRIDEVAL;
+  static bool alarmShown = false;
+  if (v != NOOVERRIDEVAL && !alarmShown) {
+    LOGP(error, "Overriding DIPOLE current to {}", v);
+    alarmShown = true;
+  }
+  return v;
+}
+
+o2::units::Current_t GRPMagField::checkL3Override()
+{
+  static float v = getenv("O2_OVERRIDE_L3_CURRENT") ? atof(getenv("O2_OVERRIDE_L3_CURRENT")) : NOOVERRIDEVAL;
+  static bool alarmShown = false;
+  if (v != NOOVERRIDEVAL && !alarmShown) {
+    LOGP(error, "Overriding L3 current to {}", v);
+    alarmShown = true;
+  }
+  return v;
+}


### PR DESCRIPTION
Magnet currents can be overridden to arbitrary values, in which case the validity check will only report unsupported values (if any) w/o producing fatal. E.g.
`O2_OVERRIDE_L3_CURRENT=0 O2_OVERRIDE_DIPOLE_CURRENT=5123.5`