### PR TITLE
[EMCAL-918, EMCAL-1045] Treatment of page corruptions

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -103,6 +103,11 @@ constexpr int MAX_RANGE_ADC = 0x3FF;           ///< Dynamic range of the ADCs (1
 constexpr double EMCAL_TRU_ADCENERGY = 0.0786; ///< resolution of the TRU digitizer, @TODO check exact value
 } // namespace constants
 
+namespace triggerbits
+{
+constexpr uint32_t Inc = 0x1 << 20; ///< trigger bit marking incomplete event
+}
+
 enum FitAlgorithm {
   Standard = 0,  ///< Standard raw fitter
   Gamma2 = 1,    ///< Gamma2 raw fitter

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
@@ -61,8 +61,9 @@ class TriggerRecord
   /// \enum TriggerBitsCoded_t
   /// \brief Position of trigger classes in compressed format
   enum TriggerBitsCoded_t {
-    PHYSTRIGGER, ///< Physics trigger
-    CALIBTRIGGER ///< Calib trigger
+    PHYSTRIGGER,     ///< Physics trigger
+    CALIBTRIGGER,    ///< Calib trigger
+    REJECTINCOMPLETE ///< Rejected as incomplete
   };
   BCData mBCData;            /// Bunch crossing data of the trigger
   DataRange mDataRange;      /// Index of the triggering event (event index and first entry in the container)

--- a/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
@@ -13,6 +13,7 @@
 #include <iostream>
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "CommonConstants/Triggers.h"
+#include "DataFormatsEMCAL/Constants.h"
 
 namespace o2
 {
@@ -29,6 +30,9 @@ uint16_t TriggerRecord::getTriggerBitsCompressed() const
   if (mTriggerBits & o2::trigger::Cal) {
     result |= 1 << TriggerBitsCoded_t::CALIBTRIGGER;
   }
+  if (mTriggerBits & o2::emcal::triggerbits::Inc) {
+    result |= 1 << TriggerBitsCoded_t::REJECTINCOMPLETE;
+  }
   return result;
 }
 
@@ -40,6 +44,9 @@ void TriggerRecord::setTriggerBitsCompressed(uint16_t triggerbits)
   }
   if (triggerbits & (1 << TriggerBitsCoded_t::CALIBTRIGGER)) {
     mTriggerBits |= o2::trigger::Cal;
+  }
+  if (triggerbits & (1 << TriggerBitsCoded_t::REJECTINCOMPLETE)) {
+    mTriggerBits |= o2::emcal::triggerbits::Inc;
   }
 }
 

--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -153,6 +153,10 @@ class RCUTrailer
   /// \return Size of the payload as number of 32 bit workds
   uint32_t getPayloadSize() const { return mPayloadSize; }
 
+  /// \brief Get number of corrupted trailer words (undefined trailer word code)
+  /// \return Number of trailer word corruptions
+  uint32_t getTrailerWordCorruptions() const { return mWordCorruptions; }
+
   /// \brief Get the firmware version
   /// \return Firmware version
   uint8_t getFirmwareVersion() const { return mFirmwareVersion; }
@@ -438,6 +442,7 @@ class RCUTrailer
   uint8_t mFirmwareVersion = 0;         ///< RCU firmware version
   uint32_t mTrailerSize = 0;            ///< Size of the trailer (in number of 32 bit words)
   uint32_t mPayloadSize = 0;            ///< Size of the payload (in nunber of 32 bit words)
+  uint32_t mWordCorruptions = 0;        ///< Number of trailer word corruptions (decoding only)
   uint32_t mFECERRA = 0;                ///< contains errors related to ALTROBUS transactions
   uint32_t mFECERRB = 0;                ///< contains errors related to ALTROBUS transactions
   ErrorCounters mErrorCounter = {0, 0}; ///< Error counter registers

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -14,6 +14,7 @@
 #include <fmt/format.h>
 #include "CommonConstants/LHCConstants.h"
 #include "EMCALBase/RCUTrailer.h"
+#include <fairlogger/Logger.h>
 
 using namespace o2::emcal;
 
@@ -94,7 +95,8 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
         mAltroConfig.mWord2 = parData & 0x1FFFFFF;
         break;
       default:
-        std::cerr << "Undefined parameter code " << parCode << ", ignore it !\n";
+        LOG(warning) << "RCU trailer: Undefined parameter code " << parCode << " in word " << index << " (0x" << std::hex << word << std::dec << "), ignoring word";
+        mWordCorruptions++;
         break;
     }
   }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
