### PR TITLE
ITS workflows to generate and parse ADAPOS data

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/CMakeLists.txt
@@ -11,3 +11,4 @@
 
 add_subdirectory(EVE)
 add_subdirectory(test)
+add_subdirectory(DCS)

--- a/Detectors/ITSMFT/ITS/macros/DCS/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/DCS/CMakeLists.txt
@@ -1,3 +1,14 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
 o2_add_test_root_macro(
   makeITSCCDBEntryForDCS.C
   PUBLIC_LINK_LIBRARIES O2::DetectorsDCS O2::CCDB)

--- a/Detectors/ITSMFT/ITS/macros/DCS/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/DCS/CMakeLists.txt
@@ -1,0 +1,7 @@
+o2_add_test_root_macro(
+  makeITSCCDBEntryForDCS.C
+  PUBLIC_LINK_LIBRARIES O2::DetectorsDCS O2::CCDB)
+
+install(
+  FILES makeITSCCDBEntryForDCS.C
+  DESTINATION share/macro/)

--- a/Detectors/ITSMFT/ITS/macros/DCS/makeITSCCDBEntryForDCS.C
+++ b/Detectors/ITSMFT/ITS/macros/DCS/makeITSCCDBEntryForDCS.C
@@ -1,0 +1,58 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CommonUtils/NameConf.h"
+#endif
+#include <vector>
+#include <string>
+#include "TFile.h"
+#include "DetectorsDCS/AliasExpander.h"
+#include "DetectorsDCS/DeliveryType.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include <unordered_map>
+#include <chrono>
+#include "CCDB/CcdbApi.h"
+
+using DPID = o2::dcs::DataPointIdentifier;
+
+int makeITSCCDBEntryForDCS(std::string ccdb_path = o2::base::NameConf::getCCDBServer())
+{
+
+  std::unordered_map<DPID, std::string> dpid2DataDesc;
+  std::vector<std::string> aliases;
+
+  // fill aliases
+  int nStaves[] = {12, 16, 20, 24, 30, 42, 48};
+  for (int iL = 0; iL < 7; iL++) {
+    for (int iS = 0; iS < nStaves[iL]; iS++) {
+      std::string stv = iS > 9 ? std::to_string(iS) : std::string(1, '0').append(std::to_string(iS));
+      aliases.push_back("ITS_L" + std::to_string(iL) + "_" + stv + "_STROBE");
+    }
+  }
+
+  std::vector<std::string> expaliases = o2::dcs::expandAliases(aliases);
+
+  DPID dpidtmp;
+  for (size_t i = 0; i < expaliases.size(); ++i) {
+    DPID::FILL(dpidtmp, expaliases[i], o2::dcs::DeliveryType::DPVAL_INT);
+    dpid2DataDesc[dpidtmp] = "ITSDATAPOINTS";
+  }
+
+  o2::ccdb::CcdbApi api;
+  api.init(ccdb_path);
+  std::map<std::string, std::string> md;
+  md["comment"] = "uploaded with O2 makeITSCCDBEntryForDCS.C";
+  long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  api.storeAsTFileAny(&dpid2DataDesc, "ITS/Config/DCSDPconfig", md, ts, ts + 365L * 10 * 24 * 3600 * 1000); // validity is 10 years
+
+  return 0;
+}

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -28,7 +28,7 @@ o2_add_library(ITSWorkflow
                        src/DCSAdaposParserWorkflow.cxx
                        src/DCSAdaposParserSpec.cxx
                        src/DCSDataGeneratorWorkflow.cxx
-		       src/DCSGeneratorSpec.cxx
+           src/DCSGeneratorSpec.cxx
          PUBLIC_LINK_LIBRARIES O2::Framework
                                O2::SimConfig
                                O2::DetectorsDCS

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -25,8 +25,13 @@ o2_add_library(ITSWorkflow
                        src/ThresholdAggregatorSpec.cxx
                        src/DCSParserWorkflow.cxx
                        src/DCSParserSpec.cxx
+                       src/DCSAdaposParserWorkflow.cxx
+                       src/DCSAdaposParserSpec.cxx
+                       src/DCSDataGeneratorWorkflow.cxx
+		       src/DCSGeneratorSpec.cxx
          PUBLIC_LINK_LIBRARIES O2::Framework
                                O2::SimConfig
+                               O2::DetectorsDCS
                                O2::DataFormatsITS
                                O2::DataFormatsDCS
                                O2::DataFormatsTRD
@@ -70,6 +75,16 @@ o2_add_executable(threshold-aggregator-workflow
 
 o2_add_executable(dcs-parser-workflow
                   SOURCES src/its-dcs-parser-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+
+o2_add_executable(dcs-generator-workflow
+                  SOURCES src/its-dcs-generator-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+
+o2_add_executable(dcs-adapos-parser-workflow
+                  SOURCES src/its-dcs-adapos-parser-workflow.cxx
                   COMPONENT_NAME its
                   PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
@@ -1,0 +1,91 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DCSAdaposParserSpec.h
+
+#ifndef O2_ITS_DCS_PARSER_SPEC_H
+#define O2_ITS_DCS_PARSER_SPEC_H
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <map>
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/InputRecordWalker.h"
+#include <fairmq/Device.h>
+
+#include <ITSMFTReconstruction/RawPixelDecoder.h>
+
+#include "Framework/RawDeviceService.h"
+#include "Headers/DataHeader.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CCDB/CcdbApi.h"
+
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+
+using namespace o2::framework;
+using namespace o2::itsmft;
+
+namespace o2
+{
+namespace its
+{
+
+using DPCOM = o2::dcs::DataPointCompositeObject;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+
+class ITSDCSAdaposParser : public Task
+{
+ public:
+  ITSDCSAdaposParser();
+  ~ITSDCSAdaposParser() override = default;
+
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+
+  //////////////////////////////////////////////////////////////////
+ private:
+  // Helper functions
+  void process(const gsl::span<const DPCOM> dps);
+  void processDP(const DPCOM& dpcom);
+  void pushToCCDB(ProcessingContext&);
+
+  // Ccdb url for ccdb upload withing the wf
+  std::string mCcdbUrl = "";
+
+  // store the strobe length for each DPID = stave
+  std::unordered_map<DPID, std::vector<DPVAL>> mDPstrobe;
+  double mStrobeToUpload = 0.;
+  bool doStrobeUpload = false;
+  bool isFirstCheck = true;
+  DPID checkDp;
+
+  long int mTF = 0;
+  std::string mSelfName;
+  bool mVerboseOutput = false;
+};
+
+// Create a processor spec
+o2::framework::DataProcessorSpec getITSDCSAdaposParserSpec();
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
@@ -83,6 +83,8 @@ class ITSDCSAdaposParser : public Task
   // for ccdb alpide param fetching
   o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>* mCcdbAlpideParam;
   std::string mCcdbFetchUrl = "http://ccdb-test.cern.ch:8080";
+  o2::ccdb::BasicCCDBManager& mMgr = o2::ccdb::BasicCCDBManager::instance();
+  long int startTime;
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
@@ -38,6 +38,7 @@
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
 #include "ITSMFTBase/DPLAlpideParam.h"
+#include "CCDB/BasicCCDBManager.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;
@@ -66,20 +67,22 @@ class ITSDCSAdaposParser : public Task
   void process(const gsl::span<const DPCOM> dps);
   void processDP(const DPCOM& dpcom);
   void pushToCCDB(ProcessingContext&);
+  void getCurrentCcdbAlpideParam();
 
   // Ccdb url for ccdb upload withing the wf
   std::string mCcdbUrl = "";
 
   // store the strobe length for each DPID = stave
-  std::unordered_map<DPID, std::vector<DPVAL>> mDPstrobe;
+  std::unordered_map<DPID, DPVAL> mDPstrobe;
   double mStrobeToUpload = 0.;
   bool doStrobeUpload = false;
-  bool isFirstCheck = true;
-  DPID checkDp;
 
-  long int mTF = 0;
   std::string mSelfName;
   bool mVerboseOutput = false;
+
+  // for ccdb alpide param fetching
+  o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>* mCcdbAlpideParam;
+  std::string mCcdbFetchUrl = "http://ccdb-test.cern.ch:8080";
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserWorkflow.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DCSAdaposParserWorkflow.h
+
+#ifndef O2_ITS_DCS_ADAPOS_PARSER_WORKFLOW_H
+#define O2_ITS_DCS_ADAPOS_PARSER_WORKFLOW_H
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+namespace dcs_adapos_parser_workflow
+{
+
+framework::WorkflowSpec getWorkflow();
+
+}
+
+} // namespace its
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSDataGeneratorWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSDataGeneratorWorkflow.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DCSDataGeneratorWorkflow.h
+
+#ifndef O2_ITS_DCS_PARSER_WORKFLOW_H
+#define O2_ITS_DCS_PARSER_WORKFLOW_H
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+namespace dcs_generator_workflow
+{
+
+framework::WorkflowSpec getWorkflow();
+
+} // namespace dcs_generator_workflow
+
+} // namespace its
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSGeneratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSGeneratorSpec.h
@@ -1,0 +1,29 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_ITS_WORKFLOW_DCS_DATA_GENERATOR_SPEC_H
+#define O2_ITS_WORKFLOW_DCS_DATA_GENERATOR_SPEC_H
+
+#include "DetectorsDCS/DCSDataPointHint.h"
+#include "Framework/DataProcessorSpec.h"
+#include <variant>
+#include <string>
+#include <vector>
+#include <cstdint>
+
+using namespace o2::framework;
+
+namespace o2::its
+{
+o2::framework::DataProcessorSpec getITSDCSDataGeneratorSpec(const char* detName = "ITS");
+} // namespace o2::its
+
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
@@ -160,8 +160,7 @@ void ITSDCSAdaposParser::pushToCCDB(ProcessingContext& pc)
   o2::ccdb::CcdbObjectInfo info(path, "dplalpideparam", filename, metadata, tstart, tend);
   // Define the dpl alpide param and set the strobe length to ship
   auto& dplAlpideParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-  int* sl = (int*)&dplAlpideParams.roFrameLengthInBC;
-  *sl = (int)mStrobeToUpload + 8; // +8 is because the strobe length of ALPIDE (sent via ADAPOS) is 200ns shorted than the external trigger strobe length.
+  dplAlpideParams.updateFromString(fmt::format("ITSAlpideParam.roFrameLengthInBC = {}", (int)mStrobeToUpload + 8)); // +8 is because the strobe length of ALPIDE (sent via ADAPOS) is 200ns shorter than the external trigger strobe length.
   auto class_name = o2::utils::MemFileHelper::getClassName(dplAlpideParams);
 
   auto image = o2::ccdb::CcdbApi::createObjectImage(&dplAlpideParams, &info);

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
@@ -1,0 +1,217 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DCSAdaposParserSpec.cxx
+
+#include "ITSWorkflow/DCSAdaposParserSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+//////////////////////////////////////////////////////////////////////////////
+// Default constructor
+ITSDCSAdaposParser::ITSDCSAdaposParser()
+{
+  this->mSelfName = o2::utils::Str::concat_string(ChipMappingITS::getName(), "ITSDCSAdaposParser");
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void ITSDCSAdaposParser::init(InitContext& ic)
+{
+  LOGF(info, "ITSDCSAdaposParser init...", mSelfName);
+
+  this->mCcdbUrl = ic.options().get<std::string>("ccdb-url");
+
+  this->mVerboseOutput = ic.options().get<bool>("verbose");
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Main running function
+// Get Data from ADAPOS and prepare CCDB objects
+void ITSDCSAdaposParser::run(ProcessingContext& pc)
+{
+
+  // Retrieve adapos data and process them
+  auto dps = pc.inputs().get<gsl::span<DPCOM>>("input");
+  process(dps);
+
+  if (doStrobeUpload && dps.size() > 0) {
+    // upload to ccdb
+    pushToCCDB(pc);
+  }
+
+  if (mTF % 50 == 0) { // clean memory after some TFs
+    mDPstrobe.clear();
+  }
+
+  mTF++;
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Function to process DPs
+void ITSDCSAdaposParser::process(const gsl::span<const DPCOM> dps)
+{
+
+  // first we check which DPs are missing - if some are, it means that
+  // the delta map was sent
+  if (mVerboseOutput) {
+    LOG(info) << "\n\n\nProcessing new TF\n-----------------";
+  }
+
+  // Process all DPs, one by one
+  for (const auto& it : dps) {
+    processDP(it);
+  }
+
+  /**************************************
+     decide whether to upload or not the object to ccdb. The logic for strobe length is:
+     - if the strobe length it's the first value filled in mDPstrobe, then upload it to CCDB (only at the first call of the wf)
+     - if the strobe length it's the second value filled, compare it with the previous one: if different, upload the most recent
+     - the logic continue... memory is cleaned every 50 TFs (random number of TFs).
+  ***************************************/
+  auto mapel = mDPstrobe.begin();
+  if (!mDPstrobe.size()) {
+    doStrobeUpload = false;
+    return;
+  }
+
+  if (mapel->second.size() == 1 && isFirstCheck) {
+    mStrobeToUpload = mapel->second[0].payload_pt1;
+    doStrobeUpload = true;
+    isFirstCheck = false;
+  } else if (mapel->second.size() == 1 && mapel->second[0].payload_pt1 != mStrobeToUpload && !isFirstCheck) { // in case the new value to be uploaded is the first on the list (we erase memory every 50 TFs)
+    mStrobeToUpload = mapel->second[0].payload_pt1;
+    doStrobeUpload = true;
+  } else if (mapel->second.size() > 1) {
+    if (mapel->second.rbegin()[0].payload_pt1 == mapel->second.rbegin()[1].payload_pt1) {
+      doStrobeUpload = false;
+    } else {
+      mStrobeToUpload = mapel->second.rbegin()[0].payload_pt1; // take the last
+      doStrobeUpload = true;
+    }
+  } else {
+    doStrobeUpload = false;
+  }
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Process single DPs
+void ITSDCSAdaposParser::processDP(const DPCOM& dpcom)
+{
+  auto& dpid = dpcom.id;
+  const auto& type = dpid.get_type();
+  auto& val = dpcom.data;
+  auto flags = val.get_flags();
+
+  if (mVerboseOutput) {
+    LOG(info) << "Processing DP = " << dpcom << ", with value = " << o2::dcs::getValue<int>(dpcom);
+  }
+
+  if (o2::dcs::getValue<int>(dpcom) < 190) {
+    if (mVerboseOutput) {
+      LOG(info) << "Value is < 190 BCs, skipping it";
+    }
+    return;
+  }
+  // Checking if the DP is updated with time stamp information
+  auto etime = val.get_epoch_time();
+
+  if (o2::dcs::getValue<int>(dpcom) > 189) { // Discard strobe length lower than this: thr scan
+    mDPstrobe[dpid].push_back(val);
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void ITSDCSAdaposParser::pushToCCDB(ProcessingContext& pc)
+{
+  // Timestamps for CCDB entry
+  long tstart = 0, tend = 0;
+  // retireve run start/stop times from CCDB
+  o2::ccdb::CcdbApi api;
+  api.init("http://alice-ccdb.cern.ch");
+  // Initialize empty metadata object for search
+  std::map<std::string, std::string> metadata;
+
+  tstart = o2::ccdb::getCurrentTimestamp();
+  tend = tstart + 365L * 2 * 24 * 3600 * 1000; // valid two years by default
+
+  // Create metadata for database object
+  metadata = {{"comment", "uploaded by flp199 (ADAPOS data)"}};
+
+  std::string path("ITS/Config/AlpideParam");
+
+  std::string filename = "o2-itsmft-DPLAlpideParam<0>_" + std::to_string(tstart) + ".root";
+  o2::ccdb::CcdbObjectInfo info(path, "dplalpideparam", filename, metadata, tstart, tend);
+  // Define the dpl alpide param and set the strobe length to ship
+  auto& dplAlpideParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
+  int* sl = (int*)&dplAlpideParams.roFrameLengthInBC;
+  *sl = (int)mStrobeToUpload + 8; // +8 is because the strobe length of ALPIDE (sent via ADAPOS) is 200ns shorted than the external trigger strobe length.
+  auto class_name = o2::utils::MemFileHelper::getClassName(dplAlpideParams);
+
+  auto image = o2::ccdb::CcdbApi::createObjectImage(&dplAlpideParams, &info);
+  info.setFileName(filename);
+
+  // Send to ccdb-populator wf
+  LOG(info) << "Class Name: " << class_name << " | File Name: " << filename
+            << "\nSending to ccdb-populator the object " << info.getPath() << "/" << info.getFileName()
+            << " of size " << image->size() << " bytes, valid for "
+            << info.getStartValidityTimestamp() << " : "
+            << info.getEndValidityTimestamp();
+
+  if (mCcdbUrl.empty()) {
+
+    pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ITSALPIDEPARAM", 0}, *image);
+    pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ITSALPIDEPARAM", 0}, info);
+
+  } else { // if url is specified, send object to ccdb from THIS wf
+
+    LOG(info) << "Sending object " << info.getFileName() << " to " << mCcdbUrl << "/browse/"
+              << info.getPath() << " from the ITS ADAPOS parser workflow";
+    o2::ccdb::CcdbApi mApi;
+    mApi.init(mCcdbUrl);
+    mApi.storeAsBinaryFile(
+      &image->at(0), image->size(), info.getFileName(), info.getObjectType(), info.getPath(),
+      info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
+  }
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+DataProcessorSpec getITSDCSAdaposParserSpec()
+{
+  o2::header::DataOrigin detOrig = o2::header::gDataOriginITS;
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("input", "ITS", "ITSDATAPOINTS");
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ITSALPIDEPARAM"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ITSALPIDEPARAM"}, Lifetime::Sporadic);
+
+  return DataProcessorSpec{
+    "its-adapos-parser",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<o2::its::ITSDCSAdaposParser>()},
+    Options{
+      {"verbose", VariantType::Bool, false, {"Use verbose output mode"}},
+      {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}}}};
+}
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
@@ -17,7 +17,6 @@ namespace o2
 {
 namespace its
 {
-
 //////////////////////////////////////////////////////////////////////////////
 // Default constructor
 ITSDCSAdaposParser::ITSDCSAdaposParser()

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserWorkflow.cxx
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DCSAdaposParserWorkflow.cxx
+
+#include "ITSWorkflow/DCSAdaposParserWorkflow.h"
+#include "ITSWorkflow/DCSAdaposParserSpec.h"
+
+namespace o2
+{
+namespace its
+{
+namespace dcs_adapos_parser_workflow
+{
+framework::WorkflowSpec getWorkflow()
+{
+  framework::WorkflowSpec specs;
+
+  specs.emplace_back(o2::its::getITSDCSAdaposParserSpec());
+
+  return specs;
+}
+} // namespace dcs_adapos_parser_workflow
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSDataGeneratorWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSDataGeneratorWorkflow.cxx
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DCSDataGeneratorWorkflow.cxx
+
+#include "ITSWorkflow/DCSDataGeneratorWorkflow.h"
+#include "ITSWorkflow/DCSGeneratorSpec.h"
+
+namespace o2
+{
+namespace its
+{
+namespace dcs_generator_workflow
+{
+framework::WorkflowSpec getWorkflow()
+{
+  framework::WorkflowSpec specs;
+
+  specs.emplace_back(o2::its::getITSDCSDataGeneratorSpec("ITS"));
+
+  return specs;
+}
+} // namespace dcs_generator_workflow
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSGeneratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSGeneratorSpec.cxx
@@ -1,0 +1,149 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSWorkflow/DCSGeneratorSpec.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "DetectorsDCS/DataPointGenerator.h"
+#include "DetectorsDCS/DataPointCreator.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/Logger.h"
+#include "Framework/Task.h"
+#include <TDatime.h>
+#include <random>
+#include <variant>
+#include <string>
+#include <algorithm>
+
+using namespace o2::its;
+
+namespace
+{
+std::vector<o2::dcs::DataPointCompositeObject> generate(std::vector<std::string> aliases, int val)
+{
+  std::vector<o2::dcs::DataPointCompositeObject> dataPoints;
+
+  for (auto alias : aliases) {
+    dataPoints.emplace_back(o2::dcs::createDataPointCompositeObject(alias, val, 1, 0));
+  }
+
+  return dataPoints;
+}
+
+//______________________________________________________________________________________________________________
+// class ITSDCSDataGenerator
+class ITSDCSDataGenerator : public o2::framework::Task
+{
+ public:
+  ITSDCSDataGenerator(o2::header::DataDescription description);
+
+  void init(o2::framework::InitContext& ic) final;
+
+  void run(o2::framework::ProcessingContext& pc) final;
+
+  void fillAliasesStrobeDuration();
+
+ private:
+  uint64_t mMaxTF = 1e6;
+  uint64_t mTFs = 0;
+  uint64_t mMaxCyclesNoFullMap;
+  uint64_t changeAfterTF = 0;
+  int valueA = 190;
+  int valueB = 190;
+  bool isStrobeDurationData = false;
+  std::vector<std::string> mAliases;
+  std::vector<o2::dcs::test::HintType> mDataPointHints;
+  o2::header::DataDescription mDataDescription;
+};
+
+ITSDCSDataGenerator::ITSDCSDataGenerator(o2::header::DataDescription description) : mDataDescription(description) {}
+
+void ITSDCSDataGenerator::fillAliasesStrobeDuration()
+{
+
+  // Aliases in this case are in the format: ITS_L0_00_STROBE
+  // Here we fill them for every stave in mAliases
+  int nStaves[] = {12, 16, 20, 24, 30, 42, 48};
+  for (int iL = 0; iL < 7; iL++) {
+    for (int iS = 0; iS < nStaves[iL]; iS++) {
+      std::string stv = iS > 9 ? std::to_string(iS) : std::string(1, '0').append(std::to_string(iS));
+      mAliases.push_back("ITS_L" + std::to_string(iL) + "_" + stv + "_STROBE");
+    }
+  }
+}
+
+void ITSDCSDataGenerator::init(o2::framework::InitContext& ic)
+{
+  mMaxTF = ic.options().get<int64_t>("max-timeframes");
+  mMaxCyclesNoFullMap = ic.options().get<int64_t>("max-cycles-no-full-map");
+  isStrobeDurationData = ic.options().get<bool>("generate-strobe-duration-data");
+  changeAfterTF = ic.options().get<int64_t>("change-after-n-timeframes");
+  valueA = ic.options().get<int>("value-a");
+  valueB = ic.options().get<int>("value-b");
+
+  if (isStrobeDurationData) {
+    fillAliasesStrobeDuration();
+  }
+}
+
+void ITSDCSDataGenerator::run(o2::framework::ProcessingContext& pc)
+{
+  auto input = pc.inputs().begin();
+  uint64_t tfid = o2::header::get<o2::framework::DataProcessingHeader*>((*input).header)->startTime;
+  if (tfid >= mMaxTF) {
+    LOG(info) << "ITS DCS Data generator reached TF " << tfid << ", stopping";
+    pc.services().get<o2::framework::ControlService>().endOfStream();
+    pc.services().get<o2::framework::ControlService>().readyToQuit(o2::framework::QuitRequest::Me);
+  }
+
+  // generate data simulating ADAPOS
+  bool doGen = mTFs % mMaxCyclesNoFullMap == 0;
+  std::vector<o2::dcs::DataPointCompositeObject> dpcoms;
+  if (doGen) {
+    dpcoms = generate(mAliases, mTFs > changeAfterTF ? valueB : valueA);
+  }
+
+  LOG(info) << "TF " << tfid << " has generated " << dpcoms.size() << " DPs";
+  auto& timingInfo = pc.services().get<o2::framework::TimingInfo>();
+  auto timeNow = std::chrono::system_clock::now();
+  timingInfo.creation = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow.time_since_epoch()).count(); // in ms
+
+  pc.outputs().snapshot(Output{"ITS", mDataDescription, 0, Lifetime::Timeframe}, dpcoms);
+  mTFs++;
+}
+} // namespace
+
+namespace o2::its
+{
+o2::framework::DataProcessorSpec getITSDCSDataGeneratorSpec(const char* detName)
+{
+  std::string desc{detName};
+  desc += "DATAPOINTS";
+
+  o2::header::DataDescription dd;
+
+  dd.runtimeInit(desc.c_str(), desc.size());
+
+  return DataProcessorSpec{
+    "its-dcs-data-generator",
+    Inputs{},
+    Outputs{{{"outputDCS"}, "ITS", dd}},
+    AlgorithmSpec{adaptFromTask<ITSDCSDataGenerator>(dd)},
+    Options{
+      {"change-after-n-timeframes", VariantType::Int64, 99999999999ll, {"change value generated after n timeframes: do not change val by default"}},
+      {"value-a", VariantType::Int, 0, {"First value to be generated, will change to value-b after nTF = change-after-n-timeframes"}},
+      {"value-b", VariantType::Int, 1, {"Second  value to be generated, will be after value-a once nTF = change-after-n-timeframes has been reached"}},
+      {"max-timeframes", VariantType::Int64, 99999999999ll, {"max TimeFrames to generate"}},
+      {"max-cycles-no-full-map", VariantType::Int64, 6000ll, {"max num of cycles between the sending of 2 full maps"}},
+      {"generate-strobe-duration-data", VariantType::Bool, false, {"enable generation of DCS data containing the strobe duration in BCs"}}}};
+}
+} // namespace o2::its

--- a/Detectors/ITSMFT/ITS/workflow/src/its-dcs-adapos-parser-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-dcs-adapos-parser-workflow.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSWorkflow/DCSAdaposParserWorkflow.h"
+#include "ITSWorkflow/DCSAdaposParserSpec.h"
+
+using namespace o2::framework;
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  LOG(info) << "Initializing O2 ITS-DCS Adapos data Parser:";
+
+  return std::move(o2::its::dcs_adapos_parser_workflow::getWorkflow());
+}

--- a/Detectors/ITSMFT/ITS/workflow/src/its-dcs-generator-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-dcs-generator-workflow.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSWorkflow/DCSDataGeneratorWorkflow.h"
+#include "ITSWorkflow/DCSGeneratorSpec.h"
+
+using namespace o2::framework;
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  LOG(info) << "Initializing O2 ITS-DCS Data Generator";
+
+  return std::move(o2::its::dcs_generator_workflow::getWorkflow());
+}


### PR DESCRIPTION
First version of the workflows to generate and parse ADAPOS-like data containing the ITS strobe length for every stave. 
Example on how to run the workflow (simple version without ccdb-populator workflow which can be anyway included already): 
```
o2-its-dcs-generator-workflow -b --session default --max-timeframes 50 --max-cycles-no-full-map 10 --generate-strobe-duration-data --change-after-n-timeframes 30 --value-a 190 --value-b 289 | \
o2-its-dcs-adapos-parser-workflow -b --session default --ccdb-url "http://ccdb-test.cern.ch:8080" --verbose
```
The first wf generates 50 TFs and every 10 it creates a set of data points (one per stave) with the strobe length: first value is set to 190 and then after 30 TFs it changes to 289. This is to simulate a change of value as it happens in real life. The second workflow parse this data: as it is now it uploads** to http://ccdb-test.cern.ch:8080/browse/ITS/Config/AlpideParam 1 object when the workflow receives the very first strobe length and then another object when the strobe length changes. The objects have 2y validity for now. The object is a `o2::itsmft::DPLAlpideParam<0>`. 
By removing `--ccdb-url` and by adding to the pipeline the ccdb-populator workflow, the object will be shipped through this workflow. 

For a first test this version can be already used at P2 with detector data. 

cc @shahor02 