### PR TITLE
TRD raw reader update QC statistics

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -45,7 +45,8 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/KrCluster.h
                        include/DataFormatsTRD/KrClusterTriggerRecord.h
                        include/DataFormatsTRD/NoiseCalibration.h
-                        include/DataFormatsTRD/PHData.h
+                       include/DataFormatsTRD/PHData.h
+                       include/DataFormatsTRD/RawDataStats.h
                        include/DataFormatsTRD/CTF.h
                        include/DataFormatsTRD/CalVdriftExB.h
                        include/DataFormatsTRD/CalGain.h

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -43,6 +43,7 @@
 #pragma link C++ class o2::trd::ChannelInfo + ;
 #pragma link C++ class o2::trd::ChannelInfoContainer + ;
 #pragma link C++ struct o2::trd::PHData + ;
+#pragma link C++ class o2::trd::TRDDataCountersPerTimeFrame + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TrackTriggerRecord> + ;

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -88,27 +88,16 @@ void EventRecordContainer::sendData(o2::framework::ProcessingContext& pc, bool g
 
 void EventRecordContainer::accumulateStats()
 {
-  int eventcount = mEventRecords.size();
-  int sumtracklets = 0;
-  int sumdigits = 0;
-  double sumdigittime = 0;
-  double sumtracklettime = 0;
-  double sumtime = 0;
-  uint64_t sumwordsrejected = 0;
-  uint64_t sumwordsread = 0;
-  for (auto event : mEventRecords) {
-    sumtracklets += event.getEventStats().mTrackletsFound;
-    sumdigits += event.getEventStats().mDigitsFound;
-    sumtracklettime += event.getEventStats().mTimeTakenForTracklets;
-    sumdigittime += event.getEventStats().mTimeTakenForDigits;
-    sumtime += event.getEventStats().mTimeTaken;
-  }
-  if (eventcount != 0) {
-    mTFStats.mTrackletsPerEvent = sumtracklets / eventcount;
-    mTFStats.mDigitsPerEvent = sumdigits / eventcount;
-    mTFStats.mTimeTakenForTracklets = sumtracklettime;
-    mTFStats.mTimeTakenForDigits = sumdigittime;
-    mTFStats.mTimeTaken = sumtime;
+  mTFStats.mNTriggersTotal = mEventRecords.size();
+  for (const auto& event : mEventRecords) {
+    mTFStats.mTrackletsFound += event.getTracklets().size();
+    mTFStats.mDigitsFound += event.getDigits().size();
+    mTFStats.mTimeTakenForTracklets += event.getTrackletTime();
+    mTFStats.mTimeTakenForDigits += event.getDigitTime();
+    mTFStats.mTimeTaken += event.getTotalTime();
+    if (event.getIsCalibTrigger()) {
+      ++mTFStats.mNTriggersCalib;
+    }
   }
 }
 


### PR DESCRIPTION
- This allows the RawData QC class to get all information from the raw data statistics so it does not need to subscribe to all TRD data anymore. That should allow to disable the sampling of the QC class so that we get the raw parsing statistics for all data.
- As follow up a PR to QC is needed to take all information from the statistics.
- Lastly another PR to O2 will follow removing the huge 165kB `mParsingErrorsByLink` array from the statistics in favor of the `mParsingErrorsLink` vector.