### PR TITLE
[EMCAL-548] Load reco params from CCDB in digits to cell reconstruction

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -22,6 +22,7 @@
 #include "EMCALBase/Geometry.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
 #include "EMCALReconstruction/AltroHelper.h"
+#include "EMCALWorkflow/CalibLoader.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
@@ -52,7 +53,7 @@ class CellConverterSpec : public framework::Task
   /// \param useccdb If true the TecoParams
   /// \param inputSubsepc Subsepc of input objects
   /// \param outputSubspec Subspec of output objects
-  CellConverterSpec(bool propagateMC, bool useccdb, int inputSubsepc, int outputSubspec) : framework::Task(), mPropagateMC(propagateMC), mLoadRecoParamFromCCDB(useccdb), mSubspecificationIn(inputSubsepc), mSubspecificationOut(outputSubspec){};
+  CellConverterSpec(bool propagateMC, int inputSubsepc, int outputSubspec, std::shared_ptr<o2::emcal::CalibLoader> calibhandler) : framework::Task(), mPropagateMC(propagateMC), mSubspecificationIn(inputSubsepc), mSubspecificationOut(outputSubspec), mCalibHandler(calibhandler){};
 
   /// \brief Destructor
   ~CellConverterSpec() override = default;
@@ -90,13 +91,16 @@ class CellConverterSpec : public framework::Task
 
   int selectMaximumBunch(const gsl::span<const Bunch>& bunchvector);
 
+  /// \brief Update calibration objects
+  void updateCalibrationObjects();
+
  private:
   bool mPropagateMC = false;                                           ///< Switch whether to process MC true labels
-  bool mLoadRecoParamFromCCDB = false;                                 ///< Flag to load the the SimParams from CCDB
   unsigned int mSubspecificationIn = 0;                                ///< Input subspecification
   unsigned int mSubspecificationOut = 0;                               ///< Output subspecification
-  o2::emcal::Geometry* mGeometry = nullptr;                            ///!<! Geometry pointer
-  std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;                ///!<! Raw fitter
+  o2::emcal::Geometry* mGeometry = nullptr;                            //!<! Geometry pointer
+  std::shared_ptr<o2::emcal::CalibLoader> mCalibHandler;               //!<! Calibration handler
+  std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;                //!<! Raw fitter
   std::vector<o2::emcal::Cell> mOutputCells;                           ///< Container with output cells
   std::vector<o2::emcal::TriggerRecord> mOutputTriggers;               ///< Container with output trigger records
   o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> mOutputLabels; ///< Container with output MC labels
@@ -110,7 +114,7 @@ class CellConverterSpec : public framework::Task
 /// \param outputSubspec Subspec of output objects
 ///
 /// Refer to CellConverterSpec::run for input and output specs
-framework::DataProcessorSpec getCellConverterSpec(bool propagateMC, bool useccdb = false, int inputSubsepc = 0, int outputSubspec = 0);
+framework::DataProcessorSpec getCellConverterSpec(bool propagateMC, int inputSubsepc = 0, int outputSubspec = 0);
 
 } // namespace reco_workflow
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -52,7 +52,9 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \param subspecificationOut Subspecification if output in case of running on different FLPs
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
-/// \param loadRecoParamsFromCCDB Load the reco params from the CCDB
+/// \param disableRootInput Disable reading from ROOT file (raw mode)
+/// \param disableRootOutput Disable writing ROOT files (sync reco)
+/// \param disableDecodingErrors Diable streaming raw decoding errors (async reco)
 /// \return EMCAL reconstruction workflow for the configuration provided
 /// \ingroup EMCALwokflow
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
@@ -64,8 +66,7 @@ framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,
                                     bool disableRootOutput = false,
-                                    bool disableDecodingErrors = false,
-                                    bool useccdb = false);
+                                    bool disableDecodingErrors = false);
 } // namespace reco_workflow
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -53,8 +53,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
                                         bool disableRootOutput,
-                                        bool disableDecodingErrors,
-                                        bool useccdb)
+                                        bool disableDecodingErrors)
 {
 
   const std::unordered_map<std::string, InputType> InputMap{
@@ -171,7 +170,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   if (isEnabled(OutputType::Cells)) {
     // add converter for cells
     if (inputType == InputType::Digits) {
-      specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC, useccdb, subspecificationIn, subspecificationOut));
+      specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC, subspecificationIn, subspecificationOut));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
       specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, disableDecodingErrors, subspecificationOut));

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -54,7 +54,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
     {"disable-decoding-errors", o2::framework::VariantType::Bool, false, {"disable propagating decoding errors"}},
     {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
-    {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb EMCAL simulation objects"}},
     {"subspecificationIn", o2::framework::VariantType::Int, 0, {"Subspecification for input in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}},
     {"subspecificationOut", o2::framework::VariantType::Int, 0, {"Subspecification for output in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -87,8 +86,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
                                                   cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),
                                                   cfgc.options().get<bool>("disable-root-output"),
-                                                  cfgc.options().get<bool>("disable-decoding-errors"),
-                                                  cfgc.options().get<bool>("use-ccdb"));
+                                                  cfgc.options().get<bool>("disable-decoding-errors"));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);


### PR DESCRIPTION
Use CalibLoader also in the Digits to cell reconstruction,
enabling loading of the reco params.