### PR TITLE
Add TPC trigger info to CTF and corresponding reader and writer

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -37,6 +37,7 @@ namespace o2::tpc
 class TrackTPC;
 using TPCClRefElem = uint32_t;
 struct ClusterNativeAccess;
+struct TriggerInfoDLBZS;
 namespace internal
 {
 struct getWorkflowTPCInput_ret;
@@ -224,6 +225,7 @@ struct DataRequest {
   void requestITSClusters(bool mc);
   void requestMFTClusters(bool mc);
   void requestTPCClusters(bool mc);
+  void requestTPCTriggers();
   void requestTOFClusters(bool mc);
   void requestTRDTracklets(bool mc);
   void requestMCHClusters(bool mc);
@@ -370,6 +372,7 @@ struct RecoContainer {
   void addITSClusters(o2::framework::ProcessingContext& pc, bool mc);
   void addMFTClusters(o2::framework::ProcessingContext& pc, bool mc);
   void addTPCClusters(o2::framework::ProcessingContext& pc, bool mc, bool shmap);
+  void addTPCTriggers(o2::framework::ProcessingContext& pc);
   void addTOFClusters(o2::framework::ProcessingContext& pc, bool mc);
   void addHMPClusters(o2::framework::ProcessingContext& pc, bool mc);
   void addTRDTracklets(o2::framework::ProcessingContext& pc, bool mc);
@@ -535,6 +538,7 @@ struct RecoContainer {
   auto getTPCTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
   const o2::tpc::ClusterNativeAccess& getTPCClusters() const;
   const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* getTPCClustersMCLabels() const;
+  auto getTPCTriggers() const { return getSpan<o2::tpc::TriggerInfoDLBZS>(GTrackID::TPC, MATCHES); }
 
   // ITS-TPC
   const o2::dataformats::TrackTPCITS& getTPCITSTrack(GTrackID gid) const { return getTrack<o2::dataformats::TrackTPCITS>(gid); }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -17,6 +17,7 @@
 #include "Framework/InputSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DataFormatsTPC/WorkflowHelper.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
 #include "DataFormatsTRD/RecoInputContainer.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITS/TrackITS.h"

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -250,6 +250,9 @@ void DataRequest::requestMFTClusters(bool mc)
 void DataRequest::requestTPCClusters(bool mc)
 {
   addInput({"clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe});
+  if (!getenv("DPL_DISABLE_TPC_TRIGGER_READER") || atoi(getenv("DPL_DISABLE_TPC_TRIGGER_READER")) != 1) {
+    requestTPCTriggers();
+  }
   if (requestMap.find("trackTPC") != requestMap.end()) {
     addInput({"clusTPCshmap", "TPC", "CLSHAREDMAP", 0, Lifetime::Timeframe});
   }
@@ -257,6 +260,12 @@ void DataRequest::requestTPCClusters(bool mc)
     addInput({"clusTPCMC", ConcreteDataTypeMatcher{"TPC", "CLNATIVEMCLBL"}, Lifetime::Timeframe});
   }
   requestMap["clusTPC"] = mc;
+}
+
+void DataRequest::requestTPCTriggers()
+{
+  addInput({"trigTPC", "TPC", "TRIGGERWORDS", 0, Lifetime::Timeframe});
+  requestMap["trigTPC"] = false;
 }
 
 void DataRequest::requestTOFClusters(bool mc)
@@ -672,6 +681,11 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
     addTPCClusters(pc, req->second, reqMap.find("trackTPC") != reqMap.end());
   }
 
+  req = reqMap.find("trigTPC");
+  if (req != reqMap.end()) {
+    addTPCTriggers(pc);
+  }
+
   req = reqMap.find("clusTOF");
   if (req != reqMap.end()) {
     addTOFClusters(pc, req->second);
@@ -1052,6 +1066,12 @@ void RecoContainer::addTPCClusters(ProcessingContext& pc, bool mc, bool shmap)
   if (shmap) {
     clusterShMapTPC = pc.inputs().get<gsl::span<unsigned char>>("clusTPCshmap");
   }
+}
+
+//__________________________________________________________
+void RecoContainer::addTPCTriggers(ProcessingContext& pc)
+{
+  commonPool[GTrackID::TPC].registerContainer(pc.inputs().get<gsl::span<o2::tpc::TriggerInfoDLBZS>>("trigTPC"), MATCHES);
 }
 
 //__________________________________________________________

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
@@ -27,14 +27,15 @@ namespace tpc
 struct CTFHeader : public ctf::CTFDictHeader, public CompressedClustersCounters {
   enum : uint32_t { CombinedColumns = 0x1 };
   uint32_t flags = 0;
-
-  ClassDefNV(CTFHeader, 2);
+  uint32_t firstOrbitTrig = 0; /// orbit of 1st trigger
+  uint16_t nTriggers = 0;      /// number of triggers
+  ClassDefNV(CTFHeader, 3);
 };
 
 /// wrapper for the Entropy-encoded clusters of the TF
-struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 23, uint32_t> {
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 26, uint32_t> {
 
-  using container_t = o2::ctf::EncodedBlocks<CTFHeader, 23, uint32_t>;
+  using container_t = o2::ctf::EncodedBlocks<CTFHeader, 26, uint32_t>;
 
   static constexpr size_t N = getNBlocks();
   static constexpr int NBitsQTot = 16;
@@ -66,9 +67,14 @@ struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 23, uint32_t> {
                BLCsigmaPadU,
                BLCsigmaTimeU, // can be combined with BLCsigmaPadU
                BLCnTrackClusters,
-               BLCnSliceRowClusters };
+               BLCnSliceRowClusters,
+               // trigger info
+               BLCTrigOrbitInc,
+               BLCTrigBCInc,
+               BLCTrigType
+  };
 
-  ClassDefNV(CTF, 2);
+  ClassDefNV(CTF, 4);
 };
 
 } // namespace tpc

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
@@ -102,6 +102,8 @@ struct TriggerWordDLBZS {
   uint16_t getTriggerBC(int entry = 0) const { return triggerEntries[entry] & 0xFFF; }
   uint16_t getTriggerType(int entry = 0) const { return (triggerEntries[entry] >> 12) & 0x7; }
   bool isValid(int entry = 0) const { return triggerEntries[entry] & 0x8000; }
+
+  ClassDefNV(TriggerWordDLBZS, 1);
 };
 
 /// Trigger info including the orbit

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -70,6 +70,7 @@
 #pragma link C++ class o2::tpc::dcs::DataPointVector < o2::tpc::dcs::HV::StackState> + ;
 #pragma link C++ class o2::tpc::dcs::Gas + ;
 #pragma link C++ class o2::tpc::PIDResponse + ;
+#pragma link C++ class o2::tpc::TriggerWordDLBZS + ;
 #pragma link C++ class o2::tpc::TriggerInfoDLBZS + ;
 #pragma link C++ class std::vector < o2::tpc::TriggerInfoDLBZS> + ;
 

--- a/Detectors/CTF/test/test_ctf_io_tpc.cxx
+++ b/Detectors/CTF/test/test_ctf_io_tpc.cxx
@@ -20,6 +20,7 @@
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/dataset.hpp>
 #include "DataFormatsTPC/CompressedClusters.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
 #include "DataFormatsTPC/CTF.h"
 #include "CommonUtils/NameConf.h"
 #include "TPCReconstruction/CTFCoder.h"
@@ -37,11 +38,20 @@ inline std::vector<bool> CombineColumns(true, false);
 
 BOOST_DATA_TEST_CASE(CTFTest, boost_data::make(ANSVersions) ^ boost_data::make(CombineColumns), ansVersion, combineColumns)
 {
+  std::vector<o2::tpc::TriggerInfoDLBZS> triggers, triggersR;
   CompressedClusters c;
   c.nAttachedClusters = 99;
   c.nUnattachedClusters = 88;
   c.nAttachedClustersReduced = 77;
   c.nTracks = 66;
+
+  triggers.emplace_back();
+  triggers.back().orbit = 1234;
+  triggers.back().triggerWord.triggerEntries[0] = (10 & 0xFFF) | ((o2::tpc::TriggerWordDLBZS::TriggerType::PhT & 0x7) << 12) | 0x8000;
+  triggers.back().triggerWord.triggerEntries[1] = (30 & 0xFFF) | ((o2::tpc::TriggerWordDLBZS::TriggerType::PP & 0x7) << 12) | 0x8000;
+  triggers.emplace_back();
+  triggers.back().orbit = 1236;
+  triggers.back().triggerWord.triggerEntries[0] = (40 & 0xFFF) | ((o2::tpc::TriggerWordDLBZS::TriggerType::Cal & 0x7) << 12) | 0x8000;
 
   std::vector<char> bVec;
   CompressedClustersFlat* ccFlat = nullptr;
@@ -96,10 +106,43 @@ BOOST_DATA_TEST_CASE(CTFTest, boost_data::make(ANSVersions) ^ boost_data::make(C
   sw.Start();
   std::vector<o2::ctf::BufferType> vecIO;
   {
-    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.setCombineColumns(combineColumns);
     coder.setANSVersion(ansVersion);
-    coder.encode(vecIO, c, c); // compress
+    // prepare trigger info
+    o2::tpc::detail::TriggerInfo trigComp;
+    for (const auto& trig : triggers) {
+      for (int it = 0; it < o2::tpc::TriggerWordDLBZS::MaxTriggerEntries; it++) {
+        if (trig.triggerWord.isValid(it)) {
+          trigComp.deltaOrbit.push_back(trig.orbit);
+          trigComp.deltaBC.push_back(trig.triggerWord.getTriggerBC(it));
+          trigComp.triggerType.push_back(trig.triggerWord.getTriggerType(it));
+        } else {
+          break;
+        }
+      }
+    }
+    // transform trigger info to differential form
+    uint32_t prevOrbit = -1;
+    uint16_t prevBC = -1;
+    if (trigComp.triggerType.size()) {
+      prevOrbit = trigComp.firstOrbit = trigComp.deltaOrbit[0];
+      prevBC = trigComp.deltaBC[0];
+      trigComp.deltaOrbit[0] = 0;
+      for (size_t it = 1; it < trigComp.triggerType.size(); it++) {
+        if (trigComp.deltaOrbit[it] == prevOrbit) {
+          auto bc = trigComp.deltaBC[it];
+          trigComp.deltaBC[it] -= prevBC;
+          prevBC = bc;
+          trigComp.deltaOrbit[it] = 0;
+        } else {
+          auto orb = trigComp.deltaOrbit[it];
+          trigComp.deltaOrbit[it] -= prevOrbit;
+          prevOrbit = orb;
+        }
+      }
+    }
+    coder.encode(vecIO, c, c, trigComp); // compress
   }
   sw.Stop();
   LOG(info) << "Compressed in " << sw.CpuTime() << " s";
@@ -135,7 +178,7 @@ BOOST_DATA_TEST_CASE(CTFTest, boost_data::make(ANSVersions) ^ boost_data::make(C
   {
     CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.setCombineColumns(true);
-    coder.decode(ctfImage, vecIn); // decompress
+    coder.decode(ctfImage, vecIn, triggersR); // decompress
   }
   sw.Stop();
   LOG(info) << "Decompressed in " << sw.CpuTime() << " s";
@@ -153,4 +196,6 @@ BOOST_DATA_TEST_CASE(CTFTest, boost_data::make(ANSVersions) ^ boost_data::make(C
   BOOST_CHECK(countOrig->solenoidBz == countDeco->solenoidBz);
   BOOST_CHECK(countOrig->maxTimeBin == countDeco->maxTimeBin);
   BOOST_CHECK(memcmp(vecIn.data() + sizeof(o2::tpc::CompressedClustersCounters), bVec.data() + sizeof(o2::tpc::CompressedClustersCounters), bVec.size() - sizeof(o2::tpc::CompressedClustersCounters)) == 0);
+  BOOST_CHECK(triggers.size() == triggersR.size());
+  BOOST_CHECK(memcmp(triggers.data(), triggersR.data(), triggers.size() * sizeof(o2::tpc::TriggerInfoDLBZS)) == 0);
 }

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -18,6 +18,7 @@
 #include "MFTWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
+#include "TPCReaderWorkflow/TriggerReaderSpec.h"
 #include "TPCWorkflow/ClusterSharingMapSpec.h"
 #include "HMPIDWorkflow/ClustersReaderSpec.h"
 #include "HMPIDWorkflow/HMPMatchedReaderSpec.h"
@@ -97,6 +98,9 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
   }
   if (maskClusters[GID::TPC]) {
     specs.emplace_back(o2::tpc::getClusterReaderSpec(maskClustersMC[GID::TPC]));
+    if (!getenv("DPL_DISABLE_TPC_TRIGGER_READER") || atoi(getenv("DPL_DISABLE_TPC_TRIGGER_READER")) != 1) {
+      specs.emplace_back(o2::tpc::getTPCTriggerReaderSpec());
+    }
   }
   if (maskTracks[GID::TPC] && maskClusters[GID::TPC]) {
     specs.emplace_back(o2::tpc::getClusterSharingMapSpec());

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -39,6 +39,7 @@ o2_add_library(TPCWorkflow
                        src/TPCIntegrateClusterReaderSpec.cxx
                        src/TPCIntegrateClusterSpec.cxx
                        src/TPCIntegrateClusterWriterSpec.cxx
+                       src/TPCTriggerWriterSpec.cxx
                        src/TPCMergeIntegrateClusterSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCTriggerWriterSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCTriggerWriterSpec.h
@@ -1,0 +1,27 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_TPCTRIGGERWRITER_SPEC
+#define O2_TPC_TPCTRIGGERWRITER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+o2::framework::DataProcessorSpec getTPCTriggerWriterSpec();
+
+} // end namespace tpc
+} // end namespace o2
+
+#endif

--- a/Detectors/TPC/workflow/readers/CMakeLists.txt
+++ b/Detectors/TPC/workflow/readers/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(TPCReaderWorkflow
                SOURCES src/ClusterReaderSpec.cxx
                        src/PublisherSpec.cxx
                        src/TrackReaderSpec.cxx
+                       src/TriggerReaderSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::DataFormatsTPC

--- a/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TriggerReaderSpec.h
+++ b/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TriggerReaderSpec.h
@@ -1,0 +1,59 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TriggerReaderSpec.h
+
+#ifndef O2_TPC_TRIGGERREADER
+#define O2_TPC_TRIGGERREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tpc
+{
+///< DPL device to read and send the TPC tracks (+MC) info
+
+class TriggerReader : public Task
+{
+ public:
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+
+ private:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::tpc::TriggerInfoDLBZS>* mTrig = nullptr;
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+
+  std::string mInputFileName = "tpctriggers.root";
+  std::string mTriggerTreeName = "triggers";
+  std::string mTriggerBranchName = "Triggers";
+};
+
+/// create a processor spec
+/// read TPC track data from a root file
+framework::DataProcessorSpec getTPCTriggerReaderSpec();
+
+} // namespace tpc
+} // namespace o2
+
+#endif /* O2_TPC_TRIGGERREADER */

--- a/Detectors/TPC/workflow/readers/src/TriggerReaderSpec.cxx
+++ b/Detectors/TPC/workflow/readers/src/TriggerReaderSpec.cxx
@@ -1,0 +1,78 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TriggerReaderSpec.cxx
+
+#include <vector>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TPCReaderWorkflow/TriggerReaderSpec.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tpc
+{
+
+void TriggerReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("infile"));
+  connectTree(mInputFileName);
+}
+
+void TriggerReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  mTree->GetEntry(ent);
+
+  pc.outputs().snapshot(Output{"TPC", "TRIGGERWORDS", 0, Lifetime::Timeframe}, *mTrig);
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void TriggerReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  if (!(mFile && !mFile->IsZombie())) {
+    throw std::runtime_error("Error opening tree file");
+  }
+  mTree.reset((TTree*)mFile->Get(mTriggerTreeName.c_str()));
+  if (!mTree) {
+    throw std::runtime_error("Error opening tree");
+  }
+
+  mTree->SetBranchAddress(mTriggerBranchName.c_str(), &mTrig);
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getTPCTriggerReaderSpec()
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("TPC", "TRIGGERWORDS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "tpc-trigger-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<TriggerReader>()},
+    Options{
+      {"infile", VariantType::String, "tpctriggers.root", {"Name of the input triggers file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "DataFormatsTPC/CompressedClusters.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
 #include "TPCWorkflow/EntropyDecoderSpec.h"
 
 using namespace o2::framework;
@@ -48,9 +49,10 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf_TPC");
 
   auto& compclusters = pc.outputs().make<std::vector<char>>(OutputRef{"output"});
+  auto& triggers = pc.outputs().make<std::vector<o2::tpc::TriggerInfoDLBZS>>(OutputRef{"trigger"});
   if (buff.size()) {
     const auto ctfImage = o2::tpc::CTF::getImage(buff.data());
-    iosize = mCTFCoder.decode(ctfImage, compclusters);
+    iosize = mCTFCoder.decode(ctfImage, compclusters, triggers);
   }
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
@@ -75,6 +77,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     "tpc-entropy-decoder",
     inputs,
     Outputs{OutputSpec{{"output"}, "TPC", "COMPCLUSTERSFLAT", 0, Lifetime::Timeframe},
+            OutputSpec{{"trigger"}, "TPC", "TRIGGERWORDS", 0, Lifetime::Timeframe},
             OutputSpec{{"ctfrep"}, "TPC", "CTFDECREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -16,6 +16,7 @@
 
 #include "TPCWorkflow/EntropyEncoderSpec.h"
 #include "DataFormatsTPC/CompressedClusters.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "Headers/DataHeader.h"
@@ -112,6 +113,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   mCTFCoder.updateTimeDependentParams(pc, true);
 
   CompressedClusters clusters;
+  static o2::tpc::detail::TriggerInfo trigComp;
 
   if (mFromFile) {
     auto tmp = pc.inputs().get<CompressedClustersROOT*>("input");
@@ -128,12 +130,28 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
     }
     clusters = *tmp;
   }
+  auto triggers = pc.inputs().get<gsl::span<o2::tpc::TriggerInfoDLBZS>>("trigger");
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TPC", "CTFDATA", 0, Lifetime::Timeframe});
   std::vector<bool> rejectHits, rejectTracks, rejectTrackHits, rejectTrackHitsReduced;
   CompressedClusters clustersFiltered = clusters;
   std::vector<std::pair<std::vector<unsigned int>, std::vector<unsigned short>>> tmpBuffer(std::max<int>(mNThreads, 1));
+
+  // prepare trigger info
+  trigComp.clear();
+  for (const auto& trig : triggers) {
+    for (int it = 0; it < o2::tpc::TriggerWordDLBZS::MaxTriggerEntries; it++) {
+      if (trig.triggerWord.isValid(it)) {
+        trigComp.deltaOrbit.push_back(trig.orbit);
+        trigComp.deltaBC.push_back(trig.triggerWord.getTriggerBC(it));
+        trigComp.triggerType.push_back(trig.triggerWord.getTriggerType(it));
+      } else {
+        break;
+      }
+    }
+  }
+
   if (mSelIR) {
     if (clusters.nTracks && clusters.solenoidBz != -1e6f && clusters.solenoidBz != mParam->bzkG) {
       throw std::runtime_error("Configured solenoid Bz does not match value used for track model encoding");
@@ -258,7 +276,29 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
     clustersFiltered.timeDiffU = tmpBuffer[0].first.data();
     clustersFiltered.padDiffU = tmpBuffer[0].second.data();
   }
-  auto iosize = mCTFCoder.encode(buffer, clusters, clustersFiltered, mSelIR ? &rejectHits : nullptr, mSelIR ? &rejectTracks : nullptr, mSelIR ? &rejectTrackHits : nullptr, mSelIR ? &rejectTrackHitsReduced : nullptr);
+
+  // transform trigger info to differential form
+  uint32_t prevOrbit = -1;
+  uint16_t prevBC = -1;
+  if (trigComp.triggerType.size()) {
+    prevOrbit = trigComp.firstOrbit = trigComp.deltaOrbit[0];
+    prevBC = trigComp.deltaBC[0];
+    trigComp.deltaOrbit[0] = 0;
+    for (size_t it = 1; it < trigComp.triggerType.size(); it++) {
+      if (trigComp.deltaOrbit[it] == prevOrbit) {
+        auto bc = trigComp.deltaBC[it];
+        trigComp.deltaBC[it] -= prevBC;
+        prevBC = bc;
+        trigComp.deltaOrbit[it] = 0;
+      } else {
+        auto orb = trigComp.deltaOrbit[it];
+        trigComp.deltaOrbit[it] -= prevOrbit;
+        prevOrbit = orb;
+      }
+    }
+  }
+
+  auto iosize = mCTFCoder.encode(buffer, clusters, clustersFiltered, trigComp, mSelIR ? &rejectHits : nullptr, mSelIR ? &rejectTracks : nullptr, mSelIR ? &rejectTrackHits : nullptr, mSelIR ? &rejectTrackHitsReduced : nullptr);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
   if (mSelIR) {
@@ -278,6 +318,7 @@ DataProcessorSpec getEntropyEncoderSpec(bool inputFromFile, bool selIR)
   std::vector<InputSpec> inputs;
   header::DataDescription inputType = inputFromFile ? header::DataDescription("COMPCLUSTERS") : header::DataDescription("COMPCLUSTERSFLAT");
   inputs.emplace_back("input", "TPC", inputType, 0, Lifetime::Timeframe);
+  inputs.emplace_back("trigger", "TPC", "TRIGGERWORDS", 0, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionaryTree"));
 
   std::shared_ptr<o2::base::GRPGeomRequest> ggreq;

--- a/Detectors/TPC/workflow/src/FileReaderWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/FileReaderWorkflow.cxx
@@ -12,6 +12,7 @@
 /// @file   FileReaderWorkflow.cxx
 
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
+#include "TPCReaderWorkflow/TriggerReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 
 #include "Algorithm/RangeTokenizer.h"
@@ -67,6 +68,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   if (isEnabled(Input::Clusters)) {
     specs.emplace_back(o2::tpc::getClusterReaderSpec(doMC));
+    if (!getenv("DPL_DISABLE_TPC_TRIGGER_READER") || atoi(getenv("DPL_DISABLE_TPC_TRIGGER_READER")) != 1) {
+      specs.emplace_back(o2::tpc::getTPCTriggerReaderSpec());
+    }
   }
 
   if (isEnabled(Input::Tracks)) {

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -19,6 +19,7 @@
 #include "Framework/Logger.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "TPCWorkflow/RecoWorkflow.h"
+#include "TPCWorkflow/TPCTriggerWriterSpec.h"
 #include "TPCReaderWorkflow/PublisherSpec.h"
 #include "TPCWorkflow/ClustererSpec.h"
 #include "TPCWorkflow/ClusterDecoderRawSpec.h"
@@ -40,6 +41,7 @@
 #include "DataFormatsTPC/Helpers.h"
 #include "DataFormatsTPC/ZeroSuppression.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
+#include "TPCReaderWorkflow/TriggerReaderSpec.h"
 
 #include <string>
 #include <stdexcept>
@@ -205,6 +207,9 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
                                                    propagateMC));
     } else if (inputType == InputType::Clusters) {
       specs.emplace_back(o2::tpc::getClusterReaderSpec(propagateMC, &tpcSectors, &laneConfiguration));
+      if (!getenv("DPL_DISABLE_TPC_TRIGGER_READER") || atoi(getenv("DPL_DISABLE_TPC_TRIGGER_READER")) != 1) {
+        specs.emplace_back(o2::tpc::getTPCTriggerReaderSpec());
+      }
     } else if (inputType == InputType::CompClusters) {
       // TODO: need to check if we want to store the MC labels alongside with compressed clusters
       // for the moment reading of labels is disabled (last parameter is false)
@@ -413,6 +418,10 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
                                                                        "TPCClusterNativeMCTruth",
                                                                        "mcbranch", fillLabels},
                                    (caClusterer || decompressTPC || inputType == InputType::PassThrough) && !isEnabled(OutputType::SendClustersPerSector)));
+  }
+
+  if ((isEnabled(OutputType::TPCTriggers) || caClusterer) && !isEnabled(OutputType::DisableWriter)) {
+    specs.push_back(o2::tpc::getTPCTriggerWriterSpec());
   }
 
   if (zsOnTheFly) {

--- a/Detectors/TPC/workflow/src/TPCTriggerWriterSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTriggerWriterSpec.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TPCIntegrateClusterWriterSpec.cxx
+
+#include <vector>
+#include "TPCWorkflow/TPCTriggerWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tpc
+{
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getTPCTriggerWriterSpec()
+{
+  return MakeRootTreeWriterSpec("tpc-trigger-writer",
+                                "tpctriggers.root",
+                                "triggers",
+                                BranchDefinition<std::vector<o2::tpc::TriggerInfoDLBZS>>{InputSpec{"trig", o2::header::gDataOriginTPC, "TRIGGERWORDS", 0}, "Triggers"})();
+}
+
+} // namespace tpc
+} // namespace o2

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -68,7 +68,7 @@ fi
 # ---------------------------------------------------------------------------------------------------------------------
 # Set some individual workflow arguments depending on configuration
 GPU_INPUT=zsraw
-GPU_OUTPUT=tracks,clusters,tpc-triggers
+GPU_OUTPUT=tracks,clusters
 GPU_CONFIG=
 GPU_CONFIG_KEY=
 TOF_CONFIG=
@@ -96,7 +96,9 @@ CTP_CONFIG=
 if [[ -z ${ALPIDE_ERR_DUMPS:-} ]]; then
   [[ $EPNSYNCMODE == 1 ]] && ALPIDE_ERR_DUMPS="1" || ALPIDE_ERR_DUMPS="0"
 fi
-
+if [[ $CTFINPUT != 1 ]]; then
+  GPU_OUTPUT+=",tpc-triggers"
+fi
 if [[ $SYNCMODE == 1 ]]; then
   if [[ $BEAMTYPE == "PbPb" ]]; then
     ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=${CUT_MULT_MIN_ITS:-100};fastMultConfig.cutMultClusHigh=${CUT_MULT_MAX_ITS:-200};fastMultConfig.cutMultVtxHigh=${CUT_MULT_VTX_ITS:-20};"


### PR DESCRIPTION
The TPC triggers will be automatically read and written at the same time when native clusters are read or written, although for technical reasons they are stored in the separate tree/file via dedicated writer.

In case previously produced data set lacking TPC triggers output file needs to be read-out, one should export DPL_DISABLE_TPC_TRIGGER_READER=1 env.var. to not initialize the trigger reader.

Triggers are added to the RecoContainer and can be accessed via `recoContainer.getTPCTriggers()`