### PR TITLE
FT0: Process new trigger DP from DCS

### DIFF
--- a/Detectors/FIT/FT0/dcsmonitoring/macros/makeFT0CCDBEntryForDCS.C
+++ b/Detectors/FIT/FT0/dcsmonitoring/macros/makeFT0CCDBEntryForDCS.C
@@ -54,7 +54,8 @@ int makeFT0CCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
                                            "FT0/Trigger4_OrC/CNT_RATE",
                                            "FT0/Trigger5_OrA/CNT_RATE",
                                            "FT0/Background/[0..9]/CNT_RATE",
-                                           "FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
+                                           "FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE",
+                                           "FT0/SecondaryCounter/CEplusSC/CNT_RATE"};
 
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAlias(aliasesADC);

--- a/Detectors/FIT/FT0/dcsmonitoring/src/FT0DCSDataProcessor.cxx
+++ b/Detectors/FIT/FT0/dcsmonitoring/src/FT0DCSDataProcessor.cxx
@@ -47,7 +47,8 @@ std::vector<o2::dcs::DataPointIdentifier> o2::ft0::FT0DCSDataProcessor::getHardC
                                            "FT0/Trigger4_OrC/CNT_RATE",
                                            "FT0/Trigger5_OrA/CNT_RATE",
                                            "FT0/Background/[0..9]/CNT_RATE",
-                                           "FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
+                                           "FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE",
+                                           "FT0/SecondaryCounter/CEplusSC/CNT_RATE"};
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAlias(aliasesADC);
   std::vector<std::string> expAliasesRates = o2::dcs::expandAliases(aliasesRates);

--- a/Detectors/FIT/FT0/dcsmonitoring/workflow/ft0-dcs-sim-workflow.cxx
+++ b/Detectors/FIT/FT0/dcsmonitoring/workflow/ft0-dcs-sim-workflow.cxx
@@ -43,6 +43,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Trigger5_OrA/CNT_RATE", 0, 5000000});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Background/[0..9]/CNT_RATE", 0, 50000});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE", 0, 50000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/SecondaryCounter/CEplusSC/CNT_RATE", 0, 5000000});
 
   o2::framework::WorkflowSpec specs;
   specs.emplace_back(o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "FT0"));

--- a/Detectors/FIT/macros/CMakeLists.txt
+++ b/Detectors/FIT/macros/CMakeLists.txt
@@ -39,3 +39,5 @@ o2_add_test_root_macro(readFITDCSdata.C
                        PUBLIC_LINK_LIBRARIES O2::DetectorsDCS
                                              O2::CCDB
                        LABELS fit)
+
+o2_data_file(COPY readFITDCSdata.C DESTINATION Detectors/FIT/macros/readFITDCSdata.C)

--- a/Detectors/FIT/macros/readFITDCSdata.C
+++ b/Detectors/FIT/macros/readFITDCSdata.C
@@ -84,7 +84,7 @@ void readFITDCSdata(std::string detectorName = "FT0",
                     const std::string& rootOutput = "",
                     const bool print = false,
                     const std::string& textOutput = "",
-                    const bool verbose = true)
+                    const bool verbose = false)
 {
   // Parse and check detector name
   boost::to_upper(detectorName);
@@ -181,7 +181,7 @@ void readFITDCSdata(std::string detectorName = "FT0",
     }
 
     // The CCDB object should always contain values for all datapoints. This is just to check that.
-    if ((detectorName == "FT0" && ccdbMap->size() != 477) || (detectorName == "FV0" && ccdbMap->size() != 147) || (detectorName == "FDD" && ccdbMap->size() != 76)) {
+    if (verbose && ((detectorName == "FT0" && ccdbMap->size() != 501) || (detectorName == "FV0" && ccdbMap->size() != 147) || (detectorName == "FDD" && ccdbMap->size() != 76))) {
       LOGP(error,
            "Wrong number of DCS datapoints fetched for {}, got {}. There is a bug, please send output of this script, with input parameters, to andreas.molander@cern.ch.",
            detectorName, ccdbMap->size());
@@ -230,16 +230,19 @@ void readFITDCSdata(std::string detectorName = "FT0",
     LOG(info) << "Printing data point values:";
     for (auto& it : dataSeries) {
       LOGP(info, "{}", it.first);
-      LOGP(info, "{} value(s):", it.second.values.size());
-      if (verbose) {
-        for (auto& value : it.second.values) {
-          LOGP(info, "TIME = {} ({}), VALUE = {}", value.first, epochToReadable(value.first), value.second);
+      int nValues = it.second.values.size();
+      LOGP(info, "{} value(s):", nValues);
+      if (nValues) {
+        if (verbose) {
+          for (auto& value : it.second.values) {
+            LOGP(info, "TIME = {} ({}), VALUE = {}", value.first, epochToReadable(value.first), value.second);
+          }
+        } else {
+          LOGP(info, "First value:");
+          LOGP(info, "TIME = {} ({}), VALUE = {}", it.second.values.front().first, epochToReadable(it.second.values.front().first), it.second.values.front().second);
+          LOGP(info, "Last value:");
+          LOGP(info, "TIME = {} ({}), VALUE = {}", it.second.values.back().first, epochToReadable(it.second.values.back().first), it.second.values.back().second);
         }
-      } else {
-        LOGP(info, "First value:");
-        LOGP(info, "TIME = {} ({}), VALUE = {}", it.second.values.front().first, epochToReadable(it.second.values.front().first), it.second.values.front().second);
-        LOGP(info, "Last value:");
-        LOGP(info, "TIME = {} ({}), VALUE = {}", it.second.values.back().first, epochToReadable(it.second.values.back().first), it.second.values.back().second);
       }
       LOG(info);
     }


### PR DESCRIPTION
One new data point for the combined FT0 central + semi-central trigger is set up for ADAPOS archiving in DCS. This commit will:
- Process this DP for CCDB upload when using the hard coded DP configuration for processing
- Include this DP in the CCDB DP config object when creating it with the macro
- Simulate this DP with the DCS simulation workflow
- Install the macro for reading DCS DPs to $O2_ROOT/share/Detectors/FIT/macro
- Apply some fixes to the macro for reading DCS DPs