### PR TITLE
Exclude GainCalibHistos from the Root dictionary

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -36,7 +36,6 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/CalibratedTracklet.h
                        include/DataFormatsTRD/DcsCcdbObjects.h
                        include/DataFormatsTRD/AngularResidHistos.h
-                       include/DataFormatsTRD/GainCalibHistos.h
                        include/DataFormatsTRD/HelperMethods.h
                        include/DataFormatsTRD/Hit.h
                        include/DataFormatsTRD/Digit.h

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -32,7 +32,6 @@
 #pragma link C++ class o2::trd::KrClusterTriggerRecord + ;
 #pragma link C++ class o2::trd::NoiseStatusMCM + ;
 #pragma link C++ class o2::trd::AngularResidHistos + ;
-#pragma link C++ class o2::trd::GainCalibHistos + ;
 #pragma link C++ class o2::trd::CalVdriftExB + ;
 #pragma link C++ class o2::trd::CalGain + ;
 #pragma link C++ class o2::trd::CalT0 + ;
@@ -50,7 +49,6 @@
 #pragma link C++ class std::vector < o2::trd::Hit > +;
 #pragma link C++ class std::vector < o2::trd::Digit> + ;
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
-#pragma link C++ class std::vector < o2::trd::GainCalibHistos> + ;
 #pragma link C++ class std::vector < o2::trd::PHData> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;


### PR DESCRIPTION
GainCalibHistos triggers inclusion of Boost polymorphic_allocator.h that is not accepted by Cling. See https://alice.its.cern.ch/jira/browse/O2-4002 for detailed discussion. 