### PR TITLE
Vectored loadFileToMemory in CcdbApi

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -24,17 +24,19 @@
 #include <TObject.h>
 #include <TMessage.h>
 #include "CCDB/CcdbObjectInfo.h"
-#include "CCDB/CCDBDownloader.h"
 #include <CommonUtils/ConfigurableParam.h>
 #include <type_traits>
 #include <vector>
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
 #include "MemoryResources/MemoryResources.h"
+#include <boost/interprocess/sync/named_semaphore.hpp>
 #include <TJAlienCredentials.h>
 #else
 class TJAlienCredentials;
 #endif
+
+#include "CCDB/CCDBDownloader.h"
 
 class TFile;
 class TGrid;
@@ -342,14 +344,43 @@ class CcdbApi //: public DatabaseInterface
   TObject* retrieveFromTFile(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp,
                              std::map<std::string, std::string>* headers, std::string const& etag,
                              const std::string& createdNotAfter, const std::string& createdNotBefore) const;
-
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
+  typedef struct RequestContext {
+    o2::pmr::vector<char>& dest;
+    std::string path;
+    std::map<std::string, std::string> const& metadata;
+    long timestamp;
+    std::map<std::string, std::string>& headers;
+    std::string etag;
+    std::string createdNotAfter;
+    std::string createdNotBefore;
+    bool considerSnapshot;
+
+    RequestContext(o2::pmr::vector<char>& d,
+                   std::map<std::string, std::string> const& m,
+                   std::map<std::string, std::string>& h)
+      : dest(d), metadata(m), headers(h) {}
+  } RequestContext;
+
+  // Stores file associated with requestContext as a snapshot.
+  void saveSnapshot(RequestContext& requestContext) const;
+
+  // Schedules download via CCDBDownloader, but doesn't perform it until mUVLoop is ran.
+  void scheduleDownload(RequestContext& requestContext, size_t* requestCounter) const;
+
+  void getFromSnapshot(bool createSnapshot, std::string const& path,
+                       long timestamp, std::map<std::string, std::string> headers,
+                       std::string& snapshotpath, o2::pmr::vector<char>& dest, int& fromSnapshot, std::string const& etag) const;
+  void releaseNamedSemaphore(boost::interprocess::named_semaphore* sem, std::string path) const;
+  boost::interprocess::named_semaphore* createNamedSempahore(std::string path) const;
   void loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& path, std::map<std::string, std::string>* localHeaders = nullptr) const;
   void loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& path,
                         std::map<std::string, std::string> const& metadata, long timestamp,
                         std::map<std::string, std::string>* headers, std::string const& etag,
                         const std::string& createdNotAfter, const std::string& createdNotBefore, bool considerSnapshot = true) const;
-  void navigateURLsAndLoadFileToMemory(o2::pmr::vector<char>& dest, CURL* curl_handle, std::string const& url, std::map<string, string>* headers) const;
+
+  // Loads files from alien and cvmfs into given destination.
+  bool loadLocalContentToMemory(o2::pmr::vector<char>& dest, std::string& url) const;
 
   // the failure to load the file to memory is signaled by 0 size and non-0 capacity
   static bool isMemoryFileInvalid(const o2::pmr::vector<char>& v) { return v.size() == 0 && v.capacity() > 0; }
@@ -364,11 +395,35 @@ class CcdbApi //: public DatabaseInterface
     }
     return obj;
   }
+
+  /**
+   * Retrieves files either as snapshot or schedules them to be downloaded via CCDBDownloader.
+   *
+   * @param requestContext Structure giving details about the transfer.
+   * @param fromSnapshot After navigateSourcesAndLoadFile returns signals whether file was retrieved from snapshot.
+   * @param requestCounter Pointer to the variable storing the number of requests to be done.
+   */
+  void navigateSourcesAndLoadFile(RequestContext& requestContext, int& fromSnapshot, size_t* requestCounter) const;
+
+  /**
+   * Retrieves files described via RequestContexts into memory. Downloads are performed in parallel via CCDBDownloader.
+   *
+   * @param requestContext Structure giving details about the transfer.
+   */
+  void vectoredLoadFileToMemory(std::vector<RequestContext>& requestContext) const;
 #endif
 
  private:
   // Sets the unique agent ID
   void setUniqueAgentID();
