### PR TITLE
TRD raw reader update

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -14,6 +14,8 @@
 
 #include "DataFormatsTRD/Constants.h"
 #include <iostream>
+#include <string>
+#include <fmt/format.h>
 
 namespace o2
 {
@@ -54,12 +56,17 @@ struct HelperMethods {
     printf("%02i_%i_%i\n", det / constants::NCHAMBERPERSEC, (det % constants::NCHAMBERPERSEC) / constants::NLAYER, det % constants::NLAYER);
   }
 
+  static std::string getSectorStackLayerSide(int hcid)
+  {
+    int det = hcid / 2;
+    std::string side = (hcid % 2 == 0) ? "A" : "B";
+    return fmt::format("{}_{}_{}{}", getSector(det), getStack(det), getLayer(det), side);
+  }
+
   static void printSectorStackLayerSide(int hcid)
   {
     // for a given half-chamber number prints SECTOR_STACK_LAYER_side
-    int det = hcid / 2;
-    std::string side = (hcid % 2 == 0) ? "A" : "B";
-    printf("%02i_%i_%i%s\n", det / constants::NCHAMBERPERSEC, (det % constants::NCHAMBERPERSEC) / constants::NLAYER, det % constants::NLAYER, side.c_str());
+    printf("%s\n", getSectorStackLayerSide(hcid).c_str());
   }
 
   static int getPadColFromADC(int irob, int imcm, int iadc)

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -119,8 +119,10 @@ class CruRawReader
   // given the total link size and the hcid from the RDH
   // parse the tracklet data. Overwrite hcid from TrackletHCHeader if mismatch is detected
   // trackletWordsRejected:  count the number of words which were skipped (subset of words read)
-  // returns total number of words read (no matter if parsed successfully or not)
-  int parseTrackletLinkData(int linkSize32, int& hcid, int& trackletWordsRejected);
+  // trackletWordsReadOK: count the number of words which could be read consecutively w/o errors
+  // numberOfTrackletsFound: count the number of tracklets found
+  // returns total number of words read (no matter if parsed successfully or not) or -1 in case of failure
+  int parseTrackletLinkData(int linkSize32, int& hcid, int& trackletWordsRejected, int& trackletWordsReadOK, int& numberOfTrackletsFound);
 
   // the parsing begins after the DigitHCHeaders have been parsed already
   // maxWords32 is the remaining number of words for the given link


### PR DESCRIPTION
Only change in raw parsing is that upon invalid MCM data there is no tracklet constructed from it. This is in any case very rare, but should of course still not be done.
Apart from that mostly changes in order to debug the verbose raw dumps more easily. For example extracting the raw data of individual links for half-chamber `8_3_0A` from log file `trd.log` via
```
awk '/Reading 8_3_0A/,/for 8_3_0A/' trd.log > 8_3_0A
```
Extracting the number of 32-bit words read successfully for the link can be done via
```
grep "Could read" 8_3_0A | grep "true" | cut -d" " -f 5 > 8_3_0A_Good
```
or for links with errors
```
grep "Could read" 8_3_0A | grep "false" | cut -d" " -f 5 > 8_3_0A_Bad
```