### PR TITLE
MCTrack: Generalize hit bit property

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
@@ -86,6 +86,9 @@ class MCEventHeader : public FairMCEventHeader
 
   MCEventStats& getMCEventStats() { return mEventStats; }
 
+  void setDetId2HitBitLUT(std::vector<int> const& v) { mDetId2HitBitIndex = v; }
+  std::vector<int> const& getDetId2HitBitLUT() const { return mDetId2HitBitIndex; }
+
   /// create a standalone ROOT file/tree with only the MCHeader branch
   static void extractFileFromKinematics(std::string_view kinefilename, std::string_view targetfilename);
 
@@ -96,9 +99,10 @@ class MCEventHeader : public FairMCEventHeader
   // store a few global properties that this event
   // had in the current simulation (which can be used quick filtering/searching)
   MCEventStats mEventStats{};
+  std::vector<int> mDetId2HitBitIndex;
   o2::utils::RootSerializableKeyValueStore mEventInfo;
 
-  ClassDefOverride(MCEventHeader, 3);
+  ClassDefOverride(MCEventHeader, 4);
 
 }; /** class MCEventHeader **/
 

--- a/DataFormats/simulation/test/MCTrack.cxx
+++ b/DataFormats/simulation/test/MCTrack.cxx
@@ -24,10 +24,17 @@ using namespace o2;
 BOOST_AUTO_TEST_CASE(MCTrack_test)
 {
   MCTrack track;
+
+  // auxiliary lookup table needed to fetch and set hit properties
+  std::vector<int> hitLUT(o2::detectors::DetID::nDetectors, -1);
+  // in this test we have a single fictional detector 1, which we map to
+  // the first bit
+  hitLUT[1] = 0;
+
   // check properties on default constructed object
   BOOST_CHECK(track.getStore() == false);
   for (auto i = o2::detectors::DetID::First; i < o2::detectors::DetID::nDetectors; ++i) {
-    BOOST_CHECK(track.leftTrace(i) == false);
+    BOOST_CHECK(track.leftTrace(i, hitLUT) == false);
   }
   BOOST_CHECK(track.getNumDet() == 0);
   BOOST_CHECK(track.hasHits() == false);
@@ -41,10 +48,10 @@ BOOST_AUTO_TEST_CASE(MCTrack_test)
   BOOST_CHECK(track.getStore() == true);
 
   // set hit for first detector
-  BOOST_CHECK(track.leftTrace(1) == false);
-  track.setHit(1);
+  BOOST_CHECK(track.leftTrace(1, hitLUT) == false);
+  track.setHit(hitLUT[1]);
   BOOST_CHECK(track.hasHits() == true);
-  BOOST_CHECK(track.leftTrace(1) == true);
+  BOOST_CHECK(track.leftTrace(1, hitLUT) == true);
   BOOST_CHECK(track.getNumDet() == 1);
 
   // check process encoding

--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -216,6 +216,10 @@ class Detector : public FairDetector
   // which is required for media creation
   static void initFieldTrackingParams(int& mode, float& maxfield);
 
+  /// set the DetID to HitBitIndex mapping. Succeeds if not already set.
+  static void setDetId2HitBitIndex(std::vector<int> const& v) { Detector::sDetId2HitBitIndex = v; }
+  static std::vector<int> const& getDetId2HitBitIndex() { return Detector::sDetId2HitBitIndex; }
+
  protected:
   Detector(const Detector& origin);
 
@@ -233,6 +237,7 @@ class Detector : public FairDetector
 
   static Float_t mDensityFactor; //! factor that is multiplied to all material densities (ONLY for
   // systematic studies)
+  static std::vector<int> sDetId2HitBitIndex; //! global lookup table keeping mapping of DetID to index in hit bit field (used in MCTrack)
 
   ClassDefOverride(Detector, 1); // Base class for ALICE Modules
 };
@@ -738,6 +743,7 @@ class DetImpl : public o2::base::Detector
   int mInitialized = false;
 
   char* mHitCollectorBufferPtr = nullptr; //! pointer to hit (collector) buffer location (strictly internal)
+
   ClassDefOverride(DetImpl, 0);
 };
 } // namespace base

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -30,6 +30,7 @@ using namespace o2::base;
 using namespace o2::detectors;
 
 Float_t Detector::mDensityFactor = 1.0;
