### PR TITLE
ctpdevL CTP inputs decoding at CTF

### DIFF
--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,9 +55,12 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
-  bool isInputEmpty() { return CTPInputMask.count() == 0; } const;
-  const bool isClassEmty() { return CTPClassMask.count() == 0; } const;
-  const bool isEmty() { return isInputEmpty() && isClassEmty(); } const;
+  bool isInputEmpty() { return CTPInputMask.count() == 0; }
+  const;
+  const bool isClassEmty() { return CTPClassMask.count() == 0; }
+  const;
+  const bool isEmty() { return isInputEmpty() && isClassEmty(); }
+  const;
   const bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,9 +55,9 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
-  bool isInputEmpty() { return CTPInputMask.count() == 0; }
-  const bool isClassEmty() { return CTPClassMask.count() == 0; }
-  const bool isEmty() { return isInputEmpty() && isClassEmty(); }
+  bool isInputEmpty() { return CTPInputMask.count() == 0; } const;
+  const bool isClassEmty() { return CTPClassMask.count() == 0; } const;
+  const bool isEmty() { return isInputEmpty() && isClassEmty(); } const;
   const bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,10 +55,10 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
-  bool isInputEmpty() { return CTPInputMask.count() == 0; } const
-  bool isClassEmty() { return CTPClassMask.count() == 0; } const
-  bool isEmty() { return isInputEmpty() && isClassEmty(); } const
-  bool operator==(const CTPDigit& d) const
+  bool isInputEmpty() { return CTPInputMask.count() == 0; }
+  const bool isClassEmty() { return CTPClassMask.count() == 0; }
+  const bool isEmty() { return isInputEmpty() && isClassEmty(); }
+  const bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;
   }

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,12 +55,9 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
-  bool isInputEmpty() { return CTPInputMask.count() == 0; }
-  const;
-  const bool isClassEmty() { return CTPClassMask.count() == 0; }
-  const;
-  const bool isEmty() { return isInputEmpty() && isClassEmty(); }
-  const;
+  bool isInputEmpty() const { return CTPInputMask.count() == 0; }
+  const bool isClassEmty() const { return CTPClassMask.count() == 0; }
+  const bool isEmty() const { return isInputEmpty() && isClassEmty(); }
   const bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,6 +55,9 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
+  bool isInputEmpty() {return CTPInputMask.count() == 0; }
+  bool isClassEmty() {return CTPClassMask.count() == 0; }
+  bool isEmty() {return isInputEmpty() && isClassEmty(); }
   bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,9 +55,9 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
