### PR TITLE
hooks and configuration for POWHEG

### DIFF
--- a/Generators/share/egconfig/pythia8_powheg.cfg
+++ b/Generators/share/egconfig/pythia8_powheg.cfg
@@ -1,0 +1,79 @@
+Beams:eCM 13000. 		# GeV
+### processes
+Next:numberShowLHA = 1
+Next:numberShowInfo = 1
+Next:numberShowProcess = 1
+Next:numberShowEvent = 1
+Main:timesAllowErrors = 10
+! Read LHE file from POWHEG
+Beams:frameType = 4
+Beams:LHEF = powheg.lhe
+
+! Number of outgoing particles of POWHEG Born level process
+! (i.e. not counting additional POWHEG radiation)
+POWHEG:nFinal = 2
+
+! How vetoing is performed:
+!  0 - No vetoing is performed (userhooks are not loaded)
+!  1 - Showers are started at the kinematical limit.
+!      Emissions are vetoed if pTemt > pThard.
+!      See also POWHEG:vetoCount below
+POWHEG:veto = 1
+
+! After 'vetoCount' accepted emissions in a row, no more emissions
+! are checked. 'vetoCount = 0' means that no emissions are checked.
+! Use a very large value, e.g. 10000, to have all emissions checked.
+POWHEG:vetoCount = 3
+
+! Selection of pThard (note, for events where there is no
+! radiation, pThard is always set to be SCALUP):
+!  0 - pThard = SCALUP (of the LHA/LHEF standard)
+!  1 - the pT of the POWHEG emission is tested against all other
+!      incoming and outgoing partons, with the minimal value chosen
+!  2 - the pT of all final-state partons is tested against all other
+!      incoming and outgoing partons, with the minimal value chosen
+POWHEG:pThard = 2
+
+! Selection of pTemt:
+!  0 - pTemt is pT of the emitted parton w.r.t. radiating parton
+!  1 - pT of the emission is checked against all incoming and outgoing
+!      partons. pTemt is set to the minimum of these values
+!  2 - the pT of all final-state partons is tested against all other
+!      incoming and outgoing partons, with the minimal value chosen
+! WARNING: the choice here can give significant variations in the final
+! distributions, notably in the tail to large pT values.
+POWHEG:pTemt = 0
+
+! Selection of emitted parton for FSR
+!  0 - Pythia definition of emitted
+!  1 - Pythia definition of radiator
+!  2 - Random selection of emitted or radiator
+!  3 - Both are emitted and radiator are tried
+POWHEG:emitted = 0
+
+! pT definitions
+!  0 - POWHEG ISR pT definition is used for both ISR and FSR
+!  1 - POWHEG ISR pT and FSR d_ij definitions
+!  2 - Pythia definitions
+POWHEG:pTdef = 1
+
+! MPI vetoing
+!  0 - No MPI vetoing is done
+!  1 - When there is no radiation, MPIs with a scale above pT_1 are vetoed,
+!      else MPIs with a scale above (pT_1 + pT_2 + pT_3) / 2 are vetoed
+POWHEG:MPIveto = 0
+! Note that POWHEG:MPIveto = 1 should be combined with
+! MultipartonInteractions:pTmaxMatch = 2
+! which here is taken care of in main31.cc.
+
+! QED vetoing
+!  0 - No QED vetoing is done for pTemt > 0.
+!  1 - QED vetoing is done for pTemt > 0.
+!  2 - QED vetoing is done for pTemt > 0.   If a photon is found
+!      with pT>pThard from the Born level process, the event is accepted
+!      and no further veto of this event is allowed (for any pTemt).
+POWHEG:QEDveto = 2
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 10.	

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -216,6 +216,11 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     auto py8config = std::string(std::getenv("O2_ROOT")) + "/share/Generators/egconfig/pythia8_hi.cfg";
     auto py8 = makePythia8Gen(py8config);
     primGen->AddGenerator(py8);
+  } else if (genconfig.compare("pythia8powheg") == 0) {
+    // pythia8 with powheg
+    auto py8config = std::string(std::getenv("O2_ROOT")) + "/share/Generators/egconfig/pythia8_powheg.cfg";
+    auto py8 = makePythia8Gen(py8config);
+    primGen->AddGenerator(py8);
 #endif
   } else if (genconfig.compare("external") == 0 || genconfig.compare("extgen") == 0) {
     // external generator via configuration macro


### PR DESCRIPTION
PYTHIA8 / POWHEG hooks and configuration from command line (-g pythia8powheg)
have been added based on the pythia8 example main31.
Pythia reads from a POWHEG output file "powheg.lhe" that needs to be present in the working directory.
 