### PR TITLE
TPC SpaceCharge: Adding static distortions

### DIFF
--- a/Detectors/TPC/spacecharge/include/TPCSpaceCharge/DataContainer3D.h
+++ b/Detectors/TPC/spacecharge/include/TPCSpaceCharge/DataContainer3D.h
@@ -102,6 +102,7 @@ struct DataContainer3D {
   /// \param nr number of vertices in r
   /// \param nphi number of vertices in phi
   static size_t getIndexZ(size_t index, const int nz, const int nr, const int nphi);
+  size_t getIndexZ(size_t index) const { return getIndexZ(index, getNZ(), getNR(), getNPhi()); }
 
   /// \return returns index ir for given global index (can be used for TTree::Draw("second : o2::tpc::DataContainer3D<float>::getIndexR(first+Iteration$, 129, 129, 360) ","","colz"))
   /// \param index global index
@@ -109,6 +110,7 @@ struct DataContainer3D {
   /// \param nr number of vertices in r
   /// \param nphi number of vertices in phi
   static size_t getIndexR(size_t index, const int nz, const int nr, const int nphi);
+  size_t getIndexR(size_t index) const { return getIndexR(index, getNZ(), getNR(), getNPhi()); }
 
   /// \return returns index iphi for given global index (can be used for TTree::Draw("second : o2::tpc::DataContainer3D<float>::getIndexPhi(first+Iteration$, 129, 129, 360) ","","colz"))
   /// \param index global index
@@ -116,6 +118,7 @@ struct DataContainer3D {
   /// \param nr number of vertices in r
   /// \param nphi number of vertices in phi
   static size_t getIndexPhi(size_t index, const int nz, const int nr, const int nphi);
+  size_t getIndexPhi(size_t index) const { return getIndexPhi(index, getNZ(), getNR(), getNPhi()); }
 
   /// set the grid points
   void setGrid(unsigned short nZ, unsigned short nR, unsigned short nPhi, const bool resize);
@@ -186,6 +189,7 @@ struct DataContainer3D {
   /// operator overload
   DataContainer3D<DataT>& operator*=(const DataT value);
   DataContainer3D<DataT>& operator+=(const DataContainer3D<DataT>& other);
+  DataContainer3D<DataT>& operator-=(const DataContainer3D<DataT>& other);
 
  private:
   unsigned short mZVertices{};   ///< number of z vertices

--- a/Detectors/TPC/spacecharge/include/TPCSpaceCharge/SpaceChargeHelpers.h
+++ b/Detectors/TPC/spacecharge/include/TPCSpaceCharge/SpaceChargeHelpers.h
@@ -219,7 +219,13 @@ class NumericalFields
   /// \param gridProperties properties of the grid
   /// \param side side of the tpc
   NumericalFields(const DataContainer& dataEr, const DataContainer& dataEz, const DataContainer& dataEphi, const RegularGrid& gridProperties, const o2::tpc::Side side)
-    : mInterpolatorEr{dataEr, gridProperties}, mInterpolatorEz{dataEz, gridProperties}, mInterpolatorEphi{dataEphi, gridProperties}, mSide{side} {};
+    : mInterpolatorEr{dataEr, gridProperties}, mInterpolatorEz{dataEz, gridProperties}, mInterpolatorEphi{dataEphi, gridProperties}, mSide{side}
+  {
+    // restrict electric fields to inner volume of the TPC!
+    mInterpolatorEr.setExtrapolateValues(false);
+    mInterpolatorEz.setExtrapolateValues(false);
+    mInterpolatorEphi.setExtrapolateValues(false);
+  };
 
   /// \param r r coordinate
   /// \param phi phi coordinate

--- a/Detectors/TPC/spacecharge/include/TPCSpaceCharge/TriCubic.h
+++ b/Detectors/TPC/spacecharge/include/TPCSpaceCharge/TriCubic.h
@@ -85,6 +85,12 @@ class TriCubicInterpolator
   /// \return returns the extrapolation technique for missing boundary values
   ExtrapolationType getExtrapolationType() const { return mExtrapolationType; }
 
+  /// enable or disable extraolating values outside of the grid
+  void setExtrapolateValues(const bool extraPolate) { mExtraPolateValues = extraPolate; }
+
+  /// \return returns whethere values outside of the grid will be extrapolated
+  bool getExtrapolateValues() const { return mExtraPolateValues; }
+
  private:
   static constexpr unsigned int FDim = Grid3D::getDim();              ///< dimensions of the grid
   static constexpr unsigned int FZ = Grid3D::getFZ();                 ///< index for z coordinate
@@ -93,6 +99,7 @@ class TriCubicInterpolator
   const DataContainer* mGridData{};                                   ///< adress to the data container of the grid
   const Grid3D* mGridProperties{};                                    ///< adress to the properties of the grid
   ExtrapolationType mExtrapolationType = ExtrapolationType::Parabola; ///< sets which type of extrapolation for missing points at boundary is used
+  bool mExtraPolateValues = true;                                     ///< extrapolating values outside of the grid or restricting query to inside of the grid
 
   //                 DEFINITION OF enum GridPos
   //========================================================

--- a/Detectors/TPC/spacecharge/src/DataContainer3D.cxx
+++ b/Detectors/TPC/spacecharge/src/DataContainer3D.cxx
@@ -241,6 +241,13 @@ DataContainer3D<DataT>& DataContainer3D<DataT>::operator+=(const DataContainer3D
 }
 
 template <typename DataT>
+DataContainer3D<DataT>& DataContainer3D<DataT>::operator-=(const DataContainer3D<DataT>& other)
+{
+  std::transform(mData.begin(), mData.end(), other.mData.begin(), mData.begin(), std::minus<>());
+  return *this;
+}
+
+template <typename DataT>
 size_t DataContainer3D<DataT>::getIndexZ(size_t index, const int nz, const int nr, const int nphi)
 {
   const size_t iphi = index / (nz * nr);

--- a/Detectors/TPC/spacecharge/src/TriCubic.cxx
+++ b/Detectors/TPC/spacecharge/src/TriCubic.cxx
@@ -82,9 +82,13 @@ DataT TriCubicInterpolator<DataT>::interpolateSparse(const DataT z, const DataT 
   const Vector<DataT, FDim> coordinates{{z, r, phi}};                                                           // vector holding the coordinates
   Vector<DataT, FDim> posRel{(coordinates - mGridProperties->getGridMin()) * mGridProperties->getInvSpacing()}; // needed for the grid index
   posRel[FPHI] = mGridProperties->clampToGridCircularRel(posRel[FPHI], FPHI);
-  const Vector<DataT, FDim> posRelN{posRel};
+  Vector<DataT, FDim> posRelN{posRel};
   posRel[FZ] = mGridProperties->clampToGridRel(posRel[FZ], FZ);
   posRel[FR] = mGridProperties->clampToGridRel(posRel[FR], FR);
+  if (!mExtraPolateValues) {
+    posRelN[FZ] = posRel[FZ];
+    posRelN[FR] = posRel[FR];
+  }
 
   const int nPoints = 4;
   std::array<Vector<DataT, nPoints>, 16> cVals;


### PR DESCRIPTION
- Add restriction of electric field to inner volume of the TPC - This is used when calculating global corrections outside of the volume of the TPC to get a smooth estimate for all vertices
- Add function to simulate misalignment of resistor rods
- Add function to simulate inner field cage charge-up
- Add function to simulate misalignment of ROCs
- Adding several helper functions
- Add function to set global corrections from function