### PR TITLE
[EMCAL-1046] Swap HG and LG at overflow cut

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -60,7 +60,8 @@ class Cell
  public:
   enum class EncoderVersion {
     EncodingV0,
-    EncodingV1
+    EncodingV1,
+    EncodingV2
   };
   /// \brief Default constructor
   Cell() = default;
@@ -202,7 +203,7 @@ class Cell
   /// the limits is provided the energy is
   /// set to the limits (0 in case of negative
   /// energy, 250. in case of energies > 250 GeV)
-  uint16_t getEnergyEncoded(EncoderVersion version = EncoderVersion::EncodingV1) const;
+  uint16_t getEnergyEncoded(EncoderVersion version = EncoderVersion::EncodingV2) const;
 
   /// \brief Get encoded bit representation of cell type (for CTF)
   /// \return Encoded bit representation
@@ -218,10 +219,14 @@ class Cell
   static uint16_t encodeTime(float timestamp);
   static uint16_t encodeEnergyV0(float energy);
   static uint16_t encodeEnergyV1(float energy, ChannelType_t celltype);
+  static uint16_t encodeEnergyV2(float energy, ChannelType_t celltype);
   static uint16_t V0toV1(uint16_t energybits, ChannelType_t celltype);
+  static uint16_t V0toV2(uint16_t energybits, ChannelType_t celltype);
+  static uint16_t V1toV2(uint16_t energybits, ChannelType_t celltype);
   static float decodeTime(uint16_t timestampBits);
   static float decodeEnergyV0(uint16_t energybits);
   static float decodeEnergyV1(uint16_t energybits, ChannelType_t celltype);
+  static float decodeEnergyV2(uint16_t energybits, ChannelType_t celltype);
 
  private:
   /// \brief Set cell energy from encoded bit representation (from CTF)

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -169,6 +169,8 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& c
   Cell::EncoderVersion encodingversion = o2::emcal::Cell::EncoderVersion::EncodingV0;
   if (header.majorVersion == 1 && header.minorVersion == 1) {
     encodingversion = o2::emcal::Cell::EncoderVersion::EncodingV1;
+  } else if (header.majorVersion == 1 && header.minorVersion == 2) {
+    encodingversion = o2::emcal::Cell::EncoderVersion::EncodingV2;
   }
 
   uint32_t firstEntry = 0, cellCount = 0;

--- a/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
@@ -66,6 +66,6 @@ void CTFCoder::assignDictVersion(o2::ctf::CTFDictHeader& h) const
     h = mExtHeader;
   } else {
     h.majorVersion = 1;
-    h.minorVersion = 1;
+    h.minorVersion = 2;
   }
 }


### PR DESCRIPTION
The reconstruction swap HG and LG at 950 ADC counts
in order to avoid saturation of the HG (i.e. due to
pedestals). The compression instead used the 10 bit
ADC range (1024). In the encoding LG cells in that
energy range are encoded with negative values and
therefore are out-of-range.