### PR TITLE
GPU: Work towards running the multi-threaded GPU pipeline standalone

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -19,7 +19,7 @@ o2_add_library(DPLUtils
                        test/DPLBroadcasterMerger.cxx
                        test/DPLOutputTest.cxx
                        test/RawPageTestData.cxx
-                       PUBLIC_LINK_LIBRARIES O2::Framework ROOT::Tree ROOT::TreePlayer)
+               PUBLIC_LINK_LIBRARIES O2::Framework ROOT::Tree ROOT::TreePlayer O2::CommonUtils)
 
 o2_add_executable(raw-proxy
                   COMPONENT_NAME dpl

--- a/Framework/Utils/include/DPLUtils/DPLRawPageSequencer.h
+++ b/Framework/Utils/include/DPLUtils/DPLRawPageSequencer.h
@@ -98,10 +98,16 @@ class DPLRawPageSequencer
     int retVal = 0;
     for (auto const& ref : mInput) {
       auto size = DataRefUtils::getPayloadSize(ref);
-      if (size == 0) {
+      const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      if (dh == nullptr) {
         continue;
       }
-      const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      if (size == 0) {
+        if (dh->subSpecification == 0xDEADBEEF) {
+          raw_parser::RawParserHelper::warnDeadBeef(dh);
+        }
+        continue;
+      }
       auto const pageSize = rawparser_type::max_size;
       auto nPages = size / pageSize + (size % pageSize ? 1 : 0);
       if (!preCheck(ref.payload, dh->subSpecification)) {

--- a/Framework/Utils/include/DPLUtils/RawParser.h
+++ b/Framework/Utils/include/DPLUtils/RawParser.h
@@ -25,6 +25,10 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+namespace o2::header
+{
+struct DataHeader;
+} // namespace o2::header
 
 // FIXME: probably moved somewhere else
 namespace o2::framework
@@ -87,6 +91,7 @@ struct RawParserHelper {
   static unsigned long sErrorScale; // Exponentionally downscale verbosity.
 
   static bool checkPrintError(size_t& localCounter);
+  static void warnDeadBeef(const o2::header::DataHeader* dh);
 };
 
 /// @class ConcreteRawParser

--- a/Framework/Utils/src/RawParser.cxx
+++ b/Framework/Utils/src/RawParser.cxx
@@ -15,6 +15,8 @@
 /// @brief  Generic parser for consecutive raw pages
 
 #include "DPLUtils/RawParser.h"
+#include "CommonUtils/VerbosityConfig.h"
+#include "Headers/DataHeader.h"
 #include "fmt/format.h"
 #include <iostream>
 
@@ -38,6 +40,15 @@ bool RawParserHelper::checkPrintError(size_t& localCounter)
     sErrorScale *= 10;
   }
   return sErrors % sErrorScale == 0;
+}
+
+void RawParserHelper::warnDeadBeef(const o2::header::DataHeader* dh)
+{
+  static auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+  static int contDeadBeef = 0;
+  if (++contDeadBeef <= maxWarn) {
+    LOGP(alarm, "Found input [{}/{}/0xDEADBEEF] assuming no payload for all links in this TF{}", dh->dataOrigin.as<std::string>(), dh->dataDescription.as<std::string>(), contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+  }
 }
 
 const char* RDHFormatter<V7>::sFormatString = "{:>5} {:>4} {:>4} {:>4} {:>4} {:>3} {:>3} {:>3}  {:>1} {:>2}";

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -1194,7 +1194,7 @@ GPUReconstruction* GPUReconstruction::CreateInstance(const GPUSettingsDeviceBack
       retVal = CreateInstance(cfg2);
     }
   } else {
-    GPUInfo("Created GPUReconstruction instance for device type %s (%u) %s", GPUDataTypes::DEVICE_TYPE_NAMES[type], type, cfg.master ? " (slave)" : "");
+    GPUInfo("Created GPUReconstruction instance for device type %s (%u)%s", GPUDataTypes::DEVICE_TYPE_NAMES[type], type, cfg.master ? " (slave)" : "");
   }
 
   return retVal;

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -335,8 +335,6 @@ int GPUReconstructionCUDA::InitDevice_Runtime()
     }
 
     dummyInitKernel<<<mBlockCount, 256>>>(mDeviceMemoryBase);
-    GPUInfo("CUDA Initialisation successfull (Device %d: %s (Frequency %d, Cores %d), %lld / %lld bytes host / global memory, Stack frame %d, Constant memory %lld)", mDeviceId, cudaDeviceProp.name, cudaDeviceProp.clockRate, cudaDeviceProp.multiProcessorCount, (long long int)mHostMemorySize,
-            (long long int)mDeviceMemorySize, (int)GPUCA_GPU_STACK_SIZE, (long long int)gGPUConstantMemBufferSize);
 
 #ifndef GPUCA_ALIROOT_LIB
     if (mProcessingSettings.rtc.enable) {
@@ -363,6 +361,8 @@ int GPUReconstructionCUDA::InitDevice_Runtime()
     }
 #endif
     mDeviceConstantMem = (GPUConstantMem*)devPtrConstantMem;
+
+    GPUInfo("CUDA Initialisation successfull (Device %d: %s (Frequency %d, Cores %d), %lld / %lld bytes host / global memory, Stack frame %d, Constant memory %lld)", mDeviceId, cudaDeviceProp.name, cudaDeviceProp.clockRate, cudaDeviceProp.multiProcessorCount, (long long int)mHostMemorySize, (long long int)mDeviceMemorySize, (int)GPUCA_GPU_STACK_SIZE, (long long int)gGPUConstantMemBufferSize);
   } else {
     GPUReconstructionCUDA* master = dynamic_cast<GPUReconstructionCUDA*>(mMaster);
     mDeviceId = master->mDeviceId;
@@ -375,6 +375,8 @@ int GPUReconstructionCUDA::InitDevice_Runtime()
     std::copy(master->mDeviceConstantMemRTC.begin(), master->mDeviceConstantMemRTC.end(), mDeviceConstantMemRTC.begin());
     mInternals = master->mInternals;
     GPUFailedMsg(cudaSetDevice(mDeviceId));
+
+    GPUInfo("CUDA Initialized from master");
   }
 
   for (unsigned int i = 0; i < mEvents.size(); i++) {

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -437,8 +437,7 @@ int GPUReconstructionHIPBackend::InitDevice_Runtime()
     mDeviceConstantMem = (GPUConstantMem*)devPtrConstantMem;
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(dummyInitKernel), dim3(mBlockCount), dim3(256), 0, 0, mDeviceMemoryBase);
-    GPUInfo("HIP Initialisation successfull (Device %d: %s (Frequency %d, Cores %d), %lld / %lld bytes host / global memory, Stack frame %d, Constant memory %lld)", mDeviceId, hipDeviceProp.name, hipDeviceProp.clockRate, hipDeviceProp.multiProcessorCount, (long long int)mHostMemorySize,
-            (long long int)mDeviceMemorySize, (int)GPUCA_GPU_STACK_SIZE, (long long int)gGPUConstantMemBufferSize);
+    GPUInfo("HIP Initialisation successfull (Device %d: %s (Frequency %d, Cores %d), %lld / %lld bytes host / global memory, Stack frame %d, Constant memory %lld)", mDeviceId, hipDeviceProp.name, hipDeviceProp.clockRate, hipDeviceProp.multiProcessorCount, (long long int)mHostMemorySize, (long long int)mDeviceMemorySize, (int)GPUCA_GPU_STACK_SIZE, (long long int)gGPUConstantMemBufferSize);
   } else {
     GPUReconstructionHIPBackend* master = dynamic_cast<GPUReconstructionHIPBackend*>(mMaster);
     mDeviceId = master->mDeviceId;
@@ -449,6 +448,7 @@ int GPUReconstructionHIPBackend::InitDevice_Runtime()
     mDeviceConstantMem = master->mDeviceConstantMem;
     mInternals = master->mInternals;
     GPUFailedMsgI(hipSetDevice(mDeviceId));
+    GPUInfo("HIP Initialized from master");
   }
   for (unsigned int i = 0; i < mEvents.size(); i++) {
     hipEvent_t* events = (hipEvent_t*)mEvents[i].data();

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -199,7 +199,7 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
         const TPCZSHDR* const hdr = (const TPCZSHDR*)(rdh_utils::getLink(o2::raw::RDHUtils::getFEEID(*rdh)) == rdh_utils::DLBZSLinkID ? (page + o2::raw::RDHUtils::getMemorySize(*rdh) - sizeof(TPCZSHDRV2)) : (page + sizeof(o2::header::RAWDataHeader)));
         if (mCFContext->zsVersion == -1) {
           mCFContext->zsVersion = hdr->version;
-          if (GetProcessingSettings().param.tpcTriggerHandling && mCFContext->zsVersion < ZSVersion::ZSVersionDenseLinkBased) {
+          if (GetProcessingSettings().param.tpcTriggerHandling && mCFContext->zsVersion < ZSVersion::ZSVersionDenseLinkBased) { // TODO: Move tpcTriggerHandling to recoSteps bitmask
             static bool errorShown = false;
             if (errorShown == false) {
               GPUAlarm("Trigger handling only possible with TPC Dense Link Based data, received version %d, disabling", mCFContext->zsVersion);

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -77,6 +77,8 @@ int GPUO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
       mCtx.reset(nullptr);
       return 1;
     }
+  }
+  for (unsigned int i = 0; i < mNContexts; i++) {
     mCtx[i].mChain = mCtx[i].mRec->AddChain<GPUChainTracking>(mConfig->configInterface.maxTPCHits, mConfig->configInterface.maxTRDTracklets);
     mCtx[i].mChain->mConfigDisplay = &mConfig->configDisplay;
     mCtx[i].mChain->mConfigQA = &mConfig->configQA;
@@ -96,7 +98,8 @@ int GPUO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
       dummy.set([](size_t size) -> void* {throw std::runtime_error("invalid output memory request, no common output buffer set"); return nullptr; });
       mCtx[i].mRec->SetOutputControl(dummy);
     }
-
+  }
+  for (unsigned int i = 0; i < mNContexts; i++) {
     if (i == 0 && mCtx[i].mRec->Init()) {
       mNContexts = 0;
       mCtx.reset(nullptr);

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -88,6 +88,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   struct Config {
     int itsTriggerType = 0;
     int lumiScaleMode = 0;
+    int enableDoublePipeline = 0;
     bool decompressTPC = false;
     bool decompressTPCFromROOT = false;
     bool caClusterer = false;
@@ -149,8 +150,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   int runITSTracking(o2::framework::ProcessingContext& pc);
 
   CompletionPolicyData* mPolicyData;
-  std::unique_ptr<o2::algorithm::ForwardParser<o2::tpc::ClusterGroupHeader>> mParser;
-  std::unique_ptr<GPUO2Interface> mTracker;
+  std::unique_ptr<GPUO2Interface> mGPUReco;
   std::unique_ptr<GPUDisplayFrontendInterface> mDisplayFrontend;
   std::unique_ptr<TPCFastTransform> mFastTransform;
   std::unique_ptr<TPCFastTransform> mFastTransformRef;

--- a/GPU/Workflow/src/GPUWorkflowITS.cxx
+++ b/GPU/Workflow/src/GPUWorkflowITS.cxx
@@ -37,8 +37,6 @@
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 #include "DataFormatsTPC/Digit.h"
 #include "TPCFastTransform.h"
-#include "DPLUtils/DPLRawParser.h"
-#include "DPLUtils/DPLRawPageSequencer.h"
 #include "DetectorsBase/MatLayerCylSet.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsBase/GeometryManager.h"

--- a/GPU/Workflow/src/GPUWorkflowITS.cxx
+++ b/GPU/Workflow/src/GPUWorkflowITS.cxx
@@ -308,7 +308,7 @@ void GPURecoWorkflowSpec::initFunctionITS(InitContext& ic)
   std::transform(mITSMode.begin(), mITSMode.end(), mITSMode.begin(), [](unsigned char c) { return std::tolower(c); });
   o2::its::VertexerTraits* vtxTraits = nullptr;
   o2::its::TrackerTraits* trkTraits = nullptr;
-  mTracker->GetITSTraits(trkTraits, vtxTraits, mITSTimeFrame);
+  mGPUReco->GetITSTraits(trkTraits, vtxTraits, mITSTimeFrame);
   mITSVertexer = std::make_unique<o2::its::Vertexer>(vtxTraits);
   mITSTracker = std::make_unique<o2::its::Tracker>(trkTraits);
   mITSVertexer->adoptTimeFrame(*mITSTimeFrame);

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -1021,7 +1021,7 @@ Inputs GPURecoWorkflowSpec::inputs()
   if (mSpecConfig.zsDecoder) {
     // All ZS raw data is published with subspec 0 by the o2-raw-file-reader-workflow and DataDistribution
     // creates subspec fom CRU and endpoint id, we create one single input route subscribing to all TPC/RAWDATA
-    inputs.emplace_back(InputSpec{"zsraw", ConcreteDataTypeMatcher{"TPC", "RAWDATA"}, Lifetime::Optional});
+    inputs.emplace_back(InputSpec{"zsraw", ConcreteDataTypeMatcher{"TPC", "RAWDATA"}, Lifetime::Timeframe});
     if (mSpecConfig.askDISTSTF) {
       inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
     }

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -122,119 +122,120 @@ void GPURecoWorkflowSpec::init(InitContext& ic)
 {
   GRPGeomHelper::instance().setRequest(mGGR);
   GPUO2InterfaceConfiguration& config = *mConfig.get();
-  {
-    mParser = std::make_unique<o2::algorithm::ForwardParser<o2::tpc::ClusterGroupHeader>>();
-    mTracker = std::make_unique<GPUO2Interface>();
 
-    // Create configuration object and fill settings
-    mConfig->configGRP.solenoidBz = 0;
-    mTFSettings->hasSimStartOrbit = 1;
-    auto& hbfu = o2::raw::HBFUtils::Instance();
-    mTFSettings->simStartOrbit = hbfu.getFirstIRofTF(o2::InteractionRecord(0, hbfu.orbitFirstSampled)).orbit;
+  // Create configuration object and fill settings
+  mConfig->configGRP.solenoidBz = 0;
+  mTFSettings->hasSimStartOrbit = 1;
+  auto& hbfu = o2::raw::HBFUtils::Instance();
+  mTFSettings->simStartOrbit = hbfu.getFirstIRofTF(o2::InteractionRecord(0, hbfu.orbitFirstSampled)).orbit;
 
-    *mConfParam = mConfig->ReadConfigurableParam();
-    if (mConfParam->display) {
-      mDisplayFrontend.reset(GPUDisplayFrontendInterface::getFrontend(mConfig->configDisplay.displayFrontend.c_str()));
-      mConfig->configProcessing.eventDisplay = mDisplayFrontend.get();
-      if (mConfig->configProcessing.eventDisplay != nullptr) {
-        LOG(info) << "Event display enabled";
-      } else {
-        throw std::runtime_error("GPU Event Display frontend could not be created!");
-      }
+  *mConfParam = mConfig->ReadConfigurableParam();
+  if (mConfParam->display) {
+    mDisplayFrontend.reset(GPUDisplayFrontendInterface::getFrontend(mConfig->configDisplay.displayFrontend.c_str()));
+    mConfig->configProcessing.eventDisplay = mDisplayFrontend.get();
+    if (mConfig->configProcessing.eventDisplay != nullptr) {
+      LOG(info) << "Event display enabled";
+    } else {
+      throw std::runtime_error("GPU Event Display frontend could not be created!");
     }
+  }
 
-    mAutoSolenoidBz = mConfParam->solenoidBz == -1e6f;
-    mAutoContinuousMaxTimeBin = mConfig->configGRP.continuousMaxTimeBin == -1;
-    if (mAutoContinuousMaxTimeBin) {
-      mConfig->configGRP.continuousMaxTimeBin = (256 * o2::constants::lhc::LHCMaxBunches + 2 * o2::tpc::constants::LHCBCPERTIMEBIN - 2) / o2::tpc::constants::LHCBCPERTIMEBIN;
+  mAutoSolenoidBz = mConfParam->solenoidBz == -1e6f;
+  mAutoContinuousMaxTimeBin = mConfig->configGRP.continuousMaxTimeBin == -1;
+  if (mAutoContinuousMaxTimeBin) {
+    mConfig->configGRP.continuousMaxTimeBin = (256 * o2::constants::lhc::LHCMaxBunches + 2 * o2::tpc::constants::LHCBCPERTIMEBIN - 2) / o2::tpc::constants::LHCBCPERTIMEBIN;
+  }
+  if (mConfig->configProcessing.deviceNum == -2) {
+    int myId = ic.services().get<const o2::framework::DeviceSpec>().inputTimesliceId;
+    int idMax = ic.services().get<const o2::framework::DeviceSpec>().maxInputTimeslices;
+    mConfig->configProcessing.deviceNum = myId;
+    LOG(info) << "GPU device number selected from pipeline id: " << myId << " / " << idMax;
+  }
+  if (mConfig->configProcessing.debugLevel >= 3 && mVerbosity == 0) {
+    mVerbosity = 1;
+  }
+  mConfig->configProcessing.runMC = mSpecConfig.processMC;
+  if (mSpecConfig.outputQA) {
+    if (!mSpecConfig.processMC && !mConfig->configQA.clusterRejectionHistograms) {
+      throw std::runtime_error("Need MC information to create QA plots");
     }
-    if (mConfig->configProcessing.deviceNum == -2) {
-      int myId = ic.services().get<const o2::framework::DeviceSpec>().inputTimesliceId;
-      int idMax = ic.services().get<const o2::framework::DeviceSpec>().maxInputTimeslices;
-      mConfig->configProcessing.deviceNum = myId;
-      LOG(info) << "GPU device number selected from pipeline id: " << myId << " / " << idMax;
+    if (!mSpecConfig.processMC) {
+      mConfig->configQA.noMC = true;
     }
-    if (mConfig->configProcessing.debugLevel >= 3 && mVerbosity == 0) {
-      mVerbosity = 1;
+    mConfig->configQA.shipToQC = true;
+    if (!mConfig->configProcessing.runQA) {
+      mConfig->configQA.enableLocalOutput = false;
+      mQATaskMask = (mSpecConfig.processMC ? 15 : 0) | (mConfig->configQA.clusterRejectionHistograms ? 32 : 0);
+      mConfig->configProcessing.runQA = -mQATaskMask;
     }
-    mConfig->configProcessing.runMC = mSpecConfig.processMC;
-    if (mSpecConfig.outputQA) {
-      if (!mSpecConfig.processMC && !mConfig->configQA.clusterRejectionHistograms) {
-        throw std::runtime_error("Need MC information to create QA plots");
-      }
-      if (!mSpecConfig.processMC) {
-        mConfig->configQA.noMC = true;
-      }
-      mConfig->configQA.shipToQC = true;
-      if (!mConfig->configProcessing.runQA) {
-        mConfig->configQA.enableLocalOutput = false;
-        mQATaskMask = (mSpecConfig.processMC ? 15 : 0) | (mConfig->configQA.clusterRejectionHistograms ? 32 : 0);
-        mConfig->configProcessing.runQA = -mQATaskMask;
-      }
-    }
-    mConfig->configReconstruction.tpc.nWaysOuter = true;
-    mConfig->configInterface.outputToExternalBuffers = true;
-    if (mConfParam->synchronousProcessing) {
-      mConfig->configReconstruction.useMatLUT = false;
-    }
+  }
+  mConfig->configReconstruction.tpc.nWaysOuter = true;
+  mConfig->configInterface.outputToExternalBuffers = true;
+  if (mConfParam->synchronousProcessing) {
+    mConfig->configReconstruction.useMatLUT = false;
+  }
 
-    // Configure the "GPU workflow" i.e. which steps we run on the GPU (or CPU)
-    if (mSpecConfig.outputTracks || mSpecConfig.outputCompClusters || mSpecConfig.outputCompClustersFlat) {
-      mConfig->configWorkflow.steps.set(GPUDataTypes::RecoStep::TPCConversion,
-                                        GPUDataTypes::RecoStep::TPCSliceTracking,
-                                        GPUDataTypes::RecoStep::TPCMerging);
-      mConfig->configWorkflow.outputs.set(GPUDataTypes::InOutType::TPCMergedTracks);
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCdEdx, mConfParam->rundEdx == -1 ? !mConfParam->synchronousProcessing : mConfParam->rundEdx);
+  // Configure the "GPU workflow" i.e. which steps we run on the GPU (or CPU)
+  if (mSpecConfig.outputTracks || mSpecConfig.outputCompClusters || mSpecConfig.outputCompClustersFlat) {
+    mConfig->configWorkflow.steps.set(GPUDataTypes::RecoStep::TPCConversion,
+                                      GPUDataTypes::RecoStep::TPCSliceTracking,
+                                      GPUDataTypes::RecoStep::TPCMerging);
+    mConfig->configWorkflow.outputs.set(GPUDataTypes::InOutType::TPCMergedTracks);
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCdEdx, mConfParam->rundEdx == -1 ? !mConfParam->synchronousProcessing : mConfParam->rundEdx);
+  }
+  if (mSpecConfig.outputCompClusters || mSpecConfig.outputCompClustersFlat) {
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCCompression, true);
+    mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCCompressedClusters, true);
+  }
+  mConfig->configWorkflow.inputs.set(GPUDataTypes::InOutType::TPCClusters);
+  if (mSpecConfig.caClusterer) { // Override some settings if we have raw data as input
+    mConfig->configWorkflow.inputs.set(GPUDataTypes::InOutType::TPCRaw);
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCClusterFinding, true);
+    mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCClusters, true);
+  }
+  if (mSpecConfig.decompressTPC) {
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCCompression, false);
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCDecompression, true);
+    mConfig->configWorkflow.inputs.set(GPUDataTypes::InOutType::TPCCompressedClusters);
+    mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCClusters, true);
+    mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCCompressedClusters, false);
+    if (mTPCSectorMask != 0xFFFFFFFFF) {
+      throw std::invalid_argument("Cannot run TPC decompression with a sector mask");
     }
-    if (mSpecConfig.outputCompClusters || mSpecConfig.outputCompClustersFlat) {
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCCompression, true);
-      mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCCompressedClusters, true);
-    }
-    mConfig->configWorkflow.inputs.set(GPUDataTypes::InOutType::TPCClusters);
-    if (mSpecConfig.caClusterer) { // Override some settings if we have raw data as input
-      mConfig->configWorkflow.inputs.set(GPUDataTypes::InOutType::TPCRaw);
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCClusterFinding, true);
-      mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCClusters, true);
-    }
-    if (mSpecConfig.decompressTPC) {
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCCompression, false);
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TPCDecompression, true);
-      mConfig->configWorkflow.inputs.set(GPUDataTypes::InOutType::TPCCompressedClusters);
-      mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCClusters, true);
-      mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::TPCCompressedClusters, false);
-      if (mTPCSectorMask != 0xFFFFFFFFF) {
-        throw std::invalid_argument("Cannot run TPC decompression with a sector mask");
-      }
-    }
-    if (mSpecConfig.runTRDTracking) {
-      mConfig->configWorkflow.inputs.setBits(GPUDataTypes::InOutType::TRDTracklets, true);
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TRDTracking, true);
-    }
-    if (mSpecConfig.runITSTracking) {
-      mConfig->configWorkflow.inputs.setBits(GPUDataTypes::InOutType::ITSClusters, true);
-      mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::ITSTracks, true);
-      mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::ITSTracking, true);
-    }
-    if (mSpecConfig.outputSharedClusterMap) {
-      mConfig->configProcessing.outputSharedClusterMap = true;
-    }
-    mConfig->configProcessing.createO2Output = mSpecConfig.outputTracks ? 2 : 0; // Disable O2 TPC track format output if no track output requested
-    mConfig->configProcessing.param.tpcTriggerHandling = mSpecConfig.tpcTriggerHandling;
+  }
+  if (mSpecConfig.runTRDTracking) {
+    mConfig->configWorkflow.inputs.setBits(GPUDataTypes::InOutType::TRDTracklets, true);
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::TRDTracking, true);
+  }
+  if (mSpecConfig.runITSTracking) {
+    mConfig->configWorkflow.inputs.setBits(GPUDataTypes::InOutType::ITSClusters, true);
+    mConfig->configWorkflow.outputs.setBits(GPUDataTypes::InOutType::ITSTracks, true);
+    mConfig->configWorkflow.steps.setBits(GPUDataTypes::RecoStep::ITSTracking, true);
+  }
+  if (mSpecConfig.outputSharedClusterMap) {
+    mConfig->configProcessing.outputSharedClusterMap = true;
+  }
+  mConfig->configProcessing.createO2Output = mSpecConfig.outputTracks ? 2 : 0; // Disable O2 TPC track format output if no track output requested
+  mConfig->configProcessing.param.tpcTriggerHandling = mSpecConfig.tpcTriggerHandling;
 
