### PR TITLE
Disable simulation shared mem on APPLE

### DIFF
--- a/Common/Utils/include/CommonUtils/ShmManager.h
+++ b/Common/Utils/include/CommonUtils/ShmManager.h
@@ -26,7 +26,7 @@
 #include <boost/interprocess/managed_external_buffer.hpp>
 #include <boost/interprocess/allocators/allocator.hpp>
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__) && !defined(__APPLE__)
 // this shared mem mode is meant for compiled stuff in o2-sim; not for ROOT sessions
 #define USESHM 1
 #endif

--- a/Common/Utils/src/ShmManager.cxx
+++ b/Common/Utils/src/ShmManager.cxx
@@ -119,8 +119,8 @@ bool ShmManager::createGlobalSegment(int nsegments)
     return false;
   }
 
-  LOG(info) << "CREATING SIM SHARED MEM SEGMENT FOR " << nsegments << " WORKERS";
 #ifdef USESHM
+  LOG(info) << "CREATING SIM SHARED MEM SEGMENT FOR " << nsegments << " WORKERS";
   // LOG(info) << "SIZEOF ShmMetaInfo " << sizeof(ShmMetaInfo);
   const auto totalsize = sizeof(ShmMetaInfo) + SHMPOOLSIZE * nsegments;
   if ((mShmID = shmget(IPC_PRIVATE, totalsize, IPC_CREAT | 0666)) == -1) {


### PR DESCRIPTION
Does no longer compile with XCode15 and in any case never worked correctly.