### PR TITLE
[rANS] Fix usage of parallel stl in librans benchmarks

### DIFF
--- a/Utilities/rANS/CMakeLists.txt
+++ b/Utilities/rANS/CMakeLists.txt
@@ -10,6 +10,8 @@
 # or submit itself to any jurisdiction.
 
 option(RANS_ENABLE_JSON "compile librans with rapidjson" ON)
+option(RANS_LOG_PROCESSED_DATA "logs data processed by encoders/decoders as JSON array to log sink" OFF)
+
 set(RANS_ARCH "" CACHE STRING "Compile librans for a given CPU type,\
  see https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html.")
  set(RANS_COMPILE_OPTIONS "" CACHE STRING "Compile librans with these compiler option")
@@ -36,6 +38,9 @@ o2_add_header_only_library(rANS
 if(${RANS_ENABLE_JSON})
   target_compile_definitions(${LIBRANS} INTERFACE RANS_ENABLE_JSON)
   target_link_libraries(${LIBRANS} INTERFACE RapidJSON::RapidJSON)
+endif()
+if(${RANS_LOG_PROCESSED_DATA})
+    target_compile_definitions(${LIBRANS} INTERFACE RANS_LOG_PROCESSED_DATA)
 endif()
 if (OpenMP_CXX_FOUND AND ( NOT APPLE ) )
     target_compile_definitions(${LIBRANS} INTERFACE RANS_OPENMP)
@@ -182,13 +187,15 @@ o2_add_test(Serialize
             LABELS utils)
             target_compile_options(${TEST_SERIALIZE} PRIVATE ${RANS_TEST_ARCH})
 
-if(${RANS_ENABLE_JSON})
-  if (${ENABLE_RANS_BENCHMARK})
-
+if (TARGET benchmark::benchmark)
     o2_add_header_only_library(libransBenchmark
                   TARGETVARNAME LIB_RANS_BENCHMARK
-                  INTERFACE_LINK_LIBRARIES O2::rANS RapidJSON::RapidJSON benchmark::benchmark TBB::tbb)
+                  INTERFACE_LINK_LIBRARIES O2::rANS benchmark::benchmark)
     target_compile_options(${LIB_RANS_BENCHMARK} INTERFACE -O3 ${RANS_OPTIONS})
+    if(TARGET TBB::tbb)
+    target_compile_definitions(${LIB_RANS_BENCHMARK} INTERFACE RANS_ENABLE_PARALLEL_STL)
+    target_link_libraries(${LIB_RANS_BENCHMARK} INTERFACE TBB::tbb)
+    endif()
     if(${ENABLE_VTUNE_PROFILER})
       target_compile_definitions(${LIB_RANS_BENCHMARK} INTERFACE ENABLE_VTUNE_PROFILER)
       target_link_libraries(${LIB_RANS_BENCHMARK} INTERFACE PkgConfig::Vtune)
@@ -248,6 +255,7 @@ if(${RANS_ENABLE_JSON})
                       IS_BENCHMARK
                       PUBLIC_LINK_LIBRARIES O2::libransBenchmark)
 
+  if(${RANS_ENABLE_JSON})
     o2_add_executable(TPCEncodeDecode
                       SOURCES benchmarks/bench_ransTPC.cxx
                       COMPONENT_NAME rANS

--- a/Utilities/rANS/benchmarks/bench_ransDecode.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransDecode.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief  compares performance of different encoders
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -51,11 +52,11 @@ inline constexpr size_t MessageSize = 1ull << 22;
 //       std::binomial_distribution<source_T> dist(draws, probability);
 //       const size_t sourceSize = messageSize / sizeof(source_T) + 1;
 //       mSourceMessage.resize(sourceSize);
-// #ifdef __cpp_lib_execution
+// #ifdef RANS_PARALLEL_STL
 //       std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 // #else
 //       std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-// #endif
+// #endif // RANS_PARALLEL_STL
 //     }
 //   }
 
@@ -82,11 +83,11 @@ class SourceMessageProxyUniform
       std::uniform_int_distribution<source_T> dist(min, max);
       const size_t sourceSize = messageSize / sizeof(source_T) + 1;
       mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
       std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
       std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
     }
   }
 

