### PR TITLE
Added asynchronous functionality

### DIFF
--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -448,7 +448,7 @@ CCDBDownloader::TransferResults* CCDBDownloader::prepareResultsStruct(size_t num
   results->transferFinishedFlags.resize(numberOfHandles);
 
   // Fill with default values
-  for(int i = 0; i < numberOfHandles; i++) {
+  for (int i = 0; i < numberOfHandles; i++) {
     results->transferFinishedFlags[i] = false;
     results->curlCodes[i] = CURLE_FAILED_INIT;
   }
@@ -470,13 +470,13 @@ std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> co
 {
   auto results = prepareResultsStruct(handleVector.size());
 
-  for(int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
+  for (int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
     auto* data = createPerformData(handleIndex, results, BLOCKING);
     setHandleOptions(handleVector[handleIndex], data);
     mHandlesToBeAdded.push_back(handleVector[handleIndex]);
   }
   checkHandleQueue();
-  while(results->requestsLeft > 0) {
+  while (results->requestsLeft > 0) {
     uv_run(mUVLoop, UV_RUN_ONCE);
   }
   vector<CURLcode> curlCodes = results->curlCodes;
@@ -488,7 +488,7 @@ CCDBDownloader::TransferResults* CCDBDownloader::batchAsynchPerform(std::vector<
 {
   auto results = prepareResultsStruct(handleVector.size());
 
-  for(int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
+  for (int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
     auto* data = createPerformData(handleIndex, results, ASYNCHRONOUS);
     setHandleOptions(handleVector[handleIndex], data);
     mHandlesToBeAdded.push_back(handleVector[handleIndex]);
@@ -499,7 +499,7 @@ CCDBDownloader::TransferResults* CCDBDownloader::batchAsynchPerform(std::vector<
 
 std::vector<CURLcode>::iterator CCDBDownloader::getAll(TransferResults* results)
 {
-  while(results->requestsLeft > 0) {
+  while (results->requestsLeft > 0) {
     runLoop(false);
   }
   return results->curlCodes.begin();

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -448,7 +448,7 @@ CCDBDownloader::TransferResults* CCDBDownloader::prepareResultsStruct(size_t num
   results->transferFinishedFlags.resize(numberOfHandles);
 
   // Fill with default values
-  for (int i = 0; i < numberOfHandles; i++) {
+  for(int i = 0; i < numberOfHandles; i++) {
     results->transferFinishedFlags[i] = false;
     results->curlCodes[i] = CURLE_FAILED_INIT;
   }
@@ -470,13 +470,13 @@ std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> co
 {
   auto results = prepareResultsStruct(handleVector.size());
 
-  for (int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
+  for(int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
     auto* data = createPerformData(handleIndex, results, BLOCKING);
     setHandleOptions(handleVector[handleIndex], data);
     mHandlesToBeAdded.push_back(handleVector[handleIndex]);
   }
   checkHandleQueue();
-  while (results->requestsLeft > 0) {
+  while(results->requestsLeft > 0) {
     uv_run(mUVLoop, UV_RUN_ONCE);
   }
   vector<CURLcode> curlCodes = results->curlCodes;
@@ -488,7 +488,7 @@ CCDBDownloader::TransferResults* CCDBDownloader::batchAsynchPerform(std::vector<
 {
   auto results = prepareResultsStruct(handleVector.size());
 
-  for (int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
+  for(int handleIndex = 0; handleIndex < handleVector.size(); handleIndex++) {
     auto* data = createPerformData(handleIndex, results, ASYNCHRONOUS);
     setHandleOptions(handleVector[handleIndex], data);
     mHandlesToBeAdded.push_back(handleVector[handleIndex]);
@@ -499,7 +499,7 @@ CCDBDownloader::TransferResults* CCDBDownloader::batchAsynchPerform(std::vector<
 
 std::vector<CURLcode>::iterator CCDBDownloader::getAll(TransferResults* results)
 {
-  while (results->requestsLeft > 0) {
+  while(results->requestsLeft > 0) {
     runLoop(false);
   }
   return results->curlCodes.begin();

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(asynch_test)
   std::vector<std::string*> destinations;
   std::vector<CURL*> handleVector;
 
-  for(int i = 0; i < 10; i++) {
+  for (int i = 0; i < 10; i++) {
     destinations.push_back(new std::string());
     handleVector.push_back(createTestHandle(destinations.back()));
   }
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(asynch_test)
     BOOST_CHECK(*curlCodesIterator == CURLE_OK);
   }
 
-  for(int i = 0; i < handleVector.size(); i++) {
+  for (int i = 0; i < handleVector.size(); i++) {
     long httpCode;
     curl_easy_getinfo(handleVector[i], CURLINFO_HTTP_CODE, &httpCode);
     BOOST_CHECK(httpCode == 200);


### PR DESCRIPTION
Added back:
- Asynchronous batch perform.
- A getAll() function, that works similar to future.get().
- Test for said perform function.

Additional information:
- The old blocking function is still present, and is the default.
- To ensure asynchronous performs are executed correctly one must run the mUVLoop often enough to ensure proper reading from sockets.
- Asynchronous perform functions return a structure which must be freed after all downloads scheduled via that perform finish and not earlier.

Additionally the code for old tests functions has been revised and compressed.

Previous PR for this functionality (which is not merged and is closed):
https://github.com/AliceO2Group/AliceO2/pull/11670