### PR TITLE
DPL Analysis: provide support for metadata

### DIFF
--- a/Framework/AnalysisSupport/src/DataInputDirector.h
+++ b/Framework/AnalysisSupport/src/DataInputDirector.h
@@ -65,6 +65,7 @@ class DataInputDescriptor
   void addFileNameHolder(FileNameHolder* fn);
   int fillInputfiles();
   bool setFile(int counter);
+  [[nodiscard]] std::string_view const getMetadata() const { return mMetadata; }
 
   // getters
   std::string getInputfilesFilename();
@@ -96,6 +97,7 @@ class DataInputDescriptor
   std::vector<FileNameHolder*> mfilenames;
   std::vector<FileNameHolder*>* mdefaultFilenamesPtr = nullptr;
   TFile* mcurrentFile = nullptr;
+  std::string mMetadata;
   int mCurrentFileID = -1;
   bool mAlienSupport = false;
 
@@ -138,8 +140,10 @@ class DataInputDirector
   DataInputDescriptor* getDataInputDescriptor(header::DataHeader dh);
   int getNumberInputDescriptors() { return mdataInputDescriptors.size(); }
 
-  std::unique_ptr<TTreeReader> getTreeReader(header::DataHeader dh, int counter, int numTF, std::string treeName);
   bool readTree(DataAllocator& outputs, header::DataHeader dh, int counter, int numTF, size_t& totalSizeCompressed, size_t& totalSizeUncompressed);
+  // Send the metadata for the current file
+  void readMetadata(DataAllocator& outputs, header::DataHeader dh);
+
   uint64_t getTimeFrameNumber(header::DataHeader dh, int counter, int numTF);
   FileAndFolder getFileFolder(header::DataHeader dh, int counter, int numTF);
   int getTimeFramesInFile(header::DataHeader dh, int counter);

--- a/Framework/Core/include/Framework/Metadata.h
+++ b/Framework/Core/include/Framework/Metadata.h
@@ -1,0 +1,82 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_METADATA_H_
+#define O2_FRAMEWORK_METADATA_H_
+#include <string>
+
+namespace o2::framework
+{
+/// Metadata for the analysis framework.
+/// You need to declare it as a member of your AnalysisTask
+/// like you do for configurable parameters. The constructor
+/// allows you to subscribe to a given key, and the value
+/// will be read from the data file and provided to you via
+/// the get() method or by using the dereference operator.
+/// Notice that for the moment metadata is provided as a string,
+/// we might provide polymorphic access if people ask for it.
+/// \example
+/// \code{.cpp}
+/// struct MyTask : AnalysisTask {
+///  Metadata<std::string> someMetadata{"label"};
+///  ...
+///  void process(aod::Tracks const& tracks) {
+///    std::cout << someMetadata.get() << std::endl;
+///  }
+/// };
+/// \endcode
+struct Metadata {
+  std::string key;
+  std::string value;
+
+  Metadata(std::string key)
+    : key(std::move(key))
+  {
+  }
+
+  [[nodiscard]] std::string_view get() const
+  {
+    return this->value;
+  }
+
+  operator std::string_view() const
+  {
+    return this->value;
+  }
+
+  std::string_view const operator*() const
+  {
+    return this->value;
+  }
+
+  std::string_view const operator->() const
+  {
+    return this->value;
+  }
+};
+
+/// Can be used to group together a number of Configurables
+/// to overcome the limit of 100 Configurables per task.
+/// In order to do so you can do:
+///
+/// struct MyTask {
+///   struct : MetadataGroup {
+///     Metadata<std::string> someMetadata{"label"};
+///   } group;
+/// };
+///
+/// and access it with
+///
+/// group.someMetadata;
+struct MetadataGroup {
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_METADATA_H_

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -501,7 +501,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
 
         // remove unmatched outputs
         auto o_end = std::remove_if(reader->outputs.begin(), reader->outputs.end(), [&](OutputSpec const& o) {
-          return !DataSpecUtils::partialMatch(o, o2::header::DataDescription{"TFNumber"}) && !DataSpecUtils::partialMatch(o, o2::header::DataDescription{"TFFilename"}) && std::none_of(requestedAODs.begin(), requestedAODs.end(), [&](InputSpec const& i) { return DataSpecUtils::match(i, o); });
+          return !DataSpecUtils::partialMatch(o, o2::header::DataDescription{"TFNumber"}) && !DataSpecUtils::partialMatch(o, o2::header::DataDescription{"TFFilename"}) && !DataSpecUtils::partialMatch(o, o2::header::DataOrigin{"AODM"}) && std::none_of(requestedAODs.begin(), requestedAODs.end(), [&](InputSpec const& i) { return DataSpecUtils::match(i, o); });
         });
         reader->outputs.erase(o_end, reader->outputs.end());
         if (reader->outputs.empty()) {

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -328,6 +328,12 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   std::vector<InputSpec> requestedAODs;
   std::vector<OutputSpec> providedAODs;
+  // We treat metadata separately. In principle
+  // we could even use this to allow non table based
+  // objects (e.g. histograms) to be created based
+  // on table inputs and be passed around.
+  std::vector<InputSpec> requestedAODMs;
+  std::vector<OutputSpec> providedAODMs;
   std::vector<InputSpec> requestedDYNs;
   std::vector<OutputSpec> providedDYNs;
   std::vector<InputSpec> requestedIDXs;
@@ -427,6 +433,9 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"AOD"})) {
         DataSpecUtils::updateInputList(requestedAODs, InputSpec{input});
       }