--- a/Utilities/rANS/benchmarks/bench_ransDecodeScaling.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransDecodeScaling.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief  compares performance of different encoders
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -48,11 +49,11 @@ class SourceMessageUniform
     std::uniform_int_distribution<source_T> dist(0, max);
     const size_t sourceSize = messageSize / sizeof(source_T) + 1;
     mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
     std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
     std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
   }
 
   const auto& get() const { return mSourceMessage; };

--- a/Utilities/rANS/benchmarks/bench_ransEncode.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransEncode.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief  compares performance of different encoders
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -51,11 +52,11 @@ class SourceMessageProxy
       std::binomial_distribution<source_T> dist(draws, probability);
       const size_t sourceSize = messageSize / sizeof(source_T) + 1;
       mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
       std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
       std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
     }
   }
 

--- a/Utilities/rANS/benchmarks/bench_ransEncodeImpl.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransEncodeImpl.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief benchmarks different encoding kernels without the need to renorm and stream data
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -66,11 +67,11 @@ class SymbolTableData
     std::binomial_distribution<source_T> dist(draws, probability);
     const size_t sourceSize = messageSize / sizeof(source_T);
     mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
     std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
     std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
 
     const auto histogram = makeDenseHistogram::fromSamples(gsl::span<const source_T>(mSourceMessage));
     Metrics<source_T> metrics{histogram};

--- a/Utilities/rANS/benchmarks/bench_ransHistogram.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransHistogram.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief  compares performance of different encoders
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -56,11 +57,11 @@ class SourceMessageProxyBinomial
       std::binomial_distribution<source_T> dist(draws, probability);
       const size_t sourceSize = messageSize / sizeof(source_T) + 1;
       mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
       std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
       std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
     }
 
     return mSourceMessage;
@@ -89,7 +90,7 @@ class SourceMessageProxyUniform
       std::uniform_int_distribution<source_T> dist(min, max);
       const size_t sourceSize = messageSize / sizeof(source_T) + 1;
       mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
       std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
       std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });

