### PR TITLE
[WIP] Provide different options for step filtering

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimParams.h
+++ b/Common/SimConfig/include/SimConfig/SimParams.h
@@ -23,6 +23,7 @@ namespace conf
 // (mostly used in O2MCApplication stepping)
 struct SimCutParams : public o2::conf::ConfigurableParamHelper<SimCutParams> {
   bool stepFiltering = true; // if we activate the step filtering in O2BaseMCApplication
+  std::string stepFilteringMacro = "";
   bool stepTrackRefHook = false;                                                                              // if we create track references during generic stepping
   std::string stepTrackRefHookFile = "${O2_ROOT}/share/Detectors/gconfig/StandardSteppingTrackRefHook.macro"; // the standard code holding the TrackRef callback
 

--- a/Common/Utils/src/FileSystemUtils.cxx
+++ b/Common/Utils/src/FileSystemUtils.cxx
@@ -74,6 +74,10 @@ std::string expandShellVarsInFileName(std::string const& input)
   std::sregex_iterator iter;
   auto words_end = std::sregex_iterator(); // the end iterator (default)
   auto words_begin = std::sregex_iterator(input.begin(), input.end(), e);
+  if (words_begin == words_end) {
+    // no match found, return original string
+    return input;
+  }
   std::string tail;
   for (auto i = words_begin; i != words_end; ++i) {
     std::smatch match = *i;

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -68,4 +68,4 @@ o2_add_test_root_macro(g3Config.C
 
 
 o2_data_file(COPY data  DESTINATION Detectors/gconfig/)
-install(FILES src/StandardSteppingTrackRefHook.macro src/FlukaRuntimeConfig.macro DESTINATION share/Detectors/gconfig/)
+install(FILES src/StandardSteppingTrackRefHook.macro src/FlukaRuntimeConfig.macro src/KeepStepCylinders.macro DESTINATION share/Detectors/gconfig/)

--- a/Detectors/gconfig/src/KeepStepCylinders.macro
+++ b/Detectors/gconfig/src/KeepStepCylinders.macro
@@ -1,0 +1,25 @@
+// An implementation to check if steps are inside cylinders aligned along the z-axis
+
+o2::steer::O2MCApplicationBase::KeepStepFcn keepStep()
+{
+  auto& modules = o2::conf::SimConfig::Instance().getActiveModules();
+
+  float zdcTubeR{50};
+
+  if (std::find(modules.begin(), modules.end(), "ZDC") == modules.end()) {
+    zdcTubeR = 0;
+  }
+
+  float rSq[] = {zdcTubeR*zdcTubeR, 130*130, 500*500, 600*600, 100*100, 80*80, zdcTubeR*zdcTubeR};
+  float edges[] = {-3001, -1881, -1789, -715, 600, 714, 1229, 2999};
+  return [rSq, edges](TVirtualMC const* mc) {
+    float x, y, z;
+    mc->TrackPosition(x, y, z);
+    for (auto i = 0U; i < 7; ++i) {
+      if (edges[i+1] > z && z >= edges[i]) {
+        return (x * x + y * y) < rSq[i];
+      }
+    }
+    return true;
+  };
+}

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -18,7 +18,8 @@ o2_add_library(Steer
                                              O2::DetectorsBase
                                              O2::SimulationDataFormat
                                              O2::DetectorsCommonDataFormats
-                                             O2::Generators O2::SimConfig)
+                                             O2::Generators O2::SimConfig
+                                             VecGeom::vecgeom)
 
 o2_add_executable(colcontexttool
                   COMPONENT_NAME steer

--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -22,6 +22,7 @@
 #include <FairMCApplication.h>
 #include "Rtypes.h" // for Int_t, Bool_t, Double_t, etc
 #include <TVirtualMC.h>
+#include "VecGeom/base/FlatVoxelHashMap.h"
 #include "SimConfig/SimParams.h"
 
 namespace o2
@@ -57,6 +58,7 @@ class O2MCApplicationBase : public FairMCApplication
   double TrackingZmax() const override { return mCutParams.maxAbsZTracking; }
 
   typedef std::function<void(TVirtualMC const*)> TrackRefFcn;
+  typedef std::function<bool(TVirtualMC const*)> KeepStepFcn;
 
  protected:
   o2::conf::SimCutParams const& mCutParams; // reference to parameter system
@@ -70,6 +72,8 @@ class O2MCApplicationBase : public FairMCApplication
   void finishEventCommon();
   TrackRefFcn mTrackRefFcn; // a function hook that gets (optionally) called during Stepping
   void initTrackRefHook();
+  KeepStepFcn mKeepStepFcn;
+
 
   ClassDefOverride(O2MCApplicationBase, 1);
 };

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -174,6 +174,9 @@ set_package_properties(FFTW3f PROPERTIES TYPE REQUIRED)
 find_package(absl CONFIG)
 set_package_properties(absl PROPERTIES TYPE REQUIRED)
 
+find_package(VecGeom)
+set_package_properties(VecGeom PROPERTIES TYPE REQUIRED)
+
 find_package(Vtune)
 set_package_properties(Vtune PROPERTIES TYPE OPTIONAL)
 


### PR DESCRIPTION
* by default, stepFiltering is activated and works as usual (z boundaries and 50cm cylinder around beam axis for abs(z) > 1900)

* a macro can be specified via --confKeyValue "SimCutParams.stepFilteringMacro=<path-to-macro>" The function should return yet another function. The returned function takes a TVirtual const* and return bool

* link against VecGeom to allow for vecgeom::FlatVoxelHashMap to be used in step filtering macro

* as usual, the step filtering can be turned off with --configKeyValues "SimCutParams.stepFiltering=false"

* small change to return original string when no match is found while expanding env variables