### PR TITLE
Adding plots to ITSTPC matching QC

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
@@ -28,6 +28,7 @@
 #include "Steer/MCKinematicsReader.h"
 #include <unordered_map>
 #include <vector>
+#include <array>
 
 namespace o2
 {
@@ -46,6 +47,10 @@ struct LblInfo {
 class MatchITSTPCQC
 {
  public:
+  enum matchType : int { TPC = 0,
+                         ITS,
+                         SIZE };
+
   MatchITSTPCQC() = default;
   ~MatchITSTPCQC();
 
@@ -56,37 +61,41 @@ class MatchITSTPCQC
   void finalize();
   void reset();
 
-  TH1D* getHistoPt() const { return mPt; }
-  TH1D* getHistoPtTPC() const { return mPtTPC; }
-  TEfficiency* getFractionITSTPCmatch() const { return mFractionITSTPCmatch; }
+  TH1D* getHistoPtNum(matchType m) const { return mPtNum[m]; }
+  TH1D* getHistoPtDen(matchType m) const { return mPtDen[m]; }
+  TEfficiency* getFractionITSTPCmatch(matchType m) const { return mFractionITSTPCmatch[m]; }
 
-  TH1F* getHistoPhi() const { return mPhi; }
-  TH1F* getHistoPhiTPC() const { return mPhiTPC; }
-  TEfficiency* getFractionITSTPCmatchPhi() const { return mFractionITSTPCmatchPhi; }
+  TH1D* getHistoPtNumNoEta0(matchType m) const { return mPtNum_noEta0[m]; }
+  TH1D* getHistoPtDenNoEta0(matchType m) const { return mPtDen_noEta0[m]; }
+  TEfficiency* getFractionITSTPCmatchNoEta0(matchType m) const { return mFractionITSTPCmatch_noEta0[m]; }
 
-  TH2F* getHistoPhiVsPt() const { return mPhiVsPt; }
-  TH2F* getHistoPhiVsPtTPC() const { return mPhiVsPtTPC; }
-  TEfficiency* getFractionITSTPCmatchPhiVsPt() const { return mFractionITSTPCmatchPhiVsPt; }
+  TH1F* getHistoPhiNum(matchType m) const { return mPhiNum[m]; }
+  TH1F* getHistoPhiDen(matchType m) const { return mPhiDen[m]; }
+  TEfficiency* getFractionITSTPCmatchPhi(matchType m) const { return mFractionITSTPCmatchPhi[m]; }
 
-  TH1F* getHistoEta() const { return mEta; }
-  TH1F* getHistoEtaTPC() const { return mEtaTPC; }
-  TEfficiency* getFractionITSTPCmatchEta() const { return mFractionITSTPCmatchEta; }
+  TH2F* getHistoPhiVsPtNum(matchType m) const { return mPhiVsPtNum[m]; }
+  TH2F* getHistoPhiVsPtDen(matchType m) const { return mPhiVsPtDen[m]; }
+  TEfficiency* getFractionITSTPCmatchPhiVsPt(matchType m) const { return mFractionITSTPCmatchPhiVsPt[m]; }
 
-  TH2F* getHistoEtaVsPt() const { return mEtaVsPt; }
-  TH2F* getHistoEtaVsPtTPC() const { return mEtaVsPtTPC; }
-  TEfficiency* getFractionITSTPCmatchEtaVsPt() const { return mFractionITSTPCmatchEtaVsPt; }
+  TH1F* getHistoEtaNum(matchType m) const { return mEtaNum[m]; }
+  TH1F* getHistoEtaDen(matchType m) const { return mEtaDen[m]; }
+  TEfficiency* getFractionITSTPCmatchEta(matchType m) const { return mFractionITSTPCmatchEta[m]; }
 
-  TH1F* getHistoPtPhysPrim() const { return mPtPhysPrim; }
-  TH1F* getHistoPtTPCPhysPrim() const { return mPtTPCPhysPrim; }
-  TEfficiency* getFractionITSTPCmatchPhysPrim() const { return mFractionITSTPCmatchPhysPrim; }
+  TH2F* getHistoEtaVsPtNum(matchType m) const { return mEtaVsPtNum[m]; }
+  TH2F* getHistoEtaVsPtDen(matchType m) const { return mEtaVsPtDen[m]; }
+  TEfficiency* getFractionITSTPCmatchEtaVsPt(matchType m) const { return mFractionITSTPCmatchEtaVsPt[m]; }
 
-  TH1F* getHistoPhiPhysPrim() const { return mPhiPhysPrim; }
-  TH1F* getHistoPhiTPCPhysPrim() const { return mPhiTPCPhysPrim; }
-  TEfficiency* getFractionITSTPCmatchPhiPhysPrim() const { return mFractionITSTPCmatchPhiPhysPrim; }
+  TH1F* getHistoPtPhysPrimNum(matchType m) const { return mPtPhysPrimNum[m]; }
+  TH1F* getHistoPtPhysPrimDen(matchType m) const { return mPtPhysPrimDen[m]; }
+  TEfficiency* getFractionITSTPCmatchPhysPrim(matchType m) const { return mFractionITSTPCmatchPhysPrim[m]; }
 
-  TH1F* getHistoEtaPhysPrim() const { return mEtaPhysPrim; }
-  TH1F* getHistoEtaTPCPhysPrim() const { return mEtaTPCPhysPrim; }
-  TEfficiency* getFractionITSTPCmatchEtaPhysPrim() const { return mFractionITSTPCmatchEtaPhysPrim; }
+  TH1F* getHistoPhiPhysPrimNum(matchType m) const { return mPhiPhysPrimNum[m]; }
+  TH1F* getHistoPhiPhysPrimDen(matchType m) const { return mPhiPhysPrimDen[m]; }
+  TEfficiency* getFractionITSTPCmatchPhiPhysPrim(matchType m) const { return mFractionITSTPCmatchPhiPhysPrim[m]; }
+
+  TH1F* getHistoEtaPhysPrimNum(matchType m) const { return mEtaPhysPrimNum[m]; }
+  TH1F* getHistoEtaPhysPrimDen(matchType m) const { return mEtaPhysPrimDen[m]; }
+  TEfficiency* getFractionITSTPCmatchEtaPhysPrim(matchType m) const { return mFractionITSTPCmatchEtaPhysPrim[m]; }
 
   TH2F* getHistoResidualPt() const { return mResidualPt; }
   TH2F* getHistoResidualPhi() const { return mResidualPhi; }
@@ -95,7 +104,18 @@ class MatchITSTPCQC
   TH1F* getHistoChi2Matching() const { return mChi2Matching; }
   TH1F* getHistoChi2Refit() const { return mChi2Refit; }
   TH2F* getHistoTimeResVsPt() const { return mTimeResVsPt; }
+  TH1F* getHistoDCAr() const { return mDCAr; }
+
+  TH1D* getHisto1OverPtNum(matchType m) const { return m1OverPtNum[m]; }
+  TH1D* getHisto1OverPtDen(matchType m) const { return m1OverPtDen[m]; }
+  TEfficiency* getFractionITSTPCmatch1OverPt(matchType m) const { return mFractionITSTPCmatch1OverPt[m]; }
+
+  TH1D* getHisto1OverPtPhysPrimNum(matchType m) const { return m1OverPtPhysPrimNum[m]; }
+  TH1D* getHisto1OverPtPhysPrimDen(matchType m) const { return m1OverPtPhysPrimDen[m]; }
+  TEfficiency* getFractionITSTPCmatchPhysPrim1OverPt(matchType m) const { return mFractionITSTPCmatchPhysPrim1OverPt[m]; }
+
   void getHistos(TObjArray& objar);
+
   void setSources(GID::mask_t src) { mSrc = src; }
   void setUseMC(bool b) { mUseMC = b; }
   bool getUseMC() const { return mUseMC; }
@@ -115,52 +135,82 @@ class MatchITSTPCQC
   void setMinDCAtoBeamPipeDistanceCut(float v) { mDCACut = v; }
   void setMinDCAtoBeamPipeYCut(float v) { mDCACutY = v; }
 
+  // to remove after merging QC PR
+  TH1D* getHistoPt() const { return nullptr; }                               // old
+  TH1D* getHistoPtTPC() const { return nullptr; }                            // old
+  TEfficiency* getFractionITSTPCmatch() const { return nullptr; }            // old
+  TH1F* getHistoPhi() const { return nullptr; }                              // old
+  TH1F* getHistoPhiTPC() const { return nullptr; }                           // old
+  TEfficiency* getFractionITSTPCmatchPhi() const { return nullptr; }         // old
+  TH2F* getHistoPhiVsPt() const { return nullptr; }                          // old
+  TEfficiency* getFractionITSTPCmatchPhiVsPt() const { return nullptr; }     // old
+  TH1F* getHistoEta() const { return nullptr; }                              // old
+  TH1F* getHistoEtaTPC() const { return nullptr; }                           // old
+  TEfficiency* getFractionITSTPCmatchEta() const { return nullptr; }         // old
+  TH2F* getHistoEtaVsPt() const { return nullptr; }                          // old
+  TH2F* getHistoEtaVsPtTPC() const { return nullptr; }                       // old
+  TEfficiency* getFractionITSTPCmatchEtaVsPt() const { return nullptr; }     // old
+  TH1F* getHistoPtPhysPrim() const { return nullptr; }                       // old
+  TH1F* getHistoPtTPCPhysPrim() const { return nullptr; }                    // old
+  TEfficiency* getFractionITSTPCmatchPhysPrim() const { return nullptr; }    // old
+  TH1F* getHistoPhiPhysPrim() const { return nullptr; }                      // old
+  TH1F* getHistoPhiTPCPhysPrim() const { return nullptr; }                   // old
+  TEfficiency* getFractionITSTPCmatchPhiPhysPrim() const { return nullptr; } // old
+  TH1F* getHistoEtaPhysPrim() const { return nullptr; }                      // old
+  TH1F* getHistoEtaTPCPhysPrim() const { return nullptr; }                   // old
+  TEfficiency* getFractionITSTPCmatchEtaPhysPrim() const { return nullptr; } // old
+
  private:
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
   o2::globaltracking::RecoContainer mRecoCont;
-  GID::mask_t mSrc = GID::getSourcesMask("TPC,ITS-TPC");
-  GID::mask_t mAllowedSources = GID::getSourcesMask("TPC,ITS-TPC");
+  GID::mask_t mSrc = GID::getSourcesMask("ITS,TPC,ITS-TPC");
+  GID::mask_t mAllowedSources = GID::getSourcesMask("ITS,TPC,ITS-TPC");
   // TPC
   gsl::span<const o2::tpc::TrackTPC> mTPCTracks;
+  // ITS
+  gsl::span<const o2::its::TrackITS> mITSTracks;
   // ITS-TPC
   gsl::span<const o2::dataformats::TrackTPCITS> mITSTPCTracks;
   bool mUseMC = false;
   float mBz = 0;                                              ///< nominal Bz
-  std::unordered_map<o2::MCCompLabel, LblInfo> mMapLabels;    // map with labels that have been found for the matched ITSTPC tracks; key is the label,
-                                                              // value is the LbLinfo with the id of the track with the highest pT found with that label so far,
-                                                              // and the flag to say if it is a physical primary or not
-  std::unordered_map<o2::MCCompLabel, LblInfo> mMapTPCLabels; // map with labels that have been found for the unmatched TPC tracks; key is the label,
-                                                              // value is the LblInfo with the id of the track with the highest number of TPC clusters found
-                                                              // with that label so far, and the flag to say if it is a physical primary or not
+  std::array<std::unordered_map<o2::MCCompLabel, LblInfo>, matchType::SIZE> mMapLabels;    // map with labels that have been found for the matched ITSTPC tracks; key is the label,
+                                                                                           // value is the LbLinfo with the id of the track with the highest pT found with that label so far,
+                                                                                           // and the flag to say if it is a physical primary or not
+  std::array<std::unordered_map<o2::MCCompLabel, LblInfo>, matchType::SIZE> mMapRefLabels; // map with labels that have been found for the unmatched TPC tracks; key is the label,
+                                                                                           // value is the LblInfo with the id of the track with the highest number of TPC clusters found
+                                                                                           // with that label so far, and the flag to say if it is a physical primary or not
   o2::steer::MCKinematicsReader mcReader;                     // reader of MC information
 
   // Pt
-  TH1D* mPt = nullptr;
-  TH1D* mPtTPC = nullptr;
-  TEfficiency* mFractionITSTPCmatch = nullptr;
-  TH1F* mPtPhysPrim = nullptr;
-  TH1F* mPtTPCPhysPrim = nullptr;
-  TEfficiency* mFractionITSTPCmatchPhysPrim = nullptr;
+  TH1D* mPtNum[matchType::SIZE] = {};
+  TH1D* mPtDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatch[matchType::SIZE] = {};
+  TH1D* mPtNum_noEta0[matchType::SIZE] = {};
+  TH1D* mPtDen_noEta0[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatch_noEta0[matchType::SIZE] = {};
+  TH1F* mPtPhysPrimNum[matchType::SIZE] = {};
+  TH1F* mPtPhysPrimDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchPhysPrim[matchType::SIZE] = {};
   // Phi
-  TH1F* mPhi = nullptr;
-  TH1F* mPhiTPC = nullptr;
-  TEfficiency* mFractionITSTPCmatchPhi = nullptr;
-  TH1F* mPhiPhysPrim = nullptr;
-  TH1F* mPhiTPCPhysPrim = nullptr;
-  TEfficiency* mFractionITSTPCmatchPhiPhysPrim = nullptr;
-  TH2F* mPhiVsPt = nullptr;
-  TH2F* mPhiVsPtTPC = nullptr;
-  TEfficiency* mFractionITSTPCmatchPhiVsPt = nullptr;
+  TH1F* mPhiNum[matchType::SIZE] = {};
+  TH1F* mPhiDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchPhi[matchType::SIZE] = {};
+  TH1F* mPhiPhysPrimNum[matchType::SIZE] = {};
+  TH1F* mPhiPhysPrimDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchPhiPhysPrim[matchType::SIZE] = {};
+  TH2F* mPhiVsPtNum[matchType::SIZE] = {};
+  TH2F* mPhiVsPtDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchPhiVsPt[matchType::SIZE] = {};
   // Eta
-  TH1F* mEta = nullptr;
-  TH1F* mEtaTPC = nullptr;
-  TEfficiency* mFractionITSTPCmatchEta = nullptr;
-  TH1F* mEtaPhysPrim = nullptr;
-  TH1F* mEtaTPCPhysPrim = nullptr;
-  TEfficiency* mFractionITSTPCmatchEtaPhysPrim = nullptr;
-  TH2F* mEtaVsPt = nullptr;
-  TH2F* mEtaVsPtTPC = nullptr;
-  TEfficiency* mFractionITSTPCmatchEtaVsPt = nullptr;
+  TH1F* mEtaNum[matchType::SIZE] = {};
+  TH1F* mEtaDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchEta[matchType::SIZE] = {};
+  TH1F* mEtaPhysPrimNum[matchType::SIZE] = {};
+  TH1F* mEtaPhysPrimDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchEtaPhysPrim[matchType::SIZE] = {};
+  TH2F* mEtaVsPtNum[matchType::SIZE] = {};
+  TH2F* mEtaVsPtDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchEtaVsPt[matchType::SIZE] = {};
   // Residuals
   TH2F* mResidualPt = nullptr;
   TH2F* mResidualPhi = nullptr;
@@ -169,11 +219,20 @@ class MatchITSTPCQC
   TH1F* mChi2Matching = nullptr;
   TH1F* mChi2Refit = nullptr;
   TH2F* mTimeResVsPt = nullptr;
+  TH1F* mDCAr = nullptr;
+  // 1/Pt
+  TH1D* m1OverPtNum[matchType::SIZE] = {};
+  TH1D* m1OverPtDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatch1OverPt[matchType::SIZE] = {};
+  TH1D* m1OverPtPhysPrimNum[matchType::SIZE] = {};
+  TH1D* m1OverPtPhysPrimDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchPhysPrim1OverPt[matchType::SIZE] = {};
 
   void setEfficiency(TEfficiency* eff, TH1* hnum, TH1* hden, bool is2D = false);
 
   int mNTPCSelectedTracks = 0;
-  int mNITSTPCSelectedTracks = 0;
+  int mNITSSelectedTracks = 0;
+  int mNITSTPCSelectedTracks[matchType::SIZE] = {0, 0};
 
   // cut values
   float mPtCut = 0.1f;

--- a/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
+++ b/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
@@ -36,33 +36,46 @@ MatchITSTPCQC::~MatchITSTPCQC()
 void MatchITSTPCQC::deleteHistograms()
 {
 
-  // Pt
-  delete mPt;
-  delete mPtTPC;
-  delete mFractionITSTPCmatch;
-  delete mPtPhysPrim;
-  delete mPtTPCPhysPrim;
-  delete mFractionITSTPCmatchPhysPrim;
-  // Phi
-  delete mPhi;
-  delete mPhiTPC;
-  delete mFractionITSTPCmatchPhi;
-  delete mPhiPhysPrim;
-  delete mPhiTPCPhysPrim;
-  delete mFractionITSTPCmatchPhiPhysPrim;
-  delete mPhiVsPt;
-  delete mPhiVsPtTPC;
-  delete mFractionITSTPCmatchPhiVsPt;
-  // Eta
-  delete mEta;
-  delete mEtaTPC;
-  delete mFractionITSTPCmatchEta;
-  delete mEtaPhysPrim;
-  delete mEtaTPCPhysPrim;
-  delete mFractionITSTPCmatchEtaPhysPrim;
-  delete mEtaVsPt;
-  delete mEtaVsPtTPC;
-  delete mFractionITSTPCmatchEtaVsPt;
+  for (int i = 0; i < matchType::SIZE; ++i) {
+    // Pt
+    delete mPtNum[i];
+    delete mPtDen[i];
+    delete mFractionITSTPCmatch[i];
+    delete mPtNum_noEta0[i];
+    delete mPtDen_noEta0[i];
+    delete mFractionITSTPCmatch_noEta0[i];
+    delete mPtPhysPrimNum[i];
+    delete mPtPhysPrimDen[i];
+    delete mFractionITSTPCmatchPhysPrim[i];
+    // Phi
+    delete mPhiNum[i];
+    delete mPhiDen[i];
+    delete mFractionITSTPCmatchPhi[i];
+    delete mPhiPhysPrimNum[i];
+    delete mPhiPhysPrimDen[i];
+    delete mFractionITSTPCmatchPhiPhysPrim[i];
+    delete mPhiVsPtNum[i];
+    delete mPhiVsPtDen[i];
+    delete mFractionITSTPCmatchPhiVsPt[i];
+    // Eta
+    delete mEtaNum[i];
+    delete mEtaDen[i];
+    delete mFractionITSTPCmatchEta[i];
+    delete mEtaPhysPrimNum[i];
+    delete mEtaPhysPrimDen[i];
+    delete mFractionITSTPCmatchEtaPhysPrim[i];
+    delete mEtaVsPtNum[i];
+    delete mEtaVsPtDen[i];
+    delete mFractionITSTPCmatchEtaVsPt[i];
+    // 1/Pt
+    delete m1OverPtNum[i];
+    delete m1OverPtDen[i];
+    delete mFractionITSTPCmatch1OverPt[i];
+    delete m1OverPtPhysPrimNum[i];
+    delete m1OverPtPhysPrimDen[i];
+    delete mFractionITSTPCmatchPhysPrim1OverPt[i];
+  }
+
   // Residuals
   delete mResidualPt;
   delete mResidualPhi;
@@ -71,31 +84,41 @@ void MatchITSTPCQC::deleteHistograms()
   delete mChi2Matching;
   delete mChi2Refit;
   delete mTimeResVsPt;
+  delete mDCAr;
 }
 
 //__________________________________________________________
 
 void MatchITSTPCQC::reset()
 {
-  // Pt
-  mPt->Reset();
-  mPtTPC->Reset();
-  mPtPhysPrim->Reset();
-  mPtTPCPhysPrim->Reset();
-  // Phi
-  mPhi->Reset();
-  mPhiTPC->Reset();
-  mPhiPhysPrim->Reset();
-  mPhiTPCPhysPrim->Reset();
-  mPhiVsPt->Reset();
-  mPhiVsPtTPC->Reset();
-  // Eta
-  mEta->Reset();
-  mEtaTPC->Reset();
-  mEtaPhysPrim->Reset();
-  mEtaTPCPhysPrim->Reset();
-  mEtaVsPt->Reset();
-  mEtaVsPtTPC->Reset();
+  for (int i = 0; i < matchType::SIZE; ++i) {
+    // Pt
+    mPtNum[i]->Reset();
+    mPtDen[i]->Reset();
+    mPtNum_noEta0[i]->Reset();
+    mPtDen_noEta0[i]->Reset();
+    mPtPhysPrimNum[i]->Reset();
+    mPtPhysPrimDen[i]->Reset();
+    // Phi
+    mPhiNum[i]->Reset();
+    mPhiDen[i]->Reset();
+    mPhiPhysPrimNum[i]->Reset();
+    mPhiPhysPrimDen[i]->Reset();
+    mPhiVsPtNum[i]->Reset();
+    mPhiVsPtDen[i]->Reset();
+    // Eta
+    mEtaNum[i]->Reset();
+    mEtaDen[i]->Reset();
+    mEtaPhysPrimNum[i]->Reset();
+    mEtaPhysPrimDen[i]->Reset();
+    mEtaVsPtNum[i]->Reset();
+    mEtaVsPtDen[i]->Reset();
+    // 1/Pt
+    m1OverPtNum[i]->Reset();
+    m1OverPtDen[i]->Reset();
+    m1OverPtPhysPrimNum[i]->Reset();
+    m1OverPtPhysPrimDen[i]->Reset();
+  }
   // Residuals
   mResidualPt->Reset();
   mResidualPhi->Reset();
@@ -104,43 +127,57 @@ void MatchITSTPCQC::reset()
   mChi2Matching->Reset();
   mChi2Refit->Reset();
   mTimeResVsPt->Reset();
+  mDCAr->Reset();
 }
 
 //__________________________________________________________
 bool MatchITSTPCQC::init()
 {
-  // Pt
-  mPtTPC = new TH1D("mPtTPC", "Pt distribution of TPC tracks; Pt [GeV/c]; dNdPt", 100, 0.f, 20.f);
-  mFractionITSTPCmatch = new TEfficiency("mFractionITSTPCmatch", "Fraction of ITSTPC matched tracks vs Pt; Pt [GeV/c]; Eff", 100, 0.f, 20.f);
-  mPt = new TH1D("mPt", "Pt distribution of matched tracks; Pt [GeV/c]; dNdPt", 100, 0.f, 20.f);
-  // Phi
-  mPhiTPC = new TH1F("mPhiTPC", "Phi distribution of TPC tracks; Phi [rad]; dNdPhi", 100, 0.f, 2 * TMath::Pi());
-  mFractionITSTPCmatchPhi = new TEfficiency("mFractionITSTPCmatchPhi", "Fraction of ITSTPC matched tracks vs Phi; Phi [rad]; Eff", 100, 0.f, 2 * TMath::Pi());
-  mPhi = new TH1F("mPhi", "Phi distribution of matched tracks; Phi [rad]; dNdPhi", 100, 0.f, 2 * TMath::Pi());
-  mPhiVsPt = new TH2F("mPhiVsPt", "Phi distribution of matched tracks vs Pt; #it{p}_{T} [GeV#it{c}]; Phi [rad]; dNdPhi", 100, 0.f, 20.f, 100, 0.f, 2 * TMath::Pi());
-  mPhiVsPtTPC = new TH2F("mPhiVsPtTPC", "Phi distribution of TPC tracks vs Pt; #it{p}_{T} [GeV#it{c}]; Phi [rad]; dNdPhi", 100, 0.f, 20.f, 100, 0.f, 2 * TMath::Pi());
-  mFractionITSTPCmatchPhiVsPt = new TEfficiency("mFractionITSTPCmatchPhiVsPt", "Fraction of ITSTPC matched tracks vs Phi; #it{p}_{T} [GeV#it{c}]; Phi [rad]; Eff", 100, 0.f, 20.f, 100, 0.f, 2 * TMath::Pi());
-  // Eta
-  mEta = new TH1F("mEta", "Eta distribution of matched tracks; Eta; dNdEta", 100, -2.f, 2.f);
-  mEtaTPC = new TH1F("mEtaTPC", "Eta distribution of TPC tracks; Eta; dNdEta", 100, -2.f, 2.f);
-  mFractionITSTPCmatchEta = new TEfficiency("mFractionITSTPCmatchEta", "Fraction of ITSTPC matched tracks vs Eta; Eta; Eff", 100, -2.f, 2.f);
-  mEtaVsPt = new TH2F("mEtaVsPt", "Eta distribution of matched tracks vs Pt; #it{p}_{T} [GeV#it{c}]; Eta; dNdEta", 100, 0.f, 20.f, 100, -2.f, 2.f);
-  mEtaVsPtTPC = new TH2F("mEtaVsPtTPC", "Eta distribution of TPC tracks vs Pt; #it{p}_{T} [GeV#it{c}]; Eta ; dNdEta", 100, 0.f, 20.f, 100, -2.f, 2.f);
-  mFractionITSTPCmatchEtaVsPt = new TEfficiency("mFractionITSTPCmatchEtaVsPt", "Fraction of ITSTPC matched tracks vs Eta; #it{p}_{T} [GeV#it{c}]; Eta; Eff", 100, 0.f, 20.f, 100, -2.f, 2.f);
-  // These will be empty in case of no MC info...
-  mPhiTPCPhysPrim = new TH1F("mPhiTPCPhysPrim", "Phi distribution of TPC tracks (physical primary); Phi [rad]; dNdPhi", 100, 0.f, 2 * TMath::Pi());
-  mFractionITSTPCmatchPhiPhysPrim = new TEfficiency("mFractionITSTPCmatchPhiPhysPrim", "Fraction of ITSTPC matched tracks vs Phi (physical primary); Phi [rad]; Eff", 100, 0.f, 2 * TMath::Pi());
-  mFractionITSTPCmatchEtaPhysPrim = new TEfficiency("mFractionITSTPCmatchEtaPhysPrim", "Fraction of ITSTPC matched tracks vs Eta (physical primary); Eta; Eff", 100, -2.f, 2.f);
-  mPhiPhysPrim = new TH1F("mPhiPhysPrim", "Phi distribution of matched tracks (physical primary); Phi [rad]; dNdPhi", 100, 0.f, 2 * TMath::Pi());
-  mEtaPhysPrim = new TH1F("mEtaPhysPrim", "Eta distribution of matched tracks (physical primary); Eta; dNdEta", 100, -2.f, 2.f);
-  mEtaTPCPhysPrim = new TH1F("mEtaTPCPhysPrim", "Eta distribution of TPC tracks (physical primary); Eta; dNdEta", 100, -2.f, 2.f);
-  // ...till here
+
+  std::array<std::string, 2> title{"TPC", "ITS"};
+  std::array<std::string, 2> etaSel{"", ", |eta| < 0.9"};
+  for (int i = 0; i < matchType::SIZE; ++i) {
+    // Pt
+    mPtNum[i] = new TH1D(Form("mPtNum_%s", title[i].c_str()), Form("Pt distribution of ITSTPC matched tracks, wrt %s tracks %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
+    mPtDen[i] = new TH1D(Form("mPtDen_%s", title[i].c_str()), Form("Pt distribution of %s tracks %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
+    mFractionITSTPCmatch[i] = new TEfficiency(Form("mFractionITSTPCmatch_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks wrt %s tracks vs Pt %s; Pt [GeV/c]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
+    mPtNum_noEta0[i] = new TH1D(Form("mPtNum_noEta0_%s", title[i].c_str()), Form("Pt distribution of ITSTPC matched tracks without |eta| < 0.05, wrt %s tracks %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
+    mPtDen_noEta0[i] = new TH1D(Form("mPtDen_noEta0_%s", title[i].c_str()), Form("Pt distribution of %s tracks without |eta| < 0.05 %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
+    mFractionITSTPCmatch_noEta0[i] = new TEfficiency(Form("mFractionITSTPCmatch_noEta0_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks wrt %s tracks vs Pt without |eta| < 0.05 %s; Pt [GeV/c]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
+    // Phi
+    mPhiNum[i] = new TH1F(Form("mPhiNum_%s", title[i].c_str()), Form("Phi distribution of ITSTPC matched tracks, wrt %s tracks %s; Phi [rad]; dNdPhi", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 2 * TMath::Pi());
+    mPhiDen[i] = new TH1F(Form("mPhiDen_%s", title[i].c_str()), Form("Phi distribution of %s tracks %s; Phi [rad]; dNdPhi", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 2 * TMath::Pi());
+    mFractionITSTPCmatchPhi[i] = new TEfficiency(Form("mFractionITSTPCmatchPhi_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks vs Phi wrt %s tracks %s; Phi [rad]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 2 * TMath::Pi());
+    mPhiVsPtNum[i] = new TH2F(Form("mPhiVsPtNum_%s", title[i].c_str()), Form("Phi vs Pt distribution of ITSTPC matched tracks wrt %s %s; #it{p}_{T} [GeV#it{c}]; Phi [rad]; dNdPhi", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f, 100, 0.f, 2 * TMath::Pi());
+    mPhiVsPtDen[i] = new TH2F(Form("mPhiVsPtDen_%s", title[i].c_str()), Form("Phi vs Pt distribution of %s tracks %s; #it{p}_{T} [GeV#it{c}]; Phi [rad]; dNdPhi", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f, 100, 0.f, 2 * TMath::Pi());
+    mFractionITSTPCmatchPhiVsPt[i] = new TEfficiency(Form("mFractionITSTPCmatchPhiVsPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks wrt %s tracks %s, Phi vs Pt; #it{p}_{T} [GeV#it{c}]; Phi [rad]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f, 100, 0.f, 2 * TMath::Pi());
+    // Eta
+    mEtaNum[i] = new TH1F(Form("mEtaNum_%s", title[i].c_str()), Form("Eta distribution of ITSTPC matched tracks, wrt %s tracks; Eta; dNdEta", title[i].c_str()), 100, -2.f, 2.f);
+    mEtaDen[i] = new TH1F(Form("mEtaDen_%s", title[i].c_str()), Form("Eta distribution of %s tracks; Eta; dNdEta", title[i].c_str()), 100, -2.f, 2.f);
+    mFractionITSTPCmatchEta[i] = new TEfficiency(Form("mFractionITSTPCmatchEta_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks , wrt %s tracks, vs Eta; Eta; Eff", title[i].c_str()), 100, -2.f, 2.f);
+    mEtaVsPtNum[i] = new TH2F(Form("mEtaVsPtNum_%s", title[i].c_str()), Form("Eta vs Pt distribution of ITSTPC matched tracks, wrt %s tracks; #it{p}_{T} [GeV#it{c}]; #it{p}_{T} [GeV#it{c}]; Eta", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
+    mEtaVsPtDen[i] = new TH2F(Form("mEtaVsPtDen_%s", title[i].c_str()), Form("Eta vs Pt distribution of %s tracks; #it{p}_{T} [GeV#it{c}]; #it{p}_{T} [GeV#it{c}]; Eta", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
+    mFractionITSTPCmatchEtaVsPt[i] = new TEfficiency(Form("mFractionITSTPCmatchEtaVsPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks, wrt %s tracks, Eta vs Pt; #it{p}_{T} [GeV#it{c}]; Eta; Eff", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
+    // 1/pt
+    m1OverPtNum[i] = new TH1D(Form("m1OverPtNum_%s", title[i].c_str()), Form("1/Pt distribution of matched tracks, wrt %s tracks %s; 1/Pt [c/GeV]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, -20.f, 20.f);
+    m1OverPtDen[i] = new TH1D(Form("m1OverPtDen_%s", title[i].c_str()), Form("1/Pt distribution of %s tracks %s; 1/Pt [c/GeV]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, -20.f, 20.f);
+    mFractionITSTPCmatch1OverPt[i] = new TEfficiency(Form("mFractionITSTPCmatch1OverPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks vs 1/Pt, wrt %s tracks %s; 1/Pt [c/GeV]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, -20.f, 20.f);
+
+    // These will be empty in case of no MC info...
+    mPhiPhysPrimNum[i] = new TH1F(Form("mPhiPhysPrimNum_%s", title[i].c_str()), Form("Phi distribution of matched tracks (physical primary), wrt %s tracks %s; Phi [rad]; dNdPhi", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 2 * TMath::Pi());
+    mPhiPhysPrimDen[i] = new TH1F(Form("mPhiPhysPrimDen_%s", title[i].c_str()), Form("Phi distribution of %s tracks (physical primary) %s; Phi [rad]; dNdPhi", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 2 * TMath::Pi());
+    mFractionITSTPCmatchPhiPhysPrim[i] = new TEfficiency(Form("mFractionITSTPCmatchPhiPhysPrim_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks vs Phi (physical primary), wrt %s tracks %s; Phi [rad]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 2 * TMath::Pi());
+    mEtaPhysPrimNum[i] = new TH1F(Form("mEtaPhysPrimNum_%s", title[i].c_str()), Form("Eta distribution of matched tracks (physical primary), wrt %s tracks; Eta; dNdEta", title[i].c_str()), 100, -2.f, 2.f);
+    mEtaPhysPrimDen[i] = new TH1F(Form("mEtaPhysPrimDen_%s", title[i].c_str()), Form("Eta distribution of %s tracks (physical primary); Eta; dNdEta", title[i].c_str()), 100, -2.f, 2.f);
+    mFractionITSTPCmatchEtaPhysPrim[i] = new TEfficiency(Form("mFractionITSTPCmatchEtaPhysPrim_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks vs Eta (physical primary), wrt %s tracks; Eta; Eff", title[i].c_str()), 100, -2.f, 2.f);
+  }
 
   mResidualPt = new TH2F("mResidualPt", "Residuals of ITS-TPC matching in #it{p}_{T}; #it{p}_{T}^{ITS-TPC} [GeV/c]; #it{p}_{T}^{ITS-TPC} - #it{p}_{T}^{TPC} [GeV/c]", 100, 0.f, 20.f, 100, -1.f, 1.f);
   mResidualPhi = new TH2F("mResidualPhi", "Residuals of ITS-TPC matching in #it{#phi}; #it{#phi}^{ITS-TPC} [rad]; #it{#phi}^{ITS-TPC} - #it{#phi}^{TPC} [rad]", 100, 0.f, 2 * TMath::Pi(), 100, -1.f, 1.f);
   mResidualEta = new TH2F("mResidualEta", "Residuals of ITS-TPC matching in #it{#eta}; #it{#eta}^{ITS-TPC}; #it{#eta}^{ITS-TPC} - #it{#eta}^{TPC}", 100, -2.f, 2.f, 100, -1.f, 1.f);
   mChi2Matching = new TH1F("mChi2Matching", "Chi2 of matching; chi2", 200, 0, 300);
   mChi2Refit = new TH1F("mChi2Refit", "Chi2 of refit; chi2", 200, 0, 300);
+  mDCAr = new TH1F("mDCAr", "DCA of TPC tracks; DCAr", 200, -100, 100);
 
   // log binning for pT
   const Int_t nbinsPt = 100;
@@ -155,36 +192,57 @@ bool MatchITSTPCQC::init()
     xbinsPt[i] = TMath::Exp(TMath::Log(10) * xlogPt);
   }
   mTimeResVsPt = new TH2F("mTimeResVsPt", "Time resolution vs Pt; Pt [GeV/c]; time res [us]", nbinsPt, xbinsPt, 100, 0.f, 2.f);
-  mPtTPCPhysPrim = new TH1F("mPtTPPhysPrimC", "Pt distribution of TPC tracks (physical primary); Pt [GeV/c]; dNdPt", nbinsPt, xbinsPt);
-  mFractionITSTPCmatchPhysPrim = new TEfficiency("mFractionITSTPCmatchPhysPrim", "Fraction of ITSTPC matched tracks vs Pt (physical primary); Pt [GeV/c]; Eff", nbinsPt, xbinsPt);
-  mPtPhysPrim = new TH1F("mPtPhysPrim", "Pt distribution of matched tracks (physical primary); Pt [GeV/c]; dNdPt", nbinsPt, xbinsPt);
 
-  mPtTPC->Sumw2();
-  mPt->Sumw2();
-  mPhiTPC->Sumw2();
-  mPhi->Sumw2();
-  mPhiVsPt->Sumw2();
-  mPhiVsPtTPC->Sumw2();
-  mPtTPCPhysPrim->Sumw2();
-  mPtPhysPrim->Sumw2();
-  mPhiTPCPhysPrim->Sumw2();
-  mPhiPhysPrim->Sumw2();
-  mEtaTPC->Sumw2();
-  mEtaPhysPrim->Sumw2();
-  mEtaTPCPhysPrim->Sumw2();
-  mEtaVsPt->Sumw2();
-  mEtaVsPtTPC->Sumw2();
+  for (int i = 0; i < matchType::SIZE; ++i) {
+    mPtPhysPrimNum[i] = new TH1F(Form("mPtPhysPrimNum_%s", title[i].c_str()), Form("Pt distribution of matched tracks (physical primary), wrt %s tracks %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), nbinsPt, xbinsPt);
+    mPtPhysPrimDen[i] = new TH1F(Form("mPtPhysPrimDen_%s", title[i].c_str()), Form("Pt distribution of %s tracks (physical primary) %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), nbinsPt, xbinsPt);
+    mFractionITSTPCmatchPhysPrim[i] = new TEfficiency(Form("mFractionITSTPCmatchPhysPrim_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks vs Pt (physical primary), wrt %s tracks %s; Pt [GeV/c]; Eff", title[i].c_str(), etaSel[i].c_str()), nbinsPt, xbinsPt);
+    m1OverPtPhysPrimNum[i] = new TH1D(Form("m1OverPtPhysPrimNum_%s", title[i].c_str()), Form("1/Pt distribution of matched tracks (physical primary), wrt %s tracks %s; 1/Pt [c/GeV]; dNd1/Pt", title[i].c_str(), etaSel[i].c_str()), 100, -20.f, 20.f);
+    m1OverPtPhysPrimDen[i] = new TH1D(Form("m1OverPtPhysPrimDen_%s", title[i].c_str()), Form("1/PtPt distribution of %s tracks (physical primary) %s; 1/Pt [c/GeV]; dNd1/Pt", title[i].c_str(), etaSel[i].c_str()), 100, -20.f, 20.f);
+    mFractionITSTPCmatchPhysPrim1OverPt[i] = new TEfficiency(Form("mFractionITSTPCmatchPhysPrim1OverPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks vs 1/Pt (physical primary), wrt %s tracks %s; 1/Pt [c/GeV]; Eff", title[i].c_str(), etaSel[i].c_str()), 100, -20.f, 20.f);
 
-  mPtTPC->SetOption("logy");
-  mPt->SetOption("logy");
-  mEta->SetOption("logy");
+    // some extra settings
+    mPtNum[i]->Sumw2();
+    mPtDen[i]->Sumw2();
+    mPtNum_noEta0[i]->Sumw2();
+    mPtDen_noEta0[i]->Sumw2();
+    mPhiNum[i]->Sumw2();
+    mPhiDen[i]->Sumw2();
+    mPhiVsPtNum[i]->Sumw2();
+    mPhiVsPtDen[i]->Sumw2();
+    mPtPhysPrimNum[i]->Sumw2();
+    mPtPhysPrimDen[i]->Sumw2();
+    mPhiPhysPrimNum[i]->Sumw2();
+    mPhiPhysPrimDen[i]->Sumw2();
+    mEtaNum[i]->Sumw2();
+    mEtaDen[i]->Sumw2();
+    mEtaPhysPrimNum[i]->Sumw2();
+    mEtaPhysPrimDen[i]->Sumw2();
+    mEtaVsPtNum[i]->Sumw2();
+    mEtaVsPtDen[i]->Sumw2();
+
+    m1OverPtNum[i]->Sumw2();
+    m1OverPtDen[i]->Sumw2();
+    m1OverPtPhysPrimNum[i]->Sumw2();
+    m1OverPtPhysPrimDen[i]->Sumw2();
+
+    mPtNum_noEta0[i]->SetOption("logy");
+    mPtDen_noEta0[i]->SetOption("logy");
+    mPtNum[i]->SetOption("logy");
+    mPtDen[i]->SetOption("logy");
+
+    mPtNum[i]->GetYaxis()->SetTitleOffset(1.4);
+    mPtDen[i]->GetYaxis()->SetTitleOffset(1.4);
+    mPtNum_noEta0[i]->GetYaxis()->SetTitleOffset(1.4);
+    mPtDen_noEta0[i]->GetYaxis()->SetTitleOffset(1.4);
+    mEtaNum[i]->GetYaxis()->SetTitleOffset(1.4);
+    mEtaDen[i]->GetYaxis()->SetTitleOffset(1.4);
+  }
+
   mChi2Matching->SetOption("logy");
   mChi2Refit->SetOption("logy");
   mTimeResVsPt->SetOption("colz logz logy logx");
 
-  mPtTPC->GetYaxis()->SetTitleOffset(1.4);
-  mPt->GetYaxis()->SetTitleOffset(1.4);
-  mEta->GetYaxis()->SetTitleOffset(1.4);
   mChi2Matching->GetYaxis()->SetTitleOffset(1.4);
   mChi2Refit->GetYaxis()->SetTitleOffset(1.4);
   mTimeResVsPt->GetYaxis()->SetTitleOffset(1.4);
@@ -205,7 +263,7 @@ void MatchITSTPCQC::initDataRequest()
 
   mSrc &= mAllowedSources;
 
-  if ((mSrc[GID::Source::ITSTPC] == 0 || mSrc[GID::Source::TPC] == 0)) {
+  if (mSrc[GID::Source::ITSTPC] == 0 || mSrc[GID::Source::TPC] == 0 || mSrc[GID::Source::ITS] == 0) {
     LOG(fatal) << "We cannot do ITSTPC QC, some sources are missing, check sources in " << mSrc;
   }
 
@@ -224,13 +282,16 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
   static int evCount = 0;
   mRecoCont.collectData(ctx, *mDataRequest.get());
   mTPCTracks = mRecoCont.getTPCTracks();
+  mITSTracks = mRecoCont.getITSTracks();
   mITSTPCTracks = mRecoCont.getTPCITSTracks();
 
   LOG(debug) << "****** Number of found ITSTPC tracks = " << mITSTPCTracks.size();
   LOG(debug) << "****** Number of found TPC    tracks = " << mTPCTracks.size();
+  LOG(debug) << "****** Number of found ITS    tracks = " << mITSTracks.size();
 
-  // cache selection for TPC tracks
+  // cache selection for TPC and ITS tracks
   std::vector<bool> isTPCTrackSelectedEntry(mTPCTracks.size(), false);
+  std::vector<bool> isITSTrackSelectedEntry(mITSTracks.size(), false);
   TrackCuts cuts;
 
   for (size_t itrk = 0; itrk < mTPCTracks.size(); ++itrk) {
@@ -244,28 +305,58 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
     }
   }
 
+  for (size_t itrk = 0; itrk < mITSTracks.size(); ++itrk) {
+    auto const& trkIts = mITSTracks[itrk];
+    o2::dataformats::GlobalTrackID id(itrk, GID::ITS);
+    if (cuts.isSelected(id, mRecoCont)) {
+      isITSTrackSelectedEntry[itrk] = true;
+    }
+  }
+
   // numerator + eta, chi2...
   if (mUseMC) {
-    mMapLabels.clear();
+    for (int i = 0; i < matchType::SIZE; ++i) {
+      mMapLabels[i].clear();
+    }
     for (int itrk = 0; itrk < static_cast<int>(mITSTPCTracks.size()); ++itrk) {
       auto const& trk = mITSTPCTracks[itrk];
       auto idxTrkTpc = trk.getRefTPC().getIndex();
       if (isTPCTrackSelectedEntry[idxTrkTpc] == true) {
         auto lbl = mRecoCont.getTrackMCLabel({(unsigned int)(itrk), GID::Source::ITSTPC});
-        if (mMapLabels.find(lbl) == mMapLabels.end()) {
+        if (mMapLabels[matchType::TPC].find(lbl) == mMapLabels[matchType::TPC].end()) {
           int source = lbl.getSourceID();
           int event = lbl.getEventID();
           const std::vector<o2::MCTrack>& pcontainer = mcReader.getTracks(source, event);
           const o2::MCTrack& p = pcontainer[lbl.getTrackID()];
           if (MCTrackNavigator::isPhysicalPrimary(p, pcontainer)) {
-            mMapLabels.insert({lbl, {itrk, true}});
+            mMapLabels[matchType::TPC].insert({lbl, {itrk, true}});
           } else {
-            mMapLabels.insert({lbl, {itrk, false}});
+            mMapLabels[matchType::TPC].insert({lbl, {itrk, false}});
           }
         } else {
           // winner (if more tracks have the same label) has the highest pt
-          if (mITSTPCTracks[mMapLabels.at(lbl).mIdx].getPt() < trk.getPt()) {
-            mMapLabels.at(lbl).mIdx = itrk;
+          if (mITSTPCTracks[mMapLabels[matchType::TPC].at(lbl).mIdx].getPt() < trk.getPt()) {
+            mMapLabels[matchType::TPC].at(lbl).mIdx = itrk;
+          }
+        }
+      }
+      auto idxTrkIts = trk.getRefITS().getIndex();
+      if (isITSTrackSelectedEntry[idxTrkIts] == true) {
+        auto lbl = mRecoCont.getTrackMCLabel({(unsigned int)(itrk), GID::Source::ITSTPC});
+        if (mMapLabels[matchType::ITS].find(lbl) == mMapLabels[matchType::ITS].end()) {
+          int source = lbl.getSourceID();
+          int event = lbl.getEventID();
+          const std::vector<o2::MCTrack>& pcontainer = mcReader.getTracks(source, event);
+          const o2::MCTrack& p = pcontainer[lbl.getTrackID()];
+          if (MCTrackNavigator::isPhysicalPrimary(p, pcontainer)) {
+            mMapLabels[matchType::ITS].insert({lbl, {itrk, true}});
+          } else {
+            mMapLabels[matchType::ITS].insert({lbl, {itrk, false}});
+          }
+        } else {
+          // winner (if more tracks have the same label) has the highest pt
+          if (mITSTPCTracks[mMapLabels[matchType::ITS].at(lbl).mIdx].getPt() < trk.getPt()) {
+            mMapLabels[matchType::ITS].at(lbl).mIdx = itrk;
           }
         }
       }
@@ -273,118 +364,288 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
     LOG(info) << "number of entries in map for nominator (without duplicates) = " << mMapLabels.size();
     // now we use only the tracks in the map to fill the histograms (--> tracks have passed the
     // track selection and there are no duplicated tracks wrt the same MC label)
-    for (auto const& el : mMapLabels) {
-      auto const& trk = mITSTPCTracks[el.second.mIdx];
-      auto const& trkTpc = mTPCTracks[trk.getRefTPC()];
-      mPt->Fill(trkTpc.getPt());
-      mPhi->Fill(trkTpc.getPhi());
-      mPhiVsPt->Fill(trkTpc.getPt(), trkTpc.getPhi());
-      mEta->Fill(trkTpc.getEta());
-      mEtaVsPt->Fill(trkTpc.getPt(), trkTpc.getEta());
-      // we fill also the denominator
-      mPtTPC->Fill(trkTpc.getPt());
-      mPhiTPC->Fill(trkTpc.getPhi());
-      mPhiVsPtTPC->Fill(trkTpc.getPt(), trkTpc.getPhi());
-      mEtaTPC->Fill(trkTpc.getEta());
-      mEtaVsPtTPC->Fill(trkTpc.getPt(), trkTpc.getEta());
-      if (el.second.mIsPhysicalPrimary) {
-        mPtPhysPrim->Fill(trkTpc.getPt());
-        mPhiPhysPrim->Fill(trkTpc.getPhi());
-        mEtaPhysPrim->Fill(trkTpc.getEta());
+    for (int i = 0; i < matchType::SIZE; ++i) {
+      for (auto const& el : mMapLabels[i]) {
+        auto const& trk = mITSTPCTracks[el.second.mIdx];
+        o2::track::TrackParCov trkDen;
+        bool isEtaITSOk = true;
+        if (i == matchType::TPC) {
+          trkDen = mTPCTracks[trk.getRefTPC()];
+        } else {
+          trkDen = mITSTracks[trk.getRefITS()];
+          if (std::abs(trkDen.getEta()) > 0.9) {
+            // ITS track outside |eta | < 0.9, we don't fill pt, nor phi , nor phi vs pt histos
+            isEtaITSOk = false;
+          }
+        }
+        if (isEtaITSOk) {
+          mPtNum[i]->Fill(trkDen.getPt());
+          if (std::abs(trkDen.getEta()) > 0.05) {
+            mPtNum_noEta0[i]->Fill(trkDen.getPt());
+          }
+          mPhiNum[i]->Fill(trkDen.getPhi());
+          mPhiVsPtNum[i]->Fill(trkDen.getPt(), trkDen.getPhi());
+          m1OverPtNum[i]->Fill(trkDen.getSign() * trkDen.getPtInv());
+          // we fill also the denominator
+          mPtDen[i]->Fill(trkDen.getPt());
+          if (std::abs(trkDen.getEta()) > 0.05) {
+            mPtDen_noEta0[i]->Fill(trkDen.getPt());
+          }
+          mPhiDen[i]->Fill(trkDen.getPhi());
+          mPhiVsPtDen[i]->Fill(trkDen.getPt(), trkDen.getPhi());
+          m1OverPtDen[i]->Fill(trkDen.getSign() * trkDen.getPtInv());
+        }
+        mEtaNum[i]->Fill(trkDen.getEta());
+        mEtaVsPtNum[i]->Fill(trkDen.getPt(), trkDen.getEta());
         // we fill also the denominator
-        mPtTPCPhysPrim->Fill(trkTpc.getPt());
-        mPhiTPCPhysPrim->Fill(trkTpc.getPhi());
-        mEtaTPCPhysPrim->Fill(trkTpc.getEta());
+        mEtaDen[i]->Fill(trkDen.getEta());
+        mEtaVsPtDen[i]->Fill(trkDen.getPt(), trkDen.getEta());
+        if (el.second.mIsPhysicalPrimary) {
+          if (isEtaITSOk) {
+            mPtPhysPrimNum[i]->Fill(trkDen.getPt());
+            mPhiPhysPrimNum[i]->Fill(trkDen.getPhi());
+            m1OverPtPhysPrimNum[i]->Fill(trkDen.getSign() * trkDen.getPtInv());
+            // we fill also the denominator
+            mPtPhysPrimDen[i]->Fill(trkDen.getPt());
+            mPhiPhysPrimDen[i]->Fill(trkDen.getPhi());
+            m1OverPtPhysPrimDen[i]->Fill(trkDen.getSign() * trkDen.getPtInv());
+          }
+          mEtaPhysPrimNum[i]->Fill(trkDen.getEta());
+          // we fill also the denominator
+          mEtaPhysPrimDen[i]->Fill(trkDen.getEta());
+        }
+        ++mNITSTPCSelectedTracks[i];
       }
-      ++mNITSTPCSelectedTracks;
     }
   }
-
+  int iITSTPC = 0;
   for (auto const& trk : mITSTPCTracks) {
     if (trk.getRefTPC().getIndex() >= mTPCTracks.size()) {
-      LOG(fatal) << "******************** ATTENTION! idx = " << trk.getRefTPC().getIndex() << ", size of container = " << mTPCTracks.size() << " in TF " << evCount;
-      continue;
+      LOG(fatal) << "******************** ATTENTION! for TPC track associated to matched track: idx = " << trk.getRefTPC().getIndex() << ", size of container = " << mTPCTracks.size() << " in TF " << evCount;
     }
-    auto const& trkTpc = mTPCTracks[trk.getRefTPC()];
-    auto idxTrkTpc = trk.getRefTPC().getIndex();
-    if (isTPCTrackSelectedEntry[idxTrkTpc] == true) {
-      if (!mUseMC) {
-        mPt->Fill(trkTpc.getPt());
-        mPhi->Fill(trkTpc.getPhi());
-        mPhiVsPt->Fill(trkTpc.getPt(), trkTpc.getPhi());
-        mEta->Fill(trkTpc.getEta());
-        mEtaVsPt->Fill(trkTpc.getPt(), trkTpc.getEta());
+    if (trk.getRefITS().getIndex() >= mITSTracks.size()) {
+      LOG(fatal) << "******************** ATTENTION! for ITS track associated to matched track: idx = " << trk.getRefITS().getIndex() << ", size of container = " << mITSTracks.size() << " in TF " << evCount;
+    }
+    std::array<std::string, 2> title{"TPC", "ITS"};
+    for (int i = 0; i < matchType::SIZE; ++i) {
+      o2::track::TrackParCov trkRef;
+      int idxTrkRef;
+      bool fillHisto = false;
+      bool isEtaITSOk = true;
+      if (i == matchType::TPC) {
+        trkRef = mTPCTracks[trk.getRefTPC()];
+        idxTrkRef = trk.getRefTPC().getIndex();
+        if (isTPCTrackSelectedEntry[idxTrkRef] == true) {
+          fillHisto = true;
+          ++mNITSTPCSelectedTracks[i];
+        }
+      } else {
+        trkRef = mITSTracks[trk.getRefITS()];
+        idxTrkRef = trk.getRefITS().getIndex();
+        LOG(debug) << "Checking track (ITS) with id " << idxTrkRef << " for ITSTPC track " << iITSTPC << " and pt = " << trkRef.getPt();
+        if (trk.getRefITS().getSource() == GID::ITSAB) {
+          // do not use afterburner tracks
+          LOG(debug) << "Track (ITS) with id " << idxTrkRef << " for ITSTPC track " << iITSTPC << " is from afterburner";
+          continue;
+        }
+        if (isITSTrackSelectedEntry[idxTrkRef] == true) {
+          LOG(debug) << "Track was selected (ITS), with id " << idxTrkRef << " for ITSTPC track " << iITSTPC << " , we keep it in the numerator, pt = " << trkRef.getPt();
+          fillHisto = true;
+          ++mNITSTPCSelectedTracks[i];
+        } else {
+          LOG(debug) << "Track was not selected (ITS), with id " << idxTrkRef << " for ITSTPC track " << iITSTPC << " , we don't keep it in the numerator, pt = " << trkRef.getPt();
+        }
+        if (std::abs(trkRef.getEta()) > 0.9) {
+          // ITS track outside |eta | < 0.9, we don't fill pt, nor phi , nor phi vs pt histos
+          isEtaITSOk = false;
+          LOG(debug) << "Track (ITS), with id " << idxTrkRef << " for ITSTPC track " << iITSTPC << " will be discarded when filling pt of phi related histograms, since eta = " << trkRef.getEta() << " , we don't keep it in the numerator, pt = " << trkRef.getPt();
+        }
       }
-      mResidualPt->Fill(trk.getPt(), trk.getPt() - trkTpc.getPt());
-      mResidualPhi->Fill(trk.getPhi(), trk.getPhi() - trkTpc.getPhi());
-      mResidualEta->Fill(trk.getEta(), trk.getEta() - trkTpc.getEta());
-      mChi2Matching->Fill(trk.getChi2Match());
-      mChi2Refit->Fill(trk.getChi2Refit());
-      mTimeResVsPt->Fill(trkTpc.getPt(), trk.getTimeMUS().getTimeStampError());
-      LOG(debug) << "*** chi2Matching = " << trk.getChi2Match() << ", chi2refit = " << trk.getChi2Refit() << ", timeResolution = " << trk.getTimeMUS().getTimeStampError();
-      ++mNITSTPCSelectedTracks;
+      if (fillHisto == true) {
+        if (!mUseMC) {
+          LOG(debug) << "Filling num (" << title[i] << ") with track with id " << idxTrkRef << " for ITSTPC track " << iITSTPC << " with pt = " << trkRef.getPt();
+          if (isEtaITSOk) {
+            mPtNum[i]->Fill(trkRef.getPt());
+            if (std::abs(trkRef.getEta()) > 0.05) {
+              mPtNum_noEta0[i]->Fill(trkRef.getPt());
+            }
+            mPhiNum[i]->Fill(trkRef.getPhi());
+            mPhiVsPtNum[i]->Fill(trkRef.getPt(), trkRef.getPhi());
+            m1OverPtNum[i]->Fill(trkRef.getSign() * trkRef.getPtInv());
+          }
+          mEtaNum[i]->Fill(trkRef.getEta());
+          mEtaVsPtNum[i]->Fill(trkRef.getPt(), trkRef.getEta());
+        }
+        if (i == matchType::TPC) {
+          mResidualPt->Fill(trk.getPt(), trk.getPt() - trkRef.getPt());
+          mResidualPhi->Fill(trk.getPhi(), trk.getPhi() - trkRef.getPhi());
+          mResidualEta->Fill(trk.getEta(), trk.getEta() - trkRef.getEta());
+          mChi2Matching->Fill(trk.getChi2Match());
+          mChi2Refit->Fill(trk.getChi2Refit());
+          mTimeResVsPt->Fill(trkRef.getPt(), trk.getTimeMUS().getTimeStampError());
+          math_utils::Point3D<float> v{};
+          std::array<float, 2> dca;
+          if (trkRef.propagateParamToDCA(v, mBz, &dca)) {
+            mDCAr->Fill(dca[0]);
+          }
+          LOG(debug) << "*** chi2Matching = " << trk.getChi2Match() << ", chi2refit = " << trk.getChi2Refit() << ", timeResolution = " << trk.getTimeMUS().getTimeStampError();
+        }
+      } else {
+        LOG(debug) << "Not filling num (" << title[i] << ") for ITSTPC track " << iITSTPC << " for track with pt " << trkRef.getPt();
+      }
     }
+    ++iITSTPC;
   }
 
   // now filling the denominator for the efficiency calculation
   if (mUseMC) {
-    mMapTPCLabels.clear();
+    for (int i = 0; i < matchType::SIZE; ++i) {
+      mMapRefLabels[i].clear();
+    }
     // filling the map where we store for each MC label, the track id of the reconstructed
     // track with the highest number of TPC clusters
     for (int itrk = 0; itrk < static_cast<int>(mTPCTracks.size()); ++itrk) {
       auto const& trk = mTPCTracks[itrk];
       if (isTPCTrackSelectedEntry[itrk] == true) {
         auto lbl = mRecoCont.getTrackMCLabel({(unsigned int)(itrk), GID::Source::TPC});
-        if (mMapLabels.find(lbl) != mMapLabels.end()) {
+        if (mMapLabels[matchType::TPC].find(lbl) != mMapLabels[matchType::TPC].end()) {
           // the track was already added to the denominator
           continue;
         }
-        if (mMapTPCLabels.find(lbl) == mMapTPCLabels.end()) {
+        if (mMapRefLabels[matchType::TPC].find(lbl) == mMapRefLabels[matchType::TPC].end()) {
           int source = lbl.getSourceID();
           int event = lbl.getEventID();
           const std::vector<o2::MCTrack>& pcontainer = mcReader.getTracks(source, event);
           const o2::MCTrack& p = pcontainer[lbl.getTrackID()];
           if (MCTrackNavigator::isPhysicalPrimary(p, pcontainer)) {
-            mMapTPCLabels.insert({lbl, {itrk, true}});
+            mMapRefLabels[matchType::TPC].insert({lbl, {itrk, true}});
           } else {
-            mMapTPCLabels.insert({lbl, {itrk, false}});
+            mMapRefLabels[matchType::TPC].insert({lbl, {itrk, false}});
           }
         } else {
           // winner (if more tracks have the same label) has the highest number of TPC clusters
-          if (mTPCTracks[mMapTPCLabels.at(lbl).mIdx].getNClusters() < trk.getNClusters()) {
-            mMapTPCLabels.at(lbl).mIdx = itrk;
+          if (mTPCTracks[mMapRefLabels[matchType::TPC].at(lbl).mIdx].getNClusters() < trk.getNClusters()) {
+            mMapRefLabels[matchType::TPC].at(lbl).mIdx = itrk;
           }
         }
       }
     }
-    LOG(info) << "number of entries in map for denominator (without duplicates) = " << mMapTPCLabels.size() + mMapLabels.size();
+    // same for ITS
+    // filling the map where we store for each MC label, the track id of the reconstructed
+    // track with the highest number of ITS clusters
+    for (int itrk = 0; itrk < static_cast<int>(mITSTracks.size()); ++itrk) {
+      auto const& trk = mITSTracks[itrk];
+      if (isITSTrackSelectedEntry[itrk] == true) {
+        auto lbl = mRecoCont.getTrackMCLabel({(unsigned int)(itrk), GID::Source::ITS});
+        if (mMapLabels[matchType::ITS].find(lbl) != mMapLabels[matchType::ITS].end()) {
+          // the track was already added to the denominator
+          continue;
+        }
+        if (mMapRefLabels[matchType::ITS].find(lbl) == mMapRefLabels[matchType::ITS].end()) {
+          int source = lbl.getSourceID();
+          int event = lbl.getEventID();
+          const std::vector<o2::MCTrack>& pcontainer = mcReader.getTracks(source, event);
+          const o2::MCTrack& p = pcontainer[lbl.getTrackID()];
+          if (MCTrackNavigator::isPhysicalPrimary(p, pcontainer)) {
+            mMapRefLabels[matchType::ITS].insert({lbl, {itrk, true}});
+          } else {
+            mMapRefLabels[matchType::ITS].insert({lbl, {itrk, false}});
+          }
+        } else {
+          // winner (if more tracks have the same label) has the highest number of ITS clusters
+          if (mITSTracks[mMapRefLabels[matchType::ITS].at(lbl).mIdx].getNClusters() < trk.getNClusters()) {
+            mMapRefLabels[matchType::ITS].at(lbl).mIdx = itrk;
+          }
+        }
+      }
+    }
+    LOG(info) << "number of entries in map for denominator of TPC tracks (without duplicates) = " << mMapRefLabels[matchType::TPC].size() + mMapLabels[matchType::TPC].size();
+    LOG(info) << "number of entries in map for denominator of ITS tracks (without duplicates) = " << mMapRefLabels[matchType::ITS].size() + mMapLabels[matchType::ITS].size();
     // now we use only the tracks in the map to fill the histograms (--> tracks have passed the
     // track selection and there are no duplicated tracks wrt the same MC label)
-    for (auto const& el : mMapTPCLabels) {
+    for (auto const& el : mMapRefLabels[matchType::TPC]) {
       auto const& trk = mTPCTracks[el.second.mIdx];
-      mPtTPC->Fill(trk.getPt());
-      mPhiTPC->Fill(trk.getPhi());
-      mPhiVsPtTPC->Fill(trk.getPt(), trk.getPhi());
-      mEtaTPC->Fill(trk.getEta());
-      mEtaVsPtTPC->Fill(trk.getPt(), trk.getEta());
+      mPtDen[matchType::TPC]->Fill(trk.getPt());
+      if (std::abs(trk.getEta()) > 0.05) {
+        mPtDen_noEta0[matchType::TPC]->Fill(trk.getPt());
+      }
+      mPhiDen[matchType::TPC]->Fill(trk.getPhi());
+      mPhiVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getPhi());
+      mEtaDen[matchType::TPC]->Fill(trk.getEta());
+      mEtaVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getEta());
+      m1OverPtDen[matchType::TPC]->Fill(trk.getSign() * trk.getPtInv());
       if (el.second.mIsPhysicalPrimary) {
-        mPtTPCPhysPrim->Fill(trk.getPt());
-        mPhiTPCPhysPrim->Fill(trk.getPhi());
-        mEtaTPCPhysPrim->Fill(trk.getEta());
+        mPtPhysPrimDen[matchType::TPC]->Fill(trk.getPt());
+        mPhiPhysPrimDen[matchType::TPC]->Fill(trk.getPhi());
+        mEtaPhysPrimDen[matchType::TPC]->Fill(trk.getEta());
+        m1OverPtPhysPrimDen[matchType::TPC]->Fill(trk.getSign() * trk.getPtInv());
       }
       ++mNTPCSelectedTracks;
+    }
+    for (auto const& el : mMapRefLabels[matchType::ITS]) {
+      auto const& trk = mITSTracks[el.second.mIdx];
+      if (std::abs(trk.getEta()) < 0.9) {
+        mPtDen[matchType::ITS]->Fill(trk.getPt());
+        if (std::abs(trk.getEta()) > 0.05) {
+          mPtDen_noEta0[matchType::ITS]->Fill(trk.getPt());
+        }
+        mPhiDen[matchType::ITS]->Fill(trk.getPhi());
+        mPhiVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getPhi());
+        m1OverPtDen[matchType::ITS]->Fill(trk.getSign() * trk.getPtInv());
+      }
+      mEtaDen[matchType::ITS]->Fill(trk.getEta());
+      mEtaVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getEta());
+      if (el.second.mIsPhysicalPrimary) {
+        if (std::abs(trk.getEta()) < 0.9) {
+          mPtPhysPrimDen[matchType::ITS]->Fill(trk.getPt());
+          mPhiPhysPrimDen[matchType::ITS]->Fill(trk.getPhi());
+          m1OverPtPhysPrimDen[matchType::ITS]->Fill(trk.getSign() * trk.getPtInv());
+        }
+        mEtaPhysPrimDen[matchType::ITS]->Fill(trk.getEta());
+      }
+      ++mNITSSelectedTracks;
     }
   } else {
     // if we are in data, we loop over all tracks (no check on the label)
     for (size_t itrk = 0; itrk < mTPCTracks.size(); ++itrk) {
       auto const& trk = mTPCTracks[itrk];
       if (isTPCTrackSelectedEntry[itrk] == true) {
-        mPtTPC->Fill(trk.getPt());
-        mPhiTPC->Fill(trk.getPhi());
-        mPhiVsPtTPC->Fill(trk.getPt(), trk.getPhi());
-        mEtaTPC->Fill(trk.getEta());
-        mEtaVsPtTPC->Fill(trk.getPt(), trk.getEta());
+        LOG(debug) << "Filling den (TPC) with track with pt = " << trk.getPt();
+        mPtDen[matchType::TPC]->Fill(trk.getPt());
+        if (std::abs(trk.getEta()) > 0.05) {
+          mPtDen_noEta0[matchType::TPC]->Fill(trk.getPt());
+        } else {
+          LOG(debug) << "Track (ITS) " << itrk << " with pt = " << trk.getPt() << " and eta = " << trk.getEta() << " not used for den pt, phi, phi vs pt, 1.pt histos";
+        }
+        mPhiDen[matchType::TPC]->Fill(trk.getPhi());
+        mPhiVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getPhi());
+        mEtaDen[matchType::TPC]->Fill(trk.getEta());
+        mEtaVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getEta());
+        m1OverPtDen[matchType::TPC]->Fill(trk.getSign() * trk.getPtInv());
         ++mNTPCSelectedTracks;
+      }
+    }
+    for (size_t itrk = 0; itrk < mITSTracks.size(); ++itrk) {
+      auto const& trk = mITSTracks[itrk];
+      LOG(debug) << "Checking den for track (ITS) " << itrk << " with pt " << trk.getPt() << " and eta = " << trk.getEta();
+      if (isITSTrackSelectedEntry[itrk] == true) {
+        if (std::abs(trk.getEta()) < 0.9) {
+          LOG(debug) << "Filling den for track (ITS) " << itrk << " with pt = " << trk.getPt() << " and eta = " << trk.getEta();
+          mPtDen[matchType::ITS]->Fill(trk.getPt());
+          if (std::abs(trk.getEta()) > 0.05) {
+            mPtDen_noEta0[matchType::ITS]->Fill(trk.getPt());
+          }
+          mPhiDen[matchType::ITS]->Fill(trk.getPhi());
+          mPhiVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getPhi());
+          m1OverPtDen[matchType::ITS]->Fill(trk.getSign() * trk.getPtInv());
+        } else {
+          LOG(debug) << "Track (ITS) " << itrk << " with pt = " << trk.getPt() << " and eta = " << trk.getEta() << " not used for num pt, phi, phi vs pt, 1.pt histos";
+        }
+        mEtaDen[matchType::ITS]->Fill(trk.getEta());
+        mEtaVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getEta());
+        ++mNITSSelectedTracks;
+      } else {
+        LOG(debug) << "Not filling for this track (ITS) " << itrk << " with pt = " << trk.getPt();
       }
     }
   }
@@ -420,36 +681,48 @@ bool MatchITSTPCQC::selectTrack(o2::tpc::TrackTPC const& track)
 void MatchITSTPCQC::finalize()
 {
 
+  std::array<std::string, 2> title{"TPC", "ITS"};
+
   // first we use denominators and nominators to set the TEfficiency; later they are scaled
 
-  for (int i = 0; i < mPtTPC->GetNbinsX(); ++i) {
-    if (mPtTPC->GetBinContent(i + 1) < mPt->GetBinContent(i + 1)) {
-      LOG(error) << "bin " << i + 1 << ": mPtTPC[i] = " << mPtTPC->GetBinContent(i + 1) << ", mPt[i] = " << mPt->GetBinContent(i + 1);
+  // some checks
+  for (int i = 0; i < matchType::SIZE; ++i) {
+    for (int i = 0; i < mPtDen[i]->GetNbinsX(); ++i) {
+      if (mPtDen[i]->GetBinContent(i + 1) < mPtNum[i]->GetBinContent(i + 1)) {
+        LOG(error) << title[i] << ": bin " << i + 1 << " in [" << mPtNum[i]->GetBinLowEdge(i + 1) << " , " << mPtNum[i]->GetBinLowEdge(i + 1) + mPtNum[i]->GetBinWidth(i + 1) << "]: mPtDen[i] = " << mPtDen[i]->GetBinContent(i + 1) << ", mPtNum[i] = " << mPtNum[i]->GetBinContent(i + 1);
+      }
     }
-  }
-  for (int i = 0; i < mPhiTPC->GetNbinsX(); ++i) {
-    if (mPhiTPC->GetBinContent(i + 1) < mPhi->GetBinContent(i + 1)) {
-      LOG(error) << "bin " << i + 1 << ": mPhiTPC[i] = " << mPhiTPC->GetBinContent(i + 1) << ", mPhi[i] = " << mPhi->GetBinContent(i + 1);
+    for (int i = 0; i < mPtDen_noEta0[i]->GetNbinsX(); ++i) {
+      if (mPtDen_noEta0[i]->GetBinContent(i + 1) < mPtNum_noEta0[i]->GetBinContent(i + 1)) {
+        LOG(error) << title[i] << ": bin " << i + 1 << " in [" << mPtNum_noEta0[i]->GetBinLowEdge(i + 1) << " , " << mPtNum_noEta0[i]->GetBinLowEdge(i + 1) + mPtNum_noEta0[i]->GetBinWidth(i + 1) << "]: mPtDen_noEta0[i] = " << mPtDen_noEta0[i]->GetBinContent(i + 1) << ", mPtNum_noEta0[i] = " << mPtNum_noEta0[i]->GetBinContent(i + 1);
+      }
     }
-  }
-  for (int i = 0; i < mEtaTPC->GetNbinsX(); ++i) {
-    if (mEtaTPC->GetBinContent(i + 1) < mEta->GetBinContent(i + 1)) {
-      LOG(error) << "bin " << i + 1 << ": mEtaTPC[i] = " << mEtaTPC->GetBinContent(i + 1) << ", mEta[i] = " << mEta->GetBinContent(i + 1);
+    for (int i = 0; i < mPhiDen[i]->GetNbinsX(); ++i) {
+      if (mPhiDen[i]->GetBinContent(i + 1) < mPhiNum[i]->GetBinContent(i + 1)) {
+        LOG(error) << title[i] << ": bin " << i + 1 << " in [" << mPhiNum[i]->GetBinLowEdge(i + 1) << " , " << mPhiNum[i]->GetBinLowEdge(i + 1) + mPhiNum[i]->GetBinWidth(i + 1) << "]: mPhiDen[i] = " << mPhiDen[i]->GetBinContent(i + 1) << ", mPhiNum[i] = " << mPhiNum[i]->GetBinContent(i + 1);
+      }
     }
-  }
+    for (int i = 0; i < mEtaDen[i]->GetNbinsX(); ++i) {
+      if (mEtaDen[i]->GetBinContent(i + 1) < mEtaNum[i]->GetBinContent(i + 1)) {
+        LOG(error) << title[i] << ": bin " << i + 1 << " in [" << mEtaNum[i]->GetBinLowEdge(i + 1) << " , " << mEtaNum[i]->GetBinLowEdge(i + 1) + mEtaNum[i]->GetBinWidth(i + 1) << "]: mEtaDen[i] = " << mEtaDen[i]->GetBinContent(i + 1) << ", mEtaNum[i] = " << mEtaNum[i]->GetBinContent(i + 1);
+      }
+    }
 
-  // we need to force to replace the total histogram, otherwise it will compare it to the previous passed one, and it might get an error of inconsistency in the bin contents
-  setEfficiency(mFractionITSTPCmatch, mPt, mPtTPC);
-  setEfficiency(mFractionITSTPCmatchPhi, mPhi, mPhiTPC);
-  setEfficiency(mFractionITSTPCmatchEta, mEta, mEtaTPC);
-  setEfficiency(mFractionITSTPCmatchPhiVsPt, mPhiVsPt, mPhiVsPtTPC, true);
-  setEfficiency(mFractionITSTPCmatchEtaVsPt, mEtaVsPt, mEtaVsPtTPC, true);
-  if (mUseMC) {
-    setEfficiency(mFractionITSTPCmatchPhysPrim, mPtPhysPrim, mPtTPCPhysPrim);
-    setEfficiency(mFractionITSTPCmatchPhiPhysPrim, mPhiPhysPrim, mPhiTPCPhysPrim);
-    setEfficiency(mFractionITSTPCmatchEtaPhysPrim, mEtaPhysPrim, mEtaTPCPhysPrim);
+    // filling the efficiency
+    setEfficiency(mFractionITSTPCmatch[i], mPtNum[i], mPtDen[i]);
+    setEfficiency(mFractionITSTPCmatch_noEta0[i], mPtNum_noEta0[i], mPtDen_noEta0[i]);
+    setEfficiency(mFractionITSTPCmatchPhi[i], mPhiNum[i], mPhiDen[i]);
+    setEfficiency(mFractionITSTPCmatchEta[i], mEtaNum[i], mEtaDen[i]);
+    setEfficiency(mFractionITSTPCmatchPhiVsPt[i], mPhiVsPtNum[i], mPhiVsPtDen[i], true);
+    setEfficiency(mFractionITSTPCmatchEtaVsPt[i], mEtaVsPtNum[i], mEtaVsPtDen[i], true);
+    setEfficiency(mFractionITSTPCmatch1OverPt[i], m1OverPtNum[i], m1OverPtDen[i]);
+    if (mUseMC) {
+      setEfficiency(mFractionITSTPCmatchPhysPrim[i], mPtPhysPrimNum[i], mPtPhysPrimDen[i]);
+      setEfficiency(mFractionITSTPCmatchPhiPhysPrim[i], mPhiPhysPrimNum[i], mPhiPhysPrimDen[i]);
+      setEfficiency(mFractionITSTPCmatchEtaPhysPrim[i], mEtaPhysPrimNum[i], mEtaPhysPrimDen[i]);
+      setEfficiency(mFractionITSTPCmatchPhysPrim1OverPt[i], m1OverPtPhysPrimNum[i], m1OverPtPhysPrimDen[i]);
+    }
   }
-
   /*
   mPtTPC->Scale(scaleFactTPC);
   mPt->Scale(scaleFactITSTPC);
@@ -493,6 +766,7 @@ void MatchITSTPCQC::setEfficiency(TEfficiency* eff, TH1* hnum, TH1* hden, bool i
       }
     }
   }
+  // we need to force to replace the total histogram, otherwise it will compare it to the previous passed one, and it might get an error of inconsistency in the bin contents
   if (!eff->SetTotalHistogram(*hden, "f")) {
     LOG(fatal) << "Something went wrong when defining the efficiency denominator " << eff->GetName() << " from " << hnum->GetName();
   }
@@ -511,30 +785,56 @@ void MatchITSTPCQC::setEfficiency(TEfficiency* eff, TH1* hnum, TH1* hden, bool i
 void MatchITSTPCQC::getHistos(TObjArray& objar)
 {
 
-  objar.Add(mPtTPC);
-  objar.Add(mFractionITSTPCmatch);
-  objar.Add(mPt);
-  objar.Add(mPhiTPC);
-  objar.Add(mPhiVsPtTPC);
-  objar.Add(mFractionITSTPCmatchPhi);
-  objar.Add(mPhi);
-  objar.Add(mPhiVsPt);
-  objar.Add(mPtTPCPhysPrim);
-  objar.Add(mFractionITSTPCmatchPhysPrim);
-  objar.Add(mPtPhysPrim);
-  objar.Add(mPhiTPCPhysPrim);
-  objar.Add(mFractionITSTPCmatchPhiPhysPrim);
-  objar.Add(mPhiPhysPrim);
-  objar.Add(mEta);
-  objar.Add(mEtaVsPt);
+  for (int i = 0; i < matchType::SIZE; ++i) {
+    objar.Add(mPtNum[i]);
+    objar.Add(mPtDen[i]);
+    objar.Add(mFractionITSTPCmatch[i]);
+
+    objar.Add(mPtNum_noEta0[i]);
+    objar.Add(mPtDen_noEta0[i]);
+    objar.Add(mFractionITSTPCmatch_noEta0[i]);
+
+    objar.Add(mPtPhysPrimNum[i]);
+    objar.Add(mPtPhysPrimDen[i]);
+    objar.Add(mFractionITSTPCmatchPhysPrim[i]);
+
+    objar.Add(mPhiNum[i]);
+    objar.Add(mPhiDen[i]);
+    objar.Add(mFractionITSTPCmatchPhi[i]);
+
+    objar.Add(mPhiPhysPrimNum[i]);
+    objar.Add(mPhiPhysPrimDen[i]);
+    objar.Add(mFractionITSTPCmatchPhiPhysPrim[i]);
+
+    objar.Add(mPhiVsPtNum[i]);
+    objar.Add(mPhiVsPtDen[i]);
+    objar.Add(mFractionITSTPCmatchPhiVsPt[i]);
+
+    objar.Add(mEtaNum[i]);
+    objar.Add(mEtaDen[i]);
+    objar.Add(mFractionITSTPCmatchEta[i]);
+
+    objar.Add(mEtaPhysPrimNum[i]);
+    objar.Add(mEtaPhysPrimDen[i]);
+    objar.Add(mFractionITSTPCmatchEtaPhysPrim[i]);
+
+    objar.Add(mEtaVsPtNum[i]);
+    objar.Add(mEtaVsPtDen[i]);
+    objar.Add(mFractionITSTPCmatchEtaVsPt[i]);
+
+    objar.Add(m1OverPtNum[i]);
+    objar.Add(m1OverPtDen[i]);
+    objar.Add(mFractionITSTPCmatch1OverPt[i]);
+
+    objar.Add(m1OverPtPhysPrimNum[i]);
+    objar.Add(m1OverPtPhysPrimDen[i]);
+    objar.Add(mFractionITSTPCmatchPhysPrim1OverPt[i]);
+  }
   objar.Add(mChi2Matching);
   objar.Add(mChi2Refit);
   objar.Add(mTimeResVsPt);
-  objar.Add(mEtaPhysPrim);
-  objar.Add(mEtaTPC);
-  objar.Add(mEtaVsPtTPC);
-  objar.Add(mEtaTPCPhysPrim);
   objar.Add(mResidualPt);
   objar.Add(mResidualPhi);
   objar.Add(mResidualEta);
+  objar.Add(mDCAr);
 }


### PR DESCRIPTION
Added: 
- matching with ITS, 
- mathcing vs 1./pt, 
- TPC tracks DCA, 
- matching vs pt removing eta ~0.

@noferini 

To test:

o2-global-track-cluster-reader --tpc-track-reader "tpctracks.root --reader-delay 10" --shm-segment-size 64000000000 --disable-mc --hbfutils-config o2_tfidinfo.root --track-types "ITS,TPC,ITS-TPC" --cluster-types "TPC,ITS" | o2-qc --config json:///home/zampolli/work/O2/RelVal/CPU_6/QC_GLO.json -b

Update of O2DPG json to be done.

Corresponding changes in QC: https://github.com/AliceO2Group/QualityControl/pull/2001

Comparison of matching vs pt with previous version:

![Screenshot from 2023-09-27 18-12-51](https://github.com/AliceO2Group/AliceO2/assets/18655040/e5ff5bf1-29bb-4a31-bdb2-9e7e3d71a15c)
![Screenshot from 2023-09-27 18-12-45](https://github.com/AliceO2Group/AliceO2/assets/18655040/56b0797d-948d-4e45-876e-9ac22e86a11a)
![Screenshot from 2023-09-27 18-12-38](https://github.com/AliceO2Group/AliceO2/assets/18655040/c1007b97-9672-4686-8bfc-ce9b7ea93d43)

