### PR TITLE
WIP TRD trap config events processing

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -25,6 +25,10 @@ o2_add_library(DataFormatsTRD
                        src/Digit.cxx
                        src/KrCluster.cxx
                        src/NoiseCalibration.cxx
+                       src/TrapRegisters.cxx
+                       src/TrapRegInfo.cxx
+                       src/MCMEvent.cxx
+                       src/TrapConfigEvent.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
 o2_target_root_dictionary(DataFormatsTRD
@@ -53,7 +57,13 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/CalT0.h
                        include/DataFormatsTRD/SignalArray.h
                        include/DataFormatsTRD/CompressedDigit.h
-                       include/DataFormatsTRD/CompressedHeader.h)
+                       include/DataFormatsTRD/CompressedHeader.h
+                       include/DataFormatsTRD/TrapConfigEvent.h
+                       include/DataFormatsTRD/MCMEvent.h
+                       include/DataFormatsTRD/TrapRegInfo.h
+                       include/DataFormatsTRD/TrapRegisters.h
+                       include/DataFormatsTRD/TrapConfigEventQC.h
+                       include/DataFormatsTRD/TrapConfigEvent.h)
 
 o2_add_test(Digit
             COMPONENT_NAME trd
@@ -70,3 +80,11 @@ o2_add_test(RawData
             ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
             LABELS trd
             )
+
+o2_add_test(TrapConfigEvent
+            COMPONENT_NAME trd
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD
+            SOURCES test/testTrapConfigEvent.cxx
+            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+            LABELS trd
+)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -98,6 +98,10 @@ constexpr unsigned int ETYPEPHYSICSTRIGGER = 0x2;     ///< CRU Half Chamber head
 constexpr unsigned int ETYPECALIBRATIONTRIGGER = 0x3; ///< CRU Half Chamber header eventtype definition
 constexpr int MAXCRUERRORVALUE = 0x2;                 ///< Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
 constexpr int INVALIDPRETRIGGERPHASE = 0xf;           ///< Invalid value for phase, used to signify there is no hcheader.
+constexpr int CONFIGEVENTNUMBER = 0x47;               ///< Major version number in Digit HC Header defining a configuration "digit" event
+constexpr int CONFIGEVENTENDA = 0x42424242;           ///< End of packed config event in message to be passed on for processing
+constexpr int CONFIGEVENTENDB = 0xedededed;           ///< End of packed config event in message to be passed on for processing
+constexpr int CONFIGEVENTBLOCKENDMARKER = 0x7fff00fe; ///< End marker for a configuration event block.
 
 } // namespace constants
 } // namespace trd

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -13,6 +13,7 @@
 #define ALICEO2_TRD_HELPERMETHODS_HH
 
 #include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/RawData.h"
 #include <iostream>
 #include <string>
 #include <fmt/format.h>
