### PR TITLE
DPL: fix performance regression when using output proxy

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1070,11 +1070,6 @@ void DataProcessingDevice::fillContext(DataProcessorContext& context, DeviceCont
   }
 
   auto decideEarlyForward = [&context, &spec, this]() -> bool {
-    // There is nothing produced by this device, so we can forward early
-    // because this is a proxy.
-    if (spec.forwards.empty() == false && spec.outputs.empty() == true) {
-      return true;
-    }
     /// We must make sure there is no optional
     /// if we want to optimize the forwarding
     bool canForwardEarly = (spec.forwards.empty() == false) && mProcessingPolicies.earlyForward != EarlyForwardPolicy::NEVER;


### PR DESCRIPTION
Enabling the early forwarding for any output proxy was actually a bad idea. The early forwarding triggers a Copy, which has a much larger overhead, even in the case it's shallow.

This makes sure that the original behavior is back: early forwarding is never enabled for the last device in the chain.