-    if (mConfParam->transformationFile.size() || mConfParam->transformationSCFile.size()) {
-      LOG(fatal) << "Deprecated configurable param options GPU_global.transformationFile or transformationSCFile used\n"
-                 << "Instead, link the corresponding file as <somedir>/TPC/Calib/CorrectionMap/snapshot.root and use it via\n"
-                 << "--condition-remap file://<somdir>=TPC/Calib/CorrectionMap option";
-    }
-    /* if (config.configProcessing.doublePipeline && ic.services().get<ThreadPool>().poolSize != 2) {
-      throw std::runtime_error("double pipeline requires exactly 2 threads");
-    } */
-    if (config.configProcessing.doublePipeline && (mSpecConfig.readTRDtracklets || mSpecConfig.runITSTracking || !(mSpecConfig.zsOnTheFly || mSpecConfig.zsDecoder))) {
-      LOG(fatal) << "GPU two-threaded pipeline works only with TPC-only processing, and with ZS input";
-    }
+  if (mConfParam->transformationFile.size() || mConfParam->transformationSCFile.size()) {
+    LOG(fatal) << "Deprecated configurable param options GPU_global.transformationFile or transformationSCFile used\n"
+               << "Instead, link the corresponding file as <somedir>/TPC/Calib/CorrectionMap/snapshot.root and use it via\n"
+               << "--condition-remap file://<somdir>=TPC/Calib/CorrectionMap option";
+  }
+  /* if (config.configProcessing.doublePipeline && ic.services().get<ThreadPool>().poolSize != 2) {
+    throw std::runtime_error("double pipeline requires exactly 2 threads");
+  } */
+  if (config.configProcessing.doublePipeline && (mSpecConfig.readTRDtracklets || mSpecConfig.runITSTracking || !(mSpecConfig.zsOnTheFly || mSpecConfig.zsDecoder))) {
+    LOG(fatal) << "GPU two-threaded pipeline works only with TPC-only processing, and with ZS input";
+  }
+
+  if (mSpecConfig.enableDoublePipeline != 2) {
+    mGPUReco = std::make_unique<GPUO2Interface>();
 
     // initialize TPC calib objects
     initFunctionTPCCalib(ic);
+
     mConfig->configCalib.fastTransform = mFastTransformHelper->getCorrMap();
     mConfig->configCalib.fastTransformRef = mFastTransformHelper->getCorrMapRef();
     mConfig->configCalib.fastTransformHelper = mFastTransformHelper.get();
@@ -264,14 +265,14 @@ void GPURecoWorkflowSpec::init(InitContext& ic)
     }
 
     // Configuration is prepared, initialize the tracker.
