### PR TITLE
Strangeness tracking: tighter cut on grid granularity

### DIFF
--- a/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/IndexTableUtils.h
+++ b/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/IndexTableUtils.h
@@ -27,7 +27,7 @@ struct IndexTableUtils {
   int getPhiBin(float phi);
   int getBinIndex(float eta, float phi);
   std::vector<int> getBinRect(float eta, float phi, float deltaEta, float deltaPhi);
-  int mEtaBins = 64, mPhiBins = 64;
+  int mEtaBins = 128, mPhiBins = 128;
   float minEta = -1.5, maxEta = 1.5;
   float minPhi = 0., maxPhi = 2 * TMath::Pi();
 };

--- a/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/StrangenessTrackingConfigParam.h
+++ b/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/StrangenessTrackingConfigParam.h
@@ -27,8 +27,8 @@ struct StrangenessTrackingParamConfig : public o2::conf::ConfigurableParamHelper
   // parameters
   float mRadiusTolIB = .3;     // Radius tolerance for matching V0s in the IB
   float mRadiusTolOB = .1;     // Radius tolerance for matching V0s in the OB
-  float mPhiBinSize = 0.02;     // Phi bin size for the matching grid
-  float mEtaBinSize = 0.01;     // Eta bin size for the matching grid
+  float mPhiBinSize = 0.02;    // Phi bin size for the matching grid
+  float mEtaBinSize = 0.01;    // Eta bin size for the matching grid
   float mMinMotherClus = 3.;   // minimum number of cluster to be attached to the mother
   float mMaxChi2 = 50;         // Maximum matching chi2
   bool mVertexMatching = true; // Flag to enable/disable vertex matching

--- a/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/StrangenessTrackingConfigParam.h
+++ b/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/StrangenessTrackingConfigParam.h
@@ -27,8 +27,8 @@ struct StrangenessTrackingParamConfig : public o2::conf::ConfigurableParamHelper
   // parameters
   float mRadiusTolIB = .3;     // Radius tolerance for matching V0s in the IB
   float mRadiusTolOB = .1;     // Radius tolerance for matching V0s in the OB
-  float mPhiBinSize = 0.1;     // Phi bin size for the matching grid
-  float mEtaBinSize = 0.1;     // Eta bin size for the matching grid
+  float mPhiBinSize = 0.02;     // Phi bin size for the matching grid
+  float mEtaBinSize = 0.01;     // Eta bin size for the matching grid
   float mMinMotherClus = 3.;   // minimum number of cluster to be attached to the mother
   float mMaxChi2 = 50;         // Maximum matching chi2
   bool mVertexMatching = true; // Flag to enable/disable vertex matching


### PR DESCRIPTION
@shahor02 , @sawenzel ,
this should remove most of the overhead due to the strangeness tracking while keeping a good efficiency of the algorithm. Tested on one ctf of LHC22s. 

**W/O strangeness tracking**
`[2369510:secondary-vertexing]: [19:39:27][INFO] Secondary vertexing total timing: Cpu: 2.141e+02 Real: 2.142e+02 s in 218 slots, nThreads = 1
`
**W/ strangeness tracking before the fix**
`[[2344557:secondary-vertexing]: [18:58:52][INFO] Secondary vertexing total timing: Cpu: 9.604e+02 Real: 9.606e+02 s in 218 slots, nThreads = 1`

**W/ strangeness tracking after the fix**
`[2404743:secondary-vertexing]: [20:20:53][INFO] Secondary vertexing total timing: Cpu: 2.570e+02 Real: 2.571e+02 s in 218 slots, nThreads = 1`


Could you give it a try before merging #11972 ?