-  bool isInputEmpty() { return CTPInputMask.count() == 0; }
-  bool isClassEmty() { return CTPClassMask.count() == 0; }
-  bool isEmty() { return isInputEmpty() && isClassEmty(); }
+  bool isInputEmpty() { return CTPInputMask.count() == 0; } const
+  bool isClassEmty() { return CTPClassMask.count() == 0; } const
+  bool isEmty() { return isInputEmpty() && isClassEmty(); } const
   bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -55,9 +55,9 @@ struct CTPDigit {
   void printStream(std::ostream& stream) const;
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
-  bool isInputEmpty() {return CTPInputMask.count() == 0; }
-  bool isClassEmty() {return CTPClassMask.count() == 0; }
-  bool isEmty() {return isInputEmpty() && isClassEmty(); }
+  bool isInputEmpty() { return CTPInputMask.count() == 0; }
+  bool isClassEmty() { return CTPClassMask.count() == 0; }
+  bool isEmty() { return isInputEmpty() && isClassEmty(); }
   bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Digits.h
@@ -56,8 +56,8 @@ struct CTPDigit {
   void setInputMask(gbtword80_t mask);
   void setClassMask(gbtword80_t mask);
   bool isInputEmpty() const { return CTPInputMask.count() == 0; }
-  const bool isClassEmty() const { return CTPClassMask.count() == 0; }
-  const bool isEmty() const { return isInputEmpty() && isClassEmty(); }
+  const bool isClassEmpty() const { return CTPClassMask.count() == 0; }
+  const bool isEmpty() const { return isInputEmpty() && isClassEmpty(); }
   const bool operator==(const CTPDigit& d) const
   {
     return intRecord == d.intRecord && CTPInputMask == d.CTPInputMask && CTPClassMask == d.CTPClassMask;

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -129,10 +129,8 @@ class CTFCoderBase
   long getIRFrameSelShift() const { return mIRFrameSelShift; }
 
   void setBCShift(int64_t n) { mBCShift = n; }
-  void setBCShiftInputs(int64_t n) { mBCShiftInputs = n; }
   void setFirstTFOrbit(uint32_t n) { mFirstTFOrbit = n; }
   auto getBCShift() const { return mBCShift; }
-  auto getBCShiftInputs() const { return mBCShiftInputs; }
   auto getFirstTFOrbit() const { return mFirstTFOrbit; }
   void setSupportBCShifts(bool v = true) { mSupportBCShifts = v; }
   bool getSupportBCShifts() const { return mSupportBCShifts; }
@@ -156,7 +154,6 @@ class CTFCoderBase
     return diff < 0 ? true : diff >= shift;
   }
   bool canApplyBCShift(const o2::InteractionRecord& ir) const { return canApplyBCShift(ir, mBCShift); }
-  bool canApplyBCShiftInputs(const o2::InteractionRecord& ir) const { return canApplyBCShift(ir, mBCShiftInputs); }
 
   template <typename CTF>
   std::vector<char> loadDictionaryFromTree(TTree* tree);
@@ -170,8 +167,7 @@ class CTFCoderBase
   bool mLoadDictFromCCDB{true};
   bool mSupportBCShifts{false};
   OpType mOpType; // Encoder or Decoder
-  int64_t mBCShift = 0;       // shift to apply to decoded Trigger Class Mask (i.e. CTP offset if was not corrected on raw data decoding level)
-  int64_t mBCShiftInputs = 0; // shift to apply to decoded Input Mask (i.e. CTP offset if was not corrected on raw data decoding level)
+  int64_t mBCShift = 0; // shift to apply to decoded IR (i.e. CTP offset if was not corrected on raw data decoding level)
   uint32_t mFirstTFOrbit = 0;
   size_t mIRFrameSelMarginBwd = 0; // margin in BC to add to the IRFrame lower boundary when selection is requested
   size_t mIRFrameSelMarginFwd = 0; // margin in BC to add to the IRFrame upper boundary when selection is requested
@@ -335,13 +331,10 @@ bool CTFCoderBase::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, voi
   } else if ((match = (matcher == o2::framework::ConcreteDataMatcher("CTP", "Trig_Offset", 0)))) {
     const auto& trigOffsParam = o2::ctp::TriggerOffsetsParam::Instance();
     auto bcshift = trigOffsParam.customOffset[mDet.getID()];
-    auto bcshiftInp = trigOffsParam.globalInputsShift;
-    if (bcshift || bcshiftInp) {
+    if (bcshift) {
       if (mSupportBCShifts) {
         LOGP(info, "Decoded IRs will be augmented by {} BCs, discarded if become prior to 1st orbit", bcshift);
         setBCShift(-bcshift); // offset is subtracted
-        setBCShiftInputs(-bcshiftInp);
-        LOG(info) << "BC shifts: Trig Classes:" << bcshift << " Inputs:" << bcshiftInp;
       } else {
         LOGP(alarm, "Decoding with {} BCs shift is requested, but the {} does not support this operation, ignoring request", bcshift, mDet.getName());
       }

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -170,7 +170,7 @@ class CTFCoderBase
   bool mLoadDictFromCCDB{true};
   bool mSupportBCShifts{false};
   OpType mOpType; // Encoder or Decoder
-  int64_t mBCShift = 0; // shift to apply to decoded Trigger Class Mask (i.e. CTP offset if was not corrected on raw data decoding level)
+  int64_t mBCShift = 0;       // shift to apply to decoded Trigger Class Mask (i.e. CTP offset if was not corrected on raw data decoding level)
   int64_t mBCShiftInputs = 0; // shift to apply to decoded Input Mask (i.e. CTP offset if was not corrected on raw data decoding level)
   uint32_t mFirstTFOrbit = 0;
   size_t mIRFrameSelMarginBwd = 0; // margin in BC to add to the IRFrame lower boundary when selection is requested

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -229,7 +229,7 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data, LumiInfo& l
   return iosize;
 }
 ///________________________________
-template <typename CTF=o2::ctp::CTF>
+template <typename CTF = o2::ctp::CTF>
 bool CTFCoder::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
   auto match = o2::ctf::CTFCoderBase::finaliseCCDB<CTF>(matcher, obj);

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -162,20 +162,20 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data, LumiInfo& l
       for (int i = 0; i < CTFHelper::CTPInpNBytes; i++) {
         CTPInputMask |= static_cast<uint64_t>(*itInp++) << (8 * i);
       }
-        if(CTPInputMask) {
+      if (CTPInputMask) {
         if (digitsMap.count(irs)) {
           if (digitsMap[irs].isInputEmpty()) {
             digitsMap[irs].CTPInputMask = CTPInputMask;
-            //LOG(info) << "IR1:";
-            //digitsMap[irs].printStream(std::cout);
+            // LOG(info) << "IR1:";
+            // digitsMap[irs].printStream(std::cout);
           } else {
             LOG(error) << "CTPInpurMask already exist:" << irs << " dig.CTPInputMask:" << digitsMap[irs].CTPInputMask << " CTPInputMask:" << CTPInputMask;
           }
         } else {
           CTPDigit dig = {irs, CTPInputMask, 0};
           digitsMap[irs] = dig;
-          //LOG(info) << "IR2:";
-          //digitsMap[irs].printStream(std::cout);
+          // LOG(info) << "IR2:";
+          // digitsMap[irs].printStream(std::cout);
         }
       }
     } else { // correction would make IR prior to mFirstTFOrbit, skip
@@ -190,20 +190,20 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data, LumiInfo& l
       for (int i = 0; i < CTFHelper::CTPClsNBytes; i++) {
         CTPClassMask |= static_cast<uint64_t>(*itCls++) << (8 * i);
       }
-      if(CTPClassMask) {
+      if (CTPClassMask) {
         if (digitsMap.count(irs)) {
           if (digitsMap[irs].isClassEmty()) {
             digitsMap[irs].CTPClassMask = CTPClassMask;
-            //LOG(info) << "TCM1:";
-            //digitsMap[irs].printStream(std::cout);
+            // LOG(info) << "TCM1:";
+            // digitsMap[irs].printStream(std::cout);
           } else {
             LOG(error) << "CTPClassMask already exist:" << irs << " dig.CTPClassMask:" << digitsMap[irs].CTPClassMask << " CTPClassMask:" << CTPClassMask;
           }
         } else {
           CTPDigit dig = {irs, 0, CTPClassMask};
           digitsMap[irs] = dig;
-          //LOG(info) << "TCM2:";
-          //digitsMap[irs].printStream(std::cout);
+          // LOG(info) << "TCM2:";
+          // digitsMap[irs].printStream(std::cout);
         }
       }
     } else { // correction would make IR prior to mFirstTFOrbit, skip

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -48,9 +48,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG>
   o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& data, LumiInfo& lumi);
 
-  /// add CTP related shifts
-  template <typename CTF>
-  bool finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj);
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc, bool askTree);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
   void setDecodeInps(bool decodeinps) { mDecodeInps = decodeinps; }
@@ -227,14 +225,6 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data, LumiInfo& l
   assert(itCls == bytesClass.end());
   iosize.rawIn = header.nTriggers * sizeof(CTPDigit);
   return iosize;
-}
-///________________________________
-template <typename CTF = o2::ctp::CTF>
-bool CTFCoder::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
-{
-  auto match = o2::ctf::CTFCoderBase::finaliseCCDB<CTF>(matcher, obj);
-  mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
-  return match;
 }
 
 } // namespace ctp

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -49,7 +49,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& data, LumiInfo& lumi);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
-  void setDecodeInps(bool decodeinps){ mDecodeInps=decodeinps; }
+  void setDecodeInps(bool decodeinps) { mDecodeInps = decodeinps; }
 
  private:
   template <typename VEC>
