### PR TITLE
Adding cluster size to track extra

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -122,13 +122,30 @@ class TrackITS : public o2::track::TrackParCov
   void setNextROFbit(bool toggle = true) { setUserField((getUserField() & ~kNextROF) | (-toggle & kNextROF)); }
   bool hasHitInNextROF() const { return getUserField() & kNextROF; }
 
+  void setClusterSize(int l, int size) {
+    if (l >= 8) return;
+    if (size > 15) size = 15;
+    mClusterSizes &= ~(0xf << (l * 4));
+    mClusterSizes |= (size << (l * 4));
+  }
+
+  int getClusterSize(int l) {
+    if (l >= 8) return 0;
+    return (mClusterSizes >> (l * 4)) & 0xf;
+  }
+
+  int getClusterSizes() const {
+    return mClusterSizes;
+  }
+
  private:
   o2::track::TrackParCov mParamOut; ///< parameter at largest radius
   ClusRefs mClusRef;                ///< references on clusters
   float mChi2 = 0.;                 ///< Chi2 for this track
   uint32_t mPattern = 0;            ///< layers pattern
+  unsigned int mClusterSizes = 0u;
 
-  ClassDefNV(TrackITS, 5);
+  ClassDefNV(TrackITS, 6);
 };
 
 class TrackITSExt : public TrackITS

--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -122,19 +122,25 @@ class TrackITS : public o2::track::TrackParCov
   void setNextROFbit(bool toggle = true) { setUserField((getUserField() & ~kNextROF) | (-toggle & kNextROF)); }
   bool hasHitInNextROF() const { return getUserField() & kNextROF; }
 
