### PR TITLE
GPU Standalone multi-threading: fix a bug where gpu-reconstruction could segfault at shutdown

### DIFF
--- a/GPU/Workflow/src/GPUWorkflowInternal.h
+++ b/GPU/Workflow/src/GPUWorkflowInternal.h
@@ -63,7 +63,8 @@ struct GPURecoWorkflowSpec_PipelineInternals {
   fair::mq::Device* fmqDevice = nullptr;
 
   fair::mq::State fmqState = fair::mq::State::Undefined;
-  volatile bool endOfStreamReceived = false;
+  volatile bool endOfStreamAsyncReceived = false;
+  volatile bool endOfStreamDplReceived = false;
   volatile bool runStarted = false;
   volatile bool shouldTerminate = false;
   std::mutex stateMutex;

--- a/GPU/Workflow/src/GPUWorkflowInternal.h
+++ b/GPU/Workflow/src/GPUWorkflowInternal.h
@@ -62,7 +62,7 @@ struct GPURecoWorkflowSpec_PipelineInternals {
 
   fair::mq::Device* fmqDevice = nullptr;
 
-  fair::mq::State fmqState = fair::mq::State::Undefined;
+  volatile fair::mq::State fmqState = fair::mq::State::Undefined, fmqPreviousState = fair::mq::State::Undefined;
   volatile bool endOfStreamAsyncReceived = false;
   volatile bool endOfStreamDplReceived = false;
   volatile bool runStarted = false;
@@ -91,8 +91,8 @@ struct GPURecoWorkflowSpec_PipelineInternals {
 
   unsigned long mNTFReceived = 0;
 
-  bool mayInject = true;
-  unsigned long mayInjectTFId = 0;
+  volatile bool mayInject = true;
+  volatile unsigned long mayInjectTFId = 0;
   std::mutex mayInjectMutex;
   std::condition_variable mayInjectCondition;
 };


### PR DESCRIPTION
Occurred if the receive thread was still trying to receive, and the FMQ device / channel was deleted before the gpu-reconstruction task was deleted.