### PR TITLE
DPL: avoid ODC waiting indefinitely for the driver

### DIFF
--- a/Framework/Core/src/DDSConfigHelpers.cxx
+++ b/Framework/Core/src/DDSConfigHelpers.cxx
@@ -135,7 +135,7 @@ void DDSConfigHelpers::dumpDeviceSpec2DDS(std::ostream& out,
   }
   out << R"(<topology name="o2-dataflow">)"
          "\n";
-  if (hasExpendableTask) {
+  if (hasExpendableTask || driverMode == DriverMode::EMBEDDED) {
     out << R"(<declrequirement name="odc_expendable_task" type="custom" value="true" />)"
            "\n";
   }
@@ -180,6 +180,9 @@ void DDSConfigHelpers::dumpDeviceSpec2DDS(std::ostream& out,
         << R"(<exe reachable="true">)";
     out << fmt::format("cat ${{DDS_LOCATION}}/dpl_json{}.asset | o2-dpl-run --driver-mode embedded", workflowSuffix);
     out << R"(</exe>)"
+        << "<requirements>\n"
+        << "  <requirement name=\"odc_expendable_task\" />\n"
+        << "</requirements>\n"
         << "\n";
     out << "</decltask>";
   }


### PR DESCRIPTION
When deploying in embedded mode, ODC will wait for the driver to transition through the state machine stetes. However right now the driver itself is not a FairMQ device, nor has any special plugin, so Control will wait for a transition which will never happen and eventually kill the run.

This marks the task as expendable, telling ODC to ignore the state changes for it, hopefully working around the problem.

Being expendable is also probably a good idea, because we do not want that a bug in the GUI crashes the whole workflow.