### PR TITLE
Debug streamer: add sampling by weight

### DIFF
--- a/Common/Utils/include/CommonUtils/DebugStreamer.h
+++ b/Common/Utils/include/CommonUtils/DebugStreamer.h
@@ -30,17 +30,18 @@ namespace o2::utils
 
 /// struct defining the flags which can be used to check if a certain debug streamer is used
 enum StreamFlags {
-  streamdEdx = 1 << 0,              ///< stream corrections and cluster properties used for the dE/dx
-  streamDigitFolding = 1 << 1,      ///< stream ion tail and saturatio information
-  streamDigits = 1 << 2,            ///< stream digit information
-  streamFastTransform = 1 << 3,     ///< stream tpc fast transform
-  streamITCorr = 1 << 4,            ///< stream ion tail correction information
-  streamDistortionsSC = 1 << 5,     ///< stream distortions applied in the TPC space-charge class (used for example in the tpc digitizer)
-  streamUpdateTrack = 1 << 6,       ///< stream update track informations
-  streamRejectCluster = 1 << 7,     ///< stream cluster rejection informations
-  streamMergeBorderTracks = 1 << 8, ///< stream MergeBorderTracks
-  streamTimeSeries = 1 << 9,        ///< stream tpc DCA debug tree
-  streamFlagsCount = 10             ///< total number of streamers
+  streamdEdx = 1 << 0,                  ///< stream corrections and cluster properties used for the dE/dx
+  streamDigitFolding = 1 << 1,          ///< stream ion tail and saturatio information
+  streamDigits = 1 << 2,                ///< stream digit information
+  streamFastTransform = 1 << 3,         ///< stream tpc fast transform
+  streamITCorr = 1 << 4,                ///< stream ion tail correction information
+  streamDistortionsSC = 1 << 5,         ///< stream distortions applied in the TPC space-charge class (used for example in the tpc digitizer)
+  streamUpdateTrack = 1 << 6,           ///< stream update track informations
+  streamRejectCluster = 1 << 7,         ///< stream cluster rejection informations
+  streamMergeBorderTracksBest = 1 << 8, ///< stream MergeBorderTracks best track
+  streamTimeSeries = 1 << 9,            ///< stream tpc DCA debug tree
+  streamMergeBorderTracksAll = 1 << 10, ///< stream MergeBorderTracks all tracks
+  streamFlagsCount = 11                 ///< total number of streamers
 };
 
 enum SamplingTypes {
@@ -48,6 +49,7 @@ enum SamplingTypes {
   sampleRandom = 1,   ///< sample randomly every n points
   sampleID = 2,       ///< sample every n IDs (per example track)
   sampleIDGlobal = 3, ///< in case different streamers have access to the same IDs use this gloabl ID
+  sampleWeights = 4,  ///< perform sampling on weights, defined where the streamer is called
 };
 
 #if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
@@ -123,6 +125,9 @@ class DebugStreamer
   /// \return returns sampling type and sampling frequency for given streamer
   static std::pair<SamplingTypes, float> getSamplingTypeFrequency(const StreamFlags streamFlag);
 
+  /// \return returns sampling type and sampling frequency for given streamer
+  static float getSamplingFrequency(const StreamFlags streamFlag) { return getSamplingTypeFrequency(streamFlag).second; }
+
   ///< return returns unique ID for each CPU thread to give each thread an own output file
   static size_t getCPUID();
 
@@ -146,7 +151,8 @@ class DebugStreamer
 
   /// check if streamer for specific flag is enabled
   /// \param samplingID optional index of the data which is streamed in to perform sampling on this index
-  static bool checkStream(const StreamFlags streamFlag, const size_t samplingID = -1);
+  /// \param weight weight which can be used to perform some weightes sampling
+  static bool checkStream(const StreamFlags streamFlag, const size_t samplingID = -1, const float weight = 1);
 
   /// merge trees with the same content structure, but different naming
   /// \param inpFile input file containing several trees with the same content

--- a/Common/Utils/src/DebugStreamer.cxx
+++ b/Common/Utils/src/DebugStreamer.cxx
@@ -55,7 +55,7 @@ void o2::utils::DebugStreamer::flush()
   }
 }
 
