### PR TITLE
ITS DCS parser: added configurable url to retrieve RCT headers

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -142,6 +142,9 @@ class ITSDCSParser : public Task
 
   // ITS Map
   o2::itsmft::ChipMappingITS mp;
+
+  // CCDB url for RCT headers
+  std::string mCcdbUrlRct = "http://alice-ccdb.cern.ch";
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -144,7 +144,7 @@ class ITSDCSParser : public Task
   o2::itsmft::ChipMappingITS mp;
 
   // CCDB url for RCT headers
-  std::string mCcdbUrlRct = "http://alice-ccdb.cern.ch";
+  std::string mCcdbUrlRct = "http://o2-ccdb.internal";
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -665,7 +665,7 @@ DataProcessorSpec getITSDCSParserSpec()
     Options{
       {"verbose", VariantType::Bool, false, {"Use verbose output mode"}},
       {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}},
-      {"ccdb-url-rct", VariantType::String, "", {"CCDB url from where to get RCT object for headers, default is alice-ccdb. Use http://o2-ccdb.internal at P2"}}}};
+      {"ccdb-url-rct", VariantType::String, "", {"CCDB url from where to get RCT object for headers, default is o2-ccdb.internal. Use http://alice-ccdb.cern.ch for local tests"}}}};
 }
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -36,6 +36,8 @@ void ITSDCSParser::init(InitContext& ic)
 
   this->mCcdbUrl = ic.options().get<std::string>("ccdb-url");
 
+  this->mCcdbUrlRct = ic.options().get<std::string>("ccdb-url-rct");
+
   this->mVerboseOutput = ic.options().get<bool>("verbose");
 
   return;
@@ -469,7 +471,7 @@ void ITSDCSParser::pushToCCDB(ProcessingContext& pc)
   long tstart = 0, tend = 0;
   // retireve run start/stop times from CCDB
   o2::ccdb::CcdbApi api;
-  api.init("http://alice-ccdb.cern.ch");
+  api.init(mCcdbUrlRct);
   // Initialize empty metadata object for search
   std::map<std::string, std::string> metadata;
   std::map<std::string, std::string> headers = api.retrieveHeaders(
@@ -582,7 +584,9 @@ void ITSDCSParser::appendDeadChipObj()
 
     unsigned short int globchipID = getGlobalChipID(hicPos, hS, chipInMod);
     this->mDeadMap.maskFullChip(globchipID);
-    LOG(info) << "Masking dead chip " << globchipID;
+    if (mVerboseOutput) {
+      LOG(info) << "Masking dead chip " << globchipID;
+    }
   }
 }
 
@@ -660,7 +664,8 @@ DataProcessorSpec getITSDCSParserSpec()
     AlgorithmSpec{adaptFromTask<o2::its::ITSDCSParser>()},
     Options{
       {"verbose", VariantType::Bool, false, {"Use verbose output mode"}},
-      {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}}}};
+      {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}},
+      {"ccdb-url-rct", VariantType::String, "", {"CCDB url from where to get RCT object for headers, default is alice-ccdb. Use http://o2-ccdb.internal at P2"}}}};
 }
 } // namespace its
 } // namespace o2


### PR DESCRIPTION
Default is o2.ccdb-internal. For local operations add
```
--ccdb-url-rct "http://alice-ccdb.cern.ch"
```
to the its-parser workflow. 
cc @shahor02 