@@ -157,55 +157,55 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data, LumiInfo& l
       ir.bc += bcInc[itrig];
     }
     if (checkIROKInputs || canApplyBCShiftInputs(ir)) { // correction will be ok
-      //checkIROK = true;
-      //CTPDigit dig;
+      // checkIROK = true;
+      // CTPDigit dig;
       auto irs = ir - mBCShiftInputs;
       uint64_t CTPInputMask = 0;
       for (int i = 0; i < CTFHelper::CTPInpNBytes; i++) {
         CTPInputMask |= static_cast<uint64_t>(*itInp++) << (8 * i);
       }
-      if(digitsMap.count(irs)) {
-        if(digitsMap[irs].CTPInputMask.count() == 0 ) {
+      if (digitsMap.count(irs)) {
+        if (digitsMap[irs].CTPInputMask.count() == 0) {
           digitsMap[irs].CTPInputMask = CTPInputMask;
         } else {
           LOG(error) << "CTPInpurMask already exist:" << irs << " dig.CTPInputMask:" << digitsMap[irs].CTPInputMask << " CTPInputMask:" << CTPInputMask;
         }
       } else {
-        CTPDigit dig = {irs,CTPInputMask,0};
+        CTPDigit dig = {irs, CTPInputMask, 0};
         digitsMap[irs] = dig;
       }
     } else { // correction would make IR prior to mFirstTFOrbit, skip
       itInp += CTFHelper::CTPInpNBytes;
-      //itCls += CTFHelper::CTPClsNBytes;
-      //continue;
+      // itCls += CTFHelper::CTPClsNBytes;
+      // continue;
     }
     if (checkIROK || canApplyBCShift(ir)) { // correction will be ok
-      //checkIROK = true;
+      // checkIROK = true;
       auto irs = ir - mBCShift;
       uint64_t CTPClassMask = 0;
       for (int i = 0; i < CTFHelper::CTPClsNBytes; i++) {
         CTPClassMask |= static_cast<uint64_t>(*itCls++) << (8 * i);
       }
-      if(digitsMap.count(irs)) {
-        if(digitsMap[irs].CTPClassMask.count() == 0) {
+      if (digitsMap.count(irs)) {
+        if (digitsMap[irs].CTPClassMask.count() == 0) {
           digitsMap[irs].CTPClassMask = CTPClassMask;
         } else {
           LOG(error) << "CTPClassMask already exist:" << irs << " dig.CTPClassMask:" << digitsMap[irs].CTPClassMask << " CTPClassMask:" << CTPClassMask;
         }
       } else {
-        CTPDigit dig = {irs,0,CTPClassMask};
+        CTPDigit dig = {irs, 0, CTPClassMask};
         digitsMap[irs] = dig;
       }
     } else { // correction would make IR prior to mFirstTFOrbit, skip
-      //itInp += CTFHelper::CTPInpNBytes;
+      // itInp += CTFHelper::CTPInpNBytes;
       itCls += CTFHelper::CTPClsNBytes;
-      //continue;
+      // continue;
     }
-    //digitsMap[dig.intRecord] = dig;
+    // digitsMap[dig.intRecord] = dig;
   }
-  if(mDecodeInps) {
+  if (mDecodeInps) {
     std::vector<CTPDigit> digits;
-    o2::ctp::RawDataDecoder::shiftInputs(digitsMap,digits,mFirstTFOrbit);
+    o2::ctp::RawDataDecoder::shiftInputs(digitsMap, digits, mFirstTFOrbit);
     for (auto const& dig : digits) {
       data.emplace_back(dig);
     }

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -232,12 +232,9 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data, LumiInfo& l
 template <typename CTF = o2::ctp::CTF>
 bool CTFCoder::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
-  bool match = false;
-  match = o2::ctf::CTFCoderBase::finaliseCCDB<CTF>(matcher, obj);
-  if ((match = (matcher == o2::framework::ConcreteDataMatcher("CTP", "Trig_Offset", 0)))) {
-    mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
-    LOG(info) << "CTP BC shifts inputs:" << mBCShiftInputs << " TClasses:" << mBCShift;
-  }
+  auto match = o2::ctf::CTFCoderBase::finaliseCCDB<CTF>(matcher, obj);
+  mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
+  LOG(info) << "BCShiftInputs:" << mBCShiftInputs;
   return match;
 }
 

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
@@ -49,6 +49,7 @@ class RawDataDecoder
   int init();
   static int shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit, std::bitset<48>& inpmask, int64_t shift, int level, std::map<o2::InteractionRecord, CTPDigit>& digmap);
   static int shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, std::vector<CTPDigit>& digits, uint32_t TFOrbit);
+
  private:
   static constexpr uint32_t TF_TRIGGERTYPE_MASK = 0x800;
   static constexpr uint32_t HB_TRIGGERTYPE_MASK = 0x2;

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
@@ -47,8 +47,8 @@ class RawDataDecoder
   int getErrorIR() { return mErrorIR; }
   int getErrorTCR() { return mErrorTCR; }
   int init();
-  int shiftNew(const o2::InteractionRecord& irin, std::bitset<48>& inpmask, int64_t shift, int level, std::map<o2::InteractionRecord, CTPDigit>& digmap);
-
+  static int shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit, std::bitset<48>& inpmask, int64_t shift, int level, std::map<o2::InteractionRecord, CTPDigit>& digmap);
+  static int shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, std::vector<CTPDigit>& digits, uint32_t TFOrbit);
  private:
   static constexpr uint32_t TF_TRIGGERTYPE_MASK = 0x800;
   static constexpr uint32_t HB_TRIGGERTYPE_MASK = 0x2;

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
@@ -34,7 +34,7 @@ class RawDataDecoder
   ~RawDataDecoder() = default;
   static void makeGBTWordInverse(std::vector<gbtword80_t>& diglets, gbtword80_t& GBTWord, gbtword80_t& remnant, uint32_t& size_gbt, uint32_t Npld);
   int addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword80_t& diglet, gbtword80_t& pldmask, std::map<o2::InteractionRecord, CTPDigit>& digits);
