### PR TITLE
[EMCAL-565, EMCAL-566]: Improvment in speed of EMCAL online calibrations

### DIFF
--- a/Common/Utils/src/BoostHistogramUtils.cxx
+++ b/Common/Utils/src/BoostHistogramUtils.cxx
@@ -40,48 +40,6 @@ std::string createErrorMessageFitGaus(o2::utils::FitGausError_t errorcode)
   return "Gaus fit failed! Unknown error code";
 }
 
-boostHisto1d_VarAxis boosthistoFromRoot_1D(TH1D* inHist1D)
-{
-  // first setup the proper boost histogram
-  int nBins = inHist1D->GetNbinsX();
-  std::vector<double> binEdges;
-  for (int i = 0; i < nBins + 1; i++) {
-    binEdges.push_back(inHist1D->GetBinLowEdge(i + 1));
-  }
-  boostHisto1d_VarAxis mHisto = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdges));
-
-  // trasfer the acutal values
-  for (Int_t x = 1; x < nBins + 1; x++) {
-    mHisto.at(x - 1) = inHist1D->GetBinContent(x);
-  }
-  return mHisto;
-}
-
-boostHisto2d_VarAxis boostHistoFromRoot_2D(TH2D* inHist2D)
-{
-  // Get Xaxis binning
-  const int nBinsX = inHist2D->GetNbinsX();
-  std::vector<double> binEdgesX;
-  for (int i = 0; i < nBinsX + 1; i++) {
-    binEdgesX.push_back(inHist2D->GetXaxis()->GetBinLowEdge(i + 1));
-  }
-  // Get Yaxis binning
-  const int nBinsY = inHist2D->GetNbinsY();
-  std::vector<double> binEdgesY;
-  for (int i = 0; i < nBinsY + 1; i++) {
-    binEdgesY.push_back(inHist2D->GetYaxis()->GetBinLowEdge(i + 1));
-  }
-
-  boostHisto2d_VarAxis mHisto = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdgesX), boost::histogram::axis::variable<>(binEdgesY));
-
-  // trasfer the acutal values
-  for (Int_t x = 1; x < nBinsX + 1; x++) {
-    for (Int_t y = 1; y < nBinsY + 1; y++) {
-      mHisto.at(x - 1, y - 1) = inHist2D->GetBinContent(x, y);
-    }
-  }
-  return mHisto;
-}
 /// \brief Printing an error message when then fit returns an invalid result
 /// \param errorcode Error of the type FitGausError_t, thrown when fit result is invalid.
 std::string createErrorMessage(o2::utils::FitGausError_t errorcode)

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -40,10 +40,9 @@ namespace o2
 {
 namespace emcal
 {
-
+using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
 class EMCALCalibExtractor
 {
-  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
   using slice_t = int;
   using cell_t = int;
 
@@ -252,7 +251,6 @@ class EMCALCalibExtractor
           outputMapEnergyPerHit[sliceIndex][cellID] = meanVal;
           outputMapNHits[sliceIndex][cellID] = sumVal;
         }
-
       } // end loop over the slices
     }   // end loop over the cells
     for (const auto& [sliceIndex, slice] : sliceMap) {

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -49,9 +49,9 @@ class EMCALCalibExtractor;
 
 class EMCALChannelData
 {
-  //using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALChannelData>;
+  // using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALChannelData>;
   using Cells = o2::emcal::Cell;
-  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>>>;
+  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>>>;
   using BadChannelMap = o2::emcal::BadChannelMap;
 
  public:
@@ -66,22 +66,8 @@ class EMCALChannelData
     o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
     int NCELLS = mGeometry->GetNCells();
 
-    // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
-    std::vector<double> binEdgesCells;
-    for (int i = 0; i <= NCELLS; i++) {
-      binEdgesCells.push_back(i);
-    }
-    std::vector<double> binEdgesEnergy;
-    for (int i = 0; i <= mNBins; i++) {
-      binEdgesEnergy.push_back(static_cast<double>(i) * mRange / mNBins);
-    }
-    std::vector<double> binEdgesTime;
-    for (int i = 0; i <= mNBinsTime; i++) {
-      binEdgesTime.push_back(mRangeTimeLow + (static_cast<double>(i) * std::abs(mRangeTimeHigh - mRangeTimeLow)) / mNBinsTime);
-    }
-
-    mHisto = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdgesEnergy), boost::histogram::axis::variable<>(binEdgesCells));
-    mHistoTime = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdgesTime), boost::histogram::axis::variable<>(binEdgesCells));
+    mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, 0., mRange), boost::histogram::axis::regular<>(NCELLS, -0.5, NCELLS - 0.5));
+    mHistoTime = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBinsTime, mRangeTimeHigh, mRangeTimeLow), boost::histogram::axis::regular<>(NCELLS, -0.5, NCELLS - 0.5));
   }
 
   ~EMCALChannelData() = default;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -46,22 +46,15 @@ class EMCALTimeCalibData
 {
  public:
   using Cells = o2::emcal::Cell;
-  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>>>;
+  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>>>;
 
   o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
   int NCELLS = mGeometry->GetNCells();
 
   EMCALTimeCalibData()
   {
-    std::vector<double> binEdgesCells;
-    for (int i = 0; i <= NCELLS; i++) {
-      binEdgesCells.push_back(i);
-    }
-    std::vector<double> binEdgesTime;
-    for (int i = 0; i <= EMCALCalibParams::Instance().nBinsTimeAxis_tc; i++) {
-      binEdgesTime.push_back(EMCALCalibParams::Instance().minValueTimeAxis_tc + (static_cast<double>(i) * std::abs(EMCALCalibParams::Instance().maxValueTimeAxis_tc - EMCALCalibParams::Instance().minValueTimeAxis_tc)) / EMCALCalibParams::Instance().nBinsTimeAxis_tc);
-    }
-    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdgesTime), boost::histogram::axis::variable<>(binEdgesCells));
+
+    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(EMCALCalibParams::Instance().nBinsTimeAxis_tc, EMCALCalibParams::Instance().minValueTimeAxis_tc, EMCALCalibParams::Instance().maxValueTimeAxis_tc), boost::histogram::axis::regular<>(NCELLS, -0.5, NCELLS - 0.5));
 
     LOG(debug) << "initialize time histogram with " << NCELLS << " cells";
   }
