### PR TITLE
DPL: notify DPL about out of band data being sent by input proxy

### DIFF
--- a/Detectors/CTP/workflowScalers/src/ctp-proxy.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctp-proxy.cxx
@@ -52,7 +52,7 @@ InjectorFunction dcs2dpl(std::string& ccdbhost)
   auto runMgr = std::make_shared<o2::ctp::CTPRunManager>();
   runMgr->setCCDBHost(ccdbhost);
   runMgr->init();
-  return [runMgr](TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
+  return [runMgr](TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) -> bool {
     // FIXME: Why isn't this function using the timeslice index?
     // make sure just 2 messages received
     // if (parts.Size() != 2) {
@@ -64,6 +64,7 @@ InjectorFunction dcs2dpl(std::string& ccdbhost)
     std::string messageData{static_cast<const char*>(parts.At(1)->GetData()), parts.At(1)->GetSize()};
     LOG(info) << "received message " << messageHeader << " of size " << dataSize << " # parts:" << parts.Size(); // << " Payload:" << messageData;
     runMgr->processMessage(messageHeader, messageData);
+    return true;
   };
 }
 

--- a/Detectors/CTP/workflowScalers/src/ctp-qc-proxy.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctp-qc-proxy.cxx
@@ -46,7 +46,7 @@ using DetID = o2::detectors::DetID;
 InjectorFunction dcs2dpl()
 // InjectorFunction dcs2dpl()
 {
-  return [](TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
+  return [](TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) -> bool {
     auto *device = services.get<RawDeviceService>().device();
     std::string messageHeader{static_cast<const char*>(parts.At(0)->GetData()), parts.At(0)->GetSize()};
     size_t dataSize = parts.At(1)->GetSize();
@@ -57,7 +57,7 @@ InjectorFunction dcs2dpl()
     auto channel = channelRetriever(outsp, newTimesliceId);
     if (channel.empty()) {
       LOG(error) << "No output channel found for OutputSpec " << outsp;
-      return;
+      return false;
     }
     hdrF.tfCounter = newTimesliceId; // this also
     hdrF.payloadSerializationMethod = o2::header::gSerializationMethodNone;
@@ -91,6 +91,7 @@ InjectorFunction dcs2dpl()
     outParts.AddPart(std::move(plMessageF));
     sendOnChannel(*device, outParts, channel, newTimesliceId);
     LOG(info) << "Sent CTP counters DPL message" << std::flush;
+    return true;
   };
 }
 

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -23,7 +23,16 @@ namespace o2::framework
 /// A callback function to retrieve the fair::mq::Channel name to be used for sending
 /// messages of the specified OutputSpec
 using ChannelRetriever = std::function<std::string(OutputSpec const&, DataProcessingHeader::StartTime)>;
-using InjectorFunction = std::function<void(TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& inputs, ChannelRetriever, size_t newTimesliceId, bool& stop)>;
+/// The callback which actually does the heavy lifting of converting the input data into
+/// DPL messages. The callback is invoked with the following parameters:
+/// @param timingInfo is the timing information of the current timeslice
+/// @param services is the service registry
+/// @param inputs is the list of input messages
+/// @param channelRetriever is a callback to retrieve the fair::mq::Channel name to be used for
+///        sending the messages
+/// @param newTimesliceId is the timeslice ID of the current timeslice
+/// @return true if any message were sent, false otherwise
+using InjectorFunction = std::function<bool(TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& inputs, ChannelRetriever, size_t newTimesliceId, bool& stop)>;
 using ChannelSelector = std::function<std::string(InputSpec const& input, const std::unordered_map<std::string, std::vector<fair::mq::Channel>>& channels)>;
 
 struct InputChannelSpec;

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -203,7 +203,7 @@ void appendForSending(fair::mq::Device& device, o2::header::Stack&& headerStack,
 
 InjectorFunction o2DataModelAdaptor(OutputSpec const& spec, uint64_t startTime, uint64_t /*step*/)
 {
-  return [spec](TimingInfo&, ServiceRegistryRef const& ref, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
+  return [spec](TimingInfo&, ServiceRegistryRef const& ref, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) -> bool {
     auto* device = ref.get<RawDeviceService>().device();
     for (int i = 0; i < parts.Size() / 2; ++i) {
       auto dh = o2::header::get<DataHeader*>(parts.At(i * 2)->GetData());
@@ -212,6 +212,7 @@ InjectorFunction o2DataModelAdaptor(OutputSpec const& spec, uint64_t startTime, 
       o2::header::Stack headerStack{*dh, dph};
       sendOnChannel(*device, std::move(headerStack), std::move(parts.At(i * 2 + 1)), spec, channelRetriever);
     }
+    return parts.Size() > 0;
   };
 }
 
@@ -589,7 +590,7 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
         }
       }
     }
-    return;
+    return didSendParts;
   };
 }
 
