### PR TITLE
Split SVs to index and kinematics parts, run str.tracking from SVertexer

### DIFF
--- a/Common/DCAFitter/CMakeLists.txt
+++ b/Common/DCAFitter/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-#add_compile_options(-O0 -g -fPIC)
+# add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(DCAFitter
                TARGETVARNAME targetName

--- a/Common/DCAFitter/CMakeLists.txt
+++ b/Common/DCAFitter/CMakeLists.txt
@@ -9,6 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+#add_compile_options(-O0 -g -fPIC)
+
 o2_add_library(DCAFitter
                TARGETVARNAME targetName
                SOURCES src/DCAFitterN.cxx

--- a/Common/DCAFitter/include/DCAFitter/DCAFitterN.h
+++ b/Common/DCAFitter/include/DCAFitter/DCAFitterN.h
@@ -112,6 +112,9 @@ class DCAFitterN
     return std::array<float, 3>{float(vd[0]), float(vd[1]), float(vd[2])};
   }
 
+  ///< return position of quality-ordered candidate in the internal structures
+  int getCandidatePosition(int cand = 0) const { return mOrder[cand]; }
+
   ///< return Chi2 at PCA candidate (no check for its validity)
   float getChi2AtPCACandidate(int cand = 0) const { return mChi2[mOrder[cand]]; }
 
@@ -205,6 +208,10 @@ class DCAFitterN
   template <class... Tr>
   int process(const Tr&... args);
   void print() const;
+
+  int getFitterID() const { return mFitterID; }
+  void setFitterID(int i) { mFitterID = i; }
+  size_t getCallID() const { return mCallID; }
 
  protected:
   bool calcPCACoefs();
@@ -326,7 +333,8 @@ class DCAFitterN
   float mMaxDist2ToMergeSeeds = 1.;                                                               // merge 2 seeds to their average if their distance^2 is below the threshold
   float mMaxSnp = 0.95;                                                                           // Max snp for propagation with Propagator
   float mMaxStep = 2.0;                                                                           // Max step for propagation with Propagator
-
+  int mFitterID = 0;                                                                              // locat fitter ID (mostly for debugging)
+  size_t mCallID = 0;
   ClassDefNV(DCAFitterN, 1);
 };
 
@@ -336,6 +344,7 @@ template <class... Tr>
 int DCAFitterN<N, Args...>::process(const Tr&... args)
 {
   // This is a main entry point: fit PCA of N tracks
+  mCallID++;
   static_assert(sizeof...(args) == N, "incorrect number of input tracks");
   assign(0, args...);
   clear();
@@ -392,7 +401,6 @@ int DCAFitterN<N, Args...>::process(const Tr&... args)
       recalculatePCAWithErrors(i);
     }
   }
-
   return mCurHyp;
 }
 

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -19,7 +19,7 @@
 #include "CommonDataFormat/InteractionRecord.h"
 #include "ReconstructionDataFormats/GlobalTrackAccessor.h"
 #include "CommonDataFormat/RangeReference.h"
-#include "ReconstructionDataFormats/DecayNbody.h"
+#include "ReconstructionDataFormats/Decay3Body.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "ReconstructionDataFormats/MatchingType.h"
 #include "CommonDataFormat/AbstractRefAccessor.h"
@@ -163,7 +163,11 @@ class PrimaryVertex;
 class VtxTrackIndex;
 class VtxTrackRef;
 class V0;
+class V0Index;
 class Cascade;
+class CascadeIndex;
+class Decay3Body;
+class Decay3BodyIndex;
 class StrangeTrack;
 class TrackCosmics;
 class GlobalFwdTrack;
@@ -280,10 +284,13 @@ struct RecoContainer {
                    NPVTXSLOTS };
 
   // slots to register secondary vertex data
-  enum SVTXSlots { V0S,            // V0 objects
+  enum SVTXSlots { V0SIDX,         // V0s indices
+                   V0S,            // V0 objects
                    PVTX_V0REFS,    // PV -> V0 references
+                   CASCSIDX,       // Cascade indices
                    CASCS,          // Cascade objects
                    PVTX_CASCREFS,  // PV -> Cascade reference
+                   DECAY3BODYIDX,  // 3-body decay indices
                    DECAY3BODY,     // 3-body decay objects
                    PVTX_3BODYREFS, // PV -> 3-body decay references
                    NSVTXSLOTS };
@@ -674,13 +681,21 @@ struct RecoContainer {
   auto getPrimaryVertexMCLabels() const { return pvtxPool.getSpan<o2::MCEventLabel>(PVTX_MCTR); }
 
   // Secondary vertices
+  const o2::dataformats::V0Index& getV0Idx(int i) const { return svtxPool.get_as<o2::dataformats::V0Index>(V0SIDX, i); }
   const o2::dataformats::V0& getV0(int i) const { return svtxPool.get_as<o2::dataformats::V0>(V0S, i); }
+  const o2::dataformats::CascadeIndex& getCascadeIdx(int i) const { return svtxPool.get_as<o2::dataformats::CascadeIndex>(CASCSIDX, i); }
   const o2::dataformats::Cascade& getCascade(int i) const { return svtxPool.get_as<o2::dataformats::Cascade>(CASCS, i); }
+
+  auto getV0sIdx() const { return svtxPool.getSpan<o2::dataformats::V0Index>(V0SIDX); }
   auto getV0s() const { return svtxPool.getSpan<o2::dataformats::V0>(V0S); }
   auto getPV2V0Refs() { return svtxPool.getSpan<o2::dataformats::RangeReference<int, int>>(PVTX_V0REFS); }
+
+  auto getCascadesIdx() const { return svtxPool.getSpan<o2::dataformats::CascadeIndex>(CASCSIDX); }
   auto getCascades() const { return svtxPool.getSpan<o2::dataformats::Cascade>(CASCS); }
   auto getPV2CascadesRefs() { return svtxPool.getSpan<o2::dataformats::RangeReference<int, int>>(PVTX_CASCREFS); }
-  auto getDecays3Body() const { return svtxPool.getSpan<o2::dataformats::DecayNbody>(DECAY3BODY); }
+
+  auto getDecays3BodyIdx() const { return svtxPool.getSpan<o2::dataformats::Decay3BodyIndex>(DECAY3BODYIDX); }
+  auto getDecays3Body() const { return svtxPool.getSpan<o2::dataformats::Decay3Body>(DECAY3BODY); }
   auto getPV2Decays3BodyRefs() { return svtxPool.getSpan<o2::dataformats::RangeReference<int, int>>(PVTX_3BODYREFS); }
 
   // Strangeness track

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -23,9 +23,10 @@
 #include "ReconstructionDataFormats/VtxTrackRef.h"
 #include "ReconstructionDataFormats/PrimaryVertex.h"
 #include "SimulationDataFormat/MCEventLabel.h"
+#include "ReconstructionDataFormats/DecayNBodyIndex.h"
 #include "ReconstructionDataFormats/V0.h"
 #include "ReconstructionDataFormats/Cascade.h"
-#include "ReconstructionDataFormats/DecayNbody.h"
+#include "ReconstructionDataFormats/Decay3Body.h"
 #include "ReconstructionDataFormats/StrangeTrack.h"
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
@@ -392,10 +393,13 @@ void DataRequest::requestPrimaryVerterticesTMP(bool mc) // primary vertices befo
 
 void DataRequest::requestSecondaryVertices(bool)
 {
+  addInput({"v0sIdx", "GLO", "V0S_IDX", 0, Lifetime::Timeframe});
   addInput({"v0s", "GLO", "V0S", 0, Lifetime::Timeframe});
   addInput({"p2v0s", "GLO", "PVTX_V0REFS", 0, Lifetime::Timeframe});
+  addInput({"cascsIdx", "GLO", "CASCS_IDX", 0, Lifetime::Timeframe});
   addInput({"cascs", "GLO", "CASCS", 0, Lifetime::Timeframe});
   addInput({"p2cascs", "GLO", "PVTX_CASCREFS", 0, Lifetime::Timeframe});
+  addInput({"decay3bodyIdx", "GLO", "DECAYS3BODY_IDX", 0, Lifetime::Timeframe});
   addInput({"decay3body", "GLO", "DECAYS3BODY", 0, Lifetime::Timeframe});
   addInput({"p2decay3body", "GLO", "PVTX_3BODYREFS", 0, Lifetime::Timeframe});
   requestMap["SVertex"] = false; // no MC provided for secondary vertices
@@ -771,11 +775,14 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
 //____________________________________________________________
 void RecoContainer::addSVertices(ProcessingContext& pc, bool)
 {
+  svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::V0Index>>("v0sIdx"), V0SIDX);
   svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::V0>>("v0s"), V0S);
   svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::RangeReference<int, int>>>("p2v0s"), PVTX_V0REFS);
+  svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::CascadeIndex>>("cascsIdx"), CASCSIDX);
   svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::Cascade>>("cascs"), CASCS);
   svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::RangeReference<int, int>>>("p2cascs"), PVTX_CASCREFS);
-  svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::DecayNbody>>("decay3body"), DECAY3BODY);
+  svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::Decay3BodyIndex>>("decay3bodyIdx"), DECAY3BODYIDX);
+  svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::Decay3Body>>("decay3body"), DECAY3BODY);
   svtxPool.registerContainer(pc.inputs().get<gsl::span<o2::dataformats::RangeReference<int, int>>>("p2decay3body"), PVTX_3BODYREFS);
   // no mc
 }

--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -99,8 +99,8 @@ class TrackITS : public o2::track::TrackParCov
 
   void setPattern(uint32_t p) { mPattern = p; }
   uint32_t getPattern() const { return mPattern; }
-  bool hasHitOnLayer(int i) { return mPattern & (0x1 << i); }
-  bool isFakeOnLayer(int i) { return !(mPattern & (0x1 << (16 + i))); }
+  bool hasHitOnLayer(int i) const { return mPattern & (0x1 << i); }
+  bool isFakeOnLayer(int i) const { return !(mPattern & (0x1 << (16 + i))); }
   uint32_t getLastClusterLayer() const
   {
     uint32_t r{0}, v{mPattern & ((1 << 16) - 1)};

--- a/DataFormats/Reconstruction/CMakeLists.txt
+++ b/DataFormats/Reconstruction/CMakeLists.txt
@@ -24,7 +24,8 @@ o2_add_library(ReconstructionDataFormats
                        src/DCA.cxx
                        src/V0.cxx
                        src/Cascade.cxx
-                       src/DecayNbody.cxx
+                       src/Decay3Body.cxx
+                       src/DecayNBodyIndex.cxx
                        src/StrangeTrack.cxx
                        src/GlobalTrackID.cxx
                        src/VtxTrackIndex.cxx
@@ -57,7 +58,8 @@ o2_target_root_dictionary(
           include/ReconstructionDataFormats/DCA.h
           include/ReconstructionDataFormats/V0.h
           include/ReconstructionDataFormats/Cascade.h
-          include/ReconstructionDataFormats/DecayNbody.h
+          include/ReconstructionDataFormats/DecayNBodyIndex.h
+          include/ReconstructionDataFormats/Decay3Body.h
           include/ReconstructionDataFormats/StrangeTrack.h
           include/ReconstructionDataFormats/GlobalTrackID.h
           include/ReconstructionDataFormats/VtxTrackIndex.h

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Cascade.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Cascade.h
@@ -27,6 +27,7 @@ namespace dataformats
 class Cascade : public V0
 {
  public:
+  using V0::V0;
   Cascade() = default;
   Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, // RS Remove after dropping indices in O2Physics
           const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
@@ -36,7 +37,7 @@ class Cascade : public V0
 
   Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
           const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
-          o2::track::PID pid = o2::track::PID::XiMinus);
+          o2::track::PID pid = o2::track::PID::XiMinus) : V0(xyz, pxyz, covxyz, v0, bachelor, pid) {}
 
   const Track& getV0Track() const { return mProngs[0]; }
   Track& getV0Track() { return mProngs[0]; }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Cascade.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Cascade.h
@@ -28,15 +28,15 @@ class Cascade : public V0
 {
  public:
   Cascade() = default;
+  Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, // RS Remove after dropping indices in O2Physics
+          const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
+          int v0ID, GIndex bachelorID, o2::track::PID pid = o2::track::PID::XiMinus) : Cascade(xyz, pxyz, covxyz, v0, bachelor, pid)
+  {
+  }
+
   Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
           const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
-          int v0ID, GIndex bachelorID, o2::track::PID pid = o2::track::PID::XiMinus);
-
-  GIndex getBachelorID() const { return mProngIDs[1]; }
-  void setBachelorID(GIndex gid) { mProngIDs[1] = gid; }
-
-  int getV0ID() const { return int(mProngIDs[0].getRaw()); }
-  void setV0ID(int vid) { mProngIDs[0].setRaw(GIndex::Base_t(vid)); }
+          o2::track::PID pid = o2::track::PID::XiMinus);
 
   const Track& getV0Track() const { return mProngs[0]; }
   Track& getV0Track() { return mProngs[0]; }