@@ -111,8 +104,7 @@ class EMCALTimeCalibData
   o2::emcal::TimeCalibrationParams process();
 
  private:
-  boostHisto mTimeHisto; ///< histogram with cell time vs. cell ID
-
+  boostHisto mTimeHisto;                                ///< histogram with cell time vs. cell ID
   int mEvents = 0;                                      ///< current number of events
   long unsigned int mNEntriesInHisto = 0;               ///< number of entries in histogram
   bool mApplyGainCalib = false;                         ///< Switch if gain calibration is applied or not

--- a/Detectors/EMCAL/calibration/run/runCalibOffline.cxx
+++ b/Detectors/EMCAL/calibration/run/runCalibOffline.cxx
@@ -50,11 +50,9 @@ int main(int argc, char** argv)
   std::string nameCalibInputHist;    // hCellIdVsTimeAbove300 for time, hCellIdVsEnergy for bad channel
   std::string nameCalibInputHistAdd; // additional input histogram for bad channel calibration if time should be considered
   std::string namePathStoreLocal;    // name for path + histogram to store the calibration locally in root TH1 format
-
-  unsigned int nthreads; // number of threads used by openMP
-
-  unsigned long rangestart; //30/10/2021, 01:02:32 for run 505566 -> 1635548552000
-  unsigned long rangeend;   // 30/10/2021, 02:31:10 for run 505566 -> 1635553870000
+  unsigned int nthreads;             // number of threads used by openMP
+  unsigned long rangestart;          // 30/10/2021, 01:02:32 for run 505566 -> 1635548552000
+  unsigned long rangeend;            // 30/10/2021, 02:31:10 for run 505566 -> 1635553870000
 
   double timeRangeLow;
   double timeRangeHigh;
