### PR TITLE
MCH: fix bad-channels-ccdb metadata default type

### DIFF
--- a/Detectors/MUON/MCH/Conditions/src/bad-channels-ccdb.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/bad-channels-ccdb.cxx
@@ -80,7 +80,8 @@ void uploadBadChannels(const std::string ccdbUrl,
             << dest << "\n";
 
   if (makeDefault) {
-    md["default"] = true;
+    md["default"] = "true";
+    md["Created"] = "1";
   }
   api.storeAsTFileAny(&bv, dest, md, startTimestamp, endTimestamp);
 }


### PR DESCRIPTION
and add Created metadata tag for default object.