### PR TITLE
GPU workflow: add possibility to dump bad TPC TFs

### DIFF
--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -468,6 +468,7 @@ AddOption(partialOutputForNonFatalErrors, bool, false, "", 0, "In case of a non-
 AddOption(checkFirstTfOrbit, bool, false, "", 0, "Check consistency of firstTfOrbit")
 AddOption(tpcTriggeredMode, bool, false, "", 0, "In case we have triggered TPC data, this must be set to true")
 AddOption(zsOnTheFlyDigitsFilter, bool, false, "", 0, "Run on the fly digits filter during zs encoding")
+AddOption(dumpBadTFs, int, 0, "", 0, "Number of bad timeframes (with decoding / processing) errors to decode at max")
 EndConfig()
 #endif // GPUCA_O2_LIB
 #endif // !GPUCA_GPUCODE_DEVICE

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -174,6 +174,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   unsigned long mTPCSectorMask = 0;
   int mVerbosity = 0;
   unsigned int mNTFs = 0;
+  unsigned int mNDebugDumps = 0;
   bool mUpdateGainMapCCDB = true;
   std::unique_ptr<o2::gpu::GPUSettingsTF> mTFSettings;
   Config mSpecConfig;

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -379,6 +379,7 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
   gsl::span<const o2::tpc::ZeroSuppressedContainer8kb> inputZS;
 
   bool getWorkflowTPCInput_clusters = false, getWorkflowTPCInput_mc = false, getWorkflowTPCInput_digits = false;
+  bool debugTFDump = false;
 
   // unsigned int totalZSPages = 0;
   if (mSpecConfig.processMC) {
@@ -471,6 +472,7 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     // the sequencer processes all inputs matching the filter and finds sequences of consecutive
     // raw pages based on the matcher predicate, and calls the inserter for each sequence
     if (DPLRawPageSequencer(pc.inputs(), filter)(isSameRdh, insertPages, checkForZSData)) {
+      debugTFDump = true;
       static unsigned int nErrors = 0;
       nErrors++;
       if (nErrors == 1 || (nErrors < 100 && nErrors % 10 == 0) || nErrors % 1000 == 0 || mNTFs % 1000 == 0) {
@@ -700,6 +702,9 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
   int retVal = 0;
   if (mConfParam->dump < 2) {
     retVal = mTracker->RunTracking(&ptrs, &outputRegions);
+    if (retVal != 0) {
+      debugTFDump = true;
+    }
 
     if (retVal == 0 && mSpecConfig.runITSTracking) {
       retVal = runITSTracking(pc);
@@ -713,6 +718,20 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
   storeUpdatedCalibsTPCPtrs();
 
   mTracker->Clear(false);
+
+  if (debugTFDump && mNDebugDumps < mConfParam->dumpBadTFs) {
+    mNDebugDumps++;
+    std::string filename = std::string("tpc_dump_") + std::to_string(pc.services().get<const o2::framework::DeviceSpec>().inputTimesliceId) + "_" + std::to_string(mNDebugDumps) + ".dump";
+    FILE* fp = fopen(filename.c_str(), "w+b");
+    std::vector<InputSpec> filter = {{"check", ConcreteDataTypeMatcher{gDataOriginTPC, "RAWDATA"}, Lifetime::Timeframe}};
+    for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+      auto data = pc.inputs().get<gsl::span<char>>(ref);
+      unsigned long size = data.size();
+      fwrite(&size, 1, sizeof(size), fp);
+      fwrite(data.data(), 1, data.size(), fp);
+    }
+    fclose(fp);
+  }
 
   if (mConfParam->dump == 2) {
     return;


### PR DESCRIPTION
first version, still untested, and want to add a possibility to dump in standalone benchmark format as well, but can come as follow-up PR.