### PR TITLE
Revert "DPL: handle spurious messages when in READY state (#11799)"

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1481,10 +1481,6 @@ void DataProcessingDevice::doPrepare(ServiceRegistryRef ref)
     if (info.channel == nullptr) {
       continue;
     }
-    // Only poll DPL channels for now.
-    if (info.channelType != ChannelAccountingType::DPL) {
-      continue;
-    }
     auto& socket = info.channel->GetSocket();
     // If we have pending events from a previous iteration,
     // we do receive in any case.


### PR DESCRIPTION
This reverts commit 44b555989a61a5a17252e3acf87556b9a23a6460.

It seems to break multinode QC test which intermittently time-outs when exiting a workflow with a proxy.
for example here: https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/QualityControl/1939/44d18779a0fe0cc80e5ee23e0c4ea583b1b308c5/build_QualityControl_o2-dataflow/fullLog.txt

The failures are intermittent, but rather often.