@@ -47,10 +47,7 @@ class Cascade : public V0
   void setV0Track(const Track& t) { mProngs[0] = t; }
   void setBachelorTrack(const Track& t) { mProngs[1] = t; }
 
- protected:
-  GIndex getProngID(int i) const = delete;
-
-  ClassDefNV(Cascade, 1);
+  ClassDefNV(Cascade, 2);
 };
 
 } // namespace dataformats

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Decay3Body.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Decay3Body.h
@@ -9,10 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef ALICEO2_NBODY_H
-#define ALICEO2_NBODY_H
+#ifndef ALICEO2_3BODY_H
+#define ALICEO2_3BODY_H
 
-#include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/PID.h"
 #include <array>
@@ -23,18 +22,14 @@ namespace o2
 namespace dataformats
 {
 
-class DecayNbody : public o2::track::TrackParCov /// TO BE DONE: extend to generic N body vertex
+class Decay3Body : public o2::track::TrackParCov /// TO BE DONE: extend to generic N body vertex
 {
  public:
-  using GIndex = o2::dataformats::VtxTrackIndex;
   using Track = o2::track::TrackParCov;
   using PID = o2::track::PID;
 
-  DecayNbody() = default;
-  DecayNbody(PID pid, const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2, GIndex trID0, GIndex trID1, GIndex trID2);
-
-  GIndex getProngID(int i) const { return mProngIDs[i]; }
-  void setProngID(int i, GIndex gid) { mProngIDs[i] = gid; }
+  Decay3Body() = default;
+  Decay3Body(PID pid, const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2);
 
   const Track& getProng(int i) const { return mProngs[i]; }
   Track& getProng(int i) { return mProngs[i]; }
@@ -46,9 +41,6 @@ class DecayNbody : public o2::track::TrackParCov /// TO BE DONE: extend to gener
   float getDCA() const { return mDCA; }
   void setDCA(float d) { mDCA = d; }
 
-  int getVertexID() const { return mVertexID; }
-  void setVertexID(int id) { mVertexID = id; }
-
   float calcMass2() const { return calcMass2(mProngs[0].getPID(), mProngs[1].getPID(), mProngs[2].getPID()); }
   float calcMass2(PID pid0, PID pid1, PID pid2) const { return calcMass2(pid0.getMass2(), pid1.getMass2(), pid2.getMass2()); }
   float calcMass2(float mass0, float mass1, float mass2) const;
@@ -56,13 +48,11 @@ class DecayNbody : public o2::track::TrackParCov /// TO BE DONE: extend to gener
   float calcR2() const { return getX() * getX() + getY() * getY(); }
 
  protected:
-  std::array<GIndex, 3> mProngIDs; // global IDs of prongs
-  std::array<Track, 3> mProngs;    // prongs kinematics at vertex
-  float mCosPA = 0;                // cos of pointing angle
-  float mDCA = 9990;               // distance of closest approach of prongs
-  int mVertexID = -1;              // id of parent vertex
+  std::array<Track, 3> mProngs; // prongs kinematics at vertex
+  float mCosPA = 0;             // cos of pointing angle
+  float mDCA = 9990;            // distance of closest approach of prongs
 
-  ClassDefNV(DecayNbody, 1);
+  ClassDefNV(Decay3Body, 1);
 };
 
 } // namespace dataformats

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DecayNBodyIndex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DecayNBodyIndex.h
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_NBODY_INDEX_H
+#define ALICEO2_NBODY_INDEX_H
+
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
+
+namespace o2::dataformats
+{
+
+template <int N>
+class DecayNBodyIndex
+{
+ public:
+  using GIndex = o2::dataformats::VtxTrackIndex;
+  DecayNBodyIndex() = default;
+  DecayNBodyIndex(int v, const std::array<GIndex, N>& arr) : mVertexID(v), mProngIDs(arr) {}
+  DecayNBodyIndex(int v, std::initializer_list<GIndex> l) : mVertexID(v)
+  {
+    assert(l.size() == N);
+    int i = 0;
+    for (auto e : l) {
+      mProngIDs[i++] = e;
+    }
+  }
+  GIndex getProngID(int i) const { return mProngIDs[i]; }
+  void setProngID(int i, GIndex gid) { mProngIDs[i] = gid; }
+  int getVertexID() const { return mVertexID; }
+  void setVertexID(int id) { mVertexID = id; }
+  const std::array<GIndex, N>& getProngs() const { return mProngIDs; }
+  static constexpr int getNProngs() { return N; }
+
+ protected:
+  int mVertexID = -1;                // id of parent vertex
+  std::array<GIndex, N> mProngIDs{}; // global IDs of prongs
+  ClassDefNV(DecayNBodyIndex, 1);
+};
+
+class V0Index : public DecayNBodyIndex<2>
+{
+ public:
+  using DecayNBodyIndex<2>::DecayNBodyIndex;
+  V0Index(int v, GIndex p, GIndex n) : DecayNBodyIndex<2>(v, {p, n}) {}
+  ClassDefNV(V0Index, 1);
+};
+
+class Decay3BodyIndex : public DecayNBodyIndex<3>
+{
+ public:
+  using DecayNBodyIndex<3>::DecayNBodyIndex;
+  Decay3BodyIndex(int v, GIndex p0, GIndex p1, GIndex p2) : DecayNBodyIndex<3>(v, {p0, p1, p2}) {}
+  ClassDefNV(Decay3BodyIndex, 1);
+};
+
+class CascadeIndex
+{
+ public:
+  using GIndex = o2::dataformats::VtxTrackIndex;
+  CascadeIndex() = default;
+  CascadeIndex(int v, int v0id, GIndex bachelorID) : mVertexID(v), mV0ID(v0id), mBach(bachelorID) {}
+
+  GIndex getBachelorID() const { return mBach; }
+  void setBachelorID(GIndex gid) { mBach = gid; }
+
+  int getV0ID() const { return mV0ID; }
+  void setV0ID(int vid) { mV0ID = vid; }
+
+  int getVertexID() const { return mVertexID; }
+  void setVertexID(int id) { mVertexID = id; }
+
+ protected:
+  int mVertexID = -1;
+  int mV0ID = -1;
+  GIndex mBach{};
+
+  ClassDefNV(CascadeIndex, 1);
+};
+
+} // namespace o2::dataformats
+
+#endif

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/V0.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/V0.h
@@ -15,6 +15,7 @@
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/PID.h"
+#include "ReconstructionDataFormats/DecayNBodyIndex.h" // RS Remove after dropping indices in O2Physics
 #include <array>
 #include <Math/SVector.h>
 
@@ -31,12 +32,14 @@ class V0 : public o2::track::TrackParCov
   using PID = o2::track::PID;
 
   V0() = default;
-  V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
+  V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, // RS Remove after dropping indices in O2Physics
      const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg,
-     GIndex trPosID, GIndex trNegID, o2::track::PID pid = o2::track::PID::K0);
+     GIndex trPosID, GIndex trNegID, o2::track::PID pid = o2::track::PID::K0) : V0(xyz, pxyz, covxyz, trPos, trNeg, pid)
+  {
+  }
 
-  GIndex getProngID(int i) const { return mProngIDs[i]; }
-  void setProngID(int i, GIndex gid) { mProngIDs[i] = gid; }
+  V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
+     const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg, o2::track::PID pid = o2::track::PID::K0);
 
   const Track& getProng(int i) const { return mProngs[i]; }
   Track& getProng(int i) { return mProngs[i]; }
@@ -48,9 +51,6 @@ class V0 : public o2::track::TrackParCov
   float getDCA() const { return mDCA; }
   void setDCA(float d) { mDCA = d; }
 
-  int getVertexID() const { return mVertexID; }
-  void setVertexID(int id) { mVertexID = id; }
-
   float calcMass2() const { return calcMass2(mProngs[0].getPID(), mProngs[1].getPID()); }
   float calcMass2(PID pidPos, PID pidNeg) const { return calcMass2(pidPos.getMass2(), pidNeg.getMass2()); }
   float calcMass2(float massPos2, float massNeg2) const;
@@ -58,13 +58,11 @@ class V0 : public o2::track::TrackParCov
   float calcR2() const { return getX() * getX() + getY() * getY(); }
 
  protected:
-  std::array<GIndex, 2> mProngIDs; // global IDs of prongs
   std::array<Track, 2> mProngs;    // prongs kinematics at vertex
   float mCosPA = 0;                // cos of pointing angle
   float mDCA = 9990;               // distance of closest approach of prongs
-  int mVertexID = -1;              // id of parent vertex
 
-  ClassDefNV(V0, 1);
+  ClassDefNV(V0, 2);
 };
 
 } // namespace dataformats

--- a/DataFormats/Reconstruction/src/Cascade.cxx
+++ b/DataFormats/Reconstruction/src/Cascade.cxx
@@ -12,9 +12,9 @@
 #include "ReconstructionDataFormats/Cascade.h"
 
 using namespace o2::dataformats;
-
+/*
 Cascade::Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
-                 const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor, o2::track::PID pid)
+                 const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor, o2::track::PID pid) : mProngs{v0, bachelor}
 {
   std::array<float, 21> covC{0.}, covV{}, covB{};
   v0.getCovXYZPxPyPzGlo(covV);
@@ -29,3 +29,4 @@ Cascade::Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& px
   setV0Track(v0);
   setBachelorTrack(bachelor);
 }
+*/

--- a/DataFormats/Reconstruction/src/Cascade.cxx
+++ b/DataFormats/Reconstruction/src/Cascade.cxx
@@ -14,8 +14,7 @@
 using namespace o2::dataformats;
 
 Cascade::Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
-                 const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
-                 int v0ID, GIndex bachelorID, o2::track::PID pid)
+                 const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor, o2::track::PID pid)
 {
   std::array<float, 21> covC{0.}, covV{}, covB{};
   v0.getCovXYZPxPyPzGlo(covV);
@@ -27,8 +26,6 @@ Cascade::Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& px
   }
   this->set(xyz, pxyz, covC, v0.getCharge() + bachelor.getCharge(), true, pid);
   this->checkCorrelations();
-  setV0ID(v0ID);
-  setBachelorID(bachelorID);
   setV0Track(v0);
   setBachelorTrack(bachelor);
 }

--- a/DataFormats/Reconstruction/src/Decay3Body.cxx
+++ b/DataFormats/Reconstruction/src/Decay3Body.cxx
@@ -9,12 +9,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "ReconstructionDataFormats/DecayNbody.h"
+#include "ReconstructionDataFormats/Decay3Body.h"
 
 using namespace o2::dataformats;
 
-DecayNbody::DecayNbody(PID pid, const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2, GIndex trID0, GIndex trID1, GIndex trID2)
-  : mProngIDs{trID0, trID1, trID2}, mProngs{tr0, tr1, tr2}
+Decay3Body::Decay3Body(PID pid, const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2)
+  : mProngs{tr0, tr1, tr2}
 {
   std::array<float, 21> cov{}, cov1{}, cov2{};
   tr0.getCovXYZPxPyPzGlo(cov);
@@ -29,7 +29,7 @@ DecayNbody::DecayNbody(PID pid, const std::array<float, 3>& xyz, const std::arra
   this->set(xyz, pxyz, cov, tr0.getCharge() + tr1.getCharge() + tr2.getCharge(), true, pid);
 }
 
-float DecayNbody::calcMass2(float mass0, float mass1, float mass2) const
+float Decay3Body::calcMass2(float mass0, float mass1, float mass2) const
 {
   auto p2 = getP2();
   auto energy = std::sqrt(mass0 + mProngs[0].getP2()) + std::sqrt(mass1 + mProngs[1].getP2()) + std::sqrt(mass1 + mProngs[2].getP2());

--- a/DataFormats/Reconstruction/src/DecayNBodyIndex.cxx
+++ b/DataFormats/Reconstruction/src/DecayNBodyIndex.cxx
@@ -9,24 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_SECONDARY_VERTEXER_SPEC_H
-#define O2_SECONDARY_VERTEXER_SPEC_H
+#include "ReconstructionDataFormats/DecayNBodyIndex.h"
 
-/// @file SecondaryVertexingSpec.h
-
-#include "ReconstructionDataFormats/GlobalTrackID.h"
-#include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-
-namespace o2
+namespace o2::dataformats
 {
-namespace vertexing
-{
-
-/// create a processor spec
-o2::framework::DataProcessorSpec getSecondaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool enableCasc, bool enable3body, bool enableStrangenesTracking, bool useMC);
-
-} // namespace vertexing
-} // namespace o2
-
-#endif
+template class DecayNBodyIndex<2>;
+template class DecayNBodyIndex<3>;
+} // namespace o2::dataformats

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -90,14 +90,26 @@
 
 #pragma link C++ class o2::dataformats::DCA + ;
 