@@ -44,7 +44,8 @@ class RawDecodingError : public std::exception
     HEADER_INVALID,     ///< Header in memory not belonging to requested superpage
     PAGE_START_INVALID, ///< Page position starting outside payload size
     PAYLOAD_INVALID,    ///< Payload in memory not belonging to requested superpage
-    TRAILER_DECODING    ///< Inconsistent trailer in memory (several trailer words missing the trailer marker)
+    TRAILER_DECODING,   ///< Inconsistent trailer in memory (several trailer words missing the trailer marker)
+    TRAILER_INCOMPLETE  ///< Incomplete trailer words (i.e. registers)
   };
 
   /// \brief Constructor
@@ -93,6 +94,8 @@ class RawDecodingError : public std::exception
         return 5;
       case ErrorType_t::TRAILER_DECODING:
         return 6;
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return 7;
     };
     // can never reach this, due to enum class
     // just to make Werror happy
@@ -101,7 +104,7 @@ class RawDecodingError : public std::exception
 
   /// \brief Get the number of error codes
   /// \return Number of error codes
-  static constexpr int getNumberOfErrorTypes() { return 7; }
+  static constexpr int getNumberOfErrorTypes() { return 8; }
 
   static ErrorType_t intToErrorType(unsigned int errortype)
   {
@@ -109,7 +112,7 @@ class RawDecodingError : public std::exception
     static constexpr std::array<ErrorType_t, getNumberOfErrorTypes()> errortypes = {{ErrorType_t::PAGE_NOTFOUND, ErrorType_t::HEADER_DECODING,
                                                                                      ErrorType_t::PAYLOAD_DECODING, ErrorType_t::HEADER_INVALID,
                                                                                      ErrorType_t::PAGE_START_INVALID, ErrorType_t::PAYLOAD_INVALID,
-                                                                                     ErrorType_t::TRAILER_DECODING}};
+                                                                                     ErrorType_t::TRAILER_DECODING, ErrorType_t::TRAILER_INCOMPLETE}};
     return errortypes[errortype];
   }
 
@@ -137,6 +140,8 @@ class RawDecodingError : public std::exception
         return "PayloadCorruption";
       case ErrorType_t::TRAILER_DECODING:
         return "TrailerDecoding";
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return "TrailerIncomplete";
     };
     return "Undefined error";
   }
@@ -177,6 +182,8 @@ class RawDecodingError : public std::exception
         return "Payload corruption";
       case ErrorType_t::TRAILER_DECODING:
         return "Trailer decoding";
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return "Trailer incomplete";
     };
     return "Undefined error";
   }
@@ -217,6 +224,8 @@ class RawDecodingError : public std::exception
         return "Access to payload not belonging to requested superpage";
       case ErrorType_t::TRAILER_DECODING:
         return "Inconsistent trailer in memory";
+      case ErrorType_t::TRAILER_INCOMPLETE:
+        return "Incomplete trailer";
     };
     return "Undefined error";
   }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
@@ -11,11 +11,13 @@
 #ifndef ALICEO2_EMCAL_RAWREADERMEMORY_H
 #define ALICEO2_EMCAL_RAWREADERMEMORY_H
 
+#include <vector>
 #include <gsl/span>
 #include <Rtypes.h>
 
 #include "EMCALBase/RCUTrailer.h"
 #include "EMCALReconstruction/RawBuffer.h"