-bool o2::utils::DebugStreamer::checkStream(const StreamFlags streamFlag, const size_t samplingID)
+bool o2::utils::DebugStreamer::checkStream(const StreamFlags streamFlag, const size_t samplingID, const float weight)
 {
   const bool isStreamerSet = ((getStreamFlags() & streamFlag) == streamFlag);
   if (!isStreamerSet) {
@@ -104,6 +104,9 @@ bool o2::utils::DebugStreamer::checkStream(const StreamFlags streamFlag, const s
         refIDs[index][samplingID] = storeTrk;
         return storeTrk;
       }
+    } else if (sampling.first == SamplingTypes::sampleWeights) {
+      // sample with weight
+      return (weight * distr(generator) < sampling.second);
     }
   }
   return true;

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -907,7 +907,7 @@ GPUd() void GPUTPCGMMerger::MergeBorderTracks<2>(int nBlocks, int nThreads, int 
           }
         }
 
-        GPUCA_DEBUG_STREAMER_CHECK(if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamMergeBorderTracks, b1.TrackID())) { MergedTrackStreamer(b1, b2, "merge_all_tracks", iSlice1, iSlice2, mergeMode); });
+        GPUCA_DEBUG_STREAMER_CHECK(float weight = b1.Par()[4] * b1.Par()[4]; if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamMergeBorderTracksAll, b1.TrackID(), weight)) { MergedTrackStreamer(b1, b2, "merge_all_tracks", iSlice1, iSlice2, mergeMode, weight, o2::utils::DebugStreamer::getSamplingFrequency(o2::utils::StreamFlags::streamMergeBorderTracksAll)); });
 
         if (!b1.CheckChi2Y(b2, factor2ys)) {
           CADEBUG2(continue, printf("!Y\n"));
@@ -941,7 +941,7 @@ GPUd() void GPUTPCGMMerger::MergeBorderTracks<2>(int nBlocks, int nThreads, int 
     if (iBest2 < 0) {
       continue;
     }
-    GPUCA_DEBUG_STREAMER_CHECK(if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamMergeBorderTracks, b1.TrackID())) { MergedTrackStreamer(b1, MergedTrackStreamerFindBorderTrack(B2, N2, iBest2), "merge_best_track", iSlice1, iSlice2, mergeMode); });
+    GPUCA_DEBUG_STREAMER_CHECK(float weight = b1.Par()[4] * b1.Par()[4]; if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamMergeBorderTracksBest, b1.TrackID(), weight)) { MergedTrackStreamer(b1, MergedTrackStreamerFindBorderTrack(B2, N2, iBest2), "merge_best_track", iSlice1, iSlice2, mergeMode, weight, o2::utils::DebugStreamer::getSamplingFrequency(o2::utils::StreamFlags::streamMergeBorderTracksBest)); });
 
     // statMerged++;
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
@@ -195,8 +195,8 @@ class GPUTPCGMMerger : public GPUProcessor
   void DumpFinal(std::ostream& out);
 
   template <int mergeType>
-  void MergedTrackStreamerInternal(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode);
-  void MergedTrackStreamer(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode);
+  void MergedTrackStreamerInternal(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode, float weight, float frac);
+  void MergedTrackStreamer(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode, float weight, float frac);
   const GPUTPCGMBorderTrack& MergedTrackStreamerFindBorderTrack(const GPUTPCGMBorderTrack* tracks, int N, int trackId);
 #endif
 
