### PR TITLE
Protection against bogus TRD PH values

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/PHData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/PHData.h
@@ -42,7 +42,7 @@ class PHData
 
   void set(int adc, int det, int tb, int nb, int type)
   {
-    mData = (type << 30) | (nb << 27) | (tb << 22) | (det << 12) | adc;
+    mData = ((type & 0x3) << 30) | ((nb & 0x7) << 27) | ((tb & 0x1f) << 22) | ((det & 0x3ff) << 12) | (adc & 0xfff);
   }
 
   // the ADC sum for given time bin for up to three neighbours


### PR DESCRIPTION
The crash of the T0 monitoring in runs with less than 30 time bins read out for the TRD has been understood (only affects runs 543707-543713). Before the fix of the raw decoder in https://github.com/AliceO2Group/AliceO2/pull/12001 there could have been bogus ADC values recorded outside of the valid range for the time bins which were not read out. This lead to the ADC data changing the detector number and subsequently accessing an array out of bounds where the detector was used as index.
Since we anyhow run with 30 time bins by default this is not a problem for PbPb. But in case in async reco for the aforementioned runs we would want to enable the t0 calibration this protection would be needed to avoid a crash.
Ping @luisabergmann just for information