### PR TITLE
wip: Add S2Y and S2Z also in case of `InvalidPatternID`

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -201,6 +201,8 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
         locXYZ = dict->getClusterCoordinates(c, patt, false);
+        sigmaY2 = o2::itsmft::SegmentationAlpide::PitchRow * o2::itsmft::SegmentationAlpide::PitchRow / 12. / patt.getRowSpan();
+        sigmaZ2 = o2::itsmft::SegmentationAlpide::PitchCol * o2::itsmft::SegmentationAlpide::PitchCol / 12. / patt.getColumnSpan();
         clusterSize = patt.getNPixels();
       }
       if (clusterSize < 255) {


### PR DESCRIPTION
@mpuccio 

Using similar logic to: https://github.com/AliceO2Group/AliceO2/blob/04ce1274f237a6fd89368ac00134a0a408bed39a/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx#L57

it adds errors for non grouped topologies. Or am I missing something?
