### PR TITLE
Adding conversion from Fwdtrack to MCH coordinate systems

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -148,7 +148,6 @@ class MatchGlobalFwd
   /// Converts FwdTrack parameters to MCH coordinate system
   o2::mch::TrackParam FwdtoMCH(const o2::dataformats::GlobalFwdTrack& fwdtrack);
 
-
  private:
   void updateTimeDependentParams();
   void fillBuiltinFunctions();

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -143,6 +143,12 @@ class MatchGlobalFwd
   const std::vector<o2::dataformats::MatchInfoFwd>& getMFTMCHMatchInfo() const { return mMatchingInfo; }
   const std::vector<o2::MCCompLabel>& getMatchLabels() const { return mMatchLabels; }
 
+  /// Converts mchTrack parameters to Forward coordinate system
+  o2::dataformats::GlobalFwdTrack MCHtoFwd(const o2::mch::TrackParam& mchTrack);
+  /// Converts FwdTrack parameters to MCH coordinate system
+  o2::mch::TrackParam FwdtoMCH(const o2::dataformats::GlobalFwdTrack& fwdtrack);
+
+
  private:
   void updateTimeDependentParams();
   void fillBuiltinFunctions();
@@ -279,9 +285,6 @@ class MatchGlobalFwd
     mCutFunc = (*func);
     return true;
   }
-
-  /// Converts mchTrack parameters to Forward coordinate system
-  o2::dataformats::GlobalFwdTrack MCHtoFwd(const o2::mch::TrackParam& mchTrack);
 
   float mBz = -5.f;                       ///< nominal Bz in kGauss
   float mMatchingPlaneZ = sLastMFTPlaneZ; ///< MCH-MFT matching plane Z position

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -771,6 +771,79 @@ o2::dataformats::GlobalFwdTrack MatchGlobalFwd::MCHtoFwd(const o2::mch::TrackPar
 }
 
 //_________________________________________________________________________________________________
