### PR TITLE
More GPU standalone multi-threading developments

### DIFF
--- a/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TPCSectorCompletionPolicy.h
+++ b/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TPCSectorCompletionPolicy.h
@@ -20,6 +20,7 @@
 #include "Framework/InputSpec.h"
 #include "Framework/InputSpan.h"
 #include "Framework/DeviceSpec.h"
+#include "Framework/DataProcessingHeader.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "Headers/DataHeaderHelpers.h"
 #include "TPCBase/Sector.h"
@@ -29,6 +30,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <regex>
+#include <functional>
 
 namespace o2
 {
@@ -89,7 +91,7 @@ class TPCSectorCompletionPolicy
       return std::regex_match(device.name.begin(), device.name.end(), std::regex(expression.c_str()));
     };
 
-    auto callback = [bRequireAll = mRequireAll, inputMatchers = mInputMatchers, externalInputMatchers = mExternalInputMatchers, pTpcSectorMask = mTpcSectorMask](framework::InputSpan const& inputs) -> framework::CompletionPolicy::CompletionOp {
+    auto callback = [bRequireAll = mRequireAll, inputMatchers = mInputMatchers, externalInputMatchers = mExternalInputMatchers, pTpcSectorMask = mTpcSectorMask, orderCheck = mOrderCheck](framework::InputSpan const& inputs) -> framework::CompletionPolicy::CompletionOp {
       unsigned long tpcSectorMask = pTpcSectorMask ? *pTpcSectorMask : 0xFFFFFFFFF;
       std::bitset<NSectors> validSectors = 0;
       bool haveMatchedInput = false;
@@ -165,6 +167,7 @@ class TPCSectorCompletionPolicy
         }
       }
 
+      o2::framework::CompletionPolicy::CompletionOp retVal = framework::CompletionPolicy::CompletionOp::Wait;
       // If the flag Config::RequireAll is set in the constructor arguments we require
       // data from all inputs in addition to the sector matching condition
       // To be fully correct we would need to require data from all inputs not going
@@ -175,7 +178,7 @@ class TPCSectorCompletionPolicy
           (!bRequireAll || nActiveInputRoutes == inputs.size())) {
         // we can process if there is input for all sectors, the required sectors are
         // transported as part of the sector header
-        return framework::CompletionPolicy::CompletionOp::Consume;
+        retVal = framework::CompletionPolicy::CompletionOp::Consume;
       } else if (activeSectors == 0 && nActiveInputRoutes == inputs.size()) {
         // no sector header is transmitted, this is the case for e.g. the ZS raw data
         // we simply require input on all routes, this is also the default of DPL DataRelayer
@@ -184,13 +187,25 @@ class TPCSectorCompletionPolicy
         // Currently, the workflow has multiple O2 messages per input route, but they all come in
         // a single multipart message. So it works fine, and we disable the warning below, but there
         // is a potential problem. Need to fix this on the level of the workflow.
-        //if (nMaxPartsPerRoute > 1) {
+        // if (nMaxPartsPerRoute ) {
         //  LOG(warning) << "No sector information is provided with the data, data set is complete with data on all input routes. But there are multiple parts on at least one route and this policy might not be complete, no check possible if other parts on some routes are still missing. It is adviced to add a custom policy.";
         //}
-        return framework::CompletionPolicy::CompletionOp::Consume;
+        retVal = framework::CompletionPolicy::CompletionOp::Consume;
       }
 
-      return framework::CompletionPolicy::CompletionOp::Wait;
+      if (retVal != framework::CompletionPolicy::CompletionOp::Wait && orderCheck && *orderCheck && **orderCheck) {
+        for (auto& input : inputs) {
+          auto* dph = framework::DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(input);
+          if (!dph) {
+            continue;
+          }
+          if (!(**orderCheck)(dph->startTime)) {
+            retVal = framework::CompletionPolicy::CompletionOp::Wait;
+          }
+          break;
+        }
+      }
+      return retVal;
     };
     return framework::CompletionPolicy{"TPCSectorCompletionPolicy", matcher, callback};
   }
@@ -211,6 +226,8 @@ class TPCSectorCompletionPolicy
       }
     } else if constexpr (std::is_same_v<Type, std::vector<o2::framework::InputSpec>*>) {
       mExternalInputMatchers = arg;
+    } else if constexpr (std::is_same_v<Type, std::function<bool(o2::framework::DataProcessingHeader::StartTime)>**>) {
+      mOrderCheck = arg;
     } else if constexpr (std::is_same_v<Type, unsigned long*> || std::is_same_v<Type, const unsigned long*>) {
       mTpcSectorMask = arg;
     } else {
@@ -223,6 +240,7 @@ class TPCSectorCompletionPolicy
 
   std::string mProcessorName;
   std::vector<framework::InputSpec> mInputMatchers;
+  std::function<bool(o2::framework::DataProcessingHeader::StartTime)>** mOrderCheck = nullptr;
   // The external input matchers behave as the internal ones with the following differences:
   // - They are controlled externally and the external entity can modify them, e.g. after parsing command line arguments.
   // - They are all matched independently, it is not sufficient that one of them is present for all sectors

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -27,6 +27,7 @@
 #include <array>
 #include <vector>
 #include <mutex>
+#include <functional>
 
 class TStopwatch;
 namespace fair::mq
@@ -122,7 +123,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
     bool tpcTriggerHandling = false;
   };
 