-    if (mTracker->Initialize(config) != 0) {
+    if (mGPUReco->Initialize(config) != 0) {
       throw std::invalid_argument("GPU Reconstruction initialization failed");
     }
     if (mSpecConfig.outputQA) {
       mQA = std::make_unique<GPUO2InterfaceQA>(mConfig.get());
     }
     if (mSpecConfig.outputErrorQA) {
-      mTracker->setErrorCodeOutput(&mErrorQA);
+      mGPUReco->setErrorCodeOutput(&mErrorQA);
     }
 
     // initialize ITS
@@ -279,49 +280,49 @@ void GPURecoWorkflowSpec::init(InitContext& ic)
       initFunctionITS(ic);
     }
 
-    mTimer->Stop();
-    mTimer->Reset();
+    auto& callbacks = ic.services().get<CallbackService>();
+    callbacks.set<CallbackService::Id::RegionInfoCallback>([this](fair::mq::RegionInfo const& info) {
+      if (info.size == 0) {
+        return;
+      }
+      if (mConfParam->registerSelectedSegmentIds != -1 && info.managed && info.id != (unsigned int)mConfParam->registerSelectedSegmentIds) {
+        return;
+      }
+      int fd = 0;
+      if (mConfParam->mutexMemReg) {
+        mode_t mask = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+        fd = open("/tmp/o2_gpu_memlock_mutex.lock", O_RDWR | O_CREAT | O_CLOEXEC, mask);
+        if (fd == -1) {
+          throw std::runtime_error("Error opening lock file");
+        }
+        fchmod(fd, mask);
+        if (lockf(fd, F_LOCK, 0)) {
+          throw std::runtime_error("Error locking file");
+        }
+      }
+      std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
+      if (mConfParam->benchmarkMemoryRegistration) {
+        start = std::chrono::high_resolution_clock::now();
+      }
+      if (mGPUReco->registerMemoryForGPU(info.ptr, info.size)) {
+        throw std::runtime_error("Error registering memory for GPU");
+      }
+      if (mConfParam->benchmarkMemoryRegistration) {
+        end = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> elapsed_seconds = end - start;
+        LOG(info) << "Memory registration time (0x" << info.ptr << ", " << info.size << " bytes): " << elapsed_seconds.count() << " s";
+      }
+      if (mConfParam->mutexMemReg) {
+        if (lockf(fd, F_ULOCK, 0)) {
+          throw std::runtime_error("Error unlocking file");
+        }
+        close(fd);
+      }
+    });
   }
 
