### PR TITLE
Ignore checking for FairMQ version

### DIFF
--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -88,7 +88,7 @@ set_package_properties(Microsoft.GSL
                        TYPE REQUIRED
                        PURPOSE "Mainly for its span")
 
-find_package(FairMQ 1.4.41 CONFIG)
+find_package(FairMQ CONFIG)
 set_package_properties(FairMQ PROPERTIES TYPE REQUIRED)
 
 # find_package(protobuf CONFIG)


### PR DESCRIPTION
Ignore checking for FairMQ version

* Version is way too obsolete in any case.
* Anything which is not the version in alidist is unsupported in any case.
* It breaks whenever git is not able to determine a valid version.
