### PR TITLE
Revert "calib-workflow: WORKAROUND: Currently cannot send CTP data to…

### DIFF
--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -276,7 +276,7 @@ fi
 if [[ $AGGREGATOR_TASKS == CALO_TF || $AGGREGATOR_TASKS == ALL ]]; then
   # EMC
   EMCAL_CALIB_CTP_OPT=
-  if true || ! has_detector CTP; then # FIXME: Currently we cannot send CTP/DIGITS to both CALO and BARREL workflow.
+  if ! has_detector CTP; then
     EMCAL_CALIB_CTP_OPT="--no-rejectL0Trigger"
   fi
   if [[ $CALIB_EMC_BADCHANNELCALIB == 1 ]]; then


### PR DESCRIPTION
… 2 output proxies"

This reverts commit abfc386f04ff79e4289569c371ccd75dd668544b.