### PR TITLE
DPL: remove aod-reader when not needed

### DIFF
--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -390,7 +390,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        arrow->updateMessagesDestroyed(totalMessages);
                        auto& stats = ctx.services().get<DataProcessingStats>();
                        stats.updateStats({static_cast<short>(ProcessingStatsId::ARROW_BYTES_DESTROYED), DataProcessingStats::Op::Set, static_cast<int64_t>(arrow->bytesDestroyed())});
-                       stats.updateStats({static_cast<short>(ProcessingStatsId::ARROW_MESSAGES_DESTROYED), DataProcessingStats::Op::Set, static_cast<int64_t>(arrow->messagesDestroyed())}); 
+                       stats.updateStats({static_cast<short>(ProcessingStatsId::ARROW_MESSAGES_DESTROYED), DataProcessingStats::Op::Set, static_cast<int64_t>(arrow->messagesDestroyed())});
                        stats.processCommandQueue(); },
     .driverInit = [](ServiceRegistryRef registry, DeviceConfig const& dc) {
                        auto config = new RateLimitConfig{};

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -504,6 +504,10 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
           return !DataSpecUtils::partialMatch(o, o2::header::DataDescription{"TFNumber"}) && !DataSpecUtils::partialMatch(o, o2::header::DataDescription{"TFFilename"}) && std::none_of(requestedAODs.begin(), requestedAODs.end(), [&](InputSpec const& i) { return DataSpecUtils::match(i, o); });
         });
         reader->outputs.erase(o_end, reader->outputs.end());
+        if (reader->outputs.empty()) {
+          // nothing to read
+          workflow.erase(reader);
+        }
       }
 
       // replace writer as some outputs may have become dangling and some are now consumed

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -514,8 +514,11 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     } else {
       aodReader.algorithm = algo;
     }
-    aodReader.outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
-    aodReader.outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
+    auto mctracks2aod = std::find_if(workflow.begin(), workflow.end(), [](auto const& x) { return x.name == "mctracks-to-aod"; });
+    if (mctracks2aod == workflow.end()) {
+      aodReader.outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
+      aodReader.outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
+    }
     extraSpecs.push_back(timePipeline(aodReader, ctx.options().get<int64_t>("readers")));
     auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);
     timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -518,10 +518,10 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     if (mctracks2aod == workflow.end()) {
       aodReader.outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
       aodReader.outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
+      auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);
+      timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});
     }
     extraSpecs.push_back(timePipeline(aodReader, ctx.options().get<int64_t>("readers")));
-    auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);
-    timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});
   }
 
   ConcreteDataMatcher dstf{"FLP", "DISTSUBTIMEFRAME", 0xccdb};

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -507,20 +507,33 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   // add the reader
   if (aodReader.outputs.empty() == false) {
-
-    auto&& algo = PluginManager::loadAlgorithmFromPlugin("O2FrameworkAnalysisSupport", "ROOTFileReader");
-    if (internalRateLimiting) {
-      aodReader.algorithm = CommonDataProcessors::wrapWithRateLimiting(algo);
-    } else {
-      aodReader.algorithm = algo;
-    }
     auto mctracks2aod = std::find_if(workflow.begin(), workflow.end(), [](auto const& x) { return x.name == "mctracks-to-aod"; });
     if (mctracks2aod == workflow.end()) {
+      // add normal reader
+      auto&& algo = PluginManager::loadAlgorithmFromPlugin("O2FrameworkAnalysisSupport", "ROOTFileReader");
+      if (internalRateLimiting) {
+        aodReader.algorithm = CommonDataProcessors::wrapWithRateLimiting(algo);
+      } else {
+        aodReader.algorithm = algo;
+      }
       aodReader.outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
       aodReader.outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
-      auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);
-      timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});
+    } else {
+      // AODs are being injected on-the-fly, add dummy reader
+      aodReader.algorithm = AlgorithmSpec{
+        adaptStateful(
+          [outputs = aodReader.outputs](DeviceSpec const&) {
+            LOGP(warn, "Workflow with injected AODs has unsatisfied inputs:");
+            for (auto const& output : outputs) {
+              LOGP(warn, "  {}", DataSpecUtils::describe(output));
+            }
+            LOGP(fatal, "Stopping.");
+            // to ensure the output type for adaptStateful
+            return adaptStateless([](DataAllocator&) {});
+          })};
     }
+    auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);
+    timer.outputs.emplace_back(concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration);
     extraSpecs.push_back(timePipeline(aodReader, ctx.options().get<int64_t>("readers")));
   }
 


### PR DESCRIPTION
* when adjusting topology, remove aod-reader from the workflow if its output list is empty
* when the workflow contains mctracks-to-aod, the reader is added with a dummy algorithm that will produce a runtime error if the complete workflow has unsatisfied inputs