### PR TITLE
Update Geant4 config - skipUnknownParticles

### DIFF
--- a/Detectors/gconfig/g4config.in
+++ b/Detectors/gconfig/g4config.in
@@ -33,6 +33,7 @@
 /mcPhysics/emModel/setEmModel  PAI
 /mcPhysics/emModel/setRegions  TRD_Gas-mix
 /mcPhysics/emModel/setParticles  all
+/mcPrimaryGenerator/skipUnknownParticles true # don't crash when seeing unknown ion etc. (issue warning)
 
 #
 # Precise Msc for EMCAL


### PR DESCRIPTION
Do not crash the simulation when seeing an unknown ion Relates to https://alice.its.cern.ch/jira/browse/O2-4140