### PR TITLE
Refactor MC part of AOD producers

### DIFF
--- a/Detectors/AOD/CMakeLists.txt
+++ b/Detectors/AOD/CMakeLists.txt
@@ -41,14 +41,14 @@ o2_add_executable(
   workflow
   COMPONENT_NAME aod-producer
   TARGETVARNAME targetName
-  SOURCES src/aod-producer-workflow.cxx src/AODProducerWorkflowSpec.cxx
+  SOURCES src/aod-producer-workflow.cxx src/AODProducerWorkflowSpec.cxx src/AODMcProducerHelpers.cxx
   PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version
 )
 
 o2_add_executable(
   workflow
   COMPONENT_NAME aod-mc-producer
-  SOURCES src/aod-mc-producer-workflow.cxx src/AODMcProducerWorkflowSpec.cxx
+  SOURCES src/aod-mc-producer-workflow.cxx src/AODMcProducerWorkflowSpec.cxx src/AODMcProducerHelpers.cxx
   PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version
 )
 

--- a/Detectors/AOD/include/AODProducerWorkflow/AODMcProducerHelpers.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODMcProducerHelpers.h
@@ -1,0 +1,324 @@
+// Copyright 2023-2099 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   AODMcProducerHelpers.h
+/// @author Christian Holm Christensen <cholm@nbi.dk>
+/// common helpers for AOD MC producers
+
+#ifndef O2_AODMCPRODUCER_HELPERS
+#define O2_AODMCPRODUCER_HELPERS
+#include <SimulationDataFormat/MCEventHeader.h>
+#include <SimulationDataFormat/MCTrack.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/FunctionalHelpers.h>
+#include <Framework/TableBuilder.h>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+/**
+ * Utilities to transform simulated data into AO2D tables.
+ *
+ * The function templates below are templated on the cursor type over
+ * the relevant AOD tables.  Such a table can be obtained from the
+ * ProcessingContext @c pc
+ *
+ * @code
+ * auto builder = pc.make<TableBulder>(OutputForTable<Table>::ref());
+ * auto cursor  = builder->cursor<Table>();
+ * @endcode
+ *
+ * If the task uses the @c Produces<Table> template,
+ *
+ * @code
+ * Produces<Table> mTable;
+ * @endcode
+ *
+ * then a cursor is obtained via,
+ *
+ * @code
+ * auto cursor = mTable.cursor;
+ * @endcode
+ *
+ * Note that these functions cannot be moved into a compilation unit,
+ * because that would require deducing the table cursor type, by
+ * f.ex.
+ *
+ * @code
+ * template <typename Table>
+ * struct TableCursor {
+ *    using cursor_t = decltype(std::declval<framework::TableBuilder>()
+ *                              .cursor<Table>());
+ * };
+ * using CollisionCursor = TableCursor<aod::McCollisions>:cursor_t;
+ * @endcode
+ *
+ * but since cursors are really Lambdas and Lambda types are specific
+ * to the compilation unit, then the implementation file (compilation
+ * unit) of these functions definitions and their use (another
+ * compilation unit) would have different types of the the cursers,
+ * and thus not be able to link.  More information is given at
+ * https://stackoverflow.com/questions/50033797.
+ */
+namespace o2::aodmchelpers
+{
+//==================================================================
+/**
+ * Deduce cursor type and wrap in std::function
+ */
+template <typename Table>
+struct TableCursor {
+  using type = decltype(framework::FFL(std::declval<framework::TableBuilder>()
+                                         .cursor<Table>()));
+};
+//==================================================================
+/** Cursor over aod::McCollisions */
+using CollisionCursor = TableCursor<aod::McCollisions>::type;
+/** Cursor over aod::McParticles */
+using ParticleCursor = TableCursor<aod::StoredMcParticles_001>::type;
+/** Cursor over aod::HepMCXSections */
+using XSectionCursor = TableCursor<aod::HepMCXSections>::type;
+/** Cursor over aod::HepMCPdfInfos */
+using PdfInfoCursor = TableCursor<aod::HepMCPdfInfos>::type;
+/** Cursor over aod::HepMCHeavyIons */
+using HeavyIonCursor = TableCursor<aod::HepMCHeavyIons>::type;
+//==================================================================
+/** Types of updates on HepMC tables. */
+enum HepMCUpdate {
+  never,
+  always,
+  anyKey,
+  allKeys
+};
+
+//==================================================================
+/**
+ * Check if header has keys.  If the argument @a anyNotAll is true,
+ * then this member function returns true if @e any of the keys
+ * were found.  If @a anyNotAll is false, then return true only if
+ * @a all keys were found.
+ *
+ * @param header    MC event header
+ * @param keys      Keys to look for
+ * @param anyNotAll If true, return true if @e any key was found.
+ *                  If false, return true only if @a all keys were found
+ *
+ * @return true if any or all keys were found
+ */
+bool hasKeys(o2::dataformats::MCEventHeader const& header,
+             const std::vector<std::string>& keys,
+             bool anyNotall = true);
+//--------------------------------------------------------------------
+/**
+ * Get a property from the header, or if not set or not valid, a
+ * default value.
+ *
+ * @param header  The MC event header
+ * @param key     Key to look for
+ * @param def     Value to return if key is not found
+ *
+ * @return Value of key or def if key is not found
+ */
+template <typename T>
+const T getEventInfo(o2::dataformats::MCEventHeader const& header,
+                     std::string const& key,
+                     T const& def)
+{
+  if (not header.hasInfo(key))
+    return def;
+
+  bool isValid = false;
+  const T& val = header.getInfo<T>(key, isValid);
+  if (not isValid)
+    return def;
+
+  return val;
+}
+//====================================================================
+/**
+ * Fill in collision information.  This is read from the passed MC
+ * header and stored in the MCCollision table.  The member function
+ * returns the encoded generator ID.
+ *
+ * @param cursor      Cursor over o2::aod::McCollisions table
+ * @param bcId        Bunch-crossing Identifier
+ * @param time        Time of collisions
+ * @param header      Event header from generator
+ * @param generatorId Default generator
+ * @param sourceId    Identifier of source
+ *
+ * @return encoded generator ID
+ */
+short updateMCCollisions(const CollisionCursor& cursor,
+                         int bcId,
+                         float time,
+                         o2::dataformats::MCEventHeader const& header,
+                         short generatorId = 0,
+                         int sourceId = 0,
+                         unsigned int mask = 0xFFFFFFF0);
+//--------------------------------------------------------------------
+/**
+ * Fill in HepMC cross-section table from event generator header.
+ *
+ * @param cursor      Cursor over o2::aod::HepMCXSections table
+ * @param collisionID Identifier of collision (as given updateMCCollision)
+ * @param generatorID Encoded generator ID
+ * @param header      Event header from generator
+ * @param anyNotAll   If true, then any key present trigger and update.
+ *                    If false, then all keys must be present to update
+ *                    the table.
+ *
+ * @return true if table was updated
+ */
+bool updateHepMCXSection(const XSectionCursor& cursor,
+                         int collisionID,
+                         short generatorID,
+                         o2::dataformats::MCEventHeader const& header,
+                         HepMCUpdate when = HepMCUpdate::anyKey);
+//--------------------------------------------------------------------
+/**
+ * Fill in HepMC parton distribution function table from event
+ * generator header
+ *
+ * @param cursor      Cursor over o2::aod::HepMCXSections table
+ * @param collisionID Identifier of collision (as given updateMCCollision)
+ * @param generatorID Encoded generator ID
+ * @param header      Event header from generator
+ * @param anyNotAll   If true, then any key present trigger and update.
+ *                    If false, then all keys must be present to update
+ *                    the table.
+ *
+ * @return true if table was updated
+ */
+bool updateHepMCPdfInfo(const PdfInfoCursor& cursor,
+                        int collisionID,
+                        short generatorID,
+                        o2::dataformats::MCEventHeader const& header,
+                        HepMCUpdate when = HepMCUpdate::anyKey);
+//--------------------------------------------------------------------
+/**
+ * Fill in HepMC heavy-ion table from generator event header.
+ *
+ * @param cursor      Cursor over o2::aod::HepMCXSections table
+ * @param collisionID Identifier of collision (as given updateMCCollision)
+ * @param generatorID Encoded generator ID
+ * @param header      Event header from generator
+ * @param anyNotAll   If true, then any key present trigger and update.
+ *                    If false, then all keys must be present to update
+ *                    the table.
+ *
+ * @return true if table was updated
+ */
+bool updateHepMCHeavyIon(const HeavyIonCursor& cursor,
+                         int collisionID,
+                         short generatorID,
+                         o2::dataformats::MCEventHeader const& header,
+                         HepMCUpdate when = HepMCUpdate::anyKey);
+//--------------------------------------------------------------------
+/**
+ * Type of mapping from track number to row index
+ */
+using TrackToIndex = std::unordered_map<int, int>;
+//--------------------------------------------------------------------
+/**
+ * Update aod::McParticles table with information from an MC track.
+ *
+ * @param cursor       Cursor over aod::McParticles table
+ * @param mapping      Maps track number to index in table
+ * @param collisionID  Collision identifier
+ * @param track        Track to update table with
+ * @param tracks       List of all tracks of current collision
+ * @param flags        Base flags of this track
+ * @param weightMask   Mask on weight floating point value
+ * @param momentumMask Mask on momentum floating point values
+ * @param positionMask Mask on position floating point values
+ */
+void updateParticle(const ParticleCursor& cursor,
+                    const TrackToIndex& toStore,
+                    int collisionID,
+                    o2::MCTrack const& track,
+                    std::vector<MCTrack> const& tracks,
+                    uint8_t flags = 0,
+                    uint32_t weightMask = 0xFFFFFFF0,
+                    uint32_t momentumMask = 0xFFFFFFF0,
+                    uint32_t positionMask = 0xFFFFFFF0);
+//--------------------------------------------------------------------
+/**
+ * Update aod::McParticles table with tracks from MC.
+ *
+ * To add particles from many events, one will do
+ *
+ * @code
+ * TrackToIndex preselect = findMcTracksToStore(...);
+ *
+ * size_t offset = 0;
+ * for (auto event : events)
+ *    offset = updateParticles(cursor,
+ *                             event.getCollisionID(),
+ *                             event.getTracks(),
+ *                             offset,
+ *                             filter,
+ *                             event.isBackground(),
+ *                             preselect);
+ * @endcode
+ *
+ * Here @a preselect must be a map from track number to a positive
+ * value.  Tracks that are mapped as such in @a preselect are stored
+ * in addition to other tracks selected by the function.  Note that @a
+ * preselect may be empty.
+ *
+ * If @a filter is false, then @a all tracks will be stored.
+ *
+ * If @a filter is true, then tracks that are
+ *
+ * - generated by the generator,
+ * - physical primaries
+ *   (MCTrackNavigator::isPhysicalPrimary),
+ * - to be kept for physics
+ *   (MCTrackNavigator::isKeepPhysics), or
+ * - is listed with a positive value in @a preselect, or
+ * - either a mother or daughter of one such track, then
+ *
+ * that track is kept
+ *
+ * On return, the @a preselect will map from track number (index in
+ * the @a tracks container) to the table row index (including offset
+ * from previous events in the same time-frame).
+ *
+ * @param cursor       Cursor over aod::McParticles
+ * @param int          Collision identifier
+ * @param tracks       List of all tracks of current collision
+ * @param offset       Index just beyond last table entry
+ * @param filter       Filter tracks
+ * @param background   True of from background event
+ * @param preselect    Mapping of preselected tracks
+ * @param weightMask   Mask on weight floating point value
+ * @param momentumMask Mask on momentum floating point values
+ * @param positionMask Mask on position floating point values
+ *
+ * @return Index beyond the last particle added to table
+ */
+uint32_t updateParticles(const ParticleCursor& cursor,
+                         int collisionID,
+                         std::vector<MCTrack> const& tracks,
+                         TrackToIndex& preselect,
+                         uint32_t offset = 0,
+                         bool filter = false,
+                         bool background = false,
+                         uint32_t weightMask = 0xFFFFFFF0,
+                         uint32_t momentumMask = 0xFFFFFFF0,
+                         uint32_t positionMask = 0xFFFFFFF0);
+} // namespace o2::aodmchelpers
+
+#endif /* O2_AODMCPRODUCER_HELPERS */
+// Local Variables:
+//   mode: C++
+// End:

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerHelpers.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerHelpers.h
@@ -20,6 +20,7 @@
 #include <boost/unordered_map.hpp>
 #include <string>
 #include <vector>
