### PR TITLE
Fix typo in subGeneratorID check

### DIFF
--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -222,7 +222,7 @@ Bool_t
 
 void Generator::addSubGenerator(int subGeneratorId, std::string const& subGeneratorDescription)
 {
-  if (mSubGeneratorId < 0) {
+  if (subGeneratorId < 0) {
     LOG(fatal) << "Sub-generator IDs must be >= 0, instead, passed value is " << subGeneratorId;
   }
   mSubGeneratorsIdToDesc.insert({subGeneratorId, subGeneratorDescription});


### PR DESCRIPTION
Just a small fix for the generator IDs feature.