### PR TITLE
MFT: LTF and CA tracking parameters refinement 

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -49,9 +49,9 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// minimum number of detector stations for a CA track
   Int_t MinTrackStationsCA = 4;
   /// maximum distance for a cluster to be attached to a seed line (LTF)
-  Float_t LTFclsRCut = 0.0100;
+  Float_t LTFclsRCut = 0.0200;
   /// maximum distance for a cluster to be attached to a seed line (CA road)
-  Float_t ROADclsRCut = 0.0400;
+  Float_t ROADclsRCut = 0.0500;
   /// number of bins in r-direction
   Int_t RBins = 30;
   /// number of bins in phi-direction


### PR DESCRIPTION
pinging @arakotoz
After some alignment considerations and inputs, the default LTF and CA tracking parameters are refined (several checks and presentations have been done, it increase slightly the total number of tracks +3%, change the balance of LTF vs CA tracks - by increase of LTF tracks and reduce CA tracks - CPU cost reduced by ~7% thanks to the LTF algo. to be faster, higher track efficiency with more clusters per tracks, chi2/NDF similar with longer tail but no large variation). 
It could be good to have them for the next pp ref and PbPb data taking 