@@ -621,6 +622,7 @@ InjectorFunction incrementalConverter(OutputSpec const& spec, o2::header::Serial
 
       sendOnChannel(*device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetriever);
     }
+    return parts.Size();
   };
 }
 

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -561,13 +561,6 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
       didSendParts = true;
       sendOnChannel(*device, channelParts, channelName, newTimesliceId);
     }
-    // In case we did not send any part at all, we need to rewind by one
-    // to avoid creating extra timeslices at the end of the run.
-    auto& decongestion = services.get<DecongestionService>();
-    decongestion.nextEnumerationTimesliceRewinded = !didSendParts;
-    if (didSendParts == false) {
-      decongestion.nextEnumerationTimeslice -= 1;
-    }
     if (not unmatchedDescriptions.empty()) {
       if (throwOnUnmatchedInputs) {
         std::string descriptions;
@@ -769,12 +762,13 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
       return count;
     };
 
-    auto dataHandler = [ref = ctx.services(), converter, doInjectMissingData, doPrintSizes,
+    // Data handler for incoming data. Must return true if it sent any data.
+    auto dataHandler = [converter, doInjectMissingData, doPrintSizes,
                         outputRoutes = std::move(outputRoutes),
                         control = &ctx.services().get<ControlService>(),
                         deviceState = &ctx.services().get<DeviceState>(),
                         timesliceIndex = &ctx.services().get<TimesliceIndex>(),
-                        outputChannels = std::move(outputChannels)](TimingInfo& timingInfo, fair::mq::Parts& inputs, int, size_t ci, bool newRun) {
+                        outputChannels = std::move(outputChannels)](ServiceRegistryRef ref, TimingInfo& timingInfo, fair::mq::Parts& inputs, int, size_t ci, bool newRun) -> bool {
       auto* device = ref.get<RawDeviceService>().device();
       // pass a copy of the outputRoutes
       auto channelRetriever = [&outputRoutes](OutputSpec const& query, DataProcessingHeader::StartTime timeslice) -> std::string {
@@ -803,7 +797,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
       if (doInjectMissingData) {
         injectMissingData(*device, inputs, outputRoutes, doInjectMissingData, doPrintSizes);
       }
-      converter(timingInfo, ref, inputs, channelRetriever, timesliceIndex->getOldestPossibleOutput().timeslice.value, shouldstop);
+      bool didSendParts = converter(timingInfo, ref, inputs, channelRetriever, timesliceIndex->getOldestPossibleOutput().timeslice.value, shouldstop);
 
       // If we have enough EoS messages, we can stop the device
       // Notice that this has a number of failure modes:
@@ -832,6 +826,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
         std::fill(eosPeersCount.begin(), eosPeersCount.end(), 0);
         control->endOfStream();
       }
+      return didSendParts;
     };
 
     auto runHandler = [dataHandler, minSHM, sendTFcounter](ProcessingContext& ctx) {
@@ -844,6 +839,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
         inStopTransition = true;
       }
 
+      bool didSendParts = false;
       for (size_t ci = 0; ci < channels.size(); ++ci) {
         std::string const& channel = channels[ci];
         int waitTime = channels.size() == 1 ? -1 : 1;
@@ -875,7 +871,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
               timingInfo.creation = dph->creation;
             }
             if (!inStopTransition) {
-              dataHandler(timingInfo, parts, 0, ci, newRun);
+              didSendParts |= dataHandler(ctx.services(), timingInfo, parts, 0, ci, newRun);
             }
             if (sendTFcounter) {
               ctx.services().get<o2::monitoring::Monitoring>().send(o2::monitoring::Metric{(uint64_t)timingInfo.tfCounter, "df-sent"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
@@ -886,6 +882,15 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
           }
           waitTime = 0;
         }
+      }
+      // In case we did not send any part at all, we need to rewind by one
+      // to avoid creating extra timeslices.
+      auto& decongestion = ctx.services().get<DecongestionService>();
+      decongestion.nextEnumerationTimesliceRewinded = !didSendParts;
+      if (didSendParts) {
+        ctx.services().get<MessageContext>().fakeDispatch();
+      } else {
+        decongestion.nextEnumerationTimeslice -= 1;
       }
     };
 

--- a/Framework/Core/test/benchmark_ExternalFairMQDeviceProxies.cxx
+++ b/Framework/Core/test/benchmark_ExternalFairMQDeviceProxies.cxx
@@ -469,22 +469,22 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   // reads the messages from the output proxy via the out-of-band channel
 
   // converter callback for the external FairMQ device proxy ProcessorSpec generator
-  auto converter = [](TimingInfo&, ServiceRegistryRef const& ref, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
+  InjectorFunction converter = [](TimingInfo&, ServiceRegistryRef const& ref, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) -> bool {
     auto* device = ref.get<RawDeviceService>().device();
     ASSERT_ERROR(inputs.Size() >= 2);
     if (inputs.Size() < 2) {
-      return;
+      return false;
     }
     int msgidx = 0;
     auto dh = o2::header::get<o2::header::DataHeader*>(inputs.At(msgidx)->GetData());
     if (!dh) {
       LOG(error) << "data on input " << msgidx << " does not follow the O2 data model, DataHeader missing";
-      return;
+      return false;
     }
     auto dph = o2::header::get<DataProcessingHeader*>(inputs.At(msgidx)->GetData());
     if (!dph) {
       LOG(error) << "data on input " << msgidx << " does not follow the O2 data model, DataProcessingHeader missing";
-      return;
+      return false;
     }
     // Note: we want to run both the output and input proxy in the same workflow and thus we need
     // different data identifiers and change the data origin in the forwarding
@@ -497,7 +497,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     ASSERT_ERROR(!isData || !channelName.empty());
     LOG(debug) << "using channel '" << channelName << "' for " << DataSpecUtils::describe(OutputSpec{dh->dataOrigin, dh->dataDescription, dh->subSpecification});
     if (channelName.empty()) {
-      return;
+      return false;
     }
     // make a copy of the header message, get the data header and change origin
     auto outHeaderMessage = device->NewMessageFor(channelName, 0, inputs.At(msgidx)->GetSize());
@@ -511,6 +511,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     output.AddPart(std::move(inputs.At(msgidx + 1)));
     LOG(debug) << "sending " << DataSpecUtils::describe(OutputSpec{odh->dataOrigin, odh->dataDescription, odh->subSpecification});
     o2::framework::sendOnChannel(*device, output, channelName, (size_t)-1);
+    return output.Size() > 0;
   };
 
   // we use the same spec to build the configuration string, ideally we would have some helpers

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -176,7 +176,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     // the compute callback of the producer
     auto producerCallback = [nRolls, channelName, proxyMode, counter = std::make_shared<size_t>()](DataAllocator& outputs, ControlService& control, RawDeviceService& rds) {
       int data = *counter;
-      //outputs.make<int>(OutputRef{"data", 0}) = data;
+      // outputs.make<int>(OutputRef{"data", 0}) = data;
 
       fair::mq::Device& device = *(rds.device());
       auto transport = device.GetChannel(*channelName, 0).Transport();
@@ -327,14 +327,14 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   Inputs checkerInputs;
   if (proxyMode != ProxyMode::All) {
     checkerInputs.emplace_back(InputSpec{"datain", ConcreteDataTypeMatcher{"TST", "DATA"}, Lifetime::Timeframe});
-    //for (unsigned int i = 0; i < pState->nChannels; i++) {
-    //  checkerInputs.emplace_back(InputSpec{{"datain"}, "TST", "DATA", i, Lifetime::Timeframe});
-    //}
+    // for (unsigned int i = 0; i < pState->nChannels; i++) {
+    //   checkerInputs.emplace_back(InputSpec{{"datain"}, "TST", "DATA", i, Lifetime::Timeframe});
+    // }
   } else {
     checkerInputs.emplace_back(InputSpec{"datain", ConcreteDataTypeMatcher{"PRX", "DATA"}, Lifetime::Timeframe});
-    //for (unsigned int i = 0; i < pState->nChannels; i++) {
-    //  checkerInputs.emplace_back(InputSpec{{"datain"}, "PRX", "DATA", i, Lifetime::Timeframe});
-    //}
+    // for (unsigned int i = 0; i < pState->nChannels; i++) {
+    //   checkerInputs.emplace_back(InputSpec{{"datain"}, "PRX", "DATA", i, Lifetime::Timeframe});
+    // }
   }
   if (proxyMode != ProxyMode::OnlyOutput) {
     // the checker is not added if the input proxy is skipped
@@ -349,22 +349,22 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   // reads the messages from the output proxy via the out-of-band channel
 
   // converter callback for the external FairMQ device proxy ProcessorSpec generator
-  auto converter = [](TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
+  InjectorFunction converter = [](TimingInfo&, ServiceRegistryRef const& services, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) -> bool {
     auto* device = services.get<RawDeviceService>().device();
     ASSERT_ERROR(inputs.Size() >= 2);
     if (inputs.Size() < 2) {
-      return;
+      return false;
     }
     int msgidx = 0;
     auto dh = o2::header::get<o2::header::DataHeader*>(inputs.At(msgidx)->GetData());
     if (!dh) {
       LOG(error) << "data on input " << msgidx << " does not follow the O2 data model, DataHeader missing";
-      return;
+      return false;
     }
     auto dph = o2::header::get<DataProcessingHeader*>(inputs.At(msgidx)->GetData());
     if (!dph) {
       LOG(error) << "data on input " << msgidx << " does not follow the O2 data model, DataProcessingHeader missing";
-      return;
+      return false;
     }
     // Note: we want to run both the output and input proxy in the same workflow and thus we need
     // different data identifiers and change the data origin in the forwarding
@@ -377,7 +377,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     ASSERT_ERROR(!isData || !channelName.empty());
     LOG(debug) << "using channel '" << channelName << "' for " << DataSpecUtils::describe(OutputSpec{dh->dataOrigin, dh->dataDescription, dh->subSpecification});
     if (channelName.empty()) {
-      return;
+      return false;
     }
     fair::mq::Parts output;
     for (; msgidx < inputs.Size(); ++msgidx) {
@@ -402,7 +402,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
       }
     }
     o2::framework::sendOnChannel(*device, output, channelName, (size_t)-1);
-    return;
+    return output.Size() != 0;
   };
 
   // we use the same spec to build the configuration string, ideally we would have some helpers

--- a/Utilities/DataSampling/src/DataSamplingReadoutAdapter.cxx
+++ b/Utilities/DataSampling/src/DataSamplingReadoutAdapter.cxx
@@ -41,6 +41,7 @@ InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
       o2::header::Stack headerStack{dh, dph};
       sendOnChannel(*device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetriever);
     }
+    return parts.Size() != 0;
   };
 }
 

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -93,8 +93,9 @@ InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, 
   auto MCTracksMessageCache = std::make_shared<fair::mq::Parts>();
   auto Nparts = std::make_shared<int>(nPerTF);
 
-  return [timesliceId, specs, step, nevents, nPerTF, totalEventCounter, eventCounter, TFcounter, Nparts, MCHeadersMessageCache = MCHeadersMessageCache, MCTracksMessageCache = MCTracksMessageCache](TimingInfo& ti, ServiceRegistryRef const& services, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) mutable {
+  return [timesliceId, specs, step, nevents, nPerTF, totalEventCounter, eventCounter, TFcounter, Nparts, MCHeadersMessageCache = MCHeadersMessageCache, MCTracksMessageCache = MCTracksMessageCache](TimingInfo& ti, ServiceRegistryRef const& services, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) mutable -> bool {
     auto*device = services.get<RawDeviceService>().device();
+    bool didSendData = false;
     if (nPerTF < 0) {
       // if no aggregation requested, forward each message with the DPL header
       if (*timesliceId != newTimesliceId) {
@@ -108,6 +109,7 @@ InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, 
         // we have to move the incoming data
         o2::header::Stack headerStack{dh, dph};
         sendOnChannel(*device, std::move(headerStack), std::move(parts.At(i)), specs[i], channelRetriever);
+        didSendData |= parts.At(i)->GetSize() > 0;
       }
       *timesliceId += step;
     } else {
@@ -141,6 +143,8 @@ InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, 
       *eventCounter = 0;
       sendOnChannel(*device, *MCHeadersMessageCache.get(), channelRetriever(specs[0], *TFcounter), *TFcounter);
       sendOnChannel(*device, *MCTracksMessageCache.get(), channelRetriever(specs[1], *TFcounter), *TFcounter);
+      didSendData |= MCHeadersMessageCache->Size() > 0;
+      didSendData |= MCTracksMessageCache->Size() > 0;
       ++(*TFcounter);
       MCHeadersMessageCache->Clear();
       MCTracksMessageCache->Clear();
@@ -150,7 +154,7 @@ InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, 
       // I am done (I don't expect more events to convert); so tell the proxy device to shut-down
       stop = true;
     }
-    return;
+    return didSendData;
   };
 }
 


### PR DESCRIPTION
DPL: notify DPL about out of band data being sent by input proxy

This is needed to avoid skipping some of the callbacks, in particular
the CCDB one.