-  auto& callbacks = ic.services().get<CallbackService>();
-  callbacks.set<CallbackService::Id::RegionInfoCallback>([this](fair::mq::RegionInfo const& info) {
-    if (info.size == 0) {
-      return;
-    }
-    if (mConfParam->registerSelectedSegmentIds != -1 && info.managed && info.id != (unsigned int)mConfParam->registerSelectedSegmentIds) {
-      return;
-    }
-    int fd = 0;
-    if (mConfParam->mutexMemReg) {
-      mode_t mask = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
-      fd = open("/tmp/o2_gpu_memlock_mutex.lock", O_RDWR | O_CREAT | O_CLOEXEC, mask);
-      if (fd == -1) {
-        throw std::runtime_error("Error opening lock file");
-      }
-      fchmod(fd, mask);
-      if (lockf(fd, F_LOCK, 0)) {
-        throw std::runtime_error("Error locking file");
-      }
-    }
-    std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
-    if (mConfParam->benchmarkMemoryRegistration) {
-      start = std::chrono::high_resolution_clock::now();
-    }
-    if (mTracker->registerMemoryForGPU(info.ptr, info.size)) {
-      throw std::runtime_error("Error registering memory for GPU");
-    }
-    if (mConfParam->benchmarkMemoryRegistration) {
-      end = std::chrono::high_resolution_clock::now();
-      std::chrono::duration<double> elapsed_seconds = end - start;
-      LOG(info) << "Memory registration time (0x" << info.ptr << ", " << info.size << " bytes): " << elapsed_seconds.count() << " s";
-    }
-    if (mConfParam->mutexMemReg) {
-      if (lockf(fd, F_ULOCK, 0)) {
-        throw std::runtime_error("Error unlocking file");
-      }
-      close(fd);
-    }
-  });
+  mTimer->Stop();
+  mTimer->Reset();
 }
 
 void GPURecoWorkflowSpec::stop()
