### PR TITLE
[EMCAL-565, EMCAL-566] Add option for subspecification for CTP information

### DIFF
--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -406,7 +406,7 @@ class EMCALChannelCalibDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, const bool loadCalibParamsFromCCDB, const bool rejectCalibTrigger, const bool rejectL0Trigger, const bool ctpcfgperrun, const bool applyGainCalib)
+DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, const bool loadCalibParamsFromCCDB, const bool rejectCalibTrigger, const bool rejectL0Trigger, const bool ctpcfgperrun, const bool applyGainCalib, const uint32_t inputsubspecCTP)
 {
   using device = o2::calibration::EMCALChannelCalibDevice;
   using clbUtils = o2::calibration::Utils;
@@ -443,7 +443,7 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
   // data request needed for rejection of EMCal trigger
   if (rejectL0Trigger) {
     inputs.emplace_back(device::getCTPConfigBinding(), "CTP", "CTPCONFIG", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/Config", ctpcfgperrun));
-    inputs.emplace_back(device::getCTPDigitsBinding(), "CTP", "DIGITS", 0, Lifetime::Timeframe);
+    inputs.emplace_back(device::getCTPDigitsBinding(), "CTP", "DIGITS", inputsubspecCTP, Lifetime::Timeframe);
   }
 
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -42,7 +42,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"no-rejectCalibTrigger", VariantType::Bool, false, {"disabled by default such that calib triggers are rejected. If enabled, calibration triggers (LED events etc.) also enter the calibration"}},
     {"no-rejectL0Trigger", VariantType::Bool, false, {"disabled by default such that L0 triggers are rejected. If enabled, L0 triggers (Gamma trigger and jet trigger) also enter the calibration"}},
     {"no-applyGainCalib", VariantType::Bool, false, {"if appplication of gain calibration should be disabled"}},
-    {"ctpconfig-run-independent", VariantType::Bool, false, {"Use CTP config w/o runNumber tag"}}};
+    {"ctpconfig-run-independent", VariantType::Bool, false, {"Use CTP config w/o runNumber tag"}},
+    {"input-subspec-ctp", VariantType::UInt32, 0U, {"Subspecification for CTP input objects"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -59,9 +60,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool rejectL0Trigger = !cfgc.options().get<bool>("no-rejectL0Trigger");
   bool ctpcfgperrun = !cfgc.options().get<bool>("ctpconfig-run-independent");
   bool applyGainCalib = !cfgc.options().get<bool>("no-applyGainCalib");
+  uint32_t inputsubspecCTP = cfgc.options().get<uint32_t>("input-subspec-ctp");
 
   WorkflowSpec specs;
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger, rejectL0Trigger, ctpcfgperrun, applyGainCalib));
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger, rejectL0Trigger, ctpcfgperrun, applyGainCalib, inputsubspecCTP));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   // o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
- EMCal online calibration relies on CTP digits to identify EMCal triggered events from minimum bias events
- As CTP digits are already send to another calib-node, the CTP information was not available online
- CTP now publishes the information to different subspecs, therefore, EMCal online calibration code is changed to have the subspec as a workflow option