### PR TITLE
Do not report OldROF error in ROF ramp up stage

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -48,6 +48,7 @@ struct RUDecodeData {
   int nLinks = 0;          // number of links seen for this TF
   int nLinksDone = 0;      // number of links finished for this TF
   int verbosity = 0;       // verbosity level, for -1,0 print only summary data, for 1: print once every error
+  bool ROFRampUpStage = false; // flag that the data come from the ROF rate ramp-up stage
   GBTCalibData calibData{}; // calibration info from GBT calibration word
   std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> chipErrorsTF{}; // vector of chip decoding errors seen in the given TF
   const RUInfo* ruInfo = nullptr;

--- a/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
@@ -116,7 +116,7 @@ bool RUDecodeData::checkLinkInSync(int icab, const o2::InteractionRecord ir)
 #ifdef _RAW_READER_ERROR_CHECKS_
     link->statistics.errorCounts[GBTLinkDecodingStat::ErrOldROF]++;
     linkHBFToDump[(uint64_t(link->subSpec) << 32) + link->hbfEntry] = link->irHBF.orbit;
-    if (link->needToPrintError(link->statistics.errorCounts[GBTLinkDecodingStat::ErrOldROF])) {
+    if (link->needToPrintError(link->statistics.errorCounts[GBTLinkDecodingStat::ErrOldROF]) && !ROFRampUpStage) {
       LOGP(error, "{} (cable {}) has IR={} for current majority IR={} -> {}", link->describe(),
            cableHWID[icab], link->ir.asString(), ir.asString(), link->statistics.ErrNames[GBTLinkDecodingStat::ErrOldROF]);
     }

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -106,6 +106,7 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
     for (int iru = 0; iru < nru; iru++) {
       auto& ru = mRUDecodeVec[iru];
       if (ru.nNonEmptyLinks) {
+        ru.ROFRampUpStage = mROFRampUpStage;
         mNPixelsFiredROF += ru.decodeROF(mMAP, mInteractionRecord);
         mNChipsFiredROF += ru.nChipsFired;
       }


### PR DESCRIPTION
@iravasen @nicolovalle, please check. Note that the flag just mutes the printing the error message,  but its counter is still increased and the decoding of cables with data out of sync is still skipped.