### PR TITLE
minor fix for TOF noisy in sim

### DIFF
--- a/Detectors/TOF/base/src/CalibTOFapi.cxx
+++ b/Detectors/TOF/base/src/CalibTOFapi.cxx
@@ -171,6 +171,10 @@ void CalibTOFapi::loadDiagnosticFrequencies()
 
     int channel = mDiaFreq->getChannel(key);
     if (channel > -1) { // noisy
+      if (!mDiaFreq->isNoisyChannel(channel, mNoisyThreshold)) {
+        continue;
+      }
+
       int crate = channel / NCH_PER_CRATE;
       float prob = pair.second / (nrow - ncrate[crate]);
       mNoisy.push_back(std::make_pair(channel, prob));


### PR DESCRIPTION
This is a fix to take into account the threshold for noisy (1kHz, 10 kHz, 100 kHz) set in clusterization to be consistent with data (current default -> level 1 -> 10 kHz).
It has not a big impact (< 0.1% in pp) but it should be corrected.