+o2::mch::TrackParam MatchGlobalFwd::FwdtoMCH(const o2::dataformats::GlobalFwdTrack& fwdtrack)
+{
+  // Convert Forward Track parameters and covariances matrix to the
+  // MCH track format. 
+
+
+  // Parameter conversion
+  double alpha1, alpha3, alpha4, x2, x3, x4;
+
+  x2 = fwdtrack.getPhi();
+  x3 = fwdtrack.getTanl();
+  x4 = fwdtrack.getInvQPt();
+
+  auto sinx2 = TMath::Sin(x2);
+  auto cosx2 = TMath::Cos(x2);
+
+  alpha1 = cosx2/x3;
+  alpha3 = sinx2/x3;
+  alpha4 = x4/TMath::Sqrt(x3*x3 + sinx2*sinx2);
+
+  auto K = TMath::Sqrt(x3*x3 + sinx2*sinx2);
+  auto K3 = K * K * K;
+
+  // Covariances matrix conversion
+  SMatrix55Std jacobian;
+  SMatrix55Sym covariances;
+
+  covariances(0, 0) = fwdtrack.getCovariances()(0, 0);
+  covariances(0, 1) = fwdtrack.getCovariances()(0, 1);
+  covariances(0, 2) = fwdtrack.getCovariances()(0, 2);
+  covariances(0, 3) = fwdtrack.getCovariances()(0, 3);
+  covariances(0, 4) = fwdtrack.getCovariances()(0, 4);
+
+  covariances(1, 1) = fwdtrack.getCovariances()(1, 1);
+  covariances(1, 2) = fwdtrack.getCovariances()(1, 2);
+  covariances(1, 3) = fwdtrack.getCovariances()(1, 3);
+  covariances(1, 4) = fwdtrack.getCovariances()(1, 4);
+
+  covariances(2, 2) = fwdtrack.getCovariances()(2, 2);
+  covariances(2, 3) = fwdtrack.getCovariances()(2, 3);
+  covariances(2, 4) = fwdtrack.getCovariances()(2, 4);
+
+  covariances(3, 3) = fwdtrack.getCovariances()(3, 3);
+  covariances(3, 4) = fwdtrack.getCovariances()(3, 4);
+
+  covariances(4, 4) = fwdtrack.getCovariances()(4, 4);
+
+  jacobian(0, 0) = 1;
+
+  jacobian(1, 2) = -sinx2 / x3;
+  jacobian(1, 3) = -cosx2 / (x3*x3);
+
+  jacobian(2, 1) = 1;
+
+  jacobian(3, 2) = cosx2 / x3;
+  jacobian(3, 3) = -sinx2 / (x3*x3);
+
+  jacobian(4, 2) = - x4 * sinx2 * cosx2 / K3;
+  jacobian(4, 3) = - x3 * x4 / K3;
+  jacobian(4, 4) = 1 / K;
+  // jacobian*covariances*jacobian^T
+  covariances = ROOT::Math::Similarity(jacobian, covariances);
+
+  double cov[] = {covariances(0,0), covariances(1,0), covariances(1,1), covariances(2,0), covariances(2,1), covariances(2,2), covariances(3,0), covariances(3,1), covariances(3,2), covariances(3,3), covariances(4,0), covariances(4,1), covariances(4,2), covariances(4,3), covariances(4,4)};
+  double param[] = {fwdtrack.getX(), alpha1, fwdtrack.getY(), alpha3, alpha4};
+
+  o2::mch::TrackParam convertedTrack(fwdtrack.getZ(), param, cov);
+  return o2::mch::TrackParam(convertedTrack);
+
+}
+
+
+//_________________________________________________________________________________________________
 MatchGlobalFwd::MatchGlobalFwd()
 {
   mClosestBunchAbove[0] = mClosestBunchAbove[0] = -1;

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -774,8 +774,7 @@ o2::dataformats::GlobalFwdTrack MatchGlobalFwd::MCHtoFwd(const o2::mch::TrackPar
 o2::mch::TrackParam MatchGlobalFwd::FwdtoMCH(const o2::dataformats::GlobalFwdTrack& fwdtrack)
 {
   // Convert Forward Track parameters and covariances matrix to the
-  // MCH track format. 
-
+  // MCH track format.
 
   // Parameter conversion
   double alpha1, alpha3, alpha4, x2, x3, x4;
@@ -787,11 +786,11 @@ o2::mch::TrackParam MatchGlobalFwd::FwdtoMCH(const o2::dataformats::GlobalFwdTra
   auto sinx2 = TMath::Sin(x2);
   auto cosx2 = TMath::Cos(x2);
 
-  alpha1 = cosx2/x3;
-  alpha3 = sinx2/x3;
-  alpha4 = x4/TMath::Sqrt(x3*x3 + sinx2*sinx2);
+  alpha1 = cosx2 / x3;
+  alpha3 = sinx2 / x3;
+  alpha4 = x4 / TMath::Sqrt(x3 * x3 + sinx2 * sinx2);
 
-  auto K = TMath::Sqrt(x3*x3 + sinx2*sinx2);
+  auto K = TMath::Sqrt(x3 * x3 + sinx2 * sinx2);
   auto K3 = K * K * K;
 
   // Covariances matrix conversion
@@ -821,27 +820,25 @@ o2::mch::TrackParam MatchGlobalFwd::FwdtoMCH(const o2::dataformats::GlobalFwdTra
   jacobian(0, 0) = 1;
 
   jacobian(1, 2) = -sinx2 / x3;
-  jacobian(1, 3) = -cosx2 / (x3*x3);
+  jacobian(1, 3) = -cosx2 / (x3 * x3);
 
   jacobian(2, 1) = 1;
 
   jacobian(3, 2) = cosx2 / x3;
-  jacobian(3, 3) = -sinx2 / (x3*x3);
+  jacobian(3, 3) = -sinx2 / (x3 * x3);
 
-  jacobian(4, 2) = - x4 * sinx2 * cosx2 / K3;
-  jacobian(4, 3) = - x3 * x4 / K3;
+  jacobian(4, 2) = -x4 * sinx2 * cosx2 / K3;
+  jacobian(4, 3) = -x3 * x4 / K3;
   jacobian(4, 4) = 1 / K;
   // jacobian*covariances*jacobian^T
   covariances = ROOT::Math::Similarity(jacobian, covariances);
 
-  double cov[] = {covariances(0,0), covariances(1,0), covariances(1,1), covariances(2,0), covariances(2,1), covariances(2,2), covariances(3,0), covariances(3,1), covariances(3,2), covariances(3,3), covariances(4,0), covariances(4,1), covariances(4,2), covariances(4,3), covariances(4,4)};
+  double cov[] = {covariances(0, 0), covariances(1, 0), covariances(1, 1), covariances(2, 0), covariances(2, 1), covariances(2, 2), covariances(3, 0), covariances(3, 1), covariances(3, 2), covariances(3, 3), covariances(4, 0), covariances(4, 1), covariances(4, 2), covariances(4, 3), covariances(4, 4)};
   double param[] = {fwdtrack.getX(), alpha1, fwdtrack.getY(), alpha3, alpha4};
 
   o2::mch::TrackParam convertedTrack(fwdtrack.getZ(), param, cov);
   return o2::mch::TrackParam(convertedTrack);
-
 }
-
 
 //_________________________________________________________________________________________________
 MatchGlobalFwd::MatchGlobalFwd()


### PR DESCRIPTION
This function is implemented in view of propagating muon tracks to PV in O2Physics.