### PR TITLE
Change to BCs_001

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2133,7 +2133,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
       if (bcClassPair != bcToClassMask.end()) {
         masks = bcClassPair->second;
       } else {
-        masks = {0,0};
+        masks = {0, 0};
       }
     }
     bcCursor(runNumber,

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2111,33 +2111,35 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   fillStrangenessTrackingTables(recoData, trackedV0Cursor, trackedCascadeCursor, tracked3BodyCurs);
 
   // helper map for fast search of a corresponding class mask for a bc
-  std::unordered_map<uint64_t, uint64_t> bcToClassMask;
+  std::unordered_map<uint64_t, std::vector<uint64_t>> bcToClassMask;
   if (mInputSources[GID::CTP]) {
     LOG(debug) << "CTP input available";
     for (auto& ctpDigit : ctpDigits) {
       uint64_t bc = ctpDigit.intRecord.toLong();
       uint64_t classMask = ctpDigit.CTPClassMask.to_ulong();
-      bcToClassMask[bc] = classMask;
+      uint64_t inputMask = ctpDigit.CTPInputMask.to_ulong();
+      bcToClassMask[bc] = {classMask, inputMask};
       // LOG(debug) << Form("classmask:0x%llx", classMask);
     }
   }
 
   // filling BC table
-  uint64_t triggerMask = 0;
+  std::vector<uint64_t> masks;
   bcCursor.reserve(bcsMap.size());
   for (auto& item : bcsMap) {
     uint64_t bc = item.first;
     if (mInputSources[GID::CTP]) {
       auto bcClassPair = bcToClassMask.find(bc);
       if (bcClassPair != bcToClassMask.end()) {
-        triggerMask = bcClassPair->second;
+        masks = bcClassPair->second;
       } else {
-        triggerMask = 0;
+        masks = {0,0};
       }
     }
     bcCursor(runNumber,
              bc,
-             triggerMask);
+             masks[0],
+             masks[1]);
   }
 
   bcToClassMask.clear();

--- a/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
@@ -78,7 +78,7 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
   mCaloEventHandler->reset();
   mCaloEventHandler->setCellData(cellsIn, triggersIn);
 
-  uint64_t triggerMask = 1;
+  uint64_t triggerMask = 1, inputMask = 1;
   // loop over events
   for (int iev = 0; iev < mCaloEventHandler->getNumberOfEvents(); iev++) {
     o2::emcal::EventData inputEvent = mCaloEventHandler->buildEvent(iev);
@@ -91,7 +91,8 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
     bcCursor(0,
              runNumber,
              bcID,
-             triggerMask);
+             triggerMask,
+             inputMask);
     auto indexBC = iev;
 
     for (auto& cell : cellsInEvent) {

--- a/Detectors/PHOS/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/PHOS/workflow/src/StandaloneAODProducerSpec.cxx
@@ -74,7 +74,7 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
   auto caloCellsCursor = caloCellsBuilder->cursor<o2::aod::Calos>();
   auto caloCellsTRGTableCursor = caloCellsTRGTableBuilder->cursor<o2::aod::CaloTriggers>();
 
-  uint64_t triggerMask = 1;
+  uint64_t triggerMask = 1, inputMask = 1;
   // loop over events
   int indexBC = -1;
   for (const auto& tr : ctr) {
@@ -112,7 +112,8 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
     bcCursor(0,
              runNumber,
              bcID,
-             triggerMask);
+             triggerMask,
+             inputMask);
 
     // fill collision cursor
     collisionsCursor(0,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -49,7 +49,7 @@ DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1, //! Root of data model for 
                             bc::RunNumber, bc::GlobalBC,
                             bc::TriggerMask, bc::InputMask);
 
-using BCs = BCs_000; // current version
+using BCs = BCs_001; // current version
 using BC = BCs::iterator;
 
 namespace timestamp


### PR DESCRIPTION
This commit: 
* changes the data model such that BCs_001 is now the default, which will require everyone to use the bc converter already merged into O2Physics. Old AO2Ds will have the input masks zeroed out by the converter. 
* changes the AO2D producer such that the input masks are also stored together in AO2Ds. 
* changes the EMCal and PHOS standalone AO2D producers to fill the BC cursor correctly (with dummy info but with an inputMask value too) as well 