### PR TITLE
Relax type check for old dictionaries in compat mode, warn only.

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -386,7 +386,11 @@ class EncodedBlocks
       assert(dictMax <= metadata.max);
 
       if ((dictMin < sourceMin) || (dictMax > sourceMax)) {
-        throw std::runtime_error(fmt::format("value range of dictionary and target datatype are incompatible: target type [{},{}] vs dictionary [{},{}]", sourceMin, sourceMax, dictMin, dictMax));
+        if (ansVersion == ANSVersionCompat && mHeader.majorVersion == 1 && mHeader.minorVersion == 0 && mHeader.dictTimeStamp < 1653192000000) {
+          LOGP(warn, "value range of dictionary and target datatype are incompatible: target type [{},{}] vs dictionary [{},{}], tolerate in compat mode for old dictionaries", sourceMin, sourceMax, dictMin, dictMax);
+        } else {
+          throw std::runtime_error(fmt::format("value range of dictionary and target datatype are incompatible: target type [{},{}] vs dictionary [{},{}]", sourceMin, sourceMax, dictMin, dictMax));
+        }
       }
     }();
 


### PR DESCRIPTION
Initially some CTF blocks were declared unsigned to store incremenets of ordered data but in some cases ordering was broken. To not inflate dynamic range due to the neagative -> unsigned cast we changed these types to signed but in a few old dictionaries we still have data min/max which does not fit to the signed range. For these old dictionaries we have no other way but to not throw exception on the failed type check. The (de)coding does not suffer since if done consistently with the same data type defined, even if it does not match to the data range.