### PR TITLE
alice 3: add simplified magnet for matbud accounting

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -99,6 +99,7 @@ void SimConfig::determineActiveModules(std::vector<std::string> const& inputargs
       }
       activeModules.emplace_back("A3IP");
       activeModules.emplace_back("A3ABSO");
+      activeModules.emplace_back("A3MAG");
     } else {
 #endif
       // add passive components manually (make a PassiveDetID for them!)

--- a/Detectors/Upgrades/ALICE3/Passive/CMakeLists.txt
+++ b/Detectors/Upgrades/ALICE3/Passive/CMakeLists.txt
@@ -13,10 +13,12 @@ o2_add_library(Alice3DetectorsPassive
                SOURCES src/Pipe.cxx
                        src/PassiveBase.cxx
                        src/Absorber.cxx
+                       src/Magnet.cxx
                PUBLIC_LINK_LIBRARIES O2::Field O2::DetectorsBase O2::SimConfig)
 
 o2_target_root_dictionary(Alice3DetectorsPassive
                           HEADERS include/Alice3DetectorsPassive/Pipe.h
                                   include/Alice3DetectorsPassive/PassiveBase.h
                                   include/Alice3DetectorsPassive/Absorber.h
+                                  include/Alice3DetectorsPassive/Magnet.h
                           LINKDEF src/PassiveLinkDef.h)

--- a/Detectors/Upgrades/ALICE3/Passive/include/Alice3DetectorsPassive/Magnet.h
+++ b/Detectors/Upgrades/ALICE3/Passive/include/Alice3DetectorsPassive/Magnet.h
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICE3_PASSIVE_MAGNET_H
+#define ALICE3_PASSIVE_MAGNET_H
+
+#include "Alice3DetectorsPassive/PassiveBase.h"
+
+namespace o2
+{
+namespace passive
+{
+
+class Alice3Magnet : public Alice3PassiveBase
+{
+ public:
+  Alice3Magnet(const char* name, const char* Title = "ALICE3 Magnet");
+  Alice3Magnet();
+  ~Alice3Magnet() override;
+  void ConstructGeometry() override;
+  void createMaterials();
+
+  /// Clone this object (used in MT mode only)
+  FairModule* CloneModule() const override;
+
+ private:
+  Alice3Magnet(const Alice3Magnet& orig);
+  Alice3Magnet& operator=(const Alice3Magnet&);
+
+  float mInnerWrapInnerRadius{160.f}; // cm
+  float mTotalThickness{10.8f};       // cm
+  float mCoilThickness{0.3f};         // cm
+  float mZLength{800.f};              // cm
+
+  ClassDefOverride(o2::passive::Alice3Magnet, 1);
+};
+} // namespace passive
+} // namespace o2
+#endif

--- a/Detectors/Upgrades/ALICE3/Passive/src/Absorber.cxx
+++ b/Detectors/Upgrades/ALICE3/Passive/src/Absorber.cxx
@@ -120,7 +120,7 @@ void Alice3Absorber::ConstructGeometry()
   TGeoVolume* top = gGeoManager->GetVolume("cave");
   TGeoVolume* barrel = gGeoManager->GetVolume("barrel");
   if (!barrel) {
-    LOG(fatal) << "Could not find the top volume";
+    LOG(fatal) << "Could not find the barrel volume while constructing absorber geometry";
   }
 
   TGeoPcon* absorings = new TGeoPcon(0., 360., 18);

--- a/Detectors/Upgrades/ALICE3/Passive/src/Magnet.cxx
+++ b/Detectors/Upgrades/ALICE3/Passive/src/Magnet.cxx
@@ -1,0 +1,128 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <DetectorsBase/Detector.h>
+#include <DetectorsBase/MaterialManager.h>
+#include <Alice3DetectorsPassive/Magnet.h>
+#include <TGeoCompositeShape.h>
+#include <TGeoManager.h>
+#include <TGeoMatrix.h>
+#include <TGeoMedium.h>
+#include <TGeoVolume.h>
+#include <TGeoTube.h>
+
+using namespace o2::passive;
+
+Alice3Magnet::~Alice3Magnet() = default;
+Alice3Magnet::Alice3Magnet() : Alice3PassiveBase("A3MAG", "") {}
+Alice3Magnet::Alice3Magnet(const char* name, const char* title) : Alice3PassiveBase(name, title) {}
+Alice3Magnet::Alice3Magnet(const Alice3Magnet& rhs) = default;
+
+Alice3Magnet& Alice3Magnet::operator=(const Alice3Magnet& rhs)
+{
+  if (this == &rhs) {
+    return *this;
+  }
+
+  Alice3PassiveBase::operator=(rhs);
+
+  return *this;
+}
+
+void Alice3Magnet::createMaterials()
+{
+  auto& matmgr = o2::base::MaterialManager::Instance();
+  int isxfld = 2.;
+  float sxmgmx = 10.;
+  o2::base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
+
+  // Current information is scarce, we have some X/X0 and thicknesses but no full material information
+  // We use then two main materials: Aluminium for insulation, cryostats, stabiliser, supports and strips.
+  // Copper for the coils.
+  // Latest updated reference table is, for the moment:
+  // +------------------+-------------------------+----------+--------+
+  // |  layer           | effective thickness [mm]|  X0 [cm] | X0 [%] |
+  // +------------------+-------------------------+----------+--------+
+  // | Support cylinder |           20            |  8.896   | 0.225  |
+  // | Al-strip         |            1            |  8.896   | 0.011  |
+  // | NbTi/Cu          |            3            |  1.598   | 0.188  |
+  // | Insulation       |           11            | 17.64    | 0.062  |
+  // | Al-stabiliser    |           33            |  8.896   | 0.371  |
+  // | Inner cryostat   |           10            |  8.896   | 0.112  |
+  // | Outer cryostat   |           30            |  8.896   | 0.337  |
+  // +------------------+-------------------------+----------+--------+
+  // Geometry will be oversimplified in two wrapping cylindrical Al layers (symmetric for the time being) with a Copper layer in between.
+
+  float epsil, stmin, tmaxfd, deemax, stemax;
+  epsil = .001;   // Tracking precision,
+  stemax = -0.01; // Maximum displacement for multiple scat
+  tmaxfd = -20.;  // Maximum angle due to field deflection
+  deemax = -.3;   // Maximum fractional energy loss, DLS
+  stmin = -.8;
+
+  matmgr.Material("A3MAG", 9, "Al1$", 26.98, 13., 2.7, 8.9, 37.2);
+  matmgr.Material("A3MAG", 19, "Cu1$", 63.55, 29., 8.96, 1.6, 18.8);
+
+  matmgr.Medium("A3MAG", 9, "ALU_C0", 9, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("A3MAG", 19, "CU_C0", 19, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+}
+
+void Alice3Magnet::ConstructGeometry()
+{
+  createMaterials();
+
+  TGeoManager* geoManager = gGeoManager;
+  TGeoVolume* barrel = geoManager->GetVolume("barrel");
+  if (!barrel) {
+    LOGP(fatal, "Could not find barrel volume while constructing Alice 3 magnet geometry");
+  }
+
+  auto& matmgr = o2::base::MaterialManager::Instance();
+  auto kMedAl = matmgr.getTGeoMedium("A3MAG_ALU_C0");
+  auto kMedCu = matmgr.getTGeoMedium("A3MAG_CU_C0");
+
+  float wrapThickness = (mTotalThickness - mCoilThickness) / 2;      // Thickness of the Al wraps
+  float innerCoilsRadius = mInnerWrapInnerRadius + wrapThickness;    // Inner radius of the Cu coils
+  float externalWrapInnerRadius = innerCoilsRadius + mCoilThickness; // Inner radius of the external wrapping Al cylinder
+
+  // inner wrap
+  LOGP(debug, "Alice 3 magnet: creating inner wrap with inner radius {} and thickness {}", mInnerWrapInnerRadius, wrapThickness);
+  TGeoTube* innerLayer = new TGeoTube(mInnerWrapInnerRadius, mInnerWrapInnerRadius + wrapThickness, mZLength / 2);
+  // coils layer
+  LOGP(debug, "Alice 3 magnet: creating coils layer with inner radius {} and thickness {}", innerCoilsRadius, mCoilThickness);
+  TGeoTube* coilsLayer = new TGeoTube(innerCoilsRadius, innerCoilsRadius + mCoilThickness, mZLength / 2);
+  // outer wrap
+  LOGP(debug, "Alice 3 magnet: creating outer wrap with inner radius {} and thickness {}", externalWrapInnerRadius, wrapThickness);
+  TGeoTube* outerLayer = new TGeoTube(externalWrapInnerRadius, externalWrapInnerRadius + wrapThickness, mZLength / 2);
+
+  TGeoVolume* innerWrap = new TGeoVolume("innerWrap", innerLayer, kMedAl);
+  TGeoVolume* coils = new TGeoVolume("coils", coilsLayer, kMedCu);
+  TGeoVolume* outerWrap = new TGeoVolume("outerWrap", outerLayer, kMedAl);
+  innerWrap->SetLineColor(kRed);
+  coils->SetLineColor(kOrange);
+  outerWrap->SetLineColor(kRed);
+
+  new TGeoVolumeAssembly("magnet");
+  auto* magnet = gGeoManager->GetVolume("magnet");
+  magnet->AddNode(innerWrap, 1, nullptr);
+  magnet->AddNode(coils, 1, nullptr);
+  magnet->AddNode(outerWrap, 1, nullptr);
+
+  magnet->SetVisibility(1);
+
+  barrel->AddNode(magnet, 1, new TGeoTranslation(0, 30.f, 0));
+}
+
+FairModule* Alice3Magnet::CloneModule() const
+{
+  return new Alice3Magnet(*this);
+}
+ClassImp(o2::passive::Alice3Magnet)

--- a/Detectors/Upgrades/ALICE3/Passive/src/PassiveLinkDef.h
+++ b/Detectors/Upgrades/ALICE3/Passive/src/PassiveLinkDef.h
@@ -18,5 +18,6 @@
 #pragma link C++ class o2::passive::Alice3PassiveBase + ;
 #pragma link C++ class o2::passive::Alice3Pipe + ;
 #pragma link C++ class o2::passive::Alice3Absorber + ;
+#pragma link C++ class o2::passive::Alice3Magnet + ;
 
 #endif

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -55,6 +55,7 @@
 #include <FCTSimulation/Detector.h>
 #include <Alice3DetectorsPassive/Pipe.h>
 #include <Alice3DetectorsPassive/Absorber.h>
+#include <Alice3DetectorsPassive/Magnet.h>
 #endif
 
 void finalize_geometry(FairRunSim* run);
@@ -168,6 +169,10 @@ void build_geometry(FairRunSim* run = nullptr)
     run->AddModule(new o2::passive::Alice3Absorber("A3ABSO", "ALICE3 Absorber"));
   }
 
+  // the magnet
+  if (isActivated("A3MAG")) {
+    run->AddModule(new o2::passive::Alice3Magnet("A3MAG", "ALICE3 Magnet"));
+  }
 #endif
 
   // the absorber


### PR DESCRIPTION
Another passive element, to mockup future alice 3 magnet, required to start radiation load studies.

With current limited information I own I am assuming it's mostly Al with a thin layer of Cu/NbTi for the coils.
This is to touch base with the basic implementation, waiting for additional input from Arturo.

![Screenshot 2023-10-28 at 19 48 28](https://github.com/AliceO2Group/AliceO2/assets/4990252/e7142302-be81-4821-9ada-96a7f3195e62)