+#pragma link C++ class o2::dataformats::DecayNBodyIndex < 2> + ;
+#pragma link C++ class o2::dataformats::DecayNBodyIndex < 3> + ;
+#pragma link C++ class o2::dataformats::Decay3BodyIndex + ;
+#pragma link C++ class o2::dataformats::V0Index + ;
+#pragma link C++ class o2::dataformats::CascadeIndex + ;
+
+#pragma link C++ class std::vector < o2::dataformats::DecayNBodyIndex < 2>> + ;
+#pragma link C++ class std::vector < o2::dataformats::DecayNBodyIndex < 3>> + ;
+#pragma link C++ class std::vector < o2::dataformats::Decay3BodyIndex> + ;
+#pragma link C++ class std::vector < o2::dataformats::V0Index> + ;
+#pragma link C++ class std::vector < o2::dataformats::CascadeIndex> + ;
+
 #pragma link C++ class o2::dataformats::V0 + ;
 #pragma link C++ class std::vector < o2::dataformats::V0> + ;
 
 #pragma link C++ class o2::dataformats::Cascade + ;
 #pragma link C++ class std::vector < o2::dataformats::Cascade> + ;
 
-#pragma link C++ class o2::dataformats::DecayNbody + ;
-#pragma link C++ class std::vector < o2::dataformats::DecayNbody> + ;
+#pragma link C++ class o2::dataformats::Decay3Body + ;
+#pragma link C++ class std::vector < o2::dataformats::Decay3Body> + ;
 
 #pragma link C++ class o2::dataformats::StrangeTrack + ;
 #pragma link C++ class std::vector < o2::dataformats::StrangeTrack> + ;

--- a/DataFormats/Reconstruction/src/V0.cxx
+++ b/DataFormats/Reconstruction/src/V0.cxx
@@ -14,7 +14,7 @@
 using namespace o2::dataformats;
 
 V0::V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
