### PR TITLE
Update MCTrackToDPL example

### DIFF
--- a/run/SimExamples/MCTrackToDPL/run.sh
+++ b/run/SimExamples/MCTrackToDPL/run.sh
@@ -11,7 +11,7 @@ SIMPROC=$!
 # launch a DPL process (having the right proxy configuration)
 # (Note that the option --o2sim-pid is not strictly necessary when only one o2-sim process is running.
 #  The socket will than be auto-determined.)
-o2-sim-mctracks-proxy -b --enable-test-consumer --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} --timeframes-rate-limit ${RATELIMIT} &
+o2-sim-mctracks-proxy -b --enable-test-consumer --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} --timeframes-rate-limit ${RATELIMIT} --aggregate-timeframe 1 &
 TRACKANAPROC=$!
 
 wait ${SIMPROC}


### PR DESCRIPTION
Add `--aggregate-timeframe 1` option. Without this, the example crashed or hangs.

Thanks to @DanielSamitz for reporting.