+
+  /**
+   * Schedules download of data associated with the curl_handle. Doing that increments the requestCounter by 1. Requests are performed by running the mUVLoop
+   *
+   * @param handle CURL handle associated with the request.
+   * @param requestCounter Pointer to the variable storing the number of requests to be done.
+   */
+  void asynchPerform(CURL* handle, size_t* requestCounter) const;
 
   // internal helper function to update a CCDB file with meta information
   static void updateMetaInformationInLocalFile(std::string const& filename, std::map<std::string, std::string> const* headers, CCDBQuery const* querysummary = nullptr);
@@ -550,7 +605,7 @@ class CcdbApi //: public DatabaseInterface
   CURLcode CURL_perform(CURL* handle) const;
 
   mutable CCDBDownloader* mDownloader = nullptr; //! the multi-handle (async) CURL downloader
-  bool mIsCCDBDownloaderEnabled = false;
+  bool mIsCCDBDownloaderPreferred = false;
   /// Base URL of the CCDB (with port)
   std::string mUniqueAgentID{}; // Unique User-Agent ID communicated to server for logging
   std::string mUrl{};

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -344,31 +344,130 @@ void CCDBDownloader::destroyCurlContext(curl_context_t* context)
   uv_close((uv_handle_t*)context->poll_handle, curlCloseCB);
 }
 
+void CCDBDownloader::tryNewHost(PerformData* performData, CURL* easy_handle)
+{
+  auto requestData = performData->requestData;
+  std::string newUrl = requestData->hosts.at(performData->hostInd) + "/" + requestData->path + "/" + std::to_string(requestData->timestamp);
+  LOG(debug) << "Connecting to another host " << newUrl;
+  requestData->hoPair.header.clear();
+  curl_easy_setopt(easy_handle, CURLOPT_URL, newUrl.c_str());
+  mHandlesToBeAdded.push_back(easy_handle);
+}
+
+void CCDBDownloader::getLocalContent(PerformData* performData, std::string& newUrl, std::string& newLocation, bool& contentRetrieved, std::vector<std::string>& locations)
+{
+  auto requestData = performData->requestData;
+  newUrl = newLocation;
+  LOG(debug) << "Redirecting to local content " << newUrl << "\n";
+  if (requestData->localContentCallback(newUrl)) {
+    contentRetrieved = true;
+  } else {
+    // Prepare next redirect url
+    newLocation = (performData->locInd < locations.size()) ? locations.at(performData->locInd) : "";
+    performData->locInd++;
+  }
+}
+
+void CCDBDownloader::httpRedirect(PerformData* performData, std::string& newUrl, std::string& newLocation, CURL* easy_handle)
+{
+  auto requestData = performData->requestData;
+  newUrl = requestData->hosts.at(performData->hostInd) + newLocation;
+  LOG(debug) << "Trying content location " << newUrl;
+  curl_easy_setopt(easy_handle, CURLOPT_URL, newUrl.c_str());
+  mHandlesToBeAdded.push_back(easy_handle);
+}
+
+void CCDBDownloader::followRedirect(PerformData* performData, CURL* easy_handle, std::vector<std::string>& locations, bool& rescheduled, bool& contentRetrieved)
+{
+  std::string newLocation = locations.at(performData->locInd++);
+  std::string newUrl;
+  if (newLocation.find("alien:/", 0) != std::string::npos || newLocation.find("file:/", 0) != std::string::npos) {
+    getLocalContent(performData, newUrl, newLocation, contentRetrieved, locations);
+  }
+  if (!contentRetrieved && newLocation != "") {
+    httpRedirect(performData, newUrl, newLocation, easy_handle);
+    rescheduled = true;
+  }
+}
+
 void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
 {
   mHandlesInUse--;
-  PerformData* data;
-  curlEasyErrorCheck(curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &data));
+  PerformData* performData;
+  curlEasyErrorCheck(curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &performData));
 
   curlMultiErrorCheck(curl_multi_remove_handle(mCurlMultiHandle, easy_handle));
-  *data->codeDestination = curlCode;
+  *performData->codeDestination = curlCode;
 
