### PR TITLE
Fix missing include

### DIFF
--- a/Utilities/rANS/include/rANS/serialize.h
+++ b/Utilities/rANS/include/rANS/serialize.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <cstdint>
 #include <stdexcept>
+#include <optional>
 
 #ifdef RANS_ENABLE_JSON
 #include <rapidjson/writer.h>


### PR DESCRIPTION
depending on abseil version, <optional> is missing