### PR TITLE
MFT: add ROF bias in BC and assessment histogram

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -134,6 +134,9 @@ class MatchGlobalFwd
   void setMFTROFrameLengthMUS(float fums);
   ///< set MFT ROFrame duration in BC (continuous mode only)
   void setMFTROFrameLengthInBC(int nbc);
+  ///< set MFT ROFrame bias in BC (continuous mode only) or time shift applied already as MFTAlpideParam.roFrameBiasInBC
+  void setMFTROFrameBiasInBC(int nbc);
+
   const std::vector<o2::dataformats::GlobalFwdTrack>& getMatchedFwdTracks() const { return mMatchedTracks; }
   const std::vector<o2::mft::TrackMFT>& getMFTMatchingPlaneParams() const { return mMFTMatchPlaneParams; }
   const std::vector<o2::track::TrackParCovFwd>& getMCHMatchingPlaneParams() const { return mMCHMatchPlaneParams; }
@@ -288,6 +291,9 @@ class MatchGlobalFwd
   int mMFTROFrameLengthInBC = 0;        ///< MFT RO frame in BC (for MFT cont. mode only)
   float mMFTROFrameLengthMUS = -1.;     ///< MFT RO frame in \mus
   float mMFTROFrameLengthMUSInv = -1.;  ///< MFT RO frame in \mus inverse
+  int mMFTROFrameBiasInBC = 0;          ///< MFT ROF bias in BC wrt to orbit start
+  float mMFTROFrameBiasMUS = -1.;       ///< MFT ROF bias in \mus
+  float mMFTROFrameBiasMUSInv = -1.;    ///< MFT ROF bias in \mus inverse
 
   std::map<std::string, MatchingFunc_t> mMatchingFunctionMap; ///< MFT-MCH Matching function
   std::map<std::string, CutFunc_t> mCutFunctionMap;           ///< MFT-MCH Candidate cut function

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -262,10 +262,10 @@ bool MatchGlobalFwd::prepareMFTData()
       }
       return false;
     }
-    float tMin = nBC * o2::constants::lhc::LHCBunchSpacingMUS;
-    float tMax = (nBC + mMFTROFrameLengthInBC) * o2::constants::lhc::LHCBunchSpacingMUS;
+    float tMin = (nBC + mMFTROFrameBiasInBC) * o2::constants::lhc::LHCBunchSpacingMUS;
+    float tMax = (nBC + mMFTROFrameLengthInBC + mMFTROFrameBiasInBC) * o2::constants::lhc::LHCBunchSpacingMUS;
     if (!mMFTTriggered) {
-      auto irofCont = nBC / mMFTROFrameLengthInBC;
+      auto irofCont = (nBC + mMFTROFrameBiasInBC) / mMFTROFrameLengthInBC;
       if (mMFTTrackROFContMapping.size() <= irofCont) { // there might be gaps in the non-empty rofs, this will map continuous ROFs index to non empty ones
         mMFTTrackROFContMapping.resize((1 + irofCont / 128) * 128, 0);
       }
@@ -649,6 +649,14 @@ void MatchGlobalFwd::setMFTROFrameLengthInBC(int nbc)
   mMFTROFrameLengthInBC = nbc;
   mMFTROFrameLengthMUS = nbc * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
   mMFTROFrameLengthMUSInv = 1. / mMFTROFrameLengthMUS;
+}
+
+//_________________________________________________________
+void MatchGlobalFwd::setMFTROFrameBiasInBC(int nbc)
+{
+  mMFTROFrameBiasInBC = nbc;
+  mMFTROFrameBiasMUS = nbc * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+  mMFTROFrameBiasMUSInv = 1. / mMFTROFrameBiasMUS;
 }
 
 //_________________________________________________________

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
@@ -157,6 +157,10 @@ void GlobalFwdMatchingDPL::updateTimeDependentParams(ProcessingContext& pc)
     } else {
       mMatching.setMFTROFrameLengthInBC(alpParams.roFrameLengthInBC); // MFT ROFrame duration in \mus
     }
+    if (alpParams.roFrameBiasInBC != 0) {
+      mMatching.setMFTROFrameBiasInBC(alpParams.roFrameBiasInBC); // MFT ROFrame bias in BCs wrt orbit start
+      LOG(info) << "Setting MFT ROF bias to " << alpParams.roFrameBiasInBC << " BCs";
+    }
 
     mMatching.init();
   }