@@ -274,7 +274,7 @@ class GPUTPCGMMerger : public GPUProcessor
   unsigned int* mTrackSort;
   tmpSort* mTrackSortO2;
   GPUAtomic(unsigned int) * mSharedCount; // Must be unsigned int unfortunately for atomic support
-  GPUTPCGMBorderTrack* mBorderMemory; // memory for border tracks
+  GPUTPCGMBorderTrack* mBorderMemory;     // memory for border tracks
   GPUTPCGMBorderTrack* mBorder[2 * NSLICES];
   gputpcgmmergertypes::GPUTPCGMBorderRange* mBorderRangeMemory;    // memory for border tracks
   gputpcgmmergertypes::GPUTPCGMBorderRange* mBorderRange[NSLICES]; // memory for border tracks

--- a/GPU/GPUTracking/Merger/GPUTPCGMMergerDump.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMergerDump.cxx
@@ -183,7 +183,7 @@ void GPUTPCGMMerger::DumpFinal(std::ostream& out)
 }
 
 template <int mergeType>
-inline void GPUTPCGMMerger::MergedTrackStreamerInternal(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode)
+inline void GPUTPCGMMerger::MergedTrackStreamerInternal(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode, float weight, float frac)
 {
 #ifdef DEBUG_STREAMER
   std::vector<int> hits1(152), hits2(152);
@@ -209,19 +209,17 @@ inline void GPUTPCGMMerger::MergedTrackStreamerInternal(const GPUTPCGMBorderTrac
 
   std::string debugname = std::string("debug_") + name;
   std::string treename = std::string("tree_") + name;
-  o2::utils::DebugStreamer::instance()->getStreamer(debugname.c_str(), "UPDATE") << o2::utils::DebugStreamer::instance()->getUniqueTreeName(treename.c_str()).data() << "slice1=" << slice1 << "slice2=" << slice2 << "b1=" << b1 << "b2=" << b2 << "clusters1=" << hits1 << "clusters2=" << hits2 << "sliceTrack1=" << sliceTrack1 << "sliceTrack2=" << sliceTrack2 << "mergeMode=" << mergeMode << "\n";
+  o2::utils::DebugStreamer::instance()->getStreamer(debugname.c_str(), "UPDATE") << o2::utils::DebugStreamer::instance()->getUniqueTreeName(treename.c_str()).data() << "slice1=" << slice1 << "slice2=" << slice2 << "b1=" << b1 << "b2=" << b2 << "clusters1=" << hits1 << "clusters2=" << hits2 << "sliceTrack1=" << sliceTrack1 << "sliceTrack2=" << sliceTrack2 << "mergeMode=" << mergeMode << "weight=" << weight << "fraction=" << frac << "\n";
 #endif
 }
 
-void GPUTPCGMMerger::MergedTrackStreamer(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode)
+void GPUTPCGMMerger::MergedTrackStreamer(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode, float weight, float frac)
 {
 #ifdef DEBUG_STREAMER
-  if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamMergeBorderTracks, b1.TrackID())) {
-    if (mergeMode == 0) {
-      MergedTrackStreamerInternal<0>(b1, b2, name, slice1, slice2, mergeMode);
-    } else if (mergeMode >= 1 && mergeMode <= 0) {
-      // MergedTrackStreamerInternal<1>(b1, b2, name, slice1, slice2, mergeMode); Not yet working
-    }
+  if (mergeMode == 0) {
+    MergedTrackStreamerInternal<0>(b1, b2, name, slice1, slice2, mergeMode, weight, frac);
+  } else if (mergeMode >= 1 && mergeMode <= 0) {
+    // MergedTrackStreamerInternal<1>(b1, b2, name, slice1, slice2, mergeMode, weight, frac); Not yet working
   }
 #endif
 }


### PR DESCRIPTION
- Storing weights and sampling frequency in debug tree
- splitting `streamMergeBorderTracks` to `streamMergeBorderTracksBest` and `streamMergeBorderTracksAll` to allow for individual sampling