### PR TITLE
ITS Adapos: added a wait time of 30s between consecutive pushes to ccdb

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
@@ -85,6 +85,10 @@ class ITSDCSAdaposParser : public Task
   std::string mCcdbFetchUrl = "http://ccdb-test.cern.ch:8080";
   o2::ccdb::BasicCCDBManager& mMgr = o2::ccdb::BasicCCDBManager::instance();
   long int startTime;
+
+  // to avoid several pushes to CCDB
+  long int pushTime = 0;
+  long int lastPushTime = 0;
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSAdaposParserSpec.cxx
@@ -111,7 +111,12 @@ void ITSDCSAdaposParser::process(const gsl::span<const DPCOM> dps)
   }
   if (mapel->second.payload_pt1 + 8 != mCcdbAlpideParam->roFrameLengthInBC) {
     mStrobeToUpload = mapel->second.payload_pt1;
-    doStrobeUpload = true;
+    pushTime = o2::ccdb::getCurrentTimestamp();
+    if (pushTime - lastPushTime > 30000) { // push to CCDB only if at least 30s passed from the last push
+      doStrobeUpload = true;
+    } else {
+      doStrobeUpload = false;
+    }
   } else {
     doStrobeUpload = false;
   }
@@ -195,6 +200,9 @@ void ITSDCSAdaposParser::pushToCCDB(ProcessingContext& pc)
       &image->at(0), image->size(), info.getFileName(), info.getObjectType(), info.getPath(),
       info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
   }
+
+  // uptade lastPushTime
+  lastPushTime = o2::ccdb::getCurrentTimestamp();
 
   return;
 }


### PR DESCRIPTION
Added because currently, when ITS changes the strobe length, the following thing happens:
- a new strobe = X arrives --> the workflow ships X to ccdb (that's ok)
- but the change of strobe happens in different moments for the staves hence the old strobe Y is still transmitted in some data points --> Y != X and the workflow ships Y to ccdb (not ideal)
- strobe configuration completed, X arrives again --> X !=Y and the workflow ships X to ccdb (not ideal)

The timestamps of the 3 entries are very close to each other (2-6 seconds maximum). Since the last value shipped is X, there is no problem but for every change in strobe we can have 3 entries in ccdb. With the modification in this PR, we wait 30s before re-shipping something to ccdb. This will avoid bullets 2 and 3. 

cc @nicolovalle @shahor02 