### PR TITLE
Warn about CTF/rawTF readers waiting for remote data to be copied

### DIFF
--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -100,6 +100,8 @@ class CTFReaderSpec : public o2::framework::Task
   int mNFailedFiles = 0;
   int mFilesRead = 0;
   int mTFLength = 128;
+  int mNWaits = 0;
+  long mTotalWaitTime = 0;
   long mLastSendTime = 0L;
   long mCurrTreeEntry = 0L;
   long mImposeRunStartMS = 0L;
@@ -127,8 +129,8 @@ void CTFReaderSpec::stopReader()
     return;
   }
   LOGP(info, "CTFReader stops processing, {} files read, {} files failed", mFilesRead - mNFailedFiles, mNFailedFiles);
-  LOGP(info, "CTF reading total timing: Cpu: {:.3f} Real: {:.3f} s for {} TFs in {} loops",
-       mTimer.CpuTime(), mTimer.RealTime(), mCTFCounter, mFileFetcher->getNLoops());
+  LOGP(info, "CTF reading total timing: Cpu: {:.3f} Real: {:.3f} s for {} TFs in {} loops, spent {:.2} s in {} data waiting states",
+       mTimer.CpuTime(), mTimer.RealTime(), mCTFCounter, mFileFetcher->getNLoops(), 1e-6 * mTotalWaitTime, mNWaits);
   mRunning = false;
   mFileFetcher->stop();
   mFileFetcher.reset();
@@ -195,6 +197,8 @@ void CTFReaderSpec::run(ProcessingContext& pc)
     mInput.tfRateLimit = std::stoi(pc.services().get<RawDeviceService>().device()->fConfig->GetValue<std::string>("timeframes-rate-limit"));
   }
   std::string tfFileName;
+  bool waitAcknowledged = false;
+  long startWait = 0;
 
   while (mRunning) {
     if (mCTFTree) { // there is a tree open with multiple CTF
@@ -218,15 +222,27 @@ void CTFReaderSpec::run(ProcessingContext& pc)
         mRunning = false;
         break;
       }
+      if (!waitAcknowledged) {
+        startWait = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+        waitAcknowledged = true;
+      }
       pc.services().get<RawDeviceService>().waitFor(5);
       continue;
+    }
+    if (waitAcknowledged) {
+      long waitTime = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count() - startWait;
+      mTotalWaitTime += waitTime;
+      if (++mNWaits > 1) {
+        LOGP(warn, "Resuming reading after waiting for data {:.2} s (accumulated {:.2} s delay in {} waits)", 1e-6 * waitTime, 1e-6 * mTotalWaitTime, mNWaits);
+      }
+      waitAcknowledged = false;
     }
     LOG(info) << "Reading CTF input " << ' ' << tfFileName;
     openCTFFile(tfFileName);
   }
 
   if (mCTFCounter >= mInput.maxTFs || (!mInput.ctfIDs.empty() && mSelIDEntry >= mInput.ctfIDs.size())) { // done
-    LOG(info) << "All CTFs from selected range were injected, stopping";
+    LOGP(info, "All CTFs from selected range were injected, stopping");
     mRunning = false;
   } else if (mRunning && !mCTFTree && mFileFetcher->getNextFileInQueue().empty() && !mFileFetcher->isRunning()) { // previous tree was done, can we read more?
     mRunning = false;

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -78,6 +78,8 @@ class TFReaderSpec : public o2f::Task
   std::unordered_map<o2h::DataIdentifier, SubSpecCount> mSeenOutputMap;
   int mTFCounter = 0;
   int mTFBuilderCounter = 0;
+  int mNWaits = 0;
+  long mTotalWaitTime = 0;
   size_t mSelIDEntry = 0; // next TFID to select from the mInput.tfIDs (if non-empty)
   bool mRunning = false;
   TFReaderInp mInput; // command line inputs
@@ -230,10 +232,6 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
   };
 
   while (1) {
-    if (mTFCounter >= mInput.maxTFs) { // done
-      stopProcessing(ctx);
-      break;
-    }
     if (mTFQueue.size()) {
       static o2f::RateLimiter limiter;
       limiter.check(ctx, mInput.tfRateLimit, mInput.minSHM);
@@ -283,6 +281,9 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
     }
     usleep(5000); // wait 5ms for new TF to be built
   }
