### PR TITLE
[EMCAL-1048] Treat faulty memory size reported by RDH

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
@@ -148,11 +148,10 @@ class RawReaderMemory
   /// Rewind stream to the first entry
   void init();
 
-  /// \brief Check whether the current page is accepted
-  /// \param page Raw page to check
-  /// \return True if the page is accepted, false otherwise
-  bool acceptPage(const char* page) const;
-
+  /// \brief Decode raw header words
+  /// \param headerwords Headerwords
+  /// \return Decoded RDH
+  /// \throw RawDecodingError with code HEADER_DECODING if the payload does not correspond to an expected header
   o2::header::RDHAny decodeRawHeader(const void* headerwords);
 
  private:

--- a/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
@@ -8,11 +8,13 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
+#include <iostream>
 #include <sstream>
 #include <string>
 #include "EMCALReconstruction/RawReaderMemory.h"
 #include "DetectorsRaw/RDHUtils.h"
+#include "Headers/RAWDataHeader.h"
+#include "Headers/DAQID.h"
 
 using namespace o2::emcal;
 
@@ -34,6 +36,16 @@ o2::header::RDHAny RawReaderMemory::decodeRawHeader(const void* payloadwords)
   auto headerversion = RDHDecoder::getVersion(payloadwords);
   if (headerversion < RDHDecoder::getVersion<o2::header::RDHLowest>() || headerversion > RDHDecoder::getVersion<o2::header::RDHHighest>()) {
     throw RawDecodingError(RawDecodingError::ErrorType_t::HEADER_DECODING, mCurrentFEE);
+  }
+  if (!RDHDecoder::checkRDH(payloadwords, false, true)) {
+    // Header size != to 64 and 0 in reserved words indicate that the header is a fake header
+    throw RawDecodingError(RawDecodingError::ErrorType_t::HEADER_DECODING, mCurrentFEE);
+  }
+  if (RDHDecoder::getVersion(payloadwords) >= 6) {
+    // If header version is >= 6 check that the source ID is EMCAL
+    if (RDHDecoder::getSourceID(payloadwords) != o2::header::DAQID::EMC) {
+      throw RawDecodingError(RawDecodingError::ErrorType_t::HEADER_DECODING, mCurrentFEE);
+    }
   }
   return {*reinterpret_cast<const o2::header::RDHAny*>(payloadwords)};
 }
@@ -117,9 +129,31 @@ void RawReaderMemory::nextPage(bool doResetPayload)
   }
   if (mCurrentPosition + RDHDecoder::getMemorySize(mRawHeader) > mRawMemoryBuffer.size()) {
     // Payload incomplete
+    // Set to offset to next or buffer size, whatever is smaller
+    if (mCurrentPosition + RDHDecoder::getOffsetToNext(mRawHeader) < mRawMemoryBuffer.size()) {
+      mCurrentPosition += RDHDecoder::getOffsetToNext(mRawHeader);
+      if (mCurrentPosition + 64 < mRawMemoryBuffer.size()) {
+        // check if the page continues with a RDH
+        // if next page is not a header decodeRawHeader will throw a RawDecodingError
+        auto nextheader = decodeRawHeader(mRawMemoryBuffer.data() + mCurrentPosition);
+        if (RDHDecoder::getVersion(nextheader) != RDHDecoder::getVersion(mRawHeader)) {
+          // Next header has different header version - clear indication that it is a fake header
+          throw RawDecodingError(RawDecodingError::ErrorType_t::HEADER_DECODING, mCurrentFEE);
+        }
+      }
+    } else {
+      mCurrentPosition = mRawMemoryBuffer.size();
+    }
+    // RDHDecoder::printRDH(mRawHeader);
     throw RawDecodingError(RawDecodingError::ErrorType_t::PAYLOAD_DECODING, mCurrentFEE);
   } else if (mCurrentPosition + RDHDecoder::getHeaderSize(mRawHeader) > mRawMemoryBuffer.size()) {
     // Start position of the payload is outside the payload range
+    // Set to offset to next or buffer size, whatever is smaller
+    if (mCurrentPosition + RDHDecoder::getOffsetToNext(mRawHeader) < mRawMemoryBuffer.size()) {
+      mCurrentPosition += RDHDecoder::getOffsetToNext(mRawHeader);
+    } else {
+      mCurrentPosition = mRawMemoryBuffer.size();
+    }
     throw RawDecodingError(RawDecodingError::ErrorType_t::PAGE_START_INVALID, mCurrentFEE);
   } else {
     mRawBuffer.readFromMemoryBuffer(gsl::span<const char>(mRawMemoryBuffer.data() + mCurrentPosition + RDHDecoder::getHeaderSize(mRawHeader), RDHDecoder::getMemorySize(mRawHeader) - RDHDecoder::getHeaderSize(mRawHeader)));
@@ -154,6 +188,13 @@ void RawReaderMemory::nextPage(bool doResetPayload)
             mMinorErrors.emplace_back(RawDecodingError::ErrorType_t::TRAILER_INCOMPLETE, mCurrentFEE);
           }
         } catch (RCUTrailer::Error& e) {
+          // We must forward the position in such cases in order to not end up in an infinity loop
+          if (mCurrentPosition + RDHDecoder::getOffsetToNext(mRawHeader) < mRawMemoryBuffer.size()) {
+            mCurrentPosition += RDHDecoder::getOffsetToNext(mRawHeader);
+          } else {
+            mCurrentPosition = mRawMemoryBuffer.size();
+          }
+          // Page is not consistent - must be skipped
           throw RawDecodingError(RawDecodingError::ErrorType_t::TRAILER_DECODING, mCurrentFEE);
         }
       } else {


### PR DESCRIPTION
In case the memory size in the RDH reported is larger
then the raw payload size forward the current positon
to payload size or offsetToNext - whatever is smaller,
before raising the error.