### PR TITLE
ALPIDE event decoding: added  FLUSHED_INCOMPLETE and STROBE_EXTENDED

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -137,7 +137,7 @@ class AlpideCoder
         chipData.setError(ChipStat::Fatal);
       } else if (roErr == MaskErrFlushedIncomplete) {
         chipData.setError(ChipStat::FlushedIncomplete);
-      } else if (roErr == MaskErrStrobeExtended ) {
+      } else if (roErr == MaskErrStrobeExtended) {
         chipData.setError(ChipStat::StrobeExtended);
       }
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -89,6 +89,8 @@ class AlpideCoder
   static constexpr uint8_t MaskErrBusyViolation = 0x1 << 3;
   static constexpr uint8_t MaskErrDataOverrun = 0x3 << 2;
   static constexpr uint8_t MaskErrFatal = 0x7 << 1;
+  static constexpr uint8_t MaskErrFlushedIncomplete = 0x1 << 2;
+  static constexpr uint8_t MaskErrStrobeExtended = 0x1 << 1;
   static constexpr uint32_t MaskTimeStamp = 0xff;                 // Time stamps as BUNCH_COUNTER[10:3] bits
   static constexpr uint32_t MaskReserved = 0xff;                  // mask for reserved byte
   static constexpr uint32_t MaskHitMap = 0x7f;                    // mask for hit map: at most 7 hits in bits (0:6)
@@ -133,6 +135,10 @@ class AlpideCoder
         chipData.setError(ChipStat::DataOverrun);
       } else if (roErr == MaskErrFatal) {
         chipData.setError(ChipStat::Fatal);
+      } else if (roErr == MaskErrFlushedIncomplete) {
+        chipData.setError(ChipStat::FlushedIncomplete);
+      } else if (roErr == MaskErrStrobeExtended ) {
+        chipData.setError(ChipStat::StrobeExtended);
       }
 #endif
     };

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -65,6 +65,8 @@ struct ChipStat {
     InterleavedChipData,          // Chip data interleaved on the cable
     TruncatedBuffer,              // truncated buffer, 0 padding
     TrailerAfterHeader,           // trailer seen after header w/o FE of FD set
+    FlushedIncomplete,            // ALPIDE MEB was flushed by the busy handling
+    StrobeExtended,               // ALPIDE received a second trigger while the strobe was still open
     NErrorsDefined
   };
 
@@ -99,7 +101,9 @@ struct ChipStat {
     "DColumns non-increasing",                      // DColumns non increasing
     "Chip data interleaved on the cable",           // Chip data interleaved on the cable
     "TruncatedBuffer",                              // truncated buffer, 0 padding
-    "TrailerAfterHeader"                            // trailer seen after header w/o FE of FD set
+    "TrailerAfterHeader",                           // trailer seen after header w/o FE of FD set
+    "FlushedIncomplete",                            // ALPIDE MEB was flushed by the busy handling
+    "StrobeExtended"                                // ALPIDE received a second trigger while the strobe was still open
   };
 
   static constexpr std::array<uint32_t, NErrorsDefined> ErrActions = {
@@ -133,7 +137,9 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // DColumns non increasing
     ErrActPropagate | ErrActDump, // Chip data interleaved on the cable
     ErrActPropagate | ErrActDump, // Truncated buffer while something was expected
-    ErrActPropagate | ErrActDump  // trailer seen after header w/o FE of FD set
+    ErrActPropagate | ErrActDump, // trailer seen after header w/o FE of FD set
+    ErrActPropagate | ErrActDump, // ALPIDE MEB was flushed by the busy handling
+    ErrActPropagate | ErrActDump  // ALPIDE received a second trigger while the strobe was still open
   };
   uint16_t feeID = -1;
   size_t nHits = 0;


### PR DESCRIPTION
- Added detection of 
  * FLUSHED_INCOMPLETE
  * STROBE_EXTENDED
- FLUSHED_INCOMPLETE
  * is needed to potentially truncate events affected by beam background
  * potentially this would need to be propagated further to mark incomplete events