+std::vector<int> o2::base::Detector::sDetId2HitBitIndex{}; // initialize empty vector
 
 Detector::Detector() : FairDetector(), mMapMaterial(), mMapMedium() {}
 Detector::Detector(const char* name, Bool_t Active)

--- a/Detectors/Base/src/Stack.cxx
+++ b/Detectors/Base/src/Stack.cxx
@@ -638,14 +638,17 @@ void Stack::Print(Option_t* option) const
 
 void Stack::addHit(int iDet)
 {
+  // translate detector ID to bit id
+  const auto bitID = o2::base::Detector::getDetId2HitBitIndex()[iDet];
+
   if (mIndexOfCurrentTrack < mNumberOfPrimaryParticles) {
     auto& part = mTracks->at(mIndexOfCurrentTrack);
-    part.setHit(iDet);
+    part.setHit(bitID);
 
   } else {
     Int_t iTrack = mTrackIDtoParticlesEntry[mIndexOfCurrentTrack];
     auto& part = mParticles[iTrack];
-    part.setHit(iDet);
+    part.setHit(bitID);
   }
   mCurrentParticle.SetBit(ParticleStatus::kHasHits, 1);
   mHitCounter++;
@@ -654,7 +657,9 @@ void Stack::addHit(int iDet, Int_t iTrack)
 {
   mHitCounter++;
   auto& part = mParticles[iTrack];
-  part.setHit(iDet);
+  // fetch the bit encoding for hits
+  const auto bitID = o2::base::Detector::getDetId2HitBitIndex()[iDet];
+  part.setHit(bitID);
   mCurrentParticle.SetBit(ParticleStatus::kHasHits, 1);
 }
 

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -197,6 +197,7 @@ void O2MCApplicationBase::finishEventCommon()
 
   auto header = static_cast<o2::dataformats::MCEventHeader*>(fMCEventHeader);
   header->getMCEventStats().setNSteps(mStepCounter);
+  header->setDetId2HitBitLUT(o2::base::Detector::getDetId2HitBitIndex());
 
   static_cast<o2::data::Stack*>(GetStack())->updateEventStats();
 }

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -179,103 +179,120 @@ void build_geometry(FairRunSim* run = nullptr)
     run->AddModule(new o2::passive::FrameStructure("FRAME", "Frame"));
   }
 
