### PR TITLE
CPV,PHS: modernize cell, digit and cluster readers

### DIFF
--- a/Detectors/CPV/workflow/CMakeLists.txt
+++ b/Detectors/CPV/workflow/CMakeLists.txt
@@ -12,6 +12,8 @@
 o2_add_library(CPVWorkflow
                SOURCES src/RecoWorkflow.cxx
                        src/ReaderSpec.cxx
+                       src/DigitReaderSpec.cxx
+                       src/ClusterReaderSpec.cxx
                        src/WriterSpec.cxx
                        src/ClusterizerSpec.cxx
                        src/DigitsPrinterSpec.cxx
@@ -40,4 +42,14 @@ o2_add_executable(entropy-encoder-workflow
 o2_add_executable(cluster-writer-workflow
                   COMPONENT_NAME cpv
                   SOURCES src/cluster-writer-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::CPVWorkflow)
+
+o2_add_executable(digit-reader-workflow
+                  COMPONENT_NAME cpv
+                  SOURCES src/digit-reader-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::CPVWorkflow)
+
+o2_add_executable(cluster-reader-workflow
+                  COMPONENT_NAME cpv
+                  SOURCES src/cluster-reader-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::CPVWorkflow)

--- a/Detectors/CPV/workflow/include/CPVWorkflow/ClusterReaderSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/ClusterReaderSpec.h
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ClusterReaderSpec.h
+
+#ifndef O2_CPV_CLUSTERREADER
+#define O2_CPV_CLUSTERREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsCPV/Cluster.h"
+#include "DataFormatsCPV/TriggerRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+
+namespace o2
+{
+namespace cpv
+{
+
+class ClusterReader : public o2::framework::Task
+{
+ public:
+  ClusterReader(bool useMC = true);
+  ~ClusterReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::cpv::Cluster> mClusters, *mClustersInp = &mClusters;
+  std::vector<o2::cpv::TriggerRecord> mTRs, *mTRsInp = &mTRs;
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+
+  o2::header::DataOrigin mOrigin = o2::header::gDataOriginCPV;
+
+  bool mUseMC = true; // use MC truth
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mClusterTreeName = "o2sim";
+  std::string mClusterBranchName = "CPVCluster";
+  std::string mTRBranchName = "CPVClusterTrigRec";
+  std::string mClusterMCTruthBranchName = "CPVClusterTrueMC";
+};
+
+/// create a processor spec
+/// read CPV Cluster data from a root file
+framework::DataProcessorSpec getCPVClusterReaderSpec(bool useMC = true);
+
+} // namespace cpv
+} // namespace o2
+
+#endif /* O2_CPV_CLUSTERREADER */

--- a/Detectors/CPV/workflow/include/CPVWorkflow/DigitReaderSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/DigitReaderSpec.h
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitReaderSpec.h
+
+#ifndef O2_CPV_DIGITREADER
+#define O2_CPV_DIGITREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsCPV/Digit.h"
+#include "DataFormatsCPV/TriggerRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+
+namespace o2
+{
+namespace cpv
+{
+
+class DigitReader : public o2::framework::Task
+{
+ public:
+  DigitReader(bool useMC = true);
+  ~DigitReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::cpv::Digit> mDigits, *mDigitsInp = &mDigits;
+  std::vector<o2::cpv::TriggerRecord> mTRs, *mTRsInp = &mTRs;
+  // std::vector<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+
+  o2::header::DataOrigin mOrigin = o2::header::gDataOriginCPV;
+
+  bool mUseMC = true; // use MC truth
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mDigitTreeName = "o2sim";
+  std::string mDigitBranchName = "CPVDigit";
+  std::string mTRBranchName = "CPVDigitTrigRecords";
+  std::string mDigitMCTruthBranchName = "CPVDigitMCTruth";
+};
+
+/// create a processor spec
+/// read CPV Digit data from a root file
+framework::DataProcessorSpec getCPVDigitReaderSpec(bool useMC = true);
+
+} // namespace cpv
+} // namespace o2
+
+#endif /* O2_CPV_DIGITREADER */

--- a/Detectors/CPV/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterReaderSpec.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ClusterReaderSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "CPVWorkflow/ClusterReaderSpec.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+using namespace o2::cpv;
+
+namespace o2
+{
+namespace cpv
+{
+
+ClusterReader::ClusterReader(bool useMC)
+{
+  mUseMC = useMC;
+}
+
+void ClusterReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("cpv-clusters-infile"));
+  connectTree(mInputFileName);
+}
+
+void ClusterReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(info) << "Pushing " << mClusters.size() << " Clusters in " << mTRs.size() << " TriggerRecords at entry " << ent;
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERS", 0, Lifetime::Timeframe}, mClusters);
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERTRIGRECS", 0, Lifetime::Timeframe}, mTRs);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERTRUEMC", 0, Lifetime::Timeframe}, mMCTruth);
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void ClusterReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mClusterTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mTRBranchName.c_str()));
+
+  mTree->SetBranchAddress(mTRBranchName.c_str(), &mTRsInp);
+  mTree->SetBranchAddress(mClusterBranchName.c_str(), &mClustersInp);
+  if (mUseMC) {
+    if (mTree->GetBranch(mClusterMCTruthBranchName.c_str())) {
+      mTree->SetBranchAddress(mClusterMCTruthBranchName.c_str(), &mMCTruthInp);
+    } else {
+      LOG(warning) << "MC-truth is missing, message will be empty";
+    }
+  }
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getCPVClusterReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("CPV", "CLUSTERS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("CPV", "CLUSTERTRIGRECS", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputSpec.emplace_back("CPV", "CLUSTERTRUEMC", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "cpv-cluster-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<ClusterReader>(useMC)},
+    Options{
+      {"cpv-clusters-infile", VariantType::String, "cpvclusters.root", {"Name of the input Cluster file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace cpv
+} // namespace o2

--- a/Detectors/CPV/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/CPV/workflow/src/DigitReaderSpec.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitReaderSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "CPVWorkflow/DigitReaderSpec.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+using namespace o2::cpv;
+
+namespace o2
+{
+namespace cpv
+{
+
+DigitReader::DigitReader(bool useMC)
+{
+  mUseMC = useMC;
+}
+
+void DigitReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("cpv-digits-infile"));
+  connectTree(mInputFileName);
+}
+
+void DigitReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(info) << "Pushing " << mDigits.size() << " Digits in " << mTRs.size() << " TriggerRecords at entry " << ent;
+  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITTRIGREC", 0, Lifetime::Timeframe}, mTRs);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void DigitReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mDigitTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mTRBranchName.c_str()));
+
+  mTree->SetBranchAddress(mTRBranchName.c_str(), &mTRsInp);
+  mTree->SetBranchAddress(mDigitBranchName.c_str(), &mDigitsInp);
+  if (mUseMC) {
+    if (mTree->GetBranch(mDigitMCTruthBranchName.c_str())) {
+      mTree->SetBranchAddress(mDigitMCTruthBranchName.c_str(), &mMCTruthInp);
+    } else {
+      LOG(warning) << "MC-truth is missing, message will be empty";
+    }
+  }
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getCPVDigitReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("CPV", "DIGITS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("CPV", "DIGITTRIGREC", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputSpec.emplace_back("CPV", "DIGITSMCTR", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "cpv-digit-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<DigitReader>(useMC)},
+    Options{
+      {"cpv-digits-infile", VariantType::String, "cpvdigits.root", {"Name of the input Digit file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace cpv
+} // namespace o2

--- a/Detectors/CPV/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CPV/workflow/src/RecoWorkflow.cxx
@@ -24,6 +24,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsCPV/TriggerRecord.h"
 #include "CPVWorkflow/RecoWorkflow.h"
+#include "CPVWorkflow/DigitReaderSpec.h"
 #include "CPVWorkflow/ClusterizerSpec.h"
 #include "CPVWorkflow/ReaderSpec.h"
 #include "CPVWorkflow/WriterSpec.h"
@@ -107,7 +108,8 @@ o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
   // Digits to ....
   if (inputType == InputType::Digits) {
     if (!disableRootInp) {
-      specs.emplace_back(o2::cpv::getDigitsReaderSpec(propagateMC));
+      specs.emplace_back(o2::cpv::getCPVDigitReaderSpec(propagateMC));
+      // specs.emplace_back(o2::cpv::getDigitsReaderSpec(propagateMC));
     }
 
     if (isEnabled(OutputType::Clusters)) {

--- a/Detectors/CPV/workflow/src/cluster-reader-workflow.cxx
+++ b/Detectors/CPV/workflow/src/cluster-reader-workflow.cxx
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ConfigParamSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/CallbacksPolicy.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "with-mc",
+      o2::framework::VariantType::Bool,
+      false,
+      {"propagate MC labels"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "configKeyValues",
+      VariantType::String,
+      "",
+      {"Semicolon separated key=value strings"}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
+}
+
+#include "Framework/runDataProcessing.h"
+#include "CPVWorkflow/ClusterReaderSpec.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cc)
+{
+  WorkflowSpec specs;
+  o2::conf::ConfigurableParam::updateFromString(cc.options().get<std::string>("configKeyValues"));
+  auto withMC = cc.options().get<bool>("with-mc");
+
+  specs.emplace_back(o2::cpv::getCPVClusterReaderSpec(withMC));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cc, specs);
+
+  return specs;
+}

--- a/Detectors/CPV/workflow/src/digit-reader-workflow.cxx
+++ b/Detectors/CPV/workflow/src/digit-reader-workflow.cxx
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ConfigParamSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/CallbacksPolicy.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "with-mc",
+      o2::framework::VariantType::Bool,
+      false,
+      {"propagate MC labels"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "configKeyValues",
+      VariantType::String,
+      "",
+      {"Semicolon separated key=value strings"}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
+}
+
+#include "Framework/runDataProcessing.h"
+#include "CPVWorkflow/DigitReaderSpec.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cc)
+{
+  WorkflowSpec specs;
+  o2::conf::ConfigurableParam::updateFromString(cc.options().get<std::string>("configKeyValues"));
+  auto withMC = cc.options().get<bool>("with-mc");
+
+  specs.emplace_back(o2::cpv::getCPVDigitReaderSpec(withMC));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cc, specs);
+
+  return specs;
+}

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -43,8 +43,8 @@
 #include "MCHIO/TrackReaderSpec.h"
 #include "MCHIO/ClusterReaderSpec.h"
 #include "MIDWorkflow/TrackReaderSpec.h"
-#include "PHOSWorkflow/ReaderSpec.h"
-#include "CPVWorkflow/ReaderSpec.h"
+#include "PHOSWorkflow/CellReaderSpec.h"
+#include "CPVWorkflow/ClusterReaderSpec.h"
 #include "EMCALWorkflow/PublisherSpec.h"
 // #include "StrangenessTrackingWorkflow/StrangenessTrackingReaderSpec.h"
 
@@ -164,11 +164,11 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
   }
 
   if (maskTracks[GID::PHS] || maskClusters[GID::PHS]) {
-    specs.emplace_back(o2::phos::getCellReaderSpec(maskTracksMC[GID::PHS] || maskClustersMC[GID::PHS]));
+    specs.emplace_back(o2::phos::getPHOSCellReaderSpec(maskTracksMC[GID::PHS] || maskClustersMC[GID::PHS]));
   }
 
   if (maskTracks[GID::CPV] || maskClusters[GID::CPV]) {
-    specs.emplace_back(o2::cpv::getClustersReaderSpec(maskTracksMC[GID::CPV] || maskClustersMC[GID::CPV]));
+    specs.emplace_back(o2::cpv::getCPVClusterReaderSpec(maskTracksMC[GID::CPV] || maskClustersMC[GID::CPV]));
   }
 
   if (maskTracks[GID::EMC] || maskClusters[GID::EMC]) {

--- a/Detectors/PHOS/testsimulation/plot_dig_phos.C
+++ b/Detectors/PHOS/testsimulation/plot_dig_phos.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 /// \file plot_dig_phos.C
 /// \brief Simple macro to plot PHOS digits per event
 
@@ -24,11 +35,11 @@ void plot_dig_phos(int ievent = 0, TString inputfile = "o2dig.root")
   TTree* digTree = (TTree*)gFile->Get("o2sim");
   std::vector<o2::phos::Digit>* mDigitsArray = nullptr;
   o2::dataformats::MCTruthContainer<o2::phos::MCLabel>* labels = nullptr;
-  digTree->SetBranchAddress("PHSDigit", &mDigitsArray);
-  digTree->SetBranchAddress("PHSDigitMCTruth", &labels);
+  digTree->SetBranchAddress("PHOSDigit", &mDigitsArray);
+  digTree->SetBranchAddress("PHOSDigitMCTruth", &labels);
 
   if (!mDigitsArray) {
-    cout << "PHOS digits not in tree. Exiting ..." << endl;
+    cout << "PHOS digits not in tree. Exiting..." << endl;
     return;
   }
   digTree->GetEvent(ievent);

--- a/Detectors/PHOS/workflow/CMakeLists.txt
+++ b/Detectors/PHOS/workflow/CMakeLists.txt
@@ -10,7 +10,9 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(PHOSWorkflow
-               SOURCES src/RecoWorkflow.cxx
+               SOURCES src/CellReaderSpec.cxx
+                       src/DigitReaderSpec.cxx
+                       src/RecoWorkflow.cxx
                        src/ReaderSpec.cxx
                        src/CellConverterSpec.cxx
                        src/RawToCellConverterSpec.cxx

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/CellReaderSpec.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/CellReaderSpec.h
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   CellReaderSpec.h
+
+#ifndef O2_PHOS_CELLREADER
+#define O2_PHOS_CELLREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsPHOS/Cell.h"
+#include "DataFormatsPHOS/TriggerRecord.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "DataFormatsPHOS/MCLabel.h"
+
+namespace o2
+{
+namespace phos
+{
+
+class CellReader : public o2::framework::Task
+{
+ public:
+  CellReader(bool useMC = true);
+  ~CellReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::phos::Cell> mCells, *mCellsInp = &mCells;
+  std::vector<o2::phos::TriggerRecord> mTRs, *mTRsInp = &mTRs;
+  o2::dataformats::MCTruthContainer<o2::phos::MCLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+
+  o2::header::DataOrigin mOrigin = o2::header::gDataOriginPHS;
+
+  bool mUseMC = true; // use MC truth
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mCellTreeName = "o2sim";
+  std::string mCellBranchName = "PHOSCell";
+  std::string mTRBranchName = "PHOSCellTrigRec";
+  std::string mCellMCTruthBranchName = "PHOSCellTrueMC";
+};
+
+/// create a processor spec
+/// read PHOS Cell data from a root file
+framework::DataProcessorSpec getPHOSCellReaderSpec(bool useMC = true);
+
+} // namespace phos
+} // namespace o2
+
+#endif /* O2_PHOS_CELLREADER */

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/DigitReaderSpec.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/DigitReaderSpec.h
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitReaderSpec.h
+
+#ifndef O2_PHOS_DIGITREADER
+#define O2_PHOS_DIGITREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsPHOS/Digit.h"
+#include "DataFormatsPHOS/TriggerRecord.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "DataFormatsPHOS/MCLabel.h"
+
+namespace o2
+{
+namespace phos
+{
+
+class DigitReader : public o2::framework::Task
+{
+ public:
+  DigitReader(bool useMC = true);
+  ~DigitReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::phos::Digit> mDigits, *mDigitsInp = &mDigits;
+  std::vector<o2::phos::TriggerRecord> mTRs, *mTRsInp = &mTRs;
+  o2::dataformats::MCTruthContainer<o2::phos::MCLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+
+  o2::header::DataOrigin mOrigin = o2::header::gDataOriginPHS;
+
+  bool mUseMC = true; // use MC truth
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mDigitTreeName = "o2sim";
+  std::string mDigitBranchName = "PHOSDigit";
+  std::string mTRBranchName = "PHOSDigitTrigRecords";
+  std::string mDigitMCTruthBranchName = "PHOSDigitMCTruth";
+};
+
+/// create a processor spec
+/// read PHOS Digit data from a root file
+framework::DataProcessorSpec getPHOSDigitReaderSpec(bool useMC = true);
+
+} // namespace phos
+} // namespace o2
+
+#endif /* O2_PHOS_DIGITREADER */

--- a/Detectors/PHOS/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/CellConverterSpec.cxx
@@ -37,10 +37,12 @@ void CellConverterSpec::init(framework::InitContext& ctx)
 
 void CellConverterSpec::run(framework::ProcessingContext& ctx)
 {
-  LOG(debug) << "[PHOSCellConverter - run] called";
-  auto dataref = ctx.inputs().get("digits");
-  auto const* phosheader = o2::framework::DataRefUtils::getHeader<o2::phos::PHOSBlockHeader*>(dataref);
-  if (!phosheader->mHasPayload) {
+  // LOG(debug) << "[PHOSCellConverter - run] called";
+  // auto dataref = ctx.inputs().get("digits");
+  // auto const* phosheader = o2::framework::DataRefUtils::getHeader<o2::phos::PHOSBlockHeader*>(dataref);
+  // if (!phosheader->mHasPayload) {
+  auto digitsTR = ctx.inputs().get<std::vector<o2::phos::TriggerRecord>>("digitTriggerRecords");
+  if (!digitsTR.size()) { // nothing to process
     mOutputCells.clear();
     ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
     mOutputCellTrigRecs.clear();
@@ -61,7 +63,6 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   mOutputCellTrigRecs.clear();
 
   auto digits = ctx.inputs().get<std::vector<o2::phos::Digit>>("digits");
-  auto digitsTR = ctx.inputs().get<std::vector<o2::phos::TriggerRecord>>("digitTriggerRecords");
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::phos::MCLabel>> truthcont(nullptr);
   if (mPropagateMC) {
     truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::phos::MCLabel>*>("digitsmctr");

--- a/Detectors/PHOS/workflow/src/CellReaderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/CellReaderSpec.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   CellReaderSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "PHOSWorkflow/CellReaderSpec.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+using namespace o2::phos;
+
+namespace o2
+{
+namespace phos
+{
+
+CellReader::CellReader(bool useMC)
+{
+  mUseMC = useMC;
+}
+
+void CellReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("phos-cells-infile"));
+  connectTree(mInputFileName);
+}
+
+void CellReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(info) << "Pushing " << mCells.size() << " Cells in " << mTRs.size() << " TriggerRecords at entry " << ent;
+  pc.outputs().snapshot(Output{mOrigin, "CELLS", 0, Lifetime::Timeframe}, mCells);
+  pc.outputs().snapshot(Output{mOrigin, "CELLTRIGREC", 0, Lifetime::Timeframe}, mTRs);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{mOrigin, "CELLSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void CellReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mCellTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mTRBranchName.c_str()));
+
+  mTree->SetBranchAddress(mTRBranchName.c_str(), &mTRsInp);
+  mTree->SetBranchAddress(mCellBranchName.c_str(), &mCellsInp);
+  if (mUseMC) {
+    if (mTree->GetBranch(mCellMCTruthBranchName.c_str())) {
+      mTree->SetBranchAddress(mCellMCTruthBranchName.c_str(), &mMCTruthInp);
+    } else {
+      LOG(warning) << "MC-truth is missing, message will be empty";
+    }
+  }
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getPHOSCellReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("PHS", "CELLS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("PHS", "CELLTRIGREC", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputSpec.emplace_back("PHS", "CELLSMCTR", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "phos-cells-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<CellReader>(useMC)},
+    Options{
+      {"phos-cells-infile", VariantType::String, "phoscells.root", {"Name of the input Cell file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace phos
+} // namespace o2

--- a/Detectors/PHOS/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/PHOS/workflow/src/ClusterizerSpec.cxx
@@ -72,9 +72,11 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
   if (mUseDigits) {
     LOG(debug) << "PHOSClusterizer - run on digits called";
 
-    auto dataref = ctx.inputs().get("digits");
-    auto const* phosheader = o2::framework::DataRefUtils::getHeader<o2::phos::PHOSBlockHeader*>(dataref);
-    if (!phosheader->mHasPayload) {
+    // auto dataref = ctx.inputs().get("digits");
+    // auto const* phosheader = o2::framework::DataRefUtils::getHeader<o2::phos::PHOSBlockHeader*>(dataref);
+    // if (!phosheader->mHasPayload) {
+    auto digitsTR = ctx.inputs().get<std::vector<o2::phos::TriggerRecord>>("digitTriggerRecords");
+    if (!digitsTR.size()) { // nothing to process
       mOutputClusters.clear();
       ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
       if (mFullCluOutput) {
@@ -89,9 +91,7 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
       }
       return;
     }
-    // auto digits = ctx.inputs().get<gsl::span<o2::phos::Digit>>("digits");
     auto digits = ctx.inputs().get<std::vector<o2::phos::Digit>>("digits");
-    auto digitsTR = ctx.inputs().get<std::vector<o2::phos::TriggerRecord>>("digitTriggerRecords");
     LOG(debug) << "[PHOSClusterizer - run]  Received " << digitsTR.size() << " TR, running clusterizer ...";
     // const o2::dataformats::MCTruthContainer<MCLabel>* truthcont=nullptr;
     if (mPropagateMC) {

--- a/Detectors/PHOS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/DigitReaderSpec.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitReaderSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "PHOSWorkflow/DigitReaderSpec.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+using namespace o2::phos;
+
+namespace o2
+{
+namespace phos
+{
+
+DigitReader::DigitReader(bool useMC)
+{
+  mUseMC = useMC;
+}
+
+void DigitReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("phos-digits-infile"));
+  connectTree(mInputFileName);
+}
+
+void DigitReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(info) << "Pushing " << mDigits.size() << " Digits in " << mTRs.size() << " TriggerRecords at entry " << ent;
+  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITTRIGREC", 0, Lifetime::Timeframe}, mTRs);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void DigitReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mDigitTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mTRBranchName.c_str()));
+
+  mTree->SetBranchAddress(mTRBranchName.c_str(), &mTRsInp);
+  mTree->SetBranchAddress(mDigitBranchName.c_str(), &mDigitsInp);
+  if (mUseMC) {
+    if (mTree->GetBranch(mDigitMCTruthBranchName.c_str())) {
+      mTree->SetBranchAddress(mDigitMCTruthBranchName.c_str(), &mMCTruthInp);
+    } else {
+      LOG(warning) << "MC-truth is missing, message will be empty";
+    }
+  }
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getPHOSDigitReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("PHS", "DIGITS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("PHS", "DIGITTRIGREC", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputSpec.emplace_back("PHS", "DIGITSMCTR", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "phos-digits-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<DigitReader>(useMC)},
+    Options{
+      {"phos-digits-infile", VariantType::String, "phosdigits.root", {"Name of the input Digit file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace phos
+} // namespace o2

--- a/Detectors/PHOS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/PHOS/workflow/src/RecoWorkflow.cxx
@@ -29,6 +29,8 @@
 #include "PHOSWorkflow/WriterSpec.h"
 #include "PHOSWorkflow/RawToCellConverterSpec.h"
 #include "PHOSWorkflow/RawWriterSpec.h"
+#include "PHOSWorkflow/DigitReaderSpec.h"
+#include "PHOSWorkflow/CellReaderSpec.h"
 #include "Framework/DataSpecUtils.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
@@ -51,7 +53,8 @@ const std::unordered_map<std::string, InputType> InputMap{
 
 const std::unordered_map<std::string, OutputType> OutputMap{
   {"cells", OutputType::Cells},
-  {"clusters", OutputType::Clusters}};
+  {"clusters", OutputType::Clusters},
+  {"digits", OutputType::Digits}};
 
 o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
                                         bool disableRootOut,
@@ -104,7 +107,8 @@ o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
   // Digits to ....
   if (inputType == InputType::Digits) {
     if (!disableRootInp) {
-      specs.emplace_back(o2::phos::getDigitsReaderSpec(propagateMC));
+      // specs.emplace_back(o2::phos::getDigitsReaderSpec(propagateMC));
+      specs.emplace_back(o2::phos::getPHOSDigitReaderSpec(propagateMC));
     }
     if (isEnabled(OutputType::Cells)) {
       // add converter for cells
@@ -125,7 +129,8 @@ o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
   // Cells to
   if (inputType == InputType::Cells) {
     if (!disableRootInp) {
-      specs.emplace_back(o2::phos::getCellReaderSpec(propagateMC));
+      // specs.emplace_back(o2::phos::getCellReaderSpec(propagateMC));
+      specs.emplace_back(o2::phos::getPHOSCellReaderSpec(propagateMC));
     }
     if (isEnabled(OutputType::Clusters)) {
       // add clusterizer


### PR DESCRIPTION
Hello! In this PR new digit & cluster reader for cpv and new digit & cell readers for phs are added. This readers needed in MC production for connecting QC. Old readers cannot be used because they produce one more empty TF when finish reading, and this empty TF crashes QC.