### PR TITLE
DPL: Protect agains empty header with non empty payload

### DIFF
--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -204,6 +204,10 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAny(const char* name, Compl
       if (input.header != nullptr) {
         return CompletionPolicy::CompletionOp::Consume;
       }
+      if (input.payload != nullptr) {
+        LOGP(warning, "Input has payload, but no header. This should not happen.");
+        return CompletionPolicy::CompletionOp::Discard;
+      }
     }
     return CompletionPolicy::CompletionOp::Wait;
   };


### PR DESCRIPTION
Not sure when that can actually happen, but clearly elsewhere we handle it as a separate case.