### PR TITLE
add flag to tof compressor to skip large payloads

### DIFF
--- a/Detectors/TOF/compression/include/TOFCompression/CompressorTask.h
+++ b/Detectors/TOF/compression/include/TOFCompression/CompressorTask.h
@@ -33,7 +33,7 @@ template <typename RDH, bool verbose, bool paranoid>
 class CompressorTask : public Task
 {
  public:
-  CompressorTask() = default;
+  CompressorTask(long payloadLim = -1) : mPayloadLimit(payloadLim) {}
   ~CompressorTask() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -41,6 +41,7 @@ class CompressorTask : public Task
  private:
   Compressor<RDH, verbose, paranoid> mCompressor;
   int mOutputBufferSize;
+  long mPayloadLimit = -1;
 };
 
 } // namespace tof

--- a/Detectors/TOF/compression/include/TOFCompression/CompressorTaskOld.h
+++ b/Detectors/TOF/compression/include/TOFCompression/CompressorTaskOld.h
@@ -33,7 +33,7 @@ template <typename RDH, bool verbose, bool paranoid>
 class CompressorTaskOld : public Task
 {
  public:
-  CompressorTaskOld() = default;
+  CompressorTaskOld(long payloadLim = -1) : mPayloadLimit(payloadLim) {}
   ~CompressorTaskOld() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -41,6 +41,7 @@ class CompressorTaskOld : public Task
  private:
   Compressor<RDH, verbose, paranoid> mCompressor;
   int mOutputBufferSize;
+  long mPayloadLimit = -1;
 };
 
 } // namespace tof

--- a/Detectors/TOF/compression/src/CompressorTask.cxx
+++ b/Detectors/TOF/compression/src/CompressorTask.cxx
@@ -30,7 +30,11 @@ namespace o2::tof
 template <typename RDH, bool verbose, bool paranoid>
 void CompressorTask<RDH, verbose, paranoid>::init(InitContext& ic)
 {
-  LOG(info) << "Compressor init";
+  if (mPayloadLimit < 0) {
+    LOG(info) << "Compressor init";
+  } else {
+    LOG(info) << "Compressor init with Payload limit at " << mPayloadLimit;
+  }
 
   auto decoderCONET = ic.options().get<bool>("tof-compressor-conet-mode");
   auto decoderVerbose = ic.options().get<bool>("tof-compressor-decoder-verbose");
@@ -136,6 +140,11 @@ void CompressorTask<RDH, verbose, paranoid>::run(ProcessingContext& pc)
       /** input **/
       auto payloadIn = ref.payload;
       auto payloadInSize = DataRefUtils::getPayloadSize(ref);
+
+      if (mPayloadLimit > -1 && payloadInSize > mPayloadLimit) {
+        LOG(error) << "Payload larger than limit (" << mPayloadLimit << "), payload = " << payloadInSize;
+        continue;
+      }
 
       /** prepare compressor **/
       mCompressor.setDecoderBuffer(payloadIn);

--- a/Detectors/TOF/compression/src/CompressorTaskOld.cxx
+++ b/Detectors/TOF/compression/src/CompressorTaskOld.cxx
@@ -36,7 +36,11 @@ namespace tof
 template <typename RDH, bool verbose, bool paranoid>
 void CompressorTaskOld<RDH, verbose, paranoid>::init(InitContext& ic)
 {
-  LOG(info) << "Compressor init";
+  if (mPayloadLimit < 0) {
+    LOG(info) << "Compressor init";
+  } else {
+    LOG(info) << "Compressor init with Payload limit at " << mPayloadLimit;
+  }
 
   auto decoderCONET = ic.options().get<bool>("tof-compressor-conet-mode");
   auto decoderVerbose = ic.options().get<bool>("tof-compressor-decoder-verbose");
@@ -165,6 +169,11 @@ void CompressorTaskOld<RDH, verbose, paranoid>::run(ProcessingContext& pc)
       auto dataProcessingHeaderIn = DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(ref);
       auto payloadIn = ref.payload;
       auto payloadInSize = DataRefUtils::getPayloadSize(ref);
+
+      if (mPayloadLimit > -1 && payloadInSize > mPayloadLimit) {
+        LOG(error) << "Payload larger than limit (" << mPayloadLimit << "), payload = " << payloadInSize;
+        continue;
+      }
 
       /** prepare compressor **/
       mCompressor.setDecoderBuffer(payloadIn);

--- a/Detectors/TOF/compression/src/tof-compressor.cxx
+++ b/Detectors/TOF/compression/src/tof-compressor.cxx
@@ -36,6 +36,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   auto verbose = ConfigParamSpec{"tof-compressor-verbose", VariantType::Bool, false, {"Enable verbose compressor"}};
   auto paranoid = ConfigParamSpec{"tof-compressor-paranoid", VariantType::Bool, false, {"Enable paranoid compressor"}};
   auto ignoreStf = ConfigParamSpec{"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}};
+  auto payloadlim = ConfigParamSpec{"payload-limit", VariantType::Int64, -1ll, {"Payload limit in Byte (-1 -> no limits)"}};
 
   workflowOptions.push_back(config);
   workflowOptions.push_back(outputDesc);
@@ -43,6 +44,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(verbose);
   workflowOptions.push_back(paranoid);
   workflowOptions.push_back(ignoreStf);
+  workflowOptions.push_back(payloadlim);
   workflowOptions.emplace_back(ConfigParamSpec{"old", VariantType::Bool, false, {"use the non-DPL version of the compressor"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
 }
@@ -60,6 +62,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto paranoid = cfgc.options().get<bool>("tof-compressor-paranoid");
   auto ignoreStf = cfgc.options().get<bool>("ignore-dist-stf");
   auto old = cfgc.options().get<bool>("old");
+  auto payloadLim = cfgc.options().get<long>("payload-limit");
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(OutputSpec(ConcreteDataTypeMatcher{"TOF", "CRAWDATA"}));
@@ -68,30 +71,30 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (rdhVersion == o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>()) {
     if (!verbose && !paranoid) {
       if (old) {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, false, false>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, false, false>>(payloadLim)};
       } else {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, false, false>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, false, false>>(payloadLim)};
       }
     }
     if (!verbose && paranoid) {
       if (old) {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, false, true>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, false, true>>(payloadLim)};
       } else {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, false, true>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, false, true>>(payloadLim)};
       }
     }
     if (verbose && !paranoid) {
       if (old) {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, true, false>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, true, false>>(payloadLim)};
       } else {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, true, false>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, true, false>>(payloadLim)};
       }
     }
     if (verbose && paranoid) {
       if (old) {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, true, true>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTaskOld<o2::header::RAWDataHeader, true, true>>(payloadLim)};
       } else {
-        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, true, true>>()};
+        algoSpec = AlgorithmSpec{adaptFromTask<o2::tof::CompressorTask<o2::header::RAWDataHeader, true, true>>(payloadLim)};
       }
     }
   }


### PR DESCRIPTION
This is a PR to allow skipping payload above a given threshold in TOF compressor
By default no threshold is applied (previous behavior)
By adding this flag in TOF compressor workflow
--payload-limit XXXXXX
we are able to filter (not process) large payload (we have indications this can produce crashes).
The filter will log an error and then not run() on the payload
(e.g. tested with a low threshold -> [482407:tof-compressor-0]: [11:48:16][ERROR] Payload larger than limit (2000), payload = 2160)

In this way we can enable and disable this feature via ControlWorkflow

@ktf @preghenella