### PR TITLE
Handling local files in CcdbApi

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -478,12 +478,12 @@ class CcdbApi //: public DatabaseInterface
   void* extractFromLocalFile(std::string const& filename, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const;
 
   /**
-   * Helper function to download binary content from alien:// storage
+   * Helper function to download binary content from alien://, cvmfs or local storage
    * @param fullUrl The alien URL
    * @param tcl The TClass object describing the serialized type
    * @return raw pointer to created object
    */
-  void* downloadAlienContent(std::string const& fullUrl, std::type_info const& tinfo) const;
+  void* downloadFilesystemContent(std::string const& fullUrl, std::type_info const& tinfo) const;
 
   // initialize the TGrid (Alien connection)
   bool initTGrid() const;

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -850,9 +850,9 @@ bool CcdbApi::initTGrid() const
   return mAlienInstance != nullptr;
 }
 
-void* CcdbApi::downloadAlienContent(std::string const& url, std::type_info const& tinfo) const
+void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info const& tinfo) const
 {
-  if (!initTGrid()) {
+  if ((url.find("alien:/", 0) != std::string::npos) && !initTGrid()) {
     return nullptr;
   }
   std::lock_guard<std::mutex> guard(gIOMutex);
@@ -894,11 +894,8 @@ void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string con
   static thread_local std::multimap<std::string, std::string> headerData;
 
   // let's see first of all if the url is something specific that curl cannot handle
-  if (url.find("alien:/", 0) != std::string::npos) {
-    return downloadAlienContent(url, tinfo);
-  }
-  if (url.find("file:///", 0) != std::string::npos) {
-    return (void*)TFile::Open(url.c_str());
+  if ((url.find("alien:/", 0) != std::string::npos) || (url.find("file:/", 0) != std::string::npos)) {
+    return downloadFilesystemContent(url, tinfo);
   }
   // add other final cases here
   // example root://

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -897,6 +897,9 @@ void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string con
   if (url.find("alien:/", 0) != std::string::npos) {
     return downloadAlienContent(url, tinfo);
   }
+  if (url.find("file:///", 0) != std::string::npos) {
+    return (void*)TFile::Open(url.c_str());
+  }
   // add other final cases here
   // example root://
 


### PR DESCRIPTION
I tested this with both local files and cvmfs. If the file located via url is not present then that information is logged and other redirects follow as usual. If the file is found then it is returned correctly.