### PR TITLE
First step in adding CTP inputs to data model

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -37,11 +37,19 @@ namespace bc
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);          //! Run number
 DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);       //! Bunch crossing number (globally unique in this run)
 DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t); //! CTP trigger mask
+DECLARE_SOA_COLUMN(InputMask, inputMask, uint64_t);     //! CTP input mask
 } // namespace bc
 
-DECLARE_SOA_TABLE(BCs, "AOD", "BC", o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
+DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", 
+                  o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
                   bc::RunNumber, bc::GlobalBC,
                   bc::TriggerMask);
+DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1,
+                  o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
+                  bc::RunNumber, bc::GlobalBC,
+                  bc::TriggerMask, bc::InputMask);
+
+using BCs = BCs_000; // current version
 using BC = BCs::iterator;
 
 namespace timestamp

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -40,8 +40,8 @@ DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t); //! CTP trigger mask
 DECLARE_SOA_COLUMN(InputMask, inputMask, uint64_t);     //! CTP input mask
 } // namespace bc
 
-DECLARE_SOA_TABLE(BCs_000, "AOD", "BC",
-                  o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
+DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", //! Root of data model for tables pointing to a bunch crossing
+                  o2::soa::Index<>,
                   bc::RunNumber, bc::GlobalBC,
                   bc::TriggerMask);
 DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -44,8 +44,8 @@ DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", //! Root of data model for tables pointi
                   o2::soa::Index<>,
                   bc::RunNumber, bc::GlobalBC,
                   bc::TriggerMask);
-DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1,
-                            o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
+DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1, //! Root of data model for tables pointing to a bunch crossing, version 1
+                            o2::soa::Index<>,
                             bc::RunNumber, bc::GlobalBC,
                             bc::TriggerMask, bc::InputMask);
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -40,14 +40,14 @@ DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t); //! CTP trigger mask
 DECLARE_SOA_COLUMN(InputMask, inputMask, uint64_t);     //! CTP input mask
 } // namespace bc
 
-DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", 
+DECLARE_SOA_TABLE(BCs_000, "AOD", "BC",
                   o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
                   bc::RunNumber, bc::GlobalBC,
                   bc::TriggerMask);
 DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1,
-                  o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
-                  bc::RunNumber, bc::GlobalBC,
-                  bc::TriggerMask, bc::InputMask);
+                            o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
+                            bc::RunNumber, bc::GlobalBC,
+                            bc::TriggerMask, bc::InputMask);
 
 using BCs = BCs_000; // current version
 using BC = BCs::iterator;


### PR DESCRIPTION
@lietava this will make it possible to write a converter from BCs_000 to BCs_001, keeping backwards compatibility (the old data will simply have a dummy value for the input mask that is completely empty. I can take care of writing this converter as it is rather simple (but it has to be built against a newer version of O2 so I guess we have to wait a day for the building to catch up). Keeping as draft for now. 

Then we also have to add the input mask saving to the AOD producer. This I don't know how to do but I am hoping that is easy as there might simply be an appropriate getter already somewhere :-) - let's discuss tomorrow morning! 