@@ -335,9 +336,11 @@ void GPURecoWorkflowSpec::endOfStream(EndOfStreamContext& ec)
 
 void GPURecoWorkflowSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
-  finaliseCCDBTPC(matcher, obj);
-  if (mSpecConfig.runITSTracking) {
-    finaliseCCDBITS(matcher, obj);
+  if (mSpecConfig.enableDoublePipeline != 2) {
+    finaliseCCDBTPC(matcher, obj);
+    if (mSpecConfig.runITSTracking) {
+      finaliseCCDBITS(matcher, obj);
+    }
   }
   if (GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
     mGRPGeomUpdated = true;
@@ -509,9 +512,51 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     LOG(fatal) << "configKeyValue tpcTriggeredMode does not match GRP isDetContinuousReadOut(TPC) setting";
   }
 
+  // ------------------------------ Handle inputs ------------------------------
+
+  GPUTrackingInOutPointers ptrs;
   processInputs(pc, tpcZSmetaPointers, tpcZSmetaPointers2, tpcZSmetaSizes, tpcZSmetaSizes2, inputZS, tpcZS, tpcZSonTheFlySizes, debugTFDump, compClustersDummy, compClustersFlatDummy, pCompClustersFlat, tmpEmptyCompClusters); // Process non-digit / non-cluster inputs
   const auto& inputsClustersDigits = o2::tpc::getWorkflowTPCInput(pc, mVerbosity, getWorkflowTPCInput_mc, getWorkflowTPCInput_clusters, mTPCSectorMask, getWorkflowTPCInput_digits);                                             // Process digit and cluster inputs
-  GPUTrackingInOutPointers ptrs;
+
+  const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+  mTFSettings->tfStartOrbit = tinfo.firstTForbit;
+  mTFSettings->hasTfStartOrbit = 1;
+  mTFSettings->hasNHBFPerTF = 1;
+  mTFSettings->nHBFPerTF = GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF();
+  mTFSettings->hasRunStartOrbit = 0;
+  if (mVerbosity) {
+    LOG(info) << "TF firstTForbit " << mTFSettings->tfStartOrbit << " nHBF " << mTFSettings->nHBFPerTF << " runStartOrbit " << mTFSettings->runStartOrbit << " simStartOrbit " << mTFSettings->simStartOrbit;
+  }
+  ptrs.settingsTF = mTFSettings.get();
+
+  if (mConfParam->checkFirstTfOrbit) {
+    static uint32_t lastFirstTFOrbit = -1;
+    static uint32_t lastTFCounter = -1;
+    if (lastFirstTFOrbit != -1 && lastTFCounter != -1) {
+      int diffOrbit = tinfo.firstTForbit - lastFirstTFOrbit;
+      int diffCounter = tinfo.tfCounter - lastTFCounter;
+      if (diffOrbit != diffCounter * mTFSettings->nHBFPerTF) {
+        LOG(error) << "Time frame has mismatching firstTfOrbit - Last orbit/counter: " << lastFirstTFOrbit << " " << lastTFCounter << " - Current: " << tinfo.firstTForbit << " " << tinfo.tfCounter;
+      }
+    }
+    lastFirstTFOrbit = tinfo.firstTForbit;
+    lastTFCounter = tinfo.tfCounter;
+  }
+
+  if (mTPCSectorMask != 0xFFFFFFFFF) {
+    // Clean out the unused sectors, such that if they were present by chance, they are not processed, and if the values are uninitialized, we should not crash
+    for (unsigned int i = 0; i < NSectors; i++) {
+      if (!(mTPCSectorMask & (1ul << i))) {
+        if (ptrs.tpcZS) {
+          for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+            tpcZS.slice[i].zsPtr[j] = nullptr;
+            tpcZS.slice[i].nZSPtr[j] = nullptr;
+            tpcZS.slice[i].count[j] = 0;
+          }
+        }
+      }
+    }
+  }
 
   o2::globaltracking::RecoContainer inputTracksTRD;
   decltype(o2::trd::getRecoInputContainer(pc, &ptrs, &inputTracksTRD)) trdInputContainer;
