### PR TITLE
Enable TRD t0 monitoring by default

### DIFF
--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -224,6 +224,9 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   if [[ $CALIB_TRD_GAIN == 1 ]]; then
     TRD_CALIB_CONFIG+=" --gain"
   fi
+  if [[ $CALIB_TRD_T0 == 1 ]]; then
+    TRD_CALIB_CONFIG+=" --t0"
+  fi
   if [[ ! -z ${TRD_CALIB_CONFIG} ]]; then
     add_W o2-calibration-trd-workflow "${TRD_CALIB_CONFIG}"
   fi

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -159,7 +159,9 @@ fi
 workflow_has_parameter CALIB && [[ $CALIB_TRD_VDRIFTEXB == 1 ]] && TRD_CONFIG+=" --enable-vdexb-calib"
 workflow_has_parameter CALIB && [[ $CALIB_TRD_GAIN == 1 ]] && TRD_CONFIG+=" --enable-gain-calib"
 ! has_detector FT0 && TRD_CONFIG+=" --disable-ft0-pileup-tagging"
-[[ ${DISABLE_TRD_PH:-} != 1 ]] && TRD_CONFIG+=" --enable-ph"
+if ( workflow_has_parameter CALIB && [[ $CALIB_TRD_T0 == 1 ]] ) || [[ ${DISABLE_TRD_PH:-} != 1 ]]; then
+  TRD_CONFIG+=" --enable-ph"
+fi
 
 SEND_ITSTPC_DTGL=
 workflow_has_parameter CALIB && [[ $CALIB_TPC_VDRIFTTGL == 1 ]] && SEND_ITSTPC_DTGL="--produce-calibration-data"


### PR DESCRIPTION
Ping @luisabergmann with this change and https://github.com/AliceO2Group/O2DPG/pull/1175 we will have the t0 monitoring running by default in the synch. reco