### PR TITLE
ITS-Studies: expand lambda/proton study functionality

### DIFF
--- a/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/AvgClusSize.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/AvgClusSize.h
@@ -17,14 +17,7 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
-#include "Framework/Task.h"
 #include <Steer/MCKinematicsReader.h>
-
-#include "ITSStudies/ITSStudiesConfigParam.h"
-
-#include <TH1F.h>
-#include <THStack.h>
-#include <TNtuple.h>
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/ITSStudiesConfigParam.h
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/include/ITSStudies/ITSStudiesConfigParam.h
@@ -32,17 +32,34 @@ struct ITSCheckTracksParamConfig : public o2::conf::ConfigurableParamHelper<ITSC
 };
 
 struct ITSAvgClusSizeParamConfig : public o2::conf::ConfigurableParamHelper<ITSAvgClusSizeParamConfig> {
+  // Data parameters
+  double b = 5; // Solenoid field in kG (+/-)
 
   // K0s ID cuts
-  float Rmin = 0.5;        // lower limit on V0 decay length
-  float Rmax = 5.4;        // upper limit on V0 decay length
-  float cosPAmin = 0.995;  // lower limit on cosine of pointing angle
-  float prongDCAmax = 0.2; // upper limit on DCA between two daughter prongs
-  float dauPVDCAmin = 0.2; // lower limit on DCA between prong and primary vertex
+  std::string targetV0 = "K0"; // target V0; set as "K0" or "Lambda"
+  float tgV0window = 0.02;     // half-width of mass window for target V0 mass hypothesis testing (GeV)
+  float bgV0window = 0.01;     // half-width of mass window for background V0 mass hypothesis testing (GeV)
+  float Rmin = 0.;             // lower limit on V0 decay length (cm?)
+  float Rmax = 5.4;            // upper limit on V0 decay length (cm?)
+  float cosPAmin = 0.995;      // lower limit on cosine of pointing angle
+  float prongDCAmax = 0.2;     // upper limit on DCA between two daughter prongs (cm?)
+  float dauPVDCAmin = 0.2;     // lower limit on DCA between prong and primary vertex (cm?)
+  float v0PVDCAmax = 0.2;      // upper limit on DCA between V0 and primary vertex (cm?)
+  int dauNClusMin = 0;         // lower limit on number of ITS clusters on daughter tracks TODO: not yet implemented
+
+  // Kinematic cut disable flags, false="leave this cut on"; NOTE: may be a better way to implement this with std::bitset<8>
+  bool disableCosPA = false;
+  bool disableRmin = false;
+  bool disableRmax = false;
+  bool disableProngDCAmax = false;
+  bool disableDauPVDCAmin = false;
+  bool disableV0PVDCAmax = false;
+  bool disableDauNClusmin = false; // TODO: not yet implemented
+  bool disableMassHypoth = true;   // applies to both target and background V0 cuts
 
   // Plotting options
-  bool performFit = false;   // determine if fit to K0s mass spectrum will be done (set to false in the case of low statistics)
-  bool generatePlots = true; // TODO: not yet tested
+  bool generatePlots = true;                                        // flag to generate plots
+  std::string outFileName = "o2standalone_cluster_size_study.root"; // filename for the ROOT output of this study
 
   // Average cluster size plot: eta binning parameters
   float etaMin = -1.5; // lower edge of lowest bin for eta binning on average cluster size

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/AvgClusSize.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/AvgClusSize.cxx
@@ -243,29 +243,6 @@ void AvgClusSizeStudy::prepareOutput()
   mMCArmPodolisTg->SetDirectory(nullptr);
   mMCArmPodolisBg->SetDirectory(nullptr);
 
-  // mMassSpectrumFullNC->SetDirectory(nullptr);
-  // mMassSpectrumFullC->SetDirectory(nullptr);
-  // mMassSpectrumK0sNC->SetDirectory(nullptr);
-  // mMassSpectrumK0sC->SetDirectory(nullptr);
-  // mAvgClusSizeNC->SetDirectory(nullptr);
-  // mAvgClusSizeC->SetDirectory(nullptr);
-  // mCosPA->SetDirectory(nullptr);
-  // mMCCosPAK0->SetDirectory(nullptr);
-  // mMCCosPAnotK0->SetDirectory(nullptr);
-  // mR->SetDirectory(nullptr);
-  // mRK0->SetDirectory(nullptr);
-  // mRnotK0->SetDirectory(nullptr);
-  // mDCA->SetDirectory(nullptr);
-  // mDCAK0->SetDirectory(nullptr);
-  // mDCAnotK0->SetDirectory(nullptr);
-  // mEtaNC->SetDirectory(nullptr);
-  // mEtaC->SetDirectory(nullptr);
-  // mMCMotherPDG->SetDirectory(nullptr);
-  // mPVDCAK0->SetDirectory(nullptr);
-  // mPVDCAnotK0->SetDirectory(nullptr);
-  // mArmPodolNC->SetDirectory(nullptr);
-  // mArmPodolC->SetDirectory(nullptr);
-
   mOutputNtupleAll->SetDirectory(nullptr);
   mOutputNtupleCut->SetDirectory(nullptr);
 
@@ -410,8 +387,6 @@ void AvgClusSizeStudy::process(o2::globaltracking::RecoContainer& recoData)
 
     dPosACS = getAverageClusterSize(&dPosRecoTrk);
     dNegACS = getAverageClusterSize(&dNegRecoTrk);
-    // mAvgClusSizeNC->Fill(dPosACS);
-    // mAvgClusSizeNC->Fill(dNegACS);
 
     tgV0HypoMass = calcV0HypoMass(v0, tgPos, tgNeg);
     bgV0HypoMass = calcV0HypoMass(v0, bgPos, bgNeg);
@@ -484,8 +459,9 @@ void AvgClusSizeStudy::process(o2::globaltracking::RecoContainer& recoData)
       if (eta > params.etaMin && eta < params.etaMax) {
         fillEtaBin(eta, dPosACS, 0);
         fillEtaBin(eta, dNegACS, 0);
-      } else
+      } else {
         nV0OutOfEtaRange++;
+      }
     }
   }
 