+  std::vector<int> detId2RunningId = std::vector<int>(o2::detectors::DetID::nDetectors, -1); // a mapping of detectorId to a dense runtime index
+  // used for instance to set bits in the hit structure of MCTracks; -1 means that there is no bit associated
+
+  auto addReadoutDetector = [&detId2RunningId, &run](o2::base::Detector* detector) {
+    static int runningid = 0; // this is static for constant lambda interfaces --> use fixed type and not auto in the lambda!
+    run->AddModule(detector);
+    if (detector->IsActive()) {
+      auto detID = detector->GetDetId();
+      detId2RunningId[detID] = runningid;
+      LOG(info) << " DETID " << detID << " vs " << detector->GetDetId() << " mapped to hit bit index " << runningid;
+      runningid++;
+    }
+  };
+
   if (isActivated("TOF")) {
     // TOF
-    run->AddModule(new o2::tof::Detector(isReadout("TOF")));
+    addReadoutDetector(new o2::tof::Detector(isReadout("TOF")));
   }
 
   if (isActivated("TRD")) {
     // TRD
-    run->AddModule(new o2::trd::Detector(isReadout("TRD")));
+    addReadoutDetector(new o2::trd::Detector(isReadout("TRD")));
   }
 
   if (isActivated("TPC")) {
     // tpc
-    run->AddModule(new o2::tpc::Detector(isReadout("TPC")));
+    addReadoutDetector(new o2::tpc::Detector(isReadout("TPC")));
   }
 #ifdef ENABLE_UPGRADES
   if (isActivated("IT3")) {
     // IT3
-    run->AddModule(new o2::its::Detector(isReadout("IT3"), "IT3"));
+    addReadoutDetector(new o2::its::Detector(isReadout("IT3"), "IT3"));
   }
 
   if (isActivated("TRK")) {
     // ALICE 3 TRK
-    run->AddModule(new o2::trk::Detector(isReadout("TRK")));
+    addReadoutDetector(new o2::trk::Detector(isReadout("TRK")));
   }
 
   if (isActivated("FT3")) {
     // ALICE 3 FT3
-    run->AddModule(new o2::ft3::Detector(isReadout("FT3")));
+    addReadoutDetector(new o2::ft3::Detector(isReadout("FT3")));
   }
 
   if (isActivated("FCT")) {
     // ALICE 3 FCT
-    run->AddModule(new o2::fct::Detector(isReadout("FCT")));
+    addReadoutDetector(new o2::fct::Detector(isReadout("FCT")));
   }
 #endif
 
   if (isActivated("ITS")) {
     // its
-    run->AddModule(new o2::its::Detector(isReadout("ITS")));
+    addReadoutDetector(new o2::its::Detector(isReadout("ITS")));
   }
 
   if (isActivated("MFT")) {
     // mft
-    run->AddModule(new o2::mft::Detector(isReadout("MFT")));
+    addReadoutDetector(new o2::mft::Detector(isReadout("MFT")));
   }
 
   if (isActivated("MCH")) {
     // mch
-    run->AddModule(new o2::mch::Detector(isReadout("MCH")));
+    addReadoutDetector(new o2::mch::Detector(isReadout("MCH")));
   }
 
   if (isActivated("MID")) {
     // mid
-    run->AddModule(new o2::mid::Detector(isReadout("MID")));
+    addReadoutDetector(new o2::mid::Detector(isReadout("MID")));
   }
 
   if (isActivated("EMC")) {
     // emcal
-    run->AddModule(new o2::emcal::Detector(isReadout("EMC")));
+    addReadoutDetector(new o2::emcal::Detector(isReadout("EMC")));
   }
 
   if (isActivated("PHS")) {
     // phos
-    run->AddModule(new o2::phos::Detector(isReadout("PHS")));
+    addReadoutDetector(new o2::phos::Detector(isReadout("PHS")));
   }
 
   if (isActivated("CPV")) {
     // cpv
-    run->AddModule(new o2::cpv::Detector(isReadout("CPV")));
+    addReadoutDetector(new o2::cpv::Detector(isReadout("CPV")));
   }
 
   if (isActivated("FT0")) {
     // FIT-T0
-    run->AddModule(new o2::ft0::Detector(isReadout("FT0")));
+    addReadoutDetector(new o2::ft0::Detector(isReadout("FT0")));
   }
 
   if (isActivated("FV0")) {
     // FIT-V0
-    run->AddModule(new o2::fv0::Detector(isReadout("FV0")));
+    addReadoutDetector(new o2::fv0::Detector(isReadout("FV0")));
   }
 
   if (isActivated("FDD")) {
     // FIT-FDD
-    run->AddModule(new o2::fdd::Detector(isReadout("FDD")));
+    addReadoutDetector(new o2::fdd::Detector(isReadout("FDD")));
   }
 
   if (isActivated("HMP")) {
     // HMP
-    run->AddModule(new o2::hmpid::Detector(isReadout("HMP")));
+    addReadoutDetector(new o2::hmpid::Detector(isReadout("HMP")));
   }
 
   if (isActivated("ZDC")) {
     // ZDC
-    run->AddModule(new o2::zdc::Detector(isReadout("ZDC")));
+    addReadoutDetector(new o2::zdc::Detector(isReadout("ZDC")));
   }
 
   if (geomonly) {
     run->Init();
   }
+
+  // register the DetId2HitIndex lookup with the detector class by copying the vector
+  o2::base::Detector::setDetId2HitBitIndex(detId2RunningId);
 }

--- a/run/SimExamples/Inspect_Hits/left_trace.macro
+++ b/run/SimExamples/Inspect_Hits/left_trace.macro
@@ -1,54 +1,54 @@
 bool
-leftTrace_golden(o2::MCTrack& t)
+leftTrace_golden(o2::MCTrack& t, std::vector<int> const& bitLUT)
 {
   bool trace = false;
-  trace |= t.leftTrace(o2::detectors::DetID::ITS);
-  trace |= t.leftTrace(o2::detectors::DetID::TPC);
-  trace |= t.leftTrace(o2::detectors::DetID::TRD);
-  trace |= t.leftTrace(o2::detectors::DetID::TOF);
+  trace |= t.leftTrace(o2::detectors::DetID::ITS, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::TPC, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::TRD, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::TOF, bitLUT);
   return trace; 
 }
 
 bool