-  int decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, std::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1);
+  int decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, o2::pmr::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1);
   void setDecodeInps(bool decodeinps) { mDecodeInps = decodeinps; }
   void setDoLumi(bool lumi) { mDoLumi = lumi; }
   void setDoDigits(bool digi) { mDoDigits = digi; }
@@ -48,7 +48,7 @@ class RawDataDecoder
   int getErrorTCR() { return mErrorTCR; }
   int init();
   static int shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit, std::bitset<48>& inpmask, int64_t shift, int level, std::map<o2::InteractionRecord, CTPDigit>& digmap);
-  static int shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, std::vector<CTPDigit>& digits, uint32_t TFOrbit);
+  static int shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, o2::pmr::vector<CTPDigit>& digits, uint32_t TFOrbit);
 
  private:
   static constexpr uint32_t TF_TRIGGERTYPE_MASK = 0x800;

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/RawDataDecoder.h
@@ -35,6 +35,7 @@ class RawDataDecoder
   static void makeGBTWordInverse(std::vector<gbtword80_t>& diglets, gbtword80_t& GBTWord, gbtword80_t& remnant, uint32_t& size_gbt, uint32_t Npld);
   int addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword80_t& diglet, gbtword80_t& pldmask, std::map<o2::InteractionRecord, CTPDigit>& digits);
   int decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, o2::pmr::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1);
+  int decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, std::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1);
   void setDecodeInps(bool decodeinps) { mDecodeInps = decodeinps; }
   void setDoLumi(bool lumi) { mDoLumi = lumi; }
   void setDoDigits(bool digi) { mDoDigits = digi; }

--- a/Detectors/CTP/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/CTP/reconstruction/src/CTFCoder.cxx
@@ -18,12 +18,6 @@
 #include <TTree.h>
 
 using namespace o2::ctp;
