### PR TITLE
DPL: change ExpirationHandler::Creator to use services

### DIFF
--- a/Framework/Core/include/Framework/ExpirationHandler.h
+++ b/Framework/Core/include/Framework/ExpirationHandler.h
@@ -30,7 +30,7 @@ struct TimesliceSlot;
 struct InputRecord;
 
 struct ExpirationHandler {
-  using Creator = std::function<TimesliceSlot(ChannelIndex, TimesliceIndex&)>;
+  using Creator = std::function<TimesliceSlot(ServiceRegistryRef, ChannelIndex)>;
   /// Callback type to check if the record must be expired
   using Checker = std::function<bool(ServiceRegistryRef, uint64_t timestamp, InputSpan const& record)>;
   /// Callback type to actually materialise a given record

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -125,7 +125,7 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
     for (auto& handler : expirationHandlers) {
       LOGP(debug, "handler.creator for {}", handler.name);
       auto channelIndex = deviceProxy.getInputChannelIndex(handler.routeIndex);
-      slotsCreatedByHandlers.push_back(handler.creator(channelIndex, mTimesliceIndex));
+      slotsCreatedByHandlers.push_back(handler.creator(services, channelIndex));
     }
   }
   // Count how many slots are not invalid

--- a/Framework/Core/src/DecongestionService.h
+++ b/Framework/Core/src/DecongestionService.h
@@ -18,6 +18,9 @@ namespace o2::framework
 struct DecongestionService {
   /// Wether we are a source in the processing chain
   bool isFirstInTopology = true;
+  /// The last timeslice which the ExpirationHandler::Creator callback
+  /// created. This can be used to skip dummy iterations.
+  size_t nextEnumerationTimeslice = 0;
   /// Last timeslice we communicated. Notice this should never go backwards.
   int64_t lastTimeslice = 0;
   /// The next timeslice we should consume, when running in order,


### PR DESCRIPTION
This allows us to easily have some state attached to the creation of new timeslices and in particular we can then use the DecongestionService to keep track of the next enumeration to be created. This comes handy when we have dummy iterations which we want to "rewind" to avoid messages about empty timeslices.