### PR TITLE
Revert TOF CTF precompressed timeTDCInc to uint16_t

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
@@ -64,7 +64,7 @@ struct CompressedInfos {
 
   // Hit data
   std::vector<int16_t> timeFrameInc;  /// time increment with respect of previous digit in TimeFrame units
-  std::vector<int16_t> timeTDCInc;    /// time increment with respect of previous digit in TDC channel (about 24.4 ps) within timeframe
+  std::vector<uint16_t> timeTDCInc;   /// time increment with respect of previous digit in TDC channel (about 24.4 ps) within timeframe
   std::vector<uint16_t> stripID;      /// increment of stripID wrt that of prev. strip
   std::vector<uint8_t> chanInStrip;   /// channel in strip 0-95 (ordered in time)
   std::vector<uint16_t> tot;          /// Time-Over-Threshold in TOF channel (about 48.8 ps)


### PR DESCRIPTION
To be compatible with existing dictionary.

Trivial change, tested locally, merging.