### PR TITLE
Fix TRD pile-up information

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalT0.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalT0.h
@@ -63,7 +63,7 @@ class CalT0
   std::array<float, constants::MAXCHAMBER> mT0{}; ///< calibrated T0 per TRD chamber
   float mT0av{-1};                                ///< average T0 obtained from fitting the PH data from all chambers combined
 
-  ClassDefNV(CalT0, 1);
+  ClassDefNV(CalT0, 2);
 };
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -22,7 +22,7 @@ namespace trd
 void Tracklet64::print() const
 {
   LOGF(info, "%02i_%i_%i, ROB(%i), MCM(%i), row(%i), col(%i), position(%i), slope(%i), pid(%i), q0(%i), q1(%i), q2(%i). Format(%i)",
-       HelperMethods::getSector(getDetector()), HelperMethods::getStack(getDetector()), HelperMethods::getLayer(getDetector()), getROB(), getMCM(), getPadRow(), getColumn(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2(), getFormat());
+       HelperMethods::getSector(getDetector()), HelperMethods::getStack(getDetector()), HelperMethods::getLayer(getDetector()), getROB(), getMCM(), getPadRow(), getPadCol(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2(), getFormat());
 }
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/Detectors/TRD/calibration/src/PulseHeight.cxx
+++ b/Detectors/TRD/calibration/src/PulseHeight.cxx
@@ -92,16 +92,19 @@ void PulseHeight::process()
         const auto& trigTrack = (*trackTriggers)[iTrigTrack];
         if (trigTrack.getBCData().differenceInBC(trig.getBCData()) > 0) {
           // aborting, since track trigger is later than digit trigger";
+          LOGP(debug, "Aborting, track trigger is too late");
           break;
         }
         if (trigTrack.getBCData() != trig.getBCData()) {
           // skipping, since track trigger earlier than digit trigger";
+          LOGP(debug, "Skipping, track trigger is too late");
           ++lastTrkTrig[iTrackType];
           continue;
         }
         if ((*tracks)[trigTrack.getFirstTrack()].hasPileUpInfo() && (*tracks)[trigTrack.getFirstTrack()].getPileUpTimeShiftMUS() < mParams.pileupCut) {
           // rejecting triggers which are close to other collisions (avoid pile-up)
           ++lastTrkTrig[iTrackType];
+          LOGP(debug, "Rececting trigger due to pileup of {}", (*tracks)[trigTrack.getFirstTrack()].getPileUpTimeShiftMUS());
           break;
         }
         for (int iTrk = trigTrack.getFirstTrack(); iTrk < trigTrack.getFirstTrack() + trigTrack.getNumberOfTracks(); iTrk++) {
@@ -125,8 +128,13 @@ void PulseHeight::process()
 void PulseHeight::findDigitsForTracklet(const Tracklet64& trklt, const TriggerRecord& trig, int type)
 {
   auto trkltDet = trklt.getDetector();
-  for (int iDigit = trig.getFirstDigit() + 1; iDigit < trig.getFirstDigit() + trig.getNumberOfDigits() - 1; ++iDigit) {
+  int iDigitFirst = trig.getFirstDigit();
+  int iDigitLast = trig.getFirstDigit() + trig.getNumberOfDigits();
+  for (int iDigit = iDigitFirst + 1; iDigit < iDigitLast - 1; ++iDigit) {
     const auto& digit = (*mDigits)[iDigit];
+    if (digit.isSharedDigit()) {
+      continue; // avoid double-counting of the same digit
+    }
     if (digit.getDetector() != trkltDet || digit.getPadRow() != trklt.getPadRow() || digit.getPadCol() != trklt.getPadCol()) {
       // for now we loose charge information from padrow-crossing tracklets (~15% of all tracklets)
       continue;
@@ -134,38 +142,45 @@ void PulseHeight::findDigitsForTracklet(const Tracklet64& trklt, const TriggerRe
     int nNeighbours = 0;
     bool left = false;
     bool right = false;
-    const auto& digitLeft = (*mDigits)[iDigit - 1];
-    const auto& digitRight = (*mDigits)[iDigit + 1];
+    const auto* digitLeft = &(*mDigits)[iDigit + 1];
+    const auto* digitRight = &(*mDigits)[iDigit - 1];
+    // due to shared digits the neighbouring element might still be in the same pad column
+    if (digitLeft->getPadCol() == digit.getPadCol() && iDigit < iDigitLast - 2) {
+      digitLeft = &(*mDigits)[iDigit + 2];
+    }
+    if (digitRight->getPadCol() == digit.getPadCol() && iDigit > iDigitFirst + 2) {
+      digitRight = &(*mDigits)[iDigit - 2];
+    }
     LOG(debug) << "Central digit: " << digit;
-    LOG(debug) << "Left digit: " << digitLeft;
-    LOG(debug) << "Right digit: " << digitRight;
-    if (digitLeft.isNeighbour(digit) && digitLeft.getChannel() < digit.getChannel()) {
+    LOG(debug) << "Left digit: " << *digitLeft;
+    LOG(debug) << "Right digit: " << *digitRight;
+    if (digitLeft->isNeighbour(digit) && digitLeft->getPadCol() > digit.getPadCol()) {
       ++nNeighbours;
       left = true;
     }
-    if (digitRight.isNeighbour(digit) && digitRight.getChannel() > digit.getChannel()) {
+    if (digitRight->isNeighbour(digit) && digitRight->getPadCol() < digit.getPadCol()) {
       ++nNeighbours;
       right = true;
     }
     if (nNeighbours > 0) {
       int digitTrackletDistance = 0;
       auto adcSumMax = digit.getADCsum();
-      if (left && digitLeft.getADCsum() > adcSumMax) {
-        adcSumMax = digitLeft.getADCsum();
+      if (left && digitLeft->getADCsum() > adcSumMax) {
+        adcSumMax = digitLeft->getADCsum();
         digitTrackletDistance = 1;
       }
-      if (right && digitRight.getADCsum() > adcSumMax) {
-        adcSumMax = digitRight.getADCsum();
+      if (right && digitRight->getADCsum() > adcSumMax) {
+        adcSumMax = digitRight->getADCsum();
         digitTrackletDistance = -1;
       }
       mDistances.push_back(digitTrackletDistance);
       for (int iTb = 0; iTb < TIMEBINS; ++iTb) {
         uint16_t phVal = digit.getADC()[iTb];
         if (left) {
-          phVal += digitLeft.getADC()[iTb];
+          phVal += digitLeft->getADC()[iTb];
         }
         if (right) {
-          phVal += digitRight.getADC()[iTb];
+          phVal += digitRight->getADC()[iTb];
         }
         mPHValues.emplace_back(phVal, trkltDet, iTb, nNeighbours, type);
       }

--- a/Detectors/TRD/calibration/src/PulseHeight.cxx
+++ b/Detectors/TRD/calibration/src/PulseHeight.cxx
@@ -154,11 +154,13 @@ void PulseHeight::findDigitsForTracklet(const Tracklet64& trklt, const TriggerRe
     LOG(debug) << "Central digit: " << digit;
     LOG(debug) << "Left digit: " << *digitLeft;
     LOG(debug) << "Right digit: " << *digitRight;
-    if (digitLeft->isNeighbour(digit) && digitLeft->getPadCol() > digit.getPadCol()) {
+    int direction = 0;
+    if (digitLeft->isNeighbour(digit)) {
       ++nNeighbours;
       left = true;
+      direction = digit.getPadCol() - digitLeft->getPadCol();
     }
-    if (digitRight->isNeighbour(digit) && digitRight->getPadCol() < digit.getPadCol()) {
+    if (digitRight->isNeighbour(digit) && digit.getPadCol() - digitRight->getPadCol() != direction) {
       ++nNeighbours;
       right = true;
     }

--- a/GPU/GPUTracking/DataTypes/GPUTRDInterfaceO2Track.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDInterfaceO2Track.h
@@ -77,10 +77,11 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
 
   GPUdi() void setPileUpDistance(unsigned char bwd, unsigned char fwd) { setUserField((((unsigned short)bwd) << 8) | fwd); }
   GPUdi() bool hasPileUpInfo() const { return getUserField() != 0; }
-  GPUdi() unsigned char getPileUpDistanceBwd() const { return ((unsigned char)getUserField()) >> 8; }
-  GPUdi() unsigned char getPileUpDistanceFwd() const { return ((unsigned char)getUserField()) & 255; }
+  GPUdi() bool hasPileUpInfoBothSides() const { return getPileUpDistanceBwd() > 0 && getPileUpDistanceFwd() > 0; }
+  GPUdi() unsigned char getPileUpDistanceBwd() const { return getUserField() >> 8; }
+  GPUdi() unsigned char getPileUpDistanceFwd() const { return getUserField() & 255; }
   GPUdi() unsigned short getPileUpSpan() const { return ((unsigned short)getPileUpDistanceBwd()) + getPileUpDistanceFwd(); }
-  GPUdi() float getPileUpMean() const { return 0.5 * ((float)getPileUpDistanceFwd()) - ((float)getPileUpDistanceBwd()); }
+  GPUdi() float getPileUpMean() const { return hasPileUpInfoBothSides() ? 0.5 * (getPileUpDistanceFwd() + getPileUpDistanceBwd()) : getPileUpDistanceFwd() + getPileUpDistanceBwd(); }
   GPUdi() float getPileUpTimeShiftMUS() const { return getPileUpMean() * o2::constants::lhc::LHCBunchSpacingMUS; }
   GPUdi() float getPileUpTimeErrorMUS() const { return getPileUpSpan() * o2::constants::lhc::LHCBunchSpacingMUS / 3.4641016; }
 


### PR DESCRIPTION
@shahor02 the problem was simply that in case there is another collision in one direction in time but not in the other the calculation of the mean distance introduced an erroneous factor 0.5. Otherwise everything looks good