+#include <Framework/AnalysisHelpers.h>
 
 namespace o2::aodhelpers
 {
@@ -48,6 +49,15 @@ struct TripletEqualTo {
 
 typedef boost::unordered_map<Triplet_t, int, TripletHash, TripletEqualTo> TripletsMap_t;
 
+template <typename T>
+framework::Produces<T> createTableCursor(framework::ProcessingContext& pc)
+{
+  framework::Produces<T> c;
+  c.resetCursor(pc.outputs()
+                  .make<framework::TableBuilder>(framework::OutputForTable<T>::ref()));
+  c.setLabel(o2::aod::MetadataTrait<T>::metadata::tableLabel());
+  return c;
+}
 } // namespace o2::aodhelpers
 
 #endif /* O2_AODPRODUCER_HELPERS */

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -14,6 +14,7 @@
 #ifndef O2_AODPRODUCER_WORKFLOW_SPEC
 #define O2_AODPRODUCER_WORKFLOW_SPEC
 
+#include "AODMcProducerHelpers.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "DataFormatsPHOS/Cell.h"
@@ -63,11 +64,19 @@ class BunchCrossings
   /// return the sorted vector of increaing BC times
   std::vector<uint64_t> const& getBCTimeVector() const { return mBCTimeVector; }
 
-  /// Performs a "lower bound" search for timestamp within the bunch crossing data.
-  /// Returns the smallest bunch crossing (index and value) equal or greater than timestamp.
-  /// The functions is expected to perform much better than
-  /// a binary search in the bunch crossing data directly. Expect O(1) instead of O(log(N)) at the cost
-  /// of the additional memory used by this class.
+  /// Performs a "lower bound" search for timestamp within the bunch
+  /// crossing data.
+  ///
+  /// Returns the smallest bunch crossing (index and value) equal or
+  /// greater than timestamp.
+  ///
+  /// The functions is expected to perform much better than a binary
+  /// search in the bunch crossing data directly. Expect O(1) instead
+  /// of O(log(N)) at the cost of the additional memory used by this
+  /// class.
+  ///
+  /// This is _not_ O(1).  The loop below makes it at least O(N).  The
+  /// call to std::lower_bound is O(log(N)).
   std::pair<size_t, uint64_t> lower_bound(uint64_t timestamp) const
   {
     // a) determine the timewindow
@@ -216,15 +225,6 @@ class AODProducerWorkflowDPL : public Task
   uint64_t relativeTime_to_GlobalBC(double relativeTimeStampInNS) const
   {
     return std::uint64_t(mStartIR.toLong()) + relativeTime_to_LocalBC(relativeTimeStampInNS);
-  }
-
-  template <typename T>
-  Produces<T> createTableCursor(ProcessingContext& pc)
-  {
-    Produces<T> c;
-    c.resetCursor(pc.outputs().make<TableBuilder>(OutputForTable<T>::ref()));
-    c.setLabel(o2::aod::MetadataTrait<T>::metadata::tableLabel());
-    return c;
   }
 
   bool mPropTracks{false};
@@ -541,9 +541,68 @@ class AODProducerWorkflowDPL : public Task
   template <typename V0C, typename CC, typename D3BC>
   void fillStrangenessTrackingTables(const o2::globaltracking::RecoContainer& data, V0C& v0Cursor, CC& cascadeCursor, D3BC& decay3bodyCursor);
 
-  template <typename MCParticlesCursorType>
+  /** some other types we will use */
+  using MCCollisionCursor = aodmchelpers::CollisionCursor;
+  using XSectionCursor = aodmchelpers::XSectionCursor;
+  using PdfInfoCursor = aodmchelpers::PdfInfoCursor;
+  using HeavyIonCursor = aodmchelpers::HeavyIonCursor;
+  using MCParticlesCursor = aodmchelpers::ParticleCursor;
+  using HepMCUpdate = aodmchelpers::HepMCUpdate;
+  using MCEventHeader = dataformats::MCEventHeader;
+  /** Rules for when to update HepMC tables */
+  HepMCUpdate mXSectionUpdate = HepMCUpdate::anyKey;
+  HepMCUpdate mPdfInfoUpdate = HepMCUpdate::anyKey;
+  HepMCUpdate mHeavyIonUpdate = HepMCUpdate::anyKey;
+  /**
+   * Update the header (collision and HepMC aux) information.
+   *
+   * When updating the HepMC aux tables, we take the relevant policies
+   * into account (mXSectionUpdate, mPdfInfoUpdate, mHeavyIonUpdate).
+   *
+   * - If a policy is "never", then the corresponding table is never
+   *   updated.
+   *
+   * - If the policy is "always", then the table is always
+   *   update.
+   *
+   * - If the policy is either "anyKey" or "allKeys", _and_
+   *   this is the first event, then we check if any or all keys,
+   *   respectively are present in the header.
+   *
+   *   - If that check fails, then we do not update and set the
+   *     corresponding policy to be "never".
+   *
+   *   - If the check succeeds, then we do update the table, and set
+   *     the corresponding policty to "always".
+   *
+   *   In this way, we will let the first event decide what to do for
+   *   subsequent events and thus avoid too many string comparisions.
+   *
+   * @param collisionCursor Cursor over aod::McCollisions
+   * @param xSectionCursor Cursor over aod::HepMCXSections
+   * @param pdfInfoCursor Cursor over aod::HepMCPdfInfos
+   * @param heavyIonCursor Cursor over aod::HepMCHeavyIons
+   * @param header Header to read information from
+   * @param collisionID Index of collision in the table
+   * @param bcID Current event identifier (bcID)
+   * @param time Time of event
+   * @param generatorID Generator identifier, if any
+   * @param sourceID Source identifier
+   *
+   */
+  void updateMCHeader(MCCollisionCursor& collisionCursor,
+                      XSectionCursor& xSectionCursor,
+                      PdfInfoCursor& pdfInfoCursor,
+                      HeavyIonCursor& heavyIonCursor,
+                      const MCEventHeader& header,
+                      int collisionID,
+                      int bcID,
+                      float time,
+                      short generatorID,
+                      int sourceID);
+
   void fillMCParticlesTable(o2::steer::MCKinematicsReader& mcReader,
-                            MCParticlesCursorType& mcParticlesCursor,
+                            MCParticlesCursor& mcParticlesCursor,
                             const gsl::span<const o2::dataformats::VtxTrackRef>& primVer2TRefs,
                             const gsl::span<const GIndex>& GIndices,
                             const o2::globaltracking::RecoContainer& data,

--- a/Detectors/AOD/src/AODMcProducerHelpers.cxx
+++ b/Detectors/AOD/src/AODMcProducerHelpers.cxx
@@ -1,0 +1,431 @@
+// Copyright 2023-2099 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   AODMcProducerHelpers.h
+/// @author Christian Holm Christensen <cholm@nbi.dk>
+/// common helpers for AOD MC producers
+#include "AODProducerWorkflow/AODMcProducerHelpers.h"
+#include <SimulationDataFormat/MCUtils.h>
+#include <Framework/AnalysisDataModel.h>
+#include <MathUtils/Utils.h>
+#include <algorithm>
+#define verbosity debug
+
+namespace o2::aodmchelpers
+{
+//==================================================================
+bool hasKeys(o2::dataformats::MCEventHeader const& header,
+             const std::vector<std::string>& keys,
+             bool anyNotAll)
+{
+  auto check = [&header](const std::string& key) { // Do not format
+    return header.hasInfo(key);
+  };
+  return (anyNotAll ? // Do not format
+            std::any_of(keys.cbegin(), keys.cend(), check)
+                    : // Do not format
+            std::all_of(keys.cbegin(), keys.cend(), check));
+}
+//====================================================================
+short updateMCCollisions(const CollisionCursor& cursor,
+                         int bcId,
+                         float time,
+                         o2::dataformats::MCEventHeader const& header,
+                         short generatorId,
+                         int sourceId,
+                         unsigned int mask)
+{
+  using Key = o2::dataformats::MCInfoKeys;
+  using GenProp = o2::mcgenid::GeneratorProperty;
+  using namespace o2::math_utils;
+
+  int subGenId = getEventInfo(header, GenProp::SUBGENERATORID, -1);
+  int genId = getEventInfo(header, GenProp::GENERATORID,
+                           int(generatorId));
+  float weight = getEventInfo(header, Key::weight, 1.f);
+
+  auto encodedGeneratorId = o2::mcgenid::getEncodedGenId(genId,
+                                                         sourceId,
+                                                         subGenId);
+
+  LOG(verbosity) << "Updating MC Collisions table w/bcId=" << bcId;
+  cursor(0,
+         bcId,
+         encodedGeneratorId,
+         truncateFloatFraction(header.GetX(), mask),
+         truncateFloatFraction(header.GetY(), mask),
+         truncateFloatFraction(header.GetZ(), mask),
+         truncateFloatFraction(time, mask),
+         truncateFloatFraction(weight, mask),
+         header.GetB());
+  return encodedGeneratorId;
+}
+//--------------------------------------------------------------------
+bool updateHepMCXSection(const XSectionCursor& cursor,
+                         int collisionID,
+                         short generatorID,
+                         o2::dataformats::MCEventHeader const& header,
+                         HepMCUpdate when)
+{
+  using Key = o2::dataformats::MCInfoKeys;
+
+  if (when == HepMCUpdate::never or
+      (when != HepMCUpdate::always and
+       not hasKeys(header, {                      // Do not
+                            Key::acceptedEvents,  // mess with
+                            Key::attemptedEvents, // with
+                            Key::xSection,        // my
+                            Key::xSectionError},  // formatting
+                   when == HepMCUpdate::anyKey))) {
+    return false;
+  }
+
+  LOG(verbosity) << "Updating HepMC cross-section table w/collisionId "
+                 << collisionID;
+  cursor(0,
+         collisionID,
+         generatorID,
+         getEventInfo(header, Key::acceptedEvents, 0),
+         getEventInfo(header, Key::attemptedEvents, 0),
+         getEventInfo(header, Key::xSection, 0.f),
+         getEventInfo(header, Key::xSectionError, 0.f),
+         getEventInfo(header, "ptHard", 1.f),
+         getEventInfo(header, "MPI", -1),
+         getEventInfo(header, "processId", -1));
+  return true;
+}
+//--------------------------------------------------------------------
+bool updateHepMCPdfInfo(const PdfInfoCursor& cursor,
+                        int collisionID,
+                        short generatorID,
+                        o2::dataformats::MCEventHeader const& header,
+                        HepMCUpdate when)
+{
+  using Key = o2::dataformats::MCInfoKeys;
+
+  if (when == HepMCUpdate::never or
+      (when != HepMCUpdate::always and         // Do
+       not hasKeys(header, {Key::pdfParton1Id, // not
+                            Key::pdfParton2Id, // mess
+                            Key::pdfCode1,     // with
+                            Key::pdfCode2,     // my
+                            Key::pdfX1,        // formatting
+                            Key::pdfX2,        // .
+                            Key::pdfScale,     // It
+                            Key::pdfXF1,       // is
+                            Key::pdfXF2},      // better
+                   when == HepMCUpdate::anyKey))) {
+    return false;
+  }
+
+  LOG(verbosity) << "Updating HepMC PDF table w/collisionId " << collisionID;
+  cursor(0,
+         collisionID,
+         generatorID,
+         getEventInfo(header, Key::pdfParton1Id, int(0)),
+         getEventInfo(header, Key::pdfParton2Id, int(0)),
+         getEventInfo(header, Key::pdfCode1, int(0)),
+         getEventInfo(header, Key::pdfCode2, int(0)),
+         getEventInfo(header, Key::pdfX1, 0.f),
+         getEventInfo(header, Key::pdfX2, 0.f),
+         getEventInfo(header, Key::pdfScale, 1.f),
+         getEventInfo(header, Key::pdfXF1, 0.f),
+         getEventInfo(header, Key::pdfXF2, 0.f));
+
+  return true;
+}
+//--------------------------------------------------------------------
+bool updateHepMCHeavyIon(const HeavyIonCursor& cursor,
+                         int collisionID,
+                         short generatorID,
+                         o2::dataformats::MCEventHeader const& header,
+                         HepMCUpdate when)
+{
+  using Key = dataformats::MCInfoKeys;
+
+  if (when == HepMCUpdate::never or
+      (when != HepMCUpdate::always and                   // clang
+       not hasKeys(header, {Key::nCollHard,              // format
+                            Key::nPartProjectile,        // is
+                            Key::nPartTarget,            // so
+                            Key::nColl,                  // annoying
+                            Key::nCollNNWounded,         // .
+                            Key::nCollNWoundedN,         // It
+                            Key::nCollNWoundedNwounded,  // messes
+                            Key::nSpecProjectileNeutron, // up
+                            Key::nSpecTargetNeutron,     // the
+                            Key::nSpecProjectileProton,  // clarity
+                            Key::nSpecTargetProton,      // of
+                            Key::planeAngle,             // the
+                            "eccentricity",              // code
+                            Key::sigmaInelNN,            // to
+                            Key::centrality},            // noavail
+                   when == HepMCUpdate::anyKey))) {
+    return false;
+  }
+
+  int specNeutrons = (getEventInfo(header, Key::nSpecProjectileNeutron, -1) +
+                      getEventInfo(header, Key::nSpecTargetNeutron, -1));
+  int specProtons = (getEventInfo(header, Key::nSpecProjectileProton, -1) +
+                     getEventInfo(header, Key::nSpecTargetProton, -1));
+
+  LOG(verbosity) << "Updating HepMC heavy-ion table w/collisionID "
+                 << collisionID;
+  cursor(0,
+         collisionID,
+         generatorID,
+         getEventInfo(header, Key::nCollHard, -1),
+         getEventInfo(header, Key::nPartProjectile, -1),
+         getEventInfo(header, Key::nPartTarget, -1),
+         getEventInfo(header, Key::nColl, -1),
+         getEventInfo(header, Key::nCollNNWounded, -1),
+         getEventInfo(header, Key::nCollNWoundedN, -1),
+         getEventInfo(header, Key::nCollNWoundedNwounded, -1),
+         specNeutrons,
+         specProtons,
+         header.GetB(),
+         getEventInfo(header, Key::planeAngle, header.GetRotZ()),
+         getEventInfo(header, "eccentricity", 0),
+         getEventInfo(header, Key::sigmaInelNN, 0.),
+         getEventInfo(header, Key::centrality, -1));
+
+  return true;
+}
+//--------------------------------------------------------------------
+void updateParticle(const ParticleCursor& cursor,
+                    const TrackToIndex& toStore,
+                    int collisionID,
+                    o2::MCTrack const& track,
+                    std::vector<MCTrack> const& tracks,
+                    uint8_t flags,
+                    uint32_t weightMask,
+                    uint32_t momentumMask,
+                    uint32_t positionMask)
+{
+  using o2::mcutils::MCTrackNavigator;
+  using namespace o2::aod::mcparticle::enums;
+  using namespace o2::math_utils;
+  using namespace o2::mcgenstatus;
+
+  auto mapping = [&toStore](int trackNo) {
+    auto iter = toStore.find(trackNo);
+    if (iter == toStore.end()) {
+      return -1;
+    }
+    return iter->second;
+  };
+
+  auto statusCode = track.getStatusCode().fullEncoding;
+  auto hepmc = getHepMCStatusCode(track.getStatusCode());
+  if (not track.isPrimary()) {
+    flags |= ProducedByTransport;
+    statusCode = track.getProcess();
+  }
+  if (MCTrackNavigator::isPhysicalPrimary(track, tracks)) {
+    flags |= PhysicalPrimary;
+  }
+
+  int daughters[2] = {-1, -1};
+  std::vector<int> mothers;
+  int id;
+  if ((id = mapping(track.getMotherTrackId())) >= 0) {
+    mothers.push_back(id);
+  }
+  if ((id = mapping(track.getSecondMotherTrackId())) >= 0) {
+    mothers.push_back(id);
+  }
+  if ((id = mapping(track.getFirstDaughterTrackId())) >= 0) {
+    daughters[0] = id;
+  }
+  if ((id = mapping(track.getFirstDaughterTrackId())) >= 0) {
+    daughters[1] = id;
+  } else {
+    daughters[1] = daughters[0];
+  }
+  if (daughters[0] < 0 and daughters[1] >= 0) {
+    LOG(error) << "Problematic daughters: " << daughters[0] << " and "
+               << daughters[1];
+    daughters[0] = daughters[1];
+  }
+  if (daughters[0] > daughters[1]) {
+    std::swap(daughters[0], daughters[1]);
+  }
+
+  float weight = track.getWeight();
+  float pX = float(track.Px());
+  float pY = float(track.Py());
+  float pZ = float(track.Pz());
+  float energy = float(track.GetEnergy());
+  float vX = float(track.Vx());
+  float vY = float(track.Vy());
+  float vZ = float(track.Vz());
+  float time = float(track.T());
+
+  LOG(verbosity) << "McParticle collisionId=" << collisionID << ","
+                 << "status=" << statusCode << ","
+                 << "hepmc=" << hepmc << ","
+                 << "pdg=" << track.GetPdgCode() << ","
+                 << "nMothers=" << mothers.size() << ","
+                 << "daughters=" << daughters[0] << ","
+                 << daughters[1];
+
+  cursor(0,
+         collisionID,
+         track.GetPdgCode(),
+         statusCode,
+         flags,
+         mothers,
+         daughters,
+         truncateFloatFraction(weight, weightMask),
+         truncateFloatFraction(pX, momentumMask),
+         truncateFloatFraction(pY, momentumMask),
+         truncateFloatFraction(pZ, momentumMask),
+         truncateFloatFraction(energy, momentumMask),
+         truncateFloatFraction(vX, positionMask),
+         truncateFloatFraction(vY, positionMask),
+         truncateFloatFraction(vZ, positionMask),
+         truncateFloatFraction(time, positionMask));
+}
+//--------------------------------------------------------------------
+uint32_t updateParticles(const ParticleCursor& cursor,
+                         int collisionID,
+                         std::vector<MCTrack> const& tracks,
+                         TrackToIndex& preselect,
+                         uint32_t offset,
+                         bool filter,
+                         bool background,
+                         uint32_t weightMask,
+                         uint32_t momentumMask,
+                         uint32_t positionMask)
+{
+  using o2::mcutils::MCTrackNavigator;
+  using namespace o2::aod::mcparticle::enums;
+  using namespace o2::mcgenstatus;
+
+  // First loop over particles to find out which to store
+  // TrackToIndex toStore(preselect.begin(), preselect.end());
+  //
+  // Guess we need to modifiy the passed in mapping so that MC labels
+  // can be set correctly
+  TrackToIndex& toStore = preselect;
+
+  // Mapping lambda.  This maps the track number to the index into
+  // the table exported.
+  auto mapping = [&toStore](int trackNo) {
+    auto iter = toStore.find(trackNo);
+    if (iter == toStore.end()) {
+      return -1;
+    }
+    return iter->second;
+  };
+
+  LOG(verbosity) << "Got a total of " << tracks.size();
+  for (int trackNo = tracks.size() - 1; trackNo >= 0; trackNo--) {
+    auto& track = tracks[trackNo];
+    auto hepmc = getHepMCStatusCode(track.getStatusCode());
+    if (filter) {
+      if (toStore.find(trackNo) == toStore.end() and
+          /* The above test is in-correct.  The track may be stored in
+             the list, but with a negative value.  In that case, the
+             above test will still check mothers and daughters, and
+             possible store them in the output.  This is however how
+             it is done in current `dev` branch, and so to enable
+             comparison on closure, we do this test for now.  The
+             correct way it commented out below. */
+          // mapping(trackNo) < 0 and
+          not track.isPrimary() and
+          not MCTrackNavigator::isPhysicalPrimary(track, tracks) and
+          not MCTrackNavigator::isKeepPhysics(track, tracks)) {
+        LOG(verbosity) << "Skipping track " << trackNo << " " << hepmc << " "
+                       << mapping(trackNo) << " "
+                       << track.isPrimary() << " "
+                       << MCTrackNavigator::isPhysicalPrimary(track, tracks)
+                       << " "
+                       << MCTrackNavigator::isKeepPhysics(track, tracks);
+        continue;
+      }
+    }
+
+    // Store this particle.  We mark that putting a 1 in the
+    // `toStore` mapping. This will later on be updated with the
+    // actual index into the table
+    toStore[trackNo] = 1;
+
+    // If we're filtering tracks, then also mark mothers and
+    // daughters(?) to be stored.
+    if (filter) {
+      int id;
+      if ((id = track.getMotherTrackId()) >= 0) {
+        toStore[id] = 1;
+      }
+      if ((id = track.getSecondMotherTrackId()) >= 0) {
+        toStore[id] = 1;
+      }
+      if ((id = track.getFirstDaughterTrackId()) >= 0) {
+        toStore[id] = 1;
+      }
+      if ((id = track.getLastDaughterTrackId()) >= 0) {
+        toStore[id] = 1;
+      }
+    }
+  }
+
+  // Second loop to set indexes.  This is needed to be done before
+  // we actually update the table, because a particle may point to a
+  // later particle.
+  LOG(verbosity) << "Will store " << toStore.size() << " particles";
+  size_t index = 0;
+
+  for (size_t trackNo = 0U; trackNo < tracks.size(); trackNo++) {
+    auto storeIt = mapping(trackNo);
+    if (storeIt < 0) {
+      continue;
+    }
+
+    toStore[trackNo] = offset + index;
+    index++;
+  }
+
+  // Make sure we have the right number
+  assert(index == toStore.size());
+  LOG(verbosity) << "Starting index " << offset << ", last index "
+                 << offset + index << " "
+                 << "Selected " << toStore.size() << " tracks out of "
+                 << tracks.size() << " "
+                 << "Collision # " << collisionID;
+  // Third loop to actually store the particles in the order given
+  for (size_t trackNo = 0U; trackNo < tracks.size(); trackNo++) {
+    auto storeIt = mapping(trackNo);
+    if (storeIt < 0) {
+      continue;
+    }
+
+    auto& track = tracks[trackNo];
+    auto hepmc = getHepMCStatusCode(track.getStatusCode());
+    uint8_t flags = (background ? FromBackgroundEvent : 0);
+    updateParticle(cursor,
+                   toStore,
+                   collisionID,
+                   track,
+                   tracks,
+                   flags,
+                   weightMask,
+                   momentumMask,
+                   positionMask);
+  }
+  LOG(verbosity) << "Return new offset " << offset + index;
+  return offset + index;
+}
+} // namespace o2::aodmchelpers
+
+// Local Variables:
+//   mode: C++
+// End:

--- a/Detectors/AOD/src/aod-mc-producer-workflow.cxx
+++ b/Detectors/AOD/src/aod-mc-producer-workflow.cxx
@@ -41,3 +41,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   wf.emplace_back(o2::aodmcproducer::getAODMcProducerWorkflowSpec());
   return std::move(wf);
 }
+//
+// EOF
+//

--- a/Generators/include/Generators/AODToHepMC.h
+++ b/Generators/include/Generators/AODToHepMC.h
@@ -24,6 +24,7 @@
 #include <HepMC3/GenCrossSection.h>
 #include <HepMC3/WriterAscii.h>
 #include <fstream>
+#define AODTOHEPMC_WITH_HEAVYION
 
 namespace o2
 {
@@ -391,6 +392,11 @@ struct AODToHepMC {
    */
   virtual void init();
   /**
+   * Call before starting to process an event.  This clears the
+   * current event and internal data structures.
+   */
+  virtual void startEvent();
+  /**
    * Process the collision header and tracks
    *
    * @param collision Header information
@@ -407,8 +413,17 @@ struct AODToHepMC {
    */
   virtual void process(Header const& collision,
                        XSections const& xsections,
-                       PdfInfos const& pdfs,
-                       HeavyIons const& heavyions);
+                       PdfInfos const& pdfs
+#ifdef AODTOHEPMC_WITH_HEAVYION
+                       ,
+                       HeavyIons const& heavyions
+#endif
+  );
+  /**
+   * Call after process an.  Thisf finalises the event and optionally
+   * outputs to dump.
+   */
+  virtual void endEvent();
   /**
    * End of run - closes output file if enabled.  This is called via
    * specialisation of o2::framework::OutputManager<AODToHepMC>.

--- a/Generators/src/AODToHepMC.cxx
+++ b/Generators/src/AODToHepMC.cxx
@@ -75,8 +75,9 @@ void AODToHepMC::process(Header const& collision,
 void AODToHepMC::endEvent()
 {
   LOG(debug) << "<<< an event";
-  if (not mWriter)
+  if (not mWriter) {
     return;
+  }
   // If we have a writer, then dump event to output file
   mWriter->write_event(mEvent);
 }

--- a/Generators/src/AODToHepMC.cxx
+++ b/Generators/src/AODToHepMC.cxx
@@ -35,15 +35,20 @@ void AODToHepMC::init()
              << "  Output precision:      " << mPrecision;
 }
 // -------------------------------------------------------------------
-void AODToHepMC::process(Header const& collision,
-                         Tracks const& tracks)
+void AODToHepMC::startEvent()
 {
-  LOG(debug) << "--- Processing track information";
+  LOG(debug) << ">>> Starting an event";
   mBeams.clear();
   mOrphans.clear();
   mParticles.clear();
   mVertices.clear();
   mEvent.clear();
+}
+// -------------------------------------------------------------------
+void AODToHepMC::process(Header const& collision,
+                         Tracks const& tracks)
+{
+  LOG(debug) << "--- Processing track information";
 
   makeHeader(collision);
   makeParticles(tracks);
@@ -52,13 +57,28 @@ void AODToHepMC::process(Header const& collision,
 // -------------------------------------------------------------------
 void AODToHepMC::process(Header const& collision,
                          XSections const& xsections,
-                         PdfInfos const& pdfs,
-                         HeavyIons const& heavyions)
+                         PdfInfos const& pdfs
+#ifdef AODTOHEPMC_WITH_HEAVYION
+                         ,
+                         HeavyIons const& heavyions
+#endif
+)
 {
   LOG(debug) << "--- Processing auxiliary information";
   makeXSection(xsections);
   makePdfInfo(pdfs);
+#ifdef AODTOHEPMC_WITH_HEAVYION
   makeHeavyIon(heavyions, collision);
+#endif
+}
+// -------------------------------------------------------------------
+void AODToHepMC::endEvent()
+{
+  LOG(debug) << "<<< an event";
+  if (not mWriter)
+    return;
+  // If we have a writer, then dump event to output file
+  mWriter->write_event(mEvent);
 }
 // ===================================================================
 void AODToHepMC::makeEvent(Header const& collision,
@@ -105,10 +125,6 @@ void AODToHepMC::makeEvent(Header const& collision,
   }
   // Flesh out the tracks based on daughter information.
   fleshOut(tracks);
-  if (mWriter) {
-    // If we have a writer, then dump event to output file
-    mWriter->write_event(mEvent);
-  }
 }
 // -------------------------------------------------------------------
 void AODToHepMC::makeHeader(Header const& header)
@@ -134,6 +150,7 @@ void AODToHepMC::makeHeader(Header const& header)
 // -------------------------------------------------------------------
 void AODToHepMC::makeXSection(XSections const& xsections)
 {
+  LOG(debug) << "--- Process cross-section information";
   if (not mCrossSec) {
     // If we do not have a cross-sections object, create it
     mCrossSec = std::make_shared<HepMC3::GenCrossSection>();
@@ -144,6 +161,7 @@ void AODToHepMC::makeXSection(XSections const& xsections)
 
   if (xsections.size() <= 0) {
     // If we have no info, skip the rest
+    LOG(warning) << "??? No input cross-section";
     return;
   }
 
@@ -156,6 +174,7 @@ void AODToHepMC::makeXSection(XSections const& xsections)
 // -------------------------------------------------------------------
 void AODToHepMC::makePdfInfo(PdfInfos const& pdfs)
 {
+  LOG(debug) << "--- Process PDF information";
   if (not mPdf) {
     // If we do not have a Parton Distribution Function object, create it
     mPdf = std::make_shared<HepMC3::GenPdfInfo>();
@@ -166,6 +185,7 @@ void AODToHepMC::makePdfInfo(PdfInfos const& pdfs)
 
   if (pdfs.size() <= 0) {
     // If we have no PDF info, skip the rest
+    LOG(warning) << "??? No input pdf-info, skipping";
     return;
   }
 
@@ -184,6 +204,7 @@ void AODToHepMC::makePdfInfo(PdfInfos const& pdfs)
 void AODToHepMC::makeHeavyIon(HeavyIons const& heavyions,
                               Header const& header)
 {
+  LOG(debug) << "--- Process input heavy-ion header";
   if (not mIon) {
     // Generate heavy ion element if it doesn't exist
     mIon = std::make_shared<HepMC3::GenHeavyIon>();
@@ -215,6 +236,7 @@ void AODToHepMC::makeHeavyIon(HeavyIons const& heavyions,
 
   if (heavyions.size() <= 0) {
     // If we have no heavy-ion information, skip the rest
+    LOG(warning) << "??? No input heavy-ion header, skipping";
     return;
   }
 

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -125,8 +125,11 @@ o2_add_executable(hepmc-publisher
 
 o2_add_executable(mctracks-to-aod
                   COMPONENT_NAME sim
-                  SOURCES o2sim_mctracks_to_aod.cxx
+                  SOURCES o2sim_mctracks_to_aod.cxx ../Detectors/AOD/src/AODMcProducerHelpers.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::SimulationDataFormat)
+target_include_directories(O2exe-sim-mctracks-to-aod
+                           PRIVATE
+                          ../Detectors/AOD/include)
 
 o2_add_executable(mc-to-hepmc
                   COMPONENT_NAME aod

--- a/run/o2aod_mc_to_hepmc.cxx
+++ b/run/o2aod_mc_to_hepmc.cxx
@@ -11,10 +11,34 @@
 
 /** @author Christian Holm Christensen <cholm@nbi.dk> */
 
-#include <Framework/runDataProcessing.h>
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
 #include <Generators/AODToHepMC.h>
+// #define HEPMC_PROCESS_AUX
+
+#ifndef HEPMC_PROCESS_AUX
+//--------------------------------------------------------------------
+using o2::framework::ConfigParamKind;
+using o2::framework::ConfigParamSpec;
+
+// -------------------------------------------------------------------
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  using o2::framework::VariantType;
+
+  workflowOptions.emplace_back(ConfigParamSpec{"hepmc-aux",               //
+                                               VariantType::Bool,         //
+                                               false,                     //
+                                               {"Also process auxiliary " //
+                                                "HepMC tables"},
+                                               ConfigParamKind::kProcessFlag});
+}
+#endif
+
+//--------------------------------------------------------------------
+// This _must_ be included after our "customize" function above, or
+// that function will not be taken into account.
+#include <Framework/runDataProcessing.h>
 
 //--------------------------------------------------------------------
 /** Task to convert AOD MC tables into HepMC event structure
@@ -74,18 +98,84 @@ struct Task1 {
   void process(Header const& collision,
                XSections const& xsections,
                PdfInfos const& pdfs,
+#ifdef AODTOHEPMC_WITH_HEAVYION
                HeavyIons const& heavyions,
+#endif
                Tracks const& tracks)
   {
     LOG(debug) << "=== Processing everything ===";
+    mConverter.startEvent();
     mConverter.process(collision,
                        xsections,
-                       pdfs,
-                       heavyions);
+                       pdfs
+#ifdef AODTOHEPMC_WITH_HEAVYION
+                       ,
+                       heavyions
+#endif
+    );
     mConverter.process(collision, tracks);
+    mConverter.endEvent();
   }
 };
 
+//--------------------------------------------------------------------
+/**
+ * Same as Task1 above, except only header and tracks are processed.
+ *
+ *  - @c o2::aod::McCollisions
+ *  - @c o2::aod::McParticles
+ *
+ */
+struct Task2 {
+  /** Alias the converter type */
+  using Converter = o2::eventgen::AODToHepMC;
+
+  /** Our converter */
+  Converter mConverter;
+
+  /** @{
+   * @name Container types */
+  /** Alias converter header table type */
+  using Headers = Converter::Headers;
+  /** Alias converter header type */
+  using Header = Converter::Header;
+  /** Alias converter track table type */
+  using Tracks = Converter::Tracks;
+  /** Alias converter cross-section table type */
+  using XSections = Converter::XSections;
+  /** Alias converter cross-section type */
+  using XSection = Converter::XSection;
+  /** Alias converter parton distribution function table type */
+  using PdfInfos = Converter::PdfInfos;
+  /** Alias converter parton distribution function type */
+  using PdfInfo = Converter::PdfInfo;
+  /** Alias converter heavy-ions table type */
+  using HeavyIons = Converter::HeavyIons;
+  /** Alias converter heavy-ions type */
+  using HeavyIon = Converter::HeavyIon;
+  /** @} */
+
+  /** Initialize the job */
+  void init(o2::framework::InitContext& ic)
+  {
+    mConverter.init();
+  }
+  /** Default processing of an event
+   *
+   *  @param collision  Event header
+   *  @param tracks     Tracks of the event
+   */
+  void process(Header const& collision,
+               Tracks const& tracks)
+  {
+    LOG(debug) << "=== Processing only tracks ===";
+    mConverter.startEvent();
+    mConverter.process(collision, tracks);
+    mConverter.endEvent();
+  }
+};
+
+#ifdef HEPMC_PROCESS_AUX
 //--------------------------------------------------------------------
 /**
  *  Ideally, this application should work with the case where only
@@ -113,6 +203,12 @@ struct Task1 {
  *  - : TFN/TFNumber/0
  *  @endverbatim
  *
+ * Or
+ *
+ * @verbatim
+ * InputRecord::get: no input with binding HepMCHeavyIons found. Available inputs: McCollisions, McParticles
+ * @endverbatim
+ *
  *  Interstingly, the application @c o2-sim-mcevent-to-aod works fine
  *  on its own, e.g., like
  *
@@ -125,8 +221,20 @@ struct Task1 {
  *  @endverbatim
  *
  *  works fine.
+ *
+ * Actually, it is not likely that this will ever work.  The various
+ * process are done out of sync.  That is, first all input events of
+ * the timeframe are passed to the regular `process` method - i.e.,
+ * tracks and collision headers are processed.  Then all input events
+ * of the timeframe are passed to the optional `processAux` method -
+ * i.e., auxiliary tables and collision headers.
+ *
+ * That means that we cannot correlate the tracks and aux tables into
+ * one event, which is what we need to format a proper HepMC
+ * event. The reason why it could work in the above example is because
+ * we only process one timeframe at a time.
  */
-struct Task2 {
+struct Task3 {
   /** Alias the converter type */
   using Converter = o2::eventgen::AODToHepMC;
 
@@ -207,15 +315,16 @@ struct Task2 {
    * command line argument (@c --hepmc-aux) rather than to rely on an
    * auto-generated name (would be @ --processAux).
    */
-  decltype(o2::framework::ProcessConfigurable{&Task2::processAux,
+  decltype(o2::framework::ProcessConfigurable{&Task3::processAux,
                                               "hepmc-aux", false,
                                               "Process auxilirary "
                                               "information"})
-    doAux = o2::framework::ProcessConfigurable{&Task2::processAux,
+    doAux = o2::framework::ProcessConfigurable{&Task3::processAux,
                                                "hepmc-aux", false,
                                                "Process auxilirary "
                                                "information"};
 };
+#endif
 
 //--------------------------------------------------------------------
 using WorkflowSpec = o2::framework::WorkflowSpec;
@@ -229,9 +338,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
   using o2::framework::adaptAnalysisTask;
 
   // Task1: One entry: header, tracks, auxiliary
-  // Task2: Two entry: header, tracks, and auxiliary
+  // Task2: One entry: header, tracks
+  // Task3: Two entry: header, tracks, and auxiliary
+#ifndef HEPMC_PROCESS_AUX
+  if (cfg.options().get<bool>("hepmc-aux")) {
+    LOG(info) << "Creating full o2-aod-to-hepmc processor";
+    return WorkflowSpec{
+      adaptAnalysisTask<Task1>(cfg, TaskName{"o2-aod-to-hepmc"})};
+  }
+  LOG(info) << "Creating minimal o2-aod-to-hepmc processor";
   return WorkflowSpec{
-    adaptAnalysisTask<Task2>(cfg, TaskName{"o2-aod-mc-to-hepmc"})};
+    adaptAnalysisTask<Task2>(cfg, TaskName{"o2-aod-to-hepmc"})};
+#else
+  return WorkflowSpec{
+    adaptAnalysisTask<Task3>(cfg, TaskName{"o2-aod-mc-to-hepmc"})};
+#endif
 }
 //
 // EOF


### PR DESCRIPTION
The MC part of the AOD producer workflow
`o2::aodproducer::AODProducerWorkflowDPL` and
`o2::aodmcproducer::AODMcProducerWorkflowDPL` is refactored to use
functions from namespace `o2::aodmchelpers`.   The helpers are

- `updateMCCollisions` which takes in the `MCEventHeader` and writes to
  the `o2::aod::McCollisions` table.
- `updateHepMCXSection` which takes the `MCEventHeader` and writes to
  the `o2::aodHepMCSections` table.  This uses the predefined key
  constants as defined in `o2::dataformats::MCInfoKeys`
- `updateHepMCPdfInfo` similar to `updateHepMCXSection` above
- `updateHepMCHeavyIon` similar to `updateHepMCXSection` above
- `updateParticle` uses information from an `o2::MCTrack` and writes it
  to the `o2::aod::McParticles` table
- `updateParticles` loops over `o2::MCTrack` objects and calls
  `updateParticle`.

These functions, in particular `updateHepMC...` uses the functions
- `hasKeys` which checks if the `MCEventHeader` has any or all of the
  keys queried.
- `getEventInfo` gets auxiliary information from the `MCEventHeader` or
  a default value.

For the `o2::aod::HepMC...` tables: Depending on the policy parameter
passed to the `updateHepMC...` functions, these tables may or may not be
updated.
- If the policy is `HepMCUpdate::never` then the tables are never
  updated.
- If the policy is `HepMCUpdate::always` then the tables are _always_
  updated, possibly with default values.
- If the policy is `HepMCUpdate::anyKey` (default) or `HepMCUpdate::allKeys`, then
  the decision of what to do is taken on the first event seen.
  - If the policy is `HepMCUpdate::anyKey`, then if _any_ of the needed
    keys are present, then updating will be enabled for this and _all_
    subsequent events.
  - If the policy is `HepMCUpdate::allKeys`, then if _all_ of the needed
    keys are present, then updating will be enabled for this and _all_
    subsequent events.
  
  Note that the availability of keys is _not_ checked after the first
  event.

  That means, if the criteria isn't met on the first event, then
  the tables will _never_ be update (as if the policy was
  `HepMCUpdate::never`).

  On the other hand, if the criteria was met, than the tables _will_ be
  update an all events (as if the policy was `HepMCUpdate::always`).

Note the slightly tricky template `TableCursor` which allows us to
define a type that corresponds to a table cursor (which is really a
lambda).   This template could be moved to `AnalysisDataFormats.h` or
the like.

The applications `o2-aod-producer-workflow` and
`o2-aod-mc-producer-workflow` have been updated (via their respective
implementation classes) to use these tools, thus unifying how the MC
information is propagated to AODs.

The utility `o2-sim-mctracks-to-aod` (`run/o2sim_mctracks_to_aod.cxx`)
has _also_ been updated to use these common tools.

Both `o2-aod-mc-producer-workflow` and `o2-sim-mctracks-to-aod` has been
tested extensively.  `o2-aod-producer-workflow` has _not_ been tested
since it is not clear to me how to set-up such a test with limited
resources (I tried the `prodtest/full_system_test.sh` but it failed in unrelated places - can't remember exactly where - due to some missing digits or the like).  However, since the changes _only_ effect the MC part, and
that part is now common between the two `o2-aod-{,mc-}producer-workflow`
applications, I believe there is no reason to think that it wouldn't
work.

**Note** Currently the helper functions, implemented in `Detectors/AOD/src/AODMcProducerHelpers.cxx` are directly compiled into  `o2-aod-producer-workflow`, `o2-aod-mc-producer-workflow`, and  `o2-sim-mctracks-to-aod`.  Ideally the code in `Detectors/AOD/src/AODMcProducerHelpers.cxx`  should probably live in a shared library linked to by these three applications.  However, at the moment there's no clear - at least to me - library to put that code into. 

BTW, the list of commits looks really long (60+ commits), but that's only because this MR builds upon two previous MRs that have been merged.  The number of files changed is small (12), though some of the changes are relatively large.  This is because large fractions have been refactored out and in to `Detectors/AOD/src/AODMcProducerHelpers.cxx`. 

Yours,
_Christian_