-  GPURecoWorkflowSpec(CompletionPolicyData* policyData, Config const& specconfig, std::vector<int> const& tpcsectors, unsigned long tpcSectorMask, std::shared_ptr<o2::base::GRPGeomRequest>& ggr);
+  GPURecoWorkflowSpec(CompletionPolicyData* policyData, Config const& specconfig, std::vector<int> const& tpcsectors, unsigned long tpcSectorMask, std::shared_ptr<o2::base::GRPGeomRequest>& ggr, std::function<bool(o2::framework::DataProcessingHeader::StartTime)>** gPolicyOrder = nullptr);
   ~GPURecoWorkflowSpec() override;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
@@ -162,8 +163,10 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   void RunReceiveThread();
   void TerminateReceiveThread();
   void handlePipelineEndOfStream(o2::framework::EndOfStreamContext& ec);
+  void initPipeline(o2::framework::InitContext& ic);
 
   CompletionPolicyData* mPolicyData;
+  std::function<bool(o2::framework::DataProcessingHeader::StartTime)> mPolicyOrder;
   std::unique_ptr<GPUO2Interface> mGPUReco;
   std::unique_ptr<GPUDisplayFrontendInterface> mDisplayFrontend;
   std::unique_ptr<TPCFastTransform> mFastTransform;

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -21,7 +21,6 @@
 #include "Framework/Task.h"
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/InitContext.h"
-#include "Framework/ProcessingContext.h"
 #include "Framework/CompletionPolicy.h"
 #include "Algorithm/Parser.h"
 #include <string>
@@ -162,6 +161,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   int handlePipeline(o2::framework::ProcessingContext& pc, GPUTrackingInOutPointers& ptrs, gpurecoworkflow_internals::GPURecoWorkflowSpec_TPCZSBuffers& tpcZSmeta, o2::gpu::GPUTrackingInOutZS& tpcZS);
   void RunReceiveThread();
   void TerminateReceiveThread();
+  void handlePipelineEndOfStream(o2::framework::EndOfStreamContext& ec);
 
   CompletionPolicyData* mPolicyData;
   std::unique_ptr<GPUO2Interface> mGPUReco;

--- a/GPU/Workflow/src/GPUWorkflowInternal.h
+++ b/GPU/Workflow/src/GPUWorkflowInternal.h
@@ -49,7 +49,6 @@ struct GPURecoWorkflowSpec_PipelineInternals {
   std::thread receiveThread;
   std::condition_variable notifyThread;
   std::mutex threadMutex;
-  volatile bool mayReceive = false;
   volatile bool shouldTerminate = false;
 
   std::queue<std::unique_ptr<GPURecoWorkflow_QueueObject>> pipelineQueue;

--- a/GPU/Workflow/src/GPUWorkflowInternal.h
+++ b/GPU/Workflow/src/GPUWorkflowInternal.h
@@ -47,13 +47,17 @@ struct GPURecoWorkflowSpec_PipelineInternals {
   fair::mq::Device* fmqDevice;
 
   std::thread receiveThread;
-  std::condition_variable notifyThread;
   std::mutex threadMutex;
   volatile bool shouldTerminate = false;
 
   std::queue<std::unique_ptr<GPURecoWorkflow_QueueObject>> pipelineQueue;
   std::mutex queueMutex;
   std::condition_variable queueNotify;
+
+  std::queue<o2::framework::DataProcessingHeader::StartTime> completionPolicyQueue;
+  bool pipelineSenderTerminating = false;
+  std::mutex completionPolicyMutex;
+  std::condition_variable completionPolicyNotify;
 };
 
 } // namespace gpurecoworkflow_internals

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -347,7 +347,7 @@ void GPURecoWorkflowSpec::stop()
 
 void GPURecoWorkflowSpec::endOfStream(EndOfStreamContext& ec)
 {
-  TerminateReceiveThread(); // TODO: Apparently breaks START / STOP / START
+  handlePipelineEndOfStream(ec);
 }
 
 void GPURecoWorkflowSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -628,9 +628,6 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
   unsigned int threadIndex = mNextThreadIndex;
   if (mConfig->configProcessing.doublePipeline) {
     mNextThreadIndex = (mNextThreadIndex + 1) % 2;
-    std::lock_guard lk(mPipeline->threadMutex);
-    mPipeline->mayReceive = true;
-    mPipeline->notifyThread.notify_one();
   }
 
   if (mSpecConfig.enableDoublePipeline) {

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -38,6 +38,7 @@ using namespace o2::gpu;
 using CompletionPolicyData = std::vector<InputSpec>;
 static CompletionPolicyData gPolicyData;
 static constexpr unsigned long gTpcSectorMask = 0xFFFFFFFFF;
+static std::function<bool(o2::framework::DataProcessingHeader::StartTime)>* gPolicyOrderCheck;
 static std::shared_ptr<GPURecoWorkflowSpec> gTask;
 
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
@@ -71,7 +72,7 @@ void customize(std::vector<DispatchPolicy>& policies)
 
 void customize(std::vector<CompletionPolicy>& policies)
 {
-  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("gpu-reconstruction.*", o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll, &gPolicyData, &gTpcSectorMask)());
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("gpu-reconstruction.*", o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll, &gPolicyData, &gTpcSectorMask, &gPolicyOrderCheck)());
 }
 
 void customize(o2::framework::OnWorkflowTerminationHook& hook)


### PR DESCRIPTION
Propagate EoS over out of band channel
Make sure we shut down orderly
Synchronize TF processing order of the prepare-workflow and the actual workflow via custom completion policy.

Follow-up of #11941, still missing are support for pipelines, feeding the pipelines asynchronously, and fix up all calib-related stuff.