@@ -211,7 +209,7 @@ int main(int argc, char** argv)
   CalibExtractor.setNThreads(nthreads);
 
   // convert the test root histogram to boost
-  auto hCalibInputHist = o2::utils::boostHistoFromRoot_2D(hCalibInputHist_ROOT);
+  boostHisto2d_VarAxis hCalibInputHist = o2::utils::boostHistoFromRoot_2D<boostHisto2d_VarAxis>(hCalibInputHist_ROOT);
 
   // instance of CalibDB
   o2::emcal::CalibDB calibdb(ccdbServerPath);
@@ -225,7 +223,7 @@ int main(int argc, char** argv)
     o2::emcal::BadChannelMap BCMap;
 
     if (doBCCalibWithTime) {
-      auto hCalibInputHistAdd = o2::utils::boostHistoFromRoot_2D(hCalibInputHistAdd_ROOT);
+      boostHisto2d_VarAxis hCalibInputHistAdd = o2::utils::boostHistoFromRoot_2D<boostHisto2d_VarAxis>(hCalibInputHistAdd_ROOT);
       BCMap = CalibExtractor.calibrateBadChannels(hCalibInputHist, hCalibInputHistAdd);
     } else {
       BCMap = CalibExtractor.calibrateBadChannels(hCalibInputHist);

--- a/Detectors/EMCAL/calibration/src/EMCALCalibExtractor.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibExtractor.cxx
@@ -15,7 +15,6 @@ namespace o2
 {
 namespace emcal
 {
-using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
 
 //-------------------------------------------------------------------------------------------
 // This function builds the scaled hit distribution
@@ -30,7 +29,7 @@ using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis
 boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double emax, boostHisto cellAmplitude)
 {
   // create the output histogram
-  auto eSumHistoScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, mNcells, "CELL ID"));
+  boostHisto eSumHistoScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, mNcells, "CELL ID"));
 
   // create a slice for each cell with energies ranging from emin to emax
   auto hEnergyCol = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100., "t-texp"));
@@ -39,7 +38,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
   auto hEnergyScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, mNcells, "CELL ID"));
 
   //...........................................
-  //start iterative process of scaling of cells
+  // start iterative process of scaling of cells
   //...........................................
   for (int iter = 1; iter < 5; iter++) {
     // array of vectors for calculating the mean hits per col/row
@@ -100,7 +99,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
     auto colResult = o2::utils::fitBoostHistoWithGaus<double>(hEnergyCol);
     double meanValCol = colResult.at(1);
 
-    //Scale each cell by the deviation of the mean of the column and the global mean
+    // Scale each cell by the deviation of the mean of the column and the global mean
     for (int iCell = 0; iCell < mNcells; iCell++) {
       auto geo = Geometry::GetInstance();
       // (0 - row, 1 - column)
@@ -114,7 +113,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
       }
     }
 
-    //Scale each cell by the deviation of the mean of the row and the global mean
+    // Scale each cell by the deviation of the mean of the row and the global mean
     for (int iCell = 0; iCell < mNcells; iCell++) {
       auto geo = Geometry::GetInstance();
       // (0 - row, 1 - column)
@@ -161,4 +160,4 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
 //____________________________________________
 
 } // end namespace emcal
-} //end namespace o2
+} // end namespace o2


### PR DESCRIPTION
- Speed of the calibration is not sufficient for Pb--Pb data taking.
- This is caused by variable binned histograms which takes too much time to fill them as the bin index cannot be calculated trivially
- The histograms for the online calibration are now changed to regular (equidistant) binning which makes them significantly faster
- As the possibility of an offline calibration with variable sized root histograms in the same code should still be possible, the root to boost function is templated to allow for both types of binning.