### PR TITLE
DPL Analysis: mitigate memory spike while writing histograms

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -271,7 +271,8 @@ struct OutputManager<HistogramRegistry> {
 
   static bool postRun(EndOfStreamContext& context, HistogramRegistry& what)
   {
-    context.outputs().snapshot(what.ref(), *(*what));
+    context.outputs().snapshot(what.ref(), *(what.getListOfHistograms()));
+    what.clean();
     return true;
   }
 };

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -119,7 +119,11 @@ class HistogramRegistry
 
   void setHash(uint32_t hash);
 
-  TList* operator*();
+  /// returns the list of histograms, properly sorted for writing.
+  TList* getListOfHistograms();
+
+  /// deletes all the histograms from the registry
+  void clean();
 
   // fill hist with values
   template <typename... Ts>

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -183,6 +183,13 @@ double HistogramRegistry::getSize(double fillFraction)
   return size;
 }
 
+void HistogramRegistry::clean()
+{
+  for (auto& value : mRegistryValue) {
+    std::visit([](auto&& hist) { hist.reset(); }, value);
+  }
+}
+
 // print some useful meta-info about the stored histograms
 void HistogramRegistry::print(bool showAxisDetails)
 {
@@ -272,7 +279,7 @@ void HistogramRegistry::print(bool showAxisDetails)
 }
 
 // create output structure will be propagated to file-sink
-TList* HistogramRegistry::operator*()
+TList* HistogramRegistry::getListOfHistograms()
 {
   TList* list = new TList();
   list->SetName(mName.data());


### PR DESCRIPTION
This is an attempt to mitigate the memory spike at the end of the processing.