### PR TITLE
Remove optional DDS package in CMake, since it is not used as far as I can tell

### DIFF
--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -131,8 +131,6 @@ message(STATUS "Output BUILD_SIMULATION=${BUILD_SIMULATION}")
 
 # Optional packages
 
-find_package(DDS CONFIG)
-set_package_properties(DDS PROPERTIES TYPE RECOMMENDED)
 find_package(benchmark CONFIG NAMES benchmark googlebenchmark)
 set_package_properties(benchmark PROPERTIES TYPE OPTIONAL)
 find_package(OpenMP)


### PR DESCRIPTION
@ktf : I believe we can remove it? Anyway, it seems to be used nowhere.
And actually, since DDS is not a dependency in alidist/o2.sh, it is anyway never found.