-///________________________________
-void CTFCoder::updateTimeDependentParams(o2::framework::ProcessingContext& pc, bool askTree)
-{
-  o2::ctf::CTFCoderBase::updateTimeDependentParams(pc, askTree);
-  mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
-}
 ///___________________________________________________________________________________
 // Register encoded data in the tree (Fill is not called, will be done by caller)
 void CTFCoder::appendToTree(TTree& tree, CTF& ec)

--- a/Detectors/CTP/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/CTP/reconstruction/src/CTFCoder.cxx
@@ -21,8 +21,8 @@ using namespace o2::ctp;
 ///________________________________
 void CTFCoder::updateTimeDependentParams(o2::framework::ProcessingContext& pc, bool askTree)
 {
-   o2::ctf::CTFCoderBase::updateTimeDependentParams(pc, askTree);
-   mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
+  o2::ctf::CTFCoderBase::updateTimeDependentParams(pc, askTree);
+  mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
 }
 ///___________________________________________________________________________________
 // Register encoded data in the tree (Fill is not called, will be done by caller)

--- a/Detectors/CTP/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/CTP/reconstruction/src/CTFCoder.cxx
@@ -18,7 +18,12 @@
 #include <TTree.h>
 
 using namespace o2::ctp;
-
+///________________________________
+void CTFCoder::updateTimeDependentParams(o2::framework::ProcessingContext& pc, bool askTree)
+{
+   o2::ctf::CTFCoderBase::updateTimeDependentParams(pc, askTree);
+   mBCShiftInputs = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
+}
 ///___________________________________________________________________________________
 // Register encoded data in the tree (Fill is not called, will be done by caller)
 void CTFCoder::appendToTree(TTree& tree, CTF& ec)

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -323,10 +323,10 @@ int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2
 int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, std::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1)
 {
   o2::pmr::vector<CTPDigit> pmrdigits;
-  for(auto const d: digits) {
+  for (auto const d : digits) {
     pmrdigits.push_back(d);
   }
-  return decodeRaw(inputs,filter,pmrdigits,lumiPointsHBF1);
+  return decodeRaw(inputs, filter, pmrdigits, lumiPointsHBF1);
 }
 //
 // Not to be called with level LM

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -54,7 +54,7 @@ int RawDataDecoder::addCTPDigit(uint32_t linkCRU, uint32_t orbit, gbtword80_t& d
   LOG(debug) << bcid << "    pld:" << pld;
   o2::InteractionRecord ir = {bcid, orbit};
   if (linkCRU == o2::ctp::GBTLinkIDIntRec) {
-    int32_t BCShiftCorrectionInps = o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
+    int32_t BCShiftCorrectionInps = -o2::ctp::TriggerOffsetsParam::Instance().globalInputsShift;
     LOG(debug) << "InputMaskCount:" << digits[ir].CTPInputMask.count();
     LOG(debug) << "ir ir ori:" << ir;
     if ((ir.orbit <= mTFOrbit) && ((int32_t)ir.bc < BCShiftCorrectionInps)) {
@@ -86,7 +86,7 @@ int RawDataDecoder::addCTPDigit(uint32_t linkCRU, uint32_t orbit, gbtword80_t& d
       ret = 2;
     }
   } else if (linkCRU == o2::ctp::GBTLinkIDClassRec) {
-    int32_t BCShiftCorrection = o2::ctp::TriggerOffsetsParam::Instance().customOffset[o2::detectors::DetID::CTP];
+    int32_t BCShiftCorrection = -o2::ctp::TriggerOffsetsParam::Instance().customOffset[o2::detectors::DetID::CTP];
     int32_t offset = BCShiftCorrection + o2::ctp::TriggerOffsetsParam::Instance().LM_L0 + o2::ctp::TriggerOffsetsParam::Instance().L0_L1 - 1;
     LOG(debug) << "tcr ir ori:" << ir;
     if ((ir.orbit <= mTFOrbit) && ((int32_t)ir.bc < offset)) {

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -323,10 +323,11 @@ int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2
 int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, std::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1)
 {
   o2::pmr::vector<CTPDigit> pmrdigits;
-  for (auto const d : digits) {
-    pmrdigits.push_back(d);
+  int ret = decodeRaw(inputs, filter, pmrdigits, lumiPointsHBF1);
+  for (auto const d : pmrdigits) {
+    digits.push_back(d);
   }
-  return decodeRaw(inputs, filter, pmrdigits, lumiPointsHBF1);
+  return ret;
 }
 //
 // Not to be called with level LM

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -320,6 +320,15 @@ int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2
   return ret;
 }
 //
+int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, std::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1)
+{
+  o2::pmr::vector<CTPDigit> pmrdigits;
+  for(auto const d: digits) {
+    pmrdigits.push_back(d);
+  }
+  return decodeRaw(inputs,filter,pmrdigits,lumiPointsHBF1);
+}
+//
 // Not to be called with level LM
 // Keeping shift in params if needed to be generalised
 int RawDataDecoder::shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit, std::bitset<48>& inpmask, int64_t shift, int level, std::map<o2::InteractionRecord, CTPDigit>& digmap)
@@ -345,6 +354,8 @@ int RawDataDecoder::shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit
   }
   return 0;
 }
