### PR TITLE
TRD raw reader infinite loop protection

### DIFF
--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -151,6 +151,13 @@ int CruRawReader::processHBFs()
   bool firstRdh = true;
   uint32_t totalDataInputSize = 0;
   mTotalHBFPayLoad = 0;
+  if (o2::raw::RDHUtils::getStop(rdh)) {
+    if (mMaxErrsPrinted > 0) {
+      LOGP(error, "First RDH for given HBF for FEE ID {:#04x} has stop bit set", o2::raw::RDHUtils::getFEEID(rdh));
+      checkNoErr();
+    }
+    return -1;
+  }
 
   // loop until RDH stop header
   while (!o2::raw::RDHUtils::getStop(rdh)) { // carry on till the end of the event.


### PR DESCRIPTION
In standalone TRD noise runs data corruption is observed where the first RDH of a given HBF for a single CRU has the stop bit set. This puts the raw decoder into an infinite loop. This has never been observed in physics runs. It is not yet clear where the data corruption comes from. Was last seen in run [541710](https://ali-bookkeeping.cern.ch/?page=run-detail&id=39068) for which 100% of raw data was stored to understand the issue.
In my reproducer I found this corruption in a TF where 2 half-CRUs were sending only 28 instead of 32 HBFs for a TF.

Example file with corruption: /alice/data/2023/LHC23zt_TRD/541710/calib/1420/o2_rawtf_run00541710_tf00000004_epn037.tf