### PR TITLE
[do not review, example only] Example AOD producer change

### DIFF
--- a/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
@@ -79,6 +79,7 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
   mCaloEventHandler->setCellData(cellsIn, triggersIn);
 
   uint64_t triggerMask = 1;
+  uint64_t inputMask = 1;
   // loop over events
   for (int iev = 0; iev < mCaloEventHandler->getNumberOfEvents(); iev++) {
     o2::emcal::EventData inputEvent = mCaloEventHandler->buildEvent(iev);
@@ -91,7 +92,8 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
     bcCursor(0,
              runNumber,
              bcID,
-             triggerMask);
+             triggerMask,
+             inputMask);
     auto indexBC = iev;
 
     for (auto& cell : cellsInEvent) {

--- a/Detectors/PHOS/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/PHOS/workflow/src/StandaloneAODProducerSpec.cxx
@@ -75,6 +75,7 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
   auto caloCellsTRGTableCursor = caloCellsTRGTableBuilder->cursor<o2::aod::CaloTriggers>();
 
   uint64_t triggerMask = 1;
+  uint64_t inputMask = 1;
   // loop over events
   int indexBC = -1;
   for (const auto& tr : ctr) {
@@ -112,7 +113,8 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
     bcCursor(0,
              runNumber,
              bcID,
-             triggerMask);
+             triggerMask,
+             inputMask);
 
     // fill collision cursor
     collisionsCursor(0,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -37,11 +37,19 @@ namespace bc
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);          //! Run number
 DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);       //! Bunch crossing number (globally unique in this run)
 DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t); //! CTP trigger mask
+DECLARE_SOA_COLUMN(InputMask, inputMask, uint64_t);     //! CTP input mask
 } // namespace bc
 
-DECLARE_SOA_TABLE(BCs, "AOD", "BC", o2::soa::Index<>, //! Root of data model for tables pointing to a bunch crossing
+DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", //! Root of data model for tables pointing to a bunch crossing
+                  o2::soa::Index<>,
                   bc::RunNumber, bc::GlobalBC,
                   bc::TriggerMask);
+DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1, //! Root of data model for tables pointing to a bunch crossing
+                  o2::soa::Index<>,
+                  bc::RunNumber, bc::GlobalBC,
+                  bc::TriggerMask, bc::InputMask);
+
+using BCs = BCs_001; // current version
 using BC = BCs::iterator;
 
 namespace timestamp


### PR DESCRIPTION
* not to be merged! 
* this example showcases - for the purposes of discussion only - how potential (minimal) changes to the AOD producers could be done to include the inputMasks. Relevant for a discussion with @lietava @jgrosseo @pzhristov 
* Since all ctpdigits are actually stored regardless of classMasks being empty, it should suffice to add inputMasks directly into the logic without further change. 
* incidentally: I am not sure we actually need the std::unordered_map that is currently being used, because the BC table entries are filled in a loop over the map entries that - AFAIK at least - just follows the order in which the BC map was filled, which is the order in which the ctp digits were stored in the first place... 