### PR TITLE
HMP: Avoid sending Cluster dynamic data members in DPL message

### DIFF
--- a/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Cluster.h
+++ b/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Cluster.h
@@ -40,18 +40,22 @@ class Cluster
                         kEmp = -1 }; // status flags
 
  public:
-  Cluster() : mCh(-1), mSi(-1), mSt(kEmp), mBox(-1), mNlocMax(-1), mMaxQpad(-1), mMaxQ(-1), mQRaw(0), mQ(0), mErrQ(-1), mXX(0), mErrX(-1), mYY(0), mErrY(-1), mChi2(-1), mParam(o2::hmpid::Param::instanceNoGeo()) { mDigs.clear(); };
-  //  Cluster(int chamber, int size, int NlocMax, float QRaw, float Q, float X, float Y)
-  //   : mCh(chamber), mSi(size), mNlocMax(NlocMax), mQRaw(QRaw), mQ(Q), mXX(X), mYY(Y) { };
+  Cluster() : mCh(-1), mSi(-1), mSt(kEmp), mBox(-1), mNlocMax(-1), mMaxQpad(-1), mMaxQ(-1), mQRaw(0), mQ(0), mErrQ(-1), mXX(0), mErrX(-1), mYY(0), mErrY(-1), mChi2(-1) {}
 
   // Methods
   // void draw(Option_t *opt=""); //overloaded TObject::Print() to draw cluster in current canvas
   void print(Option_t* opt = "") const;                                                  // overloaded TObject::Print() to print cluster info
   static void fitFunc(int& iNpars, double* deriv, double& chi2, double* par, int iflag); // fit function to be used by MINUIT
+  void cleanPointers()
+  {
+    mDigs = nullptr;
+  }
   void coG();                                                                            // calculates center of gravity
   void corrSin();                                                                        // sinoidal correction
   void digAdd(const o2::hmpid::Digit* pDig);                                             // add new digit to the cluster
-  const o2::hmpid::Digit* dig(int i) const { return mDigs[i]; }                          // pointer to i-th digi
+  const o2::hmpid::Digit* dig(int i) const { return mDigs ? (*mDigs)[i] : nullptr; }     // pointer to i-th digi
+  const std::vector<const o2::hmpid::Digit*>* getDigits() const { return mDigs; }
+  void setDigits(std::vector<const o2::hmpid::Digit*>* v = nullptr) { mDigs = v; }
   inline bool isInPc();                                                                  // check if is in the current PC
   void reset();                                                                          // cleans the cluster
   // void setClusterParams(float xL, float yL, int iCh); //Set AliCluster3D part
@@ -110,11 +114,10 @@ class Cluster
   double mYY;                                 // local y postion, [cm]
   double mErrY;                               // error on y postion, [cm]
   double mChi2;                               // some estimator of the fit quality
-  std::vector<const o2::hmpid::Digit*> mDigs; //! list of digits forming this cluster
+  std::vector<const o2::hmpid::Digit*>* mDigs = nullptr; //! list of digits forming this cluster
 
  public:
   static bool fgDoCorrSin; // flag to switch on/off correction for Sinusoidal to cluster reco
-  Param* mParam;           //! Pointer to AliHMPIDParam
 
   ClassDefNV(Cluster, 3);
 };

--- a/Detectors/GlobalTracking/src/MatchHMP.cxx
+++ b/Detectors/GlobalTracking/src/MatchHMP.cxx
@@ -430,9 +430,7 @@ void MatchHMP::doMatching()
           if (cluster.ch() != iCh) {
             continue;
           }
-
           oneEventClusters.push_back(cluster);
-
           double qthre = pParam->qCut();
 
           if (cluster.q() < 150.) {

--- a/Detectors/HMPID/reconstruction/src/Clusterer.cxx
+++ b/Detectors/HMPID/reconstruction/src/Clusterer.cxx
@@ -48,7 +48,7 @@ void Clusterer::Dig2Clu(gsl::span<const o2::hmpid::Digit> digs, std::vector<o2::
   int pUsedDig = -1;
   int padChX = 0, padChY = 0, module = 0;
   std::vector<Pad> vPad;
-
+  std::vector<const Digit*> digVec;
   for (int iCh = Param::kMinCh; iCh <= Param::kMaxCh; iCh++) { // chambers loop
     padMap = (Float_t)-1;                                      // reset map to -1 (means no digit for this pad)
     for (size_t iDig = 0; iDig < digs.size(); iDig++) {
@@ -64,7 +64,9 @@ void Clusterer::Dig2Clu(gsl::span<const o2::hmpid::Digit> digs, std::vector<o2::
       if (vPad.at(iDig).m != iCh || (pUsedDig = UseDig(vPad.at(iDig).x, vPad.at(iDig).y, padMap)) == -1) { // this digit is from other module or already taken in FormClu(), go after next digit
         continue;
       }
+      digVec.clear();
       Cluster clu;
+      clu.setDigits(&digVec);
       clu.setCh(iCh);
       FormClu(clu, pUsedDig, digs, padMap); // form cluster starting from this digit by recursion
       clu.solve(&clus, pUserCut, isUnfold); // solve this cluster and add all unfolded clusters to provided list

--- a/Detectors/HMPID/workflow/src/DigitsToClustersSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DigitsToClustersSpec.cxx
@@ -108,30 +108,19 @@ void DigitsToClustersTask::run(framework::ProcessingContext& pc)
         size_t(trig.getNumberOfObjects())};
       size_t clStart = clusters.size();
       mRec->Dig2Clu(trigDigits, clusters, mSigmaCut, true);
-      clusterTriggers.emplace_back(trig.getIr(), clStart,
-                                   clusters.size() - clStart);
+      clusterTriggers.emplace_back(trig.getIr(), clStart, clusters.size() - clStart);
     }
   }
   LOGP(info, "Received {} triggers with {} digits -> {} triggers with {} clusters",
-       triggers.size(), digits.size(), clusterTriggers.size(),
-       clusters.size());
-
+       triggers.size(), digits.size(), clusterTriggers.size(), clusters.size());
   mDigitsReceived += digits.size();
   mClustersReceived += clusters.size();
 
-  pc.outputs().snapshot(
-    o2::framework::Output{"HMP", "CLUSTERS", 0,
-                          o2::framework::Lifetime::Timeframe},
-    clusters);
-  pc.outputs().snapshot(
-    o2::framework::Output{"HMP", "INTRECORDS1", 0,
-                          o2::framework::Lifetime::Timeframe},
-    clusterTriggers);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, clusters);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS1", 0, o2::framework::Lifetime::Timeframe}, clusterTriggers);
 
-  mExTimer.elapseMes("Clusterization of Digits received = " +
-                     std::to_string(mDigitsReceived));
-  mExTimer.elapseMes("Clusterization of Clusters received = " +
-                     std::to_string(mClustersReceived));
+  mExTimer.elapseMes("Clusterization of Digits received = " + std::to_string(mDigitsReceived));
+  mExTimer.elapseMes("Clusterization of Clusters received = " + std::to_string(mClustersReceived));
 }
 
 void DigitsToClustersTask::endOfStream(framework::EndOfStreamContext& ec)


### PR DESCRIPTION
@gvolpe79 HMP matching was crashing due to sending the clusters containing vector data member as a messageable object, which it is not.
This PR fixes the problem by changing the vector to a pointer to the vector set from outside only when this vector is needed for calculations, then the nullpointer is assigned. Therefore, for the output clusters container this pointer is always null.
The best solution (up to you) would be to completely get rid of this digits vector in the cluster class data members but to pass the vector as an argument to methods building / fitting the cluster.