+  if (mTFCounter >= mInput.maxTFs) { // done
+    stopProcessing(ctx);
+  }
 }
 
 //____________________________________________________________
@@ -300,7 +301,7 @@ void TFReaderSpec::endOfStream(o2f::EndOfStreamContext& ec)
 //___________________________________________________________
 void TFReaderSpec::stopProcessing(o2f::ProcessingContext& ctx)
 {
-  LOG(info) << mTFCounter << " TFs in " << mFileFetcher->getNLoops() << " loops were sent";
+  LOGP(info, "{} TFs in {}  loops were sent, spent {:.2} s in {} data waiting states", mTFCounter, mFileFetcher->getNLoops(), 1e-6 * mTotalWaitTime, mNWaits);
   mRunning = false;
   mFileFetcher->stop();
   mFileFetcher.reset();
@@ -333,6 +334,8 @@ void TFReaderSpec::TFBuilder()
   // build TFs and add to the queue
   std::string tfFileName;
   auto sleepTime = std::chrono::microseconds(mInput.delay_us > 10000 ? mInput.delay_us : 10000);
+  bool waitAcknowledged = false;
+  long startWait = 0;
   while (mRunning && mDevice) {
     if (mTFQueue.size() >= size_t(mInput.maxTFCache)) {
       std::this_thread::sleep_for(sleepTime);
@@ -352,9 +355,23 @@ void TFReaderSpec::TFBuilder()
       break;
     }
     if (tfFileName.empty()) {
-      std::this_thread::sleep_for(10ms); // fait for the files cache to be filled
+      if (!waitAcknowledged) {
+        startWait = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+        waitAcknowledged = true;
+      }
+      std::this_thread::sleep_for(10ms); // wait for the files cache to be filled
       continue;
     }
+    if (waitAcknowledged) {
+      long waitTime = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count() - startWait;
+      mTotalWaitTime += waitTime;
+      if (++mNWaits > 1) {
+        LOGP(warn, "Resuming reading after waiting for data {:.2} s (accumulated {:.2} s delay in {} waits)", 1e-6 * waitTime, 1e-6 * mTotalWaitTime, mNWaits);
+      }
+      waitAcknowledged = false;
+      startWait = 0;
+    }
+
     LOG(info) << "Processing file " << tfFileName;
     SubTimeFrameFileReader reader(tfFileName, mInput.detMask);
     size_t locID = 0;


### PR DESCRIPTION
@davidrohr , the warning for the 1st file is not logged:

```
o2-ctf-reader-workflow --ctf-input ctf.lst --onlyDet FV0 --shm-segment-size 16000000000 --run --no-batch | tee xx.log
grep wait xx.log
[1219445:ctf-reader]: [01:48:27][WARN] Resuming reading after waiting for data 0.93 s (accumulated 8 s delay in 2 waits)
[1219445:ctf-reader]: [01:48:30][WARN] Resuming reading after waiting for data 2.8 s (accumulated 11 s delay in 3 waits)
[1219445:ctf-reader]: [01:48:33][WARN] Resuming reading after waiting for data 2.7 s (accumulated 14 s delay in 4 waits)
[1219445:ctf-reader]: [01:48:33][INFO] CTF reading total timing: Cpu: 1.520 Real: 1.545 s for 5 TFs in 1 loops, spent 14 s in 4 data waiting states


o2-raw-tf-reader-workflow --input-data rtw.lst --onlyDet FV0 --shm-segment-size 16000000000 --run --no-batch | tee rr.log
grep wait rr.log
[1220142:tf-reader]: [01:50:04][WARN] Resuming reading after waiting for data 9.8 s (accumulated 21 s delay in 2 waits)
[1220142:tf-reader]: [01:50:14][WARN] Resuming reading after waiting for data 10 s (accumulated 32 s delay in 3 waits)
[1220142:tf-reader]: [01:50:24][WARN] Resuming reading after waiting for data 8.7 s (accumulated 41 s delay in 4 waits)
[1220142:tf-reader]: [01:50:24][INFO] 4 TFs in 1  loops were sent, spent 41 s in 4 data waiting states

```