@@ -210,6 +211,30 @@ struct HelperMethods {
     rob = (mcmCol >= constants::NMCMROBINCOL) ? (row / constants::NMCMROBINROW) * 2 + 1 : (row / constants::NMCMROBINROW) * 2;
     mcm = (row % constants::NMCMROBINROW) * constants::NMCMROBINCOL + (mcmCol % constants::NMCMROBINCOL);
     channel = constants::NADCMCM - 1 - ((chamberIndex % constants::NCHANNELSPERROW) % constants::NADCMCM);
+  }
+
+  static int getMCMId(int sector, int stack, int layer, int rob, int mcm)
+  {
+    // return the mcmid of the indexed mcm
+    int mcmid = (sector * constants::NSTACK * constants::NLAYER + stack * constants::NLAYER + layer) * constants::NROBC1 * constants::NMCMROB + rob * constants::NMCMROB + mcm;
+    return mcmid;
+  }
+
+  static int getMCMId(int det, int rob, int mcm)
+  {
+    // return the mcmid of the indexed mcm
+    int mcmid = det * constants::NROBC1 * constants::NMCMROB + rob * constants::NMCMROB + mcm;
+    return mcmid;
+  }
+
+  static int getHCIDFromMCMId(int mcmid)
+  {
+    return mcmid / (constants::NROBC1 * constants::NMCMROB);
+  }
+
+  static int getHCIDFromDigitHCHeader(DigitHCHeader header)
+  {
+    return header.supermodule * constants::NHCPERSEC + header.stack * constants::NLAYER * 2 + header.layer * 2 + header.side;
   }
 };
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/MCMEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/MCMEvent.h
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDMCMEVENT_H
+#define O2_TRDMCMEVENT_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include <fairlogger/Logger.h>
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/TrapRegInfo.h"
+#include "DataFormatsTRD/TrapRegisters.h"
+#include "DataFormatsTRD/Digit.h"
+
+#include <string>
+#include <map>
+#include <unordered_map>
+#include <array>
+#include <vector>
+#include <bitset>
+#include <gsl/span>
+
+namespace o2
+{
+namespace trd
+{
+
+/*!
+  A class to hold a configuration event from a single mcm.
+  All packed registers are simply stored in an array.
+  Unpacking and packing is internal to this class.
+*/
+
+class MCMEvent
+{
+
+ public:
+  MCMEvent() = default;
+  MCMEvent(int mcmid) { setMCMId(mcmid); }
+  ~MCMEvent() = default;
+  // get and set the mcmid, this could be extracted from the location of this class in other objects. Its just easier to have it handy here.
+  int32_t const getMCMId() { return mMCMId; }
+  void setMCMId(const int32_t mcmid) { mMCMId = mcmid; }
+
+  // get and set a specific register. Get/Set the value from its internal compressed format.
+  bool setRegister(const uint32_t data, const uint32_t regidx, const TrapRegInfo& trapreg);
+
+  // bool setRegister(const uint32_t data, const uint32_t regidx, const uint32_t base, const uint32_t wordnumber, const uint32_t shift, const uint32_t mask);
+  const uint32_t getRegister(const uint32_t regidx, const TrapRegInfo& trapreg) const;
+
+  const uint32_t getvalue(const uint32_t index) { return mRegisterData[index]; };
+
+ private:
+  std::array<uint32_t, kTrapRegistersSize> mRegisterData{0}; // a block of mcm register data.
+  int32_t mMCMId{-1};                                        // the id of this mcm. -1 to know when it has not been set yet.
+  ClassDefNV(MCMEvent, 2);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <cstdint>
 #include <ostream>
+#include <bitset>
 #include "DataFormatsTRD/Constants.h"
 #include "Rtypes.h"
 
@@ -427,6 +428,55 @@ struct LinkToHCIDMapping {
   std::map<int, int> linkIDToHCID;
   std::map<int, int> hcIDToLinkID;
   ClassDefNV(LinkToHCIDMapping, 1);
+};
+
+struct DigitHCHeaderAll {
+  // store all the digit hcheaders for carrying them around all together.
+  // all 4 of them are 32 bit integers and its simpler to just store them like that.
+  std::array<uint32_t, 4> mHeaders;
+  std::bitset<4> mHasHeader;
+  bool isSet(int header) { return mHasHeader.test(header); }
+  void setHeader(uint32_t header, uint32_t value)
+  {
+    mHasHeader.set(header);
+    mHeaders[header] = value;
+  }
+  uint32_t getHeader(uint32_t header)
+  {
+    if (isSet(header))
+      return mHeaders[header];
+    else
+      return 0;
+  }
+  uint32_t getHeader()
+  {
+    if (isSet(0)) {
+      return mHeaders[0];
+    } else
+      return 0;
+  }
+  uint32_t getHeader1()
+  {
+    if (isSet(1)) {
+      return mHeaders[1];
+    } else
+      return 0;
+  }
+  uint32_t getHeader2()
+  {
+    if (isSet(2)) {
+      return mHeaders[2];
+    } else
+      return 0;
+  }
+  uint32_t getHeader3()
+  {
+    if (isSet(3)) {
+      return mHeaders[3];
+    } else
+      return 0;
+  }
+  void reset() { mHeaders.fill(0); } ///< reset the headers to zero
 };
 
 uint32_t setHalfCRUHeader(HalfCRUHeader& cruhead, int crurdhversion, int bunchcrossing, int stopbits, int endpoint, int eventtype, int feeid, int cruid);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -120,7 +120,8 @@ enum OptionBits {
   TRDGenerateStats,
   TRDOnlyCalibrationTriggerBit,
   TRDSortDigits,
-  TRDLinkStats
+  TRDLinkStats,
+  TRDEnableConfigEvents
 }; // this is currently 16 options, the array is 16, if you add here you need to change the 16;
 
 struct DataCountersPerTrigger {

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEvent.h
@@ -1,0 +1,144 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPCONFIGEVENT_H
+#define O2_TRDTRAPCONFIGEVENT_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include <fairlogger/Logger.h>
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/MCMEvent.h"
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/TrapRegisters.h"
+#include "DataFormatsTRD/TrapRegInfo.h"
+
+#include <string>
+#include <map>
+#include <unordered_map>
+#include <array>
+#include <vector>
+#include <bitset>
+#include <gsl/span>
+
+namespace o2
+{
+namespace trd
+{
+
+class TrapConfigEvent
+{
+  // class that is actually stored in ccdb.
+  // it holds a compressed version of what comes in the config events
+
+ public:
+  TrapConfigEvent();
+  ~TrapConfigEvent() = default;
+
+  TrapConfigEvent(const TrapConfigEvent& A);
+
+  // get a config register value by index, addr, and name, via mcm index
+  uint32_t getRegisterValue(const uint32_t regidx, const int mcmidx);
+  bool setRegisterValue(const uint32_t data, const uint32_t regidx, const int mcmidx);
+
+  // get a registers index (enum value) by address or name
+  // due to the speed, it is never used in normal operations, only debugging.
+  int32_t getRegIndexByName(const std::string& name);
+
+  // get a registers address by index or name
+  int32_t getRegAddrByIdx(const unsigned int regidx);
+  int32_t getRegAddrByName(const std::string& name);
+
+  // move to parser bool isValidAddress(const uint32_t addr);
+  const std::string getRegisterName(const unsigned int regidx) { return mTrapRegisters[regidx].getName(); }
+  const uint32_t getRegisterMax(const unsigned int regidx) { return mTrapRegisters[regidx].getMax(); }
+  const uint32_t getRegisterNBits(const unsigned int regidx) { return mTrapRegisters[regidx].getNbits(); }
+  const TrapRegInfo& getRegisterInfo(const uint32_t regidx) { return mTrapRegisters[regidx]; }
+  const uint16_t getRegisterAddress(const uint32_t regidx) { return mTrapRegisters[regidx].getAddr(); }
+
+  // return all the registers for a particular mcm
+  void getAllRegisters(const int mcmidx, std::array<uint32_t, o2::trd::TrapRegisters::kLastReg>& registers);
+
+  // return all the mcm values for a particular register index
+  void getAllMCMByIndex(const int regindex, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& registers);
+
+  // return all the mcm values for a particular register name
+  void getAllMCMByName(const std::string& registername, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms);
+
+  // return all the config data in an unpacked array.
+  void getAll(std::array<uint32_t, o2::trd::TrapRegisters::kLastReg * o2::trd::constants::MAXMCMCOUNT>& configdata);
+
+  // population pending
+  uint32_t getConfigVersion(const int mcmid = 0) { return getRegisterValue(TrapRegisters::kQ2VINFO, mcmid); }    // these must some how be gotten from git or wingdb.
+  uint32_t getConfigName(const int mcmid = 0) { return getRegisterValue(TrapRegisters::kQ2VINFO, mcmid); }       // these must be gotten from git or wingdb.
+  uint16_t getConfigSavedVersion(const int mcmid = 0) { return getRegisterValue(TrapRegisters::kVINFO, mcmid); } // the version that is saved, for the ability to later save the config differently.
+
+  bool isConfigDifferent(const TrapConfigEvent& trapconfigevent) const;
+
+  // for compliance with the same interface to o2::trd::TrapConfig and its run1/2 inherited interface:
+  // only these 2 are used in the simulations.
+  uint32_t getDmemUnsigned(uint32_t address, int detector, int rob, int mcm);
+  uint32_t getTrapReg(const uint32_t index, const int detector, const int rob, const int mcm);
+
+  //  bool isHCIDPresent(const int hcid) const { return mHCIDPresent.test(hcid); }
+  //  void HCIDIsPresent(const int hcid) { mHCIDPresent.set(hcid); }
+  //  uint32_t countHCIDPresent() { return mHCIDPresent.count(); }
+  uint32_t countHCIDPresent() { return constants::MAXHALFCHAMBER - std::count(mHCIDPresentCount.begin(), mHCIDPresentCount.end(), -1); } // count those indices not set and subtract from the total number of mcm
+                                                                                                                                         //  const std::bitset<constants::MAXHALFCHAMBER>& getHCIDPresent() const { return mHCIDPresent; }
+  bool isMCMPresent(const int mcmid) const { return (mConfigDataIndex[mcmid] != -1) ? true : false; }
+  // const std::bitset<constants::MAXMCMCOUNT>& getMCMPresent() const { return mMCMPresent; }
+  uint32_t countMCMPresent() { return constants::MAXMCMCOUNT - std::count(mConfigDataIndex.begin(), mConfigDataIndex.end(), -1); } // count those indices not set and subtract from the total number of mcm
+  // void clearMCMPresent() { mMCMPresent.reset(); }
+  void clearMCMEvent() { mConfigData.clear(); }
+  void clear()
+  {
+    // clearMCMPresent();
+    clearMCMEvent();
+  }
+  bool ignoreWord(const int offset) const { return mWordNumberIgnore.test(offset); }
+
+  // required for a container for calibration
+  void fill(const TrapConfigEvent& input);
+  void fill(const gsl::span<const TrapConfigEvent> input); // dummy!
+  void merge(const TrapConfigEvent* prev);
+  void print();
+  int getRegisterBase(const int regidx) { return mTrapRegisters[regidx].getBase(); }
+  const MCMEvent& getMCMEvent(const int mcmidx) { return mConfigData[mcmidx]; }
+  int getMCMEventSize() { return mConfigDataIndex.size(); }
+  uint32_t getrawdata(uint32_t idx) { return mConfigData[0].getvalue(idx); }
+  // TODO put into QC
+  void buildAverage();
+  void buildDefaults();
+  void setDefaultRegisterValue(const int regidx, const uint32_t registervalue) { mDefaultRegisters.setRegister(regidx, registervalue, mTrapRegisters[regidx]); }
+  uint32_t getDefaultRegisterValue(const int regidx) { return mDefaultRegisters.getRegister(regidx, mTrapRegisters[regidx]); }
+
+ private:
+  TrapRegisters mTrapRegisters;
+  MCMEvent mDefaultRegisters;                                           // default values for registers
+  std::array<uint16_t, constants::MAXHALFCHAMBER> mHCIDPresentCount{0}; // did the link actually receive data.
+  std::array<uint16_t, constants::MAXMCMCOUNT> mMCMPresentCount{0};     // how many times did this mcm receive a config event to build this config event. Ideally all present ones would have the same number, this is not the case and the reason for this array.
+  std::vector<MCMEvent> mConfigData;                                    // vector of register data blocks
+  std::array<int32_t, constants::MAXMCMCOUNT> mConfigDataIndex{-1};     // one block of data per mcm, array as one wants to query if an mcm is present with having to walk the whole index.
+                                                                        //  std::map<uint16_t, uint16_t> mTrapRegistersAddressIndexMap;    moved to parser   //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
+  std::bitset<kTrapRegistersSize> mWordNumberIgnore;                    // whether to ignore a register or not. Here to speed lookups up.
+  // alternate storage:
+  // std::array<std::vector<uint32_t>,o2::trd::TrapRegisters::kLastReg> mConfigDataint;                 // vector of vectors of register data, 1 value for a constant register, 69k for individual
+  //  now we dont know if we actually have data for a specific mcm, so keep a record of which ones have been actually read and known to be current
+  // std::bitset<o2::trd::constants::MAXMCMCOUNT> mMCMsPresent;                 // which mcms were actually seen to build this series of configuration events
+
+  ClassDefNV(TrapConfigEvent, 5);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEventQC.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapConfigEventQC.h
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPCONFIGEVENTQC_H
+#define O2_TRDTRAPCONFIGEVENTQC_H
+
+#include <string>
+#include <vector>
+#include "TObject.h"
+
+namespace o2
+{
+namespace trd
+{
+
+struct TrapConfigEventQCItem {
+  uint32_t mMCMId;                     //!< index of this mcm, this removes the need for an index.
+  uint16_t mRegistersSuccessfullyRead; //!< How many registers an MCM read, in range [0-433];
+  uint16_t mMissingRegisters;          //!< [0-433];  433 - the above number
+  uint16_t mStartRegister;             //!< [0-433];  which register this mcm started on
+  uint16_t mEndRegister;               //!< [0-433];  which register this mcm finished on
+  uint8_t mParseStatus;                //!< 0x01 .. 0x4f bit pattern
+  ClassDefNV(TrapConfigEventQCItem, 1);
+};
+
+class TrapConfigEventQC
+{
+  // This is an object that sent to qc for each timeframe that contains any config events.
+  // accumulation and frequency is done on the qc side, this implies that qc receives all of these objects not a sampling.
+  // in a single timeframe there can never be more than a single mcm sending data.
+ public:
+  TrapConfigEventQC() = default;
+  TrapConfigEventQC(uint16_t mcmid) { mQCData.emplace_back(TrapConfigEventQCItem()); }
+  ~TrapConfigEventQC() = default;
+  // get and set methods of the underlying entries in the mQCData vector.
+  uint32_t getReadRegisters(int mcmid) { return mQCData[mcmid].mRegistersSuccessfullyRead; }
+  uint32_t getMissedRegisters(int mcmid) { return mQCData[mcmid].mMissingRegisters; }
+  uint32_t getStartRegister(int mcmid) { return mQCData[mcmid].mStartRegister; }
+  uint32_t getStopRegister(int mcmid) { return mQCData[mcmid].mEndRegister; }
+  uint32_t getParseStatus(int mcmid) { return mQCData[mcmid].mParseStatus; }
+  void setReadRegisters(int mcmid, int regread) { mQCData[mcmid].mRegistersSuccessfullyRead = regread; }
+  void setMissedRegisters(int mcmid, int missed) { mQCData[mcmid].mMissingRegisters = missed; }
+  void setStartRegister(int mcmid, int start) { mQCData[mcmid].mStartRegister = start; }
+  void setStopRegister(int mcmid, int end) { mQCData[mcmid].mEndRegister = end; }
+  void setParseStatus(int mcmid, int parsing) { mQCData[mcmid].mParseStatus = parsing; }
+
+  void addMCM(int mcmid) { mQCData.emplace_back(TrapConfigEventQCItem()); }
+  void clear() { mQCData.clear(); }
+
+ private:
+  std::vector<o2::trd::TrapConfigEventQCItem> mQCData; //!< one item per mcm for the given timeframe
+  ClassDefNV(TrapConfigEventQC, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapRegInfo.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapRegInfo.h
@@ -1,0 +1,91 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPREGINFO_H
+#define O2_TRDTRAPREGINFO_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include <fairlogger/Logger.h>
+
+#include "DataFormatsTRD/Constants.h"
+
+namespace o2::trd
+{
+
+class TrapRegInfo
+{
+  // class to store the parameters associated with a register
+  // some info related to the hardware, some to the packing/unpacking we do here.
+ public:
+  TrapRegInfo() = default;
+  TrapRegInfo(const std::string& name, int addr, int nBits, int base, int wordoffset, bool ignorechange, uint32_t max);
+
+  ~TrapRegInfo();
+
+  void init(const std::string& name, int addr, int nBits, int base, int wordnumber, bool ignorechange, uint32_t max);
+
+  // getters and setters, this is just a storage class.
+  const std::string getName() const { return mName; }
+  const unsigned short getAddr() const { return mAddr; }
+  const unsigned short getNbits() const { return mNbits; }
+  const unsigned int getBase() const { return mBase; }
+  const unsigned int getWordNumber() const { return mWordNumber; }
+  const unsigned int getDataWordNumber() const { return mDataWordNumber; }
+  const unsigned int getShift() const { return mShift; }
+  const uint32_t getMask() const { return mMask; }
+  const uint32_t getMax() const { return mMax; }
+  bool getIgnoreChange() { return mIgnoreChange; }
+
+  void setName(const std::string name) { mName = name; }
+  void setAddr(const uint32_t addr) { mAddr = addr; }
+  void setNbits(const uint32_t bits) { mNbits = bits; }
+  void setBase(const uint32_t base) { mBase = base; }
+  void setWordNumber(const uint32_t wordnum) { mWordNumber = wordnum; }
+  void setDataWordNumber(const uint32_t datawordnum) { mDataWordNumber = datawordnum; }
+  void setShift(const uint32_t shift) { mShift = shift; }
+  void setMask(const uint32_t mask) { mMask = mask; }
+  void setMax(uint32_t max) { mMax = pow(2, max) - 1; }
+  void setIgnoreChange(const uint32_t ignorechange) { mIgnoreChange = ignorechange; }
+
+  void logTrapRegInfo(); // output the contents to log info
+
+ private:
+  // TrapRegInfo(const TrapRegInfo& rhs);
+  // TrapRegInfo& operator=(const TrapRegInfo& rhs);
+
+  // fixed properties of the register
+  // which do not need to be stored on a per mcm basis
+  // nominal example :
+  //  3         2         1         0
+  // 10987654321098765432109876543210
+  // ----------------------xxxxx-----
+  // TPL01 Nbits=5; mBase=0;WordNumber=0;DataWordNumber=0;Mask=0x170;Shift=5;
+  //  3         2         1         0
+  // 10987654321098765432109876543210
+  // --xxxxxxxxxx--------------------
+  // FGF10 Nbits=10; mBase=27;WordNumber=10;DataWordNumber=10;Mask=0x3ff00000;Shift=20;
+  // mTrapRegisters[kFGF10].init("FGF10", 0x308A, 10, 27, 10, false, 10);
+  std::string mName;        //!< Name of the register
+  uint16_t mAddr;           //!< Address in GIO of TRAP
+  uint16_t mNbits;          //!< Number of bits, from 1 to 32
+  uint32_t mBase;           //!< base of this registers block, i.e. TFL?? will have 0 and is in the range [0,kTrapRegistersSize]
+  uint32_t mWordNumber;     //!< word number offset, of size Nbits, in the block of registers
+  uint32_t mDataWordNumber; //!< offset, into "compressed" 32 bit words for the 32 bit word containing this register, offset from the base;
+  uint32_t mMask;           //!< mask to extract register from the word identified by WordNumber
+  uint32_t mMax;            //!< max is not the same as the mask, some values come in as 15 bit mask but are only 12 or 13 bits for max, IRQ values for example
+  uint32_t mShift;          //!< shift to extract the register
+  bool mIgnoreChange;       //!< we are not concerned with this value changing for purposes of the differential comparison.
+  ClassDefNV(TrapRegInfo, 1);
+};
+
+} // namespace o2::trd
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapRegisters.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrapRegisters.h
@@ -1,0 +1,109 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPREGISTERS_H
+#define O2_TRDTRAPREGISTERS_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include <fairlogger/Logger.h>
+#include <cwchar>
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapRegInfo.h"
+#include "TrapRegInfo.h"
+
+namespace o2
+{
+namespace trd
+{
+
+static const int kTrapRegistersSize = 151; //!< size of our compressed trap registers in units of 32 bits
+                                           // enum of all TRAP registers, to be used for access to them
+
+class TrapRegisters
+{
+ public:
+  // registers in the order they come in.
+  // clang-format off
+  enum TrapReg {
+    kTPL00, kTPL01, kTPL02, kTPL03, kTPL04, kTPL05, kTPL06, kTPL07, kTPL08, kTPL09, kTPL0A,
+    kTPL0B, kTPL0C, kTPL0D, kTPL0E, kTPL0F, kTPL10, kTPL11, kTPL12, kTPL13, kTPL14, kTPL15,
+    kTPL16, kTPL17, kTPL18, kTPL19, kTPL1A, kTPL1B, kTPL1C, kTPL1D, kTPL1E, kTPL1F, kTPL20,
+    kTPL21, kTPL22, kTPL23, kTPL24, kTPL25, kTPL26, kTPL27, kTPL28, kTPL29, kTPL2A, kTPL2B,
+    kTPL2C, kTPL2D, kTPL2E, kTPL2F, kTPL30, kTPL31, kTPL32, kTPL33, kTPL34, kTPL35, kTPL36,
+    kTPL37, kTPL38, kTPL39, kTPL3A, kTPL3B, kTPL3C, kTPL3D, kTPL3E, kTPL3F, kTPL40, kTPL41,
+    kTPL42, kTPL43, kTPL44, kTPL45, kTPL46, kTPL47, kTPL48, kTPL49, kTPL4A, kTPL4B, kTPL4C,
+    kTPL4D, kTPL4E, kTPL4F, kTPL50, kTPL51, kTPL52, kTPL53, kTPL54, kTPL55, kTPL56, kTPL57,
+    kTPL58, kTPL59, kTPL5A, kTPL5B, kTPL5C, kTPL5D, kTPL5E, kTPL5F, kTPL60, kTPL61, kTPL62,
+    kTPL63, kTPL64, kTPL65, kTPL66, kTPL67, kTPL68, kTPL69, kTPL6A, kTPL6B, kTPL6C, kTPL6D,
+    kTPL6E, kTPL6F, kTPL70, kTPL71, kTPL72, kTPL73, kTPL74, kTPL75, kTPL76, kTPL77, kTPL78,
+    kTPL79, kTPL7A, kTPL7B, kTPL7C, kTPL7D, kTPL7E, kTPL7F, kFGA0, kFGA1, kFGA2, kFGA3, kFGA4,
+    kFGA5, kFGA6, kFGA7, kFGA8, kFGA9, kFGA10, kFGA11, kFGA12, kFGA13, kFGA14, kFGA15, kFGA16,
+    kFGA17, kFGA18, kFGA19, kFGA20, kFGF0, kFGF1, kFGF2, kFGF3, kFGF4, kFGF5, kFGF6, kFGF7, kFGF8,
+    kFGF9, kFGF10, kFGF11, kFGF12, kFGF13, kFGF14, kFGF15, kFGF16, kFGF17, kFGF18, kFGF19, kFGF20,
+    kCPU0CLK, kCPU1CLK, kCPU2CLK, kCPU3CLK, kNICLK, kFILCLK, kPRECLK, kADCEN, kNIODE, kNIOCE,
+    kNIIDE, kNIICE, kEBIS, kEBIT, kEBIL, kTPVT, kTPVBY, kTPCT, kTPCL, kTPCBY, kTPD, kTPCI0, kTPCI1,
+    kTPCI2, kTPCI3, kEBIN, kFLBY, kFPBY, kFGBY, kFTBY, kFCBY, kFLL00, kFLL01, kFLL02, kFLL03, kFLL04,
+    kFLL05, kFLL06, kFLL07, kFLL08, kFLL09, kFLL0A, kFLL0B, kFLL0C, kFLL0D, kFLL0E, kFLL0F, kFLL10,
+    kFLL11, kFLL12, kFLL13, kFLL14, kFLL15, kFLL16, kFLL17, kFLL18, kFLL19, kFLL1A, kFLL1B, kFLL1C,
+    kFLL1D, kFLL1E, kFLL1F, kFLL20, kFLL21, kFLL22, kFLL23, kFLL24, kFLL25, kFLL26, kFLL27, kFLL28,
+    kFLL29, kFLL2A, kFLL2B, kFLL2C, kFLL2D, kFLL2E, kFLL2F, kFLL30, kFLL31, kFLL32, kFLL33, kFLL34,
+    kFLL35, kFLL36, kFLL37, kFLL38, kFLL39, kFLL3A, kFLL3B, kFLL3C, kFLL3D, kFLL3E, kFLL3F, kTPPT0,
+    kTPFS, kTPFE, kTPPGR, kTPPAE, kTPQS0, kTPQE0, kTPQS1, kTPQE1, kEBD, kEBAQA, kEBSIA, kEBSF,
+    kEBSIM, kEBPP, kEBPC, kFPTC, kFPNP, kFPCL, kFGTA, kFGTB, kFGCL, kFTAL, kFTLL, kFTLS,
+    kFCW1, kFCW2, kFCW3, kFCW4, kFCW5, kTPFP, kTPHT, kADCMSK, kADCINB, kADCDAC, kADCPAR, kADCTST,
+    kSADCAZ, kPASADEL, kPASAPHA, kPASAPRA, kPASADAC, kPASASTL, kPASAPR1, kPASAPR0, kSADCTRG, kSADCRUN,
+    kSADCPWR, kL0TSIM, kSADCEC, kSADCMC, kSADCOC, kSADCGTB, kSEBDEN, kSEBDOU, kSML0, kSML1, kSML2,
+    kSMMODE, kNITM0, kNITM1, kNITM2, kNIP4D, kARBTIM, kIA0IRQ0, kIA0IRQ1, kIA0IRQ2, kIA0IRQ3, kIA0IRQ4,
+    kIA0IRQ5, kIA0IRQ6, kIA0IRQ7, kIA0IRQ8, kIA0IRQ9, kIA0IRQA, kIA0IRQB, kIA0IRQC, kIRQSW0, kIRQHW0,
+    kIRQHL0, kIA1IRQ0, kIA1IRQ1, kIA1IRQ2, kIA1IRQ3, kIA1IRQ4, kIA1IRQ5, kIA1IRQ6, kIA1IRQ7, kIA1IRQ8,
+    kIA1IRQ9, kIA1IRQA, kIA1IRQB, kIA1IRQC, kIRQSW1, kIRQHW1, kIRQHL1, kIA2IRQ0, kIA2IRQ1, kIA2IRQ2,
+    kIA2IRQ3, kIA2IRQ4, kIA2IRQ5, kIA2IRQ6, kIA2IRQ7, kIA2IRQ8, kIA2IRQ9, kIA2IRQA, kIA2IRQB, kIA2IRQC,
+    kIRQSW2, kIRQHW2, kIRQHL2, kIA3IRQ0, kIA3IRQ1, kIA3IRQ2, kIA3IRQ3, kIA3IRQ4, kIA3IRQ5, kIA3IRQ6,
+    kIA3IRQ7, kIA3IRQ8, kIA3IRQ9, kIA3IRQA, kIA3IRQB, kIA3IRQC, kIRQSW3, kIRQHW3, kIRQHL3, kCTGDINI,
+    kCTGCTRL, kMEMRW, kMEMCOR, kDMDELA, kDMDELS, kNMOD, kNDLY, kNED, kNTRO, kNRRO, kNBND, kNP0, kNP1,
+    kNP2, kNP3, kC08CPU0, kQ2VINFO /*C09CPU0  will be q2 pid window settings, and partial version info.*/,
+    kC10CPU0, kC11CPU0, kC12CPUA, kC13CPUA, kC14CPUA, kC15CPUA, kC08CPU1, kVINFO/*kC09CPU1  version of trap code.*/,
+    kC10CPU1, kC11CPU1, kC08CPU2, kNDRIFT /*kC09CPU2*/, kC10CPU2, kC11CPU2, kC08CPU3, kYCORR /*kC09CPU3*/,
+    kC10CPU3, kC11CPU3, kNES, kNTP, kNCUT, kPASACHM, kLastReg
+  };
+  // clang-format on
+
+ public:
+  TrapRegisters();
+  ~TrapRegisters() = default;
+  /*static TrapRegisters* Instance(){
+      static TrapRegisters trapreg;
+      return &trapreg;
+  }*/
+  const uint32_t getRegBase(int idx) { return mTrapRegisters[idx].getBase(); }
+  const uint32_t getRegWordNumber(int idx) { return mTrapRegisters[idx].getWordNumber(); }
+  const uint32_t getRegMask(int idx) { return mTrapRegisters[idx].getMask(); }
+  const uint32_t getRegShift(int idx) { return mTrapRegisters[idx].getShift(); }
+  TrapRegInfo& operator[](uint32_t); // simplify the access via an overloaded operator to the registers.
+
+  int32_t getRegIndexByName(const std::string& name);
+  int32_t getRegAddrByName(const std::string& name);
+  int32_t getRegAddr(const uint16_t regidx) { return mTrapRegisters[regidx].getAddr(); }
+
+ private:
+  // TrapRegisters();  // to make singleton
+  std::array<TrapRegInfo, kLastReg> mTrapRegisters;         // store of layout of each block of mTrapRegisterSize, populated via initialiseRegisters
+  std::array<uint32_t, kLastReg> mTrapRegisterAverageValue; // store the average values to be used for those ones where the mcm is not in the data stream
+  void initialiseRegisters();
+
+  ClassDefNV(TrapRegisters, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -45,6 +45,12 @@
 #pragma link C++ struct o2::trd::PHData + ;
 #pragma link C++ class o2::trd::TRDDataCountersPerTimeFrame + ;
 #pragma link C++ class o2::trd::DataCountersPerTrigger + ;
+#pragma link C++ class o2::trd::TrapRegInfo + ;
+#pragma link C++ class o2::trd::TrapRegisters + ;
+#pragma link C++ class o2::trd::TrapConfigEvent + ;
+#pragma link C++ class o2::trd::TrapConfigEventQC + ;
+#pragma link C++ class o2::trd::TrapConfigEventQCItem + ;
+#pragma link C++ class o2::trd::MCMEvent + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TrackTriggerRecord> + ;
@@ -59,6 +65,11 @@
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 #pragma link C++ class std::vector < o2::trd::DataCountersPerTrigger> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEvent> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEventQC> + ;
+#pragma link C++ class std::vector < o2::trd::TrapConfigEventQCItem> + ;
+#pragma link C++ class std::vector < o2::trd::MCMEvent> + ;
+#pragma link C++ class std::vector < o2::trd::TrapRegInfo> + ;
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/MCMEvent.cxx
+++ b/DataFormats/Detectors/TRD/src/MCMEvent.cxx
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsTRD/MCMEvent.h"
+
+namespace o2
+{
+namespace trd
+{
+
+const uint32_t MCMEvent::getRegister(const uint32_t regidx, const TrapRegInfo& trapreg) const
+{
+  // get the register value based on the address of the register;
+  // find register in mTrapRegisters.
+  // calculate the offset from the base for the register and get the mask.
+  /*if(regidx == TrapRegisters::kADCMSK){
+    LOGP(info,"mcmevent : reading back :ADCMSK  adcmsk : 0x0 mask {:08x} base {:08x} datawordnumber: {} shift: {} name : {}",  trapreg.getMask(),trapreg.getBase(), trapreg.getDataWordNumber(), trapreg.getShift(), trapreg.getName());
+  }*/
+  int regoffset = trapreg.getBase() + trapreg.getDataWordNumber(); // get the offset to the register in question
+  uint32_t data = mRegisterData[regoffset];
+  data = data >> trapreg.getShift();
+  data &= trapreg.getMask(); // mask the data off as need be.
+  /*if(regidx == TrapRegisters::kADCMSK){
+    LOGP(info,"mcmevent  reading back :ADCMSK  adcmsk : {:08x} mask {:08x} base {:08x} shift {:08x} name : {}",data, trapreg.getMask(),trapreg.getBase(),trapreg.getShift(), trapreg.getName());
+  }*/
+  return data;
+}
+
+bool MCMEvent::setRegister(const uint32_t data, const uint32_t regidx, const TrapRegInfo& trapreg)
+{
+  uint32_t regvalue = data;
+  int regoffset = trapreg.getBase() + trapreg.getDataWordNumber(); // wordnumber; // get the offset to the register in question
+  regvalue &= trapreg.getMask();                                   // mask the data off as need be.
+  uint32_t notdatamask = ~(trapreg.getMask() << trapreg.getShift());
+  regvalue = regvalue << trapreg.getShift();
+  auto trapregvalue = mRegisterData[regoffset];
+  mRegisterData[regoffset] = mRegisterData[regoffset] & notdatamask;
+  mRegisterData[regoffset] = mRegisterData[regoffset] | regvalue;
+  return true;
+}
+
+} // namespace trd
+} // namespace o2

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -372,17 +372,17 @@ void printDigitHCHeaders(o2::trd::DigitHCHeader& header, uint32_t headers[3], in
            header.word, header.res, header.side, header.stack, header.layer, header.supermodule,
            header.numberHCW, header.minor, header.major, header.version);
       break;
-    case 0:
+    case 1:
       o2::trd::DigitHCHeader1 header1;
       header1.word = headers[offset];
       LOGF(info, "%s Digit HalfChamber Header1 Raw:0x%08x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x", (good) ? "" : "*Corrupt*", header1.word, header1.res, header1.ptrigcount, header1.ptrigphase, header1.bunchcrossing, header1.numtimebins);
       break;
-    case 1:
+    case 2:
       o2::trd::DigitHCHeader2 header2;
       header2.word = headers[offset];
       LOGF(info, "%s Digit HalfChamber Header2 Raw:0x%08x reserve:0x%08x PedestalFilter:0x%01x GainFilter:0x%01x TailFilter:0x%01x CrosstalkFilter:0x%01x Non-linFilter:0x%01x RawDataBypassFilter:0x%01x DigitFilterCommonAdditive:0x%02x ", (good) ? "" : "*Corrupt*", header2.word, header2.res, header2.dfilter, header2.rfilter, header2.nlfilter, header2.xtfilter, header2.tfilter, header2.gfilter, header2.pfilter);
       break;
-    case 2:
+    case 3:
       o2::trd::DigitHCHeader3 header3;
       header3.word = headers[offset];
       LOGF(info, "%s Digit HalfChamber Header3: Raw:0x%08x reserve:0x%08x readout program revision:0x%08x assembler program version:0x%01x", (good) ? "" : "*Corrupt*", header3.word, header3.res, header3.svnrver, header3.svnver);

--- a/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapConfigEvent.cxx
@@ -1,0 +1,269 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+//  TRAP config as received from the trap chips in the form of            //
+//  configuration events, configs are packed into digit events.           //
+//  Header major version defines the config event payload follows as a    //
+//  known block.                                                          //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/TrapRegInfo.h"
+#include "DataFormatsTRD/TrapRegisters.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#include "DataFormatsTRD/RawData.h"
+
+#include <fairlogger/Logger.h>
+
+#include <array>
+#include <map>
+
+using namespace o2::trd;
+
+TrapConfigEvent::TrapConfigEvent()
+{
+  mConfigDataIndex.fill(-1); //!< one block of data per mcm.
+  // initialiseRegisters();
+  //   setConfigSavedVersion(2);
+}
+
+TrapConfigEvent::TrapConfigEvent(const TrapConfigEvent& A)
+{
+  LOGP(info, "TrapConfigEvent Copy Constructor Called   .....");
+}
+
+uint32_t TrapConfigEvent::getRegisterValue(const uint32_t regidx, const int mcmidx)
+{
+  // get the register value based on the address of the register;
+  // find register in mTrapRegisters.
+  // calculate the offset from the base for the register and get the mask.
+
+  if ((regidx < 0) || (regidx >= TrapRegisters::kLastReg) || (mcmidx < 0 || mcmidx >= o2::trd::constants::MAXMCMCOUNT)) {
+    LOGP(warning, "get reg value : for regidx : {} for mcm : {} one or other is out of bounds of [0,{}] and [0,{}] respectively", (int)regidx, (int)mcmidx, (int)TrapRegisters::kLastReg, (int)constants::MAXMCMCOUNT);
+    return 0; // TODO this could be a problem ?!
+  }
+  int regbase = mTrapRegisters[regidx].getBase();                       // get the base of this register in the underlying storage block
+  int regoffset = regbase + mTrapRegisters[regidx].getDataWordNumber(); // get the offset to the register in question
+
+  uint32_t data = mConfigData[mConfigDataIndex[mcmidx]].getRegister(regidx, mTrapRegisters[regidx]);
+  return data;
+}
+
+bool TrapConfigEvent::setRegisterValue(uint32_t data, uint32_t regidx, int mcmidx)
+{
+  if (regidx < 0 || regidx >= TrapRegisters::kLastReg || mcmidx < 0 || mcmidx >= o2::trd::constants::MAXMCMCOUNT) {
+    return false;
+  }
+  int mcmoffset = 0;
+  if (mConfigDataIndex[mcmidx] == -1) {
+    // we dont have this mcm in the data store yet.
+    mConfigData.emplace_back(mcmidx);
+    mConfigDataIndex[mcmidx] = mConfigData.size() - 1;
+  }
+  uint32_t index = mConfigDataIndex[mcmidx];
+  // LOGP(info, "{} {} setting register data {} for regidx {} for mcmidx {} and index {}",__FILE__,__LINE__,data,regidx,mcmidx,index);
+  bool success = mConfigData[mConfigDataIndex[mcmidx]].setRegister(data, regidx, mTrapRegisters[regidx]);
+  return success;
+  // return mConfigData[mConfigDataIndex[mcmidx]].setRegister(data, regidx,  mTrapRegisters[regidx].getBase(),mTrapRegisters[regidx].getWordNumber(),mTrapRegisters[regidx].getShift(),mTrapRegisters[regidx].getMask());
+}
+
+int32_t TrapConfigEvent::getRegIndexByName(const std::string& name)
+{
+  // there is no index for this but its not used online
+  return mTrapRegisters.getRegIndexByName(name);
+}
+
+int32_t TrapConfigEvent::getRegAddrByIdx(unsigned int regidx)
+{
+  if ((regidx < 0) && (regidx > TrapRegisters::kLastReg)) {
+    return -1;
+  }
+  return mTrapRegisters[regidx].getAddr();
+}
+
+int32_t TrapConfigEvent::getRegAddrByName(const std::string& name)
+{
+  // there is no index for this but its not used online
+  return mTrapRegisters.getRegAddrByName(name);
+}
+
+// get all the register values for a given mcm
+void TrapConfigEvent::getAllRegisters(const int mcmidx, std::array<uint32_t, TrapRegisters::kLastReg>& mcmregisters)
+{
+  for (int reg = 0; reg < TrapRegisters::kLastReg; ++reg) {
+    mcmregisters[reg] = getRegisterValue(reg, mcmidx);
+  }
+}
+
+// get all the values for a given register, all mcms
+void TrapConfigEvent::getAllMCMByIndex(const int regidx, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms)
+{
+  if ((regidx < 0) && (regidx >= TrapRegisters::kLastReg)) {
+    LOGP(info, "invalid regidx of {} ", regidx);
+    return;
+  }
+  for (int mcm = 0; mcm < o2::trd::constants::MAXMCMCOUNT; ++mcm) {
+    if (mConfigDataIndex[mcm] != -1) {
+      mcms[mcm] = getRegisterValue(regidx, mcm);
+    } else {
+      mcms[mcm] = 0;
+    }
+  }
+}
+
+// get all the values for a given register name, all mcms
+void TrapConfigEvent::getAllMCMByName(const std::string& registername, std::array<uint32_t, o2::trd::constants::MAXMCMCOUNT>& mcms) // return all the mcm values for a particular register name
+{
+  int regindex = getRegIndexByName(registername);
+  for (int mcm = 0; mcm < o2::trd::constants::MAXMCMCOUNT; ++mcm) {
+    mcms[mcm] = getRegisterValue(regindex, mcm);
+  }
+}
+
+// get all the values for a given register values for all the mcm
+void TrapConfigEvent::getAll(std::array<uint32_t, TrapRegisters::kLastReg * o2::trd::constants::MAXMCMCOUNT>& configdata)
+{
+  for (int mcm = 0; mcm < constants::MAXMCMCOUNT; ++mcm) {
+    for (int reg = 0; reg < TrapRegisters::kLastReg; ++reg) {
+      configdata[mcm * TrapRegisters::kLastReg + reg] = getRegisterValue(reg, mcm);
+    }
+  }
+}
+
+uint32_t TrapConfigEvent::getDmemUnsigned(const uint32_t address, const int detector, const int rob, const int mcm)
+{
+  LOGP(error, "Dmem data is not provided in config events");
+  return 0;
+}
+
+uint32_t TrapConfigEvent::getTrapReg(const uint32_t index, const int detector, const int rob, const int mcm)
+{
+
+  uint32_t data = 0;
+  uint32_t mcmidx;
+  if ((detector >= 0 && detector < o2::trd::constants::MAXCHAMBER) &&
+      (rob >= 0 && rob < o2::trd::constants::NROBC1) &&
+      (mcm >= 0 && mcm < o2::trd::constants::NMCMROB + 2)) {
+    mcmidx = HelperMethods::getMCMId(detector, rob, mcm);
+    data = getRegisterValue(index, mcmidx);
+  }
+  return data;
+}
+
+bool TrapConfigEvent::isConfigDifferent(const TrapConfigEvent& trapconfigevent) const
+{
+  // is other different from this.
+  // v1 walk through all 32 bit ints and compare, ignore the internals, ones to ignore are 32 bit themselves.
+  // TODO do we care where the difference is?
+  uint32_t max = constants::MAXMCMCOUNT;
+  uint32_t maxreg = TrapRegisters::kLastReg;
+  // start with the biggest granularity and work down.
+  // compare hcid in the 2.
+  // this would be simpler with != but that is removed in c++20
+  /*if (getHCIDPresent() == trapconfigevent.getHCIDPresent()) {
+    // we can continue if the bitpattern of half chambers is the same.
+  } else {
+    for (int hcid = 0; hcid < constants::MAXHALFCHAMBER; ++hcid) {
+      if (isHCIDPresent(hcid) == 0 && trapconfigevent.isHCIDPresent(hcid) == 1) {
+        // it is not in the ccdb but now is present, this is a change and needs to be saved.
+        LOGP(info, " hcid {} is present in new but not in ccdb version", hcid);
+        return false;
+      }
+      // other cases we can continue.
+      // 1. both present its ok.
+      // 2. present in ccdb but not in current one.
+    }
+  }*/
+  // could check the rob/side present/notpresent as an optimisation?
+  /*if (getMCMPresent() == trapconfigevent.getMCMPresent()) {
+    // we can continue the bit pattern of mcm in the config are the same
+  } else {
+    for (int mcmid = 0; mcmid < constants::MAXMCMCOUNT; ++mcmid) {
+      if (isMCMPresent(mcmid) == 0 && trapconfigevent.isMCMPresent(mcmid) == 1) {
+        // it is not in the ccdb but now is present, this is a change and needs to be saved.
+        return false;
+      }
+      // other cases we can continue.
+      // 1. both present its ok.
+      // 2. present in ccdb but not in current one.
+    }
+  }*/
+  // Now the long part, compare the register data
+  // There is no need to unpack registers. We can simply store their underlying 32 bit stored value.
+  for (int mcm = 0; mcm < max; ++mcm) {
+    for (int rawoffset = 0; rawoffset < kTrapRegistersSize; ++rawoffset) {
+      // if (!ignoreWord(rawoffset)) { // we do indeed care if this register is different.
+      //                               //        if (mConfigData[mcm].mRegisterData[rawoffset] != trapconfigevent.mConfigData[mcm].mRegisterData[rawoffset]) {
+      //   return false;
+      //         }
+      // }
+    }
+  }
+  return true;
+}
+
+void TrapConfigEvent::print()
+{
+  // walk through MCMSeen, and print out the mcm seen for this config event.
+  uint32_t startmcm = 0;
+  uint32_t endmcm = 0;
+  uint32_t lastseenmcm = 0;
+  bool continuousmcm = false;
+  std::string mcmList;
+  std::string totalList;
+  totalList += "MCMs seen:";
+  LOGP(debug, "Which MCM were seen in this event so far:");
+
+  uint32_t mcmposition = 0;
+  for (int mcmcount = 0; mcmcount < constants::MAXCHAMBER; ++mcmcount) {
+    auto seenmcm = 0; // TODO pull from map of maps isMCMPresent(mcmcount);
+
+    if (seenmcm == 0 && lastseenmcm == 1) {
+      // dump string
+      mcmList += fmt::format("-{},", mcmposition - 1);
+      //    LOGP(info,"{}",mcmList);
+      totalList += mcmList;
+      mcmList = "";
+    }
+    if (lastseenmcm == 0 && seenmcm == 1) {
+      startmcm = seenmcm;
+      mcmList = fmt::format("{}", mcmposition);
+    }
+    if (lastseenmcm == 1 && seenmcm == 1) {
+      // do nothing but add a - for 1 or more of these.
+    }
+    lastseenmcm = seenmcm;
+    mcmposition++;
+  }
+  totalList += mcmList;
+  LOGP(debug, "{}", totalList);
+}
+
+void TrapConfigEvent::merge(const TrapConfigEvent* prev)
+{
+  LOGP(info, " Merge called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
+  // take the 2 slots (trapconfigeventslot) and merge the update the map of maps of value.
+  // this will be collapsed in the finalise of the calibrator, for the object to be written to the ccdb.
+}
+
+void TrapConfigEvent::fill(const TrapConfigEvent& input)
+{
+  LOGP(info, "unimplemented fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
+}
+
+void TrapConfigEvent::fill(const gsl::span<const TrapConfigEvent> input)
+{
+  LOGP(info, "unimplemented fill called for TrapConfigEvent {} {} {}", __FILE__, __func__, __LINE__);
+}

--- a/DataFormats/Detectors/TRD/src/TrapRegInfo.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapRegInfo.cxx
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsTRD/TrapRegisters.h"
+#include "DataFormatsTRD/TrapRegInfo.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#include "DataFormatsTRD/RawData.h"
+
+#include <fairlogger/Logger.h>
+
+#include <array>
+#include <map>
+
+using namespace o2::trd;
+
+TrapRegInfo::TrapRegInfo(const std::string& name, int addr, int nBits, int base, int wordoffset, bool ignorechange, uint32_t max)
+{
+  init(name, addr, nBits, base, wordoffset, ignorechange, max);
+}
+
+TrapRegInfo::~TrapRegInfo() = default;
+
+void TrapRegInfo::init(const std::string& name, int addr, int nbits, int base, int wordnumber, bool ignorechange, uint32_t max)
+{
+  // initialise a TRAP register information
+  // uint32_t mNbits,mBase,mWordNumber,mShift,mMask,mMax;
+  // see headerfile for exact definition, WordNumber: the sequence of register in a block of data, like registers.
+  int bitoffset;
+  int gapbits = 0;
+  int bitwordoffset32; // the beginning of the 32 bit word containing this reg
+  int packedwordsize = 30;
+  /*if(name == "ADCMSK"){
+     LOGP(info, " TrapRegInfo : before {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} ", name, nbits, addr, 0, wordnumber, base, max);
+  }*/
+  if (addr != 0) {
+    mAddr = addr;
+    mName = name;
+    mNbits = nbits;
+    mBase = base;
+    mWordNumber = wordnumber;
+    mMax = pow(2, max) - 1; // this can be different from the mask, not sure why.
+    packedwordsize = 30;
+    if (mNbits > 30 || mNbits == 16 || mNbits == 4) { // these are 32 bit aligned the rest are 30 bit aligned.
+      packedwordsize = 32;
+      if (mNbits == 31) {
+        gapbits = 1;
+      }
+    }
+    mDataWordNumber = mWordNumber * (nbits + gapbits) / packedwordsize; // the 32 bit word offset to the word containing the register in question
+    bitoffset = mWordNumber * (nbits)-mDataWordNumber * packedwordsize; // the offset bit with in that word for the start of this register
+    mMask = (1 << mNbits) - 1;                                          // e.g. 5 = 0x1f 10=0x3ff
+    mShift = 32 - bitoffset - mNbits;                                   // 32-remainder= the right hand side of bits that need to be dropped.
+    if (mNbits == 32) {
+      mShift = 0;
+      mMask = 0xffffffff;
+    }
+    if (mNbits == 31) {
+      mShift = 1;
+    }
+  } else {
+    LOGP(warn, "Initialising an TRAP register with address of {:08x} ", addr);
+    mAddr = 0;
+    mName = "";
+    mNbits = 0;
+    mBase = 0;
+    mWordNumber = 0;
+    mMax = 0;
+    mShift = 0;
+  }
+  /*if(name == "ADCMSK"){
+    LOGP(info, " TrapRegInfo end : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} shift {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax(), getShift());
+  }
+  if(mShift==42) {
+    LOGP(info, "Shift is 42 TrapRegInfo end : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} shift {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax(), getShift());
+  }
+  if(mMask==0x1f) {
+    LOGP(info, "Shift is 0x1f TrapRegInfo end : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} shift {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax(), getShift());
+  }*/
+}
+
+void TrapRegInfo::logTrapRegInfo()
+{
+  LOGP(info, " TrapRegInfo : {} with nbits={} addr {:08x} mask {:04x} word number {} and baseword {} max {} ", getName(), getNbits(), getAddr(), getMask(), getWordNumber(), getBase(), getMax());
+}

--- a/DataFormats/Detectors/TRD/src/TrapRegisters.cxx
+++ b/DataFormats/Detectors/TRD/src/TrapRegisters.cxx
@@ -1,0 +1,504 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+//  TRAP config as received from the trap chips in the form of            //
+//  configuration events, configs are packed into digit events.           //
+//  Header major version defines the config event payload follows as a    //
+//  known block.                                                          //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/TrapRegisters.h"
+
+#include <fairlogger/Logger.h>
+
+#include <array>
+#include <map>
+
+using namespace o2::trd;
+
+TrapRegisters::TrapRegisters()
+{
+  initialiseRegisters();
+}
+
+void TrapRegisters::initialiseRegisters()
+{
+
+  // initialize all TRAP registers
+  mTrapRegisters[kTPL00].init("TPL00", 0x3180, 5, 0, 0, false, 5);
+  mTrapRegisters[kTPL01].init("TPL01", 0x3181, 5, 0, 1, false, 5);
+  mTrapRegisters[kTPL02].init("TPL02", 0x3182, 5, 0, 2, false, 5);
+  mTrapRegisters[kTPL03].init("TPL03", 0x3183, 5, 0, 3, false, 5);
+  mTrapRegisters[kTPL04].init("TPL04", 0x3184, 5, 0, 4, false, 5);
+  mTrapRegisters[kTPL05].init("TPL05", 0x3185, 5, 0, 5, false, 5);
+  mTrapRegisters[kTPL06].init("TPL06", 0x3186, 5, 0, 6, false, 5);
+  mTrapRegisters[kTPL07].init("TPL07", 0x3187, 5, 0, 7, false, 5);
+  mTrapRegisters[kTPL08].init("TPL08", 0x3188, 5, 0, 8, false, 5);
+  mTrapRegisters[kTPL09].init("TPL09", 0x3189, 5, 0, 9, false, 5);
+  mTrapRegisters[kTPL0A].init("TPL0A", 0x318A, 5, 0, 10, false, 5);
+  mTrapRegisters[kTPL0B].init("TPL0B", 0x318B, 5, 0, 11, false, 5);
+  mTrapRegisters[kTPL0C].init("TPL0C", 0x318C, 5, 0, 12, false, 5);
+  mTrapRegisters[kTPL0D].init("TPL0D", 0x318D, 5, 0, 13, false, 5);
+  mTrapRegisters[kTPL0E].init("TPL0E", 0x318E, 5, 0, 14, false, 5);
+  mTrapRegisters[kTPL0F].init("TPL0F", 0x318F, 5, 0, 15, false, 5);
+  mTrapRegisters[kTPL10].init("TPL10", 0x3190, 5, 0, 16, false, 5);
+  mTrapRegisters[kTPL11].init("TPL11", 0x3191, 5, 0, 17, false, 5);
+  mTrapRegisters[kTPL12].init("TPL12", 0x3192, 5, 0, 18, false, 5);
+  mTrapRegisters[kTPL13].init("TPL13", 0x3193, 5, 0, 19, false, 5);
+  mTrapRegisters[kTPL14].init("TPL14", 0x3194, 5, 0, 20, false, 5);
+  mTrapRegisters[kTPL15].init("TPL15", 0x3195, 5, 0, 21, false, 5);
+  mTrapRegisters[kTPL16].init("TPL16", 0x3196, 5, 0, 22, false, 5);
+  mTrapRegisters[kTPL17].init("TPL17", 0x3197, 5, 0, 23, false, 5);
+  mTrapRegisters[kTPL18].init("TPL18", 0x3198, 5, 0, 24, false, 5);
+  mTrapRegisters[kTPL19].init("TPL19", 0x3199, 5, 0, 25, false, 5);
+  mTrapRegisters[kTPL1A].init("TPL1A", 0x319A, 5, 0, 26, false, 5);
+  mTrapRegisters[kTPL1B].init("TPL1B", 0x319B, 5, 0, 27, false, 5);
+  mTrapRegisters[kTPL1C].init("TPL1C", 0x319C, 5, 0, 28, false, 5);
+  mTrapRegisters[kTPL1D].init("TPL1D", 0x319D, 5, 0, 29, false, 5);
+  mTrapRegisters[kTPL1E].init("TPL1E", 0x319E, 5, 0, 30, false, 5);
+  mTrapRegisters[kTPL1F].init("TPL1F", 0x319F, 5, 0, 31, false, 5);
+  mTrapRegisters[kTPL20].init("TPL20", 0x31A0, 5, 0, 32, false, 5);
+  mTrapRegisters[kTPL21].init("TPL21", 0x31A1, 5, 0, 33, false, 5);
+  mTrapRegisters[kTPL22].init("TPL22", 0x31A2, 5, 0, 34, false, 5);
+  mTrapRegisters[kTPL23].init("TPL23", 0x31A3, 5, 0, 35, false, 5);
+  mTrapRegisters[kTPL24].init("TPL24", 0x31A4, 5, 0, 36, false, 5);
+  mTrapRegisters[kTPL25].init("TPL25", 0x31A5, 5, 0, 37, false, 5);
+  mTrapRegisters[kTPL26].init("TPL26", 0x31A6, 5, 0, 38, false, 5);
+  mTrapRegisters[kTPL27].init("TPL27", 0x31A7, 5, 0, 39, false, 5);
+  mTrapRegisters[kTPL28].init("TPL28", 0x31A8, 5, 0, 40, false, 5);
+  mTrapRegisters[kTPL29].init("TPL29", 0x31A9, 5, 0, 41, false, 5);
+  mTrapRegisters[kTPL2A].init("TPL2A", 0x31AA, 5, 0, 42, false, 5);
+  mTrapRegisters[kTPL2B].init("TPL2B", 0x31AB, 5, 0, 43, false, 5);
+  mTrapRegisters[kTPL2C].init("TPL2C", 0x31AC, 5, 0, 44, false, 5);
+  mTrapRegisters[kTPL2D].init("TPL2D", 0x31AD, 5, 0, 45, false, 5);
+  mTrapRegisters[kTPL2E].init("TPL2E", 0x31AE, 5, 0, 46, false, 5);
+  mTrapRegisters[kTPL2F].init("TPL2F", 0x31AF, 5, 0, 47, false, 5);
+  mTrapRegisters[kTPL30].init("TPL30", 0x31B0, 5, 0, 48, false, 5);
+  mTrapRegisters[kTPL31].init("TPL31", 0x31B1, 5, 0, 49, false, 5);
+  mTrapRegisters[kTPL32].init("TPL32", 0x31B2, 5, 0, 50, false, 5);
+  mTrapRegisters[kTPL33].init("TPL33", 0x31B3, 5, 0, 51, false, 5);
+  mTrapRegisters[kTPL34].init("TPL34", 0x31B4, 5, 0, 52, false, 5);
+  mTrapRegisters[kTPL35].init("TPL35", 0x31B5, 5, 0, 53, false, 5);
+  mTrapRegisters[kTPL36].init("TPL36", 0x31B6, 5, 0, 54, false, 5);
+  mTrapRegisters[kTPL37].init("TPL37", 0x31B7, 5, 0, 55, false, 5);
+  mTrapRegisters[kTPL38].init("TPL38", 0x31B8, 5, 0, 56, false, 5);
+  mTrapRegisters[kTPL39].init("TPL39", 0x31B9, 5, 0, 57, false, 5);
+  mTrapRegisters[kTPL3A].init("TPL3A", 0x31BA, 5, 0, 58, false, 5);
+  mTrapRegisters[kTPL3B].init("TPL3B", 0x31BB, 5, 0, 59, false, 5);
+  mTrapRegisters[kTPL3C].init("TPL3C", 0x31BC, 5, 0, 60, false, 5);
+  mTrapRegisters[kTPL3D].init("TPL3D", 0x31BD, 5, 0, 61, false, 5);
+  mTrapRegisters[kTPL3E].init("TPL3E", 0x31BE, 5, 0, 62, false, 5);
+  mTrapRegisters[kTPL3F].init("TPL3F", 0x31BF, 5, 0, 63, false, 5);
+  mTrapRegisters[kTPL40].init("TPL40", 0x31C0, 5, 0, 64, false, 5);
+  mTrapRegisters[kTPL41].init("TPL41", 0x31C1, 5, 0, 65, false, 5);
+  mTrapRegisters[kTPL42].init("TPL42", 0x31C2, 5, 0, 66, false, 5);
+  mTrapRegisters[kTPL43].init("TPL43", 0x31C3, 5, 0, 67, false, 5);
+  mTrapRegisters[kTPL44].init("TPL44", 0x31C4, 5, 0, 68, false, 5);
+  mTrapRegisters[kTPL45].init("TPL45", 0x31C5, 5, 0, 69, false, 5);
+  mTrapRegisters[kTPL46].init("TPL46", 0x31C6, 5, 0, 70, false, 5);
+  mTrapRegisters[kTPL47].init("TPL47", 0x31C7, 5, 0, 71, false, 5);
+  mTrapRegisters[kTPL48].init("TPL48", 0x31C8, 5, 0, 72, false, 5);
+  mTrapRegisters[kTPL49].init("TPL49", 0x31C9, 5, 0, 73, false, 5);
+  mTrapRegisters[kTPL4A].init("TPL4A", 0x31CA, 5, 0, 74, false, 5);
+  mTrapRegisters[kTPL4B].init("TPL4B", 0x31CB, 5, 0, 75, false, 5);
+  mTrapRegisters[kTPL4C].init("TPL4C", 0x31CC, 5, 0, 76, false, 5);
+  mTrapRegisters[kTPL4D].init("TPL4D", 0x31CD, 5, 0, 77, false, 5);
+  mTrapRegisters[kTPL4E].init("TPL4E", 0x31CE, 5, 0, 78, false, 5);
+  mTrapRegisters[kTPL4F].init("TPL4F", 0x31CF, 5, 0, 79, false, 5);
+  mTrapRegisters[kTPL50].init("TPL50", 0x31D0, 5, 0, 80, false, 5);
+  mTrapRegisters[kTPL51].init("TPL51", 0x31D1, 5, 0, 81, false, 5);
+  mTrapRegisters[kTPL52].init("TPL52", 0x31D2, 5, 0, 82, false, 5);
+  mTrapRegisters[kTPL53].init("TPL53", 0x31D3, 5, 0, 83, false, 5);
+  mTrapRegisters[kTPL54].init("TPL54", 0x31D4, 5, 0, 84, false, 5);
+  mTrapRegisters[kTPL55].init("TPL55", 0x31D5, 5, 0, 85, false, 5);
+  mTrapRegisters[kTPL56].init("TPL56", 0x31D6, 5, 0, 86, false, 5);
+  mTrapRegisters[kTPL57].init("TPL57", 0x31D7, 5, 0, 87, false, 5);
+  mTrapRegisters[kTPL58].init("TPL58", 0x31D8, 5, 0, 88, false, 5);
+  mTrapRegisters[kTPL59].init("TPL59", 0x31D9, 5, 0, 89, false, 5);
+  mTrapRegisters[kTPL5A].init("TPL5A", 0x31DA, 5, 0, 90, false, 5);
+  mTrapRegisters[kTPL5B].init("TPL5B", 0x31DB, 5, 0, 91, false, 5);
+  mTrapRegisters[kTPL5C].init("TPL5C", 0x31DC, 5, 0, 92, false, 5);
+  mTrapRegisters[kTPL5D].init("TPL5D", 0x31DD, 5, 0, 93, false, 5);
+  mTrapRegisters[kTPL5E].init("TPL5E", 0x31DE, 5, 0, 94, false, 5);
+  mTrapRegisters[kTPL5F].init("TPL5F", 0x31DF, 5, 0, 95, false, 5);
+  mTrapRegisters[kTPL60].init("TPL60", 0x31E0, 5, 0, 96, false, 5);
+  mTrapRegisters[kTPL61].init("TPL61", 0x31E1, 5, 0, 97, false, 5);
+  mTrapRegisters[kTPL62].init("TPL62", 0x31E2, 5, 0, 98, false, 5);
+  mTrapRegisters[kTPL63].init("TPL63", 0x31E3, 5, 0, 99, false, 5);
+  mTrapRegisters[kTPL64].init("TPL64", 0x31E4, 5, 0, 100, false, 5);
+  mTrapRegisters[kTPL65].init("TPL65", 0x31E5, 5, 0, 101, false, 5);
+  mTrapRegisters[kTPL66].init("TPL66", 0x31E6, 5, 0, 102, false, 5);
+  mTrapRegisters[kTPL67].init("TPL67", 0x31E7, 5, 0, 103, false, 5);
+  mTrapRegisters[kTPL68].init("TPL68", 0x31E8, 5, 0, 104, false, 5);
+  mTrapRegisters[kTPL69].init("TPL69", 0x31E9, 5, 0, 105, false, 5);
+  mTrapRegisters[kTPL6A].init("TPL6A", 0x31EA, 5, 0, 106, false, 5);
+  mTrapRegisters[kTPL6B].init("TPL6B", 0x31EB, 5, 0, 107, false, 5);
+  mTrapRegisters[kTPL6C].init("TPL6C", 0x31EC, 5, 0, 108, false, 5);
+  mTrapRegisters[kTPL6D].init("TPL6D", 0x31ED, 5, 0, 109, false, 5);
+  mTrapRegisters[kTPL6E].init("TPL6E", 0x31EE, 5, 0, 110, false, 5);
+  mTrapRegisters[kTPL6F].init("TPL6F", 0x31EF, 5, 0, 111, false, 5);
+  mTrapRegisters[kTPL70].init("TPL70", 0x31F0, 5, 0, 112, false, 5);
+  mTrapRegisters[kTPL71].init("TPL71", 0x31F1, 5, 0, 113, false, 5);
+  mTrapRegisters[kTPL72].init("TPL72", 0x31F2, 5, 0, 114, false, 5);
+  mTrapRegisters[kTPL73].init("TPL73", 0x31F3, 5, 0, 115, false, 5);
+  mTrapRegisters[kTPL74].init("TPL74", 0x31F4, 5, 0, 116, false, 5);
+  mTrapRegisters[kTPL75].init("TPL75", 0x31F5, 5, 0, 117, false, 5);
+  mTrapRegisters[kTPL76].init("TPL76", 0x31F6, 5, 0, 118, false, 5);
+  mTrapRegisters[kTPL77].init("TPL77", 0x31F7, 5, 0, 119, false, 5);
+  mTrapRegisters[kTPL78].init("TPL78", 0x31F8, 5, 0, 120, false, 5);
+  mTrapRegisters[kTPL79].init("TPL79", 0x31F9, 5, 0, 121, false, 5);
+  mTrapRegisters[kTPL7A].init("TPL7A", 0x31FA, 5, 0, 122, false, 5);
+  mTrapRegisters[kTPL7B].init("TPL7B", 0x31FB, 5, 0, 123, false, 5);
+  mTrapRegisters[kTPL7C].init("TPL7C", 0x31FC, 5, 0, 124, false, 5);
+  mTrapRegisters[kTPL7D].init("TPL7D", 0x31FD, 5, 0, 125, false, 5);
+  mTrapRegisters[kTPL7E].init("TPL7E", 0x31FE, 5, 0, 126, false, 5);
+  mTrapRegisters[kTPL7F].init("TPL7F", 0x31FF, 5, 0, 127, false, 5);
+  mTrapRegisters[kFGA0].init("FGA0", 0x30A0, 6, 22, 0, false, 6);
+  mTrapRegisters[kFGA1].init("FGA1", 0x30A1, 6, 22, 1, false, 6);
+  mTrapRegisters[kFGA2].init("FGA2", 0x30A2, 6, 22, 2, false, 6);
+  mTrapRegisters[kFGA3].init("FGA3", 0x30A3, 6, 22, 3, false, 6);
+  mTrapRegisters[kFGA4].init("FGA4", 0x30A4, 6, 22, 4, false, 6);
+  mTrapRegisters[kFGA5].init("FGA5", 0x30A5, 6, 22, 5, false, 6);
+  mTrapRegisters[kFGA6].init("FGA6", 0x30A6, 6, 22, 6, false, 6);
+  mTrapRegisters[kFGA7].init("FGA7", 0x30A7, 6, 22, 7, false, 6);
+  mTrapRegisters[kFGA8].init("FGA8", 0x30A8, 6, 22, 8, false, 6);
+  mTrapRegisters[kFGA9].init("FGA9", 0x30A9, 6, 22, 9, false, 6);
+  mTrapRegisters[kFGA10].init("FGA10", 0x30AA, 6, 22, 10, false, 6);
+  mTrapRegisters[kFGA11].init("FGA11", 0x30AB, 6, 22, 11, false, 6);
+  mTrapRegisters[kFGA12].init("FGA12", 0x30AC, 6, 22, 12, false, 6);
+  mTrapRegisters[kFGA13].init("FGA13", 0x30AD, 6, 22, 13, false, 6);
+  mTrapRegisters[kFGA14].init("FGA14", 0x30AE, 6, 22, 14, false, 6);
+  mTrapRegisters[kFGA15].init("FGA15", 0x30AF, 6, 22, 15, false, 6);
+  mTrapRegisters[kFGA16].init("FGA16", 0x30B0, 6, 22, 16, false, 6);
+  mTrapRegisters[kFGA17].init("FGA17", 0x30B1, 6, 22, 17, false, 6);
+  mTrapRegisters[kFGA18].init("FGA18", 0x30B2, 6, 22, 18, false, 6);
+  mTrapRegisters[kFGA19].init("FGA19", 0x30B3, 6, 22, 19, false, 6);
+  mTrapRegisters[kFGA20].init("FGA20", 0x30B4, 6, 22, 20, false, 6);
+  mTrapRegisters[kFGF0].init("FGF0", 0x3080, 10, 27, 0, false, 10);
+  mTrapRegisters[kFGF1].init("FGF1", 0x3081, 10, 27, 1, false, 10);
+  mTrapRegisters[kFGF2].init("FGF2", 0x3082, 10, 27, 2, false, 10);
+  mTrapRegisters[kFGF3].init("FGF3", 0x3083, 10, 27, 3, false, 10);
+  mTrapRegisters[kFGF4].init("FGF4", 0x3084, 10, 27, 4, false, 10);
+  mTrapRegisters[kFGF5].init("FGF5", 0x3085, 10, 27, 5, false, 10);
+  mTrapRegisters[kFGF6].init("FGF6", 0x3086, 10, 27, 6, false, 10);
+  mTrapRegisters[kFGF7].init("FGF7", 0x3087, 10, 27, 7, false, 10);
+  mTrapRegisters[kFGF8].init("FGF8", 0x3088, 10, 27, 8, false, 10);
+  mTrapRegisters[kFGF9].init("FGF9", 0x3089, 10, 27, 9, false, 10);
+  mTrapRegisters[kFGF10].init("FGF10", 0x308A, 10, 27, 10, false, 10);
+  mTrapRegisters[kFGF11].init("FGF11", 0x308B, 10, 27, 11, false, 10);
+  mTrapRegisters[kFGF12].init("FGF12", 0x308C, 10, 27, 12, false, 10);
+  mTrapRegisters[kFGF13].init("FGF13", 0x308D, 10, 27, 13, false, 10);
+  mTrapRegisters[kFGF14].init("FGF14", 0x308E, 10, 27, 14, false, 10);
+  mTrapRegisters[kFGF15].init("FGF15", 0x308F, 10, 27, 15, false, 10);
+  mTrapRegisters[kFGF16].init("FGF16", 0x3090, 10, 27, 16, false, 10);
+  mTrapRegisters[kFGF17].init("FGF17", 0x3091, 10, 27, 17, false, 10);
+  mTrapRegisters[kFGF18].init("FGF18", 0x3092, 10, 27, 18, false, 10);
+  mTrapRegisters[kFGF19].init("FGF19", 0x3093, 10, 27, 19, false, 10);
+  mTrapRegisters[kFGF20].init("FGF20", 0x3094, 10, 27, 20, false, 10);
+  mTrapRegisters[kCPU0CLK].init("CPU0CLK", 0x0A20, 5, 34, 0, false, 5);
+  mTrapRegisters[kCPU1CLK].init("CPU1CLK", 0x0A22, 5, 34, 1, false, 5);
+  mTrapRegisters[kCPU2CLK].init("CPU2CLK", 0x0A24, 5, 34, 2, false, 5);
+  mTrapRegisters[kCPU3CLK].init("CPU3CLK", 0x0A26, 5, 34, 3, false, 5);
+  mTrapRegisters[kNICLK].init("NICLK", 0x0A28, 5, 34, 4, false, 5);
+  mTrapRegisters[kFILCLK].init("FILCLK", 0x0A2A, 5, 34, 5, false, 5);
+  mTrapRegisters[kPRECLK].init("PRECLK", 0x0A2C, 5, 34, 6, false, 5);
+  mTrapRegisters[kADCEN].init("ADCEN", 0x0A2E, 5, 34, 7, false, 5);
+  mTrapRegisters[kNIODE].init("NIODE", 0x0A30, 5, 34, 8, false, 5);
+  mTrapRegisters[kNIOCE].init("NIOCE", 0x0A32, 5, 34, 9, false, 5);
+  mTrapRegisters[kNIIDE].init("NIIDE", 0x0A34, 5, 34, 10, false, 5);
+  mTrapRegisters[kNIICE].init("NIICE", 0x0A36, 5, 34, 11, false, 5);
+  mTrapRegisters[kEBIS].init("EBIS", 0x3014, 15, 36, 0, false, 15);
+  mTrapRegisters[kEBIT].init("EBIT", 0x3015, 15, 36, 1, false, 15);
+  mTrapRegisters[kEBIL].init("EBIL", 0x3016, 15, 36, 2, false, 15);
+  mTrapRegisters[kTPVT].init("TPVT", 0x3042, 6, 38, 0, false, 6);
+  mTrapRegisters[kTPVBY].init("TPVBY", 0x3043, 6, 38, 1, false, 6);
+  mTrapRegisters[kTPCT].init("TPCT", 0x3044, 6, 38, 2, false, 6);
+  mTrapRegisters[kTPCL].init("TPCL", 0x3045, 6, 38, 3, false, 6);
+  mTrapRegisters[kTPCBY].init("TPCBY", 0x3046, 6, 38, 4, false, 6);
+  mTrapRegisters[kTPD].init("TPD", 0x3047, 6, 38, 5, false, 6);
+  mTrapRegisters[kTPCI0].init("TPCI0", 0x3048, 6, 38, 6, false, 6);
+  mTrapRegisters[kTPCI1].init("TPCI1", 0x3049, 6, 38, 7, false, 6);
+  mTrapRegisters[kTPCI2].init("TPCI2", 0x304A, 6, 38, 8, false, 6);
+  mTrapRegisters[kTPCI3].init("TPCI3", 0x304B, 6, 38, 9, false, 6);
+  mTrapRegisters[kEBIN].init("EBIN", 0x3017, 5, 40, 0, false, 5);
+  mTrapRegisters[kFLBY].init("FLBY", 0x3018, 5, 40, 1, false, 5);
+  mTrapRegisters[kFPBY].init("FPBY", 0x3019, 5, 40, 2, false, 5);
+  mTrapRegisters[kFGBY].init("FGBY", 0x301A, 5, 40, 3, false, 5);
+  mTrapRegisters[kFTBY].init("FTBY", 0x301B, 5, 40, 4, false, 5);
+  mTrapRegisters[kFCBY].init("FCBY", 0x301C, 5, 40, 5, false, 5);
+  mTrapRegisters[kFLL00].init("FLL00", 0x3100, 6, 41, 0, false, 6);
+  mTrapRegisters[kFLL01].init("FLL01", 0x3101, 6, 41, 1, false, 6);
+  mTrapRegisters[kFLL02].init("FLL02", 0x3102, 6, 41, 2, false, 6);
+  mTrapRegisters[kFLL03].init("FLL03", 0x3103, 6, 41, 3, false, 6);
+  mTrapRegisters[kFLL04].init("FLL04", 0x3104, 6, 41, 4, false, 6);
+  mTrapRegisters[kFLL05].init("FLL05", 0x3105, 6, 41, 5, false, 6);
+  mTrapRegisters[kFLL06].init("FLL06", 0x3106, 6, 41, 6, false, 6);
+  mTrapRegisters[kFLL07].init("FLL07", 0x3107, 6, 41, 7, false, 6);
+  mTrapRegisters[kFLL08].init("FLL08", 0x3108, 6, 41, 8, false, 6);
+  mTrapRegisters[kFLL09].init("FLL09", 0x3109, 6, 41, 9, false, 6);
+  mTrapRegisters[kFLL0A].init("FLL0A", 0x310A, 6, 41, 10, false, 6);
+  mTrapRegisters[kFLL0B].init("FLL0B", 0x310B, 6, 41, 11, false, 6);
+  mTrapRegisters[kFLL0C].init("FLL0C", 0x310C, 6, 41, 12, false, 6);
+  mTrapRegisters[kFLL0D].init("FLL0D", 0x310D, 6, 41, 13, false, 6);
+  mTrapRegisters[kFLL0E].init("FLL0E", 0x310E, 6, 41, 14, false, 6);
+  mTrapRegisters[kFLL0F].init("FLL0F", 0x310F, 6, 41, 15, false, 6);
+  mTrapRegisters[kFLL10].init("FLL10", 0x3110, 6, 41, 16, false, 6);
+  mTrapRegisters[kFLL11].init("FLL11", 0x3111, 6, 41, 17, false, 6);
+  mTrapRegisters[kFLL12].init("FLL12", 0x3112, 6, 41, 18, false, 6);
+  mTrapRegisters[kFLL13].init("FLL13", 0x3113, 6, 41, 19, false, 6);
+  mTrapRegisters[kFLL14].init("FLL14", 0x3114, 6, 41, 20, false, 6);
+  mTrapRegisters[kFLL15].init("FLL15", 0x3115, 6, 41, 21, false, 6);
+  mTrapRegisters[kFLL16].init("FLL16", 0x3116, 6, 41, 22, false, 6);
+  mTrapRegisters[kFLL17].init("FLL17", 0x3117, 6, 41, 23, false, 6);
+  mTrapRegisters[kFLL18].init("FLL18", 0x3118, 6, 41, 24, false, 6);
+  mTrapRegisters[kFLL19].init("FLL19", 0x3119, 6, 41, 25, false, 6);
+  mTrapRegisters[kFLL1A].init("FLL1A", 0x311A, 6, 41, 26, false, 6);
+  mTrapRegisters[kFLL1B].init("FLL1B", 0x311B, 6, 41, 27, false, 6);
+  mTrapRegisters[kFLL1C].init("FLL1C", 0x311C, 6, 41, 28, false, 6);
+  mTrapRegisters[kFLL1D].init("FLL1D", 0x311D, 6, 41, 29, false, 6);
+  mTrapRegisters[kFLL1E].init("FLL1E", 0x311E, 6, 41, 30, false, 6);
+  mTrapRegisters[kFLL1F].init("FLL1F", 0x311F, 6, 41, 31, false, 6);
+  mTrapRegisters[kFLL20].init("FLL20", 0x3120, 6, 41, 32, false, 6);
+  mTrapRegisters[kFLL21].init("FLL21", 0x3121, 6, 41, 33, false, 6);
+  mTrapRegisters[kFLL22].init("FLL22", 0x3122, 6, 41, 34, false, 6);
+  mTrapRegisters[kFLL23].init("FLL23", 0x3123, 6, 41, 35, false, 6);
+  mTrapRegisters[kFLL24].init("FLL24", 0x3124, 6, 41, 36, false, 6);
+  mTrapRegisters[kFLL25].init("FLL25", 0x3125, 6, 41, 37, false, 6);
+  mTrapRegisters[kFLL26].init("FLL26", 0x3126, 6, 41, 38, false, 6);
+  mTrapRegisters[kFLL27].init("FLL27", 0x3127, 6, 41, 39, false, 6);
+  mTrapRegisters[kFLL28].init("FLL28", 0x3128, 6, 41, 40, false, 6);
+  mTrapRegisters[kFLL29].init("FLL29", 0x3129, 6, 41, 41, false, 6);
+  mTrapRegisters[kFLL2A].init("FLL2A", 0x312A, 6, 41, 42, false, 6);
+  mTrapRegisters[kFLL2B].init("FLL2B", 0x312B, 6, 41, 43, false, 6);
+  mTrapRegisters[kFLL2C].init("FLL2C", 0x312C, 6, 41, 44, false, 6);
+  mTrapRegisters[kFLL2D].init("FLL2D", 0x312D, 6, 41, 45, false, 6);
+  mTrapRegisters[kFLL2E].init("FLL2E", 0x312E, 6, 41, 46, false, 6);
+  mTrapRegisters[kFLL2F].init("FLL2F", 0x312F, 6, 41, 47, false, 6);
+  mTrapRegisters[kFLL30].init("FLL30", 0x3130, 6, 41, 48, false, 6);
+  mTrapRegisters[kFLL31].init("FLL31", 0x3131, 6, 41, 49, false, 6);
+  mTrapRegisters[kFLL32].init("FLL32", 0x3132, 6, 41, 50, false, 6);
+  mTrapRegisters[kFLL33].init("FLL33", 0x3133, 6, 41, 51, false, 6);
+  mTrapRegisters[kFLL34].init("FLL34", 0x3134, 6, 41, 52, false, 6);
+  mTrapRegisters[kFLL35].init("FLL35", 0x3135, 6, 41, 53, false, 6);
+  mTrapRegisters[kFLL36].init("FLL36", 0x3136, 6, 41, 54, false, 6);
+  mTrapRegisters[kFLL37].init("FLL37", 0x3137, 6, 41, 55, false, 6);
+  mTrapRegisters[kFLL38].init("FLL38", 0x3138, 6, 41, 56, false, 6);
+  mTrapRegisters[kFLL39].init("FLL39", 0x3139, 6, 41, 57, false, 6);
+  mTrapRegisters[kFLL3A].init("FLL3A", 0x313A, 6, 41, 58, false, 6);
+  mTrapRegisters[kFLL3B].init("FLL3B", 0x313B, 6, 41, 59, false, 6);
+  mTrapRegisters[kFLL3C].init("FLL3C", 0x313C, 6, 41, 60, false, 6);
+  mTrapRegisters[kFLL3D].init("FLL3D", 0x313D, 6, 41, 61, false, 6);
+  mTrapRegisters[kFLL3E].init("FLL3E", 0x313E, 6, 41, 62, false, 6);
+  mTrapRegisters[kFLL3F].init("FLL3F", 0x313F, 6, 41, 63, false, 6);
+  mTrapRegisters[kTPPT0].init("TPPT0", 0x3000, 7, 54, 0, false, 7);
+  mTrapRegisters[kTPFS].init("TPFS", 0x3001, 7, 54, 1, false, 7);
+  mTrapRegisters[kTPFE].init("TPFE", 0x3002, 7, 54, 2, false, 7);
+  mTrapRegisters[kTPPGR].init("TPPGR", 0x3003, 7, 54, 3, false, 7);
+  mTrapRegisters[kTPPAE].init("TPPAE", 0x3004, 7, 54, 4, false, 7);
+  mTrapRegisters[kTPQS0].init("TPQS0", 0x3005, 7, 54, 5, false, 7);
+  mTrapRegisters[kTPQE0].init("TPQE0", 0x3006, 7, 54, 6, false, 7);
+  mTrapRegisters[kTPQS1].init("TPQS1", 0x3007, 7, 54, 7, false, 7);
+  mTrapRegisters[kTPQE1].init("TPQE1", 0x3008, 7, 54, 8, false, 7);
+  mTrapRegisters[kEBD].init("EBD", 0x3009, 7, 54, 9, false, 7);
+  mTrapRegisters[kEBAQA].init("EBAQA", 0x300A, 7, 54, 10, false, 7);
+  mTrapRegisters[kEBSIA].init("EBSIA", 0x300B, 7, 54, 11, false, 7);
+  mTrapRegisters[kEBSF].init("EBSF", 0x300C, 7, 54, 12, false, 7);
+  mTrapRegisters[kEBSIM].init("EBSIM", 0x300D, 7, 54, 13, false, 7);
+  mTrapRegisters[kEBPP].init("EBPP", 0x300E, 7, 54, 14, false, 7);
+  mTrapRegisters[kEBPC].init("EBPC", 0x300F, 7, 54, 15, false, 7);
+  mTrapRegisters[kFPTC].init("FPTC", 0x3020, 10, 58, 0, false, 10);
+  mTrapRegisters[kFPNP].init("FPNP", 0x3021, 10, 58, 1, false, 10);
+  mTrapRegisters[kFPCL].init("FPCL", 0x3022, 10, 58, 2, false, 10);
+  mTrapRegisters[kFGTA].init("FGTA", 0x3028, 15, 59, 0, false, 15);
+  mTrapRegisters[kFGTB].init("FGTB", 0x3029, 15, 59, 1, false, 15);
+  mTrapRegisters[kFGCL].init("FGCL", 0x302A, 15, 59, 2, false, 15);
+  mTrapRegisters[kFTAL].init("FTAL", 0x3030, 10, 61, 0, false, 10);
+  mTrapRegisters[kFTLL].init("FTLL", 0x3031, 10, 61, 1, false, 10);
+  mTrapRegisters[kFTLS].init("FTLS", 0x3032, 10, 61, 2, false, 10);
+  mTrapRegisters[kFCW1].init("FCW1", 0x3038, 10, 62, 0, false, 10);
+  mTrapRegisters[kFCW2].init("FCW2", 0x3039, 10, 62, 1, false, 10);
+  mTrapRegisters[kFCW3].init("FCW3", 0x303A, 10, 62, 2, false, 10);
+  mTrapRegisters[kFCW4].init("FCW4", 0x303B, 10, 62, 3, false, 10);
+  mTrapRegisters[kFCW5].init("FCW5", 0x303C, 10, 62, 4, false, 10);
+  mTrapRegisters[kTPFP].init("TPFP", 0x3040, 15, 64, 0, false, 15);
+  mTrapRegisters[kTPHT].init("TPHT", 0x3041, 15, 64, 1, false, 15);
+  mTrapRegisters[kADCMSK].init("ADCMSK", 0x3050, 32, 65, 0, false, 32);
+  mTrapRegisters[kADCINB].init("ADCINB", 0x3051, 5, 66, 0, false, 5);
+  mTrapRegisters[kADCDAC].init("ADCDAC", 0x3052, 5, 66, 1, false, 5);
+  mTrapRegisters[kADCPAR].init("ADCPAR", 0x3053, 32, 67, 0, false, 32);
+  mTrapRegisters[kADCTST].init("ADCTST", 0x3054, 5, 68, 0, false, 5);
+  mTrapRegisters[kSADCAZ].init("SADCAZ", 0x3055, 5, 68, 1, false, 5);
+  mTrapRegisters[kPASADEL].init("PASADEL", 0x3158, 10, 69, 0, false, 10);
+  mTrapRegisters[kPASAPHA].init("PASAPHA", 0x3159, 10, 69, 1, false, 10);
+  mTrapRegisters[kPASAPRA].init("PASAPRA", 0x315A, 10, 69, 2, false, 10);
+  mTrapRegisters[kPASADAC].init("PASADAC", 0x315B, 10, 69, 3, false, 10);
+  mTrapRegisters[kPASASTL].init("PASASTL", 0x315D, 10, 71, 0, false, 10);
+  mTrapRegisters[kPASAPR1].init("PASAPR1", 0x315E, 10, 71, 1, false, 10);
+  mTrapRegisters[kPASAPR0].init("PASAPR0", 0x315F, 10, 71, 2, false, 10);
+  mTrapRegisters[kSADCTRG].init("SADCTRG", 0x3161, 5, 72, 0, false, 5);
+  mTrapRegisters[kSADCRUN].init("SADCRUN", 0x3162, 5, 72, 1, false, 5);
+  mTrapRegisters[kSADCPWR].init("SADCPWR", 0x3163, 5, 72, 2, false, 5);
+  mTrapRegisters[kL0TSIM].init("L0TSIM", 0x3165, 15, 73, 0, false, 15);
+  mTrapRegisters[kSADCEC].init("SADCEC", 0x3166, 15, 73, 1, false, 15);
+  mTrapRegisters[kSADCMC].init("SADCMC", 0x3170, 10, 74, 0, false, 10);
+  mTrapRegisters[kSADCOC].init("SADCOC", 0x3171, 10, 74, 1, false, 10);
+  mTrapRegisters[kSADCGTB].init("SADCGTB", 0x3172, 32, 75, 0, false, 32);
+  mTrapRegisters[kSEBDEN].init("SEBDEN", 0x3178, 5, 76, 0, false, 5);
+  mTrapRegisters[kSEBDOU].init("SEBDOU", 0x3179, 5, 76, 1, false, 5);
+  mTrapRegisters[kSML0].init("SML0", 0x0A00, 15, 77, 0, false, 15);
+  mTrapRegisters[kSML1].init("SML1", 0x0A01, 15, 77, 1, false, 15);
+  mTrapRegisters[kSML2].init("SML2", 0x0A02, 15, 77, 2, false, 15);
+  mTrapRegisters[kSMMODE].init("SMMODE", 0x0A03, 16, 79, 0, false, 16);
+  mTrapRegisters[kNITM0].init("NITM0", 0x0A08, 15, 80, 0, false, 12);
+  mTrapRegisters[kNITM1].init("NITM1", 0x0A09, 15, 80, 1, false, 12);
+  mTrapRegisters[kNITM2].init("NITM2", 0x0A0A, 15, 80, 2, false, 12);
+  mTrapRegisters[kNIP4D].init("NIP4D", 0x0A0B, 15, 80, 3, false, 12);
+  mTrapRegisters[kARBTIM].init("ARBTIM", 0x0A3F, 16, 82, 0, false, 12);
+  mTrapRegisters[kIA0IRQ0].init("IA0IRQ0", 0x0B00, 15, 83, 0, true, 12);
+  mTrapRegisters[kIA0IRQ1].init("IA0IRQ1", 0x0B01, 15, 83, 1, true, 12);
+  mTrapRegisters[kIA0IRQ2].init("IA0IRQ2", 0x0B02, 15, 83, 2, true, 12);
+  mTrapRegisters[kIA0IRQ3].init("IA0IRQ3", 0x0B03, 15, 83, 3, true, 12);
+  mTrapRegisters[kIA0IRQ4].init("IA0IRQ4", 0x0B04, 15, 83, 4, true, 12);
+  mTrapRegisters[kIA0IRQ5].init("IA0IRQ5", 0x0B05, 15, 83, 5, true, 12);
+  mTrapRegisters[kIA0IRQ6].init("IA0IRQ6", 0x0B06, 15, 83, 6, true, 12);
+  mTrapRegisters[kIA0IRQ7].init("IA0IRQ7", 0x0B07, 15, 83, 7, true, 12);
+  mTrapRegisters[kIA0IRQ8].init("IA0IRQ8", 0x0B08, 15, 83, 8, true, 12);
+  mTrapRegisters[kIA0IRQ9].init("IA0IRQ9", 0x0B09, 15, 83, 9, true, 12);
+  mTrapRegisters[kIA0IRQA].init("IA0IRQA", 0x0B0A, 15, 83, 10, true, 12);
+  mTrapRegisters[kIA0IRQB].init("IA0IRQB", 0x0B0B, 15, 83, 11, true, 12);
+  mTrapRegisters[kIA0IRQC].init("IA0IRQC", 0x0B0C, 15, 83, 12, true, 12);
+  mTrapRegisters[kIRQSW0].init("IRQSW0", 0x0B0D, 15, 83, 13, true, 13);
+  mTrapRegisters[kIRQHW0].init("IRQHW0", 0x0B0E, 15, 83, 14, true, 13);
+  mTrapRegisters[kIRQHL0].init("IRQHL0", 0x0B0F, 15, 83, 15, true, 13);
+  mTrapRegisters[kIA1IRQ0].init("IA1IRQ0", 0x0B20, 15, 91, 0, true, 12);
+  mTrapRegisters[kIA1IRQ1].init("IA1IRQ1", 0x0B21, 15, 91, 1, true, 12);
+  mTrapRegisters[kIA1IRQ2].init("IA1IRQ2", 0x0B22, 15, 91, 2, true, 12);
+  mTrapRegisters[kIA1IRQ3].init("IA1IRQ3", 0x0B23, 15, 91, 3, true, 12);
+  mTrapRegisters[kIA1IRQ4].init("IA1IRQ4", 0x0B24, 15, 91, 4, true, 12);
+  mTrapRegisters[kIA1IRQ5].init("IA1IRQ5", 0x0B25, 15, 91, 5, true, 12);
+  mTrapRegisters[kIA1IRQ6].init("IA1IRQ6", 0x0B26, 15, 91, 6, true, 12);
+  mTrapRegisters[kIA1IRQ7].init("IA1IRQ7", 0x0B27, 15, 91, 7, true, 12);
+  mTrapRegisters[kIA1IRQ8].init("IA1IRQ8", 0x0B28, 15, 91, 8, true, 12);
+  mTrapRegisters[kIA1IRQ9].init("IA1IRQ9", 0x0B29, 15, 91, 9, true, 12);
+  mTrapRegisters[kIA1IRQA].init("IA1IRQA", 0x0B2A, 15, 91, 10, true, 12);
+  mTrapRegisters[kIA1IRQB].init("IA1IRQB", 0x0B2B, 15, 91, 11, true, 12);
+  mTrapRegisters[kIA1IRQC].init("IA1IRQC", 0x0B2C, 15, 91, 12, true, 12);
+  mTrapRegisters[kIRQSW1].init("IRQSW1", 0x0B2D, 15, 91, 13, true, 13);
+  mTrapRegisters[kIRQHW1].init("IRQHW1", 0x0B2E, 15, 91, 14, true, 13);
+  mTrapRegisters[kIRQHL1].init("IRQHL1", 0x0B2F, 15, 91, 15, true, 13);
+  mTrapRegisters[kIA2IRQ0].init("IA2IRQ0", 0x0B40, 15, 99, 0, true, 12);
+  mTrapRegisters[kIA2IRQ1].init("IA2IRQ1", 0x0B41, 15, 99, 1, true, 12);
+  mTrapRegisters[kIA2IRQ2].init("IA2IRQ2", 0x0B42, 15, 99, 2, true, 12);
+  mTrapRegisters[kIA2IRQ3].init("IA2IRQ3", 0x0B43, 15, 99, 3, true, 12);
+  mTrapRegisters[kIA2IRQ4].init("IA2IRQ4", 0x0B44, 15, 99, 4, true, 12);
+  mTrapRegisters[kIA2IRQ5].init("IA2IRQ5", 0x0B45, 15, 99, 5, true, 12);
+  mTrapRegisters[kIA2IRQ6].init("IA2IRQ6", 0x0B46, 15, 99, 6, true, 12);
+  mTrapRegisters[kIA2IRQ7].init("IA2IRQ7", 0x0B47, 15, 99, 7, true, 12);
+  mTrapRegisters[kIA2IRQ8].init("IA2IRQ8", 0x0B48, 15, 99, 8, true, 12);
+  mTrapRegisters[kIA2IRQ9].init("IA2IRQ9", 0x0B49, 15, 99, 9, true, 12);
+  mTrapRegisters[kIA2IRQA].init("IA2IRQA", 0x0B4A, 15, 99, 10, true, 12);
+  mTrapRegisters[kIA2IRQB].init("IA2IRQB", 0x0B4B, 15, 99, 11, true, 12);
+  mTrapRegisters[kIA2IRQC].init("IA2IRQC", 0x0B4C, 15, 99, 12, true, 12);
+  mTrapRegisters[kIRQSW2].init("IRQSW2", 0x0B4D, 15, 99, 13, true, 13);
+  mTrapRegisters[kIRQHW2].init("IRQHW2", 0x0B4E, 15, 99, 14, true, 13);
+  mTrapRegisters[kIRQHL2].init("IRQHL2", 0x0B4F, 15, 99, 15, true, 13);
+  mTrapRegisters[kIA3IRQ0].init("IA3IRQ0", 0x0B60, 15, 107, 0, true, 12);
+  mTrapRegisters[kIA3IRQ1].init("IA3IRQ1", 0x0B61, 15, 107, 1, true, 12);
+  mTrapRegisters[kIA3IRQ2].init("IA3IRQ2", 0x0B62, 15, 107, 2, true, 12);
+  mTrapRegisters[kIA3IRQ3].init("IA3IRQ3", 0x0B63, 15, 107, 3, true, 12);
+  mTrapRegisters[kIA3IRQ4].init("IA3IRQ4", 0x0B64, 15, 107, 4, true, 12);
+  mTrapRegisters[kIA3IRQ5].init("IA3IRQ5", 0x0B65, 15, 107, 5, true, 12);
+  mTrapRegisters[kIA3IRQ6].init("IA3IRQ6", 0x0B66, 15, 107, 6, true, 12);
+  mTrapRegisters[kIA3IRQ7].init("IA3IRQ7", 0x0B67, 15, 107, 7, true, 12);
+  mTrapRegisters[kIA3IRQ8].init("IA3IRQ8", 0x0B68, 15, 107, 8, true, 12);
+  mTrapRegisters[kIA3IRQ9].init("IA3IRQ9", 0x0B69, 15, 107, 9, true, 12);
+  mTrapRegisters[kIA3IRQA].init("IA3IRQA", 0x0B6A, 15, 107, 10, true, 12);
+  mTrapRegisters[kIA3IRQB].init("IA3IRQB", 0x0B6B, 15, 107, 11, true, 12);
+  mTrapRegisters[kIA3IRQC].init("IA3IRQC", 0x0B6C, 15, 107, 12, true, 12);
+  mTrapRegisters[kIRQSW3].init("IRQSW3", 0x0B6D, 15, 107, 13, true, 13);
+  mTrapRegisters[kIRQHW3].init("IRQHW3", 0x0B6E, 15, 107, 14, true, 13);
+  mTrapRegisters[kIRQHL3].init("IRQHL3", 0x0B6F, 15, 107, 15, true, 13);
+  mTrapRegisters[kCTGDINI].init("CTGDINI", 0x0B80, 32, 115, 0, false, 32);
+  mTrapRegisters[kCTGCTRL].init("CTGCTRL", 0x0B81, 16, 116, 0, false, 16);
+  mTrapRegisters[kMEMRW].init("MEMRW", 0xD000, 10, 117, 0, false, 10);
+  mTrapRegisters[kMEMCOR].init("MEMCOR", 0xD001, 10, 117, 1, false, 10);
+  mTrapRegisters[kDMDELA].init("DMDELA", 0xD002, 10, 117, 2, false, 10);
+  mTrapRegisters[kDMDELS].init("DMDELS", 0xD003, 10, 117, 3, false, 10);
+  mTrapRegisters[kNMOD].init("NMOD", 0x0D40, 31, 119, 0, false, 31);
+  mTrapRegisters[kNDLY].init("NDLY", 0x0D41, 31, 119, 1, false, 31);
+  mTrapRegisters[kNED].init("NED", 0x0D42, 31, 119, 2, false, 31);
+  mTrapRegisters[kNTRO].init("NTRO", 0x0D43, 31, 119, 3, false, 31);
+  mTrapRegisters[kNRRO].init("NRRO", 0x0D44, 31, 119, 4, false, 31);
+  mTrapRegisters[kNBND].init("NBND", 0x0D47, 16, 124, 0, false, 16);
+  mTrapRegisters[kNP0].init("NP0", 0x0D48, 15, 125, 0, false, 15);
+  mTrapRegisters[kNP1].init("NP1", 0x0D49, 15, 125, 1, false, 15);
+  mTrapRegisters[kNP2].init("NP2", 0x0D4A, 15, 125, 2, false, 15);
+  mTrapRegisters[kNP3].init("NP3", 0x0D4B, 15, 125, 3, false, 15);
+  mTrapRegisters[kC08CPU0].init("C08CPU0", 0x0C00, 32, 126, 0, true, 32);
+  mTrapRegisters[kQ2VINFO].init("Q2VINFO", 0x0C01, 32, 127, 0, false, 32); // Q2 start, end and tracklet format
+  mTrapRegisters[kC10CPU0].init("C10CPU0", 0x0C02, 32, 128, 0, true, 32);
+  mTrapRegisters[kC11CPU0].init("C11CPU0", 0x0C03, 32, 129, 0, true, 32);
+  mTrapRegisters[kC12CPUA].init("C12CPUA", 0x0C04, 32, 130, 0, true, 32);
+  mTrapRegisters[kC13CPUA].init("C13CPUA", 0x0C05, 32, 131, 0, true, 32);
+  mTrapRegisters[kC14CPUA].init("C14CPUA", 0x0C06, 32, 132, 0, true, 32);
+  mTrapRegisters[kC15CPUA].init("C15CPUA", 0x0C07, 32, 133, 0, true, 32);
+  mTrapRegisters[kC08CPU1].init("C08CPU1", 0x0C08, 32, 134, 0, true, 32);
+  mTrapRegisters[kVINFO].init("VINFO", 0x0C09, 32, 135, 0, false, 32); // source version 24bit version + # of commits
+  mTrapRegisters[kC10CPU1].init("C10CPU1", 0x0C0A, 32, 136, 0, true, 32);
+  mTrapRegisters[kC11CPU1].init("C11CPU1", 0x0C0B, 32, 137, 0, true, 32);
+  mTrapRegisters[kC08CPU2].init("C08CPU2", 0x0C10, 32, 138, 0, true, 32);
+  mTrapRegisters[kNDRIFT].init("NDRIFT", 0x0C11, 32, 139, 0, false, 32); // was called C09CPU2
+  mTrapRegisters[kC10CPU2].init("C10CPU2", 0x0C12, 32, 140, 0, true, 32);
+  mTrapRegisters[kC11CPU2].init("C11CPU2", 0x0C13, 32, 141, 0, true, 32);
+  mTrapRegisters[kC08CPU3].init("C08CPU3", 0x0C18, 32, 142, 0, true, 32);
+  mTrapRegisters[kYCORR].init("YCORR", 0x0C19, 32, 143, 0, false, 32); // was called C09CPU3
+  mTrapRegisters[kC10CPU3].init("C10CPU3", 0x0C1A, 32, 144, 0, true, 32);
+  mTrapRegisters[kC11CPU3].init("C11CPU3", 0x0C1B, 32, 145, 0, true, 32);
+  mTrapRegisters[kNES].init("NES", 0x0D45, 31, 146, 0, false, 31);
+  mTrapRegisters[kNTP].init("NTP", 0x0D46, 31, 147, 0, false, 31);
+  mTrapRegisters[kNCUT].init("NCUT", 0x0D4C, 32, 148, 0, false, 32);
+  mTrapRegisters[kPASACHM].init("PASACHM", 0x315C, 32, 149, 0, false, 19);
+}
+
+TrapRegInfo& TrapRegisters::operator[](uint32_t regid)
+{
+  return mTrapRegisters[regid];
+}
+
+int32_t TrapRegisters::getRegIndexByName(const std::string& name)
+{
+  // there is no index for this but its not used online
+  int counter = 0;
+  for (auto& reg : mTrapRegisters) {
+    if (reg.getName() == name) {
+      return counter;
+    }
+    counter++;
+  }
+  return -1; // error condition
+}
+
+int32_t TrapRegisters::getRegAddrByName(const std::string& name)
+{
+  // there is no index for this but its not used online
+  for (auto& reg : mTrapRegisters) {
+    if (reg.getName() == name) {
+      return reg.getAddr();
+    }
+  }
+  return -1; // error condition
+}

--- a/DataFormats/Detectors/TRD/test/testTrapConfigEvent.cxx
+++ b/DataFormats/Detectors/TRD/test/testTrapConfigEvent.cxx
@@ -1,0 +1,252 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TRD_TrapConfigEvent
+/// \file testTRDTrapConfigEvent
+/// \brief This task tests the trap config
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <algorithm>
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/TrapRegisters.h"
+#include "DataFormatsTRD/HelperMethods.h"
+
+namespace o2::trd
+{
+
+// structs to make defining the tests easier.
+struct mcmIndexing {
+  uint mSector;
+  uint mStack;
+  uint mLayer;
+  uint mRob;
+  uint mMcm;
+  mcmIndexing(int sector, int stack, int layer, int rob, int mcm) : mSector(sector), mStack(stack), mLayer(layer), mRob(rob), mMcm(mcm){};
+};
+
+struct regtotest {
+  uint32_t mRegIdx;
+  std::array<uint32_t, 4> mValue;
+  regtotest(uint32_t regidx, std::array<uint32_t, 4> value) : mRegIdx(regidx), mValue(value){};
+};
+
+// vectors of what and where we want to test.
+std::vector<int> mcmids = {0, 1, 127, 128, 12917, 69119, 69120, 69130};
+std::vector<mcmIndexing> mcmfullindex = {{0, 0, 0, 0, 0}, {0, 0, 0, 0, 1}, {0, 0, 0, 7, 15}, {0, 0, 1, 0, 0}, {3, 1, 4, 7, 5}, {17, 4, 5, 7, 15}, {17, 4, 5, 8, 15}, {18, 0, 0, 1, 2}}; // decomposition of the line above, last 2 of course being fictitious
+
+std::vector<uint32_t> registersOfInterest; // store of the registers we want to look at.
+std::vector<regtotest> registervalues;     // index by regidx,value[4]
+
+void trapregCheck(std::unique_ptr<TrapConfigEvent>& trapconfig, uint32_t mcmidx, int mcmidxcount)
+{
+  // loop over the mcm
+  // loop over the register
+  for (const auto& [key, values] : registervalues) {
+    uint32_t regidx = key;
+    uint32_t index = regidx;
+    std::string name = trapconfig->getRegisterName(index);
+    for (auto& value : values) {
+      if (trapconfig->setRegisterValue(value, index, mcmidx)) {
+        BOOST_CHECK_EQUAL(trapconfig->getRegisterValue(index, mcmidx), value);
+        BOOST_CHECK_EQUAL(trapconfig->getRegisterValue(regidx, mcmidx), value);
+        BOOST_CHECK_EQUAL(trapconfig->getRegisterValue(index, HelperMethods::getMCMId(mcmfullindex[mcmidxcount].mSector, mcmfullindex[mcmidxcount].mStack, mcmfullindex[mcmidxcount].mLayer, mcmfullindex[mcmidxcount].mRob, mcmfullindex[mcmidxcount].mMcm)), value);
+        BOOST_CHECK_EQUAL(trapconfig->getRegisterValue(regidx, HelperMethods::getMCMId(mcmfullindex[mcmidxcount].mSector, mcmfullindex[mcmidxcount].mStack, mcmfullindex[mcmidxcount].mLayer, mcmfullindex[mcmidxcount].mRob, mcmfullindex[mcmidxcount].mMcm)), value);
+        BOOST_CHECK_EQUAL(trapconfig->getRegisterValue(trapconfig->getRegIndexByName(name), mcmidx), value);
+      }
+    }
+  }
+}
+
+/// \brief Test the trap register generation functions
+//
+BOOST_AUTO_TEST_CASE(TRDTrapConfigEventInternals)
+{
+  // test trap register initialisation
+  TrapRegInfo trapreg;
+  trapreg.init("testreg", 0x3000, 6, 0, 1, false, 6);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 20);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x3f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 6, 0, 5, false, 6);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 26);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x3f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+  trapreg.init("testreg", 0x3000, 5, 0, 1, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 22);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 5, 0, 4, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 7);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 5, 0, 5, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 2);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 5, 0, 6, false, 5);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 27);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x1f);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+  trapreg.init("testreg", 0x3000, 31, 0, 1, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 1);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x7fffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+  trapreg.init("testreg", 0x3000, 31, 0, 0, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 1);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0x7fffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 32, 0, 0, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 0);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0xffffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 0);
+  trapreg.init("testreg", 0x3000, 32, 0, 1, false, 31);
+  BOOST_CHECK_EQUAL(trapreg.getShift(), 0);
+  BOOST_CHECK_EQUAL(trapreg.getMask(), 0xffffffff);
+  BOOST_CHECK_EQUAL(trapreg.getDataWordNumber(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(TRDTrapConfigEventGetSet)
+{
+
+  std::unique_ptr<TrapConfigEvent> trapconfig1(new TrapConfigEvent());
+
+  std::vector<uint32_t> registerToLookAt = {
+    TrapRegisters::kTPL00,   // first register TPL00
+    TrapRegisters::kTPL05,   // TPL05 last reg of first 32 bit word
+    TrapRegisters::kTPL06,   // TPL06 first reg of second 32 bit word
+    TrapRegisters::kTPL07,   // TPL07 second reg of second 32 bit word
+    TrapRegisters::kTPL7F,   // TPL7F last TPL register
+    TrapRegisters::kFGA0,    // FGA0 first reg after TPL7f
+    TrapRegisters::kFGA4,    // last 6bit reg in a 32 bit word
+    TrapRegisters::kFGA5,    // the next 6bit reg, first in the subsequent 32 bit word
+    TrapRegisters::kFGA6,    // the next 6bit reg, second in the subsequent 32 bit word
+    TrapRegisters::kFGA7,    // the next 6bit reg, third in the subsequent 32 bit word
+    TrapRegisters::kFGA20,   // last 6 bit register
+    TrapRegisters::kFGF0,    // first 10 bit register
+    TrapRegisters::kFGF12,   // next 2 of 10 bit  register spanning a 32 bit data word.
+    TrapRegisters::kFGF13,   // 2nd part of above
+    TrapRegisters::kFLL3F,   //
+    TrapRegisters::kTPPT0,   //
+    TrapRegisters::kTPFE,    //
+    TrapRegisters::kTPPGR,   //
+    TrapRegisters::kEBPC,    //
+    TrapRegisters::kFPTC,    //
+    TrapRegisters::kFPCL,    //
+    TrapRegisters::kFGTA,    //
+    TrapRegisters::kFGCL,    // 15 bits last of the set by itself in a lone 32 bit reg
+    TrapRegisters::kFTAL,    //
+    TrapRegisters::kADCMSK,  //
+    TrapRegisters::kADCINB,  //
+    TrapRegisters::kADCDAC,  // 5 bit in the middle of a register and the last of the set.
+    TrapRegisters::kADCPAR,  //
+    TrapRegisters::kIA3IRQC, // last 10 bit word
+    TrapRegisters::kIRQHW3,  // then a 32 bit register again
+    TrapRegisters::kIRQHL3,  // last 15 bit reg in a 32bit word
+    TrapRegisters::kCTGDINI, // first
+    TrapRegisters::kCTGCTRL, // second
+    TrapRegisters::kMEMRW,   // lone 32 bit reg
+    TrapRegisters::kMEMCOR,  // lone 16 bit reg
+    TrapRegisters::kDMDELA,  // first 10 after a 16
+    TrapRegisters::kDMDELS,  // middle 10 in a 32 bit word (30 used)
+    TrapRegisters::kNMOD,    // last 10 bit in a 32 bit word
+    TrapRegisters::kNDLY,    // 11 bit in the subsequent 32 bit word*/
+    TrapRegisters::kPASACHM  // last register
+  };
+  TrapRegisters trapRegisters;
+  // setup the resgisters we will look at chosen for various reasons, size, on the edges, changes of register bit size
+  for (auto& reg : registerToLookAt) {
+    registersOfInterest.push_back(reg);
+    // add a zero value, value of 1, mid point and its max.
+    auto max = trapconfig1->getRegisterMax(reg);
+    std::array<uint32_t, 4> regvalues;
+    regvalues[0] = 0;
+    regvalues[1] = 1;
+    regvalues[2] = max / 2;
+    regvalues[3] = max;
+    registervalues.emplace_back(regtotest(reg, regvalues));
+  }
+
+  // walk through map and test
+  int count = 0;
+  for (auto& mcm : mcmids) {
+    trapregCheck(trapconfig1, mcm, count);
+    ++count;
+  }
+  // all those values have been written so we can now try read those back in bulk
+  std::array<uint32_t, constants::MAXMCMCOUNT> allregisterdata{0};  // data for a single register across all mcm
+  std::array<uint32_t, TrapRegisters::kLastReg> allmcmregisters{0}; // data for a single mcm, all registers. std::memset(&allregisters->at(0), 0, sizeof(uint32_t));
+  std::unique_ptr<TrapConfigEvent> trapconfig(new TrapConfigEvent());
+  // loop over all mcm's we want to test and add them to the trapconfig via setregister, this allows us to also view them before anything happens for debugging purposees.
+  for (auto& mcmidx : mcmids) {
+    uint32_t retval = trapconfig->setRegisterValue(0, 0, mcmidx);
+  }
+
+  int registerindex = 0;
+  uint32_t registerreadvalue = 0;
+  for (int valuecount = 0; valuecount < 4; ++valuecount) {
+    // loop over each of the value sets 0,1,mid, max
+    std::vector<uint32_t> addressesseen;
+    std::map<uint32_t, uint32_t> setValues;
+    // loop through all registers for pulling out the valuecount instance of each, put data in and then check against the regall;
+    // its sorted so we know a key will come 4 times sequentially, and use valuecount to denote which value we are working with.
+    uint32_t fgcal_value = registervalues[TrapRegisters::kFGCL + valuecount].mValue[valuecount];
+    for (int regtest = 0; regtest < registervalues.size(); ++regtest) { // loop over the 4th elements to pull out like values, 0,1,max/2,max
+      registerreadvalue = registervalues[regtest].mValue[valuecount];
+      uint32_t index = registervalues[regtest].mRegIdx;
+      for (auto& mcmidx : mcmids) {
+        std::string name = trapconfig->getRegisterName(index);
+        uint32_t retval = trapconfig->setRegisterValue(registerreadvalue, index, mcmidx);
+        if (!retval) {
+          // index is invalid or mcmidx is invalid
+          continue;
+        }
+      }
+    }
+    // all registers now written to ccdbconfig for this value set
+    int elemcount = 0;
+    // now check the values that were written
+    // trapconfig->getAll(*allregisters);
+    // check done in next double for loop
+    uint32_t value = 0;
+    int registersofinterestindex = 0;
+
+    for (auto& mcmidx : mcmids) {
+      if (mcmidx < 0 || mcmidx > constants::MAXCHAMBER)
+        continue;
+      // pull out the values on for a specific mcm
+      trapconfig->getAllRegisters(mcmidx, allmcmregisters);
+      // check the values are set correctly
+      int regcount = 0;
+      for (auto& reg : registersOfInterest) {
+        // loop over all registers for the given mcmq
+        auto value = registervalues[regcount].mValue[valuecount];
+        // value = registervalues[regcount + valuecount].mValue[1];
+        if (reg == TrapRegisters::kFGA5) {
+          int count = 0;
+          for (auto& mcmreg : allmcmregisters) {
+          }
+        }
+        BOOST_CHECK_EQUAL(allmcmregisters[reg], value);
+        ++regcount;
+      }
+    }
+  }
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(TRDCalibration
                        src/T0Fit.cxx
                        src/PadCalibCCDBBuilder.cxx
                        src/KrClusterFinder.cxx
+                       src/CalibratorConfigEvents.cxx
                        src/DCSProcessor.cxx
                        src/CalibrationParams.cxx
                        src/PulseHeight.cxx
@@ -29,6 +30,7 @@ o2_add_library(TRDCalibration
                                      O2::DetectorsCalibration
                                      O2::MathUtils
                                      O2::GPUTracking
+                                     O2::TRDQC
                                      O2::DetectorsDCS)
 
  o2_target_root_dictionary(TRDCalibration
@@ -41,6 +43,7 @@ o2_add_library(TRDCalibration
                                    include/TRDCalibration/PadCalibCCDBBuilder.h
                                    include/TRDCalibration/KrClusterFinder.h
                                    include/TRDCalibration/PulseHeight.h
+                                   include/TRDCalibration/CalibratorConfigEvents.h
                                    include/TRDCalibration/DCSProcessor.h)
 
 o2_add_executable(trd-dcs-sim-workflow

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -49,6 +49,10 @@ struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams>
   // parameters related to noise calibration
   size_t minNumberOfDigits = 1'000'000'000UL; ///< when reached, noise calibration will be finalized
 
+  // parameters for config events.
+  uint32_t configEventAccumulationTime = 15; ///< time to accumulate config events before comparison to
+  bool takeAllConfigEvents = 0;              ///< do we save all the intermediary config events
+
   // boilerplate
   O2ParamDef(TRDCalibParams, "TRDCalibParams");
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorConfigEvents.h
@@ -1,0 +1,133 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorVdExB.h
+/// \brief TimeSlot-based calibration of vDrift and ExB
+/// \author Ole Schmidt
+
+#ifndef O2_TRD_CALIBRATORCONFIGEVENTS_H
+#define O2_TRD_CALIBRATORCONFIGEVENTS_H
+
+// #include "DetectorsCalibration/TimeSlotCalibration.h"
+// #include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "TRDCalibration/CalibrationParams.h"
+
+#include "Rtypes.h"
+#include "TProfile.h"
+#include "TFile.h"
+#include "TTree.h"
+
+#include <array>
+#include <cstdlib>
+#include <memory>
+
+namespace o2::trd
+{
+
+class CalibratorConfigEvents
+{
+
+ public:
+  CalibratorConfigEvents() { LOGP(info, "Start/end of contstructor"); }
+  ~CalibratorConfigEvents() = default;
+
+  bool hasEnoughData() const;
+
+  void initOutput();
+  void init();
+
+  void createFile();
+
+  void closeFile();
+
+  // Add information from incoming partial trapconfig events that have been accumulated for 1 epn and 1 tf.
+  void process(const gsl::span<MCMEvent>& trapconfigevents);
+
+  // void retrievePrev(o2::framework::ProcessingContext& pc);
+  bool timeLimitReached()
+  {
+    mTimeLimitCount++;
+    if (mTimeLimitCount > 10) {
+      mTimeLimitCount = 0;
+      return true;
+    } else
+      return false;
+  }
+  const TrapConfigEvent& getCcdbObject() const { return mCCDBObject; }
+
+  // collapse the maps holding frequency of values, into singular values for each register
+  void collapseRegisterValues();
+
+  // TrapConfigEvent& getCcdbObject() { return mCCDBObject; }
+
+  bool isDifferent();
+
+  void clearEventStructures();
+  void setMaskedHalfChambers(const std::bitset<constants::MAXHALFCHAMBER>& hcstatusqc) { mDisabledHalfChambers = hcstatusqc; }
+  std::bitset<constants::MAXHALFCHAMBER>& getDisabledHalfChambers() { return mDisabledHalfChambers; }
+  int getMissingChambers() { return mDisabledHalfChambers.count() - std::count(mTimesSeenHCID.begin(), mTimesSeenHCID.end(), 0); }
+  int countHCIDPresent()
+  {
+    int sum = 0;
+    for (const auto& temp : mTimesSeenHCID) {
+      LOGP(info, " {} ", temp);
+      if (temp > 0)
+        ++sum;
+    }
+    LOGP(info, "HCID SUM : {}", sum);
+    return std::count_if(mTimesSeenHCID.begin(), mTimesSeenHCID.end(), [](int i) { return i > 0; });
+  }
+
+  // based off the currently listed disabled half chambers, figure out which of the currently enabled hcid we have not seen yet.
+  void stillMissingHCID(std::stringstream& missinghcid);
+
+  // sim to above but for mcm, so includes all enabled hcid, and accounts for disabled mcm.
+  void stillMissingMCM(std::stringstream& missingmcm);
+
+ private:
+  bool mInitCompleted;
+  uint32_t mTimeLimitCount = 0;
+  uint32_t mTimeReached = 0;
+  uint32_t mTimeBeforeComparison;               ///< time of accumulating data and before comparison will be done
+  bool mFirstCCDBObject;                        ///< We have already saved the first config for this run.
+  bool mEnableOutput{false};                    ///< enable output of configevent to a root file instead of the ccdb
+  bool mSaveAllChanges = false;                 ///< Do we save all the changes to configs as they come in.
+  o2::ccdb::CcdbObjectInfo mCCDBInfo;           ///< CCDB infos filled with CCDB description of accompanying CCDB calibration object
+  o2::trd::TrapConfigEvent mCCDBObject;         ///< CCDB calibration  object of TrapConfigEvent
+  o2::trd::TrapConfigEvent mPreviousCCDBObject; ///< CCDB calibration  object of the previously saved TrapConfigEvent
+
+  std::bitset<constants::MAXHALFCHAMBER> mDisabledHalfChambers = 0; ///< Count of the currently enabled half chambers, used as a reference to determine the completeness of the received events.
+
+  // both of these could be calculated in collapsing the array of array of maps, but we need this at other times as well.
+  std::array<uint32_t, constants::MAXMCMCOUNT> mTimesSeenMCM;     // How many times have we seen this mcm.
+  std::array<uint32_t, constants::MAXHALFCHAMBER> mTimesSeenHCID; // How many times have we seen this half chamber, count of the headers not the constituent mcm.
+
+  // similar to above, but for hcid/mcm seen in the data stream of the rawreader (tracklets/digits)
+  std::array<uint32_t, constants::MAXMCMCOUNT> mMCMSeenInData;     // How many times have we seen this mcm in the raw data stream.
+  std::array<uint32_t, constants::MAXHALFCHAMBER> mHCIDSeenInData; // How many times have we seen this half chamber in the raw data stream.
+
+  std::array<int32_t, constants::MAXMCMCOUNT> mTrapRegistersMapVectorIndex; // index of mcm in the vector of array of maps
+  // TODO switch to vector of array of maps, with an array index.
+  std::array<std::array<std::unordered_map<uint32_t, uint32_t>, TrapRegisters::kLastReg>, constants::MAXMCMCOUNT> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers
+
+  const TRDCalibParams& mParams{TRDCalibParams::Instance()}; ///< reference to calibration parameters
+
+  std::unique_ptr<TFile> mOutFile{nullptr}; ///< output file
+  std::unique_ptr<TTree> mOutTree{nullptr}; ///< output tree
+
+  ClassDefNV(CalibratorConfigEvents, 1);
+};
+
+} // namespace o2::trd
+
+#endif // O2_TRD_CALIBRATORVDEXB_H

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -1,0 +1,280 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorConfigEvents.cxx
+/// \brief Config Events calibrator
+/// \author Sean Murray
+
+#include "Framework/ProcessingContext.h"
+#include "Framework/TimingInfo.h"
+#include "Framework/InputRecord.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CommonUtils/NameConf.h"
+#include "CommonUtils/MemFileHelper.h"
+
+#include "DataFormatsTRD/Constants.h"
+#include "TRDCalibration/CalibratorConfigEvents.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "TRDQC/StatusHelper.h"
+#include "TRDBase/GeometryBase.h"
+
+#include "TStopwatch.h"
+#include <TFile.h>
+#include <TTree.h>
+
+#include <string>
+#include <map>
+#include <memory>
+#include <ctime>
+
+using namespace o2::trd::constants;
+
+namespace o2::trd
+{
+
+void CalibratorConfigEvents::clearEventStructures()
+{
+  mCCDBObject.clear();
+  for (auto& mcm : mTrapRegistersFrequencyMap) {
+    for (auto& reg : mcm) {
+      reg.clear();
+    }
+  }
+  mTimesSeenMCM.fill(0);
+  // mTimesSeenHCID.fill(0);
+}
+
+void CalibratorConfigEvents::init()
+{
+  std::unique_ptr<o2::ccdb::CCDBManagerInstance> mgr;
+  mgr = std::make_unique<o2::ccdb::CCDBManagerInstance>("http://ccdb-test.cern.ch:8080");
+  LOGP(info, "get valid half chambers from ccdb");
+  auto now = std::chrono::high_resolution_clock::now();
+  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+  auto timeStamp = now_ms.time_since_epoch();
+  auto halfChamberStatus = mgr->getForTimeStamp<o2::trd::HalfChamberStatusQC>("TRD/Calib/HalfChamberStatusQC", timeStamp.count());
+  if (halfChamberStatus == nullptr) {
+    LOGP(info, "Could not find a halfchamberstatusqc for this time, searching for a known time");
+    // TODO ...
+  }
+  setMaskedHalfChambers(halfChamberStatus->getBitSet());
+}
+
+void CalibratorConfigEvents::process(const gsl::span<MCMEvent>& MCMEvents)
+{
+  // if (mInitCompleted) {
+  //   return;
+  // }
+
+  // set tree addresses
+  if (mEnableOutput) {
+    mOutTree->Branch("trapconfigevent", &mCCDBObject);
+    //  what do we want to save?
+  }
+
+  // take incoming trapconfigevents and populate the array of array of maps, seen values for eventual
+  // collapsing into a singular trapconfigevent at the end of the alloted accumulation time.
+  // additionally fill in the mcmindex and the hcidpresent mcmpresent is built into the index.
+  int count = 0;
+  int mcmcount = 0;
+  int mcmregmax = 23;
+  int hcid = 0;
+  uint32_t regvalue = 0;
+  std::bitset<constants::MAXCHAMBER> hcidseen;
+  // take the incoming events and pack them into the array of array of maps
+  for (auto& mcmevent : MCMEvents) {
+    for (int mcmreg = 0; mcmreg < TrapRegisters::kLastReg; ++mcmreg) {
+      regvalue = mcmevent.getRegister(mcmreg, mCCDBObject.getRegisterInfo(mcmreg));
+      auto mcmid = mcmevent.getMCMId();
+      if (mcmid < constants::MAXMCMCOUNT) {
+        mTimesSeenMCM[mcmid]++; // frequency map for values in the respective registers
+        hcid = HelperMethods::getHCIDFromMCMId(mcmid);
+        // LOGP(info, " we got hcid : {} from mcmid : {}", hcid, mcmid);
+        if (!hcidseen.test(hcid)) {
+          // first time for this hcid
+          mTimesSeenHCID[hcid]++;
+          hcidseen.set(hcid);
+        }
+        // LOGP(info, "XXX calibrator incoming value for mcmid #{} mcm register : [{},{}] value : {:08x} ", count++, mcmid, mCCDBObject.getRegisterName(mcmreg), mcmreg, regvalue);
+        mCCDBObject.setRegisterValue(regvalue, mcmreg, mcmid);
+        if (mTrapRegistersFrequencyMap[mcmid][mcmreg][regvalue] == 0) {
+          //  this =1 is actually not required as ++ will increment the zero, its more here for clarity, as this is the case of regvalue not being in the map yet.
+          mTrapRegistersFrequencyMap[mcmid][mcmreg][regvalue] = 1;
+        } else {
+          mTrapRegistersFrequencyMap[mcmid][mcmreg][regvalue]++;
+          // LOGP(info, "XXXYYY  [{}]  for mcmid #{} mcm register : [{},{}] value : {:08x} count 1=={} ", count++, mcmid, mCCDBObject.getRegisterName(mcmreg), mcmreg, regvalue, mTrapRegistersFrequencyMap[mcmid][mcmreg].size());
+        }
+        if (mTrapRegistersFrequencyMap[mcmid][mcmreg].size() > 1) {
+          int count = 0;
+          for (auto& apair : mTrapRegistersFrequencyMap[mcmid][mcmreg]) {
+            LOGP(debug, "XXX  [{}] GREATER than 1 value for mcmid #{} mcm register : [{},{}] value : {:08x} count 1=={} ", count++, mcmid, mCCDBObject.getRegisterName(mcmreg), mcmreg, apair.first, mTrapRegistersFrequencyMap[mcmid][mcmreg].size());
+          }
+        }
+      } // if(mcmid<constants::MAXMCMCOUNT)
+      else {
+        LOGP(warn, "mcmid from mcmevent is too big : {} > {}", mcmid, constants::MAXMCMCOUNT);
+      }
+    }
+  }
+  mTimeReached++; // count the number of timeframes with configevents.
+  LOGP(info, "increment time reached to {} ", mTimeReached);
+}
+
+bool CalibratorConfigEvents::hasEnoughData() const
+{
+  // determine if this slot has enough data ... normal calibration.
+  // this method triggers a merge and a finaliseSlot.
+  // if the slot does not have enough data this slot together with the next one are merged.
+
+  // We therefore have 2 options :
+  // a:keep all the difference and ergo, save to ccdb after each incoming config event.
+  // b: the normal option, accumulate for 10,15 minutes and then compare and write to ccdb if new and flag qc.
+  bool timereached = 0;
+  if (mSaveAllChanges) {
+    return true;
+  } else {
+    // case b:
+    //  we just care about the time taken since the beginning.
+    //
+    if (mTimeReached % 10 && mTimeReached != 0) {
+      LOGP(info, "Reached a count of 10 : {} ", mTimeReached);
+      return true;
+    } else {
+      LOGP(info, "Not Reached a count of 10 : {} ", mTimeReached);
+      return false;
+    }
+  }
+}
+
+void CalibratorConfigEvents::collapseRegisterValues()
+{
+  // map to store unique values for each register to infer mo
+  std::array<std::map<uint32_t, uint32_t>, TrapRegisters::kLastReg> registersvaluemap;
+  // Collapse the frequency maps of registers into singular values
+  for (uint32_t mcmid = 0; mcmid < constants::MAXMCMCOUNT; ++mcmid) {
+
+    if (mCCDBObject.isMCMPresent(mcmid)) {
+      // LOGP(info, "Collapsing with mcmid {} is present", mcmid);
+      auto mcmevent = mCCDBObject.getMCMEvent(mcmid);
+      if (mTimesSeenMCM[mcmid] > 0) {
+        // avoid those mcm that have no data.
+        for (int mcmreg = 0; mcmreg < TrapRegisters::kLastReg; ++mcmreg) {
+          // auto regvalue = mcmevent.getRegister(mcmreg,mCCDBObject.getTrapRegInfo(mcmreg));
+          // do we have more than a single value?
+          if (mTrapRegistersFrequencyMap[mcmid][mcmreg].size() > 1) {
+            // find most frequent value
+            auto maxelement = std::max_element(mTrapRegistersFrequencyMap[mcmid][mcmreg].begin(), mTrapRegistersFrequencyMap[mcmid][mcmreg].end(), [](const auto& x, const auto& y) {
+              return x.second < y.second;
+            });
+            /*if(mcmreg== TrapRegisters::kADCMSK){
+              LOGP(info, "mcm {} {} == {:08x} had {} values",mcmid,mCCDBObject.getRegisterName(mcmreg),maxelement->first,mTrapRegistersFrequencyMap[mcmid][mcmreg].size());
+            }*/
+            mCCDBObject.setRegisterValue(maxelement->first, mcmreg, mcmid);
+            registersvaluemap[mcmreg][maxelement->first]++;
+            int count = 0;
+            for (auto& apair : mTrapRegistersFrequencyMap[mcmid][mcmreg]) {
+              // debug output the multiple values and their frequency
+            }
+          } else {
+            // we only have one value so use that one.
+            //  if(mcmreg== TrapRegisters::kADCMSK){
+            // LOGP(info, "mcm {} {} == {:08x} had {} values datacount {}",mcmid,mCCDBObject.getRegisterName(mcmreg), mTrapRegistersFrequencyMap[mcmid][mcmreg].begin()->first,mTrapRegistersFrequencyMap[mcmid][mcmreg].size(),mTrapRegistersFrequencyMap[mcmid][mcmreg].begin()->second);
+            //  }
+            auto data = mTrapRegistersFrequencyMap[mcmid][mcmreg].begin()->first;
+            auto datacount = mTrapRegistersFrequencyMap[mcmid][mcmreg].begin()->second;
+            mCCDBObject.setRegisterValue(data, mcmreg, mcmid);
+            registersvaluemap[mcmreg][data]++;
+          }
+        }
+      }
+    } else {
+      LOGP(info, "Collapsing with mcmid {} is not present", mcmid);
+    }
+  }
+
+  // walk the register value map and figure out the most prevelant values for a particular register.
+  for (int mcmreg = 0; mcmreg < TrapRegisters::kLastReg; ++mcmreg) {
+    // auto& map = registervaluemap[mcmreg] ;
+    auto mostcommonelement = std::max_element(registersvaluemap[mcmreg].begin(), registersvaluemap[mcmreg].end(), [](const auto& x, const auto& y) {
+      return x.second < y.second;
+    });
+    // now to put the most common value in the default value for unenabled mcm for simulation
+    mCCDBObject.setDefaultRegisterValue(mcmreg, mostcommonelement->first);
+    LOGP(info, "register [{}:{}] has most common value of 0x{:08x} occured {} times, this reg had {} values in the map ", mcmreg, mCCDBObject.getRegisterName(mcmreg), mostcommonelement->first, mostcommonelement->second, registersvaluemap[mcmreg].size());
+  }
+}
+
+void CalibratorConfigEvents::createFile()
+{
+  mEnableOutput = true;
+  mOutFile = std::make_unique<TFile>("trd_configevents.root", "RECREATE");
+  if (mOutFile->IsZombie()) {
+    LOG(error) << "Failed to create output file for config events!";
+    mEnableOutput = false;
+    return;
+  }
+  mOutTree = std::make_unique<TTree>("calib", "Config Events");
+  LOG(info) << "Created output file trd_configevents.root";
+}
+
+void CalibratorConfigEvents::closeFile()
+{
+  if (!mEnableOutput) {
+    return;
+  }
+
+  try {
+    mOutFile->cd();
+    mOutTree->Write();
+    mOutTree.reset();
+    mOutFile->Close();
+    mOutFile.reset();
+  } catch (std::exception const& e) {
+    LOG(error) << "Failed to write config event calibration data file, reason: " << e.what();
+  }
+  // after closing, we won't open a new file
+  mEnableOutput = false;
+}
+
+bool CalibratorConfigEvents::isDifferent()
+{
+  // compare the accumulated config to that stored in the ccdb.
+  return mCCDBObject.isConfigDifferent(mPreviousCCDBObject);
+}
+
+void CalibratorConfigEvents::stillMissingHCID(std::stringstream& missinghcid)
+{
+  // compare which hcid we see vs the ones that should be seen, send back the ones we should have seen but dont
+  // std::array<uint32_t, constants::MAXHALFCHAMBER> mTimesSeenHCID; has the ones we have seen in config events
+  missinghcid << "HCID seen in data but not in configs : ";
+  for (uint32_t hcid = 0; hcid < constants::NCHAMBER * 2; ++hcid) {
+    if (mHCIDSeenInData[hcid] > 0 && mTimesSeenHCID[hcid] == 0) {
+      // HCID has data coming in but we did not get a config event on this hcid(link)
+      missinghcid << fmt::format("[{} != {}], ", mHCIDSeenInData[hcid], mTimesSeenHCID[hcid]);
+    }
+  }
+}
+
+void CalibratorConfigEvents::stillMissingMCM(std::stringstream& missingmcm)
+{
+  // compare which mcm we see vs the ones that should be seen, send back the ones we should have seen but dont
+  // std::array<uint32_t, constants::MAXMCMCOUNT> mTimesSeenMCM; has the ones we have seen in config events
+  missingmcm << "MCM seen in data but not in configs : ";
+  for (uint32_t mcmid = 0; mcmid < constants::NCHAMBER * 2; ++mcmid) {
+    if (mMCMSeenInData[mcmid] > 0 && mTimesSeenMCM[mcmid] == 0) {
+      // mcmid has data coming in but we did not get a config event on this mcmid
+      missingmcm << fmt::format("[{} != {}], ", mMCMSeenInData[mcmid], mTimesSeenMCM[mcmid]);
+    }
+  }
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorConfigEvents.cxx
@@ -66,7 +66,7 @@ void CalibratorConfigEvents::init()
     LOGP(info, "Could not find a halfchamberstatusqc for this time, searching for a known time");
     // TODO ...
   }
-  setMaskedHalfChambers(halfChamberStatus->getBitSet());
+  //  setMaskedHalfChambers(halfChamberStatus->getBitSet());
 }
 
 void CalibratorConfigEvents::process(const gsl::span<MCMEvent>& MCMEvents)

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::trd::CalibratorVdExB + ;
+#pragma link C++ class o2::trd::CalibratorConfigEvents + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::GainCalibHistos> + ;

--- a/Detectors/TRD/macros/CMakeLists.txt
+++ b/Detectors/TRD/macros/CMakeLists.txt
@@ -31,5 +31,10 @@ o2_add_test_root_macro(CheckNoiseRun.C
                        PUBLIC_LINK_LIBRARIES O2::TRDBase
                        LABELS trd)
 
+                   #o2_add_test_root_macro(CheckTrapConfig.C
+                   #    PUBLIC_LINK_LIBRARIES O2::TRDBase O2::DataFormatsTRD
+                   #    LABELS trd)
+
 install(FILES CheckNoiseRun.C
     DESTINATION share/Detectors/TRD/macros/)
+

--- a/Detectors/TRD/macros/CheckConfigEvent.C
+++ b/Detectors/TRD/macros/CheckConfigEvent.C
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CheckConfigEvent.C
+/// \brief Check a config event
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TFile.h>
+#include <TTree.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+
+#include <fairlogger/Logger.h>
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#endif
+
+using namespace o2::trd;
+
+constexpr int kMINENTRIES = 100;
+
+void CheckDigits(std::string configeventfile = "trddigits.root", uint32_t mcmid = 42)
+{
+  TFile* fin = TFile::Open(configeventfile.data());
+  TTree* configeventTree = (TTree*)fin->Get("o2sim");
+  TrapConfigEvent* trapconfigevent = nullptr;
+  configeventTree->SetBranchAddress("ConfigEvent", &trapconfigevent);
+  int nev = configeventTree->GetEntries();
+
+  LOG(info) << nev << " entries found";
+  configeventTree->GetEvent(0);
+  for (int reg = 0; reg < 433; ++reg) {
+    LOGP(info, "register :{}, value :{} ", trapconfigevent->getRegisterName(reg), trapconfigevent->getRegisterValue(reg, mcmid));
+  }
+}

--- a/Detectors/TRD/macros/ParseTrapRawOutput.C
+++ b/Detectors/TRD/macros/ParseTrapRawOutput.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <TChain.h>
 #include <TFile.h>

--- a/Detectors/TRD/macros/convertRun2ToRun3Digits.C
+++ b/Detectors/TRD/macros/convertRun2ToRun3Digits.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #if !defined(__CINT__) || defined(__MAKECINT__)
 
 // ROOT

--- a/Detectors/TRD/reconstruction/CMakeLists.txt
+++ b/Detectors/TRD/reconstruction/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(TRDReconstruction
                        src/CruRawReader.cxx
                        src/DataReaderTask.cxx
                        src/EventRecord.cxx
+                       src/TrapConfigEventParser.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
                                      O2::DataFormatsTRD
                                      O2::DataFormatsTPC
@@ -26,7 +27,6 @@ o2_add_library(TRDReconstruction
                                      O2::rANS
                                      O2::DataFormatsCTP
                                      Microsoft.GSL::GSL)
-
 
 o2_add_executable(datareader
     COMPONENT_NAME trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -22,6 +22,8 @@
 #include <set>
 #include <utility>
 #include <array>
+#include <TH2F.h>
+#include <TFile.h>
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -174,6 +176,7 @@ class CruRawReader
   HalfCRUHeader mPreviousHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   bool mPreviousHalfCRUHeaderSet;       // flag, whether we can use mPreviousHalfCRUHeader for additional sanity checks
   DigitHCHeader mDigitHCHeader;         // Digit HalfChamber header we are currently on.
+  DigitHCHeaderAll mDigitHCHeaderAll;   // Store all the possible parts of the Digit HC Header
   uint16_t mTimeBins{constants::TIMEBINS}; // the number of time bins to be read out (default 30, can be overwritten from digit HC header)
   bool mTimeBinsFixed{false};              // flag, whether number of time bins different from default was configured
   bool mHaveSeenDigitHCHeader3{false};     // flag, whether we can compare an incoming DigitHCHeader3 with a header we have seen before
@@ -191,6 +194,10 @@ class CruRawReader
   o2::InteractionRecord mIR;
   std::array<uint16_t, 15> mCurrentHalfCRULinkLengths;
   std::array<uint8_t, 15> mCurrentHalfCRULinkErrorFlags;
+
+  bool mFirstConfigIR{true};
+  o2::InteractionRecord mLastConfigIR;
+  std::chrono::duration<double, std::micro> mTotalConfigTime;
 
   const LinkToHCIDMapping* mLinkMap = nullptr; // to retrieve HCID from Link ID
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
@@ -17,15 +17,23 @@
 #include <fairlogger/Logger.h>
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/RawDataStats.h"
+#include "DataFormatsTRD/RawData.h"
 #include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
 
-namespace o2::framework
+namespace o2
+{
+namespace framework
 {
 class ProcessingContext;
 }
+} // namespace o2
 
-namespace o2::trd
+namespace o2
 {
+namespace trd
+{
+
 class TriggerRecord;
 
 /// \class EventRecord
@@ -96,6 +104,7 @@ class EventRecordContainer
   void incLinkWordsRead(int hcid, int count) { mTFStats.mLinkWordsRead[hcid] += count; }
   void incLinkWordsRejected(int hcid, int count) { mTFStats.mLinkWordsRejected[hcid] += count; }
   void incMajorVersion(int version) { mTFStats.mDataFormatRead[version]++; }
+  void addConfigEvent(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>& data, uint32_t start, uint32_t end, uint32_t configeventlength, DigitHCHeaderAll& digithcheaders, InteractionRecord& ir);
 
   void incParsingError(int error, int hcid)
   {
@@ -111,12 +120,21 @@ class EventRecordContainer
   void reset();
   void accumulateStats();
 
+  void incHCIDProducedData(const int hcid) { mHCIDProducedData[hcid]++; }
+  void incMCMProducedData(const int mcmid) { mMCMProducedData[mcmid]++; }
+
  private:
   int mCurrEventRecord = 0;
   std::vector<EventRecord> mEventRecords;
   TRDDataCountersPerTimeFrame mTFStats;
+  std::vector<uint32_t> mConfigEventData; ///< unparse config event data, format : IR, HcHeader, event data, repeat.
+  bool mConfigEventPresent{false};
+  // used by config events to figure out which links/mcm are live and which are not.
+  std::array<uint32_t, constants::MAXHALFCHAMBER> mHCIDProducedData;
+  std::array<uint32_t, constants::MAXMCMCOUNT> mMCMProducedData;
 };
 
-} // namespace o2::trd
+} // namespace trd
+} // namespace o2
 
 #endif

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrapConfigEventParser.h
@@ -1,0 +1,159 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPCONFIGPARSER_H
+#define O2_TRDTRAPCONFIGPARSER_H
+
+#include <fairlogger/Logger.h>
+#include "CommonDataFormat/InteractionRecord.h"
+
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/TrapConfigEventQC.h"
+#include "DataFormatsTRD/RawData.h"
+
+#include <chrono>  // chrono::system_clock
+#include <ctime>   // localtime
+#include <sstream> // stringstream
+#include <iomanip> // put_time
+#include <string>  // string
+#include <vector>
+#include <memory>
+#include <map>
+#include <tuple>
+#include <bitset>
+#include <gsl/span>
+#include "Rtypes.h"
+#include "TH2F.h"
+
+// Configuration of the TRD Tracklet Processor
+// (TRD Front-End Electronics)
+// There is a manual to describe all the internals of the electronics.
+// A very detailed manual, will try put it in the source code.
+// TRAP registers
+// TRAP data memory (DMEM)
+//
+
+namespace o2
+{
+namespace trd
+{
+
+enum TrapConfigEventErrorTypes {
+  kTrapConfigEventAllGood = 0x1,
+  kTrapConfigEventNoEnd = 0x2,
+  kTrapConfigEventNoBegin = 0x4,
+  kTrapConfigEventNoGarbageEnd = 0x8,
+  kTrapConfigEventNoGarbageBegin = 0x10,
+  kTrapConfigEventLastError = 0x20,
+  kTrapConfigEventRegisterGap = 0x40,
+  kTrapConfigEventCorruptData = 0x80
+}; // possible errors for parsing.
+
+class TrapConfigEventParser
+{
+  // class used to unpack the trap config events, and figure out what to do to them.
+ public:
+  TrapConfigEventParser();
+  ~TrapConfigEventParser();
+
+  // int getTrapReg(TrapReg reg, int det = -1, int rob = -1, int mcm = -1);
+
+  unsigned int getDmemUnsigned(int addr, int det, int rob, int mcm);
+
+  // TrapReg getRegByAddress(int address);
+
+  void printMCMRegisterCount(int hcid);
+  void unpackBlockHeader(uint32_t& header, uint32_t& registerdata, uint32_t& step, uint32_t& bwidth, uint32_t& nwords, uint32_t& registeraddr, uint32_t& exit_flag);
+  bool parse(std::vector<uint32_t>& data);
+  int parseLink(std::vector<uint32_t>& data, uint32_t start, uint32_t end);
+  int parseSingleData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward);
+  int parseBlockData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward);
+
+  bool checkRegister(uint32_t& registeraddr, uint32_t& registerdata);
+
+  void FillHistograms(int eventnum); //;TH2F *hists[6])
+  void compareToTrackletsHCID(std::bitset<1080> trackletshcid);
+  std::array<int, TrapRegisters::kLastReg>& getStartRegArray() { return mStartReg; }      // the number of time this register was read as the first register
+  std::array<int, TrapRegisters::kLastReg>& getStopRegArray() { return mStopReg; }        // the number of time this register was read as the last register
+  std::array<int, TrapRegisters::kLastReg>& getMissedRegArray() { return mMissedReg; }    // the number of times this register was not read
+  std::array<int, TrapRegisters::kLastReg>& getRegisterCount() { return mRegisterCount; } // total count for each register
+  void init(){};
+  TrapConfigEvent getNewConfig() { return *(mTrapConfigEvent.get()); };
+  TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
+  // TrapConfigEvent getNewConfig() { return *mTrapConfigEvent.get(); };
+  // TrapConfigEvent* getNewConfigPtr() { return mTrapConfigEvent.get(); };
+  void sendTrapConfigEvent(framework::ProcessingContext& pc);
+
+  uint32_t countHCIDPresent() const { return mHCHasBeenSeen.count(); }
+  uint32_t countMCMPresent() const { return mMCMHasBeenSeen.count(); }
+
+  // flush the stats that are config event specific
+  // a single parse is almost certainly not going to contain the complete event, this is then run after we think we have the complete set.
+  int flushParsingStats();
+  int64_t getConfigSize() { return sizeof(*mTrapConfigEvent.get()); }
+  void setMCMParsingStatus(uint32_t mcmid, int status) { mMcmParsingStatus[mcmid] |= status; }
+  int getMCMParsingStatus(uint32_t mcmid) { return mMcmParsingStatus[mcmid]; }
+
+  bool setRegister(const uint32_t regidx, const uint32_t mcmid, const uint32_t registerdata);
+  const uint32_t getRegister(const uint32_t regidx, const uint32_t mcmid);
+  void addMCM(const int mcmid);
+  void clearEventBasedStats();
+  void analyseEventBaseStats();
+  void buildAddressMap();
+  const int32_t getRegIndexByAddr(unsigned int addr);
+  bool isValidAddress(uint32_t addr);
+  const std::string getRegNameByAddr(uint16_t addr);
+  const std::string getRegNameByIdx(const uint32_t regidx) { return mTrapConfigEvent.get()->getRegisterName(regidx); }
+  void getRegisterByAddr(uint32_t registeraddr, std::string& regname, int32_t& newregidx, int32_t& numberbits);
+
+ private:
+  uint32_t mCurrentHCID = 0;
+  DigitMCMHeader mCurrentMCMHeader;
+  uint32_t mCurrentMCMID = 0;
+  uint32_t mCurrentDataIndex = 0;
+  uint32_t mCurrentHCTime = 0;
+  uint32_t mTrapConfigEventCounter = 0;
+  uint32_t mLastRegIndex = 0;
+  uint32_t mRegistersReadForCurrentMCM = 0;
+  uint32_t mCurrentRegisterWordsCount = 0;
+  uint32_t mPreviousRegisterAddressRead = 0;
+  uint32_t mRegisterErrorGap = 0;
+  int32_t mCurrentRegisterIndex = 0;
+  int32_t mPreviousRegisterIndex = 0;
+  std::array<int, o2::trd::constants::MAXMCMCOUNT> mMcmParsingStatus{0}; // status of what was found, errors types in the parsing
+  std::array<int, 8 * 16> mcmSeen;                                       // the mcm has been seen with or with out error, local to a link
+  std::array<int, 8 * 16> mcmMCM;                                        // the mcm has been seen with or with out error, local to a link
+  std::array<int, 8 * 16> mcmROB;                                        // the mcm has been seen with or with out error, local to a link
+  std::array<int, 8 * 16> mcmSeenMissedRegister;                         // the mcm does not have a complete set of registers, local to a link
+  std::bitset<constants::MAXMCMCOUNT> mMCMHasBeenSeen;                   // the mcm has been seen with or with out error, local to a link
+  std::bitset<constants::MAXHALFCHAMBER> mHCHasBeenSeen;                 // the mcm has been seen with or with out error, local to a link
+  bool firsttime = false;
+  InteractionRecord mIR;
+  InteractionRecord mPreviousIR;
+  std::time_t mConfigDate;
+  std::array<int, TrapRegisters::kLastReg> mStartReg{0};      // count which register a config starts at
+  std::array<int, TrapRegisters::kLastReg> mStopReg{0};       // count which register a config stops at.
+  std::array<int, TrapRegisters::kLastReg> mMissedReg{0};     // count the number of missed reigsters
+  std::array<int, TrapRegisters::kLastReg> mRegisterCount{0}; // register frequency, a count of how many times each register appears
+  std::shared_ptr<TrapConfigEvent> mTrapConfigEvent;          // emptry trap config to store the register information.
+  std::vector<MCMEvent> mMCMData;
+  std::array<int32_t, constants::MAXMCMCOUNT> mMCMDataIndex;
+  std::array<std::map<uint32_t, uint32_t>, TrapRegisters::kLastReg> mTrapRegistersFrequencyMap; // frequency map for values in the respective registers
+  std::map<uint16_t, uint16_t> mTrapRegistersAddressIndexMap;                                   //!< map of address into mTrapRegisters, populated at the end of initialiseRegisters
+  TrapConfigEventQC mQCData;
+  int configcount = 0;
+  ClassDefNV(TrapConfigEventParser, 1);
+};
+
+} // namespace trd
+} // namespace o2
+#endif

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -49,6 +49,7 @@ void CruRawReader::configure(int tracklethcheader, int halfchamberwords, int hal
   if (mOptions[TRDVerboseErrorsBit] && (ParsingErrorsString.size() - 1) != TRDLastParsingError) {
     LOG(error) << "Verbose error reporting requested, but the mapping of error code to error string is not complete";
   }
+  mTotalConfigTime = (std::chrono::duration<double, std::micro>)0;
 }
 
 void CruRawReader::incrementErrors(int error, int hcid, std::string message)
@@ -243,6 +244,7 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
   // mHBFoffset32 is the current offset into the current buffer,
   //
   mDigitHCHeader.word = mHBFPayload[mHBFoffset32++];
+  mDigitHCHeaderAll.setHeader(0, mDigitHCHeader.word);
 
   // in case DigitHCHeader1 is not available for providing the phase, flag with invalid one
   mPreTriggerPhase = INVALIDPRETRIGGERPHASE;
@@ -312,6 +314,7 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
           return false;
         }
         mTimeBins = header1.numtimebins;
+        mDigitHCHeaderAll.setHeader(1, header1.word);
         break;
 
       case 2: // header header2;
@@ -324,11 +327,14 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
           incrementErrors(DigitHCHeader2Problem, hcid);
           return false;
         }
+        DigitHCHeader2 header2;
+        header2.word = headers[headerwordcount];
         /* Currently we don't do anything with the information stored in DigitHCHeader2
         DigitHCHeader2 header2;
         header2.word = headers[headerwordcount];
         */
         headersfound.set(1);
+        mDigitHCHeaderAll.setHeader(2, header2.word);
         break;
 
       case 3: // header header3;
@@ -350,6 +356,7 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
               LOG(warning) << "Conflicting SVN in DigitHCHeader3";
               printDigitHCHeader(mDigitHCHeader, headers.data());
             }
+            LOGP(info, "SVN MisMatch: svnver {}=?{} and svnrver {}=?{} ", (unsigned int)header3.svnver, mPreviousDigitHCHeadersvnver, (unsigned int)header3.svnrver, mPreviousDigitHCHeadersvnrver);
             incrementErrors(DigitHCHeaderSVNMismatch, hcid);
             return false;
           }
@@ -357,6 +364,7 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
           mPreviousDigitHCHeadersvnver = header3.svnver;
           mPreviousDigitHCHeadersvnrver = header3.svnrver;
           mHaveSeenDigitHCHeader3 = true;
+          mDigitHCHeaderAll.setHeader(3, header3.word);
         }
         break;
 
@@ -480,6 +488,7 @@ bool CruRawReader::processHalfCRU(int iteration)
     // apply CTP offset shift
     mIR.bc -= o2::ctp::TriggerOffsetsParam::Instance().LM_L0;
   }
+
   mEventRecords.setCurrentEventRecord(mIR);
   if (mCurrentHalfCRUHeader.EventType == ETYPECALIBRATIONTRIGGER) {
     mEventRecords.getCurrentEventRecord().setIsCalibTrigger();
@@ -509,12 +518,12 @@ bool CruRawReader::processHalfCRU(int iteration)
     }
     if (mOptions[TRDVerboseBit]) {
       if (currentlinksize32 > 0) {
-        LOGF(info, "Half-CRU link %i raw dump before parsing starts:", currentlinkindex);
+        LOGP(info, "Half-CRU link {}(hcid:{}) LME : {} raw dump before parsing starts:", currentlinkindex, halfChamberId, mCurrentHalfCRULinkErrorFlags[currentlinkindex]);
         for (uint32_t dumpoffset = mHBFoffset32; dumpoffset < mHBFoffset32 + currentlinksize32; dumpoffset += 8) {
           LOGF(info, "0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x", mHBFPayload[dumpoffset], mHBFPayload[dumpoffset + 1], mHBFPayload[dumpoffset + 2], mHBFPayload[dumpoffset + 3], mHBFPayload[dumpoffset + 4], mHBFPayload[dumpoffset + 5], mHBFPayload[dumpoffset + 6], mHBFPayload[dumpoffset + 7]);
         }
       } else {
-        LOGF(info, "Half-CRU link %i has zero link size", currentlinkindex);
+        LOGP(info, "Half-CRU link {}(hcid:{}) LMR : {} has zero link size", currentlinkindex, halfChamberId, mCurrentHalfCRULinkErrorFlags[currentlinkindex]);
       }
     }
     if (currentlinksize32 > 0) { // if link is not empty
@@ -538,6 +547,8 @@ bool CruRawReader::processHalfCRU(int iteration)
       }
       if (trackletWordsRejected > 0) {
         linkOK = false;
+      } else {
+        mEventRecords.incHCIDProducedData(halfChamberId); // flip the bit to say we have tracklets on this hcid.
       }
       mHBFoffset32 += trackletWordsRead;
       if (mCurrentHalfCRUHeader.EventType == ETYPEPHYSICSTRIGGER &&
@@ -584,16 +595,23 @@ bool CruRawReader::processHalfCRU(int iteration)
         }
 
         mEventRecords.incMajorVersion(mDigitHCHeader.major); // 127 is max histogram goes to 256
-
-        if (mDigitHCHeader.major == 0x47) {
+        if (mDigitHCHeader.major == constants::CONFIGEVENTNUMBER) {
           // config event so ignore for now and bail out of parsing.
           //advance data pointers to the end;
+          auto configeventlength = mCurrentHalfCRULinkLengths[currentlinkindex];
+          // config event so ignore for now and bail out of parsing.
+          // advance data pointers to the end;
+          int counter = 0;
+          // LOGP(debug, "New Config event for : on hcid : {}  link: {} -- for IR  bc: {} orbit:{}  Trackletwords : {}", halfChamberId, currentlinkindex, mIR.bc, mIR.orbit, trackletWordsRead);
+          if (mOptions[TRDEnableConfigEvents]) {
+            // avoid filing the events unless we enable it.
+            mEventRecords.addConfigEvent(mHBFPayload, mHBFoffset32, endOfCurrentLink, configeventlength * 8, mDigitHCHeaderAll, mIR);
+          }
           mHBFoffset32 = hbfOffsetTmp + currentlinksize32;
-          mDigitWordsRejected += hbfOffsetTmp + currentlinksize32; // count full link as rejected
-          LOG(info) << "Configuration event  ";
         } else {
           auto digitsparsingstart = std::chrono::high_resolution_clock::now();
           int digitWordsRejected = 0;
+          // TODO remove this before comitting, its to speed up the parsing to get to the config events.
           int digitWordsRead = parseDigitLinkData(endOfCurrentLink - mHBFoffset32, halfChamberId, digitWordsRejected);
           std::chrono::duration<float, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - digitsparsingstart;
           if (digitWordsRead == -1) {
@@ -603,7 +621,7 @@ bool CruRawReader::processHalfCRU(int iteration)
           }
           mHBFoffset32 += digitWordsRead;
           if (endOfCurrentLink - mHBFoffset32 >= 8) {
-            // check if some data is lost (probably due to bug in CRU user logic)
+            // check if some data is lost (probably due to bug in CRU user logic, or does the)
             // we should have max 7 padding words to align the link to 256 bits
             if (mMaxWarnPrinted > 0) {
               LOGF(warn, "After successfully parsing the digit data for link %i there are %u words remaining which did not get parsed", currentlinkindex, endOfCurrentLink - mHBFoffset32);
@@ -714,6 +732,7 @@ int CruRawReader::parseDigitLinkData(int maxWords32, int hcid, int& wordsRejecte
         previousMcm = mcmHeader.mcm;
         previousRob = mcmHeader.rob;
       }
+      mEventRecords.incMCMProducedData(HelperMethods::getMCMId(hcid / 2, mcmHeader.rob, mcmHeader.mcm));
       if (mDigitHCHeader.major & 0x20) {
         // zero suppression (ZS) is ON, we expect ADC mask next
         state = StateDigitADCMask;
@@ -1068,14 +1087,14 @@ Tracklet64 CruRawReader::assembleTracklet64(int format, TrackletMCMHeader& mcmHe
 void CruRawReader::dumpInputPayload() const
 {
   // we print 8 32-bit words per line
-  LOG(info) << "Dumping full input payload ----->";
+  LOG(error) << "Dumping full input payload ----->";
   for (int iWord = 0; iWord < (mDataBufferSize / 4); iWord += 8) {
     LOGF(info, "Word %4i/%4i: 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x",
          iWord, mDataBufferSize / 4,
          *((uint32_t*)mDataBufferPtr + iWord), *((uint32_t*)mDataBufferPtr + iWord + 1), *((uint32_t*)mDataBufferPtr + iWord + 2), *((uint32_t*)mDataBufferPtr + iWord + 3),
          *((uint32_t*)mDataBufferPtr + iWord + 4), *((uint32_t*)mDataBufferPtr + iWord + 5), *((uint32_t*)mDataBufferPtr + iWord + 6), *((uint32_t*)mDataBufferPtr + iWord + 7));
   }
-  LOG(info) << "<------ Done dumping full input payload";
+  LOG(error) << "<------ Done dumping full input payload";
 }
 
 void CruRawReader::run()

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -46,6 +46,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"disable-stats", VariantType::Bool, false, {"Do not generate stat messages for qc"}},
     {"disable-root-output", VariantType::Bool, false, {"Do not write the digits and tracklets to file"}},
+    {"enable-config-events", VariantType::Bool, false, {"Permit the handling of config events"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
 }
@@ -68,6 +69,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   outputs.emplace_back("TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
+  outputs.emplace_back("TRD", "CONFEVT", 0, Lifetime::Sporadic);
 
   std::bitset<16> binaryoptions;
   binaryoptions[o2::trd::TRDVerboseBit] = cfgc.options().get<bool>("verbose");
@@ -77,6 +79,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDOnlyCalibrationTriggerBit] = cfgc.options().get<bool>("onlycalibrationtrigger");
   binaryoptions[o2::trd::TRDSortDigits] = cfgc.options().get<bool>("sortDigits");
   binaryoptions[o2::trd::TRDLinkStats] = cfgc.options().get<bool>("detailed-link-stats");
+  binaryoptions[o2::trd::TRDEnableConfigEvents] = cfgc.options().get<bool>("enable-config-events");
+
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, binaryoptions)};
   if (binaryoptions[o2::trd::TRDGenerateStats]) {

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -50,13 +50,16 @@ void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
 
 void DataReaderTask::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
+  LOG(info) << " finalise CCDB " << __func__ << " " << __LINE__;
   if (matcher == ConcreteDataMatcher("CTP", "Trig_Offset", 0)) {
     LOG(info) << " CTP/Config/TriggerOffsets updated.";
     o2::ctp::TriggerOffsetsParam::Instance().printKeyValues();
+    LOG(info) << "trigger offset done from ctp ";
     return;
   } else if (matcher == ConcreteDataMatcher("TRD", "LinkToHcid", 0)) {
     LOG(info) << "Updated Link ID to HCID mapping";
     mReader.setLinkMap((const o2::trd::LinkToHCIDMapping*)obj);
+    LOG(info) << "link to hcid mapping done ";
     return;
   }
 }
@@ -131,7 +134,8 @@ void DataReaderTask::run(ProcessingContext& pc)
       LOG(info) << "relevant vectors to read : " << mReader.getTrackletsFound() << " tracklets and " << mReader.getDigitsFound() << " compressed digits";
     }
   }
-
+  // end of time frame build a list of links that fired, in particular for major=0x47
+  // check hcid with tracklets vs hcid that had no config events.
   mReader.buildDPLOutputs(pc);
   std::chrono::duration<double, std::milli> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
   LOGP(info, "Digits: {}, Tracklets: {}, DataRead in: {:.3f} MB, Rejected: {:.3f} kB for TF {} in {} ms",

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -93,7 +93,6 @@ void EventRecordContainer::sendData(o2::framework::ProcessingContext& pc, bool g
   LOG(debug) << "Preparing for sending and sending data took  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
   if (mConfigEventPresent) {
     pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "CONFEVT", 0}, mConfigEventData);
-    // pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "CONFEVT", 0, o2::framework::Lifetime::Condition}, mConfigEventData);
   }
 }
 

--- a/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrapConfigEventParser.cxx
@@ -1,0 +1,713 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+//  TRAP config Parser                                                    //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include <fairlogger/Logger.h>
+#include "Framework/ProcessingContext.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/DataProcessorSpec.h"
+
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/HelperMethods.h"
+
+#include "TRDReconstruction/TrapConfigEventParser.h"
+
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <array>
+#include <bitset>
+#include <gsl/span>
+
+using namespace o2::trd;
+
+TrapConfigEventParser::TrapConfigEventParser()
+{
+  LOGP(info, "Creating trapconfig event object");
+  mTrapConfigEvent = std::make_unique<o2::trd::TrapConfigEvent>();
+  mMCMDataIndex.fill(-1);
+  buildAddressMap();
+}
+
+TrapConfigEventParser::~TrapConfigEventParser()
+{
+}
+
+void TrapConfigEventParser::buildAddressMap()
+{
+  LOGP(info, "Initing registers, build the map : ");
+  for (int reg = 0; reg < TrapRegisters::kLastReg; ++reg) {
+    // reindex to speed things up, this time by address, map instead of a rather large lookup table.
+    auto addr = mTrapConfigEvent.get()->getRegisterAddress(reg);
+    mTrapRegistersAddressIndexMap[addr] = reg;
+  }
+  LOGP(info, "finished buildng the map ");
+}
+bool TrapConfigEventParser::checkRegister(uint32_t& registeraddr, uint32_t& registerdata)
+{
+  mPreviousRegisterAddressRead = registeraddr;
+  int32_t numberbits = 0;
+  std::string regname = "";
+  int32_t newregidx = 0;
+  bool badregister = true;
+  getRegisterByAddr(registeraddr, regname, newregidx, numberbits);
+  // Are the registers sequential
+  if (newregidx != mLastRegIndex + 1 && newregidx != 0) {
+    if (mCurrentMCMID > constants::MAXMCMCOUNT) {
+      LOGP(warning, "MCMID is : {}, out of bounds", mCurrentMCMID);
+      return false;
+    }
+    setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventRegisterGap); // missing registers
+    for (int miss = mLastRegIndex; miss < newregidx; ++miss) {
+      mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
+    }
+    // TODO add to QC
+  }
+  mLastRegIndex = newregidx;
+  if (numberbits >= 0 || regname != "" || newregidx >= 0) {
+    // this is a bogus or unknown register
+    mCurrentRegisterIndex = newregidx;
+    if (mCurrentRegisterIndex < mPreviousRegisterIndex) {
+      setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventNoEnd);
+      mStopReg[mPreviousRegisterIndex]++;
+      mStartReg[mCurrentRegisterIndex]++;
+      // TODO add to QC
+      for (int miss = mRegistersReadForCurrentMCM; miss < newregidx; ++miss) {
+        mMissedReg[miss]++; // count the gaps, we count the start and stop point of gaps elsewhere
+                            //   mcmMissedRegister[currentrob * constants::NMCMROB + currentmcm].set(miss);
+      }
+    } else {
+      if (registeraddr != mTrapConfigEvent.get()->getRegAddrByIdx(mRegistersReadForCurrentMCM)) {
+        // if (registeraddr != std::get<1>(TrapRegisterMap[mRegistersReadForCurrentMCM]))
+        mRegisterErrorGap += abs((int)mRegistersReadForCurrentMCM - (int)newregidx) + 1; // +1 as reg index is zero based.
+        setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventNoBegin);                     // no end
+        // TODO add to QC
+        mRegistersReadForCurrentMCM = newregidx + 1;
+        for (int miss = mRegistersReadForCurrentMCM; miss < newregidx; ++miss) {
+          mMissedReg[miss]++; // count the gaps, we log the start and stop point of gaps elsewhere
+        }
+        // TODO add to QC
+      } else {
+        mRegistersReadForCurrentMCM++;
+        badregister = false;
+      }
+    }
+    mCurrentRegisterWordsCount++;
+  } else {
+    LOGP(debug, "bad register : name:'{}' newregindex:{} numberofbits:{}, lastregindex:{} registeraddr:{:08x} ?= ", regname, newregidx, numberbits, mPreviousRegisterIndex, registeraddr);
+    // TODO add to QC
+  }
+  mPreviousRegisterIndex = mCurrentRegisterIndex;
+  return badregister;
+}
+
+void TrapConfigEventParser::compareToTrackletsHCID(std::bitset<1080> trackletshcid)
+{
+  // loop over config hcid and if its not present check if the config event had tracklets.
+  // this is of course not conclusive but a start.
+  /*  for (int i = 0; i < constants::MAXCHAMBER; ++i) {
+      if (mTrapConfigEvent->isHCIDPresent(i)) {
+        if (trackletshcid.test(i)) {
+          LOGP(debug, "Config event had tracklets for hcid {}", i);
+        } else {
+          LOGP(debug, "Config event had no tracklets for hcid {}", i);
+        }
+      } else {
+        if (trackletshcid.test(i) && !mTrapConfigEvent->isHCIDPresent(i)) {
+          LOGP(debug, "No Config event but we have tracklets for HCID  {}", i);
+        }
+      }
+    }*/
+}
+
+void TrapConfigEventParser::printMCMRegisterCount(int hcid)
+{
+  int roboffset = 1;
+  if (hcid % 2 == 0) {
+    roboffset = 0;
+  }
+  std::stringstream errorMCM;
+  LOGP(info, "bp rob for hcid : {}....", hcid);
+  for (int robidx = roboffset; robidx < 8; robidx += 2) {
+    std::stringstream display;
+    display << "bp rob:" << robidx << " ";
+    for (int mcmidx = 0; mcmidx < 16; ++mcmidx) {
+      display << fmt::format("[{:04} ({:04})] ", mcmSeen[robidx * 16 + mcmidx], mcmSeenMissedRegister[robidx * constants::NROBC1 + mcmidx]);
+      if (mcmSeen[robidx * 16 + mcmidx] != 433)
+        errorMCM << fmt::format("[{:04} ({:04}) == hcid:{} mcm:{} rob:{} ] ", mcmSeen[robidx * constants::NROBC1 + mcmidx], mcmSeenMissedRegister[robidx * constants::NROBC1 + mcmidx], hcid, mcmMCM[robidx * constants::NROBC1 + mcmidx], mcmROB[robidx * constants::NROBC1 + mcmidx]);
+    }
+    LOG(info) << display.str();
+  }
+  LOG(info) << errorMCM.str();
+  LOG(info) << "bp rob ....";
+}
+
+void TrapConfigEventParser::unpackBlockHeader(uint32_t& header, uint32_t& registerdata, uint32_t& step, uint32_t& bwidth, uint32_t& nwords, uint32_t& registeraddr, uint32_t& exit_flag)
+{
+  registerdata = (header >> 2) & 0xFFFF; // 16 bit data
+  step = (header >> 1) & 0x0003;
+  bwidth = ((header >> 3) & 0x001F) + 1;
+  // check that the bit width matches what is should be
+  nwords = (header >> 8) & 0x00FF;
+  registeraddr = (header >> 16) & 0xFFFF;
+  exit_flag = (step == 0) || (step == 3) || (nwords == 0);
+}
+
+bool TrapConfigEventParser::parse(std::vector<uint32_t>& data)
+{
+  // data comes in as ir, digithcheaderall, data payload.
+  uint32_t start = 0;
+  uint32_t end = 0;
+  int position = 0;
+  while (position < data.size()) {
+    position += 2;
+    DigitHCHeader digithcheader;
+    digithcheader.word = data[position++];
+    DigitHCHeader1 digithcheader1;
+    digithcheader1.word = data[position++];
+    DigitHCHeader2 digithcheader2;
+    digithcheader2.word = data[position++];
+    DigitHCHeader3 digithcheader3;
+    digithcheader3.word = data[position++];
+    mCurrentHCTime = (int)digithcheader1.ptrigcount;
+    auto headerwords = digithcheader.numberHCW;
+    // all 4 headers are sent, unfilled ones come in as zero.
+    uint32_t length = data[position++];
+    //  printDigitHCHeader(a, &data[digithcheaderextra]);
+    mCurrentHCID = HelperMethods::getHCIDFromDigitHCHeader(digithcheader);
+    start = position;
+    end = start + length;
+    //   mTrapConfigEvent->isHCIDPresent(mCurrentHCID);
+    //   LOGP(debug, "HCIDHCIDP HC={}", mCurrentHCID);
+    if (mHCHasBeenSeen.test(mCurrentHCID)) {
+      // we have already seen this HC, so we must be on a new event.
+      LOGP(debug, "HC based analysis because of hc : {}", mCurrentHCID);
+      analyseEventBaseStats();
+      clearEventBasedStats();
+    }
+    mHCHasBeenSeen.set(mCurrentHCID);
+    parseLink(data, start, end);
+    position += end - start;
+    auto trailer1 = data[position++];
+    auto trailer2 = data[position++];
+    LOGP(debug, "Trailers : {:08x} {:08x}", trailer1, trailer2);
+  }
+  return true;
+}
+
+int TrapConfigEventParser::parseSingleData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward)
+{
+  uint32_t registerdata = (header >> 2) & 0xFFFF;  // 16 bit data
+  uint32_t registeraddr = (header >> 18) & 0x3FFF; // 14 bit address
+  uint16_t data_hi = 0;
+  uint32_t err = 0;
+  ++idx;
+  if (registeraddr != 0x1FFF) {
+    if (header & 0x02) { // check if > 16 bits
+      data_hi = data[idx];
+      LOGP(debug, "read {:08x} for data > 16 bits", data_hi);
+      ++idx;
+      err += ((data_hi ^ (registerdata | 1)) & 0xFFFF) != 0;
+      registerdata = (data_hi & 0xFFFF0000) | registerdata;
+    }
+    auto badreg = checkRegister(registeraddr, registerdata);
+    if (badreg == true) {
+      fastforward = true;
+      return false;
+    }
+    if (mCurrentMCMID < o2::trd::constants::MAXMCMCOUNT && mRegistersReadForCurrentMCM - 1 < TrapRegisters::kLastReg) {
+      LOGP(debug, "Adding single register {:08x} [{:08x}] name: {} for mcm {}, mCurrentRegisterWordsCount {} mRegistersReadForCurrentMCM:{} regindex {} with badreg:{}", registeraddr, registerdata, getRegNameByAddr(registeraddr), mCurrentMCMID, mCurrentRegisterWordsCount, mRegistersReadForCurrentMCM, idx, badreg);
+      // update frequency map:
+      if (mRegistersReadForCurrentMCM > 0) {
+        setRegister(mRegistersReadForCurrentMCM, mCurrentMCMID, registerdata);
+        auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
+        if (registerdata > regmax) {
+          LOGP(debug, "assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", registerdata, regmax, getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
+          // TODO put into QC
+          mQCData.setStopRegister(mCurrentMCMID, mRegistersReadForCurrentMCM);
+        }
+      }
+      mRegisterCount[getRegIndexByAddr(registeraddr)]++; // keep a count of seen and accepted registers
+      if (getMCMParsingStatus(mCurrentMCMID) | (kTrapConfigEventNoEnd | kTrapConfigEventAllGood)) {
+        // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
+        setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventAllGood);
+      }
+    }
+    if (idx >= end && data[idx] != constants::CONFIGEVENTBLOCKENDMARKER) {
+      LOGP(debug, "(single-write): no more data, missing end marker Config leaving parsing due to no more data at line {}", __LINE__);
+      // TOOD put into QC.
+      return false;
+    }
+
+  } else {
+    LOGP(warn, "Config while parsing leaving parsing due to 1fff as addr");
+    return err;
+  }
+
+  return true;
+}
+
+int TrapConfigEventParser::parseBlockData(std::vector<uint32_t>& data, uint32_t header, uint32_t& idx, uint32_t end, bool& fastforward)
+{
+  uint32_t step = 0, bwidth = 0, nwords = 0, err = 0, exit_flag = 0;
+  uint32_t registeraddr;
+  uint32_t registerdata;
+  uint32_t msk = 0;
+  int32_t bitcnt = 0;
+  unpackBlockHeader(header, registerdata, step, bwidth, nwords, registeraddr, exit_flag);
+  LOGP(debug, "unpacked, registeraddr:{:08x} step : {} bwidth {} nwords {} exit_flag {} registerdata {}", registeraddr, step, bwidth, nwords, exit_flag, registerdata);
+  if (isValidAddress(registeraddr)) {
+    auto trapregindex = getRegIndexByAddr(registeraddr);
+    if (bwidth != mTrapConfigEvent.get()->getRegisterNBits(trapregindex)) {
+      // check that the bit width matches what it should be
+      //  something is corrupt. What we read does not match what we expect.
+      //  log to info for now until figured out.
+      LOGP(warn, " probably corrupt data : bwidth of {} does not match expected bandwidth of {} for reg {} registeraddr of : {:08x} registerindex : {}", bwidth, mTrapConfigEvent.get()->getRegisterNBits(trapregindex), mTrapConfigEvent.get()->getRegisterName(trapregindex), registeraddr, trapregindex);
+      // TODO bail out but how far ? just mcm or whole link?
+      // TODO put into qc
+    }
+  } else {
+    LOGP(debug, "trapreg address {:08x} is not valid", registeraddr);
+    idx++;
+    // something wrong jump over this data word.
+    // TODO put into qc
+  }
+  if (exit_flag) {
+    LOGP(debug, "Exit flag found.");
+    // TODO put into qc
+    fastforward = true;
+    return err;
+  }
+  LOGP(debug, "bwidth {}: read {:08x}  ", bwidth, data[idx]);
+  if (bwidth == 31 || (bwidth > 4 && bwidth < 8) || bwidth == 10 || bwidth == 15) {
+    // TODO the part after 31 is probably not required given the above if statement of bwidth, when its out mechanism is figured out.
+    //  only possible values for blocks of registers is 5, 6, 7, 10, 15, and 31
+    msk = (1 << bwidth) - 1;
+    bitcnt = 0;
+    while (nwords > 0) {
+      if (bwidth == 31) {
+        ++idx;
+      }
+      --nwords;
+      bitcnt -= bwidth;
+      err += (data[idx] & 1);
+      if (bwidth != 31 && bitcnt < 0) { // handle the settings for when there are multiple registers packed into 1 word
+        LOGP(debug, "block next data [{}] {:08x} at line {} nwords {}", idx, data[idx], __LINE__, nwords);
+        header = data[idx];
+        idx++;
+        err += (header & 1);
+        header = header >> 1;
+        bitcnt = 31 - bwidth;
+        registerdata = header & (1 << bwidth) - 1;
+        LOGP(debug, "block next data registerdata : {:08x} header: {} bwidth {} at line {} nwords {}", registerdata, header, bwidth, idx, data[idx], __LINE__, nwords);
+      }
+      auto badreg = checkRegister(registeraddr, registerdata);
+      if (badreg == true) {
+        fastforward = true;
+        continue;
+      }
+      if (mCurrentMCMID < o2::trd::constants::MAXMCMCOUNT && mRegistersReadForCurrentMCM < TrapRegisters::kLastReg) {
+        LOGP(debug, "Adding block register {:09x} [{:08x}] name: {}  for mcm {} mCurrentRegisterWordsCount {} mRegistersReadForCurrentMCM {} regindex {} header {:08x} with badreg:{}", registeraddr, registerdata, getRegNameByAddr(registeraddr), mCurrentMCMID, mCurrentRegisterWordsCount, mRegistersReadForCurrentMCM, idx, header, badreg);
+        if (mRegistersReadForCurrentMCM > 0) {
+          setRegister(mRegistersReadForCurrentMCM, mCurrentMCMID, registerdata);
+          auto regmax = mTrapConfigEvent.get()->getRegisterMax(mRegistersReadForCurrentMCM - 1);
+          if (registerdata <= regmax) {
+            mTrapRegistersFrequencyMap[mRegistersReadForCurrentMCM - 1][registerdata]++;
+          } else {
+            LOGP(warn, "{} assumed corrupted data as register data is greater than the mask : {:08x} for max {:08x} registername : {} regaddress : {}", __LINE__, registerdata, regmax, getRegNameByIdx(mRegistersReadForCurrentMCM - 1), registeraddr);
+          }
+        }
+      } else {
+        LOGP(debug, "if statement failed for currentmcmregister {:08x}  registerdata {:08x}", mRegistersReadForCurrentMCM, registerdata);
+        // TODO send to qc. if (mCurrentMCMID < o2::trd::constants::MAXMCMCOUNT && mRegistersReadForCurrentMCM < TrapRegisters::kLastReg)
+      }
+
+      mRegisterCount[getRegIndexByAddr(registeraddr)]++; // keep a count of seen and accepted registers
+      if (getMCMParsingStatus(mCurrentMCMID) | (kTrapConfigEventAllGood | kTrapConfigEventNoEnd)) {
+        // this handles the gaps in registers, where it might be good (1) before and after the gap, but this should stay with status of gap.
+        setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventRegisterGap);
+      }
+      registeraddr += step;
+      header = header >> bwidth; // this is not used for the bwidth=31 case
+      if (idx >= end) {
+        LOGP(error, "no end markermore data, {} words read Config parsing getting out due to end of data at line : {}", idx, __LINE__);
+        return false;
+      }
+    }
+  } else {
+    // must be corrupt data header.
+    LOGP(debug, "Unknown bwidth from block header of {}", bwidth);
+    // TODO put into QC
+    setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventCorruptData);
+  }
+  if (data[idx] != constants::CONFIGEVENTBLOCKENDMARKER) {
+    LOGP(debug, "increment idx to {} due trailer of block data data[{}]={:08x} to data[{}]={:08x}", idx + 1, idx, data[idx], idx + 1, data[idx + 1]);
+    ++idx; // jump over the block trailer
+  }
+  if (data[idx + 1] == constants::CONFIGEVENTBLOCKENDMARKER || data[idx] == 0x00007fff) {
+    LOGP(debug, "end of block ignoring bogus : {:08x}?", data[idx]);
+    // TODO put into QC
+  }
+
+  return idx;
+}
+
+void TrapConfigEventParser::addMCM(const int mcmid)
+{
+  mMCMData.emplace_back(MCMEvent(mcmid));
+  mQCData.addMCM(mcmid);
+  mMCMDataIndex[mcmid] = mMCMData.size() - 1;
+}
+
+void TrapConfigEventParser::analyseEventBaseStats()
+{
+  // check which links have not produced data.
+  // check which mcm have not produced any data.
+  uint32_t mcm = 0;
+  std::stringstream missingMCM;
+  std::stringstream missingHC;
+  std::stringstream missingHCdsl;
+  uint32_t countmcm = 0;
+  uint32_t counthc = 0;
+  LOGP(info, "Analysing event based stats");
+  missingMCM << fmt::format(" missing mcm : ");
+  missingHC << fmt::format(" missing halfchambers : ");
+  while (mcm < constants::MAXMCMCOUNT) {
+    if (!mMCMHasBeenSeen.test(mcm)) {
+      missingMCM << fmt::format(" [{}", mcm); // the start of a sequence
+
+      mcm++;
+      while (mcm < constants::MAXMCMCOUNT && !mMCMHasBeenSeen.test(mcm)) {
+        // jump over a block of unseen ones
+        mcm++;
+      }
+      countmcm++;
+      missingMCM << fmt::format("-{}],", mcm - 1);
+    } else {
+      // we can ignore this mcm (for the purposes of display) as it was present
+      mcm++;
+      countmcm++;
+    }
+  }
+  // we now have a string of missing mcm in [?-?],[?-?], format
+  int hc = 0;
+  while (hc < constants::MAXHALFCHAMBER) {
+    if (!mHCHasBeenSeen.test(hc)) {
+      missingHC << fmt::format(" [{}", hc); // the start of a sequence
+      hc++;
+      while (hc < constants::MAXHALFCHAMBER && !mHCHasBeenSeen.test(hc)) {
+        // jump do nothing till we get to the next valid one ....
+        hc++;
+      }
+      counthc++;
+      missingHC << fmt::format(" -{}]", hc - 1); // the start of a sequence
+    } else {
+      // we can ignore this mcm as it was present
+      hc++;
+      counthc++;
+    }
+  }
+  // we now have a string of missing mcm in [?-?],[?-?], format
+
+  // so display them
+  LOG(info) << missingHC.str();
+  LOGP(info, " Total HalfChambers : {} ", counthc);
+  LOG(info) << missingMCM.str();
+  LOGP(info, " Total MCMs : {} ", countmcm);
+}
+
+void TrapConfigEventParser::clearEventBasedStats()
+{
+  // rest those stats that should not span a "complete" set of config events.
+  LOGP(info, "HC Count : {}", mHCHasBeenSeen.count());
+  LOGP(info, "MCM Count : {}", mMCMHasBeenSeen.count());
+  mMCMHasBeenSeen.reset();
+  mHCHasBeenSeen.reset();
+}
+
+int TrapConfigEventParser::parseLink(std::vector<uint32_t>& data, uint32_t start, uint32_t end)
+{
+  uint32_t step, bwidth, nwords, idx, err, exit_flag;
+  int32_t bitcnt, werr;
+  uint16_t registeraddr;
+  uint32_t registerdata, msk, header, data_hi, rawdat;
+  mcmSeen.fill(-1);
+  mcmMCM.fill(-1);
+  mcmROB.fill(-1);
+  mcmSeenMissedRegister.fill(-1);
+  // mcmheader, header, then data
+  idx = 0; // index in the packed configuration
+  err = 0;
+  mLastRegIndex = 0;
+  int previdx = 0;
+  int datalength = data.size();
+  bool dualmcm = false;
+  int rawidx = 0;
+  mRegisterErrorGap = 0;
+  mCurrentRegisterIndex = 0;
+  mPreviousRegisterIndex = 0;
+  bool endmarker = false;
+  bool mcmendmarker = false;
+  bool hcendmarker = false;
+  bool fastforward = false;
+  idx = start;
+  bool firstfastforward = true;
+  while (idx < end) {
+    LOGP(debug, "************** Raw data : data[{}] = {:08x}", idx, data[idx]);
+    if (fastforward) {
+      LOGP(debug, "** fastforward on data ::  Raw data : data[{}] = {:08x}", idx, data[idx]);
+      // loop until the next digitmcmheader, or end.
+      // search for :
+      //  a : end marker
+      //  b : mcmheader
+      //  c : end of data
+      while (data[idx] && fastforward) {
+        if (firstfastforward) {
+          LOGP(debug, "fastforwaring from idx:{} for mcm {}", idx, mCurrentMCMID);
+          // TODO put into qc
+          firstfastforward = false;
+        }
+        // read until we find an end marker, i gnoring the data coming in so as not to pollute the configs.
+        if (data[idx] == constants::CONFIGEVENTBLOCKENDMARKER) {
+          ++idx; // go past the end marker with the expectation of a DigitMCMHeader to come next.
+          endmarker = true;
+          fastforward = false;
+          continue;
+        } else {
+          // LOGP(warn, " no end marker found ");
+          mMcmParsingStatus[mCurrentMCMID] |= kTrapConfigEventNoEnd;
+          // TODO put into QC
+        }
+        ++idx;
+      }
+      fastforward = false;
+      continue;
+    }
+    if (idx == start || mcmendmarker) {
+      // mcm header
+      mCurrentMCMHeader.word = data[idx];
+      LOGP(debug, "header at data[{}] had : {:06} registers, last register read : {:08x} ({}) and a register gap of {}", idx, mCurrentRegisterWordsCount, mPreviousRegisterAddressRead, getRegNameByAddr(mPreviousRegisterAddressRead), mRegisterErrorGap);
+      LOGP(debug, "HC end marker ?? {:08x} {:08x} {:08x} {:08x}", data[idx], data[idx + 1], data[idx + 2], data[idx + 3]);
+
+      if (data[idx] == constants::CONFIGEVENTBLOCKENDMARKER || data[idx] == 0xeeeeeeee) {
+        LOGP(debug, " we have a the first part of a config event block end marker");
+        if (data[idx + 1] == constants::CONFIGEVENTBLOCKENDMARKER || data[idx] == 0xeeeeeeee) {
+          LOGP(debug, " yip we have a double config event block end marker");
+        }
+        while (idx < end && data[idx] == 0xeeeeeeee) {
+          idx++;
+        }
+        break; // we are done with this link;
+      }
+      // printDigitMCMHeader(mCurrentMCMHeader);
+      if (idx != start) {
+        int index = mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm;
+        if (index < constants::NMCMROB * constants::NROBC1) {
+          mcmSeen[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mCurrentRegisterWordsCount; // registers seen for this mcm
+          LOGP(debug, "mcmSeen updated at {}, with value : {} rob {} * 16 + mcm {} ", mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm, mCurrentRegisterWordsCount, (uint32_t)mCurrentMCMHeader.rob, (uint32_t)mCurrentMCMHeader.mcm);
+          mcmSeenMissedRegister[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mRegisterErrorGap; // registers missed for this mcm
+          mcmMCM[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mCurrentMCMHeader.mcm;            // registers seen for this mcm
+          mcmROB[mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm] = mCurrentMCMHeader.rob;            // registers seen for this mcm
+        }
+      }
+      mCurrentRegisterWordsCount = 0;                                                                                    // count of register words read for this mcm
+      mRegistersReadForCurrentMCM = 0;                                                                                   // count of registers read for this mcm
+      mRegisterErrorGap = 0;                                                                                             // reset the count as we are starting a fresh
+      mPreviousRegisterIndex = 0;                                                                                        // register index of the last register read.
+      mCurrentRegisterIndex = 0;                                                                                         // index of the current register
+      mCurrentMCMID = HelperMethods::getMCMId(mCurrentHCID / 2, (int)mCurrentMCMHeader.rob, (int)mCurrentMCMHeader.mcm); // (mCurrentHCID / 2) * 128 + mCurrentMCMHeader.rob * constants::NMCMROB + mCurrentMCMHeader.mcm; // current rob is 0-7/0-5 and currentmcm is 0-16.
+      LOGP(debug, "MCMMCMP MCM:{} hcid: {}   rob:{} mcm: {} idx : {} endmarker : {} eventcounter: {}", mCurrentMCMID, mCurrentHCID, (int)mCurrentMCMHeader.rob, (int)mCurrentMCMHeader.mcm, idx, endmarker, (uint32_t)mCurrentMCMHeader.eventcount);
+
+      if (mMCMHasBeenSeen.test(mCurrentMCMID)) {
+        // we are now on a new trapconfig event
+        LOGP(debug, "MCM based analysis because of mcm : {}", mCurrentMCMID);
+        // analyseEventBaseStats();
+        dualmcm = true;
+      }
+
+      mMCMHasBeenSeen.set(mCurrentMCMID);
+
+      // new mcm so add to 2 index and data.
+      addMCM(mCurrentMCMID);
+      setMCMParsingStatus(mCurrentMCMID, kTrapConfigEventAllGood);
+      if (data[idx] == 0) {
+        LOGP(debug, "Breaking as a zero after endmarker idx: {} ", idx);
+        // TODO put into QC.
+        LOGP(debug, "header at data[{}] had : {:06} registers, last register read : {:08x} ({}) and a register gap of {}", idx, mCurrentRegisterWordsCount, mPreviousRegisterAddressRead, getRegNameByAddr(mPreviousRegisterAddressRead), mRegisterErrorGap);
+        break;
+      }
+      mcmendmarker = false;
+      mLastRegIndex = 0;
+      ++idx;
+      continue; // dont parse and go back through the loop
+    }
+    if (data[idx] == 0x7fff00fe) {
+      if (data[idx + 1] == 0x0) {
+        LOGP(debug, "MCM End Marker [{}]  {:08x} {:08x} {:08x}", idx, data[idx], data[idx + 1], data[idx + 2]);
+        // end of an mcm
+        mcmendmarker = true;
+        idx += 2; // jump over both tailing markers
+        while (data[idx] == 0 && idx < end) {
+          idx++;
+        }
+        continue;
+      } else {
+        mcmendmarker = true;
+        idx++;
+        LOGP(debug, "MCM End Marker but the following 0x0 is missing");
+        while (data[idx] == 0 && idx < end) {
+          idx++;
+        }
+        while (data[idx] == 0 && idx < end) {
+          idx++;
+        }
+        continue;
+      }
+    }
+    if (data[idx] == constants::CONFIGEVENTBLOCKENDMARKER && data[idx + 1] == constants::CONFIGEVENTBLOCKENDMARKER) {
+      // end marker next value which should be a header.
+      LOGP(debug, "after end marker Header :  address:{0:08x}  words: {1:08x} width: {2:08x} astep: {3:08x} zero: {4:08x} at idx : {5:0d} gap: {6:0d}", (data[idx + 1] >> 16) & 0xffff, (data[idx + 1] >> 8) & 0xff, (data[idx + 1] >> 3) & 0x1f, (data[idx + 1] >> 1) & 0x3, data[idx + 1] & 0x1, idx, idx - previdx);
+      previdx = idx;
+      hcendmarker = true;
+      ++idx;
+      if (idx + 1 == end) {
+        // end of half chamber
+        LOGP(debug, "end of block idx : {} mcmid: {} hcid:{}", idx, mCurrentMCMID, mCurrentHCID);
+      } else {
+      }
+      if (data[idx] == constants::CONFIGEVENTBLOCKENDMARKER) {
+        ++idx; // handle the second case of the previous if statement.
+      }
+      continue;
+    }
+    header = data[idx];
+    LOGP(debug, "************** Raw data : data[{}] = {:08x} at {}", idx, data[idx], __LINE__);
+    if (header & 0x01) { // single data
+      /**********
+      SINGLE DATA
+      ***********/
+      parseSingleData(data, header, idx, end, fastforward);
+    } else {
+      /*********
+      BLOCK DATA
+      **********/
+      parseBlockData(data, header, idx, end, fastforward);
+    } // end block case
+  }   // end while
+  // printMCMRegisterCount(mCurrentHCID);
+  if (dualmcm) {
+    analyseEventBaseStats();
+    clearEventBasedStats();
+    mTrapConfigEventCounter++;
+  }
+  return false; // we only get here if the max length of the block reached
+}
+
+bool TrapConfigEventParser::setRegister(const uint32_t regidx, const uint32_t mcmid, const uint32_t registerdata)
+{
+  // check MCMEvent has said mcm.
+  int32_t index;
+  if (mcmid > constants::MAXMCMCOUNT) {
+    LOGP(warn, "MCMID is : {}", mcmid);
+    return false;
+  }
+  if (mMCMDataIndex[mcmid] == -1) {
+    // not in the index add to mcmdata and create the index :
+    LOGP(warn, "index for mcm : {} is invalid in setRegister", mcmid);
+    return false;
+  }
+  index = mMCMDataIndex[mcmid];
+  TrapRegInfo reginfo = mTrapConfigEvent.get()->getRegisterInfo(regidx - 1);
+  mMCMData[index].setRegister(registerdata, regidx - 1, reginfo);
+
+  return true;
+}
+
+const uint32_t TrapConfigEventParser::getRegister(const uint32_t regidx, const uint32_t mcmid)
+{
+  int32_t index;
+  if (mMCMDataIndex[mcmid] == -1) {
+    // not in the index add to mcmdata and create the index :
+    LOGP(warn, "index for mcm : {} is invalid in getRegister", mcmid);
+    return false;
+  }
+  index = mMCMDataIndex[mcmid];
+  uint32_t regdata = mMCMData[index].getRegister(regidx, mTrapConfigEvent.get()->getRegisterInfo(regidx));
+  return regdata;
+}
+
+int TrapConfigEventParser::flushParsingStats()
+{
+  mMcmParsingStatus.fill(-1);
+  return 0;
+}
+
+void TrapConfigEventParser::sendTrapConfigEvent(framework::ProcessingContext& pc)
+{
+  LOGP(info, "About to send message with mMCMData having size : {}", mMCMData.size());
+  pc.outputs().snapshot(framework::Output{o2::header::gDataOriginTRD, "TRDCFG", 0}, mMCMData);
+  pc.outputs().snapshot(framework::Output{o2::header::gDataOriginTRD, "TRDCFGQC", 0}, mQCData);
+  //  pc.outputs().snapshot(framework::Output{o2::header::gDataOriginTRD, "TRDCFG", 0, framework::Lifetime::Condition}, mMCMData);
+  //  pc.outputs().snapshot(framework::Output{o2::header::gDataOriginTRD, "TRDCFGQC", 0, framework::Lifetime::Condition}, mQCData);
+  mMCMData.clear();
+  mMCMDataIndex.fill(-1); // clear();
+  mQCData.clear();
+}
+
+// this is here to be able to use the on the fly index.
+const int32_t TrapConfigEventParser::getRegIndexByAddr(unsigned int addr)
+{
+  if (isValidAddress(addr)) {
+    return mTrapRegistersAddressIndexMap[addr];
+  } else
+    return -1;
+}
+
+// this is here to be able to use the on the fly index.
+bool TrapConfigEventParser::isValidAddress(uint32_t addr)
+{
+  auto search = mTrapRegistersAddressIndexMap.find(addr);
+  return (search != mTrapRegistersAddressIndexMap.end());
+}
+
+// this is here to be able to use the on the fly index.
+const std::string TrapConfigEventParser::getRegNameByAddr(uint16_t addr)
+{
+  std::string name = "";
+  if (auto search = mTrapRegistersAddressIndexMap.find(addr); search != mTrapRegistersAddressIndexMap.end()) {
+    name = mTrapConfigEvent.get()->getRegisterName(mTrapRegistersAddressIndexMap[addr]);
+  }
+  return name;
+}
+
+void TrapConfigEventParser::getRegisterByAddr(uint32_t registeraddr, std::string& regname, int32_t& newregidx, int32_t& numberbits)
+{
+  int idx = -1;
+  idx = getRegIndexByAddr(registeraddr);
+  if (idx >= 0) {
+    regname = mTrapConfigEvent.get()->getRegisterName(idx);
+    numberbits = mTrapConfigEvent.get()->getRegisterNBits(idx);
+    newregidx = idx;
+  } else {
+    regname = "";
+    numberbits = -1;
+    newregidx = -1;
+  }
+}

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -27,6 +27,7 @@
 #include "TRDBase/FeeParam.h"
 
 #include "DataFormatsTRD/TrapConfigEvent.h"
+#include "TRDSimulation/TrapConfig.h"
 #include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/RawData.h"
@@ -108,6 +109,7 @@ class TrapSimulator
 
   // Initialize MCM by the position parameters
   void init(TrapConfigEvent* trapconfig, int det, int rob, int mcm);
+  void init(TrapConfig* trapconfig, int det, int rob, int mcm);
 
   bool checkInitialized() const { return mInitialized; }
 
@@ -195,7 +197,7 @@ class TrapSimulator
 
   static bool readPackedConfig(TrapConfigEvent* cfg, int hc, unsigned int* data, int size);
 
-  // DMEM addresses
+  // DMEM addresses None of these are accesable from a trapconfig event.
   static constexpr int mgkDmemAddrLUTcor0 = 0xC02A;
   static constexpr int mgkDmemAddrLUTcor1 = 0xC028;
   static constexpr int mgkDmemAddrLUTnbins = 0xC029;
@@ -213,7 +215,9 @@ class TrapSimulator
   static constexpr int mgkDmemAddrDeflCutEnd = 0xc055;   // DMEM end address of deflection cut
   static constexpr int mgkDmemAddrTimeOffset = 0xc3fe;   // DMEM address of time offset t0
   static constexpr int mgkDmemAddrYcorr = 0xc3ff;        // DMEM address of y correction (mis-alignment)
-  static constexpr int mQ2Startbin = 3;                  // Start range of Q2, for now here. TODO pull from a revised TrapConfigEvent?
+                                                         // DMEM addresses None of these are accesable from a trapconfig event.
+
+  static constexpr int mQ2Startbin = 3;              // Start range of Q2, for now here. TODO pull from a revised TrapConfigEvent?
   static constexpr int mQ2Endbin = 5;                // End range of Q2, also pull from a revised trapconfig at some point.
 
   static const int mgkFormatIndex;   // index for format settings in stream
@@ -275,6 +279,9 @@ class TrapSimulator
   // Parameter classes
   FeeParam* mFeeParam{FeeParam::instance()}; // FEE parameters, a singleton
   TrapConfigEvent* mTrapConfigEvent{nullptr}; // TRAP config
+  TrapConfig* mTrapConfig{nullptr};           // TRAP config
+  bool mUseTrapConfigEvent{false};            // this is temporary until we fully migrate to TrapConfigEvent
+
   // wrappers for trap config events.
   uint32_t getTrapReg(uint32_t reg, uint32_t det, uint32_t rob, uint32_t mcm);
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -25,8 +25,8 @@
 #include <gsl/span>
 
 #include "TRDBase/FeeParam.h"
-#include "TRDSimulation/TrapConfig.h"
 
+#include "DataFormatsTRD/TrapConfigEvent.h"
 #include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/RawData.h"
@@ -107,7 +107,7 @@ class TrapSimulator
   ~TrapSimulator() = default;
 
   // Initialize MCM by the position parameters
-  void init(TrapConfig* trapconfig, int det, int rob, int mcm);
+  void init(TrapConfigEvent* trapconfig, int det, int rob, int mcm);
 
   bool checkInitialized() const { return mInitialized; }
 
@@ -138,7 +138,7 @@ class TrapSimulator
   int getDetector() const { return mDetector; }; // Returns Chamber ID (0-539)
   int getRobPos() const { return mRobPos; };     // Returns ROB position (0-7)
   int getMcmPos() const { return mMcmPos; };     // Returns MCM position (0-17) (16,17 are mergers)
-  int getNumberOfTimeBins() const { return mNTimeBin; }; // Set via TrapConfig, but should be the same as o2::trd::constants::TIMEBINS
+  int getNumberOfTimeBins() const { return mNTimeBin; }; // Set via TrapConfigEvent, but should be the same as o2::trd::constants::TIMEBINS
 
   // transform Tracklet64 data into raw data format (up to 4 32-bit words)
   // FIXME offset is not used, should it be removed?
@@ -189,12 +189,11 @@ class TrapSimulator
   // I/O
   void printFitRegXml(std::ostream& os) const;
   void printTrackletsXml(std::ostream& os) const;
-  void printAdcDatTxt(std::ostream& os) const;
   void printAdcDatHuman(std::ostream& os) const;
   void printAdcDatXml(std::ostream& os) const;
   void printAdcDatDatx(std::ostream& os, bool broadcast = kFALSE, int timeBinOffset = -1) const;
 
-  static bool readPackedConfig(TrapConfig* cfg, int hc, unsigned int* data, int size);
+  static bool readPackedConfig(TrapConfigEvent* cfg, int hc, unsigned int* data, int size);
 
   // DMEM addresses
   static constexpr int mgkDmemAddrLUTcor0 = 0xC02A;
@@ -214,7 +213,7 @@ class TrapSimulator
   static constexpr int mgkDmemAddrDeflCutEnd = 0xc055;   // DMEM end address of deflection cut
   static constexpr int mgkDmemAddrTimeOffset = 0xc3fe;   // DMEM address of time offset t0
   static constexpr int mgkDmemAddrYcorr = 0xc3ff;        // DMEM address of y correction (mis-alignment)
-  static constexpr int mQ2Startbin = 3;              // Start range of Q2, for now here. TODO pull from a revised TrapConfig?
+  static constexpr int mQ2Startbin = 3;                  // Start range of Q2, for now here. TODO pull from a revised TrapConfigEvent?
   static constexpr int mQ2Endbin = 5;                // End range of Q2, also pull from a revised trapconfig at some point.
 
   static const int mgkFormatIndex;   // index for format settings in stream
@@ -275,7 +274,9 @@ class TrapSimulator
 
   // Parameter classes
   FeeParam* mFeeParam{FeeParam::instance()}; // FEE parameters, a singleton
-  TrapConfig* mTrapConfig{nullptr};          // TRAP config
+  TrapConfigEvent* mTrapConfigEvent{nullptr}; // TRAP config
+  // wrappers for trap config events.
+  uint32_t getTrapReg(uint32_t reg, uint32_t det, uint32_t rob, uint32_t mcm);
 
   // Sort functions as in TRAP
   void sort2(uint16_t idx1i, uint16_t idx2i, uint16_t val1i, uint16_t val2i,

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -18,11 +18,6 @@
 #pragma link C++ class o2::trd::Detector + ;
 #pragma link C++ class o2::base::DetImpl < o2::trd::Detector> + ;
 #pragma link C++ class o2::trd::TRsim + ;
-#pragma link C++ class o2::trd::TrapConfigHandler + ;
-#pragma link C++ class o2::trd::TrapConfig + ;
-#pragma link C++ class o2::trd::TrapConfig::TrapValue + ;
-#pragma link C++ class o2::trd::TrapConfig::TrapDmemWord + ;
-#pragma link C++ class o2::trd::TrapConfig::TrapRegister + ;
 #pragma link C++ class o2::trd::TrapSimulator + ;
 // dictionaries for the internal classes of TrapSimulator are needed for the debug output
 #pragma link C++ class o2::trd::TrapSimulator::FitReg + ;
@@ -30,6 +25,8 @@
 #pragma link C++ class o2::trd::Trap2CRU + ;
 #pragma link C++ class o2::trd::SimParam + ;
 #pragma link C++ class o2::trd::TRDSimParams + ;
+#pragma link C++ class o2::trd::TrapConfig + ;
+#pragma link C++ class o2::trd::TrapConfigHandler + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDSimParams> + ;
 
 #endif

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -22,12 +22,14 @@ o2_add_library(TRDWorkflow
                        src/EntropyEncoderSpec.cxx
                        src/TrackBasedCalibSpec.cxx
                        include/TRDWorkflow/KrClustererSpec.h
+                       src/TrapConfigEventSpec.cxx
                        include/TRDWorkflow/VdAndExBCalibSpec.h
                        include/TRDWorkflow/GainCalibSpec.h
                        include/TRDWorkflow/TRDPulseHeightSpec.h
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
                        include/TRDWorkflow/T0FitSpec.h
+                       include/TRDWorkflow/ConfigEventCalibSpec.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils
                                      O2::Steer
                                      O2::Algorithm
@@ -90,6 +92,11 @@ o2_add_executable(kr-clusterer
                   COMPONENT_NAME trd
                   SOURCES src/trd-kr-clusterer.cxx
                   PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
+
+o2_add_executable(configevent-workflow
+                  COMPONENT_NAME trd
+                  SOURCES src/trd-configevent-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflow O2::DataFormatsTRD O2::TRDReconstruction)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/ConfigEventCalibSpec.h
@@ -1,0 +1,182 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_CONFIGEVENTCALIBSPEC_H
+#define O2_TRD_CONFIGEVENTCALIBSPEC_H
+
+/// \file   ConfigEventCalibSpec.h
+/// \brief DPL device for dealing with the configuration events
+
+#include "DetectorsCalibration/Utils.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/CCDBParamSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+
+#include "TRDCalibration/CalibratorConfigEvents.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "TRDQC/StatusHelper.h"
+
+#include <chrono>
+#include <unistd.h>
+#include <memory>
+
+using namespace o2::framework;
+
+namespace o2::trd
+{
+
+class ConfigEventCalibDevice : public o2::framework::Task
+{
+ public:
+  // ConfigEventCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  ConfigEventCalibDevice(bool dummy) : mIsDummy(dummy) {}
+
+  void init(o2::framework::InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    auto delay = ic.options().get<uint32_t>("max-delay");
+    mCalibrator = std::make_unique<o2::trd::CalibratorConfigEvents>();
+    if (ic.options().get<bool>("enable-root-output")) {
+      mCalibrator->createFile();
+    }
+    // we dont need to get currently valid config as we will *always* write a new one into ccdb on start of run.
+    // assuming run is long enough.
+    // TODO should the first write be quicker?
+  }
+
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
+  {
+    o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto trapConfigEvent = pc.inputs().get<const std::vector<MCMEvent>>("input");
+    const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+    // Obtain rough time from the data header (done only once)
+    if (mStartTime == 0) {
+      o2::dataformats::TFIDInfo ti;
+      o2::base::TFIDInfoHelper::fillTFIDInfo(pc, ti);
+      if (!ti.isDummy()) {
+        mStartTime = ti.creation;
+      }
+    }
+    // consume the incoming partial configuration events.
+    mCalibrator->process(trapConfigEvent);
+    if (mCalibrator->timeLimitReached()) {
+      LOGP(info, "Sending TrapConfigEvent after {} TFs seen, HCID seen {} [{:.2f}%] finalising trapconfig event comparison",
+           mNumberConfigTFsProcessed, mCalibrator->countHCIDPresent(), ((float)mCalibrator->countHCIDPresent()) / constants::NCHAMBER * 50.0);
+      mCalibrator->collapseRegisterValues();
+      if (mCalibrator->isDifferent()) {
+        sendOutput(pc.outputs());
+        mCalibrator->clearEventStructures();
+      }
+      // figure out missing mcm and hcid that we should have seen but have not yet seen.
+      std::stringstream missingMCM;
+      std::stringstream missingHCID;
+      mCalibrator->stillMissingHCID(missingHCID);
+      mCalibrator->stillMissingMCM(missingMCM);
+    }
+    ++mNumberConfigTFsProcessed;
+
+    if (pc.transitionState() == TransitionHandlingState::Requested) {
+      LOGP(info, "Run stop requested, finalizing");
+      mRunStopRequested = true;
+      mCalibrator->closeFile();
+    }
+    // sendOutput(pc.outputs());
+    // mCalibrator->clearEventStructures();
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    if (mRunStopRequested) {
+      return;
+    }
+    // TODO should I not be saving at end of stream, *if* sufficient data, i.e. like 5 minutes from last clear?
+    mCalibrator->closeFile();
+    sendOutput(ec.outputs());
+  }
+
+  void stop() final
+  {
+    mCalibrator->closeFile();
+  }
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    const auto& payload = mCalibrator->getCcdbObject();
+
+    auto clName = o2::utils::MemFileHelper::getClassName(payload);
+    auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+    std::map<std::string, std::string> metadata;
+    long startValidity = mStartTime;
+    o2::ccdb::CcdbObjectInfo info("TRD/Calib/ConfigEvent", clName, flName, metadata, startValidity, startValidity + 3 * o2::ccdb::CcdbObjectInfo::MONTH);
+
+    auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+    LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+              << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TRAPEVT", 0}, *image.get()); // o2::trd::TrapConfigEvent
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TRAPEVT", 0}, info);         // root-serialized
+  }
+
+ private:
+  std::unique_ptr<o2::trd::CalibratorConfigEvents> mCalibrator;
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  std::shared_ptr<o2::trd::TrapConfigEvent> mCCDBCurrentTrapConfigEvent;
+  bool mRunStopRequested = false; // flag that run was stopped (and the last output is sent)
+  uint64_t mStartTime = 0;
+  uint64_t mNumberConfigTFsProcessed = 0;
+  bool mIsDummy;
+};
+
+DataProcessorSpec getTRDConfigEventCalibSpec()
+{
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TRAPEVT"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRAPEVT"}, Lifetime::Sporadic);
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("input", "TRD", "TRDCFG");
+
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                                true,                           // GRPECS=true
+                                                                false,                          // GRPLHCIF
+                                                                false,                          // GRPMagField
+                                                                false,                          // askMatLUT
+                                                                o2::base::GRPGeomRequest::None, // geometry
+                                                                inputs);
+  return DataProcessorSpec{
+    "calib-confevt-calibration",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<ConfigEventCalibDevice>(false)}, // TRDConfigEventCalibSpec)},
+
+    Options{
+      {"min-to-accumulate", VariantType::Int, 900, {"time to accumulate config events before we check ccdb for a difference, in seconds."}},
+      {"enable-store-all", VariantType::Bool, false, {"store all the intermediate values"}},
+      {"max-delay", VariantType::UInt32, 2u, {"number of slots in past to consider"}},
+      {"enable-root-output", VariantType::Bool, false, {"output configs to a root file"}},
+    }};
+}
+
+} // namespace o2::trd
+
+#endif // O2_TRD_CONFIGEVENTCALIBSPEC_H

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -29,6 +29,7 @@ namespace trd
 {
 
 class TrapConfig;
+class TrapConfigEvent;
 
 class TRDDPLTrapSimulatorTask : public o2::framework::Task
 {
@@ -41,7 +42,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
 
 
  private:
-  TrapConfig* mTrapConfig{nullptr};
+  TrapConfigEvent* mTrapConfigEvent{nullptr};
   int mRunNumber{297595}; // run number to anchor simulation to.
   int mDigitDownscaling{1}; // only digits of every mDigitDownscaling-th trigger will be kept
   int mChargeScalingFactor{-1}; // can be overwritten to set custom charge scaling factor for tracklets
@@ -52,11 +53,11 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mInitCcdbObjectsDone{false}; // flag whether one time download of CCDB objects has been done
   int mNumThreads{-1};              // number of threads used for parallel processing
   std::string mTrapConfigName;      // the name of the config to be used.
-  std::string mOnlineGainTableName;
-  std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
+                                    //  std::string mOnlineGainTableName;
+                                    //  std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
 
   void initTrapConfig(long timeStamp);
-  void setOnlineGainTables();
+  // void setOnlineGainTables();
   void processTRAPchips(int& nTracklets, std::vector<Tracklet64>& trackletsAccum, std::array<TrapSimulator, constants::NMCMHCMAX>& trapSimulators, std::vector<short>& digitCounts, std::vector<int>& digitIndices);
 };
 

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TrapConfigEventSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TrapConfigEventSpec.h
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRAPCONFIGEVENTSPEC_H
+#define O2_TRD_TRAPCONFIGEVENTSPEC_H
+
+/// \file  TrapConfigEventSpec.h
+/// \brief Steers TrapConfigEvent comparison and parsing.
+/// \author Sean Murray
+
+// input TRD config events, current config from ccdb
+// output new ccdb config if required
+
+#include <vector>
+#include <array>
+#include <string>
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#include "TRDReconstruction/TrapConfigEventParser.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getTrapConfigEventSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRD_TRAPCONFIGSPEC

--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -22,6 +22,8 @@ o2_add_library(TRDWorkflowIO
                        src/TRDTrackReaderSpec.cxx
                        src/TRDCalibWriterSpec.cxx
                        src/TRDPHReaderSpec.cxx
+                       src/TRDConfigEventWriterSpec.cxx
+                       src/TRDConfigEventReaderSpec.cxx
                        include/TRDWorkflowIO/KrClusterWriterSpec.h
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD O2::SimulationDataFormat O2::DPLUtils O2::GPUDataTypeHeaders O2::DataFormatsTPC)
 
@@ -37,4 +39,12 @@ o2_add_executable(track-reader
 o2_add_executable(digittracklet-writer
                  COMPONENT_NAME trd
                  SOURCES src/trd-digittracklet-writer-workflow.cxx
+                 PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
+o2_add_executable(configevent-reader-workflow
+                 COMPONENT_NAME trd
+                 SOURCES src/trd-configevent-reader-workflow.cxx
+                 PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
+o2_add_executable(configevent-writer-workflow
+                 COMPONENT_NAME trd
+                 SOURCES src/trd-configevent-writer-workflow.cxx
                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventReaderSpec.h
@@ -1,0 +1,53 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDCONFIGEVENTREADERSPEC_H
+#define O2_TRDCONFIGEVENTREADERSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include <memory>
+#include <string>
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDConfigEventReaderSpec : public o2::framework::Task
+{
+ public:
+  TRDConfigEventReaderSpec() = default;
+  ~TRDConfigEventReaderSpec() override = default;
+  void init(o2::framework::InitContext& ic) override;
+  void run(o2::framework::ProcessingContext& pc) override;
+
+ private:
+  void connectTree();
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTreeConfigEvent;
+  std::string mFileName = "trdconfigevent.root";
+  std::string mConfigEventTreeName = "o2sim";
+  std::string mConfigEventBranchName = "TRDConfigEvent";
+  std::vector<o2::trd::TrapConfigEvent> mTrapConfigEvent, *mTrapConfigEventPtr = &mTrapConfigEvent;
+};
+
+o2::framework::DataProcessorSpec getTRDConfigEventReaderSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDCONFIGEVENTREADERSPEC_H

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDConfigEventWriterSpec.h
@@ -1,0 +1,30 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef TRDWORKFLOW_SRC_TRDCONFIGEVENTSPEC_H_
+#define TRDWORKFLOW_SRC_TRDCONFIGEVENTSPEC_H_
+
+namespace o2
+{
+namespace framework
+{
+struct DataProcessorSpec;
+} // end namespace framework
+
+namespace trd
+{
+
+o2::framework::DataProcessorSpec getTRDConfigEventWriterSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif /* TRDWORKFLOW_SRC_TRDCONFIGEVENTSPEC_H_ */

--- a/Detectors/TRD/workflow/io/src/TRDConfigEventReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDConfigEventReaderSpec.cxx
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "CommonUtils/StringUtils.h"
+#include "fairlogger/Logger.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDConfigEventReaderSpec::init(InitContext& ic)
+{
+
+  mFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                            ic.options().get<std::string>("configeventsfile"));
+  connectTree();
+}
+
+void TRDConfigEventReaderSpec::connectTree()
+{
+  mTreeConfigEvent.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(mFileName.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTreeConfigEvent.reset((TTree*)mFile->Get(mConfigEventTreeName.c_str()));
+  assert(mTreeConfigEvent);
+  mTreeConfigEvent->SetBranchAddress(mConfigEventBranchName.c_str(), &mTrapConfigEventPtr);
+  LOG(info) << "Loaded tree from " << mFileName << " with a trapconfig";
+}
+
+void TRDConfigEventReaderSpec::run(ProcessingContext& pc)
+{
+  auto currEntry = mTreeConfigEvent->GetReadEntry() + 1;
+  assert(currEntry < mTreeConfigEvent->GetEntries()); // this should not happen
+  mTreeConfigEvent->GetEntry(currEntry);
+  LOG(info) << "Pushing Trapconfig to file ";
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "CONFEVT", 1}, mTrapConfigEvent);
+  //  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "CONFEVT", 1, Lifetime::Timeframe}, mTrapConfigEvent);
+  if (mTreeConfigEvent->GetReadEntry() + 1 >= mTreeConfigEvent->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+DataProcessorSpec getTRDConfigEventReaderSpec()
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("TRD", "CFGEVT", 1, Lifetime::Timeframe);
+  return DataProcessorSpec{"TRDCONFIGEVENTREADER",
+                           Inputs{},
+                           outputs,
+                           AlgorithmSpec{adaptFromTask<TRDConfigEventReaderSpec>()},
+                           Options{
+                             {"configeventfile", VariantType::String, "trdconfigevent.root", {"Input Configuration event"}},
+                             {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+};
+
+} // end namespace trd
+} // end namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDConfigEventWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDConfigEventWriterSpec.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef CONFIGEVENT_SRC_TRDDIGITWRITERSPEC_H_
+#define CONFIGEVENT_SRC_TRDDIGITWRITERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+#include "DataFormatsTRD/Digit.h"
+#include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getTRDConfigEventWriterSpec()
+{
+  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  using DataRef = framework::DataRef;
+  LOGP(info, " ZZZ writing config event to root file");
+
+  return MakeRootTreeWriterSpec("TRDConfigEventWriter",
+                                "trdconfigevents.root",
+                                "o2sim",
+                                // setting a custom callback for closing the writer
+                                BranchDefinition<o2::trd::TrapConfigEvent>{InputSpec{"trapconfig", o2::header::gDataOriginTRD, "TRDCFG"}, "ConfigEvent"})();
+}
+
+} // end namespace trd
+} // end namespace o2
+
+#endif /* CONFIGEVENT_SRC_TRDDIGITWRITERSPEC_H_ */

--- a/Detectors/TRD/workflow/io/src/trd-configevent-reader-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-configevent-reader-workflow.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDConfigEventReaderSpec());
+  return specs;
+}

--- a/Detectors/TRD/workflow/io/src/trd-configevent-writer-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-configevent-writer-workflow.cxx
@@ -1,0 +1,52 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+// this is simply to enable one to write out the tracklet and digits and triggers after reading in the ctf
+// to do a comparison pre and post ctf. Use case is probably only unit tests.
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDConfigEventWriterSpec());
+  return specs;
+}

--- a/Detectors/TRD/workflow/src/TrapConfigEventSpec.cxx
+++ b/Detectors/TRD/workflow/src/TrapConfigEventSpec.cxx
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   TrapConfigEventSpec.cxx
+/// \brief  DPL device for handling the trap configuration events
+/// \author Sean Murray
+
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include <fairlogger/Logger.h>
+
+#include "TRDReconstruction/TrapConfigEventParser.h"
+#include "TRDWorkflow/TrapConfigEventSpec.h"
+#include "DataFormatsTRD/TrapConfigEvent.h"
+
+#include "TStopwatch.h"
+#include "TFile.h"
+
+using namespace o2::framework;
+
+namespace o2::trd
+{
+
+class TrapConfigEventDevice : public Task
+{
+ public:
+  TrapConfigEventDevice() = default;
+  ~TrapConfigEventDevice() = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::trd::TrapConfigEventParser mTrapConfigEventParser;
+  std::bitset<constants::MAXHALFCHAMBER> mOldHalfChamberPresent; // keep a store of which half chambers have been seen so far.
+  uint32_t mConfigCounter = 0;
+};
+
+void TrapConfigEventDevice::init(InitContext& ic)
+{
+  mTrapConfigEventParser.init();
+  mOldHalfChamberPresent.set(0);
+  mConfigCounter = 0;
+}
+
+void TrapConfigEventDevice::run(ProcessingContext& pc)
+{
+  TStopwatch timer;
+
+  std::vector<uint32_t> configdata = pc.inputs().get<std::vector<uint32_t>>("trapconfigs");
+
+  LOGP(info, " Config event coming in with size : {}", configdata.size());
+  timer.Start();
+  mTrapConfigEventParser.parse(configdata);
+  timer.Stop();
+  int mcmsparsed = configdata.size() / 433;
+  LOGP(info, "TRD config event took:  Cpu: {:.3} s Real: {:.3} s mcms parsed : {} halfchambers with data : {} [{:.2f}%], and a datasize of {:.2f} MB", timer.CpuTime(), timer.RealTime(), mcmsparsed, mTrapConfigEventParser.countHCIDPresent(), ((float)mTrapConfigEventParser.countHCIDPresent()) / constants::NCHAMBER * 50.0, (((float)configdata.size()) / 1024. / 1024.));
+
+  mOldHalfChamberPresent = mTrapConfigEventParser.countHCIDPresent();
+  // send a timeframes worth of config events
+  LOGP(info, "We have a new config and sending ....");
+  mTrapConfigEventParser.sendTrapConfigEvent(pc);
+  mConfigCounter++;
+}
+
+void TrapConfigEventDevice::endOfStream(EndOfStreamContext& ec)
+{
+  LOG(info) << "Finished with TRD Trap Config event (EoS received)";
+}
+
+DataProcessorSpec getTrapConfigEventSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("trapconfigs", ConcreteDataTypeMatcher{o2::header::gDataOriginTRD, "CONFEVT"}, Lifetime::Sporadic);
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRDCFG", 0, Lifetime::Condition);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRDCFGQC", 0, Lifetime::Condition);
+  LOGP(info, " done inputs and outputs of getTrapConfigEventSpec");
+  return DataProcessorSpec{
+    "trd-configevents",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TrapConfigEventDevice>()},
+    Options{}};
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -13,10 +13,12 @@
 #include "TRDWorkflowIO/TRDCalibReaderSpec.h"
 #include "TRDWorkflowIO/TRDDigitReaderSpec.h"
 #include "TRDWorkflowIO/TRDPHReaderSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventReaderSpec.h"
 #include "TRDWorkflow/VdAndExBCalibSpec.h"
 #include "TRDWorkflow/GainCalibSpec.h"
 #include "TRDWorkflow/NoiseCalibSpec.h"
 #include "TRDWorkflow/T0FitSpec.h"
+#include "TRDWorkflow/ConfigEventCalibSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
@@ -31,8 +33,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"noise", o2::framework::VariantType::Bool, false, {"enable noise and pad status calibration"}},
     {"gain", o2::framework::VariantType::Bool, false, {"enable gain calibration"}},
     {"t0", o2::framework::VariantType::Bool, false, {"enable t0 fit"}},
+    {"configevents", o2::framework::VariantType::Bool, false, {"enable config even handling"}},
     {"calib-dds-collection-index", VariantType::Int, -1, {"allow only single collection to produce calibration objects (use -1 for no limit)"}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+  };
 
   std::swap(workflowOptions, options);
 }
@@ -85,6 +89,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       specs.emplace_back(o2::trd::getTRDPHReaderSpec());
     }
     specs.emplace_back(getTRDT0FitSpec());
+  }
+
+  if (configcontext.options().get<bool>("configevents")) {
+    if (enableRootInp) {
+      specs.emplace_back(o2::trd::getTRDConfigEventReaderSpec());
+    }
+    specs.emplace_back(o2::trd::getTRDConfigEventCalibSpec());
   }
 
   return specs;

