### PR TITLE
Override DRM-id from DRM Header using FEEID

### DIFF
--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -402,7 +402,7 @@ bool Compressor<RDH, verbose, paranoid>::processDRM()
   /** encode Crate Header **/
   *mEncoderPointer = 0x80000000;
   *mEncoderPointer |= GET_DRMHEADW1_PARTSLOTMASK(*mDecoderSummary.drmHeadW1) << 12;
-// R+OLD  *mEncoderPointer |= GET_DRMDATAHEADER_DRMID(*mDecoderSummary.drmDataHeader) << 24;
+  // R+OLD  *mEncoderPointer |= GET_DRMDATAHEADER_DRMID(*mDecoderSummary.drmDataHeader) << 24;
   *mEncoderPointer |= (mDecoderRDH->feeId & 0xFF) << 24;
   *mEncoderPointer |= GET_DRMHEADW3_GBTBUNCHCNT(*mDecoderSummary.drmHeadW3);
   if (verbose && mEncoderVerbose) {

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -222,7 +222,7 @@ bool Compressor<RDH, verbose, paranoid>::processHBF()
       LOG(debug) << "processHBF: nsteps in while loop = " << nsteps << ", infity loop?";
     }
     mEventCounter++;
-    if (processDRM()) {            // if this breaks, we did not run the checker and the summary is not reset!
+    if (processDRM()) {  // if this breaks, we did not run the checker and the summary is not reset!
       mDecoderSummary = {nullptr}; // reset it like this, perhaps a better way can be found
       break;
     }
@@ -402,7 +402,8 @@ bool Compressor<RDH, verbose, paranoid>::processDRM()
   /** encode Crate Header **/
   *mEncoderPointer = 0x80000000;
   *mEncoderPointer |= GET_DRMHEADW1_PARTSLOTMASK(*mDecoderSummary.drmHeadW1) << 12;
-  *mEncoderPointer |= GET_DRMDATAHEADER_DRMID(*mDecoderSummary.drmDataHeader) << 24;
+// R+OLD  *mEncoderPointer |= GET_DRMDATAHEADER_DRMID(*mDecoderSummary.drmDataHeader) << 24;
+  *mEncoderPointer |= (mDecoderRDH->feeId & 0xFF) << 24;
   *mEncoderPointer |= GET_DRMHEADW3_GBTBUNCHCNT(*mDecoderSummary.drmHeadW3);
   if (verbose && mEncoderVerbose) {
     auto crateHeader = reinterpret_cast<compressed::CrateHeader_t*>(mEncoderPointer);

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -222,7 +222,7 @@ bool Compressor<RDH, verbose, paranoid>::processHBF()
       LOG(debug) << "processHBF: nsteps in while loop = " << nsteps << ", infity loop?";
     }
     mEventCounter++;
-    if (processDRM()) {  // if this breaks, we did not run the checker and the summary is not reset!
+    if (processDRM()) {            // if this breaks, we did not run the checker and the summary is not reset!
       mDecoderSummary = {nullptr}; // reset it like this, perhaps a better way can be found
       break;
     }


### PR DESCRIPTION
this commit changes the value of the DRMid written in the TOF compressed data.
previously, the compressed data contained the DRMid coming from the DRM header.
it is now overridden by using the FEEid from the RDH.

the remaining functionality and data is unaffected.