@@ -559,14 +604,24 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     }
   }
 
-  // a byte size resizable vector object, the DataAllocator returns reference to internal object
-  // initialize optional pointer to the vector object
   o2::tpc::TPCSectorHeader clusterOutputSectorHeader{0};
   if (mClusterOutputIds.size() > 0) {
     clusterOutputSectorHeader.sectorBits = mTPCSectorMask;
     // subspecs [0, NSectors - 1] are used to identify sector data, we use NSectors to indicate the full TPC
     clusterOutputSectorHeader.activeSectors = mTPCSectorMask;
   }
+
+  // ------------------------------ Prepare stage for double-pipeline before normal output preparation ------------------------------
+
+  if (mSpecConfig.enableDoublePipeline == 2) {
+    size_t prepareBufferSize = sizeof(*ptrs.settingsTF);
+    auto prepareBuffer = pc.outputs().make<DataAllocator::UninitializedVector<char>>(Output{gDataOriginGPU, "PIPELINEPREPARE", 0, Lifetime::Timeframe}, prepareBufferSize);
+    char* prepareBufferPtr = prepareBuffer.data();
+    memcpy(prepareBufferPtr, ptrs.settingsTF, prepareBufferSize);
+    return;
+  }
+
+  // ------------------------------ Prepare outputs ------------------------------
 
   GPUInterfaceOutputs outputRegions;
   using outputDataType = char;
@@ -645,45 +700,7 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     outputRegions.clusterLabels.allocator = [&clustersMCBuffer](size_t size) -> void* { return &clustersMCBuffer; };
   }
 