--- a/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
+++ b/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
@@ -138,6 +138,7 @@ class MFTAssessment
   std::unique_ptr<TH1F> mPositiveTrackPhi = nullptr;
   std::unique_ptr<TH1F> mNegativeTrackPhi = nullptr;
   std::unique_ptr<TH1F> mTrackEta = nullptr;
+  std::unique_ptr<TH2F> mTrackChi2pT = nullptr;
 
   std::unique_ptr<TH1F> mMFTClsZ = nullptr;
   std::unique_ptr<TH1F> mMFTClsOfTracksZ = nullptr;

--- a/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
+++ b/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
@@ -46,6 +46,7 @@ void MFTAssessment::reset()
   mPositiveTrackPhi->Reset();
   mNegativeTrackPhi->Reset();
   mTrackEta->Reset();
+  mTrackChi2pT->Reset();
 
   mMFTClsZ->Reset();
   mMFTClsOfTracksZ->Reset();
@@ -150,6 +151,8 @@ void MFTAssessment::createHistos()
   mNegativeTrackPhi = std::make_unique<TH1F>("mMFTNegativeTrackPhi", "Negative Track #phi; #phi; # entries", 100, -3.2, 3.2);
 
   mTrackEta = std::make_unique<TH1F>("mMFTTrackEta", "Track #eta; #eta; # entries", 50, -4, -2);
+
+  mTrackChi2pT = std::make_unique<TH2F>("mMFTTrackChi2pT", "Track #chi^{2}/NDF vs p_{T}; #it{p}_{T} (GeV/c); #chi^{2}/NDF", 210, -0.5, 20.5, 210, -0.5, 20.5);
 
   //----------------------------------------------------------------------------
 
@@ -368,6 +371,7 @@ void MFTAssessment::runASyncQC(o2::framework::ProcessingContext& ctx)
     mTrackPhi->Fill(oneTrack.getPhi());
     mTrackEta->Fill(oneTrack.getEta());
     mTrackCotl->Fill(1. / oneTrack.getTanl());
+    mTrackChi2pT->Fill(oneTrack.getPt(), oneTrack.getChi2OverNDF());
 
     for (auto idisk = 0; idisk < 5; idisk++) {
       clsEntriesForRedundancy[idisk] = {-1, -1};
@@ -676,6 +680,7 @@ void MFTAssessment::getHistos(TObjArray& objar)
   objar.Add(mPositiveTrackPhi.get());
   objar.Add(mNegativeTrackPhi.get());
   objar.Add(mTrackEta.get());
+  objar.Add(mTrackChi2pT.get());
 
   //------
   objar.Add(mMFTClsZ.get());
@@ -869,6 +874,8 @@ bool MFTAssessment::loadHistos()
   mNegativeTrackPhi = std::unique_ptr<TH1F>((TH1F*)f->Get("mMFTNegativeTrackPhi"));
 
   mTrackEta = std::unique_ptr<TH1F>((TH1F*)f->Get("mMFTTrackEta"));
+
+  mTrackChi2pT = std::unique_ptr<TH2F>((TH2F*)f->Get("mMFTTrackChi2pT"));
 
   //---------------------------------------------------------------------------
 

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
@@ -59,7 +59,7 @@ struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<
   static constexpr int DEFROFBiasInBC()
   {
     // default ROF length bias in MC, see https://github.com/AliceO2Group/AliceO2/pull/11108 for ITS
-    return N == o2::detectors::DetID::ITS ? 64 : 0;
+    return N == o2::detectors::DetID::ITS ? 64 : 60;
   }
 
   static_assert(N == o2::detectors::DetID::ITS || N == o2::detectors::DetID::MFT, "only DetID::ITS orDetID:: MFT are allowed");


### PR DESCRIPTION
Apply the time shift observed between MFT and FT0C, it was measured to be ~60 BCs @sarahherrmann 
ROF bias in BC modified in `DPLAlpideParam.h` as `MFTAlpideParam.roFrameBiasInBC=60` will affect vertex-MFTtrack association, this bias is also added to the fwd matching workflow to correct the BC window with `mMatching.setMFTROFrameBiasInBC(alpParams.roFrameBiasInBC);` 