+#include "EMCALReconstruction/RawDecodingError.h"
 #include "EMCALReconstruction/RawPayload.h"
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
@@ -36,6 +38,46 @@ namespace emcal
 class RawReaderMemory
 {
  public:
+  /// \class MinorError
+  /// \brief Minor (non-crashing) raw decoding errors
+  ///
+  /// Minor errors share the same codes as major raw decoding errors,
+  /// however are not crashing.
+  class MinorError
+  {
+   public:
+    /// \brief Dummy constructor
+    MinorError() = default;
+
+    /// \brief Main constructor
+    /// \param errortype Type of the error
+    /// \param feeID ID of the FEE equipment
+    MinorError(RawDecodingError::ErrorType_t errortype, int feeID) : mErrorType(errortype), mFEEID(feeID) {}
+
+    /// \brief Destructor
+    ~MinorError() = default;
+
+    /// \brief Set the type of the error
+    /// \param errortype Type of the error
+    void setErrorType(RawDecodingError::ErrorType_t errortype) { mErrorType = errortype; }
+
+    /// \brief Set the ID of the FEE equipment
+    /// \param feeID ID of the FEE
+    void setFEEID(int feeID) { mFEEID = feeID; }
+
+    /// \brief Get type of the error
+    /// \return Type of the error
+    RawDecodingError::ErrorType_t getErrorType() const { return mErrorType; }
+
+    /// \brief Get ID of the FEE
+    /// \return ID of the FEE
+    int getFEEID() const { return mFEEID; }
+
+   private:
+    RawDecodingError::ErrorType_t mErrorType; ///< Type of the error
+    int mFEEID;                               ///< ID of the FEC responsible for the ERROR
+  };
+
   /// \brief Constructor
   RawReaderMemory(const gsl::span<const char> rawmemory);
 
@@ -58,8 +100,7 @@ class RawReaderMemory
   /// \brief Read next payload from the stream
   ///
   /// Read the next pages until the stop bit is found.
-  void
-    next();
+  void next();
 
   /// \brief Read the next page from the stream (single DMA page)
   /// \param resetPayload If true the raw payload is reset
@@ -84,6 +125,10 @@ class RawReaderMemory
   /// \brief access to the full raw payload (single or multiple DMA pages)
   /// \return Raw Payload of the data until the stop bit is received.
   const RawPayload& getPayload() const { return mRawPayload; }
+
+  /// \brief Get minor (non-crashing) raw decoding errors
+  /// \return Minor raw decoding errors
+  gsl::span<const MinorError> getMinorErrors() const { return mMinorErrors; }
 
   /// \brief Return size of the payload
   /// \return size of the payload
@@ -123,6 +168,7 @@ class RawReaderMemory
   int mCurrentFEE = -1;                   ///< Current FEE in the data stream
   bool mRawHeaderInitialized = false;     ///< RDH for current page initialized
   bool mPayloadInitialized = false;       ///< Payload for current page initialized
+  std::vector<MinorError> mMinorErrors;   ///< Minor raw decoding errors
 
   ClassDefNV(RawReaderMemory, 1);
 };

--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -42,7 +42,6 @@ void AltroDecoder::readRCUTrailer()
     gsl::span<const uint32_t> payloadwords(payloadwordsOrig.data(), payloadwordsOrig.size());
     mRCUTrailer.constructFromRawPayload(payloadwords);
   } catch (RCUTrailer::Error& e) {
-    LOG(error) << "Error while decoding RCU trailer: " << e.what();
     throw AltroDecoderError(AltroDecoderError::ErrorType_t::RCU_TRAILER_ERROR, fmt::format("{} {}", AltroDecoderError::getErrorTypeDescription(AltroDecoderError::ErrorType_t::RCU_TRAILER_ERROR), e.what()));
   }
 }