+//
+
 int RawDataDecoder::shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, o2::pmr::vector<CTPDigit>& digits, uint32_t TFOrbit)
 {
   int nClasswoInp = 0; // counting classes without input which should never happen

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -292,7 +292,7 @@ int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2
     // std::cout << "last lumi:" << nhb  << std::endl;
   }
   if (mDoDigits & mDecodeInps) {
-    shiftInputs(digitsMap,digits,mTFOrbit);
+    shiftInputs(digitsMap, digits, mTFOrbit);
   }
   if (mDoDigits && !mDecodeInps) {
     for (auto const& dig : digitsMap) {
@@ -346,84 +346,84 @@ int RawDataDecoder::shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit
   }
   return 0;
 }
-int RawDataDecoder::shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap,std::vector<CTPDigit>& digits,uint32_t TFOrbit)
+int RawDataDecoder::shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, std::vector<CTPDigit>& digits, uint32_t TFOrbit)
 {
-    int nClasswoInp = 0; // counting classes without input which should never happen
-    int nLM = 0;
-    int nL0 = 0;
-    int nL1 = 0;
-    int nTwI = 0;
-    int nTwoI = 0;
-    std::map<o2::InteractionRecord, CTPDigit> digitsMapShifted;
-    auto L0shift = o2::ctp::TriggerOffsetsParam::Instance().LM_L0;
-    auto L1shift = L0shift + o2::ctp::TriggerOffsetsParam::Instance().L0_L1;
-    for (auto const& dig : digitsMap) {
-      auto inpmask = dig.second.CTPInputMask;
-      auto inpmaskLM = inpmask & LMMASKInputs;
-      auto inpmaskL0 = inpmask & L0MASKInputs;
-      auto inpmaskL1 = inpmask & L1MASKInputs;
-      int lm = inpmaskLM.count() > 0;
-      int l0 = inpmaskL0.count() > 0;
-      int l1 = inpmaskL1.count() > 0;
-      int lut = lm + (l0 << 1) + (l1 << 2);
-      // std::cout << "L0mask:" << L0MASKInputs << std::endl;
-      // std::cout << "L0:" << inpmaskL0 << std::endl;
-      // std::cout << "L1:" << inpmaskL1 << std::endl;
-      if (lut == 0 || lut == 1) { // no inps or LM
-        digitsMapShifted[dig.first] = dig.second;
-      } else if (lut == 2) { // L0
-        shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
-        if (dig.second.CTPClassMask.count()) {
-          LOG(error) << "Adding class mask without input ?";
-          CTPDigit digi = {dig.first, 0, dig.second.CTPClassMask};
-          digitsMapShifted[dig.first] = digi;
-        }
-      } else if (lut == 4) { // L1
-        shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
-      } else if (lut == 6) { // L0 and L1
-        shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
-        shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
-      } else if (lut == 3) { // LM and L0
-        shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
-        CTPDigit digi = {dig.first, inpmask & (~L0MASKInputs), dig.second.CTPClassMask};
-        // LOG(info) << "LM-L0 present";
+  int nClasswoInp = 0; // counting classes without input which should never happen
+  int nLM = 0;
+  int nL0 = 0;
+  int nL1 = 0;
+  int nTwI = 0;
+  int nTwoI = 0;
+  std::map<o2::InteractionRecord, CTPDigit> digitsMapShifted;
+  auto L0shift = o2::ctp::TriggerOffsetsParam::Instance().LM_L0;
+  auto L1shift = L0shift + o2::ctp::TriggerOffsetsParam::Instance().L0_L1;
+  for (auto const& dig : digitsMap) {
+    auto inpmask = dig.second.CTPInputMask;
+    auto inpmaskLM = inpmask & LMMASKInputs;
+    auto inpmaskL0 = inpmask & L0MASKInputs;
+    auto inpmaskL1 = inpmask & L1MASKInputs;
+    int lm = inpmaskLM.count() > 0;
+    int l0 = inpmaskL0.count() > 0;
+    int l1 = inpmaskL1.count() > 0;
+    int lut = lm + (l0 << 1) + (l1 << 2);
+    // std::cout << "L0mask:" << L0MASKInputs << std::endl;
+    // std::cout << "L0:" << inpmaskL0 << std::endl;
+    // std::cout << "L1:" << inpmaskL1 << std::endl;
+    if (lut == 0 || lut == 1) { // no inps or LM
+      digitsMapShifted[dig.first] = dig.second;
+    } else if (lut == 2) { // L0
+      shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
+      if (dig.second.CTPClassMask.count()) {
+        LOG(error) << "Adding class mask without input ?";
+        CTPDigit digi = {dig.first, 0, dig.second.CTPClassMask};
         digitsMapShifted[dig.first] = digi;
-      } else if (lut == 5) { // LM and L1
-        shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
-        CTPDigit digi = {dig.first, inpmask & (~L1MASKInputs), dig.second.CTPClassMask};
-        digitsMapShifted[dig.first] = digi;
-      } else if (lut == 7) { // LM and L0 and L1
-        shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
-        shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
-        CTPDigit digi = {dig.first, inpmaskLM, dig.second.CTPClassMask};
-        digitsMapShifted[dig.first] = digi;
+      }
+    } else if (lut == 4) { // L1
+      shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
+    } else if (lut == 6) { // L0 and L1
+      shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
+      shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
+    } else if (lut == 3) { // LM and L0
+      shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
+      CTPDigit digi = {dig.first, inpmask & (~L0MASKInputs), dig.second.CTPClassMask};
+      // LOG(info) << "LM-L0 present";
+      digitsMapShifted[dig.first] = digi;
+    } else if (lut == 5) { // LM and L1
+      shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
+      CTPDigit digi = {dig.first, inpmask & (~L1MASKInputs), dig.second.CTPClassMask};
+      digitsMapShifted[dig.first] = digi;
+    } else if (lut == 7) { // LM and L0 and L1
+      shiftNew(dig.first, TFOrbit, inpmask, L0shift, 0, digitsMapShifted);
+      shiftNew(dig.first, TFOrbit, inpmask, L1shift, 1, digitsMapShifted);
+      CTPDigit digi = {dig.first, inpmaskLM, dig.second.CTPClassMask};
+      digitsMapShifted[dig.first] = digi;
+    } else {
+      LOG(fatal) << "lut = " << lut;
+    }
+  }
+  for (auto const& dig : digitsMapShifted) {
+    auto d = dig.second;
+    if ((d.CTPInputMask & LMMASKInputs).count()) {
+      nLM++;
+    }
+    if ((d.CTPInputMask & L0MASKInputs).count()) {
+      nL0++;
+    }
+    if ((d.CTPInputMask & L1MASKInputs).count()) {
+      nL1++;
+    }
+    if (d.CTPClassMask.count()) {
+      if (d.CTPInputMask.count()) {
+        nTwI++;
       } else {
-        LOG(fatal) << "lut = " << lut;
+        nTwoI++;
       }
     }
-    for (auto const& dig : digitsMapShifted) {
-      auto d = dig.second;
-      if ((d.CTPInputMask & LMMASKInputs).count()) {
-        nLM++;
-      }
-      if ((d.CTPInputMask & L0MASKInputs).count()) {
-        nL0++;
-      }
-      if ((d.CTPInputMask & L1MASKInputs).count()) {
-        nL1++;
-      }
-      if (d.CTPClassMask.count()) {
-        if (d.CTPInputMask.count()) {
-          nTwI++;
-        } else {
-          nTwoI++;
-        }
-      }
-      digits.push_back(dig.second);
-    }
-    if (nTwoI) { // Trigger class wo Input
-      LOG(error) << "LM:" << nLM << " L0:" << nL0 << " L1:" << nL1 << " TwI:" << nTwI << " Trigger cals wo inputTwoI:" << nTwoI;
-    }
+    digits.push_back(dig.second);
+  }
+  if (nTwoI) { // Trigger class wo Input
+    LOG(error) << "LM:" << nLM << " L0:" << nL0 << " L1:" << nL1 << " TwI:" << nTwI << " Trigger cals wo inputTwoI:" << nTwoI;
+  }
   return 0;
 }
 //

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -126,7 +126,7 @@ int RawDataDecoder::addCTPDigit(uint32_t linkCRU, uint32_t orbit, gbtword80_t& d
 // Decodes one page
 // It is assumed that CTP HBF has never more than one page - valid until ~ 5Mhz rate:
 // 1 HBF/page <= 8000kB = 8*1024*8/120 = 546 GBT words = 546 IRs/page = 5.5 MHz
-int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, std::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1)
+int RawDataDecoder::decodeRaw(o2::framework::InputRecord& inputs, std::vector<o2::framework::InputSpec>& filter, o2::pmr::vector<CTPDigit>& digits, std::vector<LumiInfo>& lumiPointsHBF1)
 {
   int ret = 0;
   static int nwrites = 0;
@@ -345,7 +345,7 @@ int RawDataDecoder::shiftNew(const o2::InteractionRecord& irin, uint32_t TFOrbit
   }
   return 0;
 }
-int RawDataDecoder::shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, std::vector<CTPDigit>& digits, uint32_t TFOrbit)
+int RawDataDecoder::shiftInputs(std::map<o2::InteractionRecord, CTPDigit>& digitsMap, o2::pmr::vector<CTPDigit>& digits, uint32_t TFOrbit)
 {
   int nClasswoInp = 0; // counting classes without input which should never happen
   int nLM = 0;

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -120,7 +120,6 @@ int RawDataDecoder::addCTPDigit(uint32_t linkCRU, uint32_t orbit, gbtword80_t& d
   } else {
     LOG(error) << "Unxpected  CTP CRU link:" << linkCRU;
   }
-  mStickyError = true;
   return ret;
 }
 //

--- a/Detectors/CTP/workflow/include/CTPWorkflow/RawDecoderSpec.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/RawDecoderSpec.h
@@ -55,7 +55,7 @@ class RawDecoderSpec : public framework::Task
  private:
   // for digits
   bool mDoDigits = true;
-  std::vector<CTPDigit> mOutputDigits;
+  o2::pmr::vector<CTPDigit> mOutputDigits;
   // for lumi
   bool mDoLumi = true;
   //

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -44,6 +44,9 @@ void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matche
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   mCTFCoder.init<CTF>(ic);
+  bool decodeinps = ic.options().get<bool>("inputs-decoding-ctf");
+  mCTFCoder.setDecodeInps(decodeinps);
+  LOG(info) << "Decode inputs:" << decodeinps;
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -91,7 +94,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}}}};
+    Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
+            {"inputs-decoding-ctf",VariantType::Bool, false,{"Inputs alignment: true - CTF decoder - has to be compatible with reco: allowed options: 10,01,00"}}}};
 }
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -95,7 +95,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
-            {"inputs-decoding-ctf",VariantType::Bool, false,{"Inputs alignment: true - CTF decoder - has to be compatible with reco: allowed options: 10,01,00"}}}};
+            {"inputs-decoding-ctf", VariantType::Bool, false, {"Inputs alignment: true - CTF decoder - has to be compatible with reco: allowed options: 10,01,00"}}}};
 }
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -44,7 +44,7 @@ void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matche
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   mCTFCoder.init<CTF>(ic);
-  bool decodeinps = ic.options().get<bool>("inputs-decoding-ctf");
+  bool decodeinps = ic.options().get<bool>("ctpinputs-decoding-ctf");
   mCTFCoder.setDecodeInps(decodeinps);
   LOG(info) << "Decode inputs:" << decodeinps;
 }
