### PR TITLE
Restore setting VDrift as a reference for the CalibLaserTracks

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibLaserTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibLaserTracks.h
@@ -154,6 +154,8 @@ class CalibLaserTracks
   /// name of the debug output tree
   void setDebugOutputName(std::string_view name) { mDebugOutputName = name; }
 
+  void setVDriftRef(float v) { mDriftV = v; }
+
  private:
   int mTriggerPos{0};                                          ///< trigger position, if < 0 it treats it as the CE position
   float mBz{0.5};                                              ///< Bz field in Tesla

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibLaserTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibLaserTracksSpec.h
@@ -25,6 +25,7 @@
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "CommonUtils/NameConf.h"
+#include "TPCCalibration/VDriftHelper.h"
 
 #include "TPCWorkflow/ProcessingHelpers.h"
 
@@ -60,6 +61,7 @@ class CalibLaserTracksDevice : public o2::framework::Task
       LOGP(warning, "CalibLaserTracksDevice::run: No DataProcessingHeader found for \"input\". Only conditions? Skipping event.");
       return;
     }
+    mTPCVDriftHelper.extractCCDBInputs(pc);
     const auto startTime = dph->startTime;
     const auto endTime = dph->startTime + dph->duration;
     mRunNumber = processing_helpers::getRunNumber(pc);
@@ -85,8 +87,20 @@ class CalibLaserTracksDevice : public o2::framework::Task
     sendOutput(ec.outputs());
   }
 
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final
+  {
+    if (mTPCVDriftHelper.accountCCDBInputs(matcher, obj)) {
+      if (mTPCVDriftHelper.isUpdated()) {
+        mTPCVDriftHelper.acknowledgeUpdate();
+        mCalib.setVDriftRef(mTPCVDriftHelper.getVDriftObject().getVDrift());
+      }
+      return;
+    }
+  }
+
  private:
   CalibLaserTracks mCalib;       ///< laser track calibration component
+  o2::tpc::VDriftHelper mTPCVDriftHelper{};
   uint64_t mRunNumber{0};        ///< processed run number
   int mMinNumberTFs{100};        ///< minimum number of TFs required for good calibration
   bool mPublished{false};        ///< if calibration was already published
@@ -145,10 +159,12 @@ DataProcessorSpec getCalibLaserTracks(const std::string inputSpec)
   outputs.emplace_back(ConcreteDataTypeMatcher{"TPC", "LtrCalibData"}, Lifetime::Sporadic);
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TPC_CalibLtr"}, Lifetime::Sporadic);
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TPC_CalibLtr"}, Lifetime::Sporadic);
+  std::vector<InputSpec> inputs = select(inputSpec.data());
+  o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
 
   return DataProcessorSpec{
     "tpc-calib-laser-tracks",
-    select(inputSpec.data()),
+    inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<device>()},
     Options{

--- a/Detectors/TPC/workflow/src/tpc-calib-laser-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calib-laser-tracks.cxx
@@ -16,13 +16,6 @@
 
 using namespace o2::framework;
 
-// customize the completion policy
-void customize(std::vector<o2::framework::CompletionPolicy>& policies)
-{
-  using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-calib-laser-tracks", CompletionPolicy::CompletionOp::Consume));
-}
-
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {

--- a/Detectors/TPC/workflow/src/tpc-laser-track-filter.cxx
+++ b/Detectors/TPC/workflow/src/tpc-laser-track-filter.cxx
@@ -23,13 +23,6 @@ using namespace o2::tpc;
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-// customize the completion policy
-void customize(std::vector<o2::framework::CompletionPolicy>& policies)
-{
-  using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-laser-track-filter", CompletionPolicy::CompletionOp::Consume));
-}
-
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {

--- a/Detectors/TPC/workflow/src/tpc-laser-tracks-calibrator.cxx
+++ b/Detectors/TPC/workflow/src/tpc-laser-tracks-calibrator.cxx
@@ -17,13 +17,6 @@
 
 using namespace o2::framework;
 
-// customize the completion policy
-void customize(std::vector<o2::framework::CompletionPolicy>& policies)
-{
-  using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-laser-tracks-calibrator", CompletionPolicy::CompletionOp::Consume));
-}
-
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {


### PR DESCRIPTION
and remove unnecessary Consume completion policies.

The problem was that few workflows were defining Consume completion policy w/o any need for it (their input is just a vector of tracks) which poses a problem when ccdbInputSpec is added.