--- a/Detectors/EMCAL/reconstruction/test/testRawDecodingError.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testRawDecodingError.cxx
@@ -28,37 +28,39 @@ void testThrow(RawDecodingError::ErrorType_t errtype, unsigned int feeID)
 
 BOOST_AUTO_TEST_CASE(RawDecodingError_test)
 {
-  BOOST_CHECK_EQUAL(RawDecodingError::getNumberOfErrorTypes(), 7);
-  std::array<std::string, 7> errornames = {{"PageNotFound",
+  BOOST_CHECK_EQUAL(RawDecodingError::getNumberOfErrorTypes(), 8);
+  std::array<std::string, 8> errornames = {{"PageNotFound",
                                             "HeaderDecoding",
                                             "PayloadDecoding",
                                             "HeaderCorruption",
                                             "PageStartInvalid",
                                             "PayloadCorruption",
-                                            "TrailerDecoding"}},
+                                            "TrailerDecoding",
+                                            "TrailerIncomplete"}},
                              errortitles = {{"Page not found",
                                              "Header decoding",
                                              "Payload decoding",
                                              "Header corruption",
                                              "Page start invalid",
                                              "Payload corruption",
-                                             "Trailer decoding"}},
+                                             "Trailer decoding",
+                                             "Trailer incomplete"}},
                              errordescriptions = {{"Page with requested index not found",
                                                    "RDH of page cannot be decoded",
                                                    "Payload of page cannot be decoded",
                                                    "Access to header not belonging to requested superpage",
                                                    "Page decoding starting outside payload size",
                                                    "Access to payload not belonging to requested superpage",
-                                                   "Inconsistent trailer in memory"}};
-  std::array<RawDecodingError::ErrorType_t, 7> errortypes = {{
-    RawDecodingError::ErrorType_t::PAGE_NOTFOUND,
-    RawDecodingError::ErrorType_t::HEADER_DECODING,
-    RawDecodingError::ErrorType_t::PAYLOAD_DECODING,
-    RawDecodingError::ErrorType_t::HEADER_INVALID,
-    RawDecodingError::ErrorType_t::PAGE_START_INVALID,
-    RawDecodingError::ErrorType_t::PAYLOAD_INVALID,
-    RawDecodingError::ErrorType_t::TRAILER_DECODING,
-  }};
+                                                   "Inconsistent trailer in memory",
+                                                   "Incomplete trailer"}};
+  std::array<RawDecodingError::ErrorType_t, 8> errortypes = {{RawDecodingError::ErrorType_t::PAGE_NOTFOUND,
+                                                              RawDecodingError::ErrorType_t::HEADER_DECODING,
+                                                              RawDecodingError::ErrorType_t::PAYLOAD_DECODING,
+                                                              RawDecodingError::ErrorType_t::HEADER_INVALID,
+                                                              RawDecodingError::ErrorType_t::PAGE_START_INVALID,
+                                                              RawDecodingError::ErrorType_t::PAYLOAD_INVALID,
+                                                              RawDecodingError::ErrorType_t::TRAILER_DECODING,
+                                                              RawDecodingError::ErrorType_t::TRAILER_INCOMPLETE}};
   for (int errortype = 0; errortype < RawDecodingError::getNumberOfErrorTypes(); errortype++) {
     BOOST_CHECK_EQUAL(RawDecodingError::ErrorTypeToInt(errortypes[errortype]), errortype);
     BOOST_CHECK_EQUAL(RawDecodingError::intToErrorType(errortype), errortypes[errortype]);

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -25,6 +25,7 @@
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/Mapper.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
+#include "EMCALReconstruction/RawReaderMemory.h"
 #include "EMCALReconstruction/RecoContainer.h"
 #include "EMCALReconstruction/ReconstructionErrors.h"
 #include "EMCALWorkflow/CalibLoader.h"
@@ -235,6 +236,8 @@ class RawToCellConverterSpec : public framework::Task
   void handleGainError(const o2::emcal::reconstructionerrors::GainError_t& errortype, int ddlID, int hwaddress);
 
   void handlePageError(const RawDecodingError& e);
+
+  void handleMinorPageError(const RawReaderMemory::MinorError& e);
 
   header::DataHeader::SubSpecificationType mSubspecification = 0;    ///< Subspecification for output channels
   int mNoiseThreshold = 0;                                           ///< Noise threshold in raw fit

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -168,6 +168,10 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         // the page format does not follow the expected format
         continue;
       }
+      for (auto& e : rawreader.getMinorErrors()) {
+        handleMinorPageError(e);
+        // For minor errors we do not need to skip the page, just print and send the error to the QC
+      }
 
       auto& header = rawreader.getRawHeader();
       auto triggerBC = raw::RDHUtils::getTriggerBC(header);
@@ -682,6 +686,22 @@ void RawToCellConverterSpec::handlePageError(const RawDecodingError& e)
   }
   if (mNumErrorMessages < mMaxErrorMessages) {
     LOG(warning) << " Page decoding: " << e.what() << " in FEE ID " << e.getFECID();
+    mNumErrorMessages++;
+    if (mNumErrorMessages == mMaxErrorMessages) {
+      LOG(warning) << "Max. amount of error messages (" << mMaxErrorMessages << " reached, further messages will be suppressed";
+    }
+  } else {
+    mErrorMessagesSuppressed++;
+  }
+}
+
+void RawToCellConverterSpec::handleMinorPageError(const RawReaderMemory::MinorError& e)
+{
+  if (mCreateRawDataErrors) {
+    mOutputDecoderErrors.emplace_back(e.getFEEID(), ErrorTypeFEE::ErrorSource_t::PAGE_ERROR, RawDecodingError::ErrorTypeToInt(e.getErrorType()), -1, -1);
+  }
+  if (mNumErrorMessages < mMaxErrorMessages) {
+    LOG(warning) << " Page decoding: " << RawDecodingError::getErrorCodeDescription(e.getErrorType()) << " in FEE ID " << e.getFEEID();
     mNumErrorMessages++;
     if (mNumErrorMessages == mMaxErrorMessages) {
       LOG(warning) << "Max. amount of error messages (" << mMaxErrorMessages << " reached, further messages will be suppressed";


### PR DESCRIPTION
[EMCAL-918] Handing of corrupted trailer words
[EMCAL-1045] Handling of corrupted RDH
[EMCAL-534] Remove error message about missing trailer word
[EMCAL-834] Apply incomplete rejection per event instead of timeframe