-  // If no requests left then signal finished based on type of operation
-  if (--(*data->requestsLeft) == 0) {
-    switch (data->type) {
-      case BLOCKING:
-        break;
-      case ASYNCHRONOUS:
-        // Temporary change before asynchronous calls are reintroduced
-        LOG(error) << "CCDBDownloader: Illegal request type";
-        break;
-      case ASYNCHRONOUS_WITH_CALLBACK:
-        // Temporary change before asynchronous calls will callbacks are reintroduced
-        LOG(error) << "CCDBDownloader: Illegal request type";
-        break;
-    }
+  bool rescheduled = false;
+  bool contentRetrieved = false;
+
+  switch (performData->type) {
+    case BLOCKING: {
+      --(*performData->requestsLeft);
+    } break;
+    case ASYNCHRONOUS: {
+      DownloaderRequestData* requestData = performData->requestData;
+
+      if (requestData->headers) {
+        for (auto& p : requestData->hoPair.header) {
+          (*requestData->headers)[p.first] = p.second;
+        }
+      }
+      if (requestData->errorflag && requestData->headers) {
+        (*requestData->headers)["Error"] = "An error occurred during retrieval";
+      }
+
+      // Log that transfer finished
+      long httpCode;
+      curl_easy_getinfo(easy_handle, CURLINFO_RESPONSE_CODE, &httpCode);
+      char* url;
+      curl_easy_getinfo(easy_handle, CURLINFO_EFFECTIVE_URL, &url);
+      LOG(debug) << "Transfer for " << url << " finished with code " << httpCode << "\n";
+
+      // Get alternative locations for the same host
+      auto locations = getLocations(requestData->hosts.at(performData->hostInd), &(requestData->hoPair.header));
+
+      // React to received http code
+      if (404 == httpCode) {
+        LOG(error) << "Requested resource does not exist: " << url;
+      } else if (304 == httpCode) {
+        LOGP(debug, "Object exists but I am not serving it since it's already in your possession");
+        contentRetrieved = true;
+      } else if (300 <= httpCode && httpCode < 400 && performData->locInd < locations.size()) {
+        followRedirect(performData, easy_handle, locations, rescheduled, contentRetrieved);
+      } else if (200 <= httpCode && httpCode < 300) {
+        contentRetrieved = true;
+      } else {
+        LOG(error) << "Error in fetching object " << url << ", curl response code:" << httpCode;
+      }
+
+      // Check if content was retrieved, or scheduled to be retrieved
+      if (!rescheduled && !contentRetrieved && performData->locInd == locations.size()) {
+        // Ran out of locations to redirect, try new host
+        if (++performData->hostInd < requestData->hosts.size()) {
+          tryNewHost(performData, easy_handle);
+          rescheduled = true;
+        } else {
+          LOG(error) << "File " << requestData->path << " could not be retrieved. No more hosts to try.";
+        }
+      }
+
+      if (!rescheduled) {
+        // No more transfers will be done for this request, do cleanup specific for ASYNCHRONOUS calls
+        --(*performData->requestsLeft);
+        delete requestData;
+        delete performData->codeDestination;
+        if (!contentRetrieved) {
+          LOGP(alarm, "Curl request to {}, response code: {}", url, httpCode);
+        }
+      }
+    } break;
   }
-  delete data;
+  if (!rescheduled) {
+    // No more transfers will be done for this request, do general cleanup
+    delete performData;
+  }
 
   checkHandleQueue();
 
@@ -450,6 +549,34 @@ CURLcode CCDBDownloader::perform(CURL* handle)
   return batchBlockingPerform(handleVector).back();
 }
 
+std::vector<std::string> CCDBDownloader::getLocations(std::string baseUrl, std::multimap<std::string, std::string>* headerMap) const
+{
+  std::vector<std::string> locs;
+  auto iter = headerMap->find("Location");
+  if (iter != headerMap->end()) {
+    if (iter->second.find("/", 0) != std::string::npos) {
+      locs.push_back(iter->second);
+    } else {
+      locs.push_back(baseUrl + iter->second);
+    }
+  }
+  // add alternative locations (not yet included)
+  auto iter2 = headerMap->find("Content-Location");
+  if (iter2 != headerMap->end()) {
+    auto range = headerMap->equal_range("Content-Location");
+    for (auto it = range.first; it != range.second; ++it) {
+      if (std::find(locs.begin(), locs.end(), it->second) == locs.end()) {
+        if (it->second.find("alien", 0) != std::string::npos) {
+          locs.push_back(it->second);
+        } else {
+          locs.push_back(baseUrl + it->second);
+        }
+      }
+    }
+  }
+  return locs;
+}
+
 std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> const& handleVector)
 {
   std::vector<CURLcode> codeVector(handleVector.size());
@@ -462,7 +589,6 @@ std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> co
 
     data->type = BLOCKING;
     data->requestsLeft = &requestsLeft;
-
     setHandleOptions(handleVector[i], data);
     mHandlesToBeAdded.push_back(handleVector[i]);
   }
@@ -470,7 +596,42 @@ std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> co
   while (requestsLeft > 0) {
     uv_run(mUVLoop, UV_RUN_ONCE);
   }
