### PR TITLE
Check if FileFetcher is done for early stop on empty queue 

### DIFF
--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -228,7 +228,7 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (mCTFCounter >= mInput.maxTFs || (!mInput.ctfIDs.empty() && mSelIDEntry >= mInput.ctfIDs.size())) { // done
     LOG(info) << "All CTFs from selected range were injected, stopping";
     mRunning = false;
-  } else if (mRunning && !mCTFTree && mFileFetcher->getNextFileInQueue().empty()) { // previous tree was done, can we read more?
+  } else if (mRunning && !mCTFTree && mFileFetcher->getNextFileInQueue().empty() && !mFileFetcher->isRunning()) { // previous tree was done, can we read more?
     mRunning = false;
   }
 


### PR DESCRIPTION
fix for PR11985: checking for the empty file queue is not enough, since the FileFetcher might be in the process of copying, make sure it is not running.

Trivial, merging.