### PR TITLE
GPU Standalone multi-threading: thread-safe calib updates, and submit to pipelines through worker threads

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -611,10 +611,11 @@ void GPUChainTracking::DoQueuedUpdates(int stream)
 {
   std::unique_ptr<GPUSettingsGRP> grp;
   const GPUSettingsProcessing* p = nullptr;
+  std::lock_guard lk(mMutexUpdateCalib);
   if (mUpdateNewCalibObjects) {
-    void** pSrc = (void**)&mNewCalibObjects;
+    void** pSrc = (void**)mNewCalibObjects.get();
     void** pDst = (void**)&processors()->calibObjects;
-    for (unsigned int i = 0; i < sizeof(mNewCalibObjects) / sizeof(void*); i++) {
+    for (unsigned int i = 0; i < sizeof(processors()->calibObjects) / sizeof(void*); i++) {
       if (pSrc[i]) {
         pDst[i] = pSrc[i];
       }
@@ -628,7 +629,7 @@ void GPUChainTracking::DoQueuedUpdates(int stream)
       if (ptrsChanged) {
         GPUInfo("Updating all calib objects since pointers changed");
       }
-      UpdateGPUCalibObjects(stream, ptrsChanged ? nullptr : &mNewCalibObjects);
+      UpdateGPUCalibObjects(stream, ptrsChanged ? nullptr : mNewCalibObjects.get());
     }
     if (mNewCalibValues->newSolenoidField || mNewCalibValues->newContinuousMaxTimeBin) {
       grp = std::make_unique<GPUSettingsGRP>(mRec->GetGRPSettings());
@@ -650,6 +651,8 @@ void GPUChainTracking::DoQueuedUpdates(int stream)
   if ((mUpdateNewCalibObjects || mRec->slavesExist()) && mRec->IsGPU()) {
     UpdateGPUCalibObjectsPtrs(stream); // Reinitialize
   }
+  mNewCalibObjects.reset(nullptr);
+  mNewCalibValues.reset(nullptr);
   mUpdateNewCalibObjects = false;
 }
 
@@ -964,7 +967,8 @@ void GPUChainTracking::SetDefaultInternalO2Propagator(bool useGPUField)
 
 void GPUChainTracking::SetUpdateCalibObjects(const GPUCalibObjectsConst& obj, const GPUNewCalibValues& vals)
 {
-  mNewCalibObjects = obj;
+  std::lock_guard lk(mMutexUpdateCalib);
+  mNewCalibObjects.reset(new GPUCalibObjectsConst(obj));
   mNewCalibValues.reset(new GPUNewCalibValues(vals));
   mUpdateNewCalibObjects = true;
 }

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -19,6 +19,7 @@
 #include "GPUReconstructionHelpers.h"
 #include "GPUDataTypes.h"
 #include <atomic>
+#include <mutex>
 #include <array>
 #include <vector>
 #include <utility>
@@ -272,7 +273,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   // (Ptrs to) configuration objects
   std::unique_ptr<GPUTPCCFChainContext> mCFContext;
   bool mTPCSliceScratchOnStack = false;
-  GPUCalibObjectsConst mNewCalibObjects;
+  std::unique_ptr<GPUCalibObjectsConst> mNewCalibObjects;
   bool mUpdateNewCalibObjects = false;
   std::unique_ptr<GPUNewCalibValues> mNewCalibValues;
 
@@ -305,7 +306,8 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void RunTPCTrackingMerger_MergeBorderTracks(char withinSlice, char mergeMode, GPUReconstruction::krnlDeviceType deviceType);
   void RunTPCTrackingMerger_Resolve(char useOrigTrackParam, char mergeAll, GPUReconstruction::krnlDeviceType deviceType);
 
-  std::atomic_flag mLockAtomic = ATOMIC_FLAG_INIT;
+  std::atomic_flag mLockAtomicOutputBuffer = ATOMIC_FLAG_INIT;
+  std::mutex mMutexUpdateCalib;
   std::unique_ptr<GPUChainTrackingFinalContext> mPipelineFinalizationCtx;
   GPUChainTrackingFinalContext* mPipelineNotifyCtx = nullptr;
 

--- a/GPU/GPUTracking/Global/GPUChainTrackingSliceTracker.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingSliceTracker.cxx
@@ -482,13 +482,12 @@ void GPUChainTracking::WriteOutput(int iSlice, int threadId)
     GPUInfo("Running WriteOutput for slice %d on thread %d\n", iSlice, threadId);
   }
   if (GetProcessingSettings().nDeviceHelperThreads) {
-    while (mLockAtomic.test_and_set(std::memory_order_acquire)) {
-      ;
+    while (mLockAtomicOutputBuffer.test_and_set(std::memory_order_acquire)) {
     }
   }
   processors()->tpcTrackers[iSlice].WriteOutputPrepare();
   if (GetProcessingSettings().nDeviceHelperThreads) {
-    mLockAtomic.clear();
+    mLockAtomicOutputBuffer.clear();
   }
   processors()->tpcTrackers[iSlice].WriteOutput();
   if (GetProcessingSettings().debugLevel >= 5) {

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -84,10 +84,12 @@ struct GPUSettingsO2;
 class GPUO2InterfaceQA;
 struct GPUTrackingInOutPointers;
 struct GPUTrackingInOutZS;
+struct GPUInterfaceOutputs;
 namespace gpurecoworkflow_internals
 {
 struct GPURecoWorkflowSpec_TPCZSBuffers;
 struct GPURecoWorkflowSpec_PipelineInternals;
+struct GPURecoWorkflow_QueueObject;
 } // namespace gpurecoworkflow_internals
 
 class GPURecoWorkflowSpec : public o2::framework::Task
@@ -159,11 +161,14 @@ class GPURecoWorkflowSpec : public o2::framework::Task
 
   int runITSTracking(o2::framework::ProcessingContext& pc);
 
-  int handlePipeline(o2::framework::ProcessingContext& pc, GPUTrackingInOutPointers& ptrs, gpurecoworkflow_internals::GPURecoWorkflowSpec_TPCZSBuffers& tpcZSmeta, o2::gpu::GPUTrackingInOutZS& tpcZS);
+  int handlePipeline(o2::framework::ProcessingContext& pc, GPUTrackingInOutPointers& ptrs, gpurecoworkflow_internals::GPURecoWorkflowSpec_TPCZSBuffers& tpcZSmeta, o2::gpu::GPUTrackingInOutZS& tpcZS, std::unique_ptr<gpurecoworkflow_internals::GPURecoWorkflow_QueueObject>& context);
   void RunReceiveThread();
-  void TerminateReceiveThread();
+  void RunWorkerThread(int id);
+  void TerminateThreads();
   void handlePipelineEndOfStream(o2::framework::EndOfStreamContext& ec);
   void initPipeline(o2::framework::InitContext& ic);
+  void enqueuePipelinedJob(GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, gpurecoworkflow_internals::GPURecoWorkflow_QueueObject* context);
+  int runMain(o2::framework::ProcessingContext* pc, GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, int threadIndex);
 
   CompletionPolicyData* mPolicyData;
   std::function<bool(o2::framework::DataProcessingHeader::StartTime)> mPolicyOrder;


### PR DESCRIPTION
Getting close to finalize this endeavor. With this PR we have 2 worker threads filling the 2 pipelines, and calib updates are fixed to not collide. So far though, the threads never get work concurrently, but one after another.
Things still to be done:
- Give work items to the threads concurrently to allow overlapping processing of time frames.
- In case of consecutive calib updates every TF, make sure that both pipelines receive the full update (currently, the second update overwrites the first one for the pipeline that didn't process the TF of the first update).
- Still works only with 1 GPU, since out-of-band channels with `--pipeline`  collide.