-  const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
-  mTFSettings->tfStartOrbit = tinfo.firstTForbit;
-  mTFSettings->hasTfStartOrbit = 1;
-  mTFSettings->hasNHBFPerTF = 1;
-  mTFSettings->nHBFPerTF = GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF();
-  mTFSettings->hasRunStartOrbit = 0;
-  if (mVerbosity) {
-    LOG(info) << "TF firstTForbit " << mTFSettings->tfStartOrbit << " nHBF " << mTFSettings->nHBFPerTF << " runStartOrbit " << mTFSettings->runStartOrbit << " simStartOrbit " << mTFSettings->simStartOrbit;
-  }
-  ptrs.settingsTF = mTFSettings.get();
-
-  if (mConfParam->checkFirstTfOrbit) {
-    static uint32_t lastFirstTFOrbit = -1;
-    static uint32_t lastTFCounter = -1;
-    if (lastFirstTFOrbit != -1 && lastTFCounter != -1) {
-      int diffOrbit = tinfo.firstTForbit - lastFirstTFOrbit;
-      int diffCounter = tinfo.tfCounter - lastTFCounter;
-      if (diffOrbit != diffCounter * mTFSettings->nHBFPerTF) {
-        LOG(error) << "Time frame has mismatching firstTfOrbit - Last orbit/counter: " << lastFirstTFOrbit << " " << lastTFCounter << " - Current: " << tinfo.firstTForbit << " " << tinfo.tfCounter;
-      }
-    }
-    lastFirstTFOrbit = tinfo.firstTForbit;
-    lastTFCounter = tinfo.tfCounter;
-  }
-
-  if (mTPCSectorMask != 0xFFFFFFFFF) {
-    // Clean out the unused sectors, such that if they were present by chance, they are not processed, and if the values are uninitialized, we should not crash
-    for (unsigned int i = 0; i < NSectors; i++) {
-      if (!(mTPCSectorMask & (1ul << i))) {
-        if (ptrs.tpcZS) {
-          for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
-            tpcZS.slice[i].zsPtr[j] = nullptr;
-            tpcZS.slice[i].nZSPtr[j] = nullptr;
-            tpcZS.slice[i].count[j] = 0;
-          }
-        }
-      }
-    }
-  }
+  // ------------------------------ Actual processing ------------------------------
 
   if ((int)(ptrs.tpcZS != nullptr) + (int)(ptrs.tpcPackedDigits != nullptr && (ptrs.tpcZS == nullptr || ptrs.tpcPackedDigits->tpcDigitsMC == nullptr)) + (int)(ptrs.clustersNative != nullptr) + (int)(ptrs.tpcCompressedClusters != nullptr) != 1) {
     throw std::runtime_error("Invalid input for gpu tracking");
@@ -697,9 +714,9 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
 
   if (mConfParam->dump) {
     if (mNTFs == 1) {
-      mTracker->DumpSettings();
+      mGPUReco->DumpSettings();
     }
-    mTracker->DumpEvent(mNTFs - 1, &ptrs);
+    mGPUReco->DumpEvent(mNTFs - 1, &ptrs);
   }
   std::unique_ptr<GPUTrackingInOutPointers> ptrsDump;
   if (mConfParam->dumpBadTFMode == 2) {
@@ -709,7 +726,7 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
 
   int retVal = 0;
   if (mConfParam->dump < 2) {
-    retVal = mTracker->RunTracking(&ptrs, &outputRegions, threadIndex);
+    retVal = mGPUReco->RunTracking(&ptrs, &outputRegions, threadIndex);
     if (retVal != 0) {
       debugTFDump = true;
     }
@@ -722,7 +739,7 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
   o2::utils::DebugStreamer::instance()->flush(); // flushing debug output to file
   cleanOldCalibsTPCPtrs();                       // setting TPC calibration objects
   // if (!mTrackingCAO2Interface->getConfig().configInterface.outputToExternalBuffers) // TODO: Why was this needed for double-pipeline?
-  mTracker->Clear(false, threadIndex); // clean non-output memory used by GPU Reconstruction
+  mGPUReco->Clear(false, threadIndex); // clean non-output memory used by GPU Reconstruction
 
   if (debugTFDump && mNDebugDumps < mConfParam->dumpBadTFs) {
     mNDebugDumps++;
@@ -740,13 +757,16 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
       }
       fclose(fp);
     } else if (mConfParam->dumpBadTFMode == 2) {
-      mTracker->DumpEvent(mNDebugDumps - 1, ptrsDump.get());
+      mGPUReco->DumpEvent(mNDebugDumps - 1, ptrsDump.get());
     }
   }
 
   if (mConfParam->dump == 2) {
     return;
   }
+
+  // ------------------------------ Varios postprocessing steps ------------------------------
+
   bool createEmptyOutput = false;
   if (retVal != 0) {
     if (retVal == 3 && mConfig->configProcessing.ignoreNonFatalGPUErrors) {
@@ -951,13 +971,16 @@ void GPURecoWorkflowSpec::doCalibUpdates(o2::framework::ProcessingContext& pc)
   }
   if (needCalibUpdate) {
     LOG(info) << "Updating GPUReconstruction calibration objects";
-    mTracker->UpdateCalibration(newCalibObjects, newCalibValues);
+    mGPUReco->UpdateCalibration(newCalibObjects, newCalibValues);
   }
 }
 
 Options GPURecoWorkflowSpec::options()
 {
   Options opts;
+  if (mSpecConfig.enableDoublePipeline == 2) {
+    return opts;
+  }
   if (mSpecConfig.outputTracks) {
     o2::tpc::CorrectionMapsLoader::addOptions(opts);
   }
@@ -967,6 +990,22 @@ Options GPURecoWorkflowSpec::options()
 Inputs GPURecoWorkflowSpec::inputs()
 {
   Inputs inputs;
+  if (mSpecConfig.zsDecoder) {
+    // All ZS raw data is published with subspec 0 by the o2-raw-file-reader-workflow and DataDistribution
+    // creates subspec fom CRU and endpoint id, we create one single input route subscribing to all TPC/RAWDATA
+    inputs.emplace_back(InputSpec{"zsraw", ConcreteDataTypeMatcher{"TPC", "RAWDATA"}, Lifetime::Timeframe});
+    if (mSpecConfig.askDISTSTF) {
+      inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
+    }
+  }
+  if (mSpecConfig.enableDoublePipeline == 2) {
+    if (!mSpecConfig.zsDecoder) {
+      LOG(fatal) << "Double pipeline mode can only work with zsraw input";
+    }
+    return inputs;
+  } else if (mSpecConfig.enableDoublePipeline == 1) {
+    inputs.emplace_back("pipelineprepare", gDataOriginGPU, "PIPELINEPREPARE", 0, Lifetime::Timeframe);
+  }
   if (mSpecConfig.outputTracks) {
     // loading calibration objects from the CCDB
     inputs.emplace_back("tpcgain", gDataOriginTPC, "PADGAINFULL", 0, Lifetime::Condition, ccdbParamSpec(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::CalPadGainFull)));
@@ -1007,14 +1046,6 @@ Inputs GPURecoWorkflowSpec::inputs()
     }
   }
 
-  if (mSpecConfig.zsDecoder) {
-    // All ZS raw data is published with subspec 0 by the o2-raw-file-reader-workflow and DataDistribution
-    // creates subspec fom CRU and endpoint id, we create one single input route subscribing to all TPC/RAWDATA
-    inputs.emplace_back(InputSpec{"zsraw", ConcreteDataTypeMatcher{"TPC", "RAWDATA"}, Lifetime::Timeframe});
-    if (mSpecConfig.askDISTSTF) {
-      inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
-    }
-  }
   if (mSpecConfig.zsOnTheFly) {
     inputs.emplace_back(InputSpec{"zsinput", ConcreteDataTypeMatcher{"TPC", "TPCZS"}, Lifetime::Timeframe});
     inputs.emplace_back(InputSpec{"zsinputsizes", ConcreteDataTypeMatcher{"TPC", "ZSSIZES"}, Lifetime::Timeframe});
@@ -1054,6 +1085,10 @@ Outputs GPURecoWorkflowSpec::outputs()
 {
   constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
   std::vector<OutputSpec> outputSpecs;
+  if (mSpecConfig.enableDoublePipeline == 2) {
+    outputSpecs.emplace_back(gDataOriginGPU, "PIPELINEPREPARE", 0, Lifetime::Timeframe);
+    return outputSpecs;
+  }
   if (mSpecConfig.outputTracks) {
     outputSpecs.emplace_back(gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe);
     outputSpecs.emplace_back(gDataOriginTPC, "CLUSREFS", 0, Lifetime::Timeframe);
@@ -1124,7 +1159,7 @@ void GPURecoWorkflowSpec::deinitialize()
 {
   mQA.reset(nullptr);
   mDisplayFrontend.reset(nullptr);
-  mTracker.reset(nullptr);
+  mGPUReco.reset(nullptr);
 }
 
 } // namespace o2::gpu

--- a/GPU/Workflow/src/GPUWorkflowTPC.cxx
+++ b/GPU/Workflow/src/GPUWorkflowTPC.cxx
@@ -37,8 +37,6 @@
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 #include "DataFormatsTPC/Digit.h"
 #include "TPCFastTransform.h"
-#include "DPLUtils/DPLRawParser.h"
-#include "DPLUtils/DPLRawPageSequencer.h"
 #include "DetectorsBase/MatLayerCylSet.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsBase/GeometryManager.h"

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -56,7 +56,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCHwClusterer.peakChargeThreshold=4;...')"}},
-    {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}}};
+    {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"enableDoublePipeline", VariantType::Bool, false, {"enable GPU double pipeline mode"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -172,13 +173,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   cfg.readTRDtracklets = isEnabled(inputTypes, ioType::TRDTracklets);
   cfg.runTRDTracking = isEnabled(outputTypes, ioType::TRDTracks);
   cfg.tpcTriggerHandling = isEnabled(outputTypes, ioType::TPCTriggers) || cfg.caClusterer;
+  cfg.enableDoublePipeline = cfgc.options().get<bool>("enableDoublePipeline");
 
   Inputs ggInputs;
   auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false, true, false, true, true, o2::base::GRPGeomRequest::Aligned, ggInputs, true);
 
   auto task = std::make_shared<GPURecoWorkflowSpec>(&gPolicyData, cfg, tpcSectors, gTpcSectorMask, ggRequest);
   Inputs taskInputs = task->inputs();
-  Options taskOptions = task->options();
   std::move(ggInputs.begin(), ggInputs.end(), std::back_inserter(taskInputs));
   gTask = task;
 
@@ -187,7 +188,22 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     taskInputs,
     task->outputs(),
     AlgorithmSpec{adoptTask<GPURecoWorkflowSpec>(task)},
-    taskOptions});
+    task->options()});
+
+  if (cfg.enableDoublePipeline) {
+    cfg.enableDoublePipeline = 2;
+    Inputs ggInputsPrepare;
+    auto ggRequestPrepare = std::make_shared<o2::base::GRPGeomRequest>(false, true, false, false, false, o2::base::GRPGeomRequest::None, ggInputsPrepare, true);
+    auto taskPrepare = std::make_shared<GPURecoWorkflowSpec>(&gPolicyData, cfg, tpcSectors, gTpcSectorMask, ggRequestPrepare);
+    Inputs taskInputsPrepare = taskPrepare->inputs();
+    std::move(ggInputsPrepare.begin(), ggInputsPrepare.end(), std::back_inserter(taskInputsPrepare));
+    specs.emplace_back(DataProcessorSpec{
+      "gpu-reconstruction-prepare",
+      taskInputsPrepare,
+      taskPrepare->outputs(),
+      AlgorithmSpec{adoptTask<GPURecoWorkflowSpec>(taskPrepare)},
+      taskPrepare->options()});
+  }
 
   if (!cfgc.options().get<bool>("ignore-dist-stf")) {
     GlobalTrackID::mask_t srcTrk = GlobalTrackID::getSourcesMask("none");

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -277,6 +277,8 @@ if has_detector_calib PHS && workflow_has_parameter CALIB; then
   PHS_CONFIG+=" --fullclu-output"
 fi
 
+[[ ${O2_GPU_DOUBLE_PIPELINE:-0} == 1 ]] && GPU_CONFIG+=" --enableDoublePipeline"
+
 ( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && has_detector EMC && RAW_EMC_SUBSPEC=" --subspecification 1 "
 has_detector_reco MID && has_detector_matching MCHMID && MFTMCHConf="FwdMatching.useMIDMatch=true;" || MFTMCHConf="FwdMatching.useMIDMatch=false;"
 
@@ -438,7 +440,7 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Common reconstruction workflows
-(has_detector_reco TPC || has_detector_ctf TPC) && ! has_detector_from_global_reader TPC && add_W o2-gpu-reco-workflow "--gpu-reconstruction \"$GPU_CONFIG_SELF\" $ASK_CTP_LUMI_GPU --input-type=$GPU_INPUT $DISABLE_MC --output-type $GPU_OUTPUT --pipeline gpu-reconstruction:${N_TPCTRK:-1} $GPU_CONFIG" "GPU_global.deviceType=$GPUTYPE;GPU_proc.debugLevel=0;$GPU_CONFIG_KEY;$TRACKTUNETPCINNER"
+(has_detector_reco TPC || has_detector_ctf TPC) && ! has_detector_from_global_reader TPC && add_W o2-gpu-reco-workflow "--gpu-reconstruction \"$GPU_CONFIG_SELF\" $ASK_CTP_LUMI_GPU --input-type=$GPU_INPUT $DISABLE_MC --output-type $GPU_OUTPUT --pipeline gpu-reconstruction:${N_TPCTRK:-1},gpu-reconstruction-prepare:${N_TPCTRK:-1} $GPU_CONFIG" "GPU_global.deviceType=$GPUTYPE;GPU_proc.debugLevel=0;$GPU_CONFIG_KEY;$TRACKTUNETPCINNER"
 (has_detector_reco TOF || has_detector_ctf TOF) && ! has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "$TOF_CONFIG --input-type $TOF_INPUT --output-type $TOF_OUTPUT $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N tof-compressed-decoder TOF RAW 1),$(get_N TOFClusterer TOF REST 1)"
 has_detector_reco ITS && ! has_detector_from_global_reader ITS && add_W o2-its-reco-workflow "--trackerCA $ITS_CONFIG $DISABLE_MC $DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N its-tracker ITS REST 1 ITSTRK)" "$ITS_CONFIG_KEY;$ITSMFT_STROBES;$ITSEXTRAERR"
 has_detector_reco FT0 && ! has_detector_from_global_reader FT0 && add_W o2-ft0-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N ft0-reconstructor FT0 REST 1)"

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -387,7 +387,7 @@ if [[ ! -z $INPUT_DETECTOR_LIST ]]; then
       done
     done
     [[ ! -z ${TIMEFRAME_RATE_LIMIT:-} ]] && [[ $TIMEFRAME_RATE_LIMIT != 0 ]] && PROXY_CHANNEL+=";name=metric-feedback,type=pull,method=connect,address=ipc://${UDS_PREFIX}metric-feedback-${O2JOBID:-$NUMAID},transport=shmem,rateLogging=0"
-    add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --readout-proxy \"--channel-config \\\"$PROXY_CHANNEL\\\"\" ${TIMEFRAME_SHM_LIMIT+--timeframes-shm-limit} ${TIMEFRAME_SHM_LIMIT:-}" "" 0
+    add_W o2-dpl-raw-proxy "--dataspec \"$PROXY_INSPEC\" --inject-missing-data --readout-proxy \"--channel-config \\\"$PROXY_CHANNEL\\\"\" ${TIMEFRAME_SHM_LIMIT+--timeframes-shm-limit} ${TIMEFRAME_SHM_LIMIT:-}" "" 0
   elif [[ $DIGITINPUT == 1 ]]; then
     [[ $NTIMEFRAMES != 1 ]] && { echo "Digit input works only with NTIMEFRAMES=1" 1>&2; exit 1; }
     DISABLE_DIGIT_ROOT_INPUT=


### PR DESCRIPTION
What is working so far:
- A prepare device is injected in the chain in front of the gpu-reconstruction, parsing the same input data, then forwarding a dummy message.
- Use the new 0xDEADBEEF in input-proxy feature to allow multiple devices to subscribe to raw data.
- Bring up 2 GPU pipelines, but feed them alternately, not yet concurrently.
Missing:
- out-of band channel between the devices to forward the input pointers.
- Feed the 2 pipelines concurrently when data arrives from the out of band channel.
- Fix some race conditions / problems with calibration data, which were never used / tested with the multi-threaded pipeline 2 years ago.