--- a/Utilities/rANS/benchmarks/bench_ransPack.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransPack.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief benchmarks packing algorithms and compares it to memcpy
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -46,11 +47,11 @@ std::vector<source_T> makeRandomUniformVector(size_t nelems, source_T min = std:
   std::mt19937 mt(0); // same seed we want always the same distrubution of random numbers;
   std::uniform_int_distribution<source_T> dist(min, max);
 
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
   std::generate(std::execution::par_unseq, result.begin(), result.end(), [&dist, &mt]() { return dist(mt); });
 #else
   std::generate(result.begin(), result.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
 
   return result;
 };

--- a/Utilities/rANS/benchmarks/bench_ransStreaming.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransStreaming.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief benchmarks streaming out data from rANS state to memory
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -61,11 +62,11 @@ class RenormingData
     std::binomial_distribution<source_T> dist(draws, probability);
     const size_t sourceSize = messageSize / sizeof(source_T);
     mSourceMessage.resize(sourceSize);
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
     std::generate(std::execution::par_unseq, mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
 #else
     std::generate(mSourceMessage.begin(), mSourceMessage.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
 
     const auto histogram = makeDenseHistogram::fromSamples(gsl::span<const source_T>(mSourceMessage));
     Metrics<source_T> metrics{histogram};

--- a/Utilities/rANS/benchmarks/bench_ransUnpack.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransUnpack.cxx
@@ -13,12 +13,13 @@
 /// @author Michael Lettrich
 /// @brief  benchmark unpacking of data compared to memcpy
 
+#include "rANS/internal/common/defines.h"
+
 #include <vector>
 #include <cstring>
 #include <random>
 #include <algorithm>
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 #include <iterator>
@@ -46,11 +47,11 @@ std::vector<source_T> makeRandomUniformVector(size_t nelems, source_T min = std:
   std::mt19937 mt(0); // same seed we want always the same distrubution of random numbers;
   std::uniform_int_distribution<source_T> dist(min, max);
 
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
   std::generate(std::execution::par_unseq, result.begin(), result.end(), [&dist, &mt]() { return dist(mt); });
 #else
   std::generate(result.begin(), result.end(), [&dist, &mt]() { return dist(mt); });
-#endif
+#endif // RANS_PARALLEL_STL
   return result;
 };
 

--- a/Utilities/rANS/benchmarks/helpers.h
+++ b/Utilities/rANS/benchmarks/helpers.h
@@ -16,25 +16,28 @@
 #ifndef RANS_BENCHMARKS_HELPERS_H_
 #define RANS_BENCHMARKS_HELPERS_H_
 
+#include "rANS/internal/common/defines.h"
+
 #ifdef ENABLE_VTUNE_PROFILER
 #include <ittnotify.h>
 #endif
 
+#ifdef RANS_ENABLE_JSON
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
-
+#endif // RANS_ENABLE_JSON
 #include <fairlogger/Logger.h>
 #include <algorithm>
 
 #include "rANS/internal/common/exceptions.h"
 
-#include <version>
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
 #include <execution>
 #endif
 
+#ifdef RANS_ENABLE_JSON
 struct TPCCompressedClusters {
 
   TPCCompressedClusters() = default;
@@ -276,6 +279,7 @@ TPCCompressedClusters readFile(const std::string& filename)
   }
   return compressedClusters;
 };
+#endif // RANS_ENABLE_JSON
 
 template <typename source_T, typename stream_T = uint32_t>
 struct EncodeBuffer {
@@ -303,11 +307,11 @@ struct DecodeBuffer {
   template <typename T>
   bool operator==(const T& correct)
   {
-#ifdef __cpp_lib_execution
+#ifdef RANS_PARALLEL_STL
     return std::equal(std::execution::par_unseq, buffer.begin(), buffer.end(), std::begin(correct), std::end(correct));
 #else
     return std::equal(buffer.begin(), buffer.end(), std::begin(correct), std::end(correct));
-#endif
+#endif // RANS_PARALLEL_STL
   }
 
   std::vector<source_T> buffer{};

--- a/Utilities/rANS/include/rANS/internal/common/defines.h
+++ b/Utilities/rANS/include/rANS/internal/common/defines.h
@@ -16,6 +16,8 @@
 #ifndef RANS_INTERNAL_COMMON_DEFINES_H_
 #define RANS_INTERNAL_COMMON_DEFINES_H_
 
+#include <version>
+
 #ifdef RANS_AVX2
 #error RANS_AVX2 cannot be directly set
 #endif
@@ -64,6 +66,10 @@
 
 #if defined(__FMA__)
 #define RANS_FMA
+#endif
+
+#if defined(RANS_ENABLE_PARALLEL_STL) && defined(__cpp_lib_execution)
+#define RANS_PARALLEL_STL
 #endif
 
 #endif /*RANS_INTERNAL_COMMON_DEFINES_H_*/

--- a/Utilities/rANS/include/rANS/internal/decode/DecoderConcept.h
+++ b/Utilities/rANS/include/rANS/internal/decode/DecoderConcept.h
@@ -83,7 +83,7 @@ class DecoderConcept
       auto decode = [&, this](coder_type& decoder) {
         const auto cumul = decoder.get();
         const value_type symbol = lookupSymbol(cumul);
-#ifdef O2_RANS_PRINT_PROCESSED_DATA
+#ifdef RANS_LOG_PROCESSED_DATA
         arrayLogger << symbol.first;
 #endif
         return std::make_tuple(symbol.first, decoder.advanceSymbol(inputIter, symbol.second));
@@ -110,7 +110,7 @@ class DecoderConcept
         std::tie(*outputIter++, inputIter) = decode(decoders[i]);
       }
 
-#ifdef O2_RANS_PRINT_PROCESSED_DATA
+#ifdef RANS_LOG_PROCESSED_DATA
       LOG(info) << "decoderOutput:" << arrayLogger;
 #endif
     }


### PR DESCRIPTION
Permanent fix of issue stated at #11864. 
Uses parallel `stl` in `librans` benchmarks only when `libtbb` is available and the `stl` in use has this feature implemented. 