--- a/Detectors/TRD/workflow/src/trd-configevent-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-configevent-workflow.cxx
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "TRDWorkflow/TrapConfigEventSpec.h"
+#include "TRDWorkflowIO/TRDConfigEventWriterSpec.h"
+#include "TRDReconstruction/TrapConfigEventParser.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+/*void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}*/
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  // o2::conf::ConfigurableParam::writeINI("o2trapconfig_workflow_configuration.ini");
+
+  o2::framework::WorkflowSpec specs;
+  /*
+    // input
+    if (!configcontext.options().get<bool>("disable-root-input")) {
+      specs.emplace_back(o2::trd::getTRDTrapConfigRawReaderReaderSpec(false));
+    }
+  */
+  // processing devices
+  specs.emplace_back(o2::trd::getTrapConfigEventSpec());
+
+  // if (!configcontext.options().get<bool>("disable-root-output")) {
+  //   specs.emplace_back(o2::trd::getTRDConfigEventWriterSpec());
+  // }
+
+  return specs;
+}

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -30,6 +30,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             Detectors/TRD/base/macros/PrintTrapConfig.C
             Detectors/TRD/base/macros/TestTrapSim.C
             Detectors/TRD/macros/convertRun2ToRun3Digits.C
+            Detectors/TRD/macros/CheckConfigEvent.C
             Detectors/TRD/simulation/macros/CheckTRDFST.C
             Detectors/gconfig/g4Config.C
             Detectors/TRD/macros/ParseTrapRawOutput.C


### PR DESCRIPTION
Implement calibration flow for trap config processing.

rawreader does not yet send active mcm or hcid yet.
rawreader sends raw blobs to parser. 
parser sends mcmevent to calibrator.
calibrator saves initial config for run, accumulates and at predetermined time compares to ccdb and if changes saves new one.


qc to come seperately.

- [x] fix trapsim to can use old config
- [x] fix version locking of trapregisters class and mcmevent stored.
- [x] time frequency of comparison.
- [ ] naming of configs in ccdb
- [ ] active mcm and active hcid to determine complete event, should possibly ultimately come from elsewhere.
- [x] speed up.
- [x] clean up. some legacy code can come out.