### PR TITLE
 [EMCAL-1048] Consistent check fo RCU trailer and channel header integrity

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -388,6 +388,11 @@ class RCUTrailer
   /// are assigned based on the trailer word marker.
   static RCUTrailer constructFromPayloadWords(const gsl::span<const uint32_t> payloadwords);
 
+  /// \brief Check whether the word is a valid last trailer word
+  /// \param trailerword Word to be checked
+  /// \return True if the word is a valid last trailer word, false if there are inconsistencies
+  static bool checkLastTrailerWord(uint32_t trailerword);
+
  private:
   /// \struct AltroConfig
   /// \brief Bit field configuration of the ALTRO config registers

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -35,6 +35,29 @@ void RCUTrailer::reset()
   mIsInitialized = false;
 }
 
+bool RCUTrailer::checkLastTrailerWord(uint32_t trailerword)
+{
+  const int MIN_FWVERSION = 2;
+  const int MAX_FWVERSION = 2;
+  if ((trailerword >> 30) != 3) {
+    return false;
+  }
+  auto firmwarevesion = (trailerword >> 16) & 0xFF;
+  auto trailerSize = (trailerword & 0x7F);
+  if (firmwarevesion < MIN_FWVERSION || firmwarevesion > MAX_FWVERSION) {
+    return false;
+  }
+  if (trailerSize < 2) {
+    return false;
+  }
+  if (firmwarevesion == 2) {
+    if (trailerSize < 9) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payloadwords)
 {
   reset();

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -156,6 +156,7 @@ class MinorAltroDecodingError
   /// \brief Error codes connected with the ALTRO decoding
   enum class ErrorType_t {
     BUNCH_HEADER_NULL,            ///< Bunch header is 0
+    CHANNEL_HEADER,               ///< Channel header corruption
     CHANNEL_END_PAYLOAD_UNEXPECT, ///< Unexpected end of payload (channel or trailer word in bunch words)
     CHANNEL_PAYLOAD_EXCEED,       ///< Exceeding channel payload block
     CHANNEL_ORDER,                ///< Channels not in increasing order
@@ -210,7 +211,7 @@ class MinorAltroDecodingError
 
   /// \brief Get the number of error types handled by the AltroDecoderError
   /// \return Number of error types
-  static constexpr int getNumberOfErrorTypes() noexcept { return 7; }
+  static constexpr int getNumberOfErrorTypes() noexcept { return 8; }
 
   /// \brief Get the name connected to the error type
   ///
@@ -351,6 +352,11 @@ class AltroDecoder
   /// Performing various consistency checks on the RCU trailer
   /// In case of failure an exception is thrown.
   void checkRCUTrailer();
+
+  /// \brief Check hardware address in channel header for consistency
+  /// \param hwaddress Hardware address to check
+  /// \return True if the channel is consistent (branch, FEC and Altro in expected range) - false otherwise
+  bool checkChannelHWAddress(int hwaddress);
 
   RawReaderMemory& mRawReader;                               ///< underlying raw reader
   RCUTrailer mRCUTrailer;                                    ///< RCU trailer

--- a/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
@@ -173,7 +173,7 @@ void RawReaderMemory::nextPage(bool doResetPayload)
       // The trailer is only decoded if the DDL is in the range of SRU DDLs. STU pages are propagated
       // 1-1 without trailer parsing
       auto lastword = *(mRawBuffer.getDataWords().rbegin());
-      if (lastword >> 30 == 3) {
+      if (RCUTrailer::checkLastTrailerWord(lastword)) {
         // lastword is a trailer word
         // decode trailer and chop
         try {

--- a/Detectors/EMCAL/reconstruction/test/testMinorAltroDecodingError.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testMinorAltroDecodingError.cxx
@@ -23,10 +23,11 @@ namespace emcal
 
 BOOST_AUTO_TEST_CASE(MinorAltroDecodingError_test)
 {
-  BOOST_CHECK_EQUAL(MinorAltroDecodingError::getNumberOfErrorTypes(), 7);
-  std::array<std::string, 7> errornames = {{"ChannelEndPayloadUnexpected",
+  BOOST_CHECK_EQUAL(MinorAltroDecodingError::getNumberOfErrorTypes(), 8);
+  std::array<std::string, 8> errornames = {{"ChannelEndPayloadUnexpected",
                                             "ChannelPayloadExceed",
                                             "ChannelOrderError",
+                                            "ChannelHeader",
                                             "BunchHeaderNull",
                                             "BunchLengthExceed",
                                             "BunchLengthAllowExceed",
@@ -34,6 +35,7 @@ BOOST_AUTO_TEST_CASE(MinorAltroDecodingError_test)
                              errortitles = {{"Channel end unexpected",
                                              "Channel exceed",
                                              "FEC order",
+                                             "Channel header invalid",
                                              "Bunch header null",
                                              "Bunch length exceed",
                                              "Bunch length impossible",
@@ -41,13 +43,15 @@ BOOST_AUTO_TEST_CASE(MinorAltroDecodingError_test)
                              errordescriptions = {{"Unexpected end of payload in altro channel payload!",
                                                    "Trying to access out-of-bound payload!",
                                                    "Invalid FEC order",
+                                                   "Invalid channel header",
                                                    "Bunch header 0 or not configured!",
                                                    "Bunch length exceeding channel payload size!",
                                                    "Bunch length exceeding max. possible bunch size!",
                                                    "Bunch start time outside range!"}};
-  std::array<MinorAltroDecodingError::ErrorType_t, 7> errortypes = {{MinorAltroDecodingError::ErrorType_t::CHANNEL_END_PAYLOAD_UNEXPECT,
+  std::array<MinorAltroDecodingError::ErrorType_t, 8> errortypes = {{MinorAltroDecodingError::ErrorType_t::CHANNEL_END_PAYLOAD_UNEXPECT,
                                                                      MinorAltroDecodingError::ErrorType_t::CHANNEL_PAYLOAD_EXCEED,
                                                                      MinorAltroDecodingError::ErrorType_t::CHANNEL_ORDER,
+                                                                     MinorAltroDecodingError::ErrorType_t::CHANNEL_HEADER,
                                                                      MinorAltroDecodingError::ErrorType_t::BUNCH_HEADER_NULL,
                                                                      MinorAltroDecodingError::ErrorType_t::BUNCH_LENGTH_EXCEED,
                                                                      MinorAltroDecodingError::ErrorType_t::BUNCH_LENGTH_ALLOW_EXCEED,


### PR DESCRIPTION
    - RCU trailer must have a valid trailer marker, valid
      trailer version and the corresponding expected size
      of the trailer
    - Channel header must have a valid branch ID (0-1),
      FEC ID (0-9) and ALTRO ID (0,2,3,4)
    - Channel headers only accept if bit 30 is set and
      bit 31 is not set

    Treating corruptions in case of bitflip of bit 31 leading to
    an artificial interpretation of a RCU trailer word in case
    the word is the last word on the page, even though the payload
    continues on the next page.