### PR TITLE
CCDBDownloader: Restoring asynchronous functions

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -204,7 +204,7 @@ class CCDBDownloader
    * @param workHandle Work handle which was used to perform the callback.
    * @param status Not used but required by template. Its value would be set as UV_ECANCELED if the callback was cancelled.
    */
-  static void afterWorkCleanup(uv_work_t *req, int status);
+  static void afterWorkCleanup(uv_work_t* req, int status);
 
   /**
    * Run the uvLoop once.

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -345,7 +345,7 @@ void CCDBDownloader::destroyCurlContext(curl_context_t* context)
   uv_close((uv_handle_t*)context->poll_handle, curlCloseCB);
 }
 
-void CCDBDownloader::afterWorkCleanup(uv_work_t *workHandle, int status)
+void CCDBDownloader::afterWorkCleanup(uv_work_t* workHandle, int status)
 {
   auto data = (CallbackData*)workHandle->data;
   delete data;

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(asynch_test)
   curl_global_cleanup();
 
   // Check if test timer and external loop are still alive
-  BOOST_CHECK(uv_is_active((uv_handle_t*)testTimer) !=  0);
+  BOOST_CHECK(uv_is_active((uv_handle_t*)testTimer) != 0);
   BOOST_CHECK(uv_loop_alive(uvLoop) != 0);
 
   // Downloader must be closed before uv_loop.
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(asynchronous_callback_test)
   curl_global_cleanup();
 
   // Check if test timer and external loop are still alive
-  BOOST_CHECK(uv_is_active((uv_handle_t*)testTimer) !=  0);
+  BOOST_CHECK(uv_is_active((uv_handle_t*)testTimer) != 0);
   BOOST_CHECK(uv_loop_alive(uvLoop) != 0);
 
   // Downloader must be closed before uv_loop.


### PR DESCRIPTION
Added back:
- Asynchronous batch perform
- Asynchronous batch perform with callback
- Tests for both functions

Additional information:
- To ensure asynchronous performs are executed correctly one must run the mUVLoop often enough to ensure proper reading from sockets.
- Asynchronous perform functions return a structure which must be freed after all downloads scheduled via that perform finish. The fields contained in that structure don't have to be freed as they use shared pointers.
- Callbacks are launched via uv_work, which means they will be executed asynchronously on another thread (managed by uv_loop) as long as the mUVLoop is running.

Additionally the code for old tests functions has been revised and compressed.