### PR TITLE
GPU Reconstrcution O2 Standalone multi-threading

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -279,7 +279,7 @@ int GPUReconstruction::InitPhaseBeforeDevice()
   if (!(mRecoStepsGPU & RecoStep::TPCMerging) || !param().rec.tpc.mergerReadFromTrackerDirectly) {
     mProcessingSettings.fullMergerOnGPU = false;
   }
-  if (mProcessingSettings.debugLevel || !mProcessingSettings.fullMergerOnGPU) {
+  if (mProcessingSettings.debugLevel > 3 || !mProcessingSettings.fullMergerOnGPU) {
     mProcessingSettings.delayedOutput = false;
   }
   if (!mProcessingSettings.fullMergerOnGPU && GetRecoStepsGPU() & RecoStep::TPCMerging) {

--- a/GPU/GPUTracking/Benchmark/standalone.cxx
+++ b/GPU/GPUTracking/Benchmark/standalone.cxx
@@ -188,7 +188,7 @@ int ReadConfiguration(int argc, char** argv)
     return 1;
   }
   if (configStandalone.proc.doublePipeline && (configStandalone.runs < 4 || !configStandalone.outputcontrolmem)) {
-    printf("Double pipeline mode needs at least 3 runs per event and external output\n");
+    printf("Double pipeline mode needs at least 3 runs per event and external output. To cycle though multiple events, use --preloadEvents and --runs n for n iterations round-robin\n");
     return 1;
   }
   if (configStandalone.TF.bunchSim && configStandalone.TF.nMerge) {

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -135,9 +135,6 @@ void GPUO2Interface::Deinitialize()
 
 void GPUO2Interface::DumpEvent(int nEvent, GPUTrackingInOutPointers* data)
 {
-  if (mConfig->configProcessing.doublePipeline) {
-    throw std::runtime_error("Cannot dump events in double pipeline mode");
-  }
   mCtx[0].mChain->ClearIOPointers();
   mCtx[0].mChain->mIOPtrs = *data;
   char fname[1024];
@@ -156,9 +153,6 @@ void GPUO2Interface::DumpEvent(int nEvent, GPUTrackingInOutPointers* data)
 
 void GPUO2Interface::DumpSettings()
 {
-  if (mConfig->configProcessing.doublePipeline) {
-    throw std::runtime_error("Cannot dump events in double pipeline mode");
-  }
   mCtx[0].mChain->DoQueuedUpdates(-1);
   mCtx[0].mRec->DumpSettings();
 }

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -163,23 +163,50 @@ void GPUO2Interface::DumpSettings()
   mCtx[0].mRec->DumpSettings();
 }
 
-int GPUO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutputs* outputs, unsigned int iThread)
+int GPUO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutputs* outputs, unsigned int iThread, GPUInterfaceInputUpdate* inputUpdateCallback)
 {
   if (mNContexts <= iThread) {
     return (1);
   }
 
   mCtx[iThread].mChain->mIOPtrs = *data;
-  if (mConfig->configInterface.outputToExternalBuffers) {
-    for (unsigned int i = 0; i < mCtx[iThread].mOutputRegions->count(); i++) {
-      if (outputs->asArray()[i].allocator) {
-        mCtx[iThread].mOutputRegions->asArray()[i].set(outputs->asArray()[i].allocator);
-      } else if (outputs->asArray()[i].ptrBase) {
-        mCtx[iThread].mOutputRegions->asArray()[i].set(outputs->asArray()[i].ptrBase, outputs->asArray()[i].size);
-      } else {
-        mCtx[iThread].mOutputRegions->asArray()[i].reset();
+
+  auto setOutputs = [this, iThread](GPUInterfaceOutputs* outputs) {
+    if (mConfig->configInterface.outputToExternalBuffers) {
+      for (unsigned int i = 0; i < mCtx[iThread].mOutputRegions->count(); i++) {
+        if (outputs->asArray()[i].allocator) {
+          mCtx[iThread].mOutputRegions->asArray()[i].set(outputs->asArray()[i].allocator);
+        } else if (outputs->asArray()[i].ptrBase) {
+          mCtx[iThread].mOutputRegions->asArray()[i].set(outputs->asArray()[i].ptrBase, outputs->asArray()[i].size);
+        } else {
+          mCtx[iThread].mOutputRegions->asArray()[i].reset();
+        }
       }
     }
+  };
+
+  auto inputWaitCallback = [this, iThread, inputUpdateCallback, &data, &outputs, &setOutputs]() {
+    GPUTrackingInOutPointers* updatedData;
+    GPUInterfaceOutputs* updatedOutputs;
+    if (inputUpdateCallback->callback) {
+      inputUpdateCallback->callback(updatedData, updatedOutputs);
+      mCtx[iThread].mChain->mIOPtrs = *updatedData;
+      outputs = updatedOutputs;
+      data = updatedData;
+      setOutputs(outputs);
+    }
+    if (inputUpdateCallback->notifyCallback) {
+      inputUpdateCallback->notifyCallback();
+    }
+  };
+
+  if (inputUpdateCallback) {
+    mCtx[iThread].mChain->SetFinalInputCallback(inputWaitCallback);
+  } else {
+    mCtx[iThread].mChain->SetFinalInputCallback(nullptr);
+  }
+  if (!inputUpdateCallback || !inputUpdateCallback->callback) {
+    setOutputs(outputs);
   }
 
   int retVal = mCtx[iThread].mRec->RunChains();

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -54,6 +54,7 @@ class GPUChainTracking;
 class GPUChainITS;
 struct GPUO2InterfaceConfiguration;
 struct GPUInterfaceOutputs;
+struct GPUInterfaceInputUpdate;
 struct GPUTrackingOutputs;
 struct GPUConstantMem;
 struct GPUNewCalibValues;
@@ -70,7 +71,7 @@ class GPUO2Interface
   int Initialize(const GPUO2InterfaceConfiguration& config);
   void Deinitialize();
 
-  int RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutputs* outputs = nullptr, unsigned int iThread = 0);
+  int RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutputs* outputs = nullptr, unsigned int iThread = 0, GPUInterfaceInputUpdate* inputUpdateCallback = nullptr);
   void Clear(bool clearOutputs, unsigned int iThread = 0);
   void DumpEvent(int nEvent, GPUTrackingInOutPointers* data);
   void DumpSettings();

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -66,6 +66,11 @@ struct GPUInterfaceOutputs : public GPUTrackingOutputs {
   GPUInterfaceQAOutputs qa;
 };
 
+struct GPUInterfaceInputUpdate {
+  std::function<void(GPUTrackingInOutPointers*& data, GPUInterfaceOutputs*& outputs)> callback; // Callback which provides final data ptrs / outputRegions after Clusterization stage
+  std::function<void()> notifyCallback;                                                         // Callback called to notify that Clusterization state has finished without update
+};
+
 // Full configuration structure with all available settings of GPU...
 struct GPUO2InterfaceConfiguration {
   GPUO2InterfaceConfiguration() = default;

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -85,6 +85,7 @@ class GPUO2InterfaceQA;
 struct GPUTrackingInOutPointers;
 struct GPUTrackingInOutZS;
 struct GPUInterfaceOutputs;
+struct GPUInterfaceInputUpdate;
 namespace gpurecoworkflow_internals
 {
 struct GPURecoWorkflowSpec_TPCZSBuffers;
@@ -167,8 +168,9 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   void TerminateThreads();
   void handlePipelineEndOfStream(o2::framework::EndOfStreamContext& ec);
   void initPipeline(o2::framework::InitContext& ic);
-  void enqueuePipelinedJob(GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, gpurecoworkflow_internals::GPURecoWorkflow_QueueObject* context);
-  int runMain(o2::framework::ProcessingContext* pc, GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, int threadIndex);
+  void enqueuePipelinedJob(GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, gpurecoworkflow_internals::GPURecoWorkflow_QueueObject* context, bool inputFinal);
+  void finalizeInputPipelinedJob(GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, gpurecoworkflow_internals::GPURecoWorkflow_QueueObject* context);
+  int runMain(o2::framework::ProcessingContext* pc, GPUTrackingInOutPointers* ptrs, GPUInterfaceOutputs* outputRegions, int threadIndex = 0, GPUInterfaceInputUpdate* inputUpdateCallback = nullptr);
 
   CompletionPolicyData* mPolicyData;
   std::function<bool(o2::framework::DataProcessingHeader::StartTime)> mPolicyOrder;

--- a/GPU/Workflow/src/GPUWorkflowInternal.h
+++ b/GPU/Workflow/src/GPUWorkflowInternal.h
@@ -41,13 +41,19 @@ struct GPURecoWorkflow_QueueObject {
   GPUTrackingInOutPointers ptrs;
   o2::framework::DataProcessingHeader::StartTime timeSliceId;
 
+  unsigned long mTFId;
+
   bool jobSubmitted = false;
   bool jobFinished = false;
   int jobReturnValue = 0;
   std::mutex jobFinishedMutex;
   std::condition_variable jobFinishedNotify;
-  GPUTrackingInOutPointers* jobPtrs;
-  GPUInterfaceOutputs* jobOutputRegions;
+  bool jobInputFinal = false;
+  std::mutex jobInputFinalMutex;
+  std::condition_variable jobInputFinalNotify;
+  GPUTrackingInOutPointers* jobPtrs = nullptr;
+  GPUInterfaceOutputs* jobOutputRegions = nullptr;
+  std::unique_ptr<GPUInterfaceInputUpdate> jobInputUpdateCallback = nullptr;
 };
 
 struct GPURecoWorkflowSpec_PipelineInternals {
@@ -75,6 +81,13 @@ struct GPURecoWorkflowSpec_PipelineInternals {
   bool pipelineSenderTerminating = false;
   std::mutex completionPolicyMutex;
   std::condition_variable completionPolicyNotify;
+
+  unsigned long mNTFReceived = 0;
+
+  bool mayInject = true;
+  unsigned long mayInjectTFId = 0;
+  std::mutex mayInjectMutex;
+  std::condition_variable mayInjectCondition;
 };
 
 } // namespace gpurecoworkflow_internals


### PR DESCRIPTION
First working version of standalone multi-threading, at least on my system with 1 NVIDIA card.
Follows up #11945 

Things still to be done:
- Find a way to configure the DPL out-of-band channel for multiple pipelined devices, so that we can run with 4 GPUs.
- double-check that calibration updates are applied correctly, and are not blocking.
- Check where the synchronization of the output of the previous TF should ideally happen during clusterization to avoid delays for receiving the final input of the current TF.