### PR TITLE
MCH: added option to output the time-clustered ROFs without filtering

### DIFF
--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterFinderSpec.h
@@ -29,6 +29,7 @@ o2::framework::DataProcessorSpec
                            std::string_view inputDigitDataDescription = "F-DIGITS",
                            std::string_view inputDigitRofDataDescription = "F-DIGITROFS",
                            std::string_view outputDigitRofDataDescription = "TC-F-DIGITROFS",
+                           std::string_view outputUnfilteredDigitRofDataDescription = "UTC-F-DIGITROFS",
                            std::string_view inputIRFrameDataDescription = "ITS/IRFRAMES");
 
 } // end namespace mch

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterizerParam.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterizerParam.h
@@ -32,6 +32,8 @@ struct TimeClusterizerParam : public o2::conf::ConfigurableParamHelper<TimeClust
   bool peakSearchSignalOnly = true; ///< only use signal-like hits in peak search
   bool irFramesOnly = false;        ///< only output ROFs that overlap one of the IRFrames (provided externally, e.g. by ITS) @see MCHROFFiltering/IRFrameFilter
 
+  bool enableUnfilteredOutput = false; ///< optionally enable the output of all the time-clustered ROFs wthout filtering
+
   float rofRejectionFraction = 0; ///< fraction of output (i.e. time-clusterized) ROFs to discard. If 0 (default) keep them all. WARNING: use a non zero value only at Pt2 for sync reco, if needed.
 
   O2ParamDef(TimeClusterizerParam, "MCHTimeClusterizer");

--- a/Detectors/MUON/MCH/TimeClustering/src/digits-to-timeclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/digits-to-timeclusters-workflow.cxx
@@ -29,6 +29,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(ConfigParamSpec{"input-digits-data-description", VariantType::String, "F-DIGITS", {"description string for the input digit data"}});
   workflowOptions.push_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "F-DIGITROFS", {"description string for the input digit rofs data"}});
+  workflowOptions.push_back(ConfigParamSpec{"output-unfiltered-digitrofs-data-description", VariantType::String, "UTC-F-DIGITROFS", {"description string for the output digit rofs data (unfiltered)"}});
   workflowOptions.push_back(ConfigParamSpec{"output-digitrofs-data-description", VariantType::String, "TC-F-DIGITROFS", {"description string for the output digit rofs data"}});
   workflowOptions.push_back(ConfigParamSpec{
     "configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
@@ -45,5 +46,6 @@ WorkflowSpec defineDataProcessing(const ConfigContext& cc)
       "mch-time-clustering",
       cc.options().get<std::string>("input-digits-data-description"),
       cc.options().get<std::string>("input-digitrofs-data-description"),
-      cc.options().get<std::string>("output-digitrofs-data-description"))};
+      cc.options().get<std::string>("output-digitrofs-data-description"),
+      cc.options().get<std::string>("output-unfiltered-digitrofs-data-description"))};
 }


### PR DESCRIPTION
The additional output containing all the time-clustered ROFs without futher filtering can be useful for diagnistics, oir example in online QC. 
The output is disabled by default, and can be enabled by setting `"MCHTimeClusterizer.enableUnfilteredOutput=true"` in the configuration keys.
The default name of the DPL message is `"UTC-F-DIGITROFS"`. It can be customized via the `--output-unfiltered-digitrofs-data-description` command-line option.