### PR TITLE
AODProducer: Code cleanup and optimization

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2111,7 +2111,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   fillStrangenessTrackingTables(recoData, trackedV0Cursor, trackedCascadeCursor, tracked3BodyCurs);
 
   // helper map for fast search of a corresponding class mask for a bc
-  std::unordered_map<uint64_t, std::vector<uint64_t>> bcToClassMask;
+  std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> bcToClassMask;
   if (mInputSources[GID::CTP]) {
     LOG(debug) << "CTP input available";
     for (auto& ctpDigit : ctpDigits) {
@@ -2124,7 +2124,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   }
 
   // filling BC table
-  std::vector<uint64_t> masks;
+  std::pair<uint64_t, uint64_t> masks{0, 0};
   bcCursor.reserve(bcsMap.size());
   for (auto& item : bcsMap) {
     uint64_t bc = item.first;
@@ -2132,16 +2132,12 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
       auto bcClassPair = bcToClassMask.find(bc);
       if (bcClassPair != bcToClassMask.end()) {
         masks = bcClassPair->second;
-      } else {
-        masks = {0, 0};
       }
-    } else {
-      masks = {0, 0};
     }
     bcCursor(runNumber,
              bc,
-             masks[0],
-             masks[1]);
+             masks.first,
+             masks.second);
   }
 
   bcToClassMask.clear();


### PR DESCRIPTION
* use std::pair for CTP ClassMasks instead of std::vector.
* avoid mem alloc which not necessary
* initialize at declaration and reduce else statements