+      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"AODM"})) {
+        DataSpecUtils::updateInputList(requestedAODMs, InputSpec{input});
+      }
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"DYN"})) {
         DataSpecUtils::updateInputList(requestedDYNs, InputSpec{input});
       }
@@ -440,6 +449,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     for (auto& output : processor.outputs) {
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
+      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AODM"})) {
+        providedAODMs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"DYN"})) {
         providedDYNs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
@@ -486,6 +497,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   addMissingOutputsToSpawner({}, spawnerInputs, requestedAODs, aodSpawner);
 
   addMissingOutputsToReader(providedAODs, requestedAODs, aodReader);
+  addMissingOutputsToReader(providedAODMs, requestedAODMs, aodReader);
   addMissingOutputsToReader(providedCCDBs, requestedCCDBs, ccdbBackend);
 
   std::vector<DataProcessorSpec> extraSpecs;

--- a/Framework/TestWorkflows/src/o2AnalysisWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2AnalysisWorkflow.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/Metadata.h"
 #include <TH2F.h>
 #include <cmath>
 
@@ -35,11 +36,13 @@ DECLARE_SOA_TABLE(Points, "AOD", "POINTS",
 } // namespace o2::aod
 
 struct EtaAndClsHistograms {
+  Metadata currentRun{"Run"};
   OutputObj<TH3F> etaClsH{TH3F("eta_vs_cls_vs_sigmapT", "#eta vs N_{cls} vs sigma_{1/pT}", 102, -2.01, 2.01, 160, -0.5, 159.5, 100, 0, 10)};
   Produces<aod::Points> points;
 
   void process(soa::Join<aod::FullTracks, aod::TracksCov> const& tracks)
   {
+    LOGP(info, "Run is {}", currentRun.get());
     for (auto& track : tracks) {
       etaClsH->Fill(track.eta(), track.tpcNClsFindable(), track.sigma1Pt());
       points(1, 2, 3);


### PR DESCRIPTION
Metadata is read from the AOD files metaData tree and provided in the form of a string to any task which subscribes to it via the "Metadata" specification in the task description itself.

E.g. to know if a given task was created for run2 or run 3 you can use:

```c++
struct MyTask : AnalysisTask {
  Metadata creationRun{"Run"};

  void process(...) {
    LOGP("Run was {}", *creationRun);
  }
};
```