### PR TITLE
ctpconfig-per-run option -> ctpconfig-run-independent

### DIFF
--- a/Detectors/AOD/src/aod-producer-workflow.cxx
+++ b/Detectors/AOD/src/aod-producer-workflow.cxx
@@ -40,7 +40,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"info-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
     {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}},
-    {"ctpconfig-per-run", o2::framework::VariantType::Bool, false, {"Use CTP config per run. 1 -- on (Data), 0 -- off (MC)"}}};
+    {"ctpconfig-run-independent", o2::framework::VariantType::Bool, false, {"Use CTP config w/o runNumber tag"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -53,7 +53,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   bool enableSV = !configcontext.options().get<bool>("disable-secondary-vertices");
   bool enableST = !configcontext.options().get<bool>("disable-strangeness-tracking");
-  bool ctpcfgperrun = configcontext.options().get<bool>("ctpconfig-per-run");
+  bool ctpcfgperrun = !configcontext.options().get<bool>("ctpconfig-run-independent");
 
   GID::mask_t allowedSrc = GID::getSourcesMask("ITS,MFT,MCH,MID,MCH-MID,TPC,TRD,ITS-TPC,TPC-TOF,TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TRD-TOF,MFT-MCH,FT0,FV0,FDD,ZDC,EMC,CTP,PHS,CPV,HMP");
   GID::mask_t src = allowedSrc & GID::getSourcesMask(configcontext.options().get<std::string>("info-sources"));

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -42,7 +42,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"no-rejectCalibTrigger", VariantType::Bool, false, {"disabled by default such that calib triggers are rejected. If enabled, calibration triggers (LED events etc.) also enter the calibration"}},
     {"no-rejectL0Trigger", VariantType::Bool, false, {"disabled by default such that L0 triggers are rejected. If enabled, L0 triggers (Gamma trigger and jet trigger) also enter the calibration"}},
     {"no-applyGainCalib", VariantType::Bool, false, {"if appplication of gain calibration should be disabled"}},
-    {"ctpconfig-per-run", VariantType::Bool, false, {"Use CTP config per run. 1 -- on (Data), 0 -- off (MC)"}}};
+    {"ctpconfig-run-independent", VariantType::Bool, false, {"Use CTP config w/o runNumber tag"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -57,7 +57,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool loadCalibParamsFromCCDB = !cfgc.options().get<bool>("no-loadCalibParamsFromCCDB");
   bool rejectCalibTrigger = !cfgc.options().get<bool>("no-rejectCalibTrigger");
   bool rejectL0Trigger = !cfgc.options().get<bool>("no-rejectL0Trigger");
-  bool ctpcfgperrun = cfgc.options().get<bool>("ctpconfig-per-run");
+  bool ctpcfgperrun = !cfgc.options().get<bool>("ctpconfig-run-independent");
   bool applyGainCalib = !cfgc.options().get<bool>("no-applyGainCalib");
 
   WorkflowSpec specs;

--- a/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
@@ -26,7 +26,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
                                        {"input-subspec", VariantType::UInt32, 0U, {"Subspecification for input objects"}},
                                        {"applyGainCalib", VariantType::Bool, false, {"Apply the gain calibration parameters for the bad channel calibration"}},
                                        {"rejectL0Trigger", VariantType::Bool, false, {"Reject all emcal triggers except the minimum bias trigger"}},
-                                       {"ctpconfig-per-run", VariantType::Bool, false, {"Use CTP config per run. 1 -- on (Data), 0 -- off (MC)"}},
+                                       {"ctpconfig-run-independent", VariantType::Bool, false, {"Use CTP config w/o runNumber tag"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -43,7 +43,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool rejectCalibTrigg = !cfgc.options().get<bool>("no-rejectCalibTrigg");
   bool doApplyGainCalib = cfgc.options().get<bool>("applyGainCalib");
   bool doRejectL0Trigger = cfgc.options().get<bool>("rejectL0Trigger");
-  bool ctpcfgperrun = cfgc.options().get<bool>("ctpconfig-per-run");
+  bool ctpcfgperrun = !cfgc.options().get<bool>("ctpconfig-run-independent");
 
   // subpsecs for input
   auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec");


### PR DESCRIPTION
Since the unanchored MC (default) CTP config is wildcarded to any run, using new CCDB feature, see https://alice.its.cern.ch/jira/browse/O2-4038. Therefore, now one can use run-dependent query both for MC and data.