### PR TITLE
DPL: propaedeutic for better GUI shutdown

### DIFF
--- a/Framework/Core/include/Framework/GuiCallbackContext.h
+++ b/Framework/Core/include/Framework/GuiCallbackContext.h
@@ -43,6 +43,7 @@ struct GuiCallbackContext {
   DebugGUI* plugin = nullptr;
   void* window = nullptr;
   bool* guiQuitRequested = nullptr;
+  bool* allChildrenGone = nullptr;
   std::function<void(void)> callback;
   std::set<GuiRenderer*> renderers;
 };

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1424,6 +1424,8 @@ int runStateMachine(DataProcessorSpecs const& workflow,
 
   uv_timer_t metricDumpTimer;
   metricDumpTimer.data = &serverContext;
+  bool allChildrenGone = false;
+  guiContext.allChildrenGone = &allChildrenGone;
 
   while (true) {
     // If control forced some transition on us, we push it to the queue.
@@ -2093,7 +2095,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
         driverInfo.sigchldRequested = false;
         processChildrenOutput(driverInfo, infos, runningWorkflow.devices, controls);
         hasError = processSigChild(infos, runningWorkflow.devices);
-        bool allChildrenGone = areAllChildrenGone(infos);
+        allChildrenGone = areAllChildrenGone(infos);
         bool canExit = checkIfCanExit(infos);
         bool supposedToQuit = (guiQuitRequested || canExit || graceful_exit);
 


### PR DESCRIPTION
DPL: propaedeutic for better GUI shutdown

This will allow in the GUI to know wether the children have
all shutdown and will keep displaying the debug gui, even
when clicking on the close button, until that is the case.
