### PR TITLE
[EMCAL-565, EMCAL-566] Add optional shift to match CTP and EMC bcs

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -78,6 +78,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool setSavedSlotAllowedSOR_EMC = true;              ///< if true, stored calibrations from last run can be loaded in the next run (if false, storing of the calib histograms is still active in contrast to setSavedSlotAllowed_EMC)
   long endTimeMargin = 2592000000;                     ///< set end TS to 30 days after slot ends (1000 * 60 * 60 * 24 * 30)
   std::string selectedClassMasks = "C0TVX-B-NOPF-EMC"; ///< name of EMCal min. bias trigger that is used for calibration
+  int bcShiftCTP = 0;                                  ///< bc shift of CTP digits to align them with EMC bc in case they are misaligned
 
   // old parameters. Keep them for a bit (can be deleted after september 5th) as otherwise ccdb and o2 version might not be in synch
   unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration


### PR DESCRIPTION
- During data taking this year, the CTP bc information was shifted by 3bcs compared to the EMCalbc. This would not enable a correct trigger selection in the online calibration and hence the calibration would be biased
- The additional shift can be set via the EMCALCalibParams, its default value is 0
- The loop over the ctp information was moved from within the EMCal trigger loop to before the loop to speed-up the code further. The bc ids with the correct trigger present are stored in a vector to allow the selection in the trigger loop