-  void setClusterSize(int l, int size) {
-    if (l >= 8) return;
-    if (size > 15) size = 15;
+  void setClusterSize(int l, int size)
+  {
+    if (l >= 8)
+      return;
+    if (size > 15)
+      size = 15;
     mClusterSizes &= ~(0xf << (l * 4));
     mClusterSizes |= (size << (l * 4));
   }
 
-  int getClusterSize(int l) {
-    if (l >= 8) return 0;
+  int getClusterSize(int l)
+  {
+    if (l >= 8)
+      return 0;
     return (mClusterSizes >> (l * 4)) & 0xf;
   }
 
-  int getClusterSizes() const {
+  int getClusterSizes() const
+  {
     return mClusterSizes;
   }
 

--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -124,18 +124,21 @@ class TrackITS : public o2::track::TrackParCov
 
   void setClusterSize(int l, int size)
   {
-    if (l >= 8)
+    if (l >= 8) {
       return;
-    if (size > 15)
+    }
+    if (size > 15) {
       size = 15;
+    }
     mClusterSizes &= ~(0xf << (l * 4));
     mClusterSizes |= (size << (l * 4));
   }
 
   int getClusterSize(int l)
   {
-    if (l >= 8)
+    if (l >= 8) {
       return 0;
+    }
     return (mClusterSizes >> (l * 4)) & 0xf;
   }
 

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TrkClusRef.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TrkClusRef.h
@@ -25,8 +25,8 @@ namespace itsmft
 // can refer to max 15 indices in the vector of total length <268435456, i.e. 17895697 tracks in worst case
 struct TrkClusRef : public o2::dataformats::RangeRefComp<4> {
   using o2::dataformats::RangeRefComp<4>::RangeRefComp;
-  uint16_t pattern = 0; ///< layers pattern
   uint32_t clsizes = 0; ///< cluster sizes for each layer
+  uint16_t pattern = 0; ///< layers pattern
 
   GPUd() int getNClusters() const { return getEntries(); }
   bool hasHitOnLayer(int i) { return pattern & (0x1 << i); }

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TrkClusRef.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TrkClusRef.h
@@ -31,24 +31,27 @@ struct TrkClusRef : public o2::dataformats::RangeRefComp<4> {
   GPUd() int getNClusters() const { return getEntries(); }
   bool hasHitOnLayer(int i) { return pattern & (0x1 << i); }
 
-
-  void setClusterSize(int l, int size) {
-    if (l >= 8) return;
-    if (size > 15) size = 15;
+  void setClusterSize(int l, int size)
+  {
+    if (l >= 8)
+      return;
+    if (size > 15)
+      size = 15;
     clsizes &= ~(0xf << (l * 4));
     clsizes |= (size << (l * 4));
   }
 
-  int getClusterSize(int l) {
-    if (l >= 8) return 0;
+  int getClusterSize(int l)
+  {
+    if (l >= 8)
+      return 0;
     return (clsizes >> (l * 4)) & 0xf;
   }
 
-  int getClusterSizes() const {
+  int getClusterSizes() const
+  {
     return clsizes;
   }
-
-
 
   ClassDefNV(TrkClusRef, 2);
 };

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TrkClusRef.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TrkClusRef.h
@@ -26,11 +26,31 @@ namespace itsmft
 struct TrkClusRef : public o2::dataformats::RangeRefComp<4> {
   using o2::dataformats::RangeRefComp<4>::RangeRefComp;
   uint16_t pattern = 0; ///< layers pattern
+  uint32_t clsizes = 0; ///< cluster sizes for each layer
 
   GPUd() int getNClusters() const { return getEntries(); }
   bool hasHitOnLayer(int i) { return pattern & (0x1 << i); }
 
-  ClassDefNV(TrkClusRef, 1);
+
+  void setClusterSize(int l, int size) {
+    if (l >= 8) return;
+    if (size > 15) size = 15;
+    clsizes &= ~(0xf << (l * 4));
+    clsizes |= (size << (l * 4));
+  }
+
+  int getClusterSize(int l) {
+    if (l >= 8) return 0;
+    return (clsizes >> (l * 4)) & 0xf;
+  }
+
+  int getClusterSizes() const {
+    return clsizes;
+  }
+
+
+
+  ClassDefNV(TrkClusRef, 2);
 };
 
 } // namespace itsmft

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -356,6 +356,7 @@ class AODProducerWorkflowDPL : public Task
   struct TrackExtraInfo {
     float tpcInnerParam = 0.f;
     uint32_t flags = 0;
+    uint32_t itsClusterSizes = 0u;
     uint8_t itsClusterMap = 0;
     uint8_t tpcNClsFindable = 0;
     int8_t tpcNClsFindableMinusFound = 0;

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -319,7 +319,7 @@ void AODProducerWorkflowDPL::addToTracksExtraTable(TracksExtraCursorType& tracks
   // extra
   tracksExtraCursor(truncateFloatFraction(extraInfoHolder.tpcInnerParam, mTrack1Pt),
                     extraInfoHolder.flags,
-                    extraInfoHolder.itsClusterSizes,
+                    extraInfoHolder.itsClusterMap,
                     extraInfoHolder.tpcNClsFindable,
                     extraInfoHolder.tpcNClsFindableMinusFound,
                     extraInfoHolder.tpcNClsFindableMinusCrossedRows,
@@ -2370,14 +2370,16 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     int nClusters = itsTrack.getNClusters();
     float chi2 = itsTrack.getChi2();
     extraInfoHolder.itsChi2NCl = nClusters != 0 ? chi2 / (float)nClusters : 0;
-    extraInfoHolder.itsClusterSizes = itsTrack.getClusterSizes();
+    // extraInfoHolder.itsClusterSizes = itsTrack.getClusterSizes();
+    extraInfoHolder.itsClusterMap = itsTrack.getPattern();
     if (src == GIndex::ITS) { // standalone ITS track should set its time from the ROF
       const auto& rof = data.getITSTracksROFRecords()[mITSROFs[trackIndex.getIndex()]];
       double t = rof.getBCData().differenceInBC(mStartIR) * o2::constants::lhc::LHCBunchSpacingNS + mITSROFrameHalfLengthNS;
       setTrackTime(t, mITSROFrameHalfLengthNS, false);
     }
   } else if (contributorsGID[GIndex::Source::ITSAB].isIndexSet()) { // this is an ITS-TPC afterburner contributor
-    extraInfoHolder.itsClusterSizes = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].clsizes;
+    // extraInfoHolder.itsClusterSizes = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].clsizes;
+    extraInfoHolder.itsClusterMap = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].pattern;
   }
   if (contributorsGID[GIndex::Source::TPC].isIndexSet()) {
     const auto& tpcOrig = data.getTPCTrack(contributorsGID[GIndex::TPC]);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2380,6 +2380,7 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     }
   } else if (contributorsGID[GIndex::Source::ITSAB].isIndexSet()) { // this is an ITS-TPC afterburner contributor
     extraInfoHolder.itsClusterMap = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].pattern;
+    extraInfoHolder.itsClusterSizes = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].clsizes;
   }
   if (contributorsGID[GIndex::Source::TPC].isIndexSet()) {
     const auto& tpcOrig = data.getTPCTrack(contributorsGID[GIndex::TPC]);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2370,7 +2370,6 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     int nClusters = itsTrack.getNClusters();
     float chi2 = itsTrack.getChi2();
     extraInfoHolder.itsChi2NCl = nClusters != 0 ? chi2 / (float)nClusters : 0;
-    // extraInfoHolder.itsClusterSizes = itsTrack.getClusterSizes();
     extraInfoHolder.itsClusterMap = itsTrack.getPattern();
     if (src == GIndex::ITS) { // standalone ITS track should set its time from the ROF
       const auto& rof = data.getITSTracksROFRecords()[mITSROFs[trackIndex.getIndex()]];
@@ -2378,7 +2377,6 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
       setTrackTime(t, mITSROFrameHalfLengthNS, false);
     }
   } else if (contributorsGID[GIndex::Source::ITSAB].isIndexSet()) { // this is an ITS-TPC afterburner contributor
-    // extraInfoHolder.itsClusterSizes = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].clsizes;
     extraInfoHolder.itsClusterMap = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].pattern;
   }
   if (contributorsGID[GIndex::Source::TPC].isIndexSet()) {

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -319,7 +319,6 @@ void AODProducerWorkflowDPL::addToTracksExtraTable(TracksExtraCursorType& tracks
   // extra
   tracksExtraCursor(truncateFloatFraction(extraInfoHolder.tpcInnerParam, mTrack1Pt),
                     extraInfoHolder.flags,
-                    extraInfoHolder.itsClusterMap,
                     extraInfoHolder.itsClusterSizes,
                     extraInfoHolder.tpcNClsFindable,
                     extraInfoHolder.tpcNClsFindableMinusFound,
@@ -2371,7 +2370,6 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     int nClusters = itsTrack.getNClusters();
     float chi2 = itsTrack.getChi2();
     extraInfoHolder.itsChi2NCl = nClusters != 0 ? chi2 / (float)nClusters : 0;
-    extraInfoHolder.itsClusterMap = itsTrack.getPattern();
     extraInfoHolder.itsClusterSizes = itsTrack.getClusterSizes();
     if (src == GIndex::ITS) { // standalone ITS track should set its time from the ROF
       const auto& rof = data.getITSTracksROFRecords()[mITSROFs[trackIndex.getIndex()]];
@@ -2379,7 +2377,6 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
       setTrackTime(t, mITSROFrameHalfLengthNS, false);
     }
   } else if (contributorsGID[GIndex::Source::ITSAB].isIndexSet()) { // this is an ITS-TPC afterburner contributor
-    extraInfoHolder.itsClusterMap = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].pattern;
     extraInfoHolder.itsClusterSizes = data.getITSABRefs()[contributorsGID[GIndex::Source::ITSAB].getIndex()].clsizes;
   }
   if (contributorsGID[GIndex::Source::TPC].isIndexSet()) {

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -320,6 +320,7 @@ void AODProducerWorkflowDPL::addToTracksExtraTable(TracksExtraCursorType& tracks
   tracksExtraCursor(truncateFloatFraction(extraInfoHolder.tpcInnerParam, mTrack1Pt),
                     extraInfoHolder.flags,
                     extraInfoHolder.itsClusterMap,
+                    extraInfoHolder.itsClusterSizes,
                     extraInfoHolder.tpcNClsFindable,
                     extraInfoHolder.tpcNClsFindableMinusFound,
                     extraInfoHolder.tpcNClsFindableMinusCrossedRows,
@@ -2371,6 +2372,7 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     float chi2 = itsTrack.getChi2();
     extraInfoHolder.itsChi2NCl = nClusters != 0 ? chi2 / (float)nClusters : 0;
     extraInfoHolder.itsClusterMap = itsTrack.getPattern();
+    extraInfoHolder.itsClusterSizes = itsTrack.getClusterSizes();
     if (src == GIndex::ITS) { // standalone ITS track should set its time from the ROF
       const auto& rof = data.getITSTracksROFRecords()[mITSROFs[trackIndex.getIndex()]];
       double t = rof.getBCData().differenceInBC(mStartIR) * o2::constants::lhc::LHCBunchSpacingNS + mITSROFrameHalfLengthNS;
@@ -2728,6 +2730,9 @@ DataProcessorSpec getAODProducerWorkflowSpec(GID::mask_t src, bool enableSV, boo
   if (enableStrangenessTracking) {
     dataRequest->requestStrangeTracks(useMC);
     LOGF(info, "requestStrangeTracks Finish");
+  }
+  if (src[GID::ITS]) {
+    dataRequest->requestClusters(GIndex::getSourcesMask("ITS"), false);
   }
   if (src[GID::TPC]) {
     dataRequest->requestClusters(GIndex::getSourcesMask("TPC"), false); // no need to ask for TOF clusters as they are requested with TOF tracks

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -594,7 +594,7 @@ class MatchTPCITS
   gsl::span<const o2::its::TrackITS> mITSTracksArray;      ///< input ITS tracks span
   gsl::span<const int> mITSTrackClusIdx;                   ///< input ITS track cluster indices span
   std::vector<ITSCluster> mITSClustersArray;               ///< ITS clusters created in loadInput
-  std::vector<unsigned int> mITSClusterSizes;                      ///< ITS cluster sizes created in loadInput
+  std::vector<unsigned int> mITSClusterSizes;              ///< ITS cluster sizes created in loadInput
 
   gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec; ///< input ITS clusters ROFRecord span
   gsl::span<const o2::ft0::RecPoints> mFITInfo;             ///< optional input FIT info span

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -607,7 +607,7 @@ class MatchTPCITS
   gsl::span<const o2::its::TrackITS> mITSTracksArray;      ///< input ITS tracks span
   gsl::span<const int> mITSTrackClusIdx;                   ///< input ITS track cluster indices span
   std::vector<ITSCluster> mITSClustersArray;               ///< ITS clusters created in loadInput
-  std::vector<unsigned short> mITSClusterSizes;              ///< ITS cluster sizes created in loadInput
+  std::vector<uint8_t> mITSClusterSizes;                   ///< ITS cluster sizes created in loadInput
 
   gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec; ///< input ITS clusters ROFRecord span
   gsl::span<const o2::ft0::RecPoints> mFITInfo;             ///< optional input FIT info span

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -86,7 +86,7 @@ namespace tpc
 {
 class TrackTPC;
 class VDriftCorrFact;
-}
+} // namespace tpc
 
 namespace gpu
 {
@@ -124,7 +124,7 @@ struct TrackLocTPC : public o2::track::TrackParCov {
   float timeErr = 0.f;                  ///< time sigma (makes sense for constrained tracks only)
   int sourceID = 0;                     ///< TPC track origin in
   o2::dataformats::GlobalTrackID gid{}; // global track source ID (TPC track may be part of it)
-  int matchID = MinusOne;              ///< entry (non if MinusOne) of its matchTPC struct in the mMatchesTPC
+  int matchID = MinusOne;               ///< entry (non if MinusOne) of its matchTPC struct in the mMatchesTPC
   Constraint_t constraint{Constrained};
 
   float getCorrectedTime(float dt) const // return time0 corrected for extra drift (to match certain Z)
@@ -145,9 +145,9 @@ struct TrackLocITS : public o2::track::TrackParCov {
   enum : uint16_t { CloneBefore = 0x1,
                     CloneAfter = 0x2 };
   o2::math_utils::Bracketf_t tBracket; ///< bracketing time in \mus
-  int sourceID = 0;       ///< track origin id
-  int roFrame = MinusOne; ///< ITS readout frame assigned to this track
-  int matchID = MinusOne; ///< entry (non if MinusOne) of its matchCand struct in the mMatchesITS
+  int sourceID = 0;                    ///< track origin id
+  int roFrame = MinusOne;              ///< ITS readout frame assigned to this track
+  int matchID = MinusOne;              ///< entry (non if MinusOne) of its matchCand struct in the mMatchesITS
   bool hasCloneBefore() const { return getUserField() & CloneBefore; }
   bool hasCloneAfter() const { return getUserField() & CloneAfter; }
   int getCloneShift() const { return hasCloneBefore() ? -1 : (hasCloneAfter() ? 1 : 0); }
@@ -523,13 +523,13 @@ class MatchTPCITS
   float correctTPCTrack(o2::track::TrackParCov& trc, const TrackLocTPC& tTPC, const InteractionCandidate& cand) const; // RS FIXME will be needed for refit
   //================================================================
 
-  bool mInitDone = false;  ///< flag init already done
-  bool mFieldON = true;    ///< flag for field ON/OFF
-  bool mCosmics = false;   ///< flag cosmics mode
-  bool mMCTruthON = false; ///< flag availability of MC truth
-  float mBz = 0;           ///< nominal Bz
-  int mTFCount = 0;        ///< internal TF counter for debugger
-  int mNThreads = 1;       ///< number of OMP threads
+  bool mInitDone = false;               ///< flag init already done
+  bool mFieldON = true;                 ///< flag for field ON/OFF
+  bool mCosmics = false;                ///< flag cosmics mode
+  bool mMCTruthON = false;              ///< flag availability of MC truth
+  float mBz = 0;                        ///< nominal Bz
+  int mTFCount = 0;                     ///< internal TF counter for debugger
+  int mNThreads = 1;                    ///< number of OMP threads
   o2::InteractionRecord mStartIR{0, 0}; ///< IR corresponding to the start of the TF
 
   ///========== Parameters to be set externally, e.g. from CCDB ====================
@@ -553,27 +553,27 @@ class MatchTPCITS
   ///< assigned time0 and its track Z position (converted from mTPCTimeEdgeZSafeMargin)
   float mTPCTimeEdgeTSafeMargin = 0.f;
   float mTPCExtConstrainedNSigmaInv = 0.f; // inverse for NSigmas for TPC time-interval from external constraint time sigma
-  int mITSROFrameLengthInBC = 0;    ///< ITS RO frame in BC (for ITS cont. mode only)
-  float mITSROFrameLengthMUS = -1.; ///< ITS RO frame in \mus
-  float mITSTimeResMUS = -1.;       ///< nominal ITS time resolution derived from ROF
-  float mITSROFrameLengthMUSInv = -1.; ///< ITS RO frame in \mus inverse
-  int mITSTimeBiasInBC = 0;            ///< ITS RO frame shift in BCs, i.e. t_i = (I_ROF*mITSROFrameLengthInBC + mITSTimeBiasInBC)*BCLength_MUS
-  float mITSTimeBiasMUS = 0.;          ///< ITS RO frame shift in \mus, i.e. t_i = (I_ROF*mITSROFrameLengthInBC)*BCLength_MUS + mITSTimeBiasMUS
-  float mTPCVDrift = -1.;              ///< TPC drift speed in cm/microseconds
-  float mTPCVDriftInv = -1.;           ///< inverse TPC nominal drift speed in cm/microseconds
-  float mTPCDriftTimeOffset = 0;       ///< drift time offset in mus
-  float mTPCTBinMUS = 0.;           ///< TPC time bin duration in microseconds
-  float mTPCTBinNS = 0.;            ///< TPC time bin duration in ns
-  float mTPCTBinMUSInv = 0.;        ///< inverse TPC time bin duration in microseconds
-  float mZ2TPCBin = 0.;             ///< conversion coeff from Z to TPC time-bin
-  float mTPCBin2Z = 0.;             ///< conversion coeff from TPC time-bin to Z
-  float mNTPCBinsFullDrift = 0.;    ///< max time bin for full drift
-  float mTPCZMax = 0.;              ///< max drift length
-  float mTPCmeanX0Inv = 1. / 31850.; ///< TPC gas 1/X0
+  int mITSROFrameLengthInBC = 0;           ///< ITS RO frame in BC (for ITS cont. mode only)
+  float mITSROFrameLengthMUS = -1.;        ///< ITS RO frame in \mus
+  float mITSTimeResMUS = -1.;              ///< nominal ITS time resolution derived from ROF
+  float mITSROFrameLengthMUSInv = -1.;     ///< ITS RO frame in \mus inverse
+  int mITSTimeBiasInBC = 0;                ///< ITS RO frame shift in BCs, i.e. t_i = (I_ROF*mITSROFrameLengthInBC + mITSTimeBiasInBC)*BCLength_MUS
+  float mITSTimeBiasMUS = 0.;              ///< ITS RO frame shift in \mus, i.e. t_i = (I_ROF*mITSROFrameLengthInBC)*BCLength_MUS + mITSTimeBiasMUS
+  float mTPCVDrift = -1.;                  ///< TPC drift speed in cm/microseconds
+  float mTPCVDriftInv = -1.;               ///< inverse TPC nominal drift speed in cm/microseconds
+  float mTPCDriftTimeOffset = 0;           ///< drift time offset in mus
+  float mTPCTBinMUS = 0.;                  ///< TPC time bin duration in microseconds
+  float mTPCTBinNS = 0.;                   ///< TPC time bin duration in ns
+  float mTPCTBinMUSInv = 0.;               ///< inverse TPC time bin duration in microseconds
+  float mZ2TPCBin = 0.;                    ///< conversion coeff from Z to TPC time-bin
+  float mTPCBin2Z = 0.;                    ///< conversion coeff from TPC time-bin to Z
+  float mNTPCBinsFullDrift = 0.;           ///< max time bin for full drift
+  float mTPCZMax = 0.;                     ///< max drift length
+  float mTPCmeanX0Inv = 1. / 31850.;       ///< TPC gas 1/X0
 
   float mMinTPCTrackPtInv = 999.; ///< cutoff on TPC track inverse pT
   float mMinITSTrackPtInv = 999.; ///< cutoff on ITS track inverse pT
-  bool mVDriftCalibOn = false;                                ///< flag to produce VDrift calibration data
+  bool mVDriftCalibOn = false;    ///< flag to produce VDrift calibration data
   o2::tpc::VDriftCorrFact mTPCDrift{};
   o2::gpu::CorrectionMapsHelper* mTPCCorrMapsHelper = nullptr;
 
@@ -588,12 +588,14 @@ class MatchTPCITS
   const o2::globaltracking::RecoContainer* mRecoCont = nullptr;
   ///>>>------ these are input arrays which should not be modified by the matching code
   //           since this info is provided by external device
-  gsl::span<const o2::tpc::TrackTPC> mTPCTracksArray;       ///< input TPC tracks span
-  gsl::span<const o2::tpc::TPCClRefElem> mTPCTrackClusIdx;  ///< input TPC track cluster indices span
-  gsl::span<const o2::itsmft::ROFRecord> mITSTrackROFRec;   ///< input ITS tracks ROFRecord span
-  gsl::span<const o2::its::TrackITS> mITSTracksArray;       ///< input ITS tracks span
-  gsl::span<const int> mITSTrackClusIdx;                    ///< input ITS track cluster indices span
-  std::vector<ITSCluster> mITSClustersArray;                ///< ITS clusters created in loadInput
+  gsl::span<const o2::tpc::TrackTPC> mTPCTracksArray;      ///< input TPC tracks span
+  gsl::span<const o2::tpc::TPCClRefElem> mTPCTrackClusIdx; ///< input TPC track cluster indices span
+  gsl::span<const o2::itsmft::ROFRecord> mITSTrackROFRec;  ///< input ITS tracks ROFRecord span
+  gsl::span<const o2::its::TrackITS> mITSTracksArray;      ///< input ITS tracks span
+  gsl::span<const int> mITSTrackClusIdx;                   ///< input ITS track cluster indices span
+  std::vector<ITSCluster> mITSClustersArray;               ///< ITS clusters created in loadInput
+  std::vector<unsigned int> mITSClusterSizes;                      ///< ITS cluster sizes created in loadInput
+
   gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec; ///< input ITS clusters ROFRecord span
   gsl::span<const o2::ft0::RecPoints> mFITInfo;             ///< optional input FIT info span
 
@@ -609,8 +611,8 @@ class MatchTPCITS
   /// <<<-----
 
   size_t mNMatchesControl = 0;
-  std::vector<InteractionCandidate> mInteractions;                     ///< possible interaction times
-  std::vector<int> mInteractionMUSLUT;                                 ///< LUT for interactions in 1MUS bins
+  std::vector<InteractionCandidate> mInteractions; ///< possible interaction times
+  std::vector<int> mInteractionMUSLUT;             ///< LUT for interactions in 1MUS bins
 
   ///< container for record the match of TPC track to single ITS track
   std::vector<MatchRecord> mMatchRecordsTPC;
@@ -632,7 +634,7 @@ class MatchTPCITS
   std::vector<int> mABWinnersIDs;
   std::vector<int> mABTrackletClusterIDs;              ///< IDs of ITS clusters for AfterBurner winners
   std::vector<o2::itsmft::TrkClusRef> mABTrackletRefs; ///< references on AfterBurner winners clusters
-  std::vector<int> mABClusterLinkIndex;            ///< index of 1st ABClusterLink for every cluster used by AfterBurner, -1: unused, -10: used by external ITS tracks
+  std::vector<int> mABClusterLinkIndex;                ///< index of 1st ABClusterLink for every cluster used by AfterBurner, -1: unused, -10: used by external ITS tracks
   MCLabContTr mABTrackletLabels;
   // ------------------------------
 
@@ -687,7 +689,6 @@ class MatchTPCITS
   static constexpr std::string_view TimerName[] = {"Total", "PrepareITS", "PrepareTPC", "DoMatching", "SelectBest", "Refit",
                                                    "ABSeeds", "ABMatching", "ABWinners", "ABRefit", "IO", "Debug"};
   TStopwatch mTimer[NStopWatches];
-
 };
 
 //______________________________________________
@@ -707,7 +708,6 @@ inline bool MatchTPCITS::isDisabledITS(const TrackLocITS& t) const { return t.ma
 
 //______________________________________________
 inline bool MatchTPCITS::isDisabledTPC(const TrackLocTPC& t) const { return t.matchID < 0; }
-
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -607,7 +607,7 @@ class MatchTPCITS
   gsl::span<const o2::its::TrackITS> mITSTracksArray;      ///< input ITS tracks span
   gsl::span<const int> mITSTrackClusIdx;                   ///< input ITS track cluster indices span
   std::vector<ITSCluster> mITSClustersArray;               ///< ITS clusters created in loadInput
-  std::vector<unsigned int> mITSClusterSizes;              ///< ITS cluster sizes created in loadInput
+  std::vector<unsigned short> mITSClusterSizes;              ///< ITS cluster sizes created in loadInput
 
   gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec; ///< input ITS clusters ROFRecord span
   gsl::span<const o2::ft0::RecPoints> mFITInfo;             ///< optional input FIT info span

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -587,7 +587,7 @@ bool MatchTPCITS::prepareITSData()
   auto pattIt2 = patterns.begin();
   for (auto& clus : clusITS) {
     auto pattID = clus.getPatternID();
-    int npix;
+    unsigned int npix;
     if (pattID == o2::itsmft::CompCluster::InvalidPatternID || mITSDict->isGroup(pattID)) {
       o2::itsmft::ClusterPattern patt;
       patt.acquirePattern(pattIt2);
@@ -595,7 +595,11 @@ bool MatchTPCITS::prepareITSData()
     } else {
       npix = mITSDict->getNpixels(pattID);
     }
-    mITSClusterSizes.push_back(npix);
+    if (npix < 255) {
+      mITSClusterSizes.push_back(npix);
+    } else {
+      mITSClusterSizes.push_back(255);
+    }
   }
 
   if (mMCTruthON) {
@@ -1313,7 +1317,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS, pmr::vector<o2::dataform
   const auto& itsTrOrig = mITSTracksArray[tITS.sourceID];
 
   auto& trfit = matchedTracks.emplace_back(tTPC, tITS); // create a copy of TPC track at xRef
-  trfit.getParamOut().setUserField(0); // reset eventual clones flag
+  trfit.getParamOut().setUserField(0);                  // reset eventual clones flag
   // in continuos mode the Z of TPC track is meaningless, unless it is CE crossing
   // track (currently absent, TODO)
   if (!mCompareTracksDZ) {

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -580,7 +580,7 @@ bool MatchTPCITS::prepareITSData()
     int npix;
     if (pattID == o2::itsmft::CompCluster::InvalidPatternID || mITSDict->isGroup(pattID)) {
       o2::itsmft::ClusterPattern patt;
-      patt.acquirePattern(pattIt);
+      patt.acquirePattern(pattIt2);
       npix = patt.getNPixels();
     } else {
       npix = mITSDict->getNpixels(pattID);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -129,6 +129,7 @@ class TimeFrame
   const gsl::span<const MCCompLabel> getClusterLabels(int layerId, const Cluster& cl) const;
   const gsl::span<const MCCompLabel> getClusterLabels(int layerId, const int clId) const;
   int getClusterExternalIndex(int layerId, const int clId) const;
+  int getClusterSize(int clusterId);
 
   std::vector<MCCompLabel>& getTrackletsLabel(int layer) { return mTrackletLabels[layer]; }
   std::vector<MCCompLabel>& getCellsLabel(int layer) { return mCellLabels[layer]; }
@@ -244,6 +245,7 @@ class TimeFrame
   std::vector<float> mMSangles;
   std::vector<float> mPhiCuts;
   std::vector<float> mPositionResolution;
+  std::vector<int> mClusterSize;
   std::vector<bool> mMultiplicityCutMask;
   std::vector<std::array<float, 2>> mPValphaX; /// PV x and alpha for track propagation
   std::vector<std::vector<Cluster>> mUnsortedClusters;
@@ -422,6 +424,10 @@ inline const gsl::span<const MCCompLabel> TimeFrame::getClusterLabels(int layerI
 inline const gsl::span<const MCCompLabel> TimeFrame::getClusterLabels(int layerId, int clId) const
 {
   return mClusterLabels->getLabels(mClusterExternalIndices[layerId][clId]);
+}
+
+inline int TimeFrame::getClusterSize(int clusterId) {
+  return mClusterSize[clusterId];
 }
 
 inline int TimeFrame::getClusterExternalIndex(int layerId, const int clId) const

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -245,7 +245,7 @@ class TimeFrame
   std::vector<float> mMSangles;
   std::vector<float> mPhiCuts;
   std::vector<float> mPositionResolution;
-  std::vector<int> mClusterSize;
+  std::vector<unsigned short> mClusterSize;
   std::vector<bool> mMultiplicityCutMask;
   std::vector<std::array<float, 2>> mPValphaX; /// PV x and alpha for track propagation
   std::vector<std::vector<Cluster>> mUnsortedClusters;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -426,7 +426,8 @@ inline const gsl::span<const MCCompLabel> TimeFrame::getClusterLabels(int layerI
   return mClusterLabels->getLabels(mClusterExternalIndices[layerId][clId]);
 }
 
-inline int TimeFrame::getClusterSize(int clusterId) {
+inline int TimeFrame::getClusterSize(int clusterId)
+{
   return mClusterSize[clusterId];
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -245,7 +245,7 @@ class TimeFrame
   std::vector<float> mMSangles;
   std::vector<float> mPhiCuts;
   std::vector<float> mPositionResolution;
-  std::vector<unsigned short> mClusterSize;
+  std::vector<uint8_t> mClusterSize;
   std::vector<bool> mMultiplicityCutMask;
   std::vector<std::array<float, 2>> mPValphaX; /// PV x and alpha for track propagation
   std::vector<std::vector<Cluster>> mUnsortedClusters;

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -186,7 +186,7 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
       auto pattID = c.getPatternID();
       o2::math_utils::Point3D<float> locXYZ;
       float sigmaY2 = DefClusError2Row, sigmaZ2 = DefClusError2Col, sigmaYZ = 0; // Dummy COG errors (about half pixel size)
-      int clusterSize{0};
+      unsigned short clusterSize{0};
       if (pattID != itsmft::CompCluster::InvalidPatternID) {
         sigmaY2 = dict->getErr2X(pattID);
         sigmaZ2 = dict->getErr2Z(pattID);

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -186,7 +186,7 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
       auto pattID = c.getPatternID();
       o2::math_utils::Point3D<float> locXYZ;
       float sigmaY2 = DefClusError2Row, sigmaZ2 = DefClusError2Col, sigmaYZ = 0; // Dummy COG errors (about half pixel size)
-      unsigned short clusterSize{0};
+      unsigned int clusterSize{0};
       if (pattID != itsmft::CompCluster::InvalidPatternID) {
         sigmaY2 = dict->getErr2X(pattID);
         sigmaZ2 = dict->getErr2Z(pattID);
@@ -203,7 +203,11 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
         locXYZ = dict->getClusterCoordinates(c, patt, false);
         clusterSize = patt.getNPixels();
       }
-      mClusterSize.push_back(clusterSize);
+      if (clusterSize < 255) {
+        mClusterSize.push_back(clusterSize);
+      } else {
+        mClusterSize.push_back(255);
+      }
       auto sensorID = c.getSensorID();
       // Inverse transformation to the local --> tracking
       auto trkXYZ = geom->getMatrixT2L(sensorID) ^ locXYZ;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -297,6 +297,7 @@ void TrackerDPL::run(ProcessingContext& pc)
         for (int ic = TrackITSExt::MaxClusters; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
           auto clid = trc.getClusterIndex(ic);
           if (clid >= 0) {
+            trc.setClusterSize(ic, mTimeFrame->getClusterSize(clid));
             allClusIdx.push_back(clid);
             nclf++;
           }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -242,20 +242,22 @@ DECLARE_SOA_COLUMN(TrackTime, trackTime, float);                                
 DECLARE_SOA_COLUMN(TrackTimeRes, trackTimeRes, float);                                        //! Resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange)
 
 // expression columns changing between versions have to be declared in different namespaces
-namespace v000
-{
+
 DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map: see enum DetectorMapEnum
                               ifnode(aod::track::itsClusterMap > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
                                 ifnode(aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
                                 ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
                                 ifnode((aod::track::tofChi2 >= 0.f) && (aod::track::tofExpMom > 0.f), static_cast<uint8_t>(o2::aod::track::TOF), (uint8_t)0x0));
-} // namespace v000
 
+
+namespace v001
+{
 DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map version 1
                               ifnode(aod::track::itsClusterSizes > (uint32_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
                                 ifnode(aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
                                 ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
                                 ifnode((aod::track::tofChi2 >= 0.f) && (aod::track::tofExpMom > 0.f), static_cast<uint8_t>(o2::aod::track::TOF), (uint8_t)0x0));
+} // namespace v001
 
 DECLARE_SOA_DYNAMIC_COLUMN(HasITS, hasITS, //! Flag to check if track has a ITS match
                            [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::ITS; });
@@ -439,8 +441,8 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
                        track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
                        track::PIDForTracking<track::Flags>,
                        track::IsPVContributor<track::Flags>,
-                       track::HasITS<track::v000::DetectorMap>, track::HasTPC<track::v000::DetectorMap>,
-                       track::HasTRD<track::v000::DetectorMap>, track::HasTOF<track::v000::DetectorMap>,
+                       track::HasITS<track::DetectorMap>, track::HasTPC<track::DetectorMap>,
+                       track::HasTRD<track::DetectorMap>, track::HasTOF<track::DetectorMap>,
                        track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                        track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
                        track::ITSNCls<track::ITSClusterMap>, track::ITSNClsInnerBarrel<track::ITSClusterMap>,
@@ -457,8 +459,8 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "T
                                  track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
                                  track::PIDForTracking<track::Flags>,
                                  track::IsPVContributor<track::Flags>,
-                                 track::HasITS<track::DetectorMap>, track::HasTPC<track::DetectorMap>,
-                                 track::HasTRD<track::DetectorMap>, track::HasTOF<track::DetectorMap>,
+                                 track::HasITS<track::v001::DetectorMap>, track::HasTPC<track::v001::DetectorMap>,
+                                 track::HasTRD<track::v001::DetectorMap>, track::HasTOF<track::v001::DetectorMap>,
                                  track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                                  track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
                                  track::ITSClusterMapDyn<track::ITSClusterSizes>, track::ITSNCls001<track::ITSClusterSizes>, track::ITSNClsInnerBarrel001<track::ITSClusterSizes>,
@@ -468,12 +470,12 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "T
                                  track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
 
 DECLARE_SOA_EXTENDED_TABLE(TracksExtra_000, StoredTracksExtra_000, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
-                           track::v000::DetectorMap);
-DECLARE_SOA_EXTENDED_TABLE(TracksExtra_001, StoredTracksExtra_001, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
                            track::DetectorMap);
+DECLARE_SOA_EXTENDED_TABLE(TracksExtra_001, StoredTracksExtra_001, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
+                           track::v001::DetectorMap);
 
-using StoredTracksExtra = StoredTracksExtra_001;
-using TracksExtra = TracksExtra_001;
+using StoredTracksExtra = StoredTracksExtra_000;
+using TracksExtra = TracksExtra_000;
 
 using Track = Tracks::iterator;
 using TrackIU = TracksIU::iterator;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -240,7 +240,18 @@ DECLARE_SOA_COLUMN(TrackEtaEMCAL, trackEtaEmcal, float);                        
 DECLARE_SOA_COLUMN(TrackPhiEMCAL, trackPhiEmcal, float);                                      //!
 DECLARE_SOA_COLUMN(TrackTime, trackTime, float);                                              //! Estimated time of the track in ns wrt collision().bc() or ambiguoustrack.bcSlice()[0]
 DECLARE_SOA_COLUMN(TrackTimeRes, trackTimeRes, float);                                        //! Resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange)
-DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t,                              //! Detector map: see enum DetectorMapEnum
+
+// expression columns changing between versions have to be declared in different namespaces
+namespace v000
+{
+DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map: see enum DetectorMapEnum
+                              ifnode(aod::track::itsClusterMap > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
+                                ifnode(aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
+                                ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
+                                ifnode((aod::track::tofChi2 >= 0.f) && (aod::track::tofExpMom > 0.f), static_cast<uint8_t>(o2::aod::track::TOF), (uint8_t)0x0));
+} // namespace v000
+
+DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map version 1
                               ifnode(aod::track::itsClusterSizes > (uint32_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
                                 ifnode(aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
                                 ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
@@ -428,8 +439,8 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
                        track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
                        track::PIDForTracking<track::Flags>,
                        track::IsPVContributor<track::Flags>,
-                       track::HasITS<track::DetectorMap>, track::HasTPC<track::DetectorMap>,
-                       track::HasTRD<track::DetectorMap>, track::HasTOF<track::DetectorMap>,
+                       track::HasITS<track::v000::DetectorMap>, track::HasTPC<track::v000::DetectorMap>,
+                       track::HasTRD<track::v000::DetectorMap>, track::HasTOF<track::v000::DetectorMap>,
                        track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                        track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
                        track::ITSNCls<track::ITSClusterMap>, track::ITSNClsInnerBarrel<track::ITSClusterMap>,
@@ -457,8 +468,7 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "T
                                  track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
 
 DECLARE_SOA_EXTENDED_TABLE(TracksExtra_000, StoredTracksExtra_000, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
-                           track::DetectorMap);
-
+                           track::v000::DetectorMap);
 DECLARE_SOA_EXTENDED_TABLE(TracksExtra_001, StoredTracksExtra_001, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
                            track::DetectorMap);
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -449,7 +449,7 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
                        track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                        track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
 
-DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "TRACKEXTRA", 1, // Version 1 of TracksExtra
+DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "TRACKEXTRA", 1, // On disk version of TracksExtra, version 1
                                  track::TPCInnerParam, track::Flags, track::ITSClusterSizes,
                                  track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                                  track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -251,7 +251,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector ma
 
 namespace v001
 {
-DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map version 1
+DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map version 1, see enum DetectorMapEnum
                               ifnode(aod::track::itsClusterSizes > (uint32_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
                                 ifnode(aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
                                 ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -222,7 +222,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
 DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float);                                      //! Momentum at inner wall of the TPC
 DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                                   //! Track flags. Run 2: see TrackFlagsRun2Enum | Run 3: see TrackFlags
 DECLARE_SOA_COLUMN(ITSClusterSizes, itsClusterSizes, uint32_t);                               //! Clusters sizes, four bits per a layer, starting from the innermost
-DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                   //! Old cluster ITS cluster map, kept for retrocompatibility
+DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                    //! Old cluster ITS cluster map, kept for retrocompatibility
 DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t);                                //! Findable TPC clusters for this track geometry
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t);             //! TPC Clusters: Findable - Found
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t); //! TPC Clusters: Findable - crossed rows

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -431,7 +431,7 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCovIU, StoredTracksCovIU, "TRACKCOV_IU", //! Tr
                            aod::track::C1PtTgl,
                            aod::track::C1Pt21Pt2);
 
-DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA", //! On disk version of TracksExtra
+DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA", //! On disk version of TracksExtra, version 0
                        track::TPCInnerParam, track::Flags, track::ITSClusterMap,
                        track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                        track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -222,7 +222,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
 DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float);                                      //! Momentum at inner wall of the TPC
 DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                                   //! Track flags. Run 2: see TrackFlagsRun2Enum | Run 3: see TrackFlags
 DECLARE_SOA_COLUMN(ITSClusterSizes, itsClusterSizes, uint32_t);                               //! Clusters sizes, four bits per a layer, starting from the innermost
-DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                    //! Old cluster ITS cluster map, kept for retrocompatibility
+DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                    //! Old cluster ITS cluster map, kept for version 0 compatibility
 DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t);                                //! Findable TPC clusters for this track geometry
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t);             //! TPC Clusters: Findable - Found
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t); //! TPC Clusters: Findable - crossed rows

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -222,6 +222,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
 DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float);                                      //! Momentum at inner wall of the TPC
 DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                                   //! Track flags. Run 2: see TrackFlagsRun2Enum | Run 3: see TrackFlags
 DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                    //! ITS cluster map, one bit per a layer, starting from the innermost
+DECLARE_SOA_COLUMN(ITSClusterSizes, itsClusterSizes, uint32_t);                               //! Clusters sizes, four bits per a layer, starting from the innermost
 DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t);                                //! Findable TPC clusters for this track geometry
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t);             //! TPC Clusters: Findable - Found
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t); //! TPC Clusters: Findable - crossed rows
@@ -391,7 +392,7 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCovIU, StoredTracksCovIU, "TRACKCOV_IU", //! Tr
                            aod::track::C1Pt21Pt2);
 
 DECLARE_SOA_TABLE_FULL(StoredTracksExtra, "TracksExtra", "AOD", "TRACKEXTRA", //! On disk version of TracksExtra
-                       track::TPCInnerParam, track::Flags, track::ITSClusterMap,
+                       track::TPCInnerParam, track::Flags, track::ITSClusterMap, track::ITSClusterSizes,
                        track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                        track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
                        track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -391,8 +391,8 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCovIU, StoredTracksCovIU, "TRACKCOV_IU", //! Tr
                            aod::track::C1PtTgl,
                            aod::track::C1Pt21Pt2);
 
-DECLARE_SOA_TABLE_FULL(StoredTracksExtra, "TracksExtra", "AOD", "TRACKEXTRA", //! On disk version of TracksExtra
-                       track::TPCInnerParam, track::Flags, track::ITSClusterMap, track::ITSClusterSizes,
+DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA", //! On disk version of TracksExtra
+                       track::TPCInnerParam, track::Flags, track::ITSClusterMap,
                        track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                        track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
                        track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
@@ -409,8 +409,33 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra, "TracksExtra", "AOD", "TRACKEXTRA", //
                        track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                        track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
 
-DECLARE_SOA_EXTENDED_TABLE(TracksExtra, StoredTracksExtra, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
+DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "TRACKEXTRA", 1, // Version 1 of TracksExtra
+                                 track::TPCInnerParam, track::Flags, track::ITSClusterMap, track::ITSClusterSizes,
+                                 track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
+                                 track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
+                                 track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
+                                 track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
+                                 track::PIDForTracking<track::Flags>,
+                                 track::IsPVContributor<track::Flags>,
+                                 track::HasITS<track::DetectorMap>, track::HasTPC<track::DetectorMap>,
+                                 track::HasTRD<track::DetectorMap>, track::HasTOF<track::DetectorMap>,
+                                 track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
+                                 track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
+                                 track::ITSNCls<track::ITSClusterMap>, track::ITSNClsInnerBarrel<track::ITSClusterMap>,
+                                 track::TPCCrossedRowsOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
+                                 track::TPCFoundOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
+                                 track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
+                                 track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
+
+
+DECLARE_SOA_EXTENDED_TABLE(TracksExtra_000, StoredTracksExtra_000, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
                            track::DetectorMap);
+
+DECLARE_SOA_EXTENDED_TABLE(TracksExtra_001, StoredTracksExtra_001, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
+                           track::DetectorMap);
+
+using StoredTracksExtra = StoredTracksExtra_001;
+using TracksExtra = TracksExtra_001;
 
 using Track = Tracks::iterator;
 using TrackIU = TracksIU::iterator;
@@ -1299,7 +1324,7 @@ using Run2BCInfo = Run2BCInfos::iterator;
 // ---- MC tables ----
 namespace mccollision
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc); //! BC index
+DECLARE_SOA_INDEX_COLUMN(BC, bc);                            //! BC index
 DECLARE_SOA_COLUMN(GeneratorsID, generatorsID, short);       //! disentangled generator IDs should be accessed from dynamic columns using getGenId, getCocktailId and getSourceId
 DECLARE_SOA_COLUMN(PosX, posX, float);                       //! X vertex position in cm
 DECLARE_SOA_COLUMN(PosY, posY, float);                       //! Y vertex position in cm
@@ -1438,8 +1463,11 @@ namespace soa
 DECLARE_EQUIVALENT_FOR_INDEX(aod::Collisions_000, aod::Collisions_001);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredMcParticles_000, aod::StoredMcParticles_001);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::StoredTracksIU);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::StoredTracksExtra);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksIU, aod::StoredTracksExtra);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::StoredTracksExtra_000);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksIU, aod::StoredTracksExtra_000);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::StoredTracksExtra_001);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksIU, aod::StoredTracksExtra_001);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksExtra_000, aod::StoredTracksExtra_001);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::HMPID_000, aod::HMPID_001);
 } // namespace soa
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -221,8 +221,8 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
 // TRACKEXTRA TABLE definition
 DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float);                                      //! Momentum at inner wall of the TPC
 DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                                   //! Track flags. Run 2: see TrackFlagsRun2Enum | Run 3: see TrackFlags
-DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                    //! ITS cluster map, one bit per a layer, starting from the innermost
 DECLARE_SOA_COLUMN(ITSClusterSizes, itsClusterSizes, uint32_t);                               //! Clusters sizes, four bits per a layer, starting from the innermost
+DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t);                                   //! Old cluster ITS cluster map, kept for retrocompatibility
 DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t);                                //! Findable TPC clusters for this track geometry
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t);             //! TPC Clusters: Findable - Found
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t); //! TPC Clusters: Findable - crossed rows
@@ -241,10 +241,11 @@ DECLARE_SOA_COLUMN(TrackPhiEMCAL, trackPhiEmcal, float);                        
 DECLARE_SOA_COLUMN(TrackTime, trackTime, float);                                              //! Estimated time of the track in ns wrt collision().bc() or ambiguoustrack.bcSlice()[0]
 DECLARE_SOA_COLUMN(TrackTimeRes, trackTimeRes, float);                                        //! Resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange)
 DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t,                              //! Detector map: see enum DetectorMapEnum