@@ -95,7 +95,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
-            {"inputs-decoding-ctf", VariantType::Bool, false, {"Inputs alignment: true - CTF decoder - has to be compatible with reco: allowed options: 10,01,00"}}}};
+            {"ctpinputs-decoding-ctf", VariantType::Bool, false, {"Inputs alignment: true - CTF decoder - has to be compatible with reco: allowed options: 10,01,00"}}}};
 }
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -25,7 +25,7 @@ using namespace o2::ctp::reco_workflow;
 
 void RawDecoderSpec::init(framework::InitContext& ctx)
 {
-  bool decodeinps = ctx.options().get<bool>("inputs-decoding");
+  bool decodeinps = ctx.options().get<bool>("ctpinputs-decoding");
   mDecoder.setDecodeInps(decodeinps);
   mNTFToIntegrate = ctx.options().get<int>("ntf-to-average");
   mVerbose = ctx.options().get<bool>("use-verbose-mode");
@@ -189,5 +189,5 @@ o2::framework::DataProcessorSpec o2::ctp::reco_workflow::getRawDecoderSpec(bool 
       {"lumi-inp1", o2::framework::VariantType::String, "TVX", {"The first input used for online lumi. Name in capital."}},
       {"lumi-inp2", o2::framework::VariantType::String, "VBA", {"The second input used for online lumi. Name in capital."}},
       {"use-verbose-mode", o2::framework::VariantType::Bool, false, {"Verbose logging"}},
-      {"inputs-decoding", o2::framework::VariantType::Bool, false, {"Inputs alignment: true - raw decoder - has to be compatible with CTF decoder: allowed options: 10,01,00"}}}};
+      {"ctpinputs-decoding", o2::framework::VariantType::Bool, false, {"Inputs alignment: true - raw decoder - has to be compatible with CTF decoder: allowed options: 10,01,00"}}}};
 }

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -189,5 +189,5 @@ o2::framework::DataProcessorSpec o2::ctp::reco_workflow::getRawDecoderSpec(bool 
       {"lumi-inp1", o2::framework::VariantType::String, "TVX", {"The first input used for online lumi. Name in capital."}},
       {"lumi-inp2", o2::framework::VariantType::String, "VBA", {"The second input used for online lumi. Name in capital."}},
       {"use-verbose-mode", o2::framework::VariantType::Bool, false, {"Verbose logging"}},
-      {"inputs-decoding", o2::framework::VariantType::Bool, false, {"Inputs alignment: false - CTF decoder, true - here "}}}};
+      {"inputs-decoding", o2::framework::VariantType::Bool, false, {"Inputs alignment: true - raw decoder - has to be compatible with CTF decoder: allowed options: 10,01,00"}}}};
 }


### PR DESCRIPTION
The idea is to have two options:
1.) no inputs decoding in reco and decode in CTF decode  : => this pull request
2.) decode ctp inputs in reco and no decoding in CTFdecode 
- this is implemented in PR 11712
- this can potentially corrupt data irreversibly
With shifts in both case there are two global shifts one for inputs and one for trigger classes.
And then for inputs there are default LM-L0, LM-L1 latency shifts.
