### PR TITLE
[O2-4034] shift MCH MC digits by the same time offset as in data

### DIFF
--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -47,8 +47,8 @@ o2_add_executable(digitizer-workflow
                                         O2::ITSMFTWorkflow
                                         O2::MCHSimulation
                                         O2::MCHMappingImpl4
-                                        O2::DataFormatsMCH
                                         O2::MCHIO
+                                        O2::MCHDigitFiltering
                                         O2::MFTSimulation
                                         O2::MIDSimulation
                                         O2::PHOSSimulation
@@ -106,6 +106,7 @@ o2_add_executable(digitizer-workflow
                                         O2::MCHSimulation
                                         O2::MCHMappingImpl4
                                         O2::MCHIO
+                                        O2::MCHDigitFiltering
                                         O2::MFTSimulation
                                         O2::MIDSimulation
                                         O2::PHOSSimulation


### PR DESCRIPTION
This PR introduces the same time shift of the MCH digits wrt the collision BC as observed in real data and corrected by default in the reconstruction since #10927.

That should fix the bug reported in [this JIRA](https://alice.its.cern.ch/jira/browse/O2-4034).