### PR TITLE
MatLUT: Option for fast layer lookup

### DIFF
--- a/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
+++ b/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
@@ -19,12 +19,9 @@
 #include "DetectorsBase/MatLayerCyl.h"
 #include "DetectorsBase/Ray.h"
 #include "FlatObject.h"
-#include <vector>
-#include <utility>
 
 #ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 #include "MathUtils/Cartesian.h"
-#include "CommonUtils/TreeStreamRedirector.h"
 #endif // !GPUCA_ALIGPUCODE
 
 /**********************************************************************
@@ -130,9 +127,10 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   static constexpr float LayerRMax = 500;    // maximum value of R lookup (corresponds to last layer of MatLUT)
   static constexpr float VoxelRDelta = 0.05; // voxel spacing for layer lookup; seems a natural choice - corresponding ~ to smallest spacing
   static constexpr float InvVoxelRDelta = 1.f / VoxelRDelta;
+  static constexpr int NumVoxels = int(LayerRMax / VoxelRDelta);
 
-  std::vector<std::pair<uint16_t, uint16_t>> mLayerVoxelLU{}; //! helper structure to lookup a layer based on radius
-  bool mLayerVoxelLUInitialized = false;                      //! if layer helper structure is initialized
+  uint16_t mLayerVoxelLU[2 * NumVoxels]; //! helper structure to lookup a layer based on known radius (static dimension for easy copy to GPU)
+  bool mInitializedLayerVoxelLU = false; //! if the voxels have been initialized
 
   ClassDefNV(MatLayerCylSet, 1);
 };

--- a/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
+++ b/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
@@ -19,9 +19,12 @@
 #include "DetectorsBase/MatLayerCyl.h"
 #include "DetectorsBase/Ray.h"
 #include "FlatObject.h"
+#include <vector>
+#include <utility>
 
 #ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 #include "MathUtils/Cartesian.h"
+#include "CommonUtils/TreeStreamRedirector.h"
 #endif // !GPUCA_ALIGPUCODE
 
 /**********************************************************************
@@ -79,6 +82,9 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   static MatLayerCylSet* loadFromFile(const std::string& inpFName = "matbud.root");
   static MatLayerCylSet* rectifyPtrFromFile(MatLayerCylSet* ptr);
 
+  // initializes internal voxel lookup
+  void initLayerVoxelLU();
+
   void flatten();
 
   MatLayerCyl& getLayer(int i) { return get()->mLayers[i]; }
@@ -97,6 +103,9 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   GPUd() MatBudget getMatBudget(float x0, float y0, float z0, float x1, float y1, float z1) const;
 
   GPUd() int searchSegment(float val, int low = -1, int high = -1) const;
+
+  /// searches a layer based on r2 input, using a lookup table
+  GPUd() int searchLayerFast(float r2, int low = -1, int high = -1) const;
 
 #ifndef GPUCA_GPUCODE
   //-----------------------------------------------------------
@@ -117,6 +126,13 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   /// Gives minimal alignment in bytes required for the flat buffer
   static constexpr size_t getBufferAlignmentBytes() { return 8; }
 #endif // !GPUCA_GPUCODE
+
+  static constexpr float LayerRMax = 500;    // maximum value of R lookup (corresponds to last layer of MatLUT)
+  static constexpr float VoxelRDelta = 0.05; // voxel spacing for layer lookup; seems a natural choice - corresponding ~ to smallest spacing
+  static constexpr float InvVoxelRDelta = 1.f / VoxelRDelta;
+
+  std::vector<std::pair<uint16_t, uint16_t>> mLayerVoxelLU{}; //! helper structure to lookup a layer based on radius
+  bool mLayerVoxelLUInitialized = false;                      //! if layer helper structure is initialized
 
   ClassDefNV(MatLayerCylSet, 1);
 };

--- a/Detectors/Base/src/GRPGeomHelper.cxx
+++ b/Detectors/Base/src/GRPGeomHelper.cxx
@@ -131,10 +131,6 @@ bool GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   if (mRequest->askMatLUT && matcher == ConcreteDataMatcher("GLO", "MATLUT", 0)) {
     LOG(info) << "material LUT updated";
     mMatLUT = o2::base::MatLayerCylSet::rectifyPtrFromFile((o2::base::MatLayerCylSet*)obj);
-    if (getenv("ALICEO2_MATBUT_VOXEL")) {
-      // the object is already const here ... so need to const_cast to finish initialization
-      const_cast<o2::base::MatLayerCylSet*>(mMatLUT)->initLayerVoxelLU();
-    }
     o2::base::Propagator::Instance(false)->setMatLUT(mMatLUT);
     if (mRequest->needPropagatorD) {
       o2::base::PropagatorD::Instance(false)->setMatLUT(mMatLUT);

--- a/Detectors/Base/src/GRPGeomHelper.cxx
+++ b/Detectors/Base/src/GRPGeomHelper.cxx
@@ -131,6 +131,10 @@ bool GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   if (mRequest->askMatLUT && matcher == ConcreteDataMatcher("GLO", "MATLUT", 0)) {
     LOG(info) << "material LUT updated";
     mMatLUT = o2::base::MatLayerCylSet::rectifyPtrFromFile((o2::base::MatLayerCylSet*)obj);
+    if (getenv("ALICEO2_MATBUT_VOXEL")) {
+      // the object is already const here ... so need to const_cast to finish initialization
+      const_cast<o2::base::MatLayerCylSet*>(mMatLUT)->initLayerVoxelLU();
+    }
     o2::base::Propagator::Instance(false)->setMatLUT(mMatLUT);
     if (mRequest->needPropagatorD) {
       o2::base::PropagatorD::Instance(false)->setMatLUT(mMatLUT);


### PR DESCRIPTION
Profile analysis has shown that material budget calculations used in tracking, spent most time in
 (a) determination of a cylindrical layer
 (b) determination of a phi sector in a layer

This commit proposes an improvement for (a). Instead of determining the layer id via binary search, we can use a simple lookup structure working on regular R-intervals.

The commit offers a 5-8% speed improvement for ITS reconstruction and should be beneficial for other things such as strangeness tracking, or any algorithm using MatLUT.

Relates to https://alice.its.cern.ch/jira/browse/O2-4170