### PR TITLE
Make sure we notify DPL about non-DPL message sending

### DIFF
--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -264,6 +264,10 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
         nparts += msgIt.second->Size() / 2;
         device->Send(*msgIt.second.get(), msgIt.first);
       }
+      // FIXME: this is to pretend we did send some messages via DPL.
+      //        we should really migrate everything to use FairMQDeviceProxy,
+      //        however this is a small enough hack for now.
+      ctx.services().get<o2f::MessageContext>().fakeDispatch();
       tNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
       deltaSending = mTFCounter ? tNow - tLastTF : 0;
       LOGP(info, "Sent TF {} of size {} with {} parts, {:.4f} s elapsed from previous TF.", mTFCounter, dataSize, nparts, double(deltaSending) * 1e-6);

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -528,6 +528,7 @@ class MessageContext
   o2::header::DataHeader* findMessageHeader(const Output& spec);
   o2::header::Stack* findMessageHeaderStack(const Output& spec);
   int countDeviceOutputs(bool excludeDPLOrigin = false);
+  void fakeDispatch() { mDidDispatch = true; }
   o2::framework::DataProcessingHeader* findMessageDataProcessingHeader(const Output& spec);
   std::pair<o2::header::DataHeader*, o2::framework::DataProcessingHeader*> findMessageHeaders(const Output& spec);
 


### PR DESCRIPTION
This is needed to avoid skipping CCDB callbacks on the last timeframe.