### PR TITLE
fix in TOF matcher for calib

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1187,8 +1187,6 @@ void MatchTOF::doMatchingForTPC(int sec)
 //______________________________________________
 int MatchTOF::findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints, unsigned long firstOrbit)
 {
-  bc -= o2::tof::Geo::LATENCYWINDOW_IN_BC;
-
   if (FITRecPoints.size() == 0) {
     return -1;
   }


### PR DESCRIPTION
This is to fix a bug when using FT0 in TOF calibs (no idea how it enters, probably I did a mistake when I switch among different branches in my local O2 before opening previous PR)