### PR TITLE
Avoid injecting data unexpectedly

### DIFF
--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -281,6 +281,10 @@ void injectMissingData(fair::mq::Device& device, fair::mq::Parts& parts, std::ve
       firstDH = dh;
     }
     for (size_t pi = 0; pi < present.size(); ++pi) {
+      // Consider uninvolved pipelines as present.
+      if (routes[pi].timeslice == (dph->startTime % routes[pi].maxTimeslices)) {
+        present[pi] = true;
+      }
       if (present[pi]) {
         continue;
       }


### PR DESCRIPTION
This protects the case of multiple pipelines.