-leftTrace_barrel(o2::MCTrack& t)
+leftTrace_barrel(o2::MCTrack& t, std::vector<int> const& bitLUT)
 {
   bool trace = false;
-  trace |= t.leftTrace(o2::detectors::DetID::ITS);
-  trace |= t.leftTrace(o2::detectors::DetID::TPC);
-  trace |= t.leftTrace(o2::detectors::DetID::TRD);
-  trace |= t.leftTrace(o2::detectors::DetID::TOF);
-  trace |= t.leftTrace(o2::detectors::DetID::HMP);
-  trace |= t.leftTrace(o2::detectors::DetID::EMC);
-  trace |= t.leftTrace(o2::detectors::DetID::PHS);
-  trace |= t.leftTrace(o2::detectors::DetID::FV0);
-  trace |= t.leftTrace(o2::detectors::DetID::FT0);
-  return trace; 
+  trace |= t.leftTrace(o2::detectors::DetID::ITS, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::TPC, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::TRD, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::TOF, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::HMP, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::EMC, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::PHS, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::FV0, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::FT0, bitLUT);
+  return trace;
 }
 
 bool
-leftTrace_muon(o2::MCTrack& t)
+leftTrace_muon(o2::MCTrack& t, std::vector<int> const& bitLUT)
 {
   bool trace = false;
-  trace |= t.leftTrace(o2::detectors::DetID::ITS);
-  trace |= t.leftTrace(o2::detectors::DetID::FV0);
-  trace |= t.leftTrace(o2::detectors::DetID::FT0);
-  trace |= t.leftTrace(o2::detectors::DetID::MFT);
-  trace |= t.leftTrace(o2::detectors::DetID::MCH);
-  trace |= t.leftTrace(o2::detectors::DetID::MID);
-  return trace; 
+  trace |= t.leftTrace(o2::detectors::DetID::ITS, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::FV0, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::FT0, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::MFT, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::MCH, bitLUT);
+  trace |= t.leftTrace(o2::detectors::DetID::MID, bitLUT);
+  return trace;
 }
 
 bool
-leftTrace_any(o2::MCTrack& t)
+leftTrace_any(o2::MCTrack& t, std::vector<int> const& bitLUT)
 {
-  return leftTrace_barrel(t) || leftTrace_muon(t);
+  return leftTrace_barrel(t, bitLUT) || leftTrace_muon(t, bitLUT);
 }
 
 
-std::function<bool(o2::MCTrack&)> leftTrace_selected = leftTrace_barrel;
+std::function<bool(o2::MCTrack&, std::vector<int> const&)> leftTrace_selected = leftTrace_barrel;
 
 /*
-std::map<std::string, std::function<bool(o2::MCTrack&)> leftTrace = {
+std::map<std::string, std::function<bool(o2::MCTrack&, std::vector<int> const&)> leftTrace = {
 								      {"golden", leftTrace_golden},
 								      {"barrel", leftTrace_barrel},
 								      {"muon"  , leftTrace_muon}  ,
@@ -57,8 +57,8 @@ std::map<std::string, std::function<bool(o2::MCTrack&)> leftTrace = {
 */
 
 bool
