### PR TITLE
Enforce FPE instead of NaN + some fixes for FPE

### DIFF
--- a/Common/Utils/src/fpu.cxx
+++ b/Common/Utils/src/fpu.cxx
@@ -33,8 +33,10 @@ static void __attribute__((constructor)) trapfpe()
 {
   // allows to disable set of particular FE's by setting corresponding bit of the O2_DISABLE_FPE_TRAP,
   // i.e. to enable only FE_DIVBYZERO use O2_DISABLE_FPE_TRAP=9
-  const char* ev = std::getenv("O2_DISABLE_FPE_TRAP");
-  int enabledFE = (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW) & ~(ev ? atoi(ev) : 0);
+  //  const char* ev = std::getenv("O2_DISABLE_FPE_TRAP");
+  //  int enabledFE = (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW) & ~(ev ? atoi(ev) : 0);
+  const char* ev = std::getenv("O2_ENABLE_FPE_TRAP");
+  int enabledFE = (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW) & (ev ? atoi(ev) : 0);
   if (enabledFE) {
     feenableexcept(enabledFE);
   }

--- a/Common/Utils/src/fpu.cxx
+++ b/Common/Utils/src/fpu.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// To enable check for problematic LIBXML version uncomment this
+// #define _PROTECT_LIBXML_
+
+#ifdef __linux
+#ifdef _PROTECT_LIBXML_
+#include <libxml/xmlversion.h>
+#if LIBXML_VERSION > 20912
+#define _DUMMY_FEE_TRAP_
+#endif // LIBXML_VERSION > 20912
+#endif // _PROTECT_LIBXML_
+#else  // __linux
+#define _DUMMY_FEE_TRAP_
+#endif // __linux
+
+#ifdef _DUMMY_FEE_TRAP_
+void trapfpe() {}
+#else // _DUMMY_FEE_TRAP_
+#define _GNU_SOURCE 1
+#include <cfenv>
+#include <cstdlib>
+static void __attribute__((constructor)) trapfpe()
+{
+  // allows to disable set of particular FE's by setting corresponding bit of the O2_DISABLE_FPE_TRAP,
+  // i.e. to enable only FE_DIVBYZERO use O2_DISABLE_FPE_TRAP=9
+  const char* ev = std::getenv("O2_DISABLE_FPE_TRAP");
+  int enabledFE = (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW) & ~(ev ? atoi(ev) : 0);
+  if (enabledFE) {
+    feenableexcept(enabledFE);
+  }
+}
+#endif // _DUMMY_FEE_TRAP_

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CaloRawFitter.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CaloRawFitter.h
@@ -97,8 +97,8 @@ class CaloRawFitter
   FitStatus mStatus = kNotEvaluated; ///< status of last evaluated sample: -1: not yet evaluated; 0: OK; 1: overflow; 2: too large RMS; 3: single spikes
   short mMaxSample = 0;              ///< maximal sample
   float mAmp;                        ///< amplitude of last processed sample
-  float mTime;                       ///< time of last processed sample
-  float mChi2;                       ///< chi2 calculated in last fit
+  float mTime = 0;                   ///< time of last processed sample
+  float mChi2 = 1e10;                ///< chi2 calculated in last fit
   short mSpikeThreshold;
   short mBaseLine;
   short mPreSamples;

--- a/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include <cstring>
+#include <cstdint>
 #include <boost/format.hpp>
 #include "InfoLogger/InfoLogger.hxx"
 #include "PHOSBase/PHOSSimParams.h"
@@ -16,7 +17,6 @@
 #include "PHOSReconstruction/AltroDecoder.h"
 #include "PHOSReconstruction/RawReaderMemory.h"
 #include "PHOSReconstruction/RawDecodingError.h"
-
 #include "DetectorsRaw/RDHUtils.h"
 #include <fairlogger/Logger.h>
 
@@ -162,7 +162,7 @@ void AltroDecoder::readChannels(const std::vector<uint32_t>& buffer, CaloRawFitt
           short chiAddr = absId;
           chiAddr |= caloFlag << 14;
           mOutputFitChi.emplace_back(chiAddr);
-          mOutputFitChi.emplace_back(short(5 * rawFitter->getChi2())); // 0.2 accuracy
+          mOutputFitChi.emplace_back(short(std::min(5.f * rawFitter->getChi2(), float(SHRT_MAX - 1)))); // 0.2 accuracy
         }
         if (fitResult == CaloRawFitter::FitStatus::kOK || fitResult == CaloRawFitter::FitStatus::kNoTime) {
           if (!mPedestalRun) {

--- a/Utilities/rANS/src/FrequencyTable.cxx
+++ b/Utilities/rANS/src/FrequencyTable.cxx
@@ -71,7 +71,8 @@ inline double_t computeEntropy(const FrequencyTable& table)
 
 count_t computeRenormingPrecision(const FrequencyTable& frequencyTable)
 {
-  const uint8_t minBits = std::ceil(std::log2(frequencyTable.getNUsedAlphabetSymbols()));
+  const auto nused = frequencyTable.getNUsedAlphabetSymbols();
+  const uint8_t minBits = nused > 0 ? std::ceil(std::log2(nused)) : 0;
   const uint8_t estimate = minBits * 3u / 2u;
   const uint8_t maxThreshold = std::max(minBits, MaxRenormThreshold);
   const uint8_t minThreshold = std::max(estimate, MinRenormThreshold);

--- a/cmake/O2AddExecutable.cmake
+++ b/cmake/O2AddExecutable.cmake
@@ -92,7 +92,7 @@ function(o2_add_executable baseTargetName)
   endif()
 
   # add the executable with its sources
-  add_executable(${target} ${A_SOURCES})
+  add_executable(${target} ${A_SOURCES} ${CMAKE_SOURCE_DIR}/Common/Utils/src/fpu.cxx)
 
   # set the executable output name
   set_property(TARGET ${target} PROPERTY OUTPUT_NAME ${exeName})
@@ -115,6 +115,9 @@ function(o2_add_executable baseTargetName)
     endif()
     target_link_libraries(${target} PUBLIC ${lib})
   endforeach()
+
+  # needed for fpu.c
+  target_link_libraries(${target} PUBLIC ROOT::XMLIO)
 
   if(NOT A_NO_INSTALL)
     # install the executable


### PR DESCRIPTION
@pzhristov @davidrohr  @ktf  this PR is a potential can or worms, following https://alice.its.cern.ch/jira/browse/O2-3754?focusedId=305287&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-305287 with the help of Peter I've enforced the FPE where before NaN was produced and already found 2 cases just in the FST.

We have to decide if we want to merge / deploy it. Perhaps, to avoid surprises in the online processing, one can make the activation of the FPE trap conditional to some env. var. 

Then there is a comment from Peter that libXML>=20913 triggers FPE. At the moment I am not activating the detection of the libXML version since in the O2 we are using 20903 (but ubuntu 22.04 system version is 20913, mostly because I am not sure how to detect the libxml/xmlversion.h path for `target_include_directories` for https://github.com/AliceO2Group/AliceO2/compare/dev...shahor02:pr_FPE?expand=1#diff-5ff8176836cd9c83c8422cc102ee8f78d80757498bbce94e6ce5ef0a3e54d12eR95. Any suggestion?