-       const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg, o2::track::PID pid)
+       const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg, o2::track::PID pid) : mProngs{trPos, trNeg}
 {
   std::array<float, 21> covV{0.}, covP, covN;
   trPos.getCovXYZPxPyPzGlo(covP);

--- a/DataFormats/Reconstruction/src/V0.cxx
+++ b/DataFormats/Reconstruction/src/V0.cxx
@@ -14,9 +14,7 @@
 using namespace o2::dataformats;
 
 V0::V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
-       const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg,
-       GIndex trPosID, GIndex trNegID, o2::track::PID pid)
-  : mProngIDs{trPosID, trNegID}, mProngs{trPos, trNeg}
+       const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg, o2::track::PID pid)
 {
   std::array<float, 21> covV{0.}, covP, covN;
   trPos.getCovXYZPxPyPzGlo(covP);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1138,9 +1138,9 @@ template <typename V0CursorType, typename CascadeCursorType, typename Decay3Body
 void AODProducerWorkflowDPL::fillSecondaryVertices(const o2::globaltracking::RecoContainer& recoData, V0CursorType& v0Cursor, CascadeCursorType& cascadeCursor, Decay3BodyCursorType& decay3BodyCursor)
 {
 
-  auto v0s = recoData.getV0s();
-  auto cascades = recoData.getCascades();
-  auto decays3Body = recoData.getDecays3Body();
+  auto v0s = recoData.getV0sIdx();
+  auto cascades = recoData.getCascadesIdx();
+  auto decays3Body = recoData.getDecays3BodyIdx();
 
   v0Cursor.reserve(v0s.size());
   // filling v0s table
@@ -1234,9 +1234,9 @@ void AODProducerWorkflowDPL::fillSecondaryVertices(const o2::globaltracking::Rec
 
 void AODProducerWorkflowDPL::prepareStrangenessTracking(const o2::globaltracking::RecoContainer& recoData)
 {
-  auto v0s = recoData.getV0s();
-  auto cascades = recoData.getCascades();
-  auto decays3Body = recoData.getDecays3Body();
+  auto v0s = recoData.getV0sIdx();
+  auto cascades = recoData.getCascadesIdx();
+  auto decays3Body = recoData.getDecays3BodyIdx();
 
   int sTrkID = 0;
   mCollisionStrTrk.clear();
@@ -1995,9 +1995,9 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   mGIDToTableMFTID.clear();
 
   if (mPropTracks) {
-    auto v0s = recoData.getV0s();
-    auto cascades = recoData.getCascades();
-    auto decays3Body = recoData.getDecays3Body();
+    auto v0s = recoData.getV0sIdx();
+    auto cascades = recoData.getCascadesIdx();
+    auto decays3Body = recoData.getDecays3BodyIdx();
     mGIDUsedBySVtx.reserve(v0s.size() * 2 + cascades.size() + decays3Body.size() * 3);
     for (const auto& v0 : v0s) {
       mGIDUsedBySVtx.insert(v0.getProngID(0));

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -11,6 +11,8 @@
 
 # FIXME: do we actually need a library here, or is the executable enough ?
 
+#add_compile_options(-O0 -g -fPIC)
+
 o2_add_library(GlobalTrackingWorkflow
                SOURCES src/TrackWriterTPCITSSpec.cxx
                        src/TPCITSMatchingSpec.cxx

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 # FIXME: do we actually need a library here, or is the executable enough ?
 
-#add_compile_options(-O0 -g -fPIC)
+# add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(GlobalTrackingWorkflow
                SOURCES src/TrackWriterTPCITSSpec.cxx

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexWriterSpec.cxx
@@ -19,7 +19,7 @@
 #include "CommonDataFormat/RangeReference.h"
 #include "ReconstructionDataFormats/V0.h"
 #include "ReconstructionDataFormats/Cascade.h"
-#include "ReconstructionDataFormats/DecayNbody.h"
+#include "ReconstructionDataFormats/Decay3Body.h"
 
 using namespace o2::framework;
 
@@ -29,8 +29,11 @@ namespace vertexing
 {
 using RRef = o2::dataformats::RangeReference<int, int>;
 using V0 = o2::dataformats::V0;
+using V0Index = o2::dataformats::V0Index;
 using Cascade = o2::dataformats::Cascade;
-using DecayNbody = o2::dataformats::DecayNbody;
+using CascadeIndex = o2::dataformats::CascadeIndex;
+using Decay3Body = o2::dataformats::Decay3Body;
+using Decay3BodyIndex = o2::dataformats::Decay3BodyIndex;
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
@@ -39,34 +42,42 @@ using namespace o2::header;
 
 DataProcessorSpec getSecondaryVertexWriterSpec()
 {
-  auto loggerV = [](std::vector<V0> const& v) {
+  auto loggerV = [](std::vector<V0Index> const& v) {
     LOG(info) << "SecondaryVertexWriter pulled " << v.size() << " v0s";
   };
 
-  auto loggerC = [](std::vector<Cascade> const& v) {
+  auto loggerC = [](std::vector<CascadeIndex> const& v) {
     LOG(info) << "SecondaryVertexWriter pulled " << v.size() << " cascades";
   };
 
-  auto loggerD = [](std::vector<DecayNbody> const& v) {
+  auto loggerD = [](std::vector<Decay3BodyIndex> const& v) {
     LOG(info) << "SecondaryVertexWriter pulled " << v.size() << " decays3body";
   };
 
-  auto inpV0ID = InputSpec{"v0s", "GLO", "V0S", 0};
-  auto inpV0RefID = InputSpec{"pv2v0ref", "GLO", "PVTX_V0REFS", 0};
-  auto inpCascID = InputSpec{"cascs", "GLO", "CASCS", 0};
-  auto inpCascRefID = InputSpec{"pv2cascref", "GLO", "PVTX_CASCREFS", 0};
-  auto inp3BodyID = InputSpec{"decays3body", "GLO", "DECAYS3BODY", 0};
-  auto inp3BodyRefID = InputSpec{"pv23bodyref", "GLO", "PVTX_3BODYREFS", 0};
+  auto inpV0 = InputSpec{"v0s", "GLO", "V0S", 0};
+  auto inpV0ID = InputSpec{"v0sIdx", "GLO", "V0S_IDX", 0};
+  auto inpV0Ref = InputSpec{"pv2v0ref", "GLO", "PVTX_V0REFS", 0};
+  auto inpCasc = InputSpec{"cascs", "GLO", "CASCS", 0};
+  auto inpCascID = InputSpec{"cascsIdx", "GLO", "CASCS_IDX", 0};
+  auto inpCascRef = InputSpec{"pv2cascref", "GLO", "PVTX_CASCREFS", 0};
+  auto inp3Body = InputSpec{"decays3body", "GLO", "DECAYS3BODY", 0};
+  auto inp3BodyID = InputSpec{"decays3bodyIdx", "GLO", "DECAYS3BODY_IDX", 0};
+  auto inp3BodyRef = InputSpec{"pv23bodyref", "GLO", "PVTX_3BODYREFS", 0};
 
   return MakeRootTreeWriterSpec("secondary-vertex-writer",
                                 "o2_secondary_vertex.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with Secondary Vertices"},
-                                BranchDefinition<std::vector<V0>>{inpV0ID, "V0s", loggerV},
-                                BranchDefinition<std::vector<RRef>>{inpV0RefID, "PV2V0Refs"},
-                                BranchDefinition<std::vector<Cascade>>{inpCascID, "Cascades", loggerC},
-                                BranchDefinition<std::vector<RRef>>{inpCascRefID, "PV2CascRefs"},
-                                BranchDefinition<std::vector<DecayNbody>>{inp3BodyID, "Decays3Body", loggerD},
-                                BranchDefinition<std::vector<RRef>>{inp3BodyRefID, "PV23BodyRefs"})();
+                                BranchDefinition<std::vector<V0Index>>{inpV0ID, "V0sID", loggerV},
+                                BranchDefinition<std::vector<V0>>{inpV0, "V0s"},
+                                BranchDefinition<std::vector<RRef>>{inpV0Ref, "PV2V0Refs"},
+
+                                BranchDefinition<std::vector<CascadeIndex>>{inpCascID, "CascadesID", loggerC},
+                                BranchDefinition<std::vector<Cascade>>{inpCasc, "Cascades"},
+                                BranchDefinition<std::vector<RRef>>{inpCascRef, "PV2CascRefs"},
+
+                                BranchDefinition<std::vector<Decay3BodyIndex>>{inp3BodyID, "Decays3BodyID", loggerD},
+                                BranchDefinition<std::vector<Decay3Body>>{inp3Body, "Decays3Body"},
+                                BranchDefinition<std::vector<RRef>>{inp3BodyRef, "PV23BodyRefs"})();
 }
 
 } // namespace vertexing

--- a/Detectors/StrangenessTracking/tracking/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/tracking/CMakeLists.txt
@@ -9,6 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+#add_compile_options(-O0 -g -fPIC)
+
 o2_add_library(StrangenessTracking
                SOURCES src/StrangenessTracker.cxx
                        src/StrangenessTrackingConfigParam.cxx
@@ -16,11 +18,12 @@ o2_add_library(StrangenessTracking
                                              O2::ITSBase
                                              O2::ITSMFTReconstruction
                                              O2::ITSMFTSimulation
+                                             O2::ITStracking
                                              O2::DataFormatsITSMFT
                                              O2::DataFormatsITS
                                              O2::SimulationDataFormat
-                                             O2::DetectorsVertexing
                                              O2::ReconstructionDataFormats
+                                             O2::DataFormatsGlobalTracking
                                              O2::DCAFitter
                )
 

--- a/Detectors/StrangenessTracking/tracking/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/tracking/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_compile_options(-O0 -g -fPIC)
+# add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(StrangenessTracking
                SOURCES src/StrangenessTracker.cxx

--- a/Detectors/StrangenessTracking/tracking/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/tracking/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-#add_compile_options(-O0 -g -fPIC)
+add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(StrangenessTracking
                SOURCES src/StrangenessTracker.cxx

--- a/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
+++ b/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
@@ -193,7 +193,7 @@ class StrangenessTracker
   {
     std::vector<ITSCluster> outVec;
     outVec.reserve(7);
-    auto firstClus = mITStrack.getFirstClusterEntry();
+    auto firstClus = itsTrack.getFirstClusterEntry();
     auto ncl = itsTrack.getNumberOfClusters();
     for (int icl = 0; icl < ncl; icl++) {
       outVec.push_back(mInputITSclusters[mInputITSidxs[firstClus + icl]]);
@@ -292,7 +292,6 @@ class StrangenessTracker
   std::vector<std::vector<o2::track::TrackParCovF>> mDaughterTracks; // vector of daughter tracks (per thread)
   StrangeTrack mStrangeTrack;                           // structure containing updated mother and daughter track refs
   ClusAttachments mStructClus;                          // # of attached tracks, 1 for mother, 2 for daughter
-  o2::its::TrackITS mITStrack;                          // ITS track
 
   ClassDefNV(StrangenessTracker, 1);
 };

--- a/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
+++ b/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
@@ -24,6 +24,7 @@
 #include "ReconstructionDataFormats/PID.h"
 #include "ReconstructionDataFormats/V0.h"
 #include "ReconstructionDataFormats/Cascade.h"
+#include "ReconstructionDataFormats/DecayNBodyIndex.h"
 #include "ReconstructionDataFormats/StrangeTrack.h"
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
@@ -61,7 +62,9 @@ class StrangenessTracker
   using TrackITS = o2::its::TrackITS;
   using ITSCluster = o2::BaseCluster<float>;
   using V0 = o2::dataformats::V0;
+  using V0Index = o2::dataformats::V0Index;
   using Cascade = o2::dataformats::Cascade;
+  using CascadeIndex = o2::dataformats::CascadeIndex;
   using GIndex = o2::dataformats::VtxTrackIndex;
   using DCAFitter2 = o2::vertexing::DCAFitterN<2>;
   using DCAFitter3 = o2::vertexing::DCAFitterN<3>;
@@ -73,14 +76,17 @@ class StrangenessTracker
   ~StrangenessTracker() = default;
 
   bool loadData(const o2::globaltracking::RecoContainer& recoData);
-  bool matchDecayToITStrack(float decayR);
+  bool matchDecayToITStrack(float decayR, StrangeTrack& strangeTrack, ClusAttachments& structClus, const TrackITS& itsTrack, std::vector<o2::track::TrackParCovF>& daughterTracks, int iThread = 0);
   void prepareITStracks();
   void process();
+  void processV0(int iv0, const V0& v0, const V0Index& v0Idx, int iThread = 0);
+  void processCascade(int icasc, const Cascade& casc, const CascadeIndex& cascIdx, const V0& cascV0, int iThread = 0);
   bool updateTrack(const ITSCluster& clus, o2::track::TrackParCov& track);
 
-  std::vector<ClusAttachments>& getClusAttachments() { return mClusAttachments; };
-  std::vector<StrangeTrack>& getStrangeTrackVec() { return mStrangeTrackVec; };
-  std::vector<o2::MCCompLabel>& getStrangeTrackLabels() { return mStrangeTrackLabels; };
+  std::vector<ClusAttachments>& getClusAttachments(int iThread = 0) { return mClusAttachments[iThread]; };
+  std::vector<StrangeTrack>& getStrangeTrackVec(int iThread = 0) { return mStrangeTrackVec[iThread]; };
+  std::vector<o2::MCCompLabel>& getStrangeTrackLabels(int iThread = 0) { return mStrangeTrackLabels[iThread]; };
+  size_t getNTracks(int ithread = 0) const { return ithread < (int)mStrangeTrackVec.size() ? mStrangeTrackVec[ithread].size() : 0; }
 
   float getBz() const { return mBz; }
   void setBz(float d) { mBz = d; }
@@ -88,29 +94,47 @@ class StrangenessTracker
   void setCorrType(const o2::base::PropagatorImpl<float>::MatCorrType& type) { mCorrType = type; }
   void setConfigParams(const StrangenessTrackingParamConfig* params) { mStrParams = params; }
   void setMCTruthOn(bool v) { mMCTruthON = v; }
+  bool getMCTruthOn() const { return mMCTruthON; }
 
   void clear()
   {
-    mDaughterTracks.clear();
-    mClusAttachments.clear();
-    mStrangeTrackVec.clear();
+    for (int i = 0; i < mNThreads; i++) {
+      mDaughterTracks[i].clear();
+      mClusAttachments[i].clear();
+      mStrangeTrackVec[i].clear();
+      if (mMCTruthON) {
+        mStrangeTrackLabels[i].clear();
+      }
+    }
     mTracksIdxTable.clear();
     mSortedITStracks.clear();
     mSortedITSindexes.clear();
     mITSvtxBrackets.clear();
     mInputITSclusters.clear();
     mInputClusterSizes.clear();
-    if (mMCTruthON) {
-      mStrangeTrackLabels.clear();
-    }
+  }
+
+  void setupThreads(int nThreads = 1)
+  {
+    mNThreads = nThreads;
+    mFitterV0.resize(nThreads);
+    mFitter3Body.resize(nThreads);
+    mStrangeTrackVec.resize(nThreads);
+    mClusAttachments.resize(nThreads);
+    mStrangeTrackLabels.resize(nThreads);
+    mDaughterTracks.resize(nThreads);
   }
 
   void setupFitters()
   {
-    mFitterV0.setBz(mBz);
-    mFitter3Body.setBz(mBz);
-    mFitterV0.setUseAbsDCA(true);
-    mFitter3Body.setUseAbsDCA(true);
+    for (auto& fitter : mFitterV0) {
+      fitter.setBz(mBz);
+      fitter.setUseAbsDCA(true);
+    }
+    for (auto& fitter : mFitter3Body) {
+      fitter.setBz(mBz);
+      fitter.setUseAbsDCA(true);
+    }
   }
 
   double calcV0alpha(const V0& v0)
@@ -140,48 +164,49 @@ class StrangenessTracker
     return std::sqrt(e2Mother - p2Mother);
   }
 
-  bool recreateV0(const o2::track::TrackParCov& posTrack, const o2::track::TrackParCov& negTrack, V0& newV0)
+  bool recreateV0(const o2::track::TrackParCov& posTrack, const o2::track::TrackParCov& negTrack, V0& newV0, int iThread = 0)
   {
-
     int nCand;
     try {
-      nCand = mFitterV0.process(posTrack, negTrack);
+      nCand = mFitterV0[iThread].process(posTrack, negTrack);
     } catch (std::runtime_error& e) {
       return false;
     }
-    if (!nCand || !mFitterV0.propagateTracksToVertex()) {
+    if (!nCand || !mFitterV0[iThread].propagateTracksToVertex()) {
       return false;
     }
 
-    const auto& v0XYZ = mFitterV0.getPCACandidatePos();
+    const auto& v0XYZ = mFitterV0[iThread].getPCACandidatePos();
 
-    auto& propPos = mFitterV0.getTrack(0, 0);
-    auto& propNeg = mFitterV0.getTrack(1, 0);
+    auto& propPos = mFitterV0[iThread].getTrack(0, 0);
+    auto& propNeg = mFitterV0[iThread].getTrack(1, 0);
 
     std::array<float, 3> pP, pN;
     propPos.getPxPyPzGlo(pP);
     propNeg.getPxPyPzGlo(pN);
     std::array<float, 3> pV0 = {pP[0] + pN[0], pP[1] + pN[1], pP[2] + pN[2]};
-    newV0 = V0(v0XYZ, pV0, mFitterV0.calcPCACovMatrixFlat(0), propPos, propNeg, mV0dauIDs[kV0DauPos], mV0dauIDs[kV0DauNeg], PID::HyperTriton);
+    newV0 = V0(v0XYZ, pV0, mFitterV0[iThread].calcPCACovMatrixFlat(0), propPos, propNeg, PID::HyperTriton);
     return true;
   };
 
-  std::vector<ITSCluster> getTrackClusters()
+  std::vector<ITSCluster> getTrackClusters(const TrackITS& itsTrack)
   {
     std::vector<ITSCluster> outVec;
+    outVec.reserve(7);
     auto firstClus = mITStrack.getFirstClusterEntry();
-    auto ncl = mITStrack.getNumberOfClusters();
+    auto ncl = itsTrack.getNumberOfClusters();
     for (int icl = 0; icl < ncl; icl++) {
       outVec.push_back(mInputITSclusters[mInputITSidxs[firstClus + icl]]);
     }
     return outVec;
   };
 
-  std::vector<int> getTrackClusterSizes()
+  std::vector<int> getTrackClusterSizes(const TrackITS& itsTrack)
   {
     std::vector<int> outVec;
-    auto firstClus = mITStrack.getFirstClusterEntry();
-    auto ncl = mITStrack.getNumberOfClusters();
+    outVec.reserve(7);
+    auto firstClus = itsTrack.getFirstClusterEntry();
+    auto ncl = itsTrack.getNumberOfClusters();
     for (int icl = 0; icl < ncl; icl++) {
       outVec.push_back(mInputClusterSizes[mInputITSidxs[firstClus + icl]]);
     }
@@ -217,12 +242,12 @@ class StrangenessTracker
     return -100;
   };
 
-  o2::MCCompLabel getStrangeTrackLabel() // ITS label with fake flag recomputed
+  o2::MCCompLabel getStrangeTrackLabel(const TrackITS& itsTrack, const StrangeTrack& strangeTrack, const ClusAttachments& structClus) // ITS label with fake flag recomputed
   {
     bool isFake = false;
-    auto itsTrkLab = mITSTrkLabels[mStrangeTrack.mITSRef];
+    auto itsTrkLab = mITSTrkLabels[strangeTrack.mITSRef];
     for (unsigned int iLay = 0; iLay < 7; iLay++) {
-      if (mITStrack.hasHitOnLayer(iLay) && mITStrack.isFakeOnLayer(iLay) && mStructClus.arr[iLay] == 0) {
+      if (itsTrack.hasHitOnLayer(iLay) && itsTrack.isFakeOnLayer(iLay) && structClus.arr[iLay] == 0) {
         isFake = true;
         break;
       }
@@ -233,6 +258,7 @@ class StrangenessTracker
 
  protected:
   bool mMCTruthON = false;                      /// flag availability of MC truth
+  int mNThreads = 1;                            /// number of threads (externally driven)
   gsl::span<const TrackITS> mInputITStracks;    // input ITS tracks
   std::vector<VBracket> mITSvtxBrackets;        // time brackets for ITS tracks
   std::vector<int> mTracksIdxTable;             // index table for ITS tracks
@@ -240,7 +266,9 @@ class StrangenessTracker
   std::vector<ITSCluster> mInputITSclusters;    // input ITS clusters
   gsl::span<const int> mInputITSidxs;           // input ITS track-cluster indexes
   gsl::span<const V0> mInputV0tracks;           // input V0 of decay daughters
-  gsl::span<const Cascade> mInputCascadeTracks; // input V0 of decay daughters
+  gsl::span<const V0Index> mInputV0Indices;     // input V0 indices of decay daughters
+  gsl::span<const Cascade> mInputCascadeTracks; // input cascade of decay daughters
+  gsl::span<const CascadeIndex> mInputCascadeIndices; // input cascade indices of decay daughters
   const MCLabContCl* mITSClsLabels = nullptr;   /// input ITS Cluster MC labels
   MCLabSpan mITSTrkLabels;                      /// input ITS Track MC labels
 
@@ -248,24 +276,23 @@ class StrangenessTracker
   std::vector<int> mSortedITSindexes;              // indexes of sorted ITS tracks
   IndexTableUtils mUtils;                          // structure for computing eta/phi matching selections
 
-  std::vector<StrangeTrack> mStrangeTrackVec;       // structure containing updated mother and daughter tracks
-  std::vector<ClusAttachments> mClusAttachments;    // # of attached tracks, -1 not attached, 0 for the mother, > 0 for the daughters
-  std::vector<o2::MCCompLabel> mStrangeTrackLabels; // vector of MC labels for mother track
+  std::vector<std::vector<StrangeTrack>> mStrangeTrackVec;       // structure containing updated mother and daughter tracks (per thread)
+  std::vector<std::vector<ClusAttachments>> mClusAttachments;    // # of attached tracks, -1 not attached, 0 for the mother, > 0 for the daughters (per thread)
+  std::vector<std::vector<o2::MCCompLabel>> mStrangeTrackLabels; // vector of MC labels for mother track (per thread)
 
   const StrangenessTrackingParamConfig* mStrParams = nullptr;
   float mBz = -5; // Magnetic field
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
 
-  DCAFitter2 mFitterV0;    // optional DCA Fitter for recreating V0 with hypertriton mass hypothesis
-  DCAFitter3 mFitter3Body; // optional DCA Fitter for final 3 Body refit
+  std::vector<DCAFitter2> mFitterV0;    // optional DCA Fitter for recreating V0 with hypertriton mass hypothesis (per thread)
+  std::vector<DCAFitter3> mFitter3Body; // optional DCA Fitter for final 3 Body refit (per thread)
 
   o2::base::PropagatorImpl<float>::MatCorrType mCorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrNONE; // use mat correction
 
-  std::vector<o2::track::TrackParCovF> mDaughterTracks; // vector of daughter tracks
+  std::vector<std::vector<o2::track::TrackParCovF>> mDaughterTracks; // vector of daughter tracks (per thread)
   StrangeTrack mStrangeTrack;                           // structure containing updated mother and daughter track refs
   ClusAttachments mStructClus;                          // # of attached tracks, 1 for mother, 2 for daughter
   o2::its::TrackITS mITStrack;                          // ITS track
-  std::array<GIndex, 2> mV0dauIDs;                      // V0 daughter IDs
 
   ClassDefNV(StrangenessTracker, 1);
 };

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_compile_options(-O0 -g -fPIC)
+# add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(DetectorsVertexing
                TARGETVARNAME targetName

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-#add_compile_options(-O0 -g -fPIC)
+add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(DetectorsVertexing
                TARGETVARNAME targetName

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -9,6 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+#add_compile_options(-O0 -g -fPIC)
+
 o2_add_library(DetectorsVertexing
                TARGETVARNAME targetName
                SOURCES src/PVertexer.cxx
@@ -31,6 +33,8 @@ o2_add_library(DetectorsVertexing
                                      O2::DataFormatsFT0
                                      O2::GlobalTracking
                                      O2::DCAFitter
+                                     O2::Framework
+                                     O2::StrangenessTracking
                                      Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(DetectorsVertexing

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -20,13 +20,15 @@
 #include "ReconstructionDataFormats/PrimaryVertex.h"
 #include "ReconstructionDataFormats/V0.h"
 #include "ReconstructionDataFormats/Cascade.h"
-#include "ReconstructionDataFormats/DecayNbody.h"
+#include "ReconstructionDataFormats/Decay3Body.h"
+#include "ReconstructionDataFormats/DecayNBodyIndex.h"
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "DCAFitter/DCAFitterN.h"
 #include "DetectorsVertexing/SVertexerParams.h"
 #include "DetectorsVertexing/SVertexHypothesis.h"
+#include "StrangenessTracking/StrangenessTracker.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include <numeric>
 #include <algorithm>
@@ -56,8 +58,11 @@ class SVertexer
   using VRef = o2::dataformats::VtxTrackRef;
   using PVertex = const o2::dataformats::PrimaryVertex;
   using V0 = o2::dataformats::V0;
+  using V0Index = o2::dataformats::V0Index;
   using Cascade = o2::dataformats::Cascade;
-  using DecayNbody = o2::dataformats::DecayNbody;
+  using CascadeIndex = o2::dataformats::CascadeIndex;
+  using Decay3Body = o2::dataformats::Decay3Body;
+  using Decay3BodyIndex = o2::dataformats::Decay3BodyIndex;
   using RRef = o2::dataformats::RangeReference<int, int>;
   using VBracket = o2::math_utils::Bracket<int>;
 
@@ -94,16 +99,25 @@ class SVertexer
     float minR = 0; // track lowest point r
   };
 
-  SVertexer(bool enabCascades = true, bool enab3body = false) : mEnableCascades{enabCascades}, mEnable3BodyDecays{enab3body} {}
+  SVertexer(bool enabCascades = true, bool enab3body = false) : mEnableCascades{enabCascades}, mEnable3BodyDecays{enab3body}
+  {
+  }
 
   void setEnableCascades(bool v) { mEnableCascades = v; }
   void setEnable3BodyDecays(bool v) { mEnable3BodyDecays = v; }
   void init();
-  void process(const o2::globaltracking::RecoContainer& recoTracks); // accessor to various tracks
+  void process(const o2::globaltracking::RecoContainer& recoTracks, o2::framework::ProcessingContext& pc);
+  int getNV0s() const { return mNV0s; }
+  int getNCascades() const { return mNCascades; }
+  int getN3Bodies() const { return mN3Bodies; }
+  int getNStrangeTracks() const { return mNStrangeTracks; }
   auto& getMeanVertex() const { return mMeanVertex; }
   void setMeanVertex(const o2d::VertexBase& v) { mMeanVertex = v; }
   void setNThreads(int n);
   int getNThreads() const { return mNThreads; }
+  void setUseMC(bool v) { mUseMC = v; }
+  bool getUseMC() const { return mUseMC; }
+
   void setTPCTBin(int nbc)
   {
     // set TPC time bin in BCs
@@ -111,15 +125,16 @@ class SVertexer
   }
   void setTPCVDrift(const o2::tpc::VDriftCorrFact& v);
   void setTPCCorrMaps(o2::gpu::CorrectionMapsHelper* maph);
-
-  template <typename V0CONT, typename V0REFCONT, typename CASCCONT, typename CASCREFCONT, typename VTX3BCONT, typename VTX3BREFCONT>
-  void extractSecondaryVertices(V0CONT& v0s, V0REFCONT& vtx2V0Refs, CASCCONT& cascades, CASCREFCONT& vtx2CascRefs, VTX3BCONT& vtx3, VTX3BREFCONT& vtx3Refs);
   void initTPCTransform();
+  void setStrangenessTracker(o2::strangeness_tracking::StrangenessTracker* tracker) { mStrTracker = tracker; }
+  o2::strangeness_tracking::StrangenessTracker* getStrangenessTracker() { return mStrTracker; }
 
  private:
+  template <class TVI, class TCI, class T3I, class TR>
+  void extractPVReferences(const TVI& v0s, TR& vtx2V0Refs, const TCI& cascades, TR& vtx2CascRefs, const T3I& vtxs3, TR& vtx2body3Refs);
   bool checkV0(const TrackCand& seed0, const TrackCand& seed1, int iP, int iN, int ithread);
-  int checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread);
-  int check3bodyDecays(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread);
+  int checkCascades(const V0Index& v0Idx, const V0& v0, float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread);
+  int check3bodyDecays(const V0Index& v0Idx, const V0& v0, float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread);
   void setupThreads();
   void buildT2V(const o2::globaltracking::RecoContainer& recoTracks);
   void updateTimeDependentParams();
@@ -135,11 +150,14 @@ class SVertexer
   // at the moment not used
   o2::gpu::CorrectionMapsHelper* mTPCCorrMapsHelper = nullptr;
   std::unique_ptr<o2::gpu::GPUO2InterfaceRefit> mTPCRefitter; ///< TPC refitter used for TPC tracks refit during the reconstruction
-
+  o2::strangeness_tracking::StrangenessTracker* mStrTracker = nullptr;
   gsl::span<const PVertex> mPVertices;
   std::vector<std::vector<V0>> mV0sTmp;
   std::vector<std::vector<Cascade>> mCascadesTmp;
-  std::vector<std::vector<DecayNbody>> m3bodyTmp;
+  std::vector<std::vector<Decay3Body>> m3bodyTmp;
+  std::vector<std::vector<V0Index>> mV0sIdxTmp;
+  std::vector<std::vector<CascadeIndex>> mCascadesIdxTmp;
+  std::vector<std::vector<Decay3BodyIndex>> m3bodyIdxTmp;
   std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
   std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
 
@@ -153,6 +171,7 @@ class SVertexer
   std::vector<DCAFitterN<2>> mFitterCasc;
   std::vector<DCAFitterN<3>> mFitter3body;
   int mNThreads = 1;
+  int mNV0s = 0, mNCascades = 0, mN3Bodies = 0, mNStrangeTracks = 0;
   float mMinR2ToMeanVertex = 0;
   float mMaxDCAXY2ToMeanVertex = 0;
   float mMaxDCAXY2ToMeanVertexV0Casc = 0;
@@ -174,124 +193,8 @@ class SVertexer
 
   bool mEnableCascades = true;
   bool mEnable3BodyDecays = false;
+  bool mUseMC = false;
 };
-
-// input containers can be std::vectors or pmr vectors
-template <typename V0CONT, typename V0REFCONT, typename CASCCONT, typename CASCREFCONT, typename VTX3BCONT, typename VTX3BREFCONT>
-void SVertexer::extractSecondaryVertices(V0CONT& v0s, V0REFCONT& vtx2V0Refs, CASCCONT& cascades, CASCREFCONT& vtx2CascRefs, VTX3BCONT& vtx3, VTX3BREFCONT& vtx3Refs)
-{
-  v0s.clear();
-  vtx2V0Refs.clear();
-  vtx2V0Refs.resize(mPVertices.size());
-  cascades.clear();
-  vtx2CascRefs.clear();
-  vtx2CascRefs.resize(mPVertices.size());
-  vtx3.clear();
-  vtx3Refs.clear();
-  vtx3Refs.resize(mPVertices.size());
-
-  auto& tmpV0s = mV0sTmp[0];
-  auto& tmpCascs = mCascadesTmp[0];
-  auto& tmp3B = m3bodyTmp[0];
-  int nv0 = tmpV0s.size(), nCasc = tmpCascs.size(), n3body = tmp3B.size();
-  std::vector<int> v0SortID(nv0), v0NewInd(nv0), cascSortID(nCasc), vtx3SortID(n3body);
-  std::iota(v0SortID.begin(), v0SortID.end(), 0);
-  std::sort(v0SortID.begin(), v0SortID.end(), [&](int i, int j) { return tmpV0s[i].getVertexID() < tmpV0s[j].getVertexID(); });
-  std::iota(cascSortID.begin(), cascSortID.end(), 0);
-  std::sort(cascSortID.begin(), cascSortID.end(), [&](int i, int j) { return tmpCascs[i].getVertexID() < tmpCascs[j].getVertexID(); });
-  std::iota(vtx3SortID.begin(), vtx3SortID.end(), 0);
-  std::sort(vtx3SortID.begin(), vtx3SortID.end(), [&](int i, int j) { return tmp3B[i].getVertexID() < tmp3B[j].getVertexID(); });
-  // relate V0s to primary vertices
-  int pvID = -1, nForPV = 0;
-  for (int iv = 0; iv < nv0; iv++) {
-    const auto& v0 = tmpV0s[v0SortID[iv]];
-    if (pvID < v0.getVertexID()) {
-      if (pvID > -1) {
-        vtx2V0Refs[pvID].setEntries(nForPV);
-      }
-      pvID = v0.getVertexID();
-      vtx2V0Refs[pvID].setFirstEntry(v0s.size());
-      nForPV = 0;
-    }
-    v0NewInd[v0SortID[iv]] = v0s.size(); // memorise updated v0 id to fix its reference in the cascade
-    v0s.push_back(v0);
-    nForPV++;
-  }
-  if (pvID != -1) { // finalize
-    vtx2V0Refs[pvID].setEntries(nForPV);
-    // fill empty slots
-    int ent = v0s.size();
-    for (int ip = vtx2V0Refs.size(); ip--;) {
-      if (vtx2V0Refs[ip].getEntries()) {
-        ent = vtx2V0Refs[ip].getFirstEntry();
-      } else {
-        vtx2V0Refs[ip].setFirstEntry(ent);
-      }
-    }
-  }
-  // update V0s references in cascades
-  for (auto& casc : tmpCascs) {
-    casc.setV0ID(v0NewInd[casc.getV0ID()]);
-  }
-
-  // relate Cascades to primary vertices
-  pvID = -1;
-  nForPV = 0;
-  for (int iv = 0; iv < nCasc; iv++) {
-    const auto& casc = tmpCascs[cascSortID[iv]];
-    if (pvID < casc.getVertexID()) {
-      if (pvID > -1) {
-        vtx2CascRefs[pvID].setEntries(nForPV);
-      }
-      pvID = casc.getVertexID();
-      vtx2CascRefs[pvID].setFirstEntry(cascades.size());
-      nForPV = 0;
-    }
-    cascades.push_back(casc);
-    nForPV++;
-  }
-  if (pvID != -1) { // finalize
-    vtx2CascRefs[pvID].setEntries(nForPV);
-    // fill empty slots
-    int ent = cascades.size();
-    for (int ip = vtx2CascRefs.size(); ip--;) {
-      if (vtx2CascRefs[ip].getEntries()) {
-        ent = vtx2CascRefs[ip].getFirstEntry();
-      } else {
-        vtx2CascRefs[ip].setFirstEntry(ent);
-      }
-    }
-  }
-
-  // relate 3 body decays to primary vertices
-  pvID = -1;
-  nForPV = 0;
-  for (int iv = 0; iv < n3body; iv++) {
-    const auto& vertex3body = tmp3B[vtx3SortID[iv]];
-    if (pvID < vertex3body.getVertexID()) {
-      if (pvID > -1) {
-        vtx3Refs[pvID].setEntries(nForPV);
-      }
-      pvID = vertex3body.getVertexID();
-      vtx3Refs[pvID].setFirstEntry(vtx3.size());
-      nForPV = 0;
-    }
-    vtx3.push_back(vertex3body);
-    nForPV++;
-  }
-  if (pvID != -1) { // finalize
-    vtx3Refs[pvID].setEntries(nForPV);
-    // fill empty slots
-    int ent = vtx3.size();
-    for (int ip = vtx3Refs.size(); ip--;) {
-      if (vtx3Refs[ip].getEntries()) {
-        ent = vtx3Refs[ip].getFirstEntry();
-      } else {
-        vtx3Refs[ip].setFirstEntry(ent);
-      }
-    }
-  }
-}
 
 } // namespace vertexing
 } // namespace o2

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -30,6 +30,10 @@ namespace vertexing
 struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParams> {
 
   // parameters
+  bool createFullV0s = false;      ///< fill V0s prongs/kinematics
+  bool createFullCascades = false; ///< fill cascades prongs/kinematics
+  bool createFull3Bodies = false;  ///< fill 3-body decays prongs/kinematics
+
   bool useAbsDCA = true;        ///< use abs dca minimization
   bool selectBestV0 = false;    ///< match only the best v0 for each cascade candidate
   float maxChi2 = 2.;           ///< max dca from prongs to vertex

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -18,29 +18,36 @@
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 #include "DataFormatsTPC/VDriftCorrFact.h"
 #include "CorrectionMapsHelper.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/DataProcessorSpec.h"
+#include "ReconstructionDataFormats/StrangeTrack.h"
 
 #ifdef WITH_OPENMP
 #include <omp.h>
 #endif
 
 #include "ReconstructionDataFormats/GlobalTrackID.h"
-using namespace o2::vertexing;
 
+using namespace o2::vertexing;
+namespace o2f = o2::framework;
 using PID = o2::track::PID;
 using TrackTPCITS = o2::dataformats::TrackTPCITS;
 using TrackITS = o2::its::TrackITS;
 using TrackTPC = o2::tpc::TrackTPC;
 
 //__________________________________________________________________
-void SVertexer::process(const o2::globaltracking::RecoContainer& recoData) // accessor to various reconstrucred data types
+void SVertexer::process(const o2::globaltracking::RecoContainer& recoData, o2::framework::ProcessingContext& pc)
 {
+  mNV0s = mNCascades = mN3Bodies = 0;
   updateTimeDependentParams(); // TODO RS: strictly speaking, one should do this only in case of the CCDB objects update
   mPVertices = recoData.getPrimaryVertices();
   buildT2V(recoData); // build track->vertex refs from vertex->track (if other workflow will need this, consider producing a message in the VertexTrackMatcher)
   int ntrP = mTracksPool[POS].size(), ntrN = mTracksPool[NEG].size(), iThread = 0;
-  mV0sTmp[0].clear();
-  mCascadesTmp[0].clear();
-  m3bodyTmp[0].clear();
+  if (mStrTracker) {
+    mStrTracker->loadData(recoData);
+    mStrTracker->prepareITStracks();
+  }
+
 #ifdef WITH_OPENMP
   int dynGrp = std::min(4, std::max(1, mNThreads / 2));
 #pragma omp parallel for schedule(dynamic, dynGrp) num_threads(mNThreads)
@@ -67,75 +74,147 @@ void SVertexer::process(const o2::globaltracking::RecoContainer& recoData) // ac
       checkV0(seedP, seedN, itp, itn, iThread);
     }
   }
+
   // sort V0s and Cascades in vertex id
   struct vid {
     int thrID;
     int entry;
     int vtxID;
   };
-  size_t nv0 = 0, ncsc = 0, n3body = 0;
-  for (int i = 0; i < mNThreads; i++) {
-    nv0 += mV0sTmp[0].size();
-    ncsc += mCascadesTmp[i].size();
-    n3body += m3bodyTmp[i].size();
+  for (int ith = 0; ith < mNThreads; ith++) {
+    mNV0s += mV0sIdxTmp[ith].size();
+    mNCascades += mCascadesIdxTmp[ith].size();
+    mN3Bodies += m3bodyIdxTmp[ith].size();
   }
   std::vector<vid> v0SortID, cascSortID, nbodySortID;
-  v0SortID.reserve(nv0);
-  cascSortID.reserve(ncsc);
-  nbodySortID.reserve(n3body);
-  for (int i = 0; i < mNThreads; i++) {
-    for (int j = 0; j < (int)mV0sTmp[i].size(); j++) {
-      v0SortID.emplace_back(vid{i, j, mV0sTmp[i][j].getVertexID()});
+  v0SortID.reserve(mNV0s);
+  cascSortID.reserve(mNCascades);
+  nbodySortID.reserve(mN3Bodies);
+  for (int ith = 0; ith < mNThreads; ith++) {
+    for (int j = 0; j < (int)mV0sIdxTmp[ith].size(); j++) {
+      v0SortID.emplace_back(vid{ith, j, mV0sIdxTmp[ith][j].getVertexID()});
     }
-    for (int j = 0; j < (int)mCascadesTmp[i].size(); j++) {
-      cascSortID.emplace_back(vid{i, j, mCascadesTmp[i][j].getVertexID()});
+    for (int j = 0; j < (int)mCascadesIdxTmp[ith].size(); j++) {
+      cascSortID.emplace_back(vid{ith, j, mCascadesIdxTmp[ith][j].getVertexID()});
     }
-    for (int j = 0; j < (int)m3bodyTmp[i].size(); j++) {
-      nbodySortID.emplace_back(vid{i, j, m3bodyTmp[i][j].getVertexID()});
+    for (int j = 0; j < (int)m3bodyIdxTmp[ith].size(); j++) {
+      nbodySortID.emplace_back(vid{ith, j, m3bodyIdxTmp[ith][j].getVertexID()});
     }
   }
   std::sort(v0SortID.begin(), v0SortID.end(), [](const vid& a, const vid& b) { return a.vtxID > b.vtxID; });
   std::sort(cascSortID.begin(), cascSortID.end(), [](const vid& a, const vid& b) { return a.vtxID > b.vtxID; });
   std::sort(nbodySortID.begin(), nbodySortID.end(), [](const vid& a, const vid& b) { return a.vtxID > b.vtxID; });
   // sorted V0s
-  std::vector<V0> bufV0;
-  bufV0.reserve(nv0);
-  for (const auto& id : v0SortID) {
-    auto& v0 = mV0sTmp[id.thrID][id.entry];
-    int pos = bufV0.size();
-    bufV0.push_back(v0);
-    v0.setVertexID(pos); // this v0 copy will be discarded, use its vertexID to store the new position of final V0
-  }
-  // since V0s were reshuffled, we need to correct the cascade -> V0 reference indices
-  for (int i = 0; i < mNThreads; i++) {  // merge results of all threads
-    for (auto& casc : mCascadesTmp[i]) { // before merging fix cascades references on v0
-      casc.setV0ID(mV0sTmp[i][casc.getV0ID()].getVertexID());
-    }
+
+  auto& v0sIdx = pc.outputs().make<std::vector<V0Index>>(o2f::Output{"GLO", "V0S_IDX", 0, o2f::Lifetime::Timeframe});
+  auto& cascsIdx = pc.outputs().make<std::vector<CascadeIndex>>(o2f::Output{"GLO", "CASCS_IDX", 0, o2f::Lifetime::Timeframe});
+  auto& body3Idx = pc.outputs().make<std::vector<Decay3BodyIndex>>(o2f::Output{"GLO", "DECAYS3BODY_IDX", 0, o2f::Lifetime::Timeframe});
+  auto& fullv0s = pc.outputs().make<std::vector<V0>>(o2f::Output{"GLO", "V0S", 0, o2f::Lifetime::Timeframe});
+  auto& fullcascs = pc.outputs().make<std::vector<Cascade>>(o2f::Output{"GLO", "CASCS", 0, o2f::Lifetime::Timeframe});
+  auto& full3body = pc.outputs().make<std::vector<Decay3Body>>(o2f::Output{"GLO", "DECAYS3BODY", 0, o2f::Lifetime::Timeframe});
+  auto& v0Refs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_V0REFS", 0, o2f::Lifetime::Timeframe});
+  auto& cascRefs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_CASCREFS", 0, o2f::Lifetime::Timeframe});
+  auto& vtx3bodyRefs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_3BODYREFS", 0, o2f::Lifetime::Timeframe});
+
+  // sorted V0s
+  v0sIdx.reserve(mNV0s);
+  if (mSVParams->createFullV0s) {
+    fullv0s.reserve(mNV0s);
   }
   // sorted Cascades
-  std::vector<Cascade> bufCasc;
-  bufCasc.reserve(ncsc);
-  for (const auto& id : cascSortID) {
-    bufCasc.push_back(mCascadesTmp[id.thrID][id.entry]);
+  cascsIdx.reserve(mNCascades);
+  if (mSVParams->createFullCascades) {
+    fullcascs.reserve(mNCascades);
   }
   // sorted 3 body decays
-  std::vector<DecayNbody> buf3body;
-  buf3body.reserve(n3body);
+  body3Idx.reserve(mN3Bodies);
+  if (mSVParams->createFull3Bodies) {
+    full3body.reserve(mN3Bodies);
+  }
+
+  for (const auto& id : v0SortID) {
+    auto& v0idx = mV0sIdxTmp[id.thrID][id.entry];
+    int pos = v0sIdx.size();
+    v0sIdx.push_back(v0idx);
+    v0idx.setVertexID(pos); // this v0 copy will be discarded, use its vertexID to store the new position of final V0
+    if (mSVParams->createFullV0s) {
+      fullv0s.push_back(mV0sTmp[id.thrID][id.entry]);
+    }
+  }
+  // since V0s were reshuffled, we need to correct the cascade -> V0 reference indices
+  for (int ith = 0; ith < mNThreads; ith++) {                     // merge results of all threads
+    for (size_t ic = 0; ic < mCascadesIdxTmp[ith].size(); ic++) { // before merging fix cascades references on v0
+      auto& cidx = mCascadesIdxTmp[ith][ic];
+      cidx.setV0ID(mV0sIdxTmp[ith][cidx.getV0ID()].getVertexID());
+    }
+  }
+  int cascCnt = 0;
+  for (const auto& id : cascSortID) {
+    cascsIdx.push_back(mCascadesIdxTmp[id.thrID][id.entry]);
+    mCascadesIdxTmp[id.thrID][id.entry].setVertexID(cascCnt++); // memorize new ID
+    if (mSVParams->createFullCascades) {
+      fullcascs.push_back(mCascadesTmp[id.thrID][id.entry]);
+    }
+  }
+  int b3cnt = 0;
   for (const auto& id : nbodySortID) {
-    auto& decay3body = m3bodyTmp[id.thrID][id.entry];
-    int pos = bufV0.size();
-    buf3body.push_back(decay3body);
+    body3Idx.push_back(m3bodyIdxTmp[id.thrID][id.entry]);
+    m3bodyIdxTmp[id.thrID][id.entry].setVertexID(b3cnt++); // memorize new ID
+    if (mSVParams->createFull3Bodies) {
+      full3body.push_back(m3bodyTmp[id.thrID][id.entry]);
+    }
+  }
+  if (mStrTracker) {
+    mNStrangeTracks = 0;
+    for (int ith = 0; ith < mNThreads; ith++) {
+      mNStrangeTracks += mStrTracker->getNTracks();
+    }
+    auto& strTracksOut = pc.outputs().make<std::vector<o2::dataformats::StrangeTrack>>(o2f::Output{"GLO", "STRANGETRACKS", 0, o2f::Lifetime::Timeframe});
+    auto& strClustOut = pc.outputs().make<std::vector<o2::strangeness_tracking::ClusAttachments>>(o2f::Output{"GLO", "CLUSUPDATES", 0, o2f::Lifetime::Timeframe});
+    o2::pmr::vector<o2::MCCompLabel> mcLabsOut;
+    strTracksOut.reserve(mNStrangeTracks);
+    strClustOut.reserve(mNStrangeTracks);
+    if (mStrTracker->getMCTruthOn()) {
+      mcLabsOut.reserve(mNStrangeTracks);
+    }
+    for (int ith = 0; ith < mNThreads; ith++) { // merge results of all threads
+      auto& strTracks = mStrTracker->getStrangeTrackVec(ith);
+      auto& strClust = mStrTracker->getClusAttachments(ith);
+      auto& stcTrMCLab = mStrTracker->getStrangeTrackLabels(ith);
+      for (int i = 0; i < (int)strTracks.size(); i++) {
+        auto& t = strTracks[i];
+        if (t.mPartType == o2::dataformats::kStrkV0) {
+          t.mDecayRef = mV0sIdxTmp[ith][t.mDecayRef].getVertexID(); // reassign merged V0 ID
+        } else if (t.mPartType == o2::dataformats::kStrkCascade) {
+          t.mDecayRef = mCascadesIdxTmp[ith][t.mDecayRef].getVertexID(); // reassign merged Cascase ID
+        } else if (t.mPartType == o2::dataformats::kStrkThreeBody) {
+          t.mDecayRef = m3bodyIdxTmp[ith][t.mDecayRef].getVertexID(); // reassign merged Cascase ID
+        } else {
+          LOGP(fatal, "Unknown strange track decay reference type {} for index {}", int(t.mPartType), t.mDecayRef);
+        }
+        strTracksOut.push_back(t);
+        strClustOut.push_back(strClust[i]);
+        if (mStrTracker->getMCTruthOn()) {
+          mcLabsOut.push_back(stcTrMCLab[i]);
+        }
+      }
+    }
+    if (mStrTracker->getMCTruthOn()) {
+      auto& strTrMCLableOut = pc.outputs().make<std::vector<o2::MCCompLabel>>(o2f::Output{"GLO", "STRANGETRACKS_MC", 0, o2f::Lifetime::Timeframe});
+      strTrMCLableOut.swap(mcLabsOut);
+    }
   }
   //
-  mV0sTmp[0].swap(bufV0);               // the final result is fetched from here
-  mCascadesTmp[0].swap(bufCasc);        // the final result is fetched from here
-  m3bodyTmp[0].swap(buf3body);          // the final result is fetched from here
-  for (int i = 1; i < mNThreads; i++) { // clean unneeded s.vertices
-    mV0sTmp[i].clear();
-    mCascadesTmp[i].clear();
-    m3bodyTmp[i].clear();
+  for (int ith = 0; ith < mNThreads; ith++) { // clean unneeded s.vertices
+    mV0sTmp[ith].clear();
+    mCascadesTmp[ith].clear();
+    m3bodyTmp[ith].clear();
+    mV0sIdxTmp[ith].clear();
+    mCascadesIdxTmp[ith].clear();
+    m3bodyIdxTmp[ith].clear();
   }
-  LOG(debug) << "DONE : " << mV0sTmp[0].size() << " " << mCascadesTmp[0].size() << " " << m3bodyTmp[0].size();
+
+  extractPVReferences(v0sIdx, v0Refs, cascsIdx, cascRefs, body3Idx, vtx3bodyRefs);
 }
 
 //__________________________________________________________________
@@ -218,6 +297,9 @@ void SVertexer::setupThreads()
   mV0sTmp.resize(mNThreads);
   mCascadesTmp.resize(mNThreads);
   m3bodyTmp.resize(mNThreads);
+  mV0sIdxTmp.resize(mNThreads);
+  mCascadesIdxTmp.resize(mNThreads);
+  m3bodyIdxTmp.resize(mNThreads);
   mFitterV0.resize(mNThreads);
   auto bz = o2::base::Propagator::Instance()->getNominalBz();
   for (auto& fitter : mFitterV0) {
@@ -398,7 +480,6 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
 //__________________________________________________________________
 bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, int iN, int ithread)
 {
-
   auto& fitterV0 = mFitterV0[ithread];
   int nCand = fitterV0.process(seedP, seedN);
   if (nCand == 0) { // discard this pair
@@ -509,9 +590,11 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   }
 
   auto vlist = seedP.vBracket.getOverlap(seedN.vBracket); // indices of vertices shared by both seeds
-  bool added = false;
+  bool candFound = false;
   auto bestCosPA = checkForCascade ? mSVParams->minCosPACascV0 : mSVParams->minCosPA;
   bestCosPA = checkFor3BodyDecays ? std::min(mSVParams->minCosPA3bodyV0, bestCosPA) : bestCosPA;
+  V0 v0new;
+  V0Index v0Idxnew;
 
   for (int iv = vlist.getMin(); iv <= vlist.getMax(); iv++) {
     const auto& pv = mPVertices[iv];
@@ -523,17 +606,17 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
       LOG(debug) << "Rej. cosPA: " << cosPA;
       continue;
     }
-    if (!added) {
-      auto& v0new = mV0sTmp[ithread].emplace_back(v0XYZ, pV0, fitterV0.calcPCACovMatrixFlat(cand), trPProp, trNProp, seedP.gid, seedN.gid);
+    if (!candFound) {
+      new (&v0new) V0(v0XYZ, pV0, fitterV0.calcPCACovMatrixFlat(cand), trPProp, trNProp);
+      new (&v0Idxnew) V0Index(-1, seedP.gid, seedN.gid);
       v0new.setDCA(fitterV0.getChi2AtPCACandidate());
-      added = true;
+      candFound = true;
     }
-    auto& v0 = mV0sTmp[ithread].back();
-    v0.setCosPA(cosPA);
-    v0.setVertexID(iv);
+    v0new.setCosPA(cosPA);
+    v0Idxnew.setVertexID(iv);
     bestCosPA = cosPA;
   }
-  if (!added) {
+  if (!candFound) {
     return false;
   }
   if (bestCosPA < mSVParams->minCosPACascV0) {
@@ -542,45 +625,60 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   if (bestCosPA < mSVParams->minCosPA && checkForCascade) {
     rejectIfNotCascade = true;
   }
-
+  int nV0Ini = mV0sIdxTmp[ithread].size();
   // check 3 body decays
   if (checkFor3BodyDecays) {
     int n3bodyDecays = 0;
-    n3bodyDecays += check3bodyDecays(rv0, pV0, p2V0, iN, NEG, vlist, ithread);
-    n3bodyDecays += check3bodyDecays(rv0, pV0, p2V0, iP, POS, vlist, ithread);
+    n3bodyDecays += check3bodyDecays(v0Idxnew, v0new, rv0, pV0, p2V0, iN, NEG, vlist, ithread);
+    n3bodyDecays += check3bodyDecays(v0Idxnew, v0new, rv0, pV0, p2V0, iP, POS, vlist, ithread);
   }
   if (rejectAfter3BodyCheck) {
-    mV0sTmp[ithread].pop_back();
     return false;
   }
 
   // check cascades
+  int nCascIni = mCascadesIdxTmp[ithread].size(), nV0Used = 0; // number of times this particular v0 (with assigned PV) was used (not counting using its clones with other PV)
   if (checkForCascade) {
-    int nCascAdded = 0;
     if (hypCheckStatus[HypV0::Lambda] || !mSVParams->checkCascadeHypothesis) {
-      nCascAdded += checkCascades(rv0, pV0, p2V0, iN, NEG, vlist, ithread);
+      nV0Used += checkCascades(v0Idxnew, v0new, rv0, pV0, p2V0, iN, NEG, vlist, ithread);
     }
     if (hypCheckStatus[HypV0::AntiLambda] || !mSVParams->checkCascadeHypothesis) {
-      nCascAdded += checkCascades(rv0, pV0, p2V0, iP, POS, vlist, ithread);
-    }
-    if (!nCascAdded && rejectIfNotCascade) { // v0 would be accepted only if it creates a cascade
-      mV0sTmp[ithread].pop_back();
-      return false;
+      nV0Used += checkCascades(v0Idxnew, v0new, rv0, pV0, p2V0, iP, POS, vlist, ithread);
     }
   }
 
-  return true;
+  if (nV0Used) { // need to fix the index of V0 for the cascades using this v0
+    for (unsigned int ic = nCascIni; ic < mCascadesIdxTmp[ithread].size(); ic++) {
+      if (mCascadesIdxTmp[ithread][ic].getV0ID() == -1) {
+        mCascadesIdxTmp[ithread][ic].setV0ID(nV0Ini);
+      }
+    }
+  }
+
+  if (nV0Used || !rejectIfNotCascade) { // need to add this v0
+    mV0sIdxTmp[ithread].push_back(v0Idxnew);
+    if (mSVParams->createFullV0s) {
+      mV0sTmp[ithread].push_back(v0new);
+    }
+  }
+
+  if (mStrTracker) {
+    for (int iv = nV0Ini; iv < (int)mV0sIdxTmp[ithread].size(); iv++) {
+      mStrTracker->processV0(iv, v0new, v0Idxnew, ithread);
+    }
+  }
+
+  return mV0sIdxTmp[ithread].size() - nV0Ini != 0;
 }
 
 //__________________________________________________________________
-int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread)
+int SVertexer::checkCascades(const V0Index& v0Idx, const V0& v0, float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread)
 {
 
   // check last added V0 for belonging to cascade
   auto& fitterCasc = mFitterCasc[ithread];
-  const auto v0Id = mV0sTmp[ithread].size() - 1; // we check the last V0 but some cascades may add V0 clones
   auto& tracks = mTracksPool[posneg];
-  int nCascIni = mCascadesTmp[ithread].size();
+  int nCascIni = mCascadesIdxTmp[ithread].size(), nv0use = 0;
 
   // check if a given PV has already been used in a cascade
   std::unordered_map<int, int> pvMap;
@@ -599,15 +697,14 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
       LOG(debug) << "Skipping";
       break; // all other bachelor candidates will be also not compatible with this PV
     }
-    const auto& v0 = mV0sTmp[ithread][v0Id];
     auto cascVlist = v0vlist.getOverlap(bach.vBracket); // indices of vertices shared by V0 and bachelor
     if (mSVParams->selectBestV0) {
       // select only the best V0 candidate among the compatible ones
-      if (v0.getVertexID() < cascVlist.getMin() || v0.getVertexID() > cascVlist.getMax()) {
+      if (v0Idx.getVertexID() < cascVlist.getMin() || v0Idx.getVertexID() > cascVlist.getMax()) {
         continue;
       }
-      cascVlist.setMin(v0.getVertexID());
-      cascVlist.setMax(v0.getVertexID());
+      cascVlist.setMin(v0Idx.getVertexID());
+      cascVlist.setMax(v0Idx.getVertexID());
     }
 
     int nCandC = fitterCasc.process(v0, bach);
@@ -689,54 +786,61 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
       LOG(debug) << "Casc not compatible with any hypothesis";
       continue;
     }
-    auto& casc = mCascadesTmp[ithread].emplace_back(cascXYZ, pCasc, fitterCasc.calcPCACovMatrixFlat(candC), trNeut, trBach, v0Id, bach.gid);
+    // note: at the moment the v0 was not added yet. If some cascade will use v0 (with its PV), the v0 will be added after checkCascades
+    // but not necessarily at the and of current v0s vector, since meanwhile checkCascades may add v0 clones (with PV redefined).
+    Cascade casc(cascXYZ, pCasc, fitterCasc.calcPCACovMatrixFlat(candC), trNeut, trBach);
     o2::track::TrackParCov trc = casc;
     o2::dataformats::DCA dca;
     if (!trc.propagateToDCA(cascPv, fitterCasc.getBz(), &dca, 5.) ||
         std::abs(dca.getY()) > mSVParams->maxDCAXYCasc || std::abs(dca.getZ()) > mSVParams->maxDCAZCasc) {
       LOG(debug) << "Casc not compatible with PV";
       LOG(debug) << "DCA: " << dca.getY() << " " << dca.getZ();
-      mCascadesTmp[ithread].pop_back();
       continue;
     }
+    CascadeIndex cascIdx(cascVtxID, -1, bach.gid); // the v0Idx was not yet added, this will be done after the checkCascades
 
-    LOG(debug) << "Casc successfully added";
-    casc.setCosPA(bestCosPA);
-    casc.setVertexID(cascVtxID);
-    casc.setDCA(fitterCasc.getChi2AtPCACandidate());
+    LOGP(debug, "cascade successfully validated");
 
     // clone the V0, set new cosPA and VerteXID, add it to the list of V0s
-    if (cascVtxID != v0.getVertexID()) {
-      auto v0clone = v0;
-      const auto& pv = mPVertices[cascVtxID];
-
-      float dx = v0.getX() - pv.getX(), dy = v0.getY() - pv.getY(), dz = v0.getZ() - pv.getZ(), prodXYZ = dx * pV0[0] + dy * pV0[1] + dz * pV0[2];
-      float cosPA = prodXYZ / std::sqrt((dx * dx + dy * dy + dz * dz) * p2V0);
-      v0clone.setCosPA(cosPA);
-      v0clone.setVertexID(cascVtxID);
-
+    if (cascVtxID != v0Idx.getVertexID()) {
       auto pvIdx = pvMap.find(cascVtxID);
       if (pvIdx != pvMap.end()) {
-        casc.setV0ID(pvIdx->second); // V0 already exists, add reference to the cascade
-      } else {
-        mV0sTmp[ithread].push_back(v0clone);
-        casc.setV0ID(mV0sTmp[ithread].size() - 1);      // set the new V0 index in the cascade
-        pvMap[cascVtxID] = mV0sTmp[ithread].size() - 1; // add the new V0 index to the map
+        cascIdx.setV0ID(pvIdx->second); // V0 already exists, add reference to the cascade
+      } else {                          // add V0 clone for this cascade (may be used also by other cascades)
+        const auto& pv = mPVertices[cascVtxID];
+        cascIdx.setV0ID(mV0sIdxTmp[ithread].size()); // set the new V0 index in the cascade
+        pvMap[cascVtxID] = mV0sTmp[ithread].size();  // add the new V0 index to the map
+        mV0sIdxTmp[ithread].emplace_back(cascVtxID, v0Idx.getProngs());
+        if (mSVParams->createFullV0s) {
+          mV0sTmp[ithread].push_back(v0);
+          float dx = v0.getX() - pv.getX(), dy = v0.getY() - pv.getY(), dz = v0.getZ() - pv.getZ(), prodXYZ = dx * pV0[0] + dy * pV0[1] + dz * pV0[2];
+          mV0sTmp[ithread].back().setCosPA(prodXYZ / std::sqrt((dx * dx + dy * dy + dz * dz) * p2V0));
+        }
       }
+    } else {
+      nv0use++; // original v0 was used
+    }
+    mCascadesIdxTmp[ithread].push_back(cascIdx);
+    if (mSVParams->createFullCascades) {
+      casc.setCosPA(bestCosPA);
+      casc.setDCA(fitterCasc.getChi2AtPCACandidate());
+      mCascadesTmp[ithread].push_back(casc);
+    }
+    if (mStrTracker) {
+      mStrTracker->processCascade(mCascadesIdxTmp[ithread].size() - 1, casc, cascIdx, v0, ithread);
     }
   }
 
-  return mCascadesTmp[ithread].size() - nCascIni;
+  return nv0use;
 }
 
 //__________________________________________________________________
-int SVertexer::check3bodyDecays(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread)
+int SVertexer::check3bodyDecays(const V0Index& v0Idx, const V0& v0, float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread)
 {
   // check last added V0 for belonging to cascade
   auto& fitter3body = mFitter3body[ithread];
-  const auto& v0 = mV0sTmp[ithread].back();
   auto& tracks = mTracksPool[posneg];
-  int n3BodyIni = m3bodyTmp[ithread].size();
+  int n3BodyIni = m3bodyIdxTmp[ithread].size();
 
   // start from the 1st bachelor track compatible with earliest vertex in the v0vlist
   int firstTr = mVtxFirstTrack[posneg][v0vlist.getMin()], nTr = tracks.size();
@@ -760,11 +864,11 @@ int SVertexer::check3bodyDecays(float rv0, std::array<float, 3> pV0, float p2V0,
     auto decay3bodyVlist = v0vlist.getOverlap(bach.vBracket); // indices of vertices shared by V0 and bachelor
     if (mSVParams->selectBestV0) {
       // select only the best V0 candidate among the compatible ones
-      if (v0.getVertexID() < decay3bodyVlist.getMin() || v0.getVertexID() > decay3bodyVlist.getMax()) {
+      if (v0Idx.getVertexID() < decay3bodyVlist.getMin() || v0Idx.getVertexID() > decay3bodyVlist.getMax()) {
         continue;
       }
-      decay3bodyVlist.setMin(v0.getVertexID());
-      decay3bodyVlist.setMax(v0.getVertexID());
+      decay3bodyVlist.setMin(v0Idx.getVertexID());
+      decay3bodyVlist.setMax(v0Idx.getVertexID());
     }
 
     if (bach.getPt() < 0.6) {
@@ -844,20 +948,116 @@ int SVertexer::check3bodyDecays(float rv0, std::array<float, 3> pV0, float p2V0,
     if (!goodHyp) {
       continue;
     }
-    auto& candidate3B = m3bodyTmp[ithread].emplace_back(PID::HyperTriton, vertexXYZ, p3B, fitter3body.calcPCACovMatrixFlat(cand3B), tr0, tr1, tr2, v0.getProngID(0), v0.getProngID(1), bach.gid);
+    Decay3Body candidate3B(PID::HyperTriton, vertexXYZ, p3B, fitter3body.calcPCACovMatrixFlat(cand3B), tr0, tr1, tr2);
     o2::track::TrackParCov trc = candidate3B;
     o2::dataformats::DCA dca;
     if (!trc.propagateToDCA(decay3bodyPv, fitter3body.getBz(), &dca, 5.) ||
         std::abs(dca.getY()) > mSVParams->maxDCAXY3Body || std::abs(dca.getZ()) > mSVParams->maxDCAZ3Body) {
-      m3bodyTmp[ithread].pop_back();
       continue;
     }
-
-    candidate3B.setCosPA(bestCosPA);
-    candidate3B.setVertexID(decay3bodyVtxID);
-    candidate3B.setDCA(fitter3body.getChi2AtPCACandidate());
+    if (mSVParams->createFull3Bodies) {
+      candidate3B.setCosPA(bestCosPA);
+      candidate3B.setDCA(fitter3body.getChi2AtPCACandidate());
+      m3bodyTmp[ithread].push_back(candidate3B);
+    }
+    m3bodyIdxTmp[ithread].emplace_back(decay3bodyVtxID, v0Idx.getProngID(0), v0Idx.getProngID(1), bach.gid);
   }
-  return m3bodyTmp[ithread].size() - n3BodyIni;
+  return m3bodyIdxTmp[ithread].size() - n3BodyIni;
+}
+
+//__________________________________________________________________
+template <class TVI, class TCI, class T3I, class TR>
+void SVertexer::extractPVReferences(const TVI& v0s, TR& vtx2V0Refs, const TCI& cascades, TR& vtx2CascRefs, const T3I& vtx3, TR& vtx2body3Refs)
+{
+  // V0s, cascades and 3bodies are already sorted in PV ID
+  vtx2V0Refs.clear();
+  vtx2V0Refs.resize(mPVertices.size());
+  vtx2CascRefs.clear();
+  vtx2CascRefs.resize(mPVertices.size());
+  vtx2body3Refs.clear();
+  vtx2body3Refs.resize(mPVertices.size());
+  int nv0 = v0s.size(), nCasc = cascades.size(), n3body = vtx3.size();
+
+  // relate V0s to primary vertices
+  int pvID = -1, nForPV = 0;
+  for (int iv = 0; iv < nv0; iv++) {
+    if (pvID < v0s[iv].getVertexID()) {
+      if (pvID > -1) {
+        vtx2V0Refs[pvID].setEntries(nForPV);
+      }
+      pvID = v0s[iv].getVertexID();
+      vtx2V0Refs[pvID].setFirstEntry(iv);
+      nForPV = 0;
+    }
+    nForPV++;
+  }
+  if (pvID != -1) { // finalize
+    vtx2V0Refs[pvID].setEntries(nForPV);
+    // fill empty slots
+    int ent = nv0;
+    for (int ip = vtx2V0Refs.size(); ip--;) {
+      if (vtx2V0Refs[ip].getEntries()) {
+        ent = vtx2V0Refs[ip].getFirstEntry();
+      } else {
+        vtx2V0Refs[ip].setFirstEntry(ent);
+      }
+    }
+  }
+
+  // relate Cascades to primary vertices
+  pvID = -1;
+  nForPV = 0;
+  for (int iv = 0; iv < nCasc; iv++) {
+    if (pvID < cascades[iv].getVertexID()) {
+      if (pvID > -1) {
+        vtx2CascRefs[pvID].setEntries(nForPV);
+      }
+      pvID = cascades[iv].getVertexID();
+      vtx2CascRefs[pvID].setFirstEntry(iv);
+      nForPV = 0;
+    }
+    nForPV++;
+  }
+  if (pvID != -1) { // finalize
+    vtx2CascRefs[pvID].setEntries(nForPV);
+    // fill empty slots
+    int ent = nCasc;
+    for (int ip = vtx2CascRefs.size(); ip--;) {
+      if (vtx2CascRefs[ip].getEntries()) {
+        ent = vtx2CascRefs[ip].getFirstEntry();
+      } else {
+        vtx2CascRefs[ip].setFirstEntry(ent);
+      }
+    }
+  }
+
+  // relate 3 body decays to primary vertices
+  pvID = -1;
+  nForPV = 0;
+  for (int iv = 0; iv < n3body; iv++) {
+    const auto& vertex3body = vtx3[iv];
+    if (pvID < vertex3body.getVertexID()) {
+      if (pvID > -1) {
+        vtx2body3Refs[pvID].setEntries(nForPV);
+      }
+      pvID = vertex3body.getVertexID();
+      vtx2body3Refs[pvID].setFirstEntry(iv);
+      nForPV = 0;
+    }
+    nForPV++;
+  }
+  if (pvID != -1) { // finalize
+    vtx2body3Refs[pvID].setEntries(nForPV);
+    // fill empty slots
+    int ent = n3body;
+    for (int ip = vtx2body3Refs.size(); ip--;) {
+      if (vtx2body3Refs[ip].getEntries()) {
+        ent = vtx2body3Refs[ip].getFirstEntry();
+      } else {
+        vtx2body3Refs[ip].setFirstEntry(ent);
+      }
+    }
+  }
 }
 
 //__________________________________________________________________

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -465,8 +465,9 @@ has_detector_reco MCH && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output 
 has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-primary-vertexing-workflow "$DISABLE_MC $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $PVERTEX_CONFIG --pipeline $(get_N primary-vertexing MATCH REST 1 PRIMVTX),$(get_N pvertex-track-matching MATCH REST 1 PRIMVTXMATCH)" "${PVERTEXING_CONFIG_KEY}"
 
 if [[ $BEAMTYPE != "cosmic" ]]; then
-  has_detectors_reco ITS && has_detector_matching SECVTX && [[ ! -z "$SVERTEXING_SOURCES" ]] && add_W o2-secondary-vertexing-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $TPC_CORR_SCALING --vertexing-sources $SVERTEXING_SOURCES --threads $SVERTEX_THREADS --pipeline $(get_N secondary-vertexing MATCH REST $SVERTEX_THREADS SECVTX)"
-  has_detectors_reco ITS && has_detector_matching SECVTX && has_detector_matching STRK && add_W o2-strangeness-tracking-workflow "$DISABLE_MC $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N strangeness-tracking MATCH REST 1 STRK)"
+  : ${STRTRACKING:="--disable-strangeness-tracker"}
+  has_detectors_reco ITS && has_detector_matching SECVTX && has_detector_matching && STRTRACKING=""
+  has_detectors_reco ITS && has_detector_matching SECVTX && [[ ! -z "$SVERTEXING_SOURCES" ]] && add_W o2-secondary-vertexing-workflow "$DISABLE_MC $STRTRACKING $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $TPC_CORR_SCALING --vertexing-sources $SVERTEXING_SOURCES --threads $SVERTEX_THREADS --pipeline $(get_N secondary-vertexing MATCH REST $SVERTEX_THREADS SECVTX)"
 fi
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -251,10 +251,13 @@ if [ "$doreco" == "1" ]; then
   taskwrapper svfinder.log o2-secondary-vertexing-workflow $gloOpt
   echo "Return status of secondary vertexing: $?"
 
-  echo "Running strangeness tracking flow"
-  #needs results of S.Vertexer + ITS reco
-  taskwrapper sttracking.log o2-strangeness-tracking-workflow $gloOpt
-  echo "Return status of strangeness tracking: $?"
+  # the strangeness trackin is now called from the secondary-vertexing. To enable it as a standalone workflow
+  # one should run the previous o2-secondary-vertexing-workflow with options
+  # --configKeyValues "svertexer.createFullV0s=true;svertexer.createFullCascades=true;svertexer.createFull3Bodies=true" --disable-strangeness-tracker
+  #  echo "Running strangeness tracking flow"
+  #  #needs results of S.Vertexer + ITS reco
+  #  taskwrapper sttracking.log o2-strangeness-tracking-workflow $gloOpt
+  #  echo "Return status of strangeness tracking: $?"
 
   echo "Producing AOD"
   taskwrapper aod.log o2-aod-producer-workflow $gloOpt --aod-writer-keep dangling --aod-writer-resfile "AO2D" --aod-writer-resmode UPDATE --aod-timeframe-id 1 --run-number 300000


### PR DESCRIPTION
V0, Cascade and 3-Body decay objects are split into indices (of prongs, PV...) and optional kinematics objects. By default, only indices will be produced. To have also kinematics filled one should use `o2-secondary-vertexing-workflow` with options e.g. `--configKeyValues svertexer.createFullV0s=true;svertexer.createFullCascades=true;svertexer.createFull3Bodies=true`.

Since the strangeness tracker needs secondary vertices kinematics, by default it will be running from the `o2-secondary-vertexing-workflow`.  One can still run it as a separate `o2-strangeness-tracking-workflow` receiving input from the `o2-secondary-vertexing-workflow` (or root file readers) provided the `o2-secondary-vertexing-workflow` was run with the request of full secondary vertices creation and with extra option `--disable-strangeness-tracker`.