### PR TITLE
Fixes to make Hijing work with Run3 simulation chain

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -69,7 +69,7 @@ class MCTrackT
   Int_t GetPdgCode() const { return mPdgCode; }
   Int_t getMotherTrackId() const { return mMotherTrackId; }
   Int_t getSecondMotherTrackId() const { return mSecondMotherTrackId; }
-  bool isPrimary() const { return getProcess() == TMCProcess::kPPrimary; }
+  bool isPrimary() const { return (getProcess() == TMCProcess::kPPrimary) || (getMotherTrackId() < 0 && getSecondMotherTrackId() < 0); }
   bool isSecondary() const { return !isPrimary(); }
   Int_t getFirstDaughterTrackId() const { return mFirstDaughterTrackId; }
   Int_t getLastDaughterTrackId() const { return mLastDaughterTrackId; }

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -784,6 +784,10 @@ void clearMCKeepStore(std::vector<std::vector<std::unordered_map<int, int>*>>& s
 // helper function to add a particle/track to the MC keep store
 void keepMCParticle(std::vector<std::vector<std::unordered_map<int, int>*>>& store, int source, int event, int track, int value = 1)
 {
+  if (track < 0) {
+    LOG(warn) << "trackID is smaller than 0. Neglecting";
+    return;
+  }
   if (!store[source][event]) {
     store[source][event] = new std::unordered_map<int, int>;
   }

--- a/Generators/include/Generators/GeneratorExternalParam.h
+++ b/Generators/include/Generators/GeneratorExternalParam.h
@@ -30,6 +30,7 @@ namespace eventgen
 struct GeneratorExternalParam : public o2::conf::ConfigurableParamHelper<GeneratorExternalParam> {
   std::string fileName = "";
   std::string funcName = "";
+  bool markAllAsPrimary = true; // marks all generator level particles as "primary" with kPPrimary as process (like Pythia8 is doing)
   O2ParamDef(GeneratorExternalParam, "GeneratorExternal");
 };
 

--- a/Generators/src/GeneratorTGenerator.cxx
+++ b/Generators/src/GeneratorTGenerator.cxx
@@ -12,11 +12,13 @@
 #include "SimulationDataFormat/MCGenProperties.h"
 #include "SimulationDataFormat/ParticleStatus.h"
 #include "Generators/GeneratorTGenerator.h"
+#include "Generators/GeneratorExternalParam.h"
 #include <fairlogger/Logger.h>
 #include "FairPrimaryGenerator.h"
 #include "TGenerator.h"
 #include "TClonesArray.h"
 #include "TParticle.h"
+#include "TMCProcess.h" // for VMC Particle Production Process
 
 namespace o2
 {
@@ -95,6 +97,12 @@ Bool_t
     mParticles.push_back(*particle);
     // Set the transport bit according to the HepMC status code as it always used to be
     mParticles.back().SetBit(ParticleStatus::kToBeDone, mcgenstatus::getHepMCStatusCode(particle->GetStatusCode()) == 1);
+
+    if (GeneratorExternalParam::Instance().markAllAsPrimary) {
+      // The production process will be set to kPPrimary which is the expected default for generator-level particles in O2
+      // not doing this might confuse transport and selection of particles to keep in AOD
+      mParticles.back().SetUniqueID(kPPrimary);
+    }
   }
 
   /** success **/


### PR DESCRIPTION
* enforce physics process to be kPPrimary for particles coming from external TGenerators. There is no guarantee that they set the process correctly and our convention is that all generator-level particles are primaries. This step fixes a problem that was seen with Hijing particles when determining the isPhysicalPrimary property.

* add a protection in AOD conversion: do not handle negative track indices (they may creep in from faulty generators)

This commit makes it possible to use Hijing (from AliRoot) as external generator up to the AOD stage in O2DPG with the procedure described in O2/run/SimExamples/AliRoot_Hijing.