-                              ifnode(aod::track::itsClusterMap > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
+                              ifnode(aod::track::itsClusterSizes > (uint32_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
                                 ifnode(aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
                                 ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
                                 ifnode((aod::track::tofChi2 >= 0.f) && (aod::track::tofExpMom > 0.f), static_cast<uint8_t>(o2::aod::track::TOF), (uint8_t)0x0));
+
 DECLARE_SOA_DYNAMIC_COLUMN(HasITS, hasITS, //! Flag to check if track has a ITS match
                            [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::ITS; });
 DECLARE_SOA_DYNAMIC_COLUMN(HasTPC, hasTPC, //! Flag to check if track has a TPC match
@@ -261,6 +262,16 @@ DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsFound, tpcNClsFound, //! Number of found TPC c
                            [](uint8_t tpcNClsFindable, int8_t tpcNClsFindableMinusFound) -> int16_t { return (int16_t)tpcNClsFindable - tpcNClsFindableMinusFound; });
 DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, //! Number of crossed TPC Rows
                            [](uint8_t tpcNClsFindable, int8_t TPCNClsFindableMinusCrossedRows) -> int16_t { return (int16_t)tpcNClsFindable - TPCNClsFindableMinusCrossedRows; });
+DECLARE_SOA_DYNAMIC_COLUMN(ITSClusterMapDyn, itsClusterMap, //! ITS cluster map, one bit per a layer, starting from the innermost
+                           [](uint32_t itsClusterSizes) -> uint8_t {
+                             uint8_t clmap = 0;
+                             for (unsigned int layer = 0; layer < 7; layer++) {
+                               if ((itsClusterSizes >> (layer * 4)) & 0xf) {
+                                 clmap |= (1 << layer);
+                               }
+                             }
+                             return clmap;
+                           });
 DECLARE_SOA_DYNAMIC_COLUMN(ITSNCls, itsNCls, //! Number of ITS clusters
                            [](uint8_t itsClusterMap) -> uint8_t {
                              uint8_t itsNcls = 0;
@@ -277,6 +288,24 @@ DECLARE_SOA_DYNAMIC_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, //! Number of
                              constexpr uint8_t bit = 1;
                              for (int layer = 0; layer < 3; layer++) {
                                if (itsClusterMap & (bit << layer))
+                                 itsNclsInnerBarrel++;
+                             }
+                             return itsNclsInnerBarrel;
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(ITSNCls001, itsNCls, //! Number of ITS clusters
+                           [](uint8_t itsClusterSizes) -> uint8_t {
+                             uint8_t itsNcls = 0;
+                             for (int layer = 0; layer < 7; layer++) {
+                               if ((itsClusterSizes >> (layer * 4)) & 0xf)
+                                 itsNcls++;
+                             }
+                             return itsNcls;
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(ITSNClsInnerBarrel001, itsNClsInnerBarrel, //! Number of ITS clusters in the Inner Barrel
+                           [](uint8_t itsClusterSizes) -> uint8_t {
+                             uint8_t itsNclsInnerBarrel = 0;
+                             for (int layer = 0; layer < 3; layer++) {
+                               if ((itsClusterSizes >> (layer * 4)) & 0xf)
                                  itsNclsInnerBarrel++;
                              }
                              return itsNclsInnerBarrel;
@@ -410,7 +439,7 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
                        track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
 
 DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "TRACKEXTRA", 1, // Version 1 of TracksExtra
-                                 track::TPCInnerParam, track::Flags, track::ITSClusterMap, track::ITSClusterSizes,
+                                 track::TPCInnerParam, track::Flags, track::ITSClusterSizes,
                                  track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                                  track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
                                  track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
@@ -421,12 +450,11 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "T
                                  track::HasTRD<track::DetectorMap>, track::HasTOF<track::DetectorMap>,
                                  track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                                  track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
-                                 track::ITSNCls<track::ITSClusterMap>, track::ITSNClsInnerBarrel<track::ITSClusterMap>,
+                                 track::ITSClusterMapDyn<track::ITSClusterSizes>, track::ITSNCls001<track::ITSClusterSizes>, track::ITSNClsInnerBarrel001<track::ITSClusterSizes>,
                                  track::TPCCrossedRowsOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
                                  track::TPCFoundOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                                  track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                                  track::TrackEtaEMCAL, track::TrackPhiEMCAL, track::TrackTime, track::TrackTimeRes);
-
 
 DECLARE_SOA_EXTENDED_TABLE(TracksExtra_000, StoredTracksExtra_000, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
                            track::DetectorMap);

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -249,7 +249,6 @@ DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector ma
                                 ifnode(aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
                                 ifnode((aod::track::tofChi2 >= 0.f) && (aod::track::tofExpMom > 0.f), static_cast<uint8_t>(o2::aod::track::TOF), (uint8_t)0x0));
 
-
 namespace v001
 {
 DECLARE_SOA_EXPRESSION_COLUMN(DetectorMap, detectorMap, uint8_t, //! Detector map version 1

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -175,7 +175,7 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& reque
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksCovExtensionMetadata{}));
         } else if (description == header::DataDescription{"TRACKCOV_IU"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksCovIUExtensionMetadata{}));
-        } else if (description == header::DataDescription{"TRACKEXTRA_000"}) {
+        } else if (description == header::DataDescription{"TRACKEXTRA"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_000ExtensionMetadata{}));
         } else if (description == header::DataDescription{"TRACKEXTRA_001"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_001ExtensionMetadata{}));

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -176,9 +176,11 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& reque
         } else if (description == header::DataDescription{"TRACKCOV_IU"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksCovIUExtensionMetadata{}));
         } else if (description == header::DataDescription{"TRACKEXTRA"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_000ExtensionMetadata{}));
-        } else if (description == header::DataDescription{"TRACKEXTRA_001"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_001ExtensionMetadata{}));
+          if (version == 0U) {
+            outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_000ExtensionMetadata{}));
+          } else if (version == 1U) {
+            outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_001ExtensionMetadata{}));
+          }
         } else if (description == header::DataDescription{"MFTTRACK"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::MFTTracksExtensionMetadata{}));
         } else if (description == header::DataDescription{"FWDTRACK"}) {

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -175,8 +175,10 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& reque
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksCovExtensionMetadata{}));
         } else if (description == header::DataDescription{"TRACKCOV_IU"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksCovIUExtensionMetadata{}));
-        } else if (description == header::DataDescription{"TRACKEXTRA"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtraExtensionMetadata{}));
+        } else if (description == header::DataDescription{"TRACKEXTRA_000"}) {
+          outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_000ExtensionMetadata{}));
+        } else if (description == header::DataDescription{"TRACKEXTRA_001"}) {
+          outputs.adopt(Output{origin, description, version}, maker(o2::aod::TracksExtra_001ExtensionMetadata{}));
         } else if (description == header::DataDescription{"MFTTRACK"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::MFTTracksExtensionMetadata{}));
         } else if (description == header::DataDescription{"FWDTRACK"}) {

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -164,7 +164,7 @@ TEST_CASE("AdaptorCompilation")
   REQUIRE(task2.inputs.size() == 10);
   REQUIRE(task2.inputs[1].binding == "TracksExtension");
   REQUIRE(task2.inputs[2].binding == "Tracks");
-  REQUIRE(task2.inputs[3].binding == "TracksExtraExtension");
+  REQUIRE(task2.inputs[3].binding == "TracksExtra_000Extension");
   REQUIRE(task2.inputs[4].binding == "TracksExtra");
   REQUIRE(task2.inputs[5].binding == "TracksCovExtension");
   REQUIRE(task2.inputs[6].binding == "TracksCov");


### PR DESCRIPTION
Follows the discussion presented in https://indico.cern.ch/event/1332124/
Cluster sizes are added to AO2Ds and cluster map is removed. Few modifications have been done to the ITS tracking and ITSTPC matching to get the cl size information (pinging @mconcas , @mpuccio , @shahor02 ). We have also updated the AnalysisDataModel and created a versioning of the trackExtra tables. Few dyn columns have been changed, I will undraft the PR as soon as I checked that we get consistent results with the old dataformat (pinging @ddobrigk , @jgrosseo )