### PR TITLE
Adjust online ITS reco prescaling for PbPb

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
@@ -27,11 +27,11 @@ namespace its
 struct FastMultEstConfig : public o2::conf::ConfigurableParamHelper<FastMultEstConfig> {
   static constexpr int NLayers = o2::itsmft::ChipMappingITS::NLayers;
 
-  /// acceptance correction per layer (relative to 1st one)
-  float accCorr[NLayers] = {1.f, 0.895, 0.825, 0.803, 0.720, 0.962, 0.911};
+  /// acceptance correction per layer (cluster / track)
+  float accCorr[NLayers] = {2.95, 2.46, 2.19, 2.26, 2.06, 3.1, 3.1};
   int firstLayer = 3;                            /// 1st layer to account
   int lastLayer = 6;                             /// last layer to account
-  float imposeNoisePerChip = 1.e-7 * 1024 * 512; // assumed noise, free parameter if<0
+  float imposeNoisePerChip = 1.e-9 * 1024 * 512; // assumed noise, free parameter if<0
 
   // cuts to reject to low or too high mult events
   float cutMultClusLow = 0;   /// reject ROF with estimated cluster mult. below this value (no cut if <0)

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -99,10 +99,10 @@ fi
 
 if [[ $SYNCMODE == 1 ]]; then
   if [[ $BEAMTYPE == "PbPb" ]]; then
-    ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=30;fastMultConfig.cutMultClusHigh=2000;fastMultConfig.cutMultVtxHigh=500;"
+    ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=${CUT_MULT_MIN_ITS:-100};fastMultConfig.cutMultClusHigh=${CUT_MULT_MAX_ITS:-200};fastMultConfig.cutMultVtxHigh=${CUT_MULT_VTX_ITS:-20};"
     MCH_CONFIG_KEY="MCHTracking.maxCandidates=50000;MCHTracking.maxTrackingDuration=20;"
   elif [[ $BEAMTYPE == "pp" ]]; then
-    ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=-1;fastMultConfig.cutMultClusHigh=-1;fastMultConfig.cutMultVtxHigh=-1;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;"
+    ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=${CUT_MULT_MIN_ITS:--1};fastMultConfig.cutMultClusHigh=${CUT_MULT_MAX_ITS:-1};fastMultConfig.cutMultVtxHigh=${CUT_MULT_VTX_ITS:--1};ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;"
     MCH_CONFIG_KEY="MCHTracking.maxCandidates=20000;MCHTracking.maxTrackingDuration=10;"
   fi
   [[ ! -z ${CUT_RANDOM_FRACTION_ITS:-} ]] && ITS_CONFIG_KEY+="fastMultConfig.cutRandomFraction=$CUT_RANDOM_FRACTION_ITS;"


### PR DESCRIPTION
cluster to track efficiencies adjusted for online ITS tracking condition to provide realistic multiplicity estimate using LHC22s, assuming negligible noise. The ITS track multiplicity estimate set to 100-200 tracks which corresponds to ~2% of all tracks and ~7% of non-empty ROFs.