### PR TITLE
DPL: optimise signposts implementation

### DIFF
--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -15,6 +15,7 @@ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/Framework
 
 o2_add_library(FrameworkFoundation
                SOURCES src/RuntimeError.cxx
+               src/Signpost.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation3rdparty
               )
@@ -25,12 +26,12 @@ target_compile_definitions(${targetName} PUBLIC -DDPL_ENABLE_BACKTRACE)
 endif()
 
 add_executable(o2-test-framework-foundation
-               test/test_FunctionalHelpers.cxx 
-               test/test_Traits.cxx 
+               test/test_FunctionalHelpers.cxx
+               test/test_Traits.cxx
                test/test_StructToTuple.cxx
                test/test_CallbackRegistry.cxx
-               test/test_CompilerBuiltins.cxx 
-               #               test/test_Signpost.cxx 
+               test/test_CompilerBuiltins.cxx
+               #               test/test_Signpost.cxx
                test/test_RuntimeError.cxx)
 target_link_libraries(o2-test-framework-foundation PRIVATE O2::FrameworkFoundation)
 target_link_libraries(o2-test-framework-foundation PRIVATE O2::Catch2)
@@ -39,9 +40,16 @@ add_executable(o2-test-framework-Signpost
                test/test_Signpost.cxx)
 target_link_libraries(o2-test-framework-Signpost PRIVATE O2::FrameworkFoundation)
 
+add_executable(o2-test-framework-SignpostLogger
+               test/test_SignpostLogger.cxx
+               test/test_SignpostLogger2.cxx
+               )
+target_link_libraries(o2-test-framework-SignpostLogger PRIVATE O2::FrameworkFoundation)
+
 get_filename_component(outdir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../tests ABSOLUTE)
 set_property(TARGET o2-test-framework-foundation PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
 set_property(TARGET o2-test-framework-Signpost PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
+set_property(TARGET o2-test-framework-SignpostLogger PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
 
 add_test(NAME framework:foundation COMMAND o2-test-framework-foundation)
 

--- a/Framework/Foundation/src/Signpost.cxx
+++ b/Framework/Foundation/src/Signpost.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define O2_SIGNPOST_IMPLEMENTATION
+#include "Framework/Signpost.h"

--- a/Framework/Foundation/test/test_SignpostLogger.cxx
+++ b/Framework/Foundation/test/test_SignpostLogger.cxx
@@ -9,8 +9,16 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+// We need the implementation on Apple, to get the logger based signposts
+// We also need the implementation in release mode, because the logger based signposts are not available in the release build
+#if defined(__APPLE__) || defined(NDEBUG)
+#define O2_SIGNPOST_IMPLEMENTATION
+#endif
+#define O2_FORCE_LOGGER_SIGNPOST 1
 #include "Framework/Signpost.h"
 #include <iostream>
+
+O2_DECLARE_LOG(test_Signpost2, "my category2");
 
 int main(int argc, char** argv)
 {

--- a/Framework/Foundation/test/test_SignpostLogger2.cxx
+++ b/Framework/Foundation/test/test_SignpostLogger2.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define O2_FORCE_LOGGER_SIGNPOST 1
+#include "Framework/Signpost.h"
+#include <iostream>
+
+O2_DECLARE_LOG(test_Signpost3, "my category3");
+O2_DECLARE_LOG(test_Signpost2, "my category2");

--- a/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
@@ -20,6 +20,7 @@
 #include "Framework/Logger.h"
 #include "Framework/DeviceController.h"
 #include "Framework/DataProcessingStates.h"
+#include "Framework/Signpost.h"
 #include <DebugGUI/icons_font_awesome.h>
 
 #include "DebugGUI/imgui.h"


### PR DESCRIPTION
* Move out of line the implementation for the Logger case.
* Wrap the log creation logic so that we can have a list of the available loggers, e.g. to enable / disable them from the gui.