### PR TITLE
o2-sim: Better VMC shutdown (via plugin code)

### DIFF
--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -133,3 +133,17 @@ void Config()
 
   std::cout << "g4Config.C finished" << std::endl;
 }
+
+void Terminate()
+{
+  static bool terminated = false;
+  if (!terminated) {
+    std::cout << "Executing G4 terminate\n";
+    TGeant4* geant4 = dynamic_cast<TGeant4*>(TVirtualMC::GetMC());
+    if (geant4) {
+      // we need to call finish run for Geant4 ... Since we use ProcessEvent() interface;
+      geant4->FinishRun();
+    }
+    terminated = true;
+  }
+}

--- a/Detectors/gconfig/include/SimSetup/SimSetup.h
+++ b/Detectors/gconfig/include/SimSetup/SimSetup.h
@@ -10,11 +10,15 @@
 // or submit itself to any jurisdiction.
 
 #ifndef O2_SIMSETUP_H
+#define O2_SIMSETUP_H
 
 namespace o2
 {
 struct SimSetup {
   static void setup(const char* engine);
+
+  // a static entrypoint to shutdown the VMC system
+  static void shutdown();
 };
 } // namespace o2
 

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -29,16 +29,23 @@ using std::endl;
 // these are used in commonConfig.C
 using o2::eventgen::DecayerPythia8;
 
+#include "../g4Config.C"
+
 namespace o2
 {
 namespace g4config
 {
-#include "../g4Config.C"
 
 void G4Config()
 {
   LOG(info) << "Setting up G4 sim from library code";
   Config();
 }
+
+void G4Terminate()
+{
+  Terminate();
+}
+
 } // namespace g4config
 } // namespace o2

--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -12,6 +12,7 @@
 /// @author Sandro Wenzel
 
 #include "O2SimDevice.h"
+#include "SimSetup/SimSetup.h"
 #include <fairmq/DeviceRunner.h>
 #include <boost/program_options.hpp>
 #include <memory>
@@ -66,7 +67,7 @@ void sigaction_handler(int signal, siginfo_t* signal_info, void*)
         break;
       }
     }
-
+    o2::SimSetup::shutdown();
     _exit(0);
   }
 
@@ -177,6 +178,7 @@ int runSim(KernelSetup setup)
   while (setup.sim->Kernel(setup.workerID, *setup.primchannel, *setup.datachannel, setup.primstatuschannel)) {
   }
   doLogInfo(setup.workerID, "simulation is done");
+  o2::SimSetup::shutdown();
   return 0;
 }
 


### PR DESCRIPTION
Introducing the ability to close/terminate the
VMC simulation engines.

* for instance to print final statistics about steps, magnetic field calls etc.