### PR TITLE
check fill scheme to clean FT0 BC in TOF calibs

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -223,6 +223,9 @@ class MatchTOF
 
   void updateTimeDependentParams();
 
+  static bool mHasFillScheme;
+  static bool mFillScheme[o2::constants::lhc::LHCMaxBunches];
+
   //================================================================
 
   // Data members


### PR DESCRIPTION
I see in Pb-Pb that relying only on FT0 BC is not enough, now requiring also BC enabled in the filling scheme.
Tested locally on one CTF

@chiarazampolli 