+
   return codeVector;
+}
+
+void CCDBDownloader::asynchSchedule(CURL* handle, size_t* requestCounter)
+{
+  (*requestCounter)++;
+
+  CURLcode* codeVector = new CURLcode();
+
+  // Get data about request
+  DownloaderRequestData* requestData;
+  std::multimap<std::string, std::string>* headerMap;
+  std::vector<std::string>* hostsPool;
+  curl_easy_getinfo(handle, CURLINFO_PRIVATE, &requestData);
+  headerMap = &(requestData->hoPair.header);
+  hostsPool = &(requestData->hosts);
+
+  // Prepare temporary data about transfer
+  auto* data = new CCDBDownloader::PerformData(); // Freed in transferFinished
+  data->codeDestination = codeVector;
+  *codeVector = CURLE_FAILED_INIT;
+
+  data->type = ASYNCHRONOUS;
+  data->requestsLeft = requestCounter;
+  data->hostInd = 0;
+  data->locInd = 0;
+  data->requestData = requestData;
+
+  // Prepare handle and schedule download
+  setHandleOptions(handle, data);
+  mHandlesToBeAdded.push_back(handle);
+
+  checkHandleQueue();
+
+  // return codeVector;
 }
 
 } // namespace o2

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -553,3 +553,40 @@ BOOST_AUTO_TEST_CASE(TestUpdateMetadata, *utf::precondition(if_reachable()))
   BOOST_CHECK(headers.count("custom") > 0);
   BOOST_CHECK(headers.at("custom") == "second");
 }
+
+BOOST_AUTO_TEST_CASE(multi_host_test)
+{
+  CcdbApi api;
+  api.init("http://bogus-host.cern.ch,http://ccdb-test.cern.ch:8080");
+  std::map<std::string, std::string> metadata;
+  std::map<std::string, std::string> headers;
+  o2::pmr::vector<char> dst;
+  std::string url = "Analysis/ALICE3/Centrality";
+  api.loadFileToMemory(dst, url, metadata, 1645780010602, &headers, "", "", "", true);
+  BOOST_CHECK(dst.size() != 0);
+}
+
+BOOST_AUTO_TEST_CASE(vectored)
+{
+  CcdbApi api;
+  api.init("http://ccdb-test.cern.ch:8080");
+
+  int TEST_SAMPLE_SIZE = 5;
+  std::vector<o2::pmr::vector<char>> dests(TEST_SAMPLE_SIZE);
+  std::vector<std::map<std::string, std::string>> metadatas(TEST_SAMPLE_SIZE);
+  std::vector<std::map<std::string, std::string>> headers(TEST_SAMPLE_SIZE);
+
+  std::vector<CcdbApi::RequestContext> contexts;
+  for (int i = 0; i < TEST_SAMPLE_SIZE; i++) {
+    contexts.push_back(CcdbApi::RequestContext(dests.at(i), metadatas.at(i), headers.at(i)));
+    contexts.at(i).path = "Analysis/ALICE3/Centrality";
+    contexts.at(i).timestamp = 1645780010602;
+    contexts.at(i).considerSnapshot = true;
+  }
+
+  api.vectoredLoadFileToMemory(contexts);
+
+  for (auto context : contexts) {
+    BOOST_CHECK(context.dest.size() != 0);
+  }
+}


### PR DESCRIPTION
This update changes the top level CcdbApi function loadFileToMemory to a vectored function, while maintaining backwards compatibility with the current signature and functionality of the original loadFileToMemory.

vectoredLoadFileToMemory is the main function which retrieves binary data, either from local content, alien, cvmfs or via http (all options can be mixed in a single batch of requests) and stores them in chosen char vectors. Additionally it stores the data in snapshot, if necessary options for that have been set, as previous loadFileToMemory would. The main advantage of this updated function is the capability of downloading files in parallel via the CcdbDownloader.

Additional information:
- Old loadFileToMemory is a proxy call to vectoredLoadFileToMemory.
- Navigating URLs is handled by the CcdbDownloader. The downloader is now always created in the CcdbApi constructor, as it became an integral part of loadFileToMemory.
- loadFromTFile has not been changed in any way. CcdbDownloader will be used in retrieveFromTFile only if ALICEO2_ENABLE_MULTIHANDLE_CCDBAPI is set to true. This matches the previous behaviour.
- Retrieving local content is handled by CcdbApi, which is called via a callback by CcdbDownloader when encountering a non-http url. 