### PR TITLE
GPU Workflow: Fix refactoring of input processing

### DIFF
--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -582,21 +582,6 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     lastTFCounter = tinfo.tfCounter;
   }
 
-  if (mTPCSectorMask != 0xFFFFFFFFF) {
-    // Clean out the unused sectors, such that if they were present by chance, they are not processed, and if the values are uninitialized, we should not crash
-    for (unsigned int i = 0; i < NSectors; i++) {
-      if (!(mTPCSectorMask & (1ul << i))) {
-        if (ptrs.tpcZS) {
-          for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
-            tpcZS.slice[i].zsPtr[j] = nullptr;
-            tpcZS.slice[i].nZSPtr[j] = nullptr;
-            tpcZS.slice[i].count[j] = 0;
-          }
-        }
-      }
-    }
-  }
-
   o2::globaltracking::RecoContainer inputTracksTRD;
   decltype(o2::trd::getRecoInputContainer(pc, &ptrs, &inputTracksTRD)) trdInputContainer;
   if (mSpecConfig.readTRDtracklets) {
@@ -625,6 +610,21 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
     doInputDigitsMC = mSpecConfig.processMC;
   } else {
     ptrs.clustersNative = &inputsClustersDigits->clusterIndex;
+  }
+
+  if (mTPCSectorMask != 0xFFFFFFFFF) {
+    // Clean out the unused sectors, such that if they were present by chance, they are not processed, and if the values are uninitialized, we should not crash
+    for (unsigned int i = 0; i < NSectors; i++) {
+      if (!(mTPCSectorMask & (1ul << i))) {
+        if (ptrs.tpcZS) {
+          for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+            tpcZS.slice[i].zsPtr[j] = nullptr;
+            tpcZS.slice[i].nZSPtr[j] = nullptr;
+            tpcZS.slice[i].count[j] = 0;
+          }
+        }
+      }
+    }
   }
 
   GPUTrackingInOutDigits tpcDigitsMap;


### PR DESCRIPTION
this happened when refactoring processing the DPL inputs for standalone multithreading.
Cleaning of excluded sectors was moved too early, and in case of digit processing with on the fly digit2zs conversion, excluded sectors are not cleaned correctly.