### PR TITLE
Avoid InputRecord include in TRD data formats lib

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/GainCalibHistos.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/GainCalibHistos.h
@@ -16,11 +16,8 @@
 #define ALICEO2_GAINCALIBHISTOS_H
 
 #include "DataFormatsTRD/Constants.h"
-#include "Framework/InputRecord.h"
 #include "Rtypes.h"
 #include <vector>
-#include <memory>
-#include <gsl/span>
 
 namespace o2
 {
@@ -35,11 +32,10 @@ class GainCalibHistos
   ~GainCalibHistos() = default;
   void reset();
   void init();
-  void addEntry(float dEdx, int chamberId);
   auto getHistogramEntry(int index) const { return mdEdxEntries[index]; }
   auto getNEntries() const { return mNEntriesTot; }
 
-  void fill(const std::unique_ptr<const GainCalibHistos, o2::framework::InputRecord::Deleter<const o2::trd::GainCalibHistos>>& input);
+  void fill(const std::vector<int>& input);
   void merge(const GainCalibHistos* prev);
   void print();
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/T0FitHistos.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/T0FitHistos.h
@@ -17,11 +17,9 @@
 
 #include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/PHData.h"
-#include "Framework/InputRecord.h"
 #include "Rtypes.h"
 #include <vector>
 #include <memory>
-#include <gsl/span>
 
 namespace o2
 {

--- a/DataFormats/Detectors/TRD/src/GainCalibHistos.cxx
+++ b/DataFormats/Detectors/TRD/src/GainCalibHistos.cxx
@@ -31,28 +31,15 @@ void GainCalibHistos::reset()
   mNEntriesTot = 0;
 }
 
-void GainCalibHistos::addEntry(float dEdx, int chamberId)
-{
-  // add entry for given dEdx
-  int chamberOffset = chamberId * NBINSGAINCALIB;
-  int iBin = (int)dEdx;
-  if (iBin < 0 || iBin >= NBINSGAINCALIB) {
-    // This could happen because of local gain correction but should be very rare, so we can just skip it
-    return;
-  }
-  ++mdEdxEntries[chamberOffset + iBin];
-  ++mNEntriesTot;
-}
-
-void GainCalibHistos::fill(const std::unique_ptr<const GainCalibHistos, o2::framework::InputRecord::Deleter<const o2::trd::GainCalibHistos>>& input)
+void GainCalibHistos::fill(const std::vector<int>& input)
 {
   if (!mInitialized) {
     init();
   }
-  for (int i = 0; i < MAXCHAMBER * NBINSGAINCALIB; ++i) {
-    mdEdxEntries[i] += input->getHistogramEntry(i);
-    mNEntriesTot += input->getHistogramEntry(i);
+  for (auto elem : input) {
+    ++mdEdxEntries[elem];
   }
+  mNEntriesTot += input.size();
 }
 
 void GainCalibHistos::merge(const GainCalibHistos* prev)

--- a/Detectors/TRD/calibration/include/TRDCalibration/TrackBasedCalib.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/TrackBasedCalib.h
@@ -82,7 +82,7 @@ class TrackBasedCalib
   bool propagateAndUpdate(TrackTRD& trk, int iLayer, bool doUpdate) const;
 
   const AngularResidHistos& getAngResHistos() const { return mAngResHistos; }
-  const GainCalibHistos& getGainCalibHistos() const { return mGainCalibHistos; }
+  const auto& getGainCalibHistos() const { return mGainCalibHistos; }
 
  private:
   float mMaxSnp{o2::base::Propagator::MAX_SIN_PHI};  ///< max snp when propagating tracks
@@ -90,7 +90,7 @@ class TrackBasedCalib
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
   RecoParam mRecoParam;                              ///< parameters required for TRD reconstruction
   AngularResidHistos mAngResHistos;                  ///< aggregated data for the track based calibration
-  GainCalibHistos mGainCalibHistos;                  ///< aggregated data for the track based calibration
+  std::vector<int> mGainCalibHistos;                 ///< aggregated input data for gain calibration
   float bz;                                          ///< magnetic field
 
   // input arrays which should not be modified since they are provided externally

--- a/Detectors/TRD/workflow/include/TRDWorkflow/GainCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/GainCalibSpec.h
@@ -70,9 +70,9 @@ class GainCalibDevice : public o2::framework::Task
       return;
     }
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-    auto dataGainCalib = pc.inputs().get<o2::trd::GainCalibHistos*>("input");
+    auto dataGainCalib = pc.inputs().get<std::vector<int>>("input");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
-    LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << dataGainCalib->getNEntries() << " GainCalibHistos entries";
+    LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << dataGainCalib.size() << " GainCalibHistos entries";
     mCalibrator->process(dataGainCalib);
     if (pc.transitionState() == TransitionHandlingState::Requested) {
       LOG(info) << "Run stop requested, finalizing";

--- a/Detectors/TRD/workflow/io/src/TRDCalibWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibWriterSpec.cxx
@@ -35,7 +35,7 @@ o2::framework::DataProcessorSpec getTRDCalibWriterSpec(bool vdexb, bool gain, bo
                                 "calibdata",
                                 BranchDefinition<o2::trd::AngularResidHistos>{InputSpec{"calibdata", "TRD", "ANGRESHISTS"}, "AngularResids", (vdexb ? 1 : 0)},
                                 BranchDefinition<std::vector<o2::trd::PHData>>{InputSpec{"phValues", "TRD", "PULSEHEIGHT"}, "PulseHeight", (ph ? 1 : 0)},
-                                BranchDefinition<o2::trd::GainCalibHistos>{InputSpec{"calibdatagain", "TRD", "GAINCALIBHISTS"}, "GainHistograms", (gain ? 1 : 0)})();
+                                BranchDefinition<std::vector<int>>{InputSpec{"calibdatagain", "TRD", "GAINCALIBHISTS"}, "GainHistograms", (gain ? 1 : 0)})();
 };
 
 } // end namespace trd


### PR DESCRIPTION
For `T0FitHistos` the include could simply be removed, for `GainCalibHistos` I changed the data type which is sent from the EPNs to the aggregator from a fixed size vector to simply a vector of histogram entries. Since the number of entries is usually smaller than `NBINSGAINCALIB*MAXCHAMBER` this should if at all have a positive performance impact.

Fixes the boost errors reported in https://alice.its.cern.ch/jira/browse/O2-4002 and replaces https://github.com/AliceO2Group/AliceO2/pull/11726