### PR TITLE
Opening local files in CcdbApi: Handling said files in navigateURLsAndLoadFileToMemory

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1586,6 +1586,14 @@ void CcdbApi::navigateURLsAndLoadFileToMemory(o2::pmr::vector<char>& dest, CURL*
   if (url.find("alien:/", 0) != std::string::npos) {
     return loadFileToMemory(dest, url, nullptr); // headers loaded from the file in case of the snapshot reading only
   }
+  if ((url.find("file:/", 0) != std::string::npos)) {
+    std::string path = url.substr(7);
+    if (std::filesystem::exists(path)) {
+      return loadFileToMemory(dest, path, nullptr);
+    } else {
+      return;
+    }
+  }
   // otherwise make an HTTP/CURL request
   struct HeaderObjectPair_t {
     std::map<std::string, std::string> header;


### PR DESCRIPTION
Follow up to: https://github.com/AliceO2Group/AliceO2/pull/11796#pullrequestreview-1586545189

The functionality to open local and cvmfs files, if redirected to them via navigateURLsAndLoadFileToMemory, has been added.