### PR TITLE
[rANS] Improve Robustness 

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -838,7 +838,7 @@ auto EncodedBlocks<H, N, W>::getImage(const void* newHead)
   // we don't modify newHead, but still need to remove constness for relocation interface
   relocate(image.mRegistry.head, const_cast<char*>(reinterpret_cast<const char*>(newHead)), reinterpret_cast<char*>(&image));
 
-  return std::move(image);
+  return image;
 }
 
 ///_____________________________________________________________________________
@@ -948,7 +948,6 @@ CTFIOSize EncodedBlocks<H, N, W>::decodeCompatImpl(dst_IT dstBegin, int slot, co
 {
 
   // get references to the right data
-  const auto& ansVersion = getANSHeader();
   const auto& block = mBlocks[slot];
   const auto& md = mMetadata[slot];
 
@@ -987,7 +986,6 @@ CTFIOSize EncodedBlocks<H, N, W>::decodeRansV1Impl(dst_IT dstBegin, int slot, co
 {
 
   // get references to the right data
-  const auto& ansVersion = getANSHeader();
   const auto& block = mBlocks[slot];
   const auto& md = mMetadata[slot];
 

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -339,7 +339,10 @@ class EncodedBlocks
   using dictionaryType = std::variant<rans::RenormedSparseHistogram<source_T>, rans::RenormedDenseHistogram<source_T>>;
 #endif
 
-  void setHeader(const H& h) { mHeader = h; }
+  void setHeader(const H& h)
+  {
+    mHeader = h;
+  }
   const H& getHeader() const { return mHeader; }
   H& getHeader() { return mHeader; }
   std::shared_ptr<H> cloneHeader() const { return std::shared_ptr<H>(new H(mHeader)); } // for dictionary creation
@@ -370,6 +373,22 @@ class EncodedBlocks
 
     assert(static_cast<int64_t>(std::numeric_limits<source_T>::min()) <= static_cast<int64_t>(metadata.max));
     assert(static_cast<int64_t>(std::numeric_limits<source_T>::max()) >= static_cast<int64_t>(metadata.min));
+
+    // check consistency of metadata and type
+    [&]() {
+      const int64_t sourceMin = std::numeric_limits<source_T>::min();
+      const int64_t sourceMax = std::numeric_limits<source_T>::max();
+
+      auto view = rans::trim(rans::HistogramView{block.getDict(), block.getDict() + block.getNDict(), metadata.min});
+      const int64_t dictMin = view.getMin();
+      const int64_t dictMax = view.getMax();
+      assert(dictMin >= metadata.min);
+      assert(dictMax <= metadata.max);
+
+      if ((dictMin < sourceMin) || (dictMax > sourceMax)) {
+        throw std::runtime_error(fmt::format("value range of dictionary and target datatype are incompatible: target type [{},{}] vs dictionary [{},{}]", sourceMin, sourceMax, dictMin, dictMax));
+      }
+    }();
 
     if (ansVersion == ANSVersionCompat) {
       rans::DenseHistogram<source_T> histogram{block.getDict(), block.getDict() + block.getNDict(), metadata.min};

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/internal/ExternalEntropyCoder.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/internal/ExternalEntropyCoder.h
@@ -79,7 +79,7 @@ template <typename dst_T>
   constexpr size_t Overhead = 10 * rans::utils::pow2(10); // 10KB overhead safety margin
   const double_t RelativeSafetyFactor = 2.0 * safetyFactor;
   const size_t messageSizeB = nElements * sizeof(source_type);
-  return rans::utils::nBytesTo<dst_T>(std::ceil(safetyFactor * messageSizeB) + Overhead);
+  return rans::utils::nBytesTo<dst_T>(std::ceil(RelativeSafetyFactor * messageSizeB) + Overhead);
 }
 
 template <typename source_T>

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/internal/InplaceEntropyCoder.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/internal/InplaceEntropyCoder.h
@@ -166,7 +166,6 @@ void InplaceEntropyCoder<source_T>::makeEncoder()
     }
 
     const size_t rangeBits = rans::utils::getRangeBits(*mMetrics.getCoderProperties().min, *mMetrics.getCoderProperties().max);
-    const size_t nSamples = mMetrics.getDatasetProperties().numSamples;
     const size_t nUsedAlphabetSymbols = mMetrics.getDatasetProperties().nUsedAlphabetSymbols;
 
     if (rangeBits <= 18) {

--- a/DataFormats/Detectors/Common/test/testCTFEntropyCoder.cxx
+++ b/DataFormats/Detectors/Common/test/testCTFEntropyCoder.cxx
@@ -126,7 +126,7 @@ void encodeInplace(source_IT begin, source_IT end)
   std::vector<buffer_type> dictBuffer(sizeEstimate.getCompressedDictionarySize<buffer_type>(), 0);
 
   auto encoderEnd = entropyCoder.encode(begin, end, encodeBuffer.data(), encodeBuffer.data() + encodeBuffer.size());
-  auto literalsEnd = entropyCoder.writeIncompressible(literalSymbolsBuffer.data(), literalSymbolsBuffer.data() + literalSymbolsBuffer.size());
+  [[maybe_unused]] auto literalsEnd = entropyCoder.writeIncompressible(literalSymbolsBuffer.data(), literalSymbolsBuffer.data() + literalSymbolsBuffer.size());
   auto dictEnd = entropyCoder.writeDictionary(dictBuffer.data(), dictBuffer.data() + dictBuffer.size());
   // decode
   const auto& coderProperties = metrics.getCoderProperties();
@@ -303,7 +303,7 @@ void encodeExternal(source_IT begin, source_IT end)
   auto encoderEnd = entropyCoder.encode(begin, end, encodeBuffer.data(), encodeBuffer.data() + encodeBuffer.size());
 
   std::vector<buffer_type> literalSymbolsBuffer(entropyCoder.template computePackedIncompressibleSize<buffer_type>(), 0);
-  auto literalsEnd = entropyCoder.writeIncompressible(literalSymbolsBuffer.data(), literalSymbolsBuffer.data() + literalSymbolsBuffer.size());
+  [[maybe_unused]] auto literalsEnd = entropyCoder.writeIncompressible(literalSymbolsBuffer.data(), literalSymbolsBuffer.data() + literalSymbolsBuffer.size());
 
   // decode
   auto decoder = ExternalEncoders.getDecoder<source_type>();

--- a/Utilities/rANS/benchmarks/bench_ransHistogram.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransHistogram.cxx
@@ -137,7 +137,7 @@ void ransMakeHistogramBenchmark(benchmark::State& st, Args&&... args)
   histogram_type hist{};
   hist.addSamples(gsl::span<const source_type>(inputData));
 
-  for (std::ptrdiff_t symbol = histogram.getOffset(); symbol != histogram.getOffset() + histogram.size(); ++symbol) {
+  for (std::ptrdiff_t symbol = histogram.getOffset(); symbol != histogram.getOffset() + static_cast<std::ptrdiff_t>(histogram.size()); ++symbol) {
     if (histogram[symbol] > 0) {
       LOG_IF(info, histogram[symbol] != hist[symbol]) << fmt::format("[{}]: {} != {}", symbol, hist[symbol], histogram[symbol]);
       isSame = isSame && (histogram[symbol] == hist[symbol]);
@@ -190,7 +190,7 @@ void ransAccessHistogramBenchmark(benchmark::State& st, Args&&... args)
 #endif
 
   bool isSame = true;
-  for (std::ptrdiff_t symbol = histogram.getOffset(); symbol != histogram.getOffset() + histogram.size(); ++symbol) {
+  for (std::ptrdiff_t symbol = histogram.getOffset(); symbol != histogram.getOffset() + static_cast<std::ptrdiff_t>(histogram.size()); ++symbol) {
     if (histogram[symbol] > 0) {
       LOG_IF(info, histogram[symbol] != hist[symbol]) << fmt::format("[{}]: {} != {}", symbol, hist[symbol], histogram[symbol]);
       isSame = isSame && (histogram[symbol] == hist[symbol]);

--- a/Utilities/rANS/include/rANS/internal/containers/DenseHistogram.h
+++ b/Utilities/rANS/include/rANS/internal/containers/DenseHistogram.h
@@ -184,7 +184,7 @@ inline bool DenseHistogram<source_T, std::enable_if_t<sizeof(source_T) == 4>>::i
       ret = false;
     }
   }
-  if (max - min > this->MaxSize) {
+  if (max - min > static_cast<difference_type>(this->MaxSize)) {
     LOGP(warning, "DenseHistogram exceeds {} elements threshold", this->MaxSize);
     ret = false;
   }
@@ -232,8 +232,6 @@ inline auto DenseHistogram<source_T, std::enable_if_t<sizeof(source_T) == 4>>::a
   constexpr size_t ElemsPerQWord = sizeof(uint64_t) / sizeof(source_type);
   constexpr size_t nUnroll = 4 * ElemsPerQWord;
   auto iter = begin;
-
-  const source_type offset = this->getOffset();
 
   if (getRangeBits(min, max) <= 17) {
     container_type histogram{this->mContainer.size(), this->mContainer.getOffset()};

--- a/Utilities/rANS/include/rANS/internal/containers/DenseHistogram.h
+++ b/Utilities/rANS/include/rANS/internal/containers/DenseHistogram.h
@@ -586,7 +586,16 @@ auto DenseHistogram<source_T, std::enable_if_t<sizeof(source_T) <= 2>>::addFrequ
   addedHistogramView = trim(addedHistogramView);
 
   if constexpr (std::is_unsigned_v<source_T>) {
-    LOG_IF(warning, addedHistogramView.getMin() < 0) << fmt::format("trying to add frequencies for a signed symbol to a DenseHistogram of an unsiged type.");
+    LOG_IF(warning, addedHistogramView.getMin() < 0) << fmt::format("trying to add frequencies of a signed symbol type to a DenseHistogram of an unsiged type.");
+  }
+  if constexpr (std::is_signed_v<source_T>) {
+    const std::ptrdiff_t sourceTypeMax = std::numeric_limits<source_T>::max();
+    const bool isMinOutOfRange = addedHistogramView.getMin() > sourceTypeMax;
+    const bool isMaxOutOfRange = addedHistogramView.getMax() > sourceTypeMax;
+
+    if (isMaxOutOfRange || isMinOutOfRange) {
+      LOGP(warning, "trying to add frequencies of an unsigned symbol type to a DenseHistogram of a signed type");
+    }
   }
 
   const auto thisHistogramView = makeHistogramView(this->mContainer);

--- a/Utilities/rANS/include/rANS/internal/containers/ReverseSymbolLookupTable.h
+++ b/Utilities/rANS/include/rANS/internal/containers/ReverseSymbolLookupTable.h
@@ -71,8 +71,8 @@ class ReverseSymbolLookupTable
     return mLut[cumul];
   };
 
-  inline const iterator_type begin() const noexcept { return mLut.data(); };
-  inline const iterator_type end() const noexcept { return mLut.data() + size(); };
+  inline iterator_type begin() const noexcept { return mLut.data(); };
+  inline iterator_type end() const noexcept { return mLut.data() + size(); };
 
   container_type mLut{};
 };

--- a/Utilities/rANS/include/rANS/internal/containers/Symbol.h
+++ b/Utilities/rANS/include/rANS/internal/containers/Symbol.h
@@ -37,11 +37,8 @@ class Symbol
 
   // TODO(milettri): fix once ROOT cling respects the standard http://wg21.link/p1286r2
   constexpr Symbol() noexcept {}; // NOLINT
-  constexpr Symbol(value_type frequency, value_type cumulative, size_t symbolTablePrecision = 0)
-    : mSymbol{frequency, cumulative}
-  {
-    (void)symbolTablePrecision; // silence compiler warnings
-  };
+  constexpr Symbol(value_type frequency, value_type cumulative, [[maybe_unused]] size_t symbolTablePrecision = 0)
+    : mSymbol{frequency, cumulative} {};
   [[nodiscard]] inline constexpr value_type getFrequency() const noexcept { return mSymbol[0]; };
   [[nodiscard]] inline constexpr value_type getCumulative() const noexcept { return mSymbol[1]; };
   [[nodiscard]] inline constexpr const value_type* data() const noexcept { return mSymbol.data(); };

--- a/Utilities/rANS/include/rANS/internal/encode/Encoder.h
+++ b/Utilities/rANS/include/rANS/internal/encode/Encoder.h
@@ -143,7 +143,11 @@ decltype(auto) Encoder<encoder_T, symbolTable_T, nStreams_V>::process(source_IT 
   EncoderSymbolMapper<symbolTable_type, coder_type, literals_IT> symbolMapper{this->mSymbolTable, literalsBegin};
   typename coder_type::symbol_type encoderSymbols[2]{};
 
+  // one past the end. Will not be dereferenced, thus safe.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
   coder_type* codersREnd = advanceIter(coders.data(), -1);
+#pragma GCC diagnostic pop
   coder_type* activeCoder = codersREnd + nPartialCoderIterations;
 
   // we are encoding backwards!

--- a/Utilities/rANS/include/rANS/internal/encode/EncoderSymbolMapper.h
+++ b/Utilities/rANS/include/rANS/internal/encode/EncoderSymbolMapper.h
@@ -254,8 +254,6 @@ class EncoderSymbolMapper<symbolTable_T,
   {
     using namespace internal::simd;
 
-    const size_type nStreams = coder_type::getNstreams();
-
     difference_type currentStream = nActiveStreams;
 
     epi32_t<SIMDWidth::SSE, 2> frequencies;
@@ -329,8 +327,6 @@ class EncoderSymbolMapper<symbolTable_T,
   [[nodiscard]] inline source_IT unpackSymbols(source_IT sourceIter, coderSymbol_type& unpacked, size_type nActiveStreams)
   {
     using namespace internal::simd;
-
-    const size_type nStreams = coder_type::getNstreams();
 
     difference_type currentStream = nActiveStreams;
 

--- a/Utilities/rANS/include/rANS/internal/encode/SingleStreamEncoderImpl.h
+++ b/Utilities/rANS/include/rANS/internal/encode/SingleStreamEncoderImpl.h
@@ -145,8 +145,6 @@ class SingleStreamEncoderImpl : public SingleStreamEncoderImplBase<lowerBound_V,
   {
     assert(symbol->getFrequency() != 0);
 
-    const state_type old = this->mState;
-
     const auto [newState, streamPosition] = this->renorm(this->mState, outputIter, symbol->getFrequency());
     // coding function
     state_type quotient = static_cast<state_type>((static_cast<uint128_t>(newState) * symbol->getReciprocalFrequency()) >> 64);

--- a/Utilities/rANS/include/rANS/internal/pack/DictionaryStreamReader.h
+++ b/Utilities/rANS/include/rANS/internal/pack/DictionaryStreamReader.h
@@ -84,7 +84,7 @@ class DictionaryStreamParser
 
 template <typename source_T>
 template <typename buffer_IT>
-DictionaryStreamParser<source_T>::DictionaryStreamParser(buffer_IT begin, buffer_IT end, source_type max) : mEnd{begin}, mPos{end}, mIndex(max)
+DictionaryStreamParser<source_T>::DictionaryStreamParser(buffer_IT begin, buffer_IT end, source_type max) : mPos{end}, mEnd{begin}, mIndex(max)
 {
   static_assert(std::is_pointer_v<buffer_IT>, "can only deserialize from raw pointers");
 

--- a/Utilities/rANS/include/rANS/internal/transform/algorithmImpl.h
+++ b/Utilities/rANS/include/rANS/internal/transform/algorithmImpl.h
@@ -161,7 +161,7 @@ inline void forEachIndexValue(container_T&& container, IT begin, IT end, F funct
   using container_type = removeCVRef_t<container_T>;
 
   typename container_type::source_type index = container.getOffset() + std::distance(container.begin(), begin);
-  for (size_t i = 0; i < std::distance(begin, end); ++i) {
+  for (std::ptrdiff_t i = 0; i < std::distance(begin, end); ++i) {
     functor(index++, begin[i]);
   }
 }

--- a/Utilities/rANS/include/rANS/internal/transform/renorm.h
+++ b/Utilities/rANS/include/rANS/internal/transform/renorm.h
@@ -143,7 +143,7 @@ decltype(auto) renorm(histogram_T histogram, Metrics<typename histogram_T::sourc
     return nSymbols;
   }();
 
-  if (nSorted < correctableIndices.size()) {
+  if ((nSorted < correctableIndices.size()) && (renormingPolicy != RenormingPolicy::ForceIncompressible)) {
     std::partial_sort(correctableIndices.begin(), correctableIndices.begin() + nSorted, correctableIndices.end(), [](const auto& a, const auto& b) { return a.second < b.second; });
   } else {
     std::stable_sort(correctableIndices.begin(), correctableIndices.end(), [](const auto& a, const auto& b) { return a.second < b.second; });

--- a/Utilities/rANS/include/rANS/internal/transform/renorm.h
+++ b/Utilities/rANS/include/rANS/internal/transform/renorm.h
@@ -74,7 +74,6 @@ decltype(auto) renorm(histogram_T histogram, Metrics<typename histogram_T::sourc
   using container_type = typename histogram_type::container_type;
   using iterator_type = typename container_type::iterator;
 
-  const source_type offset = histogram.getOffset();
   const double_t nSamples = histogram.getNumSamples();
   const size_t renormingPrecisionBits = *metrics.getCoderProperties().renormingPrecisionBits;
   const size_t nUsedAlphabetSymbols = metrics.getDatasetProperties().nUsedAlphabetSymbols;

--- a/Utilities/rANS/run/bin-encode-decode.cxx
+++ b/Utilities/rANS/run/bin-encode-decode.cxx
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
 
   if (renormedHistogram.hasIncompressibleSymbol()) {
     LOG(info) << "With incompressible symbols";
-    auto [encoderEnd, incompressibleEnd] = encoder.process(tokens.begin(), tokens.end(), std::back_inserter(encoderBuffer), std::back_inserter(incompressibleSymbols));
+    [[maybe_unused]] auto res = encoder.process(tokens.begin(), tokens.end(), std::back_inserter(encoderBuffer), std::back_inserter(incompressibleSymbols));
     LOGP(info, "nIncompressible {}", incompressibleSymbols.size());
     decoder.process(encoderBuffer.end(), decodeBuffer.begin(), tokens.size(), NSTREAMS, incompressibleSymbols.end());
   } else {

--- a/Utilities/rANS/test/test_ransHistograms.cxx
+++ b/Utilities/rANS/test/test_ransHistograms.cxx
@@ -359,8 +359,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_addFrequenciesSignChange, histogram_T, histog
     {static_cast<source_type>(5), 5},
   };
 
-  const size_t fixedSizeOffset = std::numeric_limits<source_type>::min();
-
   histogram_T histogram{};
   histogram.addFrequencies(frequencies.begin(), frequencies.end(), 0);
 
@@ -389,7 +387,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_addFrequenciesSignChange, histogram_T, histog
     const std::ptrdiff_t offset = utils::pow2(utils::toBits<source_type>() - 1);
 
     if constexpr (std::is_same_v<histogram_T, DenseHistogram<int32_t>>) {
-      const std::ptrdiff_t largeOffset = utils::toBits<source_type>() - 1;
       BOOST_CHECK_THROW(histogram.addFrequencies(frequencies2.begin(), frequencies2.end(), offset), HistogramError);
       BOOST_CHECK_THROW(histogram2.addFrequencies(gsl::make_span(frequencies2), offset), HistogramError);
     } else {

--- a/Utilities/rANS/test/test_ransMetrics.cxx
+++ b/Utilities/rANS/test/test_ransMetrics.cxx
@@ -238,7 +238,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_singleElementMetrics, histogram_T, histogram_
   std::vector<uint32_t> frequencies{5};
   histogram_T histogram{frequencies.begin(), frequencies.end(), 2};
   const auto [min, max] = getMinMax(histogram);
-  const float eps = 1e-2;
   const size_t nUsedAlphabetSymbols = countNUsedAlphabetSymbols(histogram);
 
   const Metrics<source_type> metrics{histogram};

--- a/Utilities/rANS/test/test_ransPack.cxx
+++ b/Utilities/rANS/test/test_ransPack.cxx
@@ -56,7 +56,6 @@ using source_types = boost::mp11::mp_list<uint8_t, uint16_t, uint32_t, uint64_t>
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_computePackingBufferSize, buffer_T, buffer_types)
 {
-  size_t nElems{};
   size_t packingWidth = utils::toBits<packing_type>() - 3;
 
   BOOST_CHECK_EQUAL(0, (computePackingBufferSize<buffer_T>(0, packingWidth)));
@@ -132,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_packUnpackStream)
 
     source_type min = *std::min_element(source.begin(), source.end());
 
-    auto packingBufferEnd = pack(source.data(), source.size(), packingBuffer.data(), packingWidth, min);
+    [[maybe_unused]] auto packingBufferEnd = pack(source.data(), source.size(), packingBuffer.data(), packingWidth, min);
 
     std::vector<source_type> unpackBuffer(source.size(), 0);
     unpack(packingBuffer.data(), source.size(), unpackBuffer.data(), packingWidth, min);

--- a/Utilities/rANS/test/test_ransSIMDEncoderKernels.cxx
+++ b/Utilities/rANS/test/test_ransSIMDEncoderKernels.cxx
@@ -120,7 +120,9 @@ struct AosToSoaFixture {
     uint32_t counter = 0;
 
     for (size_t i = 0; i < nElems; ++i) {
-      Symbol symbol{counter++, counter++, 0};
+      const auto freq = counter++;
+      const auto cumul = counter++;
+      Symbol symbol{freq, cumul, 0};
       mFrequencies(i) = symbol.getFrequency();
       mCumulative(i) = symbol.getCumulative();
 
@@ -228,10 +230,10 @@ struct SSERenormFixture {
     statesVec[0] = load(states[0]);
     statesVec[1] = load(states[1]);
 
-    stream_iterator newstreamOutIter = ransRenorm<stream_iterator, LowerBound, StreamBits>(statesVec,
-                                                                                           frequenciesVec,
-                                                                                           SymbolTablePrecisionBits,
-                                                                                           streamOutBuffer.begin(), newStatesVec);
+    [[maybe_unused]] stream_iterator newstreamOutIter = ransRenorm<stream_iterator, LowerBound, StreamBits>(statesVec,
+                                                                                                            frequenciesVec,
+                                                                                                            SymbolTablePrecisionBits,
+                                                                                                            streamOutBuffer.begin(), newStatesVec);
 
     epi64_t<SIMDWidth::SSE, 2> newStates(0);
     store(newStatesVec[0], newStates[0]);

--- a/Utilities/rANS/test/test_ransSparseVector.cxx
+++ b/Utilities/rANS/test/test_ransSparseVector.cxx
@@ -47,8 +47,6 @@ BOOST_AUTO_TEST_CASE(test_write)
 {
   sparseVector_type vec{};
 
-  const size_t fixedSizeOffset = std::numeric_limits<source_type>::min();
-
   std::vector<source_type> samples{-5, -2, 1, 3, 5, 8, -5, 5, 1, 1, 1, 14, 8, 8, 8, 8, 8, 8, 8, 8, utils::pow2(18) + 1};
 
   std::unordered_map<source_type, uint32_t> results{{-5, 2}, {-2, 1}, {-1, 0}, {0, 0}, {1, 4}, {2, 0}, {3, 1}, {4, 0}, {5, 2}, {8, 9}, {14, 1}, {utils::pow2(18) + 1, 1}};

--- a/Utilities/rANS/test/test_ransSymbolTables.cxx
+++ b/Utilities/rANS/test/test_ransSymbolTables.cxx
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_symbolTable, histogram_T, histogram_t)
 
   BOOST_CHECK_EQUAL(symbolTable.getPrecision(), scaleBits);
 
-  for (source_type index = 0; index < rescaledFrequencies.size(); ++index) {
+  for (source_type index = 0; index < static_cast<source_type>(rescaledFrequencies.size()); ++index) {
     auto symbol = symbolTable[index + 6];
     BOOST_CHECK_EQUAL(symbol.getFrequency(), rescaledFrequencies[index]);
     BOOST_CHECK_EQUAL(symbol.getCumulative(), cumulativeFrequencies[index]);


### PR DESCRIPTION
Observation of inconsistencies between encoded/decoded data if a signed integer dictionary is interpreted as an unsigned integer dictionary and vice-versa, caused by the rANS algorithm's sensitivity to the order of the elements in the dictionary. Interpreting a signed integer as an unsigned integer will cause negative values to become large positive values, resulting in a different ordering inside the dictionary caused by the internal machine representation of signed integers via the two's complement. This PR detects these inconsistencies and will throw an exception to prevent unnoticed data corruption.

Furthermore, this PR fixes all compiler warnings from librans-related code in O2.

Fixes issues observed with #12011
