### PR TITLE
DPL: When enumeration timeframe was rewinded, don't send a newer oldestPossible

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -466,6 +466,11 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       timesliceIndex.updateOldestPossibleOutput();
       auto& proxy = ctx.services().get<FairMQDeviceProxy>();
       auto oldestPossibleOutput = relayer.getOldestPossibleOutput();
+      if (decongestion->nextEnumerationTimesliceRewinded && decongestion->nextEnumerationTimeslice < oldestPossibleOutput.timeslice.value) {
+        LOGP(detail, "Not sending oldestPossible if nextEnumerationTimeslice was rewinded");
+        return;
+      }
+
       if (decongestion->lastTimeslice && oldestPossibleOutput.timeslice.value == decongestion->lastTimeslice) {
         LOGP(debug, "Not sending already sent value");
         return;

--- a/Framework/Core/src/DecongestionService.h
+++ b/Framework/Core/src/DecongestionService.h
@@ -21,6 +21,9 @@ struct DecongestionService {
   /// The last timeslice which the ExpirationHandler::Creator callback
   /// created. This can be used to skip dummy iterations.
   size_t nextEnumerationTimeslice = 0;
+  /// Flag to indicate that we rewinded the nextExnumerationTimeslice.
+  /// The rewinded value must be checked when sending the oldestPossible.
+  bool nextEnumerationTimesliceRewinded = false;
   /// Last timeslice we communicated. Notice this should never go backwards.
   int64_t lastTimeslice = 0;
   /// The next timeslice we should consume, when running in order,

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -563,8 +563,9 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
     }
     // In case we did not send any part at all, we need to rewind by one
     // to avoid creating extra timeslices at the end of the run.
+    auto& decongestion = services.get<DecongestionService>();
+    decongestion.nextEnumerationTimesliceRewinded = !didSendParts;
     if (didSendParts == false) {
-      auto& decongestion = services.get<DecongestionService>();
       decongestion.nextEnumerationTimeslice -= 1;
     }
     if (not unmatchedDescriptions.empty()) {


### PR DESCRIPTION
@ktf : Without this, we rewind the next enumeration, but we still send the oldestPossible after not sending any data.
First I wanted to do it without the extra flag, just checking if `nextEnumerationTimeslice != 0`, but that fails in case the run is stopped without ever sending data, so I added the rewind flag to make it explicit.