### PR TITLE
Handling of cvmfs urls in CcdbApi

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -897,6 +897,9 @@ void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string con
   if (url.find("alien:/", 0) != std::string::npos) {
     return downloadAlienContent(url, tinfo);
   }
+  if (url.find("file:///cvmfs", 0) != std::string::npos) {
+    return (void*)TFile::Open(url.c_str());
+  }
   // add other final cases here
   // example root://
 


### PR DESCRIPTION
I've tested this change on a url in ccdb, which first redirect pointed to cvmfs. If the file was located in cvmfs then the file was opened and returned correctly. If file was not present then the information was logged and api proceeded with further redirects as normal.