@@ -515,7 +491,7 @@ float AvgClusSizeStudy::getAverageClusterSize(TrackITS* daughter)
 
 float AvgClusSizeStudy::calcV0HypoMass(const V0& v0, PID hypothPIDPos, PID hypothPIDNeg)
 {
-  // Taken from StrangenessTracker.h lines 127-141
+  // Mass hypothesis calculation; taken from o2::strangeness_tracking::StrangenessTracker::calcMotherMass()
   std::array<float, 3> pPos, pNeg, pV0;
   v0.getProng(0).getPxPyPzGlo(pPos);
   v0.getProng(1).getPxPyPzGlo(pNeg);
@@ -561,7 +537,7 @@ void AvgClusSizeStudy::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   static bool initOnceDone = false;
-  if (!initOnceDone) { // this params need to be queried only once
+  if (!initOnceDone) { // this param need to be queried only once
     initOnceDone = true;
     o2::its::GeometryTGeo* geom = o2::its::GeometryTGeo::Instance();
     geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot, o2::math_utils::TransformType::T2G));

--- a/Detectors/ITSMFT/ITS/postprocessing/workflow/standalone-postprocessing-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/workflow/standalone-postprocessing-workflow.cxx
@@ -41,6 +41,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"track-study", VariantType::Bool, false, {"Perform the track study"}},
     {"impact-parameter-study", VariantType::Bool, false, {"Perform the impact parameter study"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options, "o2_tfidinfo.root");
   std::swap(workflowOptions, options);
 }
 
@@ -86,6 +87,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     LOGP(info, "No study selected, dryrunning");
   }
 
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
   // write the configuration used for the studies workflow
   o2::conf::ConfigurableParam::writeINI("o2_its_standalone_configuration.ini");
 


### PR DESCRIPTION
PR adds functionality for lambda V0 and proton studies.  It also restructures the study output so different kinematic cuts can be applied without rerunning the full study, and outputs plots that can help refine such cuts.