### PR TITLE
DPL: Use ALIEN_PROC_ID to know we run on Grid

### DIFF
--- a/Framework/Core/src/DefaultsHelpers.cxx
+++ b/Framework/Core/src/DefaultsHelpers.cxx
@@ -55,7 +55,7 @@ static DeploymentMode getDeploymentMode_internal()
       throw std::runtime_error("Invalid deployment mode");
     }
   }
-  return getenv("DDS_SESSION_ID") != nullptr ? DeploymentMode::OnlineDDS : (getenv("OCC_CONTROL_PORT") != nullptr ? DeploymentMode::OnlineECS : (getenv("ALIEN_JOB_ID") != nullptr ? DeploymentMode::Grid : (getenv("ALICE_O2_FST") ? DeploymentMode::FST : (DeploymentMode::Local))));
+  return getenv("DDS_SESSION_ID") != nullptr ? DeploymentMode::OnlineDDS : (getenv("OCC_CONTROL_PORT") != nullptr ? DeploymentMode::OnlineECS : (getenv("ALIEN_PROC_ID") != nullptr ? DeploymentMode::Grid : (getenv("ALICE_O2_FST") ? DeploymentMode::FST : (DeploymentMode::Local))));
 }
 
 DeploymentMode DefaultsHelpers::deploymentMode()


### PR DESCRIPTION
According to Catalin ALIEN_PROC_ID is there is every grid job, ALIEN_JOB_ID is probably a typo.