-leftTrace(o2::MCTrack& t, vector<o2::MCTrack>* tracks) {
-  if (leftTrace_selected(t)) return true; // this track has left trace in requested detectors
+leftTrace(o2::MCTrack& t, vector<o2::MCTrack>* tracks, std::vector<int> const& bitLUT) {
+  if (leftTrace_selected(t, bitLUT)) return true; // this track has left trace in requested detectors
   //  if (leftTrace_barrel(t)) return true; // this track has left trace in requested detectors
   // check if any of the daughters left trace
   auto id1 = t.getFirstDaughterTrackId();
@@ -67,7 +67,7 @@ leftTrace(o2::MCTrack& t, vector<o2::MCTrack>* tracks) {
   bool trace = false;
   for (int id = id1; id <= id2; ++id) {
     auto d = tracks->at(id);
-    trace |= leftTrace(d, tracks); // at least one daughter has left trace
+    trace |= leftTrace(d, tracks, bitLUT); // at least one daughter has left trace
   }
   return trace;
 }

--- a/run/SimExamples/Inspect_Hits/primary_and_hits.macro
+++ b/run/SimExamples/Inspect_Hits/primary_and_hits.macro
@@ -15,6 +15,10 @@ primary_and_hits(const char *fname, std::string where = "barrel")
   tin->SetBranchAddress("MCTrack", &tracks);
   auto nev = tin->GetEntries();
 
+  // get the LUT for detector ID to bit index for hits
+  o2::dataformats::MCEventHeader *m = nullptr;
+  tin->SetBranchAddress("MCEventHeader.", &m);
+
   std::map<int, TH2F*> hEtaPtGen, hEtaPtHit;
 
   for (int iev = 0; iev < nev; ++iev) {
@@ -31,7 +35,7 @@ primary_and_hits(const char *fname, std::string where = "barrel")
       
       hEtaPtGen[pdg]->Fill(t.GetEta(), t.GetPt());
 
-      if (!leftTrace(t, tracks)) continue;
+      if (!leftTrace(t, tracks, m->getDetId2HitBitLUT())) continue;
 
       hEtaPtHit[pdg]->Fill(t.GetEta(), t.GetPt());
 

--- a/run/SimExamples/Inspect_Hits/secondary_and_hits.macro
+++ b/run/SimExamples/Inspect_Hits/secondary_and_hits.macro
@@ -15,6 +15,10 @@ secondary_and_hits(const char *fname, std::string where = "barrel")
   tin->SetBranchAddress("MCTrack", &tracks);
   auto nev = tin->GetEntries();
 
+  // get the LUT for detector ID to bit index for hits
+  o2::dataformats::MCEventHeader *m = nullptr;
+  tin->SetBranchAddress("MCEventHeader.", &m);
+
   std::map<int, TH2F*> hZRGen, hZRHit;
 
   for (int iev = 0; iev < nev; ++iev) {
@@ -32,7 +36,9 @@ secondary_and_hits(const char *fname, std::string where = "barrel")
       auto R = std::hypot(t.GetStartVertexCoordinatesX(), t.GetStartVertexCoordinatesY());
       hZRGen[pdg]->Fill(z, R);
 
-      if (!leftTrace(t, tracks)) continue;
+      if (!leftTrace(t, tracks, m->getDetId2HitBitLUT())) {
+        continue;
+      }
 
       hZRHit[pdg]->Fill(z, R);
 

--- a/run/checkStack.cxx
+++ b/run/checkStack.cxx
@@ -89,6 +89,9 @@ int main(int argc, char** argv)
     std::vector<int> trackidsinTPC;
     std::vector<int> trackidsinITS;
 
+    // fetch the encoding of DetIDs to bits for the hit properties (can be fetched from any MCEventHeader)
+    auto& mcEventHeader = mcreader.getMCEventHeader(0, 0);
+
     int primaries = 0;
     int physicalprimaries = 0;
     int secondaries = 0;
@@ -103,12 +106,14 @@ int main(int argc, char** argv)
         // for primaries, this may be different (for instance with Pythia8)
         assert(ti > t.getMotherTrackId());
       }
-      if (t.leftTrace(o2::detectors::DetID::TPC)) {
+
+      if (t.leftTrace(o2::detectors::DetID::TPC, mcEventHeader.getDetId2HitBitLUT())) {
         trackidsinTPC.emplace_back(ti);
       }
-      if (t.leftTrace(o2::detectors::DetID::ITS)) {
+      if (t.leftTrace(o2::detectors::DetID::ITS, mcEventHeader.getDetId2HitBitLUT())) {
         trackidsinITS.emplace_back(ti);
       }
+
       bool physicalPrim = o2::mcutils::MCTrackNavigator::isPhysicalPrimary(t, *mctracks);
       LOG(debug) << " track " << ti << "\t" << t.getMotherTrackId() << " hits " << t.hasHits() << " isPhysicalPrimary " << physicalPrim;
       if (t.isPrimary()) {


### PR DESCRIPTION
So far, every possible sensitive detector for ALICE Run3 had a dedicated bit assigned inside MCTracks. The number of such bit was fixed to be 22 maximally.
In this way we could store information if a particular Monte Carlo track caused energy deposits in detectors.

Since more and more detectors are being added to the code (ALICE3, ITS3, R&D), we'll soon have more than 22 DetIDs in our code which will conflict with the space available in MCTrack.

Since enlarging the MCTrack class in memory is to be avoided, this commit proposes a solution based on an intermediate lookup table which dynamically maps the detector ID to a particular bit.

This solution should scale much further than before. The limit is now 22 simultaneous sensitive detectors in the geometry and not 22 total sensitive detectors in the code.