### PR TITLE
[EMCAL-551] Increase Cell ClassDef version

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -185,7 +185,7 @@ class Cell
 
   char mCellWords[6]; ///< data word
 
-  ClassDefNV(Cell, 1);
+  ClassDefNV(Cell, 2);
 };
 
 /// \brief Stream operator for EMCAL cell

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -24,6 +24,9 @@
 #pragma link C++ class o2::emcal::MCLabel + ;
 #pragma link C++ class o2::emcal::ErrorTypeFEE + ;
 
+#pragma read \
+  sourceClass = "o2::emcal::Cell" targetClass = "o2::emcal::Cell" source = "UShort_t mCellWords[3]" version = "[1]" include = "iostream" target = "mCellWords" code = "{const char *oldwords = reinterpret_cast<const char *>(onfile.mCellWords); for(int i = 0; i < 6; i++) {mCellWords[i] = oldwords[i];} }"
+
 #pragma link C++ class std::vector < o2::emcal::TriggerRecord> + ;
 #pragma link C++ class std::vector < o2::emcal::Cell> + ;
 #pragma link C++ class std::vector < o2::emcal::Digit> + ;


### PR DESCRIPTION
- Increase ClassDef version of cell to 2, as the type
  of the data word has changed from ushort array to
  char array
- Add method in LinkDef to convert the data words
  from the old format to the new format.