### PR TITLE
GPU: Implement out-of-band message from prepare device to GPU device transfering ptrs to input data

### DIFF
--- a/GPU/Workflow/CMakeLists.txt
+++ b/GPU/Workflow/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(GPUWorkflow
                SOURCES src/GPUWorkflowSpec.cxx
                        src/GPUWorkflowTPC.cxx
                        src/GPUWorkflowITS.cxx
+                       src/GPUWorkflowPipeline.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::DataFormatsTPC

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -30,6 +30,10 @@
 #include <mutex>
 
 class TStopwatch;
+namespace fair::mq
+{
+struct RegionInfo;
+} // namespace fair::mq
 namespace o2
 {
 namespace base
@@ -79,6 +83,8 @@ struct TPCZSLinkMapping;
 struct GPUSettingsO2;
 class GPUO2InterfaceQA;
 struct GPUTrackingInOutPointers;
+struct GPUTrackingInOutZS;
+struct GPURecoWorkflowSpec_TPCZSBuffers;
 
 class GPURecoWorkflowSpec : public o2::framework::Task
 {
@@ -144,10 +150,12 @@ class GPURecoWorkflowSpec : public o2::framework::Task
 
   void doTrackTuneTPC(GPUTrackingInOutPointers& ptrs, char* buffout);
 
-  template <class A, class B, class C, class D, class E, class F, class G, class H, class I, class J, class K>
-  void processInputs(o2::framework::ProcessingContext&, A&, B&, C&, D&, E&, F&, G&, bool&, H&, I&, J&, K&);
+  template <class D, class E, class F, class G, class H, class I, class J, class K>
+  void processInputs(o2::framework::ProcessingContext&, D&, E&, F&, G&, bool&, H&, I&, J&, K&);
 
   int runITSTracking(o2::framework::ProcessingContext& pc);
+
+  int handlePipeline(o2::framework::ProcessingContext& pc, GPUTrackingInOutPointers& ptrs, GPURecoWorkflowSpec_TPCZSBuffers& tpcZSmeta, o2::gpu::GPUTrackingInOutZS& tpcZS);
 
   CompletionPolicyData* mPolicyData;
   std::unique_ptr<GPUO2Interface> mGPUReco;
@@ -178,6 +186,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   std::unique_ptr<o2::its::Vertexer> mITSVertexer;
   std::mutex mMutexDecodeInput;
   o2::its::TimeFrame* mITSTimeFrame = nullptr;
+  std::vector<fair::mq::RegionInfo> mRegionInfos;
   const o2::itsmft::TopologyDictionary* mITSDict = nullptr;
   const o2::dataformats::MeanVertexObject* mMeanVertex;
   unsigned long mTPCSectorMask = 0;

--- a/GPU/Workflow/src/GPUWorkflowInternal.h
+++ b/GPU/Workflow/src/GPUWorkflowInternal.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   GPUWorkflowInternal.h
+/// @author David Rohr
+
+#ifndef O2_GPU_GPUWORKFLOWINTERNAL_H
+#define O2_GPU_GPUWORKFLOWINTERNAL_H
+
+#include "GPUDataTypes.h"
+
+namespace o2::gpu
+{
+
+struct GPURecoWorkflowSpec_TPCZSBuffers {
+  std::vector<const void*> Pointers[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+  std::vector<unsigned int> Sizes[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+  const void** Pointers2[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+  const unsigned int* Sizes2[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+};
+
+} // namespace o2::gpu
+
+#endif

--- a/GPU/Workflow/src/GPUWorkflowPipeline.cxx
+++ b/GPU/Workflow/src/GPUWorkflowPipeline.cxx
@@ -1,0 +1,169 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   GPUWorkflowPipeline.cxx
+/// @author David Rohr
+
+#include "GPUWorkflow/GPUWorkflowSpec.h"
+#include "GPUO2InterfaceConfiguration.h"
+#include "GPUO2Interface.h"
+#include "GPUDataTypes.h"
+#include "GPUSettings.h"
+#include "GPUWorkflowInternal.h"
+
+#include "Framework/WorkflowSpec.h" // o2::framework::mergeInputs
+#include "Framework/DataRefUtils.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/InputRecordWalker.h"
+#include "Framework/SerializationMethods.h"
+#include "Framework/Logger.h"
+#include "Framework/CallbackService.h"
+#include "Framework/DataProcessingContext.h"
+#include "Framework/RawDeviceService.h"
+
+#include <fairmq/Device.h>
+#include <fairmq/Channel.h>
+
+using namespace o2::framework;
+using namespace o2::header;
+using namespace o2::gpu;
+using namespace o2::base;
+using namespace o2::dataformats;
+
+namespace o2::gpu
+{
+
+struct pipelinePrepareMessage {
+  static constexpr size_t MAGIC_WORD = 0X8473957353424134;
+  size_t magicWord = MAGIC_WORD;
+  DataProcessingHeader::StartTime timeSliceId;
+  GPUSettingsTF tfSettings;
+  fair::mq::RegionInfo regionInfo;
+  size_t pointerCounts[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+  size_t pointersTotal;
+};
+
+int GPURecoWorkflowSpec::handlePipeline(ProcessingContext& pc, GPUTrackingInOutPointers& ptrs, GPURecoWorkflowSpec_TPCZSBuffers& tpcZSmeta, o2::gpu::GPUTrackingInOutZS& tpcZS)
+{
+  auto device = pc.services().get<RawDeviceService>().device();
+  const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+  if (mSpecConfig.enableDoublePipeline == 1) {
+    auto msg = device->NewMessageFor("gpu-prepare-channel", 0, 0);
+    bool received = false;
+    int recvTimeot = 1000;
+    do {
+      LOG(info) << "Waiting for out of band message";
+      received = device->Receive(msg, "gpu-prepare-channel", 0, recvTimeot);
+    } while (!received && !device->NewStatePending());
+    if (!received) {
+      return 1;
+    }
+    if (msg->GetSize() < sizeof(pipelinePrepareMessage)) {
+      LOG(fatal) << "Received prepare message of invalid size";
+    }
+    const pipelinePrepareMessage* m = (const pipelinePrepareMessage*)msg->GetData();
+    if (m->magicWord != m->MAGIC_WORD) {
+      LOG(fatal) << "Prepare message corrupted, invalid magic word";
+    }
+    if (m->timeSliceId != tinfo.timeslice) {
+      LOG(fatal) << "Prepare message for incorrect time frame received, time frames seem out of sync";
+    }
+    size_t regionOffset = 0;
+    if (m->pointersTotal) {
+      bool regionFound = false;
+      for (unsigned int i = 0; i < mRegionInfos.size(); i++) {
+        if (mRegionInfos[i].managed == m->regionInfo.managed && mRegionInfos[i].id == m->regionInfo.id) {
+          regionFound = true;
+          regionOffset = (size_t)mRegionInfos[i].ptr;
+          break;
+        }
+      }
+    }
+    size_t ptrsCopied = 0;
+    size_t* ptrBuffer = (size_t*)msg->GetData() + sizeof(pipelinePrepareMessage) / sizeof(size_t);
+    tpcZSmeta.Pointers[0][0].resize(m->pointersTotal);
+    tpcZSmeta.Sizes[0][0].resize(m->pointersTotal);
+    for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {
+      for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+        tpcZS.slice[i].count[j] = m->pointerCounts[i][j];
+        for (unsigned int k = 0; k < tpcZS.slice[i].count[j]; k++) {
+          tpcZSmeta.Pointers[0][0][ptrsCopied + k] = (void*)(ptrBuffer[ptrsCopied + k] + regionOffset);
+          tpcZSmeta.Sizes[0][0][ptrsCopied + k] = ptrBuffer[m->pointersTotal + ptrsCopied + k];
+        }
+        tpcZS.slice[i].zsPtr[j] = tpcZSmeta.Pointers[0][0].data() + ptrsCopied;
+        tpcZS.slice[i].nZSPtr[j] = tpcZSmeta.Sizes[0][0].data() + ptrsCopied;
+        ptrsCopied += tpcZS.slice[i].count[j];
+      }
+    }
+    ptrs.tpcZS = &tpcZS;
+  }
+  if (mSpecConfig.enableDoublePipeline == 2) {
+    auto prepareBuffer = pc.outputs().make<DataAllocator::UninitializedVector<char>>(Output{gDataOriginGPU, "PIPELINEPREPARE", 0, Lifetime::Timeframe}, 0u);
+
+    size_t ptrsTotal = 0;
+    const void* firstPtr = nullptr;
+    for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {
+      for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+        if (firstPtr == nullptr && ptrs.tpcZS->slice[i].count[j]) {
+          firstPtr = ptrs.tpcZS->slice[i].zsPtr[j][0];
+        }
+        ptrsTotal += ptrs.tpcZS->slice[i].count[j];
+      }
+    }
+
+    size_t prepareBufferSize = sizeof(pipelinePrepareMessage) + ptrsTotal * sizeof(size_t) * 2;
+    std::vector<size_t> messageBuffer(prepareBufferSize / sizeof(size_t));
+    pipelinePrepareMessage& preMessage = *(pipelinePrepareMessage*)messageBuffer.data();
+    preMessage.magicWord = preMessage.MAGIC_WORD;
+    preMessage.timeSliceId = tinfo.timeslice;
+    preMessage.pointersTotal = ptrsTotal;
+    memcpy((void*)&preMessage.tfSettings, (const void*)ptrs.settingsTF, sizeof(preMessage.tfSettings));
+
+    if (ptrsTotal) {
+      bool regionFound = false;
+      for (unsigned int i = 0; i < mRegionInfos.size(); i++) {
+        if ((size_t)firstPtr >= (size_t)mRegionInfos[i].ptr && (size_t)firstPtr < (size_t)mRegionInfos[i].ptr + mRegionInfos[i].size) {
+          preMessage.regionInfo = mRegionInfos[i];
+          regionFound = true;
+          break;
+        }
+      }
+      if (!regionFound) {
+        LOG(fatal) << "Found a TPC ZS pointer outside of shared memory";
+      }
+    }
+
+    size_t* ptrBuffer = messageBuffer.data() + sizeof(preMessage) / sizeof(size_t);
+    size_t ptrsCopied = 0;
+    for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {
+      for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+        preMessage.pointerCounts[i][j] = ptrs.tpcZS->slice[i].count[j];
+        for (unsigned int k = 0; k < ptrs.tpcZS->slice[i].count[j]; k++) {
+          ptrBuffer[ptrsCopied + k] = (size_t)ptrs.tpcZS->slice[i].zsPtr[j][k] - (size_t)preMessage.regionInfo.ptr;
+          ptrBuffer[ptrsTotal + ptrsCopied + k] = ptrs.tpcZS->slice[i].nZSPtr[j][k];
+        }
+        ptrsCopied += ptrs.tpcZS->slice[i].count[j];
+      }
+    }
+
+    auto channel = device->GetChannels().find("gpu-prepare-channel");
+    fair::mq::MessagePtr payload(device->NewMessage());
+    payload->Rebuild(messageBuffer.data(), prepareBufferSize, nullptr, nullptr);
+    channel->second[0].Send(payload);
+    return 2;
+  }
+  return 0;
+}
+
+} // namespace o2::gpu


### PR DESCRIPTION
Following up #11938
Forwards the pointers to the input in the SHM from the gpu-prepare device to the gpu device, such that the actual GPU device does not longer need to parse the input data received by DPL.
This is using the FairMQ SHM Region information to obtain SHM base pointers, and correct the TPC ZS pointers by the offset of the base addresses when moving them from one process to another.

Still missing:
- Out-of-band message must be received asynchronously.
- A completion policy must make sure that gpu-reco-workflow processes data in the same order as the prepare workflow.
- Solve some problem with the calibration data.
- Must have multiple independent out-of-band channels when using pipelining for multiple GPUs. Not clear how to set that up using `--channel-config` option.