### PR TITLE
[EMCAL-565, EMCAL-566] Enable Multithreading for EMCal online calib

### DIFF
--- a/Common/Utils/include/CommonUtils/BoostHistogramUtils.h
+++ b/Common/Utils/include/CommonUtils/BoostHistogramUtils.h
@@ -618,7 +618,7 @@ auto ProjectBoostHistoXFast(const boost::histogram::histogram<axes...>& hist2d, 
 /// \return result
 ///      1d boost histogram from projection of the input 2d boost histogram
 template <typename... axes>
-auto ReduceBoostHistoFastSlice(boost::histogram::histogram<axes...>& hist2d, int binXLow, int binXHigh, int binYLow, int binYHigh, bool includeOverflowUnderflow)
+auto ReduceBoostHistoFastSlice(const boost::histogram::histogram<axes...>& hist2d, int binXLow, int binXHigh, int binYLow, int binYHigh, bool includeOverflowUnderflow)
 {
   int nXbins = binXHigh - binXLow + 1;
   int nYbins = binYHigh - binYLow + 1;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -49,6 +49,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   float minNHitsForNHitCut = 1;         ///< mean number of hits per cell that is needed to cut on the mean number of hits. Needed for high energy intervals as outliers can distort the distribution
   float minCellEnergy_bc = 0.1;         ///< minimum cell energy considered for filling the histograms for bad channel calib. Should speedup the filling of the histogram to suppress noise
   float fractionEvents_bc = 1.;         ///< fraction of events used in bad channel calibration
+  size_t nThreads_bc = 4;               ///< number of threads used for the bad channel calinration for filling the histograms
 
   // parameters for time calibration
   unsigned int minNEvents_tc = 1e7;      ///< minimum number of events to trigger the calibration
@@ -66,6 +67,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool UpdateAtEndOfRunOnly_tc = false;  ///< switch to enable trigger of calibration only at end of run
   float maxAllowedDeviationFromMax = 10; ///< maximum deviation allowed between the estimated maximum of the fit and the true maximum from the distribution. If deviation is larger then value, the fit likely failed. In this case, the true value is taken
   float fractionEvents_tc = 1.;          ///< fraction of events used in time calibration
+  size_t nThreads_tc = 2;                ///< number of threads used for the time calinration for filling the histograms
 
   // common parameters
   std::string calibType = "time";                      ///< type of calibration to run

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -36,7 +36,7 @@ using boost::histogram::indexed;
 //_____________________________________________
 void EMCALTimeCalibData::PrintStream(std::ostream& stream) const
 {
-  stream << "EMCAL Cell ID:  " << mTimeHisto << "\n";
+  stream << "EMCAL Cell ID:  " << mTimeHisto[0] << "\n";
 }
 //_____________________________________________
 void EMCALTimeCalibData::print()
@@ -50,11 +50,11 @@ std::ostream& operator<<(std::ostream& stream, const EMCALTimeCalibData& emcdata
   return stream;
 }
 //_____________________________________________
-void EMCALTimeCalibData::merge(const EMCALTimeCalibData* prev)
+void EMCALTimeCalibData::merge(EMCALTimeCalibData* prev)
 {
   mEvents += prev->getNEvents();
   mNEntriesInHisto += prev->getNEntriesInHisto();
-  mTimeHisto += prev->getHisto();
+  mTimeHisto[0] += prev->getHisto();
 }
 //_____________________________________________
 bool EMCALTimeCalibData::hasEnoughData() const
@@ -73,24 +73,63 @@ bool EMCALTimeCalibData::hasEnoughData() const
 
   return enough;
 }
+
 //_____________________________________________
 void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
 {
   // the fill function is called once per event
   mEvents++;
 
-  for (auto cell : data) {
-    double cellEnergy = cell.getEnergy();
-    double cellTime = cell.getTimeStamp();
-    int id = cell.getTower();
-    if (mApplyGainCalib) {
-      LOG(debug) << " gain calib factor for cell " << id << " = " << mGainCalibFactors->getGainCalibFactors(id);
-      cellEnergy *= mGainCalibFactors->getGainCalibFactors(id);
+  if (data.size() == 0)
+    return;
+  auto fillfunction = [this](int thread, const gsl::span<const o2::emcal::Cell> data, double minCellEnergy) {
+    LOG(debug) << "filling in thread " << thread << " ncells = " << data.size();
+    auto& mCurrentHist = mTimeHisto[thread];
+    unsigned int nEntries = 0;
+    for (auto cell : data) {
+      double cellEnergy = cell.getEnergy();
+      double cellTime = cell.getTimeStamp();
+      int id = cell.getTower();
+      if (mApplyGainCalib) {
+        LOG(debug) << " gain calib factor for cell " << id << " = " << mGainCalibFactors->getGainCalibFactors(id);
+        cellEnergy *= mGainCalibFactors->getGainCalibFactors(id);
+      }
+      if (cellEnergy > minCellEnergy) {
+        LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
+        mCurrentHist(cellTime, id);
+        nEntries++;
+      }
     }
-    if (cellEnergy > EMCALCalibParams::Instance().minCellEnergy_tc) {
-      LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
-      mTimeHisto(cellTime, id);
-      mNEntriesInHisto++;
+    mVecNEntriesInHisto[thread] += nEntries;
+  };
+
+  std::vector<gsl::span<const o2::emcal::Cell>> ranges(mNThreads);
+  auto size_per_thread = static_cast<unsigned int>(std::ceil((static_cast<float>(data.size()) / mNThreads)));
+  unsigned int currentfirst = 0;
+  for (int ithread = 0; ithread < mNThreads; ithread++) {
+    unsigned int nelements = std::min(size_per_thread, static_cast<unsigned int>(data.size() - 1 - currentfirst));
+    ranges[ithread] = data.subspan(currentfirst, nelements);
+    currentfirst += nelements;
+    LOG(debug) << "currentfirst " << currentfirst << "  nelements " << nelements;
+  }
+
+  double minCellEnergy = EMCALCalibParams::Instance().minCellEnergy_tc;
+
+#if (defined(WITH_OPENMP) && !defined(__CLING__))
+  LOG(debug) << "Number of threads that will be used = " << mNThreads;
+#pragma omp parallel for num_threads(mNThreads)
+#else
+  LOG(debug) << "OPEN MP will not be used for the bad channel calibration";
+#endif
+  for (int ithread = 0; ithread < mNThreads; ithread++) {
+    fillfunction(ithread, ranges[ithread], minCellEnergy);
+  }
+
+  // only sum up entries if needed
+  if (!o2::emcal::EMCALCalibParams::Instance().useNEventsForCalib_tc) {
+    for (auto& nEntr : mVecNEntriesInHisto) {
+      mNEntriesInHisto += nEntr;
+      nEntr = 0;
     }
   }
 }


### PR DESCRIPTION
- To increase the speed of the online calibration, multithreading is introduced to fill the histograms
- Each thread is assigned its own histogram (stored in a vector with the size = number of threads)
- The data for each event is then splitted into nThread chunks and filled into the corresponding histograms
- The number of threads can be set via the EMCal calib params
- Merging of the individual histograms happens if the histogram is retrieved from the Data class
- Local tests show a significant increase in speed of more threads are being used. The overhead is negligible