### PR TITLE
Time-series: adding more variables to monitor

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
@@ -199,7 +199,11 @@ struct TimeSeries {
 
   unsigned char mNBinsPhi{}; ///< number of tgl bins
   unsigned char mNBinsTgl{}; ///< number of phi bins
+  float mTglMax{};           ///< absolute max tgl
   unsigned char mNBinsqPt{}; ///< number of qPt bins
+  float mQPtMax{};           ///< abs qPt max
+  unsigned char mMultBins{}; ///< multiplicity bins
+  float mMultMax{};          ///< max local multiplicity
   long mTimeMS{};            ///< start time in ms
 
   /// dump object to tree
@@ -212,7 +216,7 @@ struct TimeSeries {
 
   size_t getEntries() const { return mDCAr_A_Median.size(); } ///< \return returns number of values stored
   /// \return returns total number of bins
-  int getNBins() const { return mNBinsTgl + mNBinsPhi + mNBinsqPt + 1; }
+  int getNBins() const { return mNBinsTgl + mNBinsPhi + mNBinsqPt + mMultBins + 1; }
 
   /// \return returns index for given phi bin
   int getIndexPhi(const int iPhi, int slice = 0) const { return iPhi + slice * getNBins(); }
@@ -222,6 +226,9 @@ struct TimeSeries {
 
   /// \return returns index for given qPt bin
   int getIndexqPt(const int iqPt, int slice = 0) const { return mNBinsPhi + mNBinsTgl + iqPt + slice * getNBins(); }
+
+  /// \return returns index for given qPt bin
+  int getIndexMult(const int iMult, int slice = 0) const { return mNBinsPhi + mNBinsTgl + mNBinsqPt + iMult + slice * getNBins(); }
 
   /// \return returns index for integrated over all bins
   int getIndexInt(int slice = 0) const { return getNBins() - 1 + slice * getNBins(); }
@@ -234,6 +241,10 @@ struct TimeSeries {
     mNBinsPhi = data.mNBinsPhi;
     mNBinsTgl = data.mNBinsTgl;
     mNBinsqPt = data.mNBinsqPt;
+    mMultBins = data.mMultBins;
+    mTglMax = data.mTglMax;
+    mQPtMax = data.mQPtMax;
+    mMultMax = data.mMultMax;
     fill(data.mDCAr_A_Median, mDCAr_A_Median, posIndex);
     fill(data.mDCAr_C_Median, mDCAr_C_Median, posIndex);
     fill(data.mDCAr_A_RMS, mDCAr_A_RMS, posIndex);
@@ -362,28 +373,71 @@ struct ITSTPC_Matching {
 };
 
 struct TimeSeriesITSTPC {
-  TimeSeries mTSTPC;                             ///< TPC standalone DCAs
-  TimeSeries mTSITSTPC;                          ///< ITS-TPC standalone DCAs
-  ITSTPC_Matching mITSTPCAll;                    ///< ITS-TPC matching efficiency for ITS standalone + afterburner
-  ITSTPC_Matching mITSTPCStandalone;             ///< ITS-TPC matching efficiency for ITS standalone
-  ITSTPC_Matching mITSTPCAfterburner;            ///< ITS-TPC matchin efficiency  fir ITS afterburner
-  std::vector<float> nPrimVertices;              ///< number of primary vertices
-  std::vector<float> nVertexContributors_Median; ///< number of primary vertices
-  std::vector<float> nVertexContributors_RMS;    ///< number of primary vertices
-  std::vector<float> vertexX_Median;             ///< vertex x position
-  std::vector<float> vertexY_Median;             ///< vertex y position
-  std::vector<float> vertexZ_Median;             ///< vertex z position
-  std::vector<float> vertexX_RMS;                ///< vertex x RMS
-  std::vector<float> vertexY_RMS;                ///< vertex y RMS
-  std::vector<float> vertexZ_RMS;                ///< vertex z RMS
-  std::vector<float> mDCAr_comb_A_Median;        ///< DCAr for ITS-TPC track - A-side
-  std::vector<float> mDCAz_comb_A_Median;        ///< DCAz for ITS-TPC track - A-side
-  std::vector<float> mDCAr_comb_A_RMS;           ///< DCAr RMS for ITS-TPC track - A-side
-  std::vector<float> mDCAz_comb_A_RMS;           ///< DCAz RMS for ITS-TPC track - A-side
-  std::vector<float> mDCAr_comb_C_Median;        ///< DCAr for ITS-TPC track - C-side
-  std::vector<float> mDCAz_comb_C_Median;        ///< DCAz for ITS-TPC track - C-side
-  std::vector<float> mDCAr_comb_C_RMS;           ///< DCAr RMS for ITS-TPC track - C-side
-  std::vector<float> mDCAz_comb_C_RMS;           ///< DCAz RMS for ITS-TPC track - C-side
+  TimeSeries mTSTPC;                  ///< TPC standalone DCAs
+  TimeSeries mTSITSTPC;               ///< ITS-TPC standalone DCAs
+  ITSTPC_Matching mITSTPCAll;         ///< ITS-TPC matching efficiency for ITS standalone + afterburner
+  ITSTPC_Matching mITSTPCStandalone;  ///< ITS-TPC matching efficiency for ITS standalone
+  ITSTPC_Matching mITSTPCAfterburner; ///< ITS-TPC matchin efficiency  fir ITS afterburner
+
+  std::vector<float> nPrimVertices_ITS;              ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> nVertexContributors_ITS_Median; ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> nVertexContributors_ITS_RMS;    ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> vertexX_ITS_Median;             ///< vertex x position selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> vertexY_ITS_Median;             ///< vertex y position selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> vertexZ_ITS_Median;             ///< vertex z position selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> vertexX_ITS_RMS;                ///< vertex x RMS selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> vertexY_ITS_RMS;                ///< vertex y RMS selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+  std::vector<float> vertexZ_ITS_RMS;                ///< vertex z RMS selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
+
+  std::vector<float> nPrimVertices_ITSTPC;              ///< number of primary vertices with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> nVertexContributors_ITSTPC_Median; ///< number of primary vertices with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> nVertexContributors_ITSTPC_RMS;    ///< number of primary vertices with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> vertexX_ITSTPC_Median;             ///< vertex x position with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> vertexY_ITSTPC_Median;             ///< vertex y position with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> vertexZ_ITSTPC_Median;             ///< vertex z position with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> vertexX_ITSTPC_RMS;                ///< vertex x RMS with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> vertexY_ITSTPC_RMS;                ///< vertex y RMS with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+  std::vector<float> vertexZ_ITSTPC_RMS;                ///< vertex z RMS with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
+
+  int quantileValues = 12;                          ///<! number of values in quantiles + truncated mean (hardcoded for the moment)
+  std::vector<float> nVertexContributors_Quantiles; ///< number of primary vertices for quantiles 0.1, 0.2, ... 0.9 and truncated mean values 0.05->0.95, 0.1->0.9, 0.2->0.8
+
+  std::vector<float> mDCAr_comb_A_Median;       ///< DCAr for ITS-TPC track - A-side
+  std::vector<float> mDCAz_comb_A_Median;       ///< DCAz for ITS-TPC track - A-side
+  std::vector<float> mDCAr_comb_A_RMS;          ///< DCAr RMS for ITS-TPC track - A-side
+  std::vector<float> mDCAz_comb_A_RMS;          ///< DCAz RMS for ITS-TPC track - A-side
+  std::vector<float> mDCAr_comb_C_Median;       ///< DCAr for ITS-TPC track - C-side
+  std::vector<float> mDCAz_comb_C_Median;       ///< DCAz for ITS-TPC track - C-side
+  std::vector<float> mDCAr_comb_C_RMS;          ///< DCAr RMS for ITS-TPC track - C-side
+  std::vector<float> mDCAz_comb_C_RMS;          ///< DCAz RMS for ITS-TPC track - C-side
+  std::vector<float> mLogdEdx_A_Median;         ///< log(dEdx_exp(pion)/dEdx) - A-side
+  std::vector<float> mLogdEdx_A_RMS;            ///< log(dEdx_exp(pion)/dEdx) - A-side
+  std::vector<float> mLogdEdx_A_IROC_Median;    ///< log(dedxIROC / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_IROC_RMS;       ///< log(dedxIROC / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC1_Median;   ///< log(dedxOROC1 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC1_RMS;      ///< log(dedxOROC1 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC2_Median;   ///< log(dedxOROC2 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC2_RMS;      ///< log(dedxOROC2 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC3_Median;   ///< log(dedxOROC3 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC3_RMS;      ///< log(dedxOROC3 / dEdx) - A-side
+  std::vector<float> mLogdEdx_C_Median;         ///< log(dEdx_exp(pion)/dEdx) - C-side
+  std::vector<float> mLogdEdx_C_RMS;            ///< log(dEdx_exp(pion)/dEdx) - C-side
+  std::vector<float> mLogdEdx_C_IROC_Median;    ///< log(dedxIROC / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_IROC_RMS;       ///< log(dedxIROC / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC1_Median;   ///< log(dedxOROC1 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC1_RMS;      ///< log(dedxOROC1 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC2_Median;   ///< log(dedxOROC2 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC2_RMS;      ///< log(dedxOROC2 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC3_Median;   ///< log(dedxOROC3 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC3_RMS;      ///< log(dedxOROC3 / dEdx) - C-side
+  std::vector<float> mITS_A_NCl_Median;         ///< its number of clusters
+  std::vector<float> mITS_A_NCl_RMS;            ///< its number of clusters
+  std::vector<float> mITS_C_NCl_Median;         ///< its number of clusters
+  std::vector<float> mITS_C_NCl_RMS;            ///< its number of clusters
+  std::vector<float> mSqrtITSChi2_Ncl_A_Median; ///< sqrt(ITC chi2 / ncl)
+  std::vector<float> mSqrtITSChi2_Ncl_C_Median; ///< sqrt(ITC chi2 / ncl)
+  std::vector<float> mSqrtITSChi2_Ncl_A_RMS;    ///< sqrt(ITC chi2 / ncl)
+  std::vector<float> mSqrtITSChi2_Ncl_C_RMS;    ///< sqrt(ITC chi2 / ncl)
 
   // dump this object to a tree
   void dumpToTree(const char* outFileName, const int nHBFPerTF = 32);
@@ -394,14 +448,22 @@ struct TimeSeriesITSTPC {
     mTSITSTPC.setStartTime(timeMS);
   }
 
-  void setBinning(const int nBinsPhi, const int nBinsTgl, const int qPtBins)
+  void setBinning(const int nBinsPhi, const int nBinsTgl, const int qPtBins, const int nBinsMult, float tglMax, float qPtMax, float multMax)
   {
     mTSTPC.mNBinsPhi = nBinsPhi;
     mTSTPC.mNBinsTgl = nBinsTgl;
     mTSTPC.mNBinsqPt = qPtBins;
+    mTSTPC.mMultBins = nBinsMult;
+    mTSTPC.mTglMax = tglMax;
+    mTSTPC.mQPtMax = qPtMax;
+    mTSTPC.mMultMax = multMax;
     mTSITSTPC.mNBinsPhi = nBinsPhi;
     mTSITSTPC.mNBinsTgl = nBinsTgl;
     mTSITSTPC.mNBinsqPt = qPtBins;
+    mTSITSTPC.mMultBins = nBinsMult;
+    mTSITSTPC.mTglMax = tglMax;
+    mTSITSTPC.mQPtMax = qPtMax;
+    mTSITSTPC.mMultMax = multMax;
   }
 
   bool areSameSize() const { return (mTSTPC.areSameSize() && mTSITSTPC.areSameSize()); } ///< check if stored currents have same number of entries
@@ -428,17 +490,57 @@ struct TimeSeriesITSTPC {
     fill(data.mDCAz_comb_C_Median, mDCAz_comb_C_Median, posIndex);
     fill(data.mDCAr_comb_C_RMS, mDCAr_comb_C_RMS, posIndex);
     fill(data.mDCAz_comb_C_RMS, mDCAz_comb_C_RMS, posIndex);
+    fill(data.mLogdEdx_A_Median, mLogdEdx_A_Median, posIndex);
+    fill(data.mLogdEdx_A_RMS, mLogdEdx_A_RMS, posIndex);
+    fill(data.mLogdEdx_A_IROC_Median, mLogdEdx_A_IROC_Median, posIndex);
+    fill(data.mLogdEdx_A_IROC_RMS, mLogdEdx_A_IROC_RMS, posIndex);
+    fill(data.mLogdEdx_A_OROC1_Median, mLogdEdx_A_OROC1_Median, posIndex);
+    fill(data.mLogdEdx_A_OROC1_RMS, mLogdEdx_A_OROC1_RMS, posIndex);
+    fill(data.mLogdEdx_A_OROC2_Median, mLogdEdx_A_OROC2_Median, posIndex);
+    fill(data.mLogdEdx_A_OROC2_RMS, mLogdEdx_A_OROC2_RMS, posIndex);
+    fill(data.mLogdEdx_A_OROC3_Median, mLogdEdx_A_OROC3_Median, posIndex);
+    fill(data.mLogdEdx_A_OROC3_RMS, mLogdEdx_A_OROC3_RMS, posIndex);
+    fill(data.mLogdEdx_C_Median, mLogdEdx_C_Median, posIndex);
+    fill(data.mLogdEdx_C_RMS, mLogdEdx_C_RMS, posIndex);
+    fill(data.mLogdEdx_C_IROC_Median, mLogdEdx_C_IROC_Median, posIndex);
+    fill(data.mLogdEdx_C_IROC_RMS, mLogdEdx_C_IROC_RMS, posIndex);
+    fill(data.mLogdEdx_C_OROC1_Median, mLogdEdx_C_OROC1_Median, posIndex);
+    fill(data.mLogdEdx_C_OROC1_RMS, mLogdEdx_C_OROC1_RMS, posIndex);
+    fill(data.mLogdEdx_C_OROC2_Median, mLogdEdx_C_OROC2_Median, posIndex);
+    fill(data.mLogdEdx_C_OROC2_RMS, mLogdEdx_C_OROC2_RMS, posIndex);
+    fill(data.mLogdEdx_C_OROC3_Median, mLogdEdx_C_OROC3_Median, posIndex);
+    fill(data.mLogdEdx_C_OROC3_RMS, mLogdEdx_C_OROC3_RMS, posIndex);
+    fill(data.mITS_A_NCl_Median, mITS_A_NCl_Median, posIndex);
+    fill(data.mITS_A_NCl_RMS, mITS_A_NCl_RMS, posIndex);
+    fill(data.mITS_C_NCl_Median, mITS_C_NCl_Median, posIndex);
+    fill(data.mITS_C_NCl_RMS, mITS_C_NCl_RMS, posIndex);
+    fill(data.mSqrtITSChi2_Ncl_A_Median, mSqrtITSChi2_Ncl_A_Median, posIndex);
+    fill(data.mSqrtITSChi2_Ncl_C_Median, mSqrtITSChi2_Ncl_C_Median, posIndex);
+    fill(data.mSqrtITSChi2_Ncl_A_RMS, mSqrtITSChi2_Ncl_A_RMS, posIndex);
+    fill(data.mSqrtITSChi2_Ncl_C_RMS, mSqrtITSChi2_Ncl_C_RMS, posIndex);
 
     const int iTF = posIndex / mTSTPC.getNBins();
-    nPrimVertices[iTF] = data.nPrimVertices.front();
-    nVertexContributors_Median[iTF] = data.nVertexContributors_Median.front();
-    nVertexContributors_RMS[iTF] = data.nVertexContributors_RMS.front();
-    vertexX_Median[iTF] = data.vertexX_Median.front();
-    vertexY_Median[iTF] = data.vertexY_Median.front();
-    vertexZ_Median[iTF] = data.vertexZ_Median.front();
-    vertexX_RMS[iTF] = data.vertexX_RMS.front();
-    vertexY_RMS[iTF] = data.vertexY_RMS.front();
-    vertexZ_RMS[iTF] = data.vertexZ_RMS.front();
+    nPrimVertices_ITS[iTF] = data.nPrimVertices_ITS.front();
+    nVertexContributors_ITS_Median[iTF] = data.nVertexContributors_ITS_Median.front();
+    nVertexContributors_ITS_RMS[iTF] = data.nVertexContributors_ITS_RMS.front();
+    vertexX_ITS_Median[iTF] = data.vertexX_ITS_Median.front();
+    vertexY_ITS_Median[iTF] = data.vertexY_ITS_Median.front();
+    vertexZ_ITS_Median[iTF] = data.vertexZ_ITS_Median.front();
+    vertexX_ITS_RMS[iTF] = data.vertexX_ITS_RMS.front();
+    vertexY_ITS_RMS[iTF] = data.vertexY_ITS_RMS.front();
+    vertexZ_ITS_RMS[iTF] = data.vertexZ_ITS_RMS.front();
+    nPrimVertices_ITSTPC[iTF] = data.nPrimVertices_ITSTPC.front();
+    nVertexContributors_ITSTPC_Median[iTF] = data.nVertexContributors_ITSTPC_Median.front();
+    nVertexContributors_ITSTPC_RMS[iTF] = data.nVertexContributors_ITSTPC_RMS.front();
+    vertexX_ITSTPC_Median[iTF] = data.vertexX_ITSTPC_Median.front();
+    vertexY_ITSTPC_Median[iTF] = data.vertexY_ITSTPC_Median.front();
+    vertexZ_ITSTPC_Median[iTF] = data.vertexZ_ITSTPC_Median.front();
+    vertexX_ITSTPC_RMS[iTF] = data.vertexX_ITSTPC_RMS.front();
+    vertexY_ITSTPC_RMS[iTF] = data.vertexY_ITSTPC_RMS.front();
+    vertexZ_ITSTPC_RMS[iTF] = data.vertexZ_ITSTPC_RMS.front();
+
+    const int iTFQ = quantileValues * posIndex / mTSTPC.getNBins();
+    fill(data.nVertexContributors_Quantiles, nVertexContributors_Quantiles, iTFQ);
   }
 
   /// \param nDummyValues number of empty values which are inserted at the beginning of the accumulated integrated currents
@@ -458,18 +560,59 @@ struct TimeSeriesITSTPC {
     insert(mDCAz_comb_C_Median, vecTmp);
     insert(mDCAr_comb_C_RMS, vecTmp);
     insert(mDCAz_comb_C_RMS, vecTmp);
+    insert(mLogdEdx_A_Median, vecTmp);
+    insert(mLogdEdx_A_RMS, vecTmp);
+    insert(mLogdEdx_A_IROC_Median, vecTmp);
+    insert(mLogdEdx_A_IROC_RMS, vecTmp);
+    insert(mLogdEdx_A_OROC1_Median, vecTmp);
+    insert(mLogdEdx_A_OROC1_RMS, vecTmp);
+    insert(mLogdEdx_A_OROC2_Median, vecTmp);
+    insert(mLogdEdx_A_OROC2_RMS, vecTmp);
+    insert(mLogdEdx_A_OROC3_Median, vecTmp);
+    insert(mLogdEdx_A_OROC3_RMS, vecTmp);
+    insert(mLogdEdx_C_Median, vecTmp);
+    insert(mLogdEdx_C_RMS, vecTmp);
+    insert(mLogdEdx_C_IROC_Median, vecTmp);
+    insert(mLogdEdx_C_IROC_RMS, vecTmp);
+    insert(mLogdEdx_C_OROC1_Median, vecTmp);
+    insert(mLogdEdx_C_OROC1_RMS, vecTmp);
+    insert(mLogdEdx_C_OROC2_Median, vecTmp);
+    insert(mLogdEdx_C_OROC2_RMS, vecTmp);
+    insert(mLogdEdx_C_OROC3_Median, vecTmp);
+    insert(mLogdEdx_C_OROC3_RMS, vecTmp);
+    insert(mITS_A_NCl_Median, vecTmp);
+    insert(mITS_A_NCl_RMS, vecTmp);
+    insert(mITS_C_NCl_Median, vecTmp);
+    insert(mITS_C_NCl_RMS, vecTmp);
+    insert(mSqrtITSChi2_Ncl_A_Median, vecTmp);
+    insert(mSqrtITSChi2_Ncl_C_Median, vecTmp);
+    insert(mSqrtITSChi2_Ncl_A_RMS, vecTmp);
+    insert(mSqrtITSChi2_Ncl_C_RMS, vecTmp);
 
     const int nDummyValuesVtx = nDummyValues / mTSTPC.getNBins();
     std::vector<float> vecTmpVtx(nDummyValuesVtx, 0);
-    insert(nPrimVertices, vecTmp);
-    insert(nVertexContributors_Median, vecTmp);
-    insert(nVertexContributors_RMS, vecTmp);
-    insert(vertexX_Median, vecTmp);
-    insert(vertexY_Median, vecTmp);
-    insert(vertexZ_Median, vecTmp);
-    insert(vertexX_RMS, vecTmp);
-    insert(vertexY_RMS, vecTmp);
-    insert(vertexZ_RMS, vecTmp);
+    insert(nPrimVertices_ITS, vecTmpVtx);
+    insert(nVertexContributors_ITS_Median, vecTmpVtx);
+    insert(nVertexContributors_ITS_RMS, vecTmpVtx);
+    insert(vertexX_ITS_Median, vecTmpVtx);
+    insert(vertexY_ITS_Median, vecTmpVtx);
+    insert(vertexZ_ITS_Median, vecTmpVtx);
+    insert(vertexX_ITS_RMS, vecTmpVtx);
+    insert(vertexY_ITS_RMS, vecTmpVtx);
+    insert(vertexZ_ITS_RMS, vecTmpVtx);
+    insert(nPrimVertices_ITSTPC, vecTmpVtx);
+    insert(nVertexContributors_ITSTPC_Median, vecTmpVtx);
+    insert(nVertexContributors_ITSTPC_RMS, vecTmpVtx);
+    insert(vertexX_ITSTPC_Median, vecTmpVtx);
+    insert(vertexY_ITSTPC_Median, vecTmpVtx);
+    insert(vertexZ_ITSTPC_Median, vecTmpVtx);
+    insert(vertexX_ITSTPC_RMS, vecTmpVtx);
+    insert(vertexY_ITSTPC_RMS, vecTmpVtx);
+    insert(vertexZ_ITSTPC_RMS, vecTmpVtx);
+
+    const int nDummyValuesQ = quantileValues * nDummyValues / mTSTPC.getNBins();
+    std::vector<float> vecTmpQ(nDummyValuesQ, 0);
+    insert(nVertexContributors_Quantiles, vecTmpQ);
   }
 
   /// resize buffer for accumulated currents
@@ -488,20 +631,60 @@ struct TimeSeriesITSTPC {
     mDCAz_comb_C_Median.resize(nTotal);
     mDCAr_comb_C_RMS.resize(nTotal);
     mDCAz_comb_C_RMS.resize(nTotal);
+    mLogdEdx_A_Median.resize(nTotal);
+    mLogdEdx_A_RMS.resize(nTotal);
+    mLogdEdx_A_IROC_Median.resize(nTotal);
+    mLogdEdx_A_IROC_RMS.resize(nTotal);
+    mLogdEdx_A_OROC1_Median.resize(nTotal);
+    mLogdEdx_A_OROC1_RMS.resize(nTotal);
+    mLogdEdx_A_OROC2_Median.resize(nTotal);
+    mLogdEdx_A_OROC2_RMS.resize(nTotal);
+    mLogdEdx_A_OROC3_Median.resize(nTotal);
+    mLogdEdx_A_OROC3_RMS.resize(nTotal);
+    mLogdEdx_C_Median.resize(nTotal);
+    mLogdEdx_C_RMS.resize(nTotal);
+    mLogdEdx_C_IROC_Median.resize(nTotal);
+    mLogdEdx_C_IROC_RMS.resize(nTotal);
+    mLogdEdx_C_OROC1_Median.resize(nTotal);
+    mLogdEdx_C_OROC1_RMS.resize(nTotal);
+    mLogdEdx_C_OROC2_Median.resize(nTotal);
+    mLogdEdx_C_OROC2_RMS.resize(nTotal);
+    mLogdEdx_C_OROC3_Median.resize(nTotal);
+    mLogdEdx_C_OROC3_RMS.resize(nTotal);
+    mITS_A_NCl_Median.resize(nTotal);
+    mITS_A_NCl_RMS.resize(nTotal);
+    mITS_C_NCl_Median.resize(nTotal);
+    mITS_C_NCl_RMS.resize(nTotal);
+    mSqrtITSChi2_Ncl_A_Median.resize(nTotal);
+    mSqrtITSChi2_Ncl_C_Median.resize(nTotal);
+    mSqrtITSChi2_Ncl_A_RMS.resize(nTotal);
+    mSqrtITSChi2_Ncl_C_RMS.resize(nTotal);
 
     const int nTotalVtx = nTotal / mTSTPC.getNBins();
-    nPrimVertices.resize(nTotalVtx);
-    nVertexContributors_Median.resize(nTotalVtx);
-    nVertexContributors_RMS.resize(nTotalVtx);
-    vertexX_Median.resize(nTotalVtx);
-    vertexY_Median.resize(nTotalVtx);
-    vertexZ_Median.resize(nTotalVtx);
-    vertexX_RMS.resize(nTotalVtx);
-    vertexY_RMS.resize(nTotalVtx);
-    vertexZ_RMS.resize(nTotalVtx);
+    nPrimVertices_ITS.resize(nTotalVtx);
+    nVertexContributors_ITS_Median.resize(nTotalVtx);
+    nVertexContributors_ITS_RMS.resize(nTotalVtx);
+    vertexX_ITS_Median.resize(nTotalVtx);
+    vertexY_ITS_Median.resize(nTotalVtx);
+    vertexZ_ITS_Median.resize(nTotalVtx);
+    vertexX_ITS_RMS.resize(nTotalVtx);
+    vertexY_ITS_RMS.resize(nTotalVtx);
+    vertexZ_ITS_RMS.resize(nTotalVtx);
+    nPrimVertices_ITSTPC.resize(nTotalVtx);
+    nVertexContributors_ITSTPC_Median.resize(nTotalVtx);
+    nVertexContributors_ITSTPC_RMS.resize(nTotalVtx);
+    vertexX_ITSTPC_Median.resize(nTotalVtx);
+    vertexY_ITSTPC_Median.resize(nTotalVtx);
+    vertexZ_ITSTPC_Median.resize(nTotalVtx);
+    vertexX_ITSTPC_RMS.resize(nTotalVtx);
+    vertexY_ITSTPC_RMS.resize(nTotalVtx);
+    vertexZ_ITSTPC_RMS.resize(nTotalVtx);
+
+    const int nTotalQ = quantileValues * nTotal / mTSTPC.getNBins();
+    nVertexContributors_Quantiles.resize(nTotalQ);
   }
 
-  ClassDefNV(TimeSeriesITSTPC, 2);
+  ClassDefNV(TimeSeriesITSTPC, 3);
 };
 
 } // end namespace tpc

--- a/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
@@ -379,6 +379,7 @@ struct TimeSeriesITSTPC {
   ITSTPC_Matching mITSTPCStandalone;  ///< ITS-TPC matching efficiency for ITS standalone
   ITSTPC_Matching mITSTPCAfterburner; ///< ITS-TPC matchin efficiency  fir ITS afterburner
 
+  std::vector<float> nPrimVertices;                  ///< number of primary vertices
   std::vector<float> nPrimVertices_ITS;              ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
   std::vector<float> nVertexContributors_ITS_Median; ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
   std::vector<float> nVertexContributors_ITS_RMS;    ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
@@ -399,7 +400,7 @@ struct TimeSeriesITSTPC {
   std::vector<float> vertexY_ITSTPC_RMS;                ///< vertex y RMS with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
   std::vector<float> vertexZ_ITSTPC_RMS;                ///< vertex z RMS with ITS-TPC cut (nContributorsITS + nContributorsITSTPC)<0.95
 
-  int quantileValues = 12;                          ///<! number of values in quantiles + truncated mean (hardcoded for the moment)
+  int quantileValues = 23;                          ///<! number of values in quantiles + truncated mean (hardcoded for the moment)
   std::vector<float> nVertexContributors_Quantiles; ///< number of primary vertices for quantiles 0.1, 0.2, ... 0.9 and truncated mean values 0.05->0.95, 0.1->0.9, 0.2->0.8
 
   std::vector<float> mDCAr_comb_A_Median;       ///< DCAr for ITS-TPC track - A-side
@@ -520,6 +521,7 @@ struct TimeSeriesITSTPC {
     fill(data.mSqrtITSChi2_Ncl_C_RMS, mSqrtITSChi2_Ncl_C_RMS, posIndex);
 
     const int iTF = posIndex / mTSTPC.getNBins();
+    nPrimVertices[iTF] = data.nPrimVertices.front();
     nPrimVertices_ITS[iTF] = data.nPrimVertices_ITS.front();
     nVertexContributors_ITS_Median[iTF] = data.nVertexContributors_ITS_Median.front();
     nVertexContributors_ITS_RMS[iTF] = data.nVertexContributors_ITS_RMS.front();
@@ -591,6 +593,7 @@ struct TimeSeriesITSTPC {
 
     const int nDummyValuesVtx = nDummyValues / mTSTPC.getNBins();
     std::vector<float> vecTmpVtx(nDummyValuesVtx, 0);
+    insert(nPrimVertices, vecTmpVtx);
     insert(nPrimVertices_ITS, vecTmpVtx);
     insert(nVertexContributors_ITS_Median, vecTmpVtx);
     insert(nVertexContributors_ITS_RMS, vecTmpVtx);
@@ -661,6 +664,7 @@ struct TimeSeriesITSTPC {
     mSqrtITSChi2_Ncl_C_RMS.resize(nTotal);
 
     const int nTotalVtx = nTotal / mTSTPC.getNBins();
+    nPrimVertices.resize(nTotalVtx);
     nPrimVertices_ITS.resize(nTotalVtx);
     nVertexContributors_ITS_Median.resize(nTotalVtx);
     nVertexContributors_ITS_RMS.resize(nTotalVtx);

--- a/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
@@ -190,8 +190,10 @@ struct TimeSeries {
   std::vector<float> mDCAz_C_RMS;          ///< integrated 1D DCAz for C-side RMS in phi/tgl slices
   std::vector<float> mDCAz_A_NTracks;      ///< number of tracks used to calculate the DCAs
   std::vector<float> mDCAz_C_NTracks;      ///< number of tracks used to calculate the DCAs
-  std::vector<float> mMIPdEdxRatioA;       ///< ratio of MIP/dEdx
-  std::vector<float> mMIPdEdxRatioC;       ///< ratio of MIP/dEdx
+  std::vector<float> mMIPdEdxRatioQMaxA;   ///< ratio of MIP/dEdx - qMax -
+  std::vector<float> mMIPdEdxRatioQMaxC;   ///< ratio of MIP/dEdx - qMax -
+  std::vector<float> mMIPdEdxRatioQTotA;   ///< ratio of MIP/dEdx - qTot -
+  std::vector<float> mMIPdEdxRatioQTotC;   ///< ratio of MIP/dEdx - qTot -
   std::vector<float> mTPCChi2A;            ///< Chi2 of TPC tracks
   std::vector<float> mTPCChi2C;            ///< Chi2 of TPC tracks
   std::vector<float> mTPCNClA;             ///< number of TPC cluster
@@ -261,8 +263,10 @@ struct TimeSeries {
     fill(data.mDCAr_C_WeightedMean, mDCAr_C_WeightedMean, posIndex);
     fill(data.mDCAz_A_WeightedMean, mDCAz_A_WeightedMean, posIndex);
     fill(data.mDCAz_C_WeightedMean, mDCAz_C_WeightedMean, posIndex);
-    fill(data.mMIPdEdxRatioA, mMIPdEdxRatioA, posIndex);
-    fill(data.mMIPdEdxRatioC, mMIPdEdxRatioC, posIndex);
+    fill(data.mMIPdEdxRatioQMaxA, mMIPdEdxRatioQMaxA, posIndex);
+    fill(data.mMIPdEdxRatioQMaxC, mMIPdEdxRatioQMaxC, posIndex);
+    fill(data.mMIPdEdxRatioQTotA, mMIPdEdxRatioQTotA, posIndex);
+    fill(data.mMIPdEdxRatioQTotC, mMIPdEdxRatioQTotC, posIndex);
     fill(data.mTPCChi2A, mTPCChi2A, posIndex);
     fill(data.mTPCChi2C, mTPCChi2C, posIndex);
     fill(data.mTPCNClA, mTPCNClA, posIndex);
@@ -291,8 +295,10 @@ struct TimeSeries {
     insert(mDCAr_C_WeightedMean, vecTmp);
     insert(mDCAz_A_WeightedMean, vecTmp);
     insert(mDCAz_C_WeightedMean, vecTmp);
-    insert(mMIPdEdxRatioA, vecTmp);
-    insert(mMIPdEdxRatioC, vecTmp);
+    insert(mMIPdEdxRatioQMaxA, vecTmp);
+    insert(mMIPdEdxRatioQMaxC, vecTmp);
+    insert(mMIPdEdxRatioQTotA, vecTmp);
+    insert(mMIPdEdxRatioQTotC, vecTmp);
     insert(mTPCChi2A, vecTmp);
     insert(mTPCChi2C, vecTmp);
     insert(mTPCNClA, vecTmp);
@@ -320,8 +326,10 @@ struct TimeSeries {
     mDCAr_C_WeightedMean.resize(nTotal);
     mDCAz_A_WeightedMean.resize(nTotal);
     mDCAz_C_WeightedMean.resize(nTotal);
-    mMIPdEdxRatioA.resize(nTotal);
-    mMIPdEdxRatioC.resize(nTotal);
+    mMIPdEdxRatioQMaxA.resize(nTotal);
+    mMIPdEdxRatioQMaxC.resize(nTotal);
+    mMIPdEdxRatioQTotA.resize(nTotal);
+    mMIPdEdxRatioQTotC.resize(nTotal);
     mTPCChi2A.resize(nTotal);
     mTPCChi2C.resize(nTotal);
     mTPCNClA.resize(nTotal);
@@ -369,7 +377,106 @@ struct ITSTPC_Matching {
     mITSTPC_C_Chi2Match.resize(nTotal);
   }
 
-  ClassDefNV(ITSTPC_Matching, 1);
+  ClassDefNV(ITSTPC_Matching, 2);
+};
+
+struct TimeSeriesdEdx {
+  std::vector<float> mLogdEdx_A_Median;       ///< log(dEdx_exp(pion)/dEdx) - A-side
+  std::vector<float> mLogdEdx_A_RMS;          ///< log(dEdx_exp(pion)/dEdx) - A-side
+  std::vector<float> mLogdEdx_A_IROC_Median;  ///< log(dedxIROC / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_IROC_RMS;     ///< log(dedxIROC / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC1_Median; ///< log(dedxOROC1 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC1_RMS;    ///< log(dedxOROC1 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC2_Median; ///< log(dedxOROC2 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC2_RMS;    ///< log(dedxOROC2 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC3_Median; ///< log(dedxOROC3 / dEdx) - A-side
+  std::vector<float> mLogdEdx_A_OROC3_RMS;    ///< log(dedxOROC3 / dEdx) - A-side
+  std::vector<float> mLogdEdx_C_Median;       ///< log(dEdx_exp(pion)/dEdx) - C-side
+  std::vector<float> mLogdEdx_C_RMS;          ///< log(dEdx_exp(pion)/dEdx) - C-side
+  std::vector<float> mLogdEdx_C_IROC_Median;  ///< log(dedxIROC / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_IROC_RMS;     ///< log(dedxIROC / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC1_Median; ///< log(dedxOROC1 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC1_RMS;    ///< log(dedxOROC1 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC2_Median; ///< log(dedxOROC2 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC2_RMS;    ///< log(dedxOROC2 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC3_Median; ///< log(dedxOROC3 / dEdx) - C-side
+  std::vector<float> mLogdEdx_C_OROC3_RMS;    ///< log(dedxOROC3 / dEdx) - C-side
+  void fill(const unsigned int posIndex, const TimeSeriesdEdx& data)
+  {
+    fill(data.mLogdEdx_A_Median, mLogdEdx_A_Median, posIndex);
+    fill(data.mLogdEdx_A_RMS, mLogdEdx_A_RMS, posIndex);
+    fill(data.mLogdEdx_A_IROC_Median, mLogdEdx_A_IROC_Median, posIndex);
+    fill(data.mLogdEdx_A_IROC_RMS, mLogdEdx_A_IROC_RMS, posIndex);
+    fill(data.mLogdEdx_A_OROC1_Median, mLogdEdx_A_OROC1_Median, posIndex);
+    fill(data.mLogdEdx_A_OROC1_RMS, mLogdEdx_A_OROC1_RMS, posIndex);
+    fill(data.mLogdEdx_A_OROC2_Median, mLogdEdx_A_OROC2_Median, posIndex);
+    fill(data.mLogdEdx_A_OROC2_RMS, mLogdEdx_A_OROC2_RMS, posIndex);
+    fill(data.mLogdEdx_A_OROC3_Median, mLogdEdx_A_OROC3_Median, posIndex);
+    fill(data.mLogdEdx_A_OROC3_RMS, mLogdEdx_A_OROC3_RMS, posIndex);
+    fill(data.mLogdEdx_C_Median, mLogdEdx_C_Median, posIndex);
+    fill(data.mLogdEdx_C_RMS, mLogdEdx_C_RMS, posIndex);
+    fill(data.mLogdEdx_C_IROC_Median, mLogdEdx_C_IROC_Median, posIndex);
+    fill(data.mLogdEdx_C_IROC_RMS, mLogdEdx_C_IROC_RMS, posIndex);
+    fill(data.mLogdEdx_C_OROC1_Median, mLogdEdx_C_OROC1_Median, posIndex);
+    fill(data.mLogdEdx_C_OROC1_RMS, mLogdEdx_C_OROC1_RMS, posIndex);
+    fill(data.mLogdEdx_C_OROC2_Median, mLogdEdx_C_OROC2_Median, posIndex);
+    fill(data.mLogdEdx_C_OROC2_RMS, mLogdEdx_C_OROC2_RMS, posIndex);
+    fill(data.mLogdEdx_C_OROC3_Median, mLogdEdx_C_OROC3_Median, posIndex);
+    fill(data.mLogdEdx_C_OROC3_RMS, mLogdEdx_C_OROC3_RMS, posIndex);
+  }
+
+  void fill(const std::vector<float>& vecFrom, std::vector<float>& vecTo, const unsigned int posIndex) { std::copy(vecFrom.begin(), vecFrom.end(), vecTo.begin() + posIndex); }
+  void insert(std::vector<float>& vec, const std::vector<float>& vecTmp) { vec.insert(vec.begin(), vecTmp.begin(), vecTmp.end()); }
+  void insert(const unsigned int nDummyValues)
+  {
+    std::vector<float> vecTmp(nDummyValues, 0);
+    insert(mLogdEdx_A_Median, vecTmp);
+    insert(mLogdEdx_A_RMS, vecTmp);
+    insert(mLogdEdx_A_IROC_Median, vecTmp);
+    insert(mLogdEdx_A_IROC_RMS, vecTmp);
+    insert(mLogdEdx_A_OROC1_Median, vecTmp);
+    insert(mLogdEdx_A_OROC1_RMS, vecTmp);
+    insert(mLogdEdx_A_OROC2_Median, vecTmp);
+    insert(mLogdEdx_A_OROC2_RMS, vecTmp);
+    insert(mLogdEdx_A_OROC3_Median, vecTmp);
+    insert(mLogdEdx_A_OROC3_RMS, vecTmp);
+    insert(mLogdEdx_C_Median, vecTmp);
+    insert(mLogdEdx_C_RMS, vecTmp);
+    insert(mLogdEdx_C_IROC_Median, vecTmp);
+    insert(mLogdEdx_C_IROC_RMS, vecTmp);
+    insert(mLogdEdx_C_OROC1_Median, vecTmp);
+    insert(mLogdEdx_C_OROC1_RMS, vecTmp);
+    insert(mLogdEdx_C_OROC2_Median, vecTmp);
+    insert(mLogdEdx_C_OROC2_RMS, vecTmp);
+    insert(mLogdEdx_C_OROC3_Median, vecTmp);
+    insert(mLogdEdx_C_OROC3_RMS, vecTmp);
+  }
+
+  void resize(const unsigned int nTotal)
+  {
+    mLogdEdx_A_Median.resize(nTotal);
+    mLogdEdx_A_RMS.resize(nTotal);
+    mLogdEdx_A_IROC_Median.resize(nTotal);
+    mLogdEdx_A_IROC_RMS.resize(nTotal);
+    mLogdEdx_A_OROC1_Median.resize(nTotal);
+    mLogdEdx_A_OROC1_RMS.resize(nTotal);
+    mLogdEdx_A_OROC2_Median.resize(nTotal);
+    mLogdEdx_A_OROC2_RMS.resize(nTotal);
+    mLogdEdx_A_OROC3_Median.resize(nTotal);
+    mLogdEdx_A_OROC3_RMS.resize(nTotal);
+    mLogdEdx_C_Median.resize(nTotal);
+    mLogdEdx_C_RMS.resize(nTotal);
+    mLogdEdx_C_IROC_Median.resize(nTotal);
+    mLogdEdx_C_IROC_RMS.resize(nTotal);
+    mLogdEdx_C_OROC1_Median.resize(nTotal);
+    mLogdEdx_C_OROC1_RMS.resize(nTotal);
+    mLogdEdx_C_OROC2_Median.resize(nTotal);
+    mLogdEdx_C_OROC2_RMS.resize(nTotal);
+    mLogdEdx_C_OROC3_Median.resize(nTotal);
+    mLogdEdx_C_OROC3_RMS.resize(nTotal);
+  }
+
+  ClassDefNV(TimeSeriesdEdx, 1);
 };
 
 struct TimeSeriesITSTPC {
@@ -378,6 +485,8 @@ struct TimeSeriesITSTPC {
   ITSTPC_Matching mITSTPCAll;         ///< ITS-TPC matching efficiency for ITS standalone + afterburner
   ITSTPC_Matching mITSTPCStandalone;  ///< ITS-TPC matching efficiency for ITS standalone
   ITSTPC_Matching mITSTPCAfterburner; ///< ITS-TPC matchin efficiency  fir ITS afterburner
+  TimeSeriesdEdx mdEdxQTot;           ///< time series for dE/dx qTot monitoring
+  TimeSeriesdEdx mdEdxQMax;           ///< time series for dE/dx qMax monitoring
 
   std::vector<float> nPrimVertices;                  ///< number of primary vertices
   std::vector<float> nPrimVertices_ITS;              ///< number of primary vertices selected with ITS cut 0.2<nContributorsITS/nContributors<0.8
@@ -411,26 +520,6 @@ struct TimeSeriesITSTPC {
   std::vector<float> mDCAz_comb_C_Median;       ///< DCAz for ITS-TPC track - C-side
   std::vector<float> mDCAr_comb_C_RMS;          ///< DCAr RMS for ITS-TPC track - C-side
   std::vector<float> mDCAz_comb_C_RMS;          ///< DCAz RMS for ITS-TPC track - C-side
-  std::vector<float> mLogdEdx_A_Median;         ///< log(dEdx_exp(pion)/dEdx) - A-side
-  std::vector<float> mLogdEdx_A_RMS;            ///< log(dEdx_exp(pion)/dEdx) - A-side
-  std::vector<float> mLogdEdx_A_IROC_Median;    ///< log(dedxIROC / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_IROC_RMS;       ///< log(dedxIROC / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_OROC1_Median;   ///< log(dedxOROC1 / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_OROC1_RMS;      ///< log(dedxOROC1 / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_OROC2_Median;   ///< log(dedxOROC2 / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_OROC2_RMS;      ///< log(dedxOROC2 / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_OROC3_Median;   ///< log(dedxOROC3 / dEdx) - A-side
-  std::vector<float> mLogdEdx_A_OROC3_RMS;      ///< log(dedxOROC3 / dEdx) - A-side
-  std::vector<float> mLogdEdx_C_Median;         ///< log(dEdx_exp(pion)/dEdx) - C-side
-  std::vector<float> mLogdEdx_C_RMS;            ///< log(dEdx_exp(pion)/dEdx) - C-side
-  std::vector<float> mLogdEdx_C_IROC_Median;    ///< log(dedxIROC / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_IROC_RMS;       ///< log(dedxIROC / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_OROC1_Median;   ///< log(dedxOROC1 / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_OROC1_RMS;      ///< log(dedxOROC1 / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_OROC2_Median;   ///< log(dedxOROC2 / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_OROC2_RMS;      ///< log(dedxOROC2 / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_OROC3_Median;   ///< log(dedxOROC3 / dEdx) - C-side
-  std::vector<float> mLogdEdx_C_OROC3_RMS;      ///< log(dedxOROC3 / dEdx) - C-side
   std::vector<float> mITS_A_NCl_Median;         ///< its number of clusters
   std::vector<float> mITS_A_NCl_RMS;            ///< its number of clusters
   std::vector<float> mITS_C_NCl_Median;         ///< its number of clusters
@@ -483,6 +572,8 @@ struct TimeSeriesITSTPC {
     mITSTPCAll.fill(posIndex, data.mITSTPCAll);
     mITSTPCStandalone.fill(posIndex, data.mITSTPCStandalone);
     mITSTPCAfterburner.fill(posIndex, data.mITSTPCAfterburner);
+    mdEdxQTot.fill(posIndex, data.mdEdxQTot);
+    mdEdxQMax.fill(posIndex, data.mdEdxQMax);
     fill(data.mDCAr_comb_A_Median, mDCAr_comb_A_Median, posIndex);
     fill(data.mDCAz_comb_A_Median, mDCAz_comb_A_Median, posIndex);
     fill(data.mDCAr_comb_A_RMS, mDCAr_comb_A_RMS, posIndex);
@@ -491,26 +582,6 @@ struct TimeSeriesITSTPC {
     fill(data.mDCAz_comb_C_Median, mDCAz_comb_C_Median, posIndex);
     fill(data.mDCAr_comb_C_RMS, mDCAr_comb_C_RMS, posIndex);
     fill(data.mDCAz_comb_C_RMS, mDCAz_comb_C_RMS, posIndex);
-    fill(data.mLogdEdx_A_Median, mLogdEdx_A_Median, posIndex);
-    fill(data.mLogdEdx_A_RMS, mLogdEdx_A_RMS, posIndex);
-    fill(data.mLogdEdx_A_IROC_Median, mLogdEdx_A_IROC_Median, posIndex);
-    fill(data.mLogdEdx_A_IROC_RMS, mLogdEdx_A_IROC_RMS, posIndex);
-    fill(data.mLogdEdx_A_OROC1_Median, mLogdEdx_A_OROC1_Median, posIndex);
-    fill(data.mLogdEdx_A_OROC1_RMS, mLogdEdx_A_OROC1_RMS, posIndex);
-    fill(data.mLogdEdx_A_OROC2_Median, mLogdEdx_A_OROC2_Median, posIndex);
-    fill(data.mLogdEdx_A_OROC2_RMS, mLogdEdx_A_OROC2_RMS, posIndex);
-    fill(data.mLogdEdx_A_OROC3_Median, mLogdEdx_A_OROC3_Median, posIndex);
-    fill(data.mLogdEdx_A_OROC3_RMS, mLogdEdx_A_OROC3_RMS, posIndex);
-    fill(data.mLogdEdx_C_Median, mLogdEdx_C_Median, posIndex);
-    fill(data.mLogdEdx_C_RMS, mLogdEdx_C_RMS, posIndex);
-    fill(data.mLogdEdx_C_IROC_Median, mLogdEdx_C_IROC_Median, posIndex);
-    fill(data.mLogdEdx_C_IROC_RMS, mLogdEdx_C_IROC_RMS, posIndex);
-    fill(data.mLogdEdx_C_OROC1_Median, mLogdEdx_C_OROC1_Median, posIndex);
-    fill(data.mLogdEdx_C_OROC1_RMS, mLogdEdx_C_OROC1_RMS, posIndex);
-    fill(data.mLogdEdx_C_OROC2_Median, mLogdEdx_C_OROC2_Median, posIndex);
-    fill(data.mLogdEdx_C_OROC2_RMS, mLogdEdx_C_OROC2_RMS, posIndex);
-    fill(data.mLogdEdx_C_OROC3_Median, mLogdEdx_C_OROC3_Median, posIndex);
-    fill(data.mLogdEdx_C_OROC3_RMS, mLogdEdx_C_OROC3_RMS, posIndex);
     fill(data.mITS_A_NCl_Median, mITS_A_NCl_Median, posIndex);
     fill(data.mITS_A_NCl_RMS, mITS_A_NCl_RMS, posIndex);
     fill(data.mITS_C_NCl_Median, mITS_C_NCl_Median, posIndex);
@@ -553,6 +624,8 @@ struct TimeSeriesITSTPC {
     mITSTPCAll.insert(nDummyValues);
     mITSTPCStandalone.insert(nDummyValues);
     mITSTPCAfterburner.insert(nDummyValues);
+    mdEdxQTot.insert(nDummyValues);
+    mdEdxQMax.insert(nDummyValues);
     std::vector<float> vecTmp(nDummyValues, 0);
     insert(mDCAr_comb_A_Median, vecTmp);
     insert(mDCAz_comb_A_Median, vecTmp);
@@ -562,26 +635,6 @@ struct TimeSeriesITSTPC {
     insert(mDCAz_comb_C_Median, vecTmp);
     insert(mDCAr_comb_C_RMS, vecTmp);
     insert(mDCAz_comb_C_RMS, vecTmp);
-    insert(mLogdEdx_A_Median, vecTmp);
-    insert(mLogdEdx_A_RMS, vecTmp);
-    insert(mLogdEdx_A_IROC_Median, vecTmp);
-    insert(mLogdEdx_A_IROC_RMS, vecTmp);
-    insert(mLogdEdx_A_OROC1_Median, vecTmp);
-    insert(mLogdEdx_A_OROC1_RMS, vecTmp);
-    insert(mLogdEdx_A_OROC2_Median, vecTmp);
-    insert(mLogdEdx_A_OROC2_RMS, vecTmp);
-    insert(mLogdEdx_A_OROC3_Median, vecTmp);
-    insert(mLogdEdx_A_OROC3_RMS, vecTmp);
-    insert(mLogdEdx_C_Median, vecTmp);
-    insert(mLogdEdx_C_RMS, vecTmp);
-    insert(mLogdEdx_C_IROC_Median, vecTmp);
-    insert(mLogdEdx_C_IROC_RMS, vecTmp);
-    insert(mLogdEdx_C_OROC1_Median, vecTmp);
-    insert(mLogdEdx_C_OROC1_RMS, vecTmp);
-    insert(mLogdEdx_C_OROC2_Median, vecTmp);
-    insert(mLogdEdx_C_OROC2_RMS, vecTmp);
-    insert(mLogdEdx_C_OROC3_Median, vecTmp);
-    insert(mLogdEdx_C_OROC3_RMS, vecTmp);
     insert(mITS_A_NCl_Median, vecTmp);
     insert(mITS_A_NCl_RMS, vecTmp);
     insert(mITS_C_NCl_Median, vecTmp);
@@ -626,6 +679,8 @@ struct TimeSeriesITSTPC {
     mITSTPCAll.resize(nTotal);
     mITSTPCStandalone.resize(nTotal);
     mITSTPCAfterburner.resize(nTotal);
+    mdEdxQTot.resize(nTotal);
+    mdEdxQMax.resize(nTotal);
     mDCAr_comb_A_Median.resize(nTotal);
     mDCAz_comb_A_Median.resize(nTotal);
     mDCAr_comb_A_RMS.resize(nTotal);
@@ -634,26 +689,6 @@ struct TimeSeriesITSTPC {
     mDCAz_comb_C_Median.resize(nTotal);
     mDCAr_comb_C_RMS.resize(nTotal);
     mDCAz_comb_C_RMS.resize(nTotal);
-    mLogdEdx_A_Median.resize(nTotal);
-    mLogdEdx_A_RMS.resize(nTotal);
-    mLogdEdx_A_IROC_Median.resize(nTotal);
-    mLogdEdx_A_IROC_RMS.resize(nTotal);
-    mLogdEdx_A_OROC1_Median.resize(nTotal);
-    mLogdEdx_A_OROC1_RMS.resize(nTotal);
-    mLogdEdx_A_OROC2_Median.resize(nTotal);
-    mLogdEdx_A_OROC2_RMS.resize(nTotal);
-    mLogdEdx_A_OROC3_Median.resize(nTotal);
-    mLogdEdx_A_OROC3_RMS.resize(nTotal);
-    mLogdEdx_C_Median.resize(nTotal);
-    mLogdEdx_C_RMS.resize(nTotal);
-    mLogdEdx_C_IROC_Median.resize(nTotal);
-    mLogdEdx_C_IROC_RMS.resize(nTotal);
-    mLogdEdx_C_OROC1_Median.resize(nTotal);
-    mLogdEdx_C_OROC1_RMS.resize(nTotal);
-    mLogdEdx_C_OROC2_Median.resize(nTotal);
-    mLogdEdx_C_OROC2_RMS.resize(nTotal);
-    mLogdEdx_C_OROC3_Median.resize(nTotal);
-    mLogdEdx_C_OROC3_RMS.resize(nTotal);
     mITS_A_NCl_Median.resize(nTotal);
     mITS_A_NCl_RMS.resize(nTotal);
     mITS_C_NCl_Median.resize(nTotal);

--- a/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
+++ b/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
@@ -56,6 +56,7 @@
 #pragma link C++ struct o2::tpc::TimeSeries + ;
 #pragma link C++ struct o2::tpc::ITSTPC_Matching + ;
 #pragma link C++ struct o2::tpc::TimeSeriesITSTPC + ;
+#pragma link C++ struct o2::tpc::TimeSeriesdEdx + ;
 #pragma link C++ class o2::calibration::IntegratedClusters < o2::tpc::TimeSeriesITSTPC> + ;
 #pragma link C++ class o2::calibration::IntegratedClusterCalibrator < o2::tpc::TimeSeriesITSTPC> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::calibration::IntegratedClusters < o2::tpc::TimeSeriesITSTPC>> + ;

--- a/Detectors/Calibration/src/IntegratedClusterCalibrator.cxx
+++ b/Detectors/Calibration/src/IntegratedClusterCalibrator.cxx
@@ -305,8 +305,6 @@ void tpc::TimeSeries::dumpToTree(TTree& tree, const char* prefix, const int nHBF
     std::vector<std::vector<float>> nTracksDCAr_C(nBins);
     std::vector<std::vector<float>> nTracksDCAz_A(nBins);
     std::vector<std::vector<float>> nTracksDCAz_C(nBins);
-    std::vector<std::vector<float>> mipdEdxRatioA(nBins);
-    std::vector<std::vector<float>> mipdEdxRatioC(nBins);
     std::vector<std::vector<float>> tpcChi2A(nBins);
     std::vector<std::vector<float>> tpcChi2C(nBins);
     std::vector<std::vector<float>> tpcNClA(nBins);
@@ -332,8 +330,6 @@ void tpc::TimeSeries::dumpToTree(TTree& tree, const char* prefix, const int nHBF
       listBranches.emplace_back(tree.Branch(fmt::format("{}mDCAr_C_NTracks_{}", prefix, brSuf).data(), &nTracksDCAr_C[i]));
       listBranches.emplace_back(tree.Branch(fmt::format("{}mDCAz_A_NTracks_{}", prefix, brSuf).data(), &nTracksDCAz_A[i]));
       listBranches.emplace_back(tree.Branch(fmt::format("{}mDCAz_C_NTracks_{}", prefix, brSuf).data(), &nTracksDCAz_C[i]));
-      listBranches.emplace_back(tree.Branch(fmt::format("{}mMIPdEdxRatioA_{}", prefix, brSuf).data(), &mipdEdxRatioA[i]));
-      listBranches.emplace_back(tree.Branch(fmt::format("{}mMIPdEdxRatioC_{}", prefix, brSuf).data(), &mipdEdxRatioC[i]));
       listBranches.emplace_back(tree.Branch(fmt::format("{}mTPCChi2A_{}", prefix, brSuf).data(), &tpcChi2A[i]));
       listBranches.emplace_back(tree.Branch(fmt::format("{}mTPCChi2C_{}", prefix, brSuf).data(), &tpcChi2C[i]));
       listBranches.emplace_back(tree.Branch(fmt::format("{}mTPCNClA_{}", prefix, brSuf).data(), &tpcNClA[i]));
@@ -358,8 +354,6 @@ void tpc::TimeSeries::dumpToTree(TTree& tree, const char* prefix, const int nHBF
       nTracksDCAr_C[i].resize(nTotPoints);
       nTracksDCAz_A[i].resize(nTotPoints);
       nTracksDCAz_C[i].resize(nTotPoints);
-      mipdEdxRatioA[i].resize(nTotPoints);
-      mipdEdxRatioC[i].resize(nTotPoints);
       tpcChi2A[i].resize(nTotPoints);
       tpcChi2C[i].resize(nTotPoints);
       tpcNClA[i].resize(nTotPoints);
@@ -397,8 +391,6 @@ void tpc::TimeSeries::dumpToTree(TTree& tree, const char* prefix, const int nHBF
         nTracksDCAr_C[i][j] = mDCAr_C_NTracks[idx];
         nTracksDCAz_A[i][j] = mDCAz_A_NTracks[idx];
         nTracksDCAz_C[i][j] = mDCAz_C_NTracks[idx];
-        mipdEdxRatioA[i][j] = mMIPdEdxRatioA[idx];
-        mipdEdxRatioC[i][j] = mMIPdEdxRatioC[idx];
         tpcChi2A[i][j] = mTPCChi2A[idx];
         tpcChi2C[i][j] = mTPCChi2C[idx];
         tpcNClA[i][j] = mTPCNClA[idx];

--- a/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
@@ -42,10 +42,13 @@ class RobustAverage
  public:
   /// constructor
   /// \param maxValues maximum number of values which will be averaged. Copy of values will be done.
-  RobustAverage(const unsigned int maxValues)
+  /// \param withWeights also storing weights for weighted mean
+  RobustAverage(const unsigned int maxValues, bool withWeights = true) : mUseWeights{withWeights}
   {
     mValues.reserve(maxValues);
-    mWeights.reserve(maxValues);
+    if (mUseWeights) {
+      mWeights.reserve(maxValues);
+    }
   }
 
   /// default constructor
@@ -63,7 +66,7 @@ class RobustAverage
   void clear();
 
   /// \param value value which will be added to the list of stored values for averaging
-  /// \param weight weight of the value
+  /// \param weight weight of the value (weight will only be stored if flag to weights is true)
   void addValue(const float value, const float weight = 1);
 
   /// returns the filtered average value
@@ -77,20 +80,25 @@ class RobustAverage
   /// \return returns mean of stored values
   float getMean() const { return mValues.empty() ? 0 : getMean(mValues.begin(), mValues.end()); }
 
+  /// returns truncated mean fir range min and max
+  float getTrunctedMean(float low, float high);
+
   /// \return returns the median
   float getMedian();
 
   /// \return returns weighted mean of stored values
-  float getWeightedMean() const { return getWeightedMean(mValues.begin(), mValues.end(), mWeights.begin(), mWeights.end()); }
+  float getWeightedMean() const { return mUseWeights ? getWeightedMean(mValues.begin(), mValues.end(), mWeights.begin(), mWeights.end()) : 0; }
 
   /// \return returns standard deviation of stored values
   float getStdDev() { return getStdDev(getMean(), mValues.begin(), mValues.end()); }
 
   /// \return returns stored values
-  const auto& getValues() { return mValues; }
+  const auto& getValues() const { return mValues; }
+
+  void setValues(const std::vector<float>& values) { mValues = values; }
 
   /// \return returns stored values
-  const auto& getWeigths() { return mWeights; }
+  const auto& getWeigths() const { return mWeights; }
 
   /// values which will be averaged and filtered
   void print() const;
@@ -98,10 +106,22 @@ class RobustAverage
   // sorting values and weights
   void sort();
 
+  /// returns if weights are stored
+  bool getUseWeights() const { return mUseWeights; }
+
+  /// returns if weights are stored
+  void setUseWeights(bool useweights) { mUseWeights = useweights; }
+
+  /// \return returns the quantile value - linear interpolation or median unbiased used -
+  /// \param quantile quantile to get
+  /// \param type interpolation type: type=0 use linear interpolation, type=1 use unbiased median (in case of low statistics)
+  float getQuantile(float quantile, int type);
+
  private:
   std::vector<float> mValues{};    ///< values which will be averaged and filtered
   std::vector<float> mWeights{};   ///< weights of each value
   std::vector<float> mTmpValues{}; ///< tmp vector used for calculation of std dev
+  bool mUseWeights{};              ///< also storing weights
 
   float getMean(std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end) const;
 

--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -78,7 +78,6 @@ class TPCTimeSeries : public Task
     maxITSTPCDCAz_comb = ic.options().get<float>("max-ITS-TPC-DCAz_comb");
     mTimeWindowMUS = ic.options().get<float>("time-window-mult-mus");
     mMIPdEdx = ic.options().get<float>("MIP-dedx");
-    mUseQMax = ic.options().get<bool>("use-qMax");
     mMaxSnp = ic.options().get<float>("max-snp");
     mXCoarse = ic.options().get<float>("mX-coarse");
     mSqrt = ic.options().get<float>("sqrts");
@@ -114,14 +113,18 @@ class TPCTimeSeries : public Task
       mAvgMeffC.resize(nBins);
       mAvgChi2MatchA.resize(nBins);
       mAvgChi2MatchC.resize(nBins);
-      mMIPdEdxRatioA.resize(nBins);
-      mMIPdEdxRatioC.resize(nBins);
+      mMIPdEdxRatioQMaxA.resize(nBins);
+      mMIPdEdxRatioQMaxC.resize(nBins);
+      mMIPdEdxRatioQTotA.resize(nBins);
+      mMIPdEdxRatioQTotC.resize(nBins);
       mTPCChi2A.resize(nBins);
       mTPCChi2C.resize(nBins);
       mTPCNClA.resize(nBins);
       mTPCNClC.resize(nBins);
-      mLogdEdxA.resize(nBins);
-      mLogdEdxC.resize(nBins);
+      mLogdEdxQTotA.resize(nBins);
+      mLogdEdxQTotC.resize(nBins);
+      mLogdEdxQMaxA.resize(nBins);
+      mLogdEdxQMaxC.resize(nBins);
       mITSPropertiesA.resize(nBins);
       mITSPropertiesC.resize(nBins);
     }
@@ -172,25 +175,33 @@ class TPCTimeSeries : public Task
         mAvgADCAz[i][type].clear();
         mAvgCDCAz[i][type].clear();
       }
-      for (int type = 0; type < mMIPdEdxRatioA[i].size(); ++type) {
-        mMIPdEdxRatioA[i][type].clear();
-        mMIPdEdxRatioC[i][type].clear();
+      for (int type = 0; type < mMIPdEdxRatioQMaxA[i].size(); ++type) {
+        mMIPdEdxRatioQMaxA[i][type].clear();
+        mMIPdEdxRatioQMaxC[i][type].clear();
+        mMIPdEdxRatioQTotA[i][type].clear();
+        mMIPdEdxRatioQTotC[i][type].clear();
         mTPCChi2A[i][type].clear();
         mTPCChi2C[i][type].clear();
         mTPCNClA[i][type].clear();
         mTPCNClC[i][type].clear();
-        mMIPdEdxRatioA[i][type].setUseWeights(false);
-        mMIPdEdxRatioC[i][type].setUseWeights(false);
+        mMIPdEdxRatioQMaxA[i][type].setUseWeights(false);
+        mMIPdEdxRatioQMaxC[i][type].setUseWeights(false);
+        mMIPdEdxRatioQTotA[i][type].setUseWeights(false);
+        mMIPdEdxRatioQTotC[i][type].setUseWeights(false);
         mTPCChi2A[i][type].setUseWeights(false);
         mTPCChi2C[i][type].setUseWeights(false);
         mTPCNClA[i][type].setUseWeights(false);
         mTPCNClC[i][type].setUseWeights(false);
       }
-      for (int type = 0; type < mLogdEdxA[i].size(); ++type) {
-        mLogdEdxA[i][type].clear();
-        mLogdEdxC[i][type].clear();
-        mLogdEdxA[i][type].setUseWeights(false);
-        mLogdEdxC[i][type].setUseWeights(false);
+      for (int type = 0; type < mLogdEdxQTotA[i].size(); ++type) {
+        mLogdEdxQTotA[i][type].clear();
+        mLogdEdxQTotC[i][type].clear();
+        mLogdEdxQMaxA[i][type].clear();
+        mLogdEdxQMaxC[i][type].clear();
+        mLogdEdxQTotA[i][type].setUseWeights(false);
+        mLogdEdxQTotC[i][type].setUseWeights(false);
+        mLogdEdxQMaxA[i][type].setUseWeights(false);
+        mLogdEdxQMaxC[i][type].setUseWeights(false);
       }
       for (int j = 0; j < mITSPropertiesA[i].size(); ++j) {
         mITSPropertiesA[i][j].clear();
@@ -246,9 +257,11 @@ class TPCTimeSeries : public Task
         mAvgADCAz[i][type].reserve(resMem);
         mAvgCDCAz[i][type].reserve(resMem);
       }
-      for (int type = 0; type < mMIPdEdxRatioA[i].size(); ++type) {
-        mMIPdEdxRatioA[i][type].reserve(resMem);
-        mMIPdEdxRatioC[i][type].reserve(resMem);
+      for (int type = 0; type < mMIPdEdxRatioQMaxA[i].size(); ++type) {
+        mMIPdEdxRatioQMaxA[i][type].reserve(resMem);
+        mMIPdEdxRatioQMaxC[i][type].reserve(resMem);
+        mMIPdEdxRatioQTotA[i][type].reserve(resMem);
+        mMIPdEdxRatioQTotC[i][type].reserve(resMem);
         mTPCChi2A[i][type].reserve(resMem);
         mTPCChi2C[i][type].reserve(resMem);
         mTPCNClA[i][type].reserve(resMem);
@@ -265,8 +278,10 @@ class TPCTimeSeries : public Task
         mITSPropertiesC[i][j].reserve(resMem);
       }
       for (int j = 0; j < mAvgMeffA[i].size(); ++j) {
-        mLogdEdxA[i][j].reserve(resMem);
-        mLogdEdxC[i][j].reserve(resMem);
+        mLogdEdxQTotA[i][j].reserve(resMem);
+        mLogdEdxQTotC[i][j].reserve(resMem);
+        mLogdEdxQMaxA[i][j].reserve(resMem);
+        mLogdEdxQMaxC[i][j].reserve(resMem);
       }
     }
     for (int iThread = 0; iThread < mNThreads; ++iThread) {
@@ -429,7 +444,8 @@ class TPCTimeSeries : public Task
         const auto dcaz = val.dcaz[i];
         const auto hasITS = val.hasITS[i];
         const auto chi2Match = val.chi2Match[i];
-        const auto dedxRatio = val.dedxRatio[i];
+        const auto dedxRatioqMax = val.dedxRatioqMax[i];
+        const auto dedxRatioqTot = val.dedxRatioqTot[i];
         const auto sqrtChi2TPC = val.sqrtChi2TPC[i];
         const auto nClTPC = val.nClTPC[i];
         const int binInt = nBins - 1;
@@ -441,10 +457,12 @@ class TPCTimeSeries : public Task
         const auto& bufferDCAMedZ = isCSide ? mBufferDCA.mTSTPC.mDCAz_C_Median : mBufferDCA.mTSTPC.mDCAz_A_Median;
         auto& mAvgEff = isCSide ? mAvgMeffC : mAvgMeffA;
         auto& mAvgChi2Match = isCSide ? mAvgChi2MatchC : mAvgChi2MatchA;
-        auto& mAvgmMIPdEdxRatio = isCSide ? mMIPdEdxRatioC : mMIPdEdxRatioA;
+        auto& mAvgmMIPdEdxRatioqMax = isCSide ? mMIPdEdxRatioQMaxC : mMIPdEdxRatioQMaxA;
+        auto& mAvgmMIPdEdxRatioqTot = isCSide ? mMIPdEdxRatioQTotC : mMIPdEdxRatioQTotA;
         auto& mAvgmTPCChi2 = isCSide ? mTPCChi2C : mTPCChi2A;
         auto& mAvgmTPCNCl = isCSide ? mTPCNClC : mTPCNClA;
-        auto& mAvgmdEdxRatio = isCSide ? mLogdEdxC : mLogdEdxA;
+        auto& mAvgmdEdxRatioQMax = isCSide ? mLogdEdxQMaxC : mLogdEdxQMaxA;
+        auto& mAvgmdEdxRatioQTot = isCSide ? mLogdEdxQTotC : mLogdEdxQTotA;
         auto& mITSProperties = isCSide ? mITSPropertiesC : mITSPropertiesA;
 
         const std::array<int, 5> bins{tglBin, phiBin, qPtBin, multBin, binInt};
@@ -473,39 +491,75 @@ class TPCTimeSeries : public Task
                 mAvgChi2Match[bin][2].addValue(chi2Match);
               }
             }
-            if (dedxRatio > 0) {
-              mAvgmMIPdEdxRatio[bin][0].addValue(dedxRatio);
+            if (dedxRatioqMax > 0) {
+              mAvgmMIPdEdxRatioqMax[bin][0].addValue(dedxRatioqMax);
+            }
+            if (dedxRatioqTot > 0) {
+              mAvgmMIPdEdxRatioqTot[bin][0].addValue(dedxRatioqTot);
             }
             mAvgmTPCChi2[bin][0].addValue(sqrtChi2TPC);
             mAvgmTPCNCl[bin][0].addValue(nClTPC);
             if (hasITS) {
-              if (dedxRatio > 0) {
-                mAvgmMIPdEdxRatio[bin][1].addValue(dedxRatio);
+              if (dedxRatioqMax > 0) {
+                mAvgmMIPdEdxRatioqMax[bin][1].addValue(dedxRatioqMax);
+              }
+              if (dedxRatioqTot > 0) {
+                mAvgmMIPdEdxRatioqTot[bin][1].addValue(dedxRatioqTot);
               }
               mAvgmTPCChi2[bin][1].addValue(sqrtChi2TPC);
               mAvgmTPCNCl[bin][1].addValue(nClTPC);
             }
-            float dedxNorm = val.dedxNorm[i];
-            if (dedxNorm > 0) {
-              mAvgmdEdxRatio[bin][0].addValue(dedxNorm);
+
+            float dedxNormQMax = val.dedxValsqMax[i].dedxNorm;
+            if (dedxNormQMax > 0) {
+              mAvgmdEdxRatioQMax[bin][0].addValue(dedxNormQMax);
             }
 
-            float dedxIROC = val.dedxIROC[i];
-            if (dedxIROC > 0) {
-              mAvgmdEdxRatio[bin][1].addValue(dedxIROC);
+            float dedxNormQTot = val.dedxValsqTot[i].dedxNorm;
+            if (dedxNormQTot > 0) {
+              mAvgmdEdxRatioQTot[bin][0].addValue(dedxNormQTot);
             }
-            float dedxOROC1 = val.dedxOROC1[i];
-            if (dedxOROC1 > 0) {
-              mAvgmdEdxRatio[bin][2].addValue(dedxOROC1);
+
+            float dedxIROCQMax = val.dedxValsqMax[i].dedxIROC;
+            if (dedxIROCQMax > 0) {
+              mAvgmdEdxRatioQMax[bin][1].addValue(dedxIROCQMax);
             }
-            float dedxOROC2 = val.dedxOROC2[i];
-            if (dedxOROC2 > 0) {
-              mAvgmdEdxRatio[bin][3].addValue(dedxOROC2);
+
+            float dedxIROCQTot = val.dedxValsqTot[i].dedxIROC;
+            if (dedxIROCQTot > 0) {
+              mAvgmdEdxRatioQTot[bin][1].addValue(dedxIROCQTot);
             }
-            float dedxOROC3 = val.dedxOROC3[i];
-            if (dedxOROC3 > 0) {
-              mAvgmdEdxRatio[bin][4].addValue(dedxOROC3);
+
+            float dedxOROC1QMax = val.dedxValsqMax[i].dedxOROC1;
+            if (dedxOROC1QMax > 0) {
+              mAvgmdEdxRatioQMax[bin][2].addValue(dedxOROC1QMax);
             }
+
+            float dedxOROC1QTot = val.dedxValsqTot[i].dedxOROC1;
+            if (dedxOROC1QTot > 0) {
+              mAvgmdEdxRatioQTot[bin][2].addValue(dedxOROC1QTot);
+            }
+
+            float dedxOROC2QMax = val.dedxValsqMax[i].dedxOROC2;
+            if (dedxOROC2QMax > 0) {
+              mAvgmdEdxRatioQMax[bin][3].addValue(dedxOROC2QMax);
+            }
+
+            float dedxOROC2QTot = val.dedxValsqTot[i].dedxOROC2;
+            if (dedxOROC2QTot > 0) {
+              mAvgmdEdxRatioQTot[bin][3].addValue(dedxOROC2QTot);
+            }
+
+            float dedxOROC3QMax = val.dedxValsqMax[i].dedxOROC3;
+            if (dedxOROC3QMax > 0) {
+              mAvgmdEdxRatioQMax[bin][4].addValue(dedxOROC3QMax);
+            }
+
+            float dedxOROC3QTot = val.dedxValsqTot[i].dedxOROC3;
+            if (dedxOROC3QTot > 0) {
+              mAvgmdEdxRatioQTot[bin][4].addValue(dedxOROC3QTot);
+            }
+
             float nClITS = val.nClITS[i];
             if (nClITS > 0) {
               mITSProperties[bin][0].addValue(nClITS);
@@ -530,38 +584,46 @@ class TPCTimeSeries : public Task
       }
 
       // loop over TPC and ITS-TPC tracks
-      for (int i = 0; i < mMIPdEdxRatioC[slice].size(); ++i) {
+      for (int i = 0; i < mMIPdEdxRatioQMaxC[slice].size(); ++i) {
         auto& buff = (i == 0) ? mBufferDCA.mTSTPC : mBufferDCA.mTSITSTPC;
-        buff.mMIPdEdxRatioC[slice] = mMIPdEdxRatioC[slice][i].getMean();
-        buff.mMIPdEdxRatioA[slice] = mMIPdEdxRatioA[slice][i].getMean();
+        buff.mMIPdEdxRatioQMaxA[slice] = mMIPdEdxRatioQMaxA[slice][i].getMean();
+        buff.mMIPdEdxRatioQMaxC[slice] = mMIPdEdxRatioQMaxC[slice][i].getMean();
+        buff.mMIPdEdxRatioQTotA[slice] = mMIPdEdxRatioQTotA[slice][i].getMean();
+        buff.mMIPdEdxRatioQTotC[slice] = mMIPdEdxRatioQTotC[slice][i].getMean();
         buff.mTPCChi2C[slice] = mTPCChi2C[slice][i].getMean();
         buff.mTPCChi2A[slice] = mTPCChi2A[slice][i].getMean();
         buff.mTPCNClC[slice] = mTPCNClC[slice][i].getMean();
         buff.mTPCNClA[slice] = mTPCNClA[slice][i].getMean();
       }
-      // dEdx ratio
-      // fill A-side
-      mBufferDCA.mLogdEdx_A_Median[slice] = mLogdEdxA[slice][0].getMedian();
-      mBufferDCA.mLogdEdx_A_RMS[slice] = mLogdEdxA[slice][0].getStdDev();
-      mBufferDCA.mLogdEdx_A_IROC_Median[slice] = mLogdEdxA[slice][1].getMedian();
-      mBufferDCA.mLogdEdx_A_IROC_RMS[slice] = mLogdEdxA[slice][1].getStdDev();
-      mBufferDCA.mLogdEdx_A_OROC1_Median[slice] = mLogdEdxA[slice][2].getMedian();
-      mBufferDCA.mLogdEdx_A_OROC1_RMS[slice] = mLogdEdxA[slice][2].getStdDev();
-      mBufferDCA.mLogdEdx_A_OROC2_Median[slice] = mLogdEdxA[slice][3].getMedian();
-      mBufferDCA.mLogdEdx_A_OROC2_RMS[slice] = mLogdEdxA[slice][3].getStdDev();
-      mBufferDCA.mLogdEdx_A_OROC3_Median[slice] = mLogdEdxA[slice][4].getMedian();
-      mBufferDCA.mLogdEdx_A_OROC3_RMS[slice] = mLogdEdxA[slice][4].getStdDev();
-      // fill C-side
-      mBufferDCA.mLogdEdx_C_Median[slice] = mLogdEdxC[slice][0].getMedian();
-      mBufferDCA.mLogdEdx_C_RMS[slice] = mLogdEdxC[slice][0].getStdDev();
-      mBufferDCA.mLogdEdx_C_IROC_Median[slice] = mLogdEdxC[slice][1].getMedian();
-      mBufferDCA.mLogdEdx_C_IROC_RMS[slice] = mLogdEdxC[slice][1].getStdDev();
-      mBufferDCA.mLogdEdx_C_OROC1_Median[slice] = mLogdEdxC[slice][2].getMedian();
-      mBufferDCA.mLogdEdx_C_OROC1_RMS[slice] = mLogdEdxC[slice][2].getStdDev();
-      mBufferDCA.mLogdEdx_C_OROC2_Median[slice] = mLogdEdxC[slice][3].getMedian();
-      mBufferDCA.mLogdEdx_C_OROC2_RMS[slice] = mLogdEdxC[slice][3].getStdDev();
-      mBufferDCA.mLogdEdx_C_OROC3_Median[slice] = mLogdEdxC[slice][4].getMedian();
-      mBufferDCA.mLogdEdx_C_OROC3_RMS[slice] = mLogdEdxC[slice][4].getStdDev();
+
+      // loop over qMax and qTot
+      for (int type = 0; type < 2; ++type) {
+        auto& logdEdxA = (type == 0) ? mLogdEdxQMaxA : mLogdEdxQTotA;
+        auto& buffer = (type == 0) ? mBufferDCA.mdEdxQMax : mBufferDCA.mdEdxQTot;
+        // fill A-side
+        buffer.mLogdEdx_A_Median[slice] = logdEdxA[slice][0].getMedian();
+        buffer.mLogdEdx_A_RMS[slice] = logdEdxA[slice][0].getStdDev();
+        buffer.mLogdEdx_A_IROC_Median[slice] = logdEdxA[slice][1].getMedian();
+        buffer.mLogdEdx_A_IROC_RMS[slice] = logdEdxA[slice][1].getStdDev();
+        buffer.mLogdEdx_A_OROC1_Median[slice] = logdEdxA[slice][2].getMedian();
+        buffer.mLogdEdx_A_OROC1_RMS[slice] = logdEdxA[slice][2].getStdDev();
+        buffer.mLogdEdx_A_OROC2_Median[slice] = logdEdxA[slice][3].getMedian();
+        buffer.mLogdEdx_A_OROC2_RMS[slice] = logdEdxA[slice][3].getStdDev();
+        buffer.mLogdEdx_A_OROC3_Median[slice] = logdEdxA[slice][4].getMedian();
+        buffer.mLogdEdx_A_OROC3_RMS[slice] = logdEdxA[slice][4].getStdDev();
+        // fill C-side
+        auto& logdEdxC = (type == 0) ? mLogdEdxQMaxC : mLogdEdxQTotC;
+        buffer.mLogdEdx_C_Median[slice] = logdEdxC[slice][0].getMedian();
+        buffer.mLogdEdx_C_RMS[slice] = logdEdxC[slice][0].getStdDev();
+        buffer.mLogdEdx_C_IROC_Median[slice] = logdEdxC[slice][1].getMedian();
+        buffer.mLogdEdx_C_IROC_RMS[slice] = logdEdxC[slice][1].getStdDev();
+        buffer.mLogdEdx_C_OROC1_Median[slice] = logdEdxC[slice][2].getMedian();
+        buffer.mLogdEdx_C_OROC1_RMS[slice] = logdEdxC[slice][2].getStdDev();
+        buffer.mLogdEdx_C_OROC2_Median[slice] = logdEdxC[slice][3].getMedian();
+        buffer.mLogdEdx_C_OROC2_RMS[slice] = logdEdxC[slice][3].getStdDev();
+        buffer.mLogdEdx_C_OROC3_Median[slice] = logdEdxC[slice][4].getMedian();
+        buffer.mLogdEdx_C_OROC3_RMS[slice] = logdEdxC[slice][4].getStdDev();
+      }
 
       // ITS properties
       // A-side
@@ -598,6 +660,14 @@ class TPCTimeSeries : public Task
 
  private:
   /// buffer struct for multithreading
+  struct ValsdEdx {
+    float dedxNorm = 0;
+    float dedxIROC = 0;
+    float dedxOROC1 = 0;
+    float dedxOROC2 = 0;
+    float dedxOROC3 = 0;
+  };
+
   struct FillVals {
     void reserve(int n, int type)
     {
@@ -609,18 +679,16 @@ class TPCTimeSeries : public Task
       dcar.reserve(n);
       dcaz.reserve(n);
       dcarW.reserve(n);
-      dedxRatio.reserve(n);
+      dedxRatioqTot.reserve(n);
+      dedxRatioqMax.reserve(n);
       sqrtChi2TPC.reserve(n);
       nClTPC.reserve(n);
       if (type == 1) {
         hasITS.reserve(n);
         chi2Match.reserve(n);
         gID.reserve(n);
-        dedxNorm.reserve(n);
-        dedxIROC.reserve(n);
-        dedxOROC1.reserve(n);
-        dedxOROC2.reserve(n);
-        dedxOROC3.reserve(n);
+        dedxValsqTot.reserve(n);
+        dedxValsqMax.reserve(n);
         nClITS.reserve(n);
         chi2ITS.reserve(n);
       } else if (type == 0) {
@@ -641,22 +709,20 @@ class TPCTimeSeries : public Task
       dcarW.clear();
       hasITS.clear();
       chi2Match.clear();
-      dedxRatio.clear();
+      dedxRatioqTot.clear();
+      dedxRatioqMax.clear();
       sqrtChi2TPC.clear();
       nClTPC.clear();
       gID.clear();
       dcarcomb.clear();
       dcazcomb.clear();
-      dedxNorm.clear();
-      dedxIROC.clear();
-      dedxOROC1.clear();
-      dedxOROC2.clear();
-      dedxOROC3.clear();
       nClITS.clear();
       chi2ITS.clear();
+      dedxValsqTot.clear();
+      dedxValsqMax.clear();
     }
 
-    void emplace_back(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, int multBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioTmp, float sqrtChi2TPCTmp, float nClTPCTmp, o2::dataformats::GlobalTrackID::Source gIDTmp, float chi2MatchTmp, int hasITSTmp, float dedxNormTmp, float dedxIROCTmp, float dedxOROC1Tmp, float dedxOROC2Tmp, float dedxOROC3Tmp, int nClITSTmp, float chi2ITSTmp)
+    void emplace_back(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, int multBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioqTotTmp, float dedxRatioqMaxTmp, float sqrtChi2TPCTmp, float nClTPCTmp, o2::dataformats::GlobalTrackID::Source gIDTmp, float chi2MatchTmp, int hasITSTmp, int nClITSTmp, float chi2ITSTmp, const ValsdEdx& dedxValsqTotTmp, const ValsdEdx& dedxValsqMaxTmp)
     {
       side.emplace_back(sideTmp);
       tglBin.emplace_back(tglBinTmp);
@@ -666,22 +732,20 @@ class TPCTimeSeries : public Task
       dcar.emplace_back(dcarTmp);
       dcaz.emplace_back(dcazTmp);
       dcarW.emplace_back(dcarWTmp);
-      dedxRatio.emplace_back(dedxRatioTmp);
+      dedxRatioqTot.emplace_back(dedxRatioqTotTmp);
+      dedxRatioqMax.emplace_back(dedxRatioqMaxTmp);
       sqrtChi2TPC.emplace_back(sqrtChi2TPCTmp);
       nClTPC.emplace_back(nClTPCTmp);
       chi2Match.emplace_back(chi2MatchTmp);
       hasITS.emplace_back(hasITSTmp);
       gID.emplace_back(gIDTmp);
-      dedxNorm.emplace_back(dedxNormTmp);
-      dedxIROC.emplace_back(dedxIROCTmp);
-      dedxOROC1.emplace_back(dedxOROC1Tmp);
-      dedxOROC2.emplace_back(dedxOROC2Tmp);
-      dedxOROC3.emplace_back(dedxOROC3Tmp);
+      dedxValsqMax.emplace_back(dedxValsqMaxTmp);
+      dedxValsqTot.emplace_back(dedxValsqTotTmp);
       nClITS.emplace_back(nClITSTmp);
       chi2ITS.emplace_back(chi2ITSTmp);
     }
 
-    void emplace_back_ITSTPC(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, int multBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioTmp, float sqrtChi2TPCTmp, float nClTPCTmp, float dcarCombTmp, float dcazCombTmp)
+    void emplace_back_ITSTPC(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, int multBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioqTotTmp, float dedxRatioqMaxTmp, float sqrtChi2TPCTmp, float nClTPCTmp, float dcarCombTmp, float dcazCombTmp)
     {
       side.emplace_back(sideTmp);
       tglBin.emplace_back(tglBinTmp);
@@ -691,7 +755,8 @@ class TPCTimeSeries : public Task
       dcar.emplace_back(dcarTmp);
       dcaz.emplace_back(dcazTmp);
       dcarW.emplace_back(dcarWTmp);
-      dedxRatio.emplace_back(dedxRatioTmp);
+      dedxRatioqTot.emplace_back(dedxRatioqTotTmp);
+      dedxRatioqMax.emplace_back(dedxRatioqMaxTmp);
       sqrtChi2TPC.emplace_back(sqrtChi2TPCTmp);
       nClTPC.emplace_back(nClTPCTmp);
       dcarcomb.emplace_back(dcarCombTmp);
@@ -708,79 +773,80 @@ class TPCTimeSeries : public Task
     std::vector<float> dcarW;
     std::vector<bool> hasITS;
     std::vector<float> chi2Match;
-    std::vector<float> dedxRatio;
+    std::vector<float> dedxRatioqTot;
+    std::vector<float> dedxRatioqMax;
     std::vector<float> sqrtChi2TPC;
     std::vector<float> nClTPC;
     std::vector<float> dcarcomb;
     std::vector<float> dcazcomb;
-    std::vector<float> dedxNorm;
-    std::vector<float> dedxIROC;
-    std::vector<float> dedxOROC1;
-    std::vector<float> dedxOROC2;
-    std::vector<float> dedxOROC3;
+    std::vector<ValsdEdx> dedxValsqTot;
+    std::vector<ValsdEdx> dedxValsqMax;
     std::vector<int> nClITS;
     std::vector<float> chi2ITS;
     std::vector<o2::dataformats::GlobalTrackID::Source> gID;
   };
-  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;    ///< info for CCDB request
-  const bool mDisableWriter{false};                          ///< flag if no ROOT output will be written
-  o2::base::Propagator::MatCorrType mMatType;                ///< material for propagation
-  int mPhiBins = SECTORSPERSIDE;                             ///< number of phi bins
-  int mTglBins{3};                                           ///< number of tgl bins
-  int mQPtBins{20};                                          ///< number of qPt bins
-  TimeSeriesITSTPC mBufferDCA;                               ///< buffer for integrate DCAs
-  std::vector<std::array<RobustAverage, 3>> mAvgADCAr;       ///< for averaging the DCAr for TPC and ITS-TPC tracks for A-side
-  std::vector<std::array<RobustAverage, 3>> mAvgCDCAr;       ///< for averaging the DCAr for TPC and ITS-TPC tracks for C-side
-  std::vector<std::array<RobustAverage, 3>> mAvgADCAz;       ///< for averaging the DCAz for TPC and ITS-TPC tracks for A-side
-  std::vector<std::array<RobustAverage, 3>> mAvgCDCAz;       ///< for averaging the DCAz for TPC and ITS-TPC tracks for C-side
-  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioA;  ///< for averaging MIP/dEdx
-  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioC;  ///< for averaging MIP/dEdx
-  std::vector<std::array<RobustAverage, 2>> mTPCChi2A;       ///< for averaging chi2 TPC A
-  std::vector<std::array<RobustAverage, 2>> mTPCChi2C;       ///< for averaging chi2 TPC C
-  std::vector<std::array<RobustAverage, 2>> mTPCNClA;        ///< for averaging number of cluster A
-  std::vector<std::array<RobustAverage, 2>> mTPCNClC;        ///< for averaging number of cluster C
-  std::vector<std::array<RobustAverage, 3>> mAvgMeffA;       ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 3>> mAvgMeffC;       ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchA;  ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchC;  ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 10>> mLogdEdxA;      ///< for log dedx A side
-  std::vector<std::array<RobustAverage, 10>> mLogdEdxC;      ///< for log dedx C side
-  std::vector<std::array<RobustAverage, 2>> mITSPropertiesA; ///< mITS_NCl, mSqrtITSChi2_Ncl, mSqrtMatchChi2
-  std::vector<std::array<RobustAverage, 2>> mITSPropertiesC; ///< mITS_NCl, mSqrtITSChi2_Ncl, mSqrtMatchChi2
-  int mNMaxTracks{-1};                                       ///< maximum number of tracks to process
-  float mMinMom{1};                                          ///< minimum accepted momentum
-  int mMinNCl{80};                                           ///< minimum accepted number of clusters per track
-  float mMaxTgl{1};                                          ///< maximum eta
-  float mMaxQPt{5};                                          ///< max qPt bin
-  float mCoarseStep{1};                                      ///< coarse step during track propagation
-  float mFineStep{0.005};                                    ///< fine step during track propagation
-  float mCutDCA{5};                                          ///< cut on the abs(DCA-median)
-  float mCutRMS{5};                                          ///< sigma cut for mean,median calculation
-  float mRefXSec{108.475};                                   ///< reference lx position for sector information (default centre of IROC)
-  int mNThreads{1};                                          ///< number of parallel threads
-  float maxITSTPCDCAr{0.2};                                  ///< maximum abs DCAr value for ITS-TPC tracks
-  float maxITSTPCDCAz{10};                                   ///< maximum abs DCAz value for ITS-TPC tracks
-  float maxITSTPCDCAr_comb{0.2};                             ///< max abs DCA for ITS-TPC DCA to vertex
-  float maxITSTPCDCAz_comb{0.2};                             ///< max abs DCA for ITS-TPC DCA to vertex
-  gsl::span<const TPCClRefElem> mTPCTrackClIdx{};            ///< cluster refs for debugging
-  std::vector<std::array<FillVals, 2>> mBufferVals;          ///< buffer for multithreading
-  uint32_t mFirstTFOrbit{0};                                 ///< first TF orbit
-  float mTimeWindowMUS{50};                                  ///< time window in mus for local mult estimate
-  float mMIPdEdx{50};                                        ///< MIP dEdx position for MIP/dEdx monitoring
-  std::vector<int> mNTracksWindow;                           ///< number of tracks in time window
-  std::vector<int> mNearestVtxTPC;                           ///< nearest vertex for tpc tracks
-  o2::tpc::VDriftHelper mTPCVDriftHelper{};                  ///< helper for v-drift
-  float mVDrift{2.64};                                       ///< v drift in mus
-  bool mUseQMax{false};                                      ///< use dedx qmax for MIP/dEdx monitoring
-  float mMaxSnp{0.85};                                       ///< max sinus phi for propagation
-  float mXCoarse{40};                                        ///< perform propagation with coarse steps up to this mx
-  float mSqrt{13600};                                        ///< centre of mass energy
-  int mMultBins{20};                                         ///< multiplicity bins
-  int mMultMax{80000};                                       ///< maximum multiplicity
-  PIDResponse mPID;                                          ///< PID response
-  int mMinTracksPerVertex{5};                                ///< minimum number of tracks per vertex
-  float mMaxdEdxRatio{0.3};                                  ///< maximum abs dedx ratio: log(dedx_exp(pion)/dedx)
-  float mMaxdEdxRegionRatio{0.5};                            ///< maximum abs dedx region ratio: log(dedx_region/dedx)
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;       ///< info for CCDB request
+  const bool mDisableWriter{false};                             ///< flag if no ROOT output will be written
+  o2::base::Propagator::MatCorrType mMatType;                   ///< material for propagation
+  int mPhiBins = SECTORSPERSIDE;                                ///< number of phi bins
+  int mTglBins{3};                                              ///< number of tgl bins
+  int mQPtBins{20};                                             ///< number of qPt bins
+  TimeSeriesITSTPC mBufferDCA;                                  ///< buffer for integrate DCAs
+  std::vector<std::array<RobustAverage, 3>> mAvgADCAr;          ///< for averaging the DCAr for TPC and ITS-TPC tracks for A-side
+  std::vector<std::array<RobustAverage, 3>> mAvgCDCAr;          ///< for averaging the DCAr for TPC and ITS-TPC tracks for C-side
+  std::vector<std::array<RobustAverage, 3>> mAvgADCAz;          ///< for averaging the DCAz for TPC and ITS-TPC tracks for A-side
+  std::vector<std::array<RobustAverage, 3>> mAvgCDCAz;          ///< for averaging the DCAz for TPC and ITS-TPC tracks for C-side
+  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioQMaxA; ///< for averaging MIP/dEdx - qMax -
+  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioQMaxC; ///< for averaging MIP/dEdx - qMax -
+  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioQTotA; ///< for averaging MIP/dEdx - qTot -
+  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioQTotC; ///< for averaging MIP/dEdx - qTot -
+  std::vector<std::array<RobustAverage, 2>> mTPCChi2A;          ///< for averaging chi2 TPC A
+  std::vector<std::array<RobustAverage, 2>> mTPCChi2C;          ///< for averaging chi2 TPC C
+  std::vector<std::array<RobustAverage, 2>> mTPCNClA;           ///< for averaging number of cluster A
+  std::vector<std::array<RobustAverage, 2>> mTPCNClC;           ///< for averaging number of cluster C
+  std::vector<std::array<RobustAverage, 3>> mAvgMeffA;          ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 3>> mAvgMeffC;          ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchA;     ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchC;     ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 10>> mLogdEdxQTotA;     ///< for log dedx A side - qTot
+  std::vector<std::array<RobustAverage, 10>> mLogdEdxQTotC;     ///< for log dedx C side - qTot
+  std::vector<std::array<RobustAverage, 10>> mLogdEdxQMaxA;     ///< for log dedx A side - qMax
+  std::vector<std::array<RobustAverage, 10>> mLogdEdxQMaxC;     ///< for log dedx C side - qMax
+  std::vector<std::array<RobustAverage, 2>> mITSPropertiesA;    ///< mITS_NCl, mSqrtITSChi2_Ncl, mSqrtMatchChi2
+  std::vector<std::array<RobustAverage, 2>> mITSPropertiesC;    ///< mITS_NCl, mSqrtITSChi2_Ncl, mSqrtMatchChi2
+  int mNMaxTracks{-1};                                          ///< maximum number of tracks to process
+  float mMinMom{1};                                             ///< minimum accepted momentum
+  int mMinNCl{80};                                              ///< minimum accepted number of clusters per track
+  float mMaxTgl{1};                                             ///< maximum eta
+  float mMaxQPt{5};                                             ///< max qPt bin
+  float mCoarseStep{1};                                         ///< coarse step during track propagation
+  float mFineStep{0.005};                                       ///< fine step during track propagation
+  float mCutDCA{5};                                             ///< cut on the abs(DCA-median)
+  float mCutRMS{5};                                             ///< sigma cut for mean,median calculation
+  float mRefXSec{108.475};                                      ///< reference lx position for sector information (default centre of IROC)
+  int mNThreads{1};                                             ///< number of parallel threads
+  float maxITSTPCDCAr{0.2};                                     ///< maximum abs DCAr value for ITS-TPC tracks
+  float maxITSTPCDCAz{10};                                      ///< maximum abs DCAz value for ITS-TPC tracks
+  float maxITSTPCDCAr_comb{0.2};                                ///< max abs DCA for ITS-TPC DCA to vertex
+  float maxITSTPCDCAz_comb{0.2};                                ///< max abs DCA for ITS-TPC DCA to vertex
+  gsl::span<const TPCClRefElem> mTPCTrackClIdx{};               ///< cluster refs for debugging
+  std::vector<std::array<FillVals, 2>> mBufferVals;             ///< buffer for multithreading
+  uint32_t mFirstTFOrbit{0};                                    ///< first TF orbit
+  float mTimeWindowMUS{50};                                     ///< time window in mus for local mult estimate
+  float mMIPdEdx{50};                                           ///< MIP dEdx position for MIP/dEdx monitoring
+  std::vector<int> mNTracksWindow;                              ///< number of tracks in time window
+  std::vector<int> mNearestVtxTPC;                              ///< nearest vertex for tpc tracks
+  o2::tpc::VDriftHelper mTPCVDriftHelper{};                     ///< helper for v-drift
+  float mVDrift{2.64};                                          ///< v drift in mus
+  float mMaxSnp{0.85};                                          ///< max sinus phi for propagation
+  float mXCoarse{40};                                           ///< perform propagation with coarse steps up to this mx
+  float mSqrt{13600};                                           ///< centre of mass energy
+  int mMultBins{20};                                            ///< multiplicity bins
+  int mMultMax{80000};                                          ///< maximum multiplicity
+  PIDResponse mPID;                                             ///< PID response
+  int mMinTracksPerVertex{5};                                   ///< minimum number of tracks per vertex
+  float mMaxdEdxRatio{0.3};                                     ///< maximum abs dedx ratio: log(dedx_exp(pion)/dedx)
+  float mMaxdEdxRegionRatio{0.5};                               ///< maximum abs dedx region ratio: log(dedx_region/dedx)
 
   /// check if track passes coarse cuts
   bool acceptTrack(const TrackTPC& track) const
@@ -876,50 +942,15 @@ class TPCTimeSeries : public Task
       }
 
       const float chi2Match = (chi2 > 0) ? std::sqrt(chi2) : -1;
-      const float dedx = mUseQMax ? track.getdEdx().dEdxMaxTPC : track.getdEdx().dEdxTotTPC;
-      const float dedxRatio = (dedx > 0) ? (mMIPdEdx / dedx) : -1;
       const float sqrtChi2TPC = (track.getChi2() > 0) ? std::sqrt(track.getChi2()) : 0;
       const float nClTPC = track.getNClusters();
-      const float dedxRatioNorm = mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx;
-      float dedxNorm = (dedxRatioNorm > 0) ? std::log(mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx) : -1;
-      // restrict to specified range
-      if (std::abs(dedxNorm > mMaxdEdxRatio)) {
-        dedxNorm = -1;
-      }
 
-      // get log(dedxRegion / dedx)
-      float dedxIROC = -1;
-      float dedxOROC1 = -1;
-      float dedxOROC2 = -1;
-      float dedxOROC3 = -1;
-      if (dedx > 0) {
-        dedxIROC = mUseQMax ? track.getdEdx().dEdxMaxIROC : track.getdEdx().dEdxTotIROC;
-        dedxOROC1 = mUseQMax ? track.getdEdx().dEdxMaxOROC1 : track.getdEdx().dEdxTotOROC1;
-        dedxOROC2 = mUseQMax ? track.getdEdx().dEdxMaxOROC2 : track.getdEdx().dEdxTotOROC2;
-        dedxOROC3 = mUseQMax ? track.getdEdx().dEdxMaxOROC3 : track.getdEdx().dEdxTotOROC3;
-        dedxIROC /= dedx;
-        dedxOROC1 /= dedx;
-        dedxOROC2 /= dedx;
-        dedxOROC3 /= dedx;
-        dedxIROC = (dedxIROC > 0) ? std::log(dedxIROC) : -1;
-        dedxOROC1 = (dedxOROC1 > 0) ? std::log(dedxOROC1) : -1;
-        dedxOROC2 = (dedxOROC2 > 0) ? std::log(dedxOROC2) : -1;
-        dedxOROC3 = (dedxOROC3 > 0) ? std::log(dedxOROC3) : -1;
+      // const float dedx = mUseQMax ? track.getdEdx().dEdxMaxTPC : track.getdEdx().dEdxTotTPC;
+      const float dedxRatioqTot = (track.getdEdx().dEdxTotTPC > 0) ? (mMIPdEdx / track.getdEdx().dEdxTotTPC) : -1;
+      const float dedxRatioqMax = (track.getdEdx().dEdxMaxTPC > 0) ? (mMIPdEdx / track.getdEdx().dEdxMaxTPC) : -1;
 
-        // restrict to specified range
-        if (std::abs(dedxIROC > mMaxdEdxRegionRatio)) {
-          dedxIROC = -1;
-        }
-        if (std::abs(dedxOROC1 > mMaxdEdxRegionRatio)) {
-          dedxOROC1 = -1;
-        }
-        if (std::abs(dedxOROC2 > mMaxdEdxRegionRatio)) {
-          dedxOROC2 = -1;
-        }
-        if (std::abs(dedxOROC3 > mMaxdEdxRegionRatio)) {
-          dedxOROC3 = -1;
-        }
-      }
+      const auto dedxQTotVars = getdEdxVars(0, track);
+      const auto dedxQMaxVars = getdEdxVars(1, track);
 
       const int nClITS = hasITSTPC ? tracksITS[tracksITSTPC[idxITSTPC.front()].getRefITS().getIndex()].getNClusters() : -1;
       float chi2ITS = hasITSTPC ? tracksITS[tracksITSTPC[idxITSTPC.front()].getRefITS().getIndex()].getChi2() : -1;
@@ -928,9 +959,9 @@ class TPCTimeSeries : public Task
       }
 
       if (track.hasCSideClustersOnly()) {
-        mBufferVals[iThread].front().emplace_back(Side::C, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC, dedxNorm, dedxIROC, dedxOROC1, dedxOROC2, dedxOROC3, nClITS, chi2ITS);
+        mBufferVals[iThread].front().emplace_back(Side::C, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatioqTot, dedxRatioqMax, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC, nClITS, chi2ITS, dedxQTotVars, dedxQMaxVars);
       } else if (track.hasASideClustersOnly()) {
-        mBufferVals[iThread].front().emplace_back(Side::A, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC, dedxNorm, dedxIROC, dedxOROC1, dedxOROC2, dedxOROC3, nClITS, chi2ITS);
+        mBufferVals[iThread].front().emplace_back(Side::A, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatioqTot, dedxRatioqMax, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC, nClITS, chi2ITS, dedxQTotVars, dedxQMaxVars);
       }
 
       // make propagation for ITS-TPC Track
@@ -959,9 +990,9 @@ class TPCTimeSeries : public Task
             }
 
             if (track.hasCSideClustersOnly()) {
-              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::C, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
+              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::C, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatioqTot, dedxRatioqMax, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
             } else if (track.hasASideClustersOnly()) {
-              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::A, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
+              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::A, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatioqTot, dedxRatioqMax, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
             }
           }
         }
@@ -1280,6 +1311,52 @@ class TPCTimeSeries : public Task
 
   /// \return returns total number of stored values per TF
   int getNBins() const { return mBufferDCA.mTSTPC.getNBins(); }
+
+  ValsdEdx getdEdxVars(bool useQMax, const TrackTPC& track) const
+  {
+    const float dedx = useQMax ? track.getdEdx().dEdxMaxTPC : track.getdEdx().dEdxTotTPC;
+    const float dedxRatioNorm = mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx;
+    float dedxNorm = (dedxRatioNorm > 0) ? std::log(mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx) : -1;
+    // restrict to specified range
+    if (std::abs(dedxNorm > mMaxdEdxRatio)) {
+      dedxNorm = -1;
+    }
+
+    // get log(dedxRegion / dedx)
+    float dedxIROC = -1;
+    float dedxOROC1 = -1;
+    float dedxOROC2 = -1;
+    float dedxOROC3 = -1;
+    if (dedx > 0) {
+      dedxIROC = useQMax ? track.getdEdx().dEdxMaxIROC : track.getdEdx().dEdxTotIROC;
+      dedxOROC1 = useQMax ? track.getdEdx().dEdxMaxOROC1 : track.getdEdx().dEdxTotOROC1;
+      dedxOROC2 = useQMax ? track.getdEdx().dEdxMaxOROC2 : track.getdEdx().dEdxTotOROC2;
+      dedxOROC3 = useQMax ? track.getdEdx().dEdxMaxOROC3 : track.getdEdx().dEdxTotOROC3;
+      dedxIROC /= dedx;
+      dedxOROC1 /= dedx;
+      dedxOROC2 /= dedx;
+      dedxOROC3 /= dedx;
+      dedxIROC = (dedxIROC > 0) ? std::log(dedxIROC) : -1;
+      dedxOROC1 = (dedxOROC1 > 0) ? std::log(dedxOROC1) : -1;
+      dedxOROC2 = (dedxOROC2 > 0) ? std::log(dedxOROC2) : -1;
+      dedxOROC3 = (dedxOROC3 > 0) ? std::log(dedxOROC3) : -1;
+
+      // restrict to specified range
+      if (std::abs(dedxIROC > mMaxdEdxRegionRatio)) {
+        dedxIROC = -1;
+      }
+      if (std::abs(dedxOROC1 > mMaxdEdxRegionRatio)) {
+        dedxOROC1 = -1;
+      }
+      if (std::abs(dedxOROC2 > mMaxdEdxRegionRatio)) {
+        dedxOROC2 = -1;
+      }
+      if (std::abs(dedxOROC3 > mMaxdEdxRegionRatio)) {
+        dedxOROC3 = -1;
+      }
+    }
+    return ValsdEdx{dedxNorm, dedxIROC, dedxOROC1, dedxOROC2, dedxOROC3};
+  }
 };
 
 o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType)
@@ -1344,7 +1421,6 @@ o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, 
       {"max-ITS-TPC-DCAz_comb", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks to vertex for combined DCA"}},
       {"MIP-dedx", VariantType::Float, 50.f, {"MIP dEdx for MIP/dEdx monitoring"}},
       {"time-window-mult-mus", VariantType::Float, 50.f, {"Time window in micro s for multiplicity estimate"}},
-      {"use-qMax", VariantType::Bool, false, {"Using qMax for MIP/dedx monitoring"}},
       {"sqrts", VariantType::Float, 13600.f, {"Centre of mass energy used for downsampling"}},
       {"min-tracks-per-vertex", VariantType::Int, 6, {"Minimum number of tracks per vertex required"}},
       {"max-dedx-ratio", VariantType::Float, 0.3f, {"Maximum absolute log(dedx(pion)/dedx) ratio"}},

--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1259,10 +1259,10 @@ class TPCTimeSeries : public Task
 
     // nPrimVertices_Quantiles
     int sizeQ = mBufferDCA.nVertexContributors_Quantiles.size();
-    if (sizeQ >= 12) {
-      for (int q = 1; q <= 9; ++q) {
-        const float quantile = q * 0.1;
-        const int iq = q - 1;
+    const int nBinsQ = 20;
+    if (sizeQ >= (nBinsQ + 3)) {
+      for (int iq = 0; iq < nBinsQ; ++iq) {
+        const float quantile = (iq + 1) / static_cast<float>(nBinsQ);
         const float val = avg.getQuantile(quantile, 1);
         mBufferDCA.nVertexContributors_Quantiles[iq] = val * val;
       }
@@ -1273,6 +1273,7 @@ class TPCTimeSeries : public Task
       mBufferDCA.nVertexContributors_Quantiles[sizeQ - 2] = tr1 * tr1;
       mBufferDCA.nVertexContributors_Quantiles[sizeQ - 1] = tr2 * tr2;
     }
+    mBufferDCA.nPrimVertices.front() = vertices.size();
 
     return indicesITSTPC_vtx;
   }

--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -39,6 +39,8 @@
 #include "TPCCalibration/VDriftHelper.h"
 #include <random>
 #include <chrono>
+#include "DataFormatsTPC/PIDResponse.h"
+#include "DataFormatsITS/TrackITS.h"
 
 using namespace o2::framework;
 
@@ -60,7 +62,7 @@ class TPCTimeSeries : public Task
     mMinMom = ic.options().get<float>("min-momentum");
     mMinNCl = ic.options().get<int>("min-cluster");
     mMaxTgl = ic.options().get<float>("max-tgl");
-    mMaxQPtBin = ic.options().get<float>("max-qPt-bin");
+    mMaxQPt = ic.options().get<float>("max-qPt");
     mCoarseStep = ic.options().get<float>("coarse-step");
     mFineStep = ic.options().get<float>("fine-step");
     mCutDCA = ic.options().get<float>("cut-DCA-median");
@@ -80,8 +82,13 @@ class TPCTimeSeries : public Task
     mMaxSnp = ic.options().get<float>("max-snp");
     mXCoarse = ic.options().get<float>("mX-coarse");
     mSqrt = ic.options().get<float>("sqrts");
+    mMultBins = ic.options().get<int>("mult-bins");
+    mMultMax = ic.options().get<int>("mult-max");
+    mMinTracksPerVertex = ic.options().get<int>("min-tracks-per-vertex");
+    mMaxdEdxRatio = ic.options().get<float>("max-dedx-ratio");
+    mMaxdEdxRegionRatio = ic.options().get<float>("max-dedx-region-ratio");
     mBufferVals.resize(mNThreads);
-    mBufferDCA.setBinning(mPhiBins, mTglBins, mQPtBins);
+    mBufferDCA.setBinning(mPhiBins, mTglBins, mQPtBins, mMultBins, mMaxTgl, mMaxQPt, mMultMax);
   }
 
   void run(ProcessingContext& pc) final
@@ -113,57 +120,26 @@ class TPCTimeSeries : public Task
       mTPCChi2C.resize(nBins);
       mTPCNClA.resize(nBins);
       mTPCNClC.resize(nBins);
+      mLogdEdxA.resize(nBins);
+      mLogdEdxC.resize(nBins);
+      mITSPropertiesA.resize(nBins);
+      mITSPropertiesC.resize(nBins);
     }
 
     // getting tracks
     auto tracksTPC = pc.inputs().get<gsl::span<TrackTPC>>("tracksTPC");
     auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("tracksITSTPC");
+    auto tracksITS = pc.inputs().get<gsl::span<o2::its::TrackITS>>("tracksITS");
 
     // getting the vertices
     const auto vertices = pc.inputs().get<gsl::span<o2::dataformats::PrimaryVertex>>("pvtx");
     const auto primMatchedTracks = pc.inputs().get<gsl::span<o2::dataformats::VtxTrackIndex>>("pvtx_trmtc");
     const auto primMatchedTracksRef = pc.inputs().get<gsl::span<o2::dataformats::VtxTrackRef>>("pvtx_tref");
 
-    LOGP(info, "Processing {} vertices, {} primary matched tracks, {} TPC tracks, {} ITS-TPC tracks", vertices.size(), primMatchedTracks.size(), tracksTPC.size(), tracksITSTPC.size());
+    LOGP(info, "Processing {} vertices, {} primary matched vertices, {} TPC tracks, {} ITS-TPC tracks", vertices.size(), primMatchedTracks.size(), tracksTPC.size(), tracksITSTPC.size());
 
     // calculate mean vertex, RMS and count vertices
-    std::array<RobustAverage, 4> avgVtx;
-    for (auto& avg : avgVtx) {
-      avg.reserve(vertices.size());
-    }
-    for (const auto& vtx : vertices) {
-      avgVtx[0].addValue(vtx.getX());
-      avgVtx[1].addValue(vtx.getY());
-      avgVtx[2].addValue(vtx.getZ());
-      avgVtx[3].addValue(vtx.getNContributors());
-    }
-    mBufferDCA.vertexX_Median.front() = avgVtx[0].getMedian();
-    mBufferDCA.vertexY_Median.front() = avgVtx[1].getMedian();
-    mBufferDCA.vertexZ_Median.front() = avgVtx[2].getMedian();
-    mBufferDCA.vertexX_RMS.front() = avgVtx[0].getStdDev();
-    mBufferDCA.vertexY_RMS.front() = avgVtx[1].getStdDev();
-    mBufferDCA.vertexZ_RMS.front() = avgVtx[2].getStdDev();
-    mBufferDCA.nPrimVertices.front() = vertices.size();
-    mBufferDCA.nVertexContributors_Median.front() = avgVtx[3].getMedian();
-    mBufferDCA.nVertexContributors_RMS.front() = avgVtx[3].getStdDev();
-
-    // storing collision vertex to ITS-TPC track index
-    std::unordered_map<unsigned int, int> indicesITSTPC_vtx; // ITS-TPC track index -> collision vertex ID
-    // loop over collisions
-    for (const auto& ref : primMatchedTracksRef) {
-      const auto source = o2::dataformats::VtxTrackIndex::Source::ITSTPC;
-      const int vID = ref.getVtxID(); // vertex ID
-      const int firstEntry = ref.getFirstEntryOfSource(source);
-      const int nEntries = ref.getEntriesOfSource(source);
-      // loop over all tracks belonging to the vertex
-      for (int i = 0; i < nEntries; ++i) {
-        // storing vertex ID for ITS-TPC track
-        const auto& matchedTrk = primMatchedTracks[i + firstEntry];
-        if (matchedTrk.isTrackSource(source)) {
-          indicesITSTPC_vtx[matchedTrk] = vID;
-        }
-      }
-    }
+    auto indicesITSTPC_vtx = processVertices(vertices, primMatchedTracks, primMatchedTracksRef);
 
     // storing indices to ITS-TPC tracks and vertex ID for tpc track
     std::unordered_map<unsigned int, std::array<int, 2>> indicesITSTPC; // TPC track index -> ITS-TPC track index, vertex ID
@@ -183,9 +159,10 @@ class TPCTimeSeries : public Task
     GPUCA_DEBUG_STREAMER_CHECK(if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamTimeSeries)) {
       mTPCTrackClIdx = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
       mFirstTFOrbit = processing_helpers::getFirstTForbit(pc);
-      // get local multiplicity - count neighbouring tracks
-      findNNeighbourTracks(tracksTPC);
     })
+
+    // get local multiplicity - count neighbouring tracks
+    findNNeighbourTracks(tracksTPC);
 
     // reset buffers
     for (int i = 0; i < nBins; ++i) {
@@ -202,12 +179,34 @@ class TPCTimeSeries : public Task
         mTPCChi2C[i][type].clear();
         mTPCNClA[i][type].clear();
         mTPCNClC[i][type].clear();
+        mMIPdEdxRatioA[i][type].setUseWeights(false);
+        mMIPdEdxRatioC[i][type].setUseWeights(false);
+        mTPCChi2A[i][type].setUseWeights(false);
+        mTPCChi2C[i][type].setUseWeights(false);
+        mTPCNClA[i][type].setUseWeights(false);
+        mTPCNClC[i][type].setUseWeights(false);
+      }
+      for (int type = 0; type < mLogdEdxA[i].size(); ++type) {
+        mLogdEdxA[i][type].clear();
+        mLogdEdxC[i][type].clear();
+        mLogdEdxA[i][type].setUseWeights(false);
+        mLogdEdxC[i][type].setUseWeights(false);
+      }
+      for (int j = 0; j < mITSPropertiesA[i].size(); ++j) {
+        mITSPropertiesA[i][j].clear();
+        mITSPropertiesC[i][j].clear();
+        mITSPropertiesA[i][j].setUseWeights(false);
+        mITSPropertiesC[i][j].setUseWeights(false);
       }
       for (int j = 0; j < mAvgMeffA[i].size(); ++j) {
         mAvgMeffA[i][j].clear();
         mAvgMeffC[i][j].clear();
         mAvgChi2MatchA[i][j].clear();
         mAvgChi2MatchC[i][j].clear();
+        mAvgMeffA[i][j].setUseWeights(false);
+        mAvgMeffC[i][j].setUseWeights(false);
+        mAvgChi2MatchA[i][j].setUseWeights(false);
+        mAvgChi2MatchC[i][j].setUseWeights(false);
       }
     }
 
@@ -222,28 +221,56 @@ class TPCTimeSeries : public Task
 
     // reserve memory
     for (int i = 0; i < nBins; ++i) {
+      const int lastIdxPhi = mBufferDCA.mTSTPC.getIndexPhi(mPhiBins);
+      const int lastIdxTgl = mBufferDCA.mTSTPC.getIndexTgl(mTglBins);
+      const int lastIdxQPt = mBufferDCA.mTSTPC.getIndexqPt(mQPtBins);
+      const int lastIdxMult = mBufferDCA.mTSTPC.getIndexMult(mMultBins);
+      const int firstIdx = mBufferDCA.mTSTPC.getIndexInt();
+      int resMem = 0;
+      if (i < lastIdxPhi) {
+        resMem = loopEnd / mPhiBins;
+      } else if (i < lastIdxTgl) {
+        resMem = loopEnd / mTglBins;
+      } else if (i < lastIdxQPt) {
+        resMem = loopEnd / mQPtBins;
+      } else if (i < lastIdxMult) {
+        resMem = loopEnd / mMultBins;
+      } else {
+        resMem = loopEnd;
+      }
+      // Divide by 2 for A-C-side
+      resMem /= 2;
       for (int type = 0; type < mAvgADCAr[i].size(); ++type) {
-        mAvgADCAr[i][type].reserve(loopEnd);
-        mAvgCDCAr[i][type].reserve(loopEnd);
-        mAvgADCAz[i][type].reserve(loopEnd);
-        mAvgCDCAz[i][type].reserve(loopEnd);
+        mAvgADCAr[i][type].reserve(resMem);
+        mAvgCDCAr[i][type].reserve(resMem);
+        mAvgADCAz[i][type].reserve(resMem);
+        mAvgCDCAz[i][type].reserve(resMem);
       }
       for (int type = 0; type < mMIPdEdxRatioA[i].size(); ++type) {
-        mMIPdEdxRatioA[i][type].reserve(loopEnd);
-        mMIPdEdxRatioC[i][type].reserve(loopEnd);
-        mTPCChi2A[i][type].reserve(loopEnd);
-        mTPCChi2C[i][type].reserve(loopEnd);
-        mTPCNClA[i][type].reserve(loopEnd);
-        mTPCNClC[i][type].reserve(loopEnd);
+        mMIPdEdxRatioA[i][type].reserve(resMem);
+        mMIPdEdxRatioC[i][type].reserve(resMem);
+        mTPCChi2A[i][type].reserve(resMem);
+        mTPCChi2C[i][type].reserve(resMem);
+        mTPCNClA[i][type].reserve(resMem);
+        mTPCNClC[i][type].reserve(resMem);
       }
       for (int j = 0; j < mAvgMeffA[i].size(); ++j) {
-        mAvgMeffA[i][j].reserve(loopEnd);
-        mAvgMeffC[i][j].reserve(loopEnd);
-        mAvgChi2MatchA[i][j].reserve(loopEnd);
-        mAvgChi2MatchC[i][j].reserve(loopEnd);
+        mAvgMeffA[i][j].reserve(resMem);
+        mAvgMeffC[i][j].reserve(resMem);
+        mAvgChi2MatchA[i][j].reserve(resMem);
+        mAvgChi2MatchC[i][j].reserve(resMem);
+      }
+      for (int j = 0; j < mITSPropertiesA[i].size(); ++j) {
+        mITSPropertiesA[i][j].reserve(resMem);
+        mITSPropertiesC[i][j].reserve(resMem);
+      }
+      for (int j = 0; j < mAvgMeffA[i].size(); ++j) {
+        mLogdEdxA[i][j].reserve(resMem);
+        mLogdEdxC[i][j].reserve(resMem);
       }
     }
     for (int iThread = 0; iThread < mNThreads; ++iThread) {
+      const int resMem = (mNThreads > 0) ? loopEnd / mNThreads : loopEnd;
       mBufferVals[iThread].front().reserve(loopEnd, 1);
       mBufferVals[iThread].back().reserve(loopEnd, 0);
     }
@@ -262,7 +289,7 @@ class TPCTimeSeries : public Task
       auto myThread = [&](int iThread) {
         for (size_t i = iThread; i < loopEnd; i += mNThreads) {
           if (acceptTrack(tracksTPC[i])) {
-            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC);
+            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC, tracksITS);
           }
         }
       };
@@ -279,7 +306,7 @@ class TPCTimeSeries : public Task
       auto myThread = [&](int iThread) {
         for (size_t i = iThread; i < loopEnd; i += mNThreads) {
           if (acceptTrack(tracksTPC[i])) {
-            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC);
+            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC, tracksITS);
           }
         }
       };
@@ -303,12 +330,13 @@ class TPCTimeSeries : public Task
           const auto tglBin = val.tglBin[i];
           const auto phiBin = val.phiBin[i];
           const auto qPtBin = val.qPtBin[i];
+          const auto multBin = val.multBin[i];
           const auto dcar = val.dcar[i];
           const auto dcaz = val.dcaz[i];
           const auto dcarW = val.dcarW[i];
           const int binInt = nBins - 1;
           const bool fillCombDCA = ((type == 1) && (val.dcarcomb[i] != -1) && (val.dcazcomb[i] != -1));
-          const std::array<int, 4> bins{tglBin, phiBin, qPtBin, binInt};
+          const std::array<int, 5> bins{tglBin, phiBin, qPtBin, multBin, binInt};
           // fill bins
           for (auto bin : bins) {
             if (val.side[i] == Side::C) {
@@ -396,6 +424,7 @@ class TPCTimeSeries : public Task
         const auto tglBin = val.tglBin[i];
         const auto phiBin = val.phiBin[i];
         const auto qPtBin = val.qPtBin[i];
+        const auto multBin = val.multBin[i];
         const auto dcar = val.dcar[i];
         const auto dcaz = val.dcaz[i];
         const auto hasITS = val.hasITS[i];
@@ -415,10 +444,13 @@ class TPCTimeSeries : public Task
         auto& mAvgmMIPdEdxRatio = isCSide ? mMIPdEdxRatioC : mMIPdEdxRatioA;
         auto& mAvgmTPCChi2 = isCSide ? mTPCChi2C : mTPCChi2A;
         auto& mAvgmTPCNCl = isCSide ? mTPCNClC : mTPCNClA;
+        auto& mAvgmdEdxRatio = isCSide ? mLogdEdxC : mLogdEdxA;
+        auto& mITSProperties = isCSide ? mITSPropertiesC : mITSPropertiesA;
 
-        const std::array<int, 4> bins{tglBin, phiBin, qPtBin, binInt};
+        const std::array<int, 5> bins{tglBin, phiBin, qPtBin, multBin, binInt};
         // fill bins
         for (auto bin : bins) {
+          // make DCA cut - select only good tracks
           if ((std::abs(dcar - bufferDCAMedR[bin]) < (bufferDCARMSR[bin] * mCutRMS)) && (std::abs(dcaz - bufferDCAMedZ[bin]) < (bufferDCARMSZ[bin] * mCutRMS))) {
             const auto gID = val.gID[i];
             mAvgEff[bin][0].addValue(hasITS);
@@ -453,6 +485,35 @@ class TPCTimeSeries : public Task
               mAvgmTPCChi2[bin][1].addValue(sqrtChi2TPC);
               mAvgmTPCNCl[bin][1].addValue(nClTPC);
             }
+            float dedxNorm = val.dedxNorm[i];
+            if (dedxNorm > 0) {
+              mAvgmdEdxRatio[bin][0].addValue(dedxNorm);
+            }
+
+            float dedxIROC = val.dedxIROC[i];
+            if (dedxIROC > 0) {
+              mAvgmdEdxRatio[bin][1].addValue(dedxIROC);
+            }
+            float dedxOROC1 = val.dedxOROC1[i];
+            if (dedxOROC1 > 0) {
+              mAvgmdEdxRatio[bin][2].addValue(dedxOROC1);
+            }
+            float dedxOROC2 = val.dedxOROC2[i];
+            if (dedxOROC2 > 0) {
+              mAvgmdEdxRatio[bin][3].addValue(dedxOROC2);
+            }
+            float dedxOROC3 = val.dedxOROC3[i];
+            if (dedxOROC3 > 0) {
+              mAvgmdEdxRatio[bin][4].addValue(dedxOROC3);
+            }
+            float nClITS = val.nClITS[i];
+            if (nClITS > 0) {
+              mITSProperties[bin][0].addValue(nClITS);
+            }
+            float chi2ITS = val.chi2ITS[i];
+            if (chi2ITS > 0) {
+              mITSProperties[bin][1].addValue(chi2ITS);
+            }
           }
         }
       }
@@ -468,6 +529,7 @@ class TPCTimeSeries : public Task
         itsBuf.mITSTPC_C_Chi2Match[slice] = mAvgChi2MatchC[slice][i].getMean();
       }
 
+      // loop over TPC and ITS-TPC tracks
       for (int i = 0; i < mMIPdEdxRatioC[slice].size(); ++i) {
         auto& buff = (i == 0) ? mBufferDCA.mTSTPC : mBufferDCA.mTSITSTPC;
         buff.mMIPdEdxRatioC[slice] = mMIPdEdxRatioC[slice][i].getMean();
@@ -477,11 +539,46 @@ class TPCTimeSeries : public Task
         buff.mTPCNClC[slice] = mTPCNClC[slice][i].getMean();
         buff.mTPCNClA[slice] = mTPCNClA[slice][i].getMean();
       }
+      // dEdx ratio
+      // fill A-side
+      mBufferDCA.mLogdEdx_A_Median[slice] = mLogdEdxA[slice][0].getMedian();
+      mBufferDCA.mLogdEdx_A_RMS[slice] = mLogdEdxA[slice][0].getStdDev();
+      mBufferDCA.mLogdEdx_A_IROC_Median[slice] = mLogdEdxA[slice][1].getMedian();
+      mBufferDCA.mLogdEdx_A_IROC_RMS[slice] = mLogdEdxA[slice][1].getStdDev();
+      mBufferDCA.mLogdEdx_A_OROC1_Median[slice] = mLogdEdxA[slice][2].getMedian();
+      mBufferDCA.mLogdEdx_A_OROC1_RMS[slice] = mLogdEdxA[slice][2].getStdDev();
+      mBufferDCA.mLogdEdx_A_OROC2_Median[slice] = mLogdEdxA[slice][3].getMedian();
+      mBufferDCA.mLogdEdx_A_OROC2_RMS[slice] = mLogdEdxA[slice][3].getStdDev();
+      mBufferDCA.mLogdEdx_A_OROC3_Median[slice] = mLogdEdxA[slice][4].getMedian();
+      mBufferDCA.mLogdEdx_A_OROC3_RMS[slice] = mLogdEdxA[slice][4].getStdDev();
+      // fill C-side
+      mBufferDCA.mLogdEdx_C_Median[slice] = mLogdEdxC[slice][0].getMedian();
+      mBufferDCA.mLogdEdx_C_RMS[slice] = mLogdEdxC[slice][0].getStdDev();
+      mBufferDCA.mLogdEdx_C_IROC_Median[slice] = mLogdEdxC[slice][1].getMedian();
+      mBufferDCA.mLogdEdx_C_IROC_RMS[slice] = mLogdEdxC[slice][1].getStdDev();
+      mBufferDCA.mLogdEdx_C_OROC1_Median[slice] = mLogdEdxC[slice][2].getMedian();
+      mBufferDCA.mLogdEdx_C_OROC1_RMS[slice] = mLogdEdxC[slice][2].getStdDev();
+      mBufferDCA.mLogdEdx_C_OROC2_Median[slice] = mLogdEdxC[slice][3].getMedian();
+      mBufferDCA.mLogdEdx_C_OROC2_RMS[slice] = mLogdEdxC[slice][3].getStdDev();
+      mBufferDCA.mLogdEdx_C_OROC3_Median[slice] = mLogdEdxC[slice][4].getMedian();
+      mBufferDCA.mLogdEdx_C_OROC3_RMS[slice] = mLogdEdxC[slice][4].getStdDev();
+
+      // ITS properties
+      // A-side
+      mBufferDCA.mITS_A_NCl_Median[slice] = mITSPropertiesA[slice][0].getMedian();
+      mBufferDCA.mITS_A_NCl_RMS[slice] = mITSPropertiesA[slice][0].getStdDev();
+      mBufferDCA.mSqrtITSChi2_Ncl_A_Median[slice] = mITSPropertiesA[slice][1].getMedian();
+      mBufferDCA.mSqrtITSChi2_Ncl_A_RMS[slice] = mITSPropertiesA[slice][1].getStdDev();
+      // C-side
+      mBufferDCA.mITS_C_NCl_Median[slice] = mITSPropertiesC[slice][0].getMedian();
+      mBufferDCA.mITS_C_NCl_RMS[slice] = mITSPropertiesC[slice][0].getStdDev();
+      mBufferDCA.mSqrtITSChi2_Ncl_C_Median[slice] = mITSPropertiesC[slice][1].getMedian();
+      mBufferDCA.mSqrtITSChi2_Ncl_C_RMS[slice] = mITSPropertiesC[slice][1].getStdDev();
     }
 
     auto stop = timer::now();
     std::chrono::duration<float> time = stop - startTotal;
-    LOGP(detail, "DCA processing took {}", time.count());
+    LOGP(info, "Time series creation took {}", time.count());
 
     // send data
     sendOutput(pc);
@@ -508,6 +605,7 @@ class TPCTimeSeries : public Task
       tglBin.reserve(n);
       phiBin.reserve(n);
       qPtBin.reserve(n);
+      multBin.reserve(n);
       dcar.reserve(n);
       dcaz.reserve(n);
       dcarW.reserve(n);
@@ -518,6 +616,13 @@ class TPCTimeSeries : public Task
         hasITS.reserve(n);
         chi2Match.reserve(n);
         gID.reserve(n);
+        dedxNorm.reserve(n);
+        dedxIROC.reserve(n);
+        dedxOROC1.reserve(n);
+        dedxOROC2.reserve(n);
+        dedxOROC3.reserve(n);
+        nClITS.reserve(n);
+        chi2ITS.reserve(n);
       } else if (type == 0) {
         dcarcomb.reserve(n);
         dcazcomb.reserve(n);
@@ -530,6 +635,7 @@ class TPCTimeSeries : public Task
       tglBin.clear();
       phiBin.clear();
       qPtBin.clear();
+      multBin.clear();
       dcar.clear();
       dcaz.clear();
       dcarW.clear();
@@ -541,33 +647,47 @@ class TPCTimeSeries : public Task
       gID.clear();
       dcarcomb.clear();
       dcazcomb.clear();
+      dedxNorm.clear();
+      dedxIROC.clear();
+      dedxOROC1.clear();
+      dedxOROC2.clear();
+      dedxOROC3.clear();
+      nClITS.clear();
+      chi2ITS.clear();
     }
 
-    void emplace_back(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioTmp, float sqrtChi2TPCTmp, float nClTPCTmp, o2::dataformats::GlobalTrackID::Source gIDTmp = o2::dataformats::GlobalTrackID::Source::NSources, float chi2MatchTmp = -2, int hasITSTmp = -1)
+    void emplace_back(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, int multBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioTmp, float sqrtChi2TPCTmp, float nClTPCTmp, o2::dataformats::GlobalTrackID::Source gIDTmp, float chi2MatchTmp, int hasITSTmp, float dedxNormTmp, float dedxIROCTmp, float dedxOROC1Tmp, float dedxOROC2Tmp, float dedxOROC3Tmp, int nClITSTmp, float chi2ITSTmp)
     {
       side.emplace_back(sideTmp);
       tglBin.emplace_back(tglBinTmp);
       phiBin.emplace_back(phiBinTmp);
       qPtBin.emplace_back(qPtBinTmp);
+      multBin.emplace_back(multBinTmp);
       dcar.emplace_back(dcarTmp);
       dcaz.emplace_back(dcazTmp);
       dcarW.emplace_back(dcarWTmp);
       dedxRatio.emplace_back(dedxRatioTmp);
       sqrtChi2TPC.emplace_back(sqrtChi2TPCTmp);
       nClTPC.emplace_back(nClTPCTmp);
-      if (chi2MatchTmp != -2) {
-        chi2Match.emplace_back(chi2MatchTmp);
-        hasITS.emplace_back(hasITSTmp);
-        gID.emplace_back(gIDTmp);
-      }
+      chi2Match.emplace_back(chi2MatchTmp);
+      hasITS.emplace_back(hasITSTmp);
+      gID.emplace_back(gIDTmp);
+      dedxNorm.emplace_back(dedxNormTmp);
+      dedxIROC.emplace_back(dedxIROCTmp);
+      dedxOROC1.emplace_back(dedxOROC1Tmp);
+      dedxOROC2.emplace_back(dedxOROC2Tmp);
+      dedxOROC3.emplace_back(dedxOROC3Tmp);
+      nClITS.emplace_back(nClITSTmp);
+      chi2ITS.emplace_back(chi2ITSTmp);
     }
 
-    void emplace_back_ITSTPC(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioTmp, float sqrtChi2TPCTmp, float nClTPCTmp, float dcarCombTmp, float dcazCombTmp)
+    void emplace_back_ITSTPC(Side sideTmp, int tglBinTmp, int phiBinTmp, int qPtBinTmp, int multBinTmp, float dcarTmp, float dcazTmp, float dcarWTmp, float dedxRatioTmp, float sqrtChi2TPCTmp, float nClTPCTmp, float dcarCombTmp, float dcazCombTmp)
     {
       side.emplace_back(sideTmp);
       tglBin.emplace_back(tglBinTmp);
       phiBin.emplace_back(phiBinTmp);
       qPtBin.emplace_back(qPtBinTmp);
+      multBin.emplace_back(multBinTmp);
       dcar.emplace_back(dcarTmp);
       dcaz.emplace_back(dcazTmp);
       dcarW.emplace_back(dcarWTmp);
@@ -582,6 +702,7 @@ class TPCTimeSeries : public Task
     std::vector<int> tglBin;
     std::vector<int> phiBin;
     std::vector<int> qPtBin;
+    std::vector<int> multBin;
     std::vector<float> dcar;
     std::vector<float> dcaz;
     std::vector<float> dcarW;
@@ -592,57 +713,74 @@ class TPCTimeSeries : public Task
     std::vector<float> nClTPC;
     std::vector<float> dcarcomb;
     std::vector<float> dcazcomb;
+    std::vector<float> dedxNorm;
+    std::vector<float> dedxIROC;
+    std::vector<float> dedxOROC1;
+    std::vector<float> dedxOROC2;
+    std::vector<float> dedxOROC3;
+    std::vector<int> nClITS;
+    std::vector<float> chi2ITS;
     std::vector<o2::dataformats::GlobalTrackID::Source> gID;
   };
-  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;   ///< info for CCDB request
-  const bool mDisableWriter{false};                         ///< flag if no ROOT output will be written
-  o2::base::Propagator::MatCorrType mMatType;               ///< material for propagation
-  int mPhiBins = SECTORSPERSIDE;                            ///< number of phi bins
-  int mTglBins{3};                                          ///< number of tgl bins
-  int mQPtBins{20};                                         ///< number of qPt bins
-  TimeSeriesITSTPC mBufferDCA;                              ///< buffer for integrate DCAs
-  std::vector<std::array<RobustAverage, 3>> mAvgADCAr;      ///< for averaging the DCAr for TPC and ITS-TPC tracks for A-side
-  std::vector<std::array<RobustAverage, 3>> mAvgCDCAr;      ///< for averaging the DCAr for TPC and ITS-TPC tracks for C-side
-  std::vector<std::array<RobustAverage, 3>> mAvgADCAz;      ///< for averaging the DCAz for TPC and ITS-TPC tracks for A-side
-  std::vector<std::array<RobustAverage, 3>> mAvgCDCAz;      ///< for averaging the DCAz for TPC and ITS-TPC tracks for C-side
-  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioA; ///< for averaging MIP/dEdx
-  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioC; ///< for averaging MIP/dEdx
-  std::vector<std::array<RobustAverage, 2>> mTPCChi2A;      ///< for averaging chi2 TPC A
-  std::vector<std::array<RobustAverage, 2>> mTPCChi2C;      ///< for averaging chi2 TPC C
-  std::vector<std::array<RobustAverage, 2>> mTPCNClA;       ///< for averaging number of cluster A
-  std::vector<std::array<RobustAverage, 2>> mTPCNClC;       ///< for averaging number of cluster C
-  std::vector<std::array<RobustAverage, 3>> mAvgMeffA;      ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 3>> mAvgMeffC;      ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchA; ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchC; ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
-  int mNMaxTracks{-1};                                      ///< maximum number of tracks to process
-  float mMinMom{1};                                         ///< minimum accepted momentum
-  int mMinNCl{80};                                          ///< minimum accepted number of clusters per track
-  float mMaxTgl{1};                                         ///< maximum eta
-  float mMaxQPtBin{5};                                      ///< max qPt bin
-  float mCoarseStep{1};                                     ///< coarse step during track propagation
-  float mFineStep{0.005};                                   ///< fine step during track propagation
-  float mCutDCA{5};                                         ///< cut on the abs(DCA-median)
-  float mCutRMS{5};                                         ///< sigma cut for mean,median calculation
-  float mRefXSec{108.475};                                  ///< reference lx position for sector information (default centre of IROC)
-  int mNThreads{1};                                         ///< number of parallel threads
-  float maxITSTPCDCAr{0.2};                                 ///< maximum abs DCAr value for ITS-TPC tracks
-  float maxITSTPCDCAz{10};                                  ///< maximum abs DCAz value for ITS-TPC tracks
-  float maxITSTPCDCAr_comb{0.2};                            ///< max abs DCA for ITS-TPC DCA to vertex
-  float maxITSTPCDCAz_comb{0.2};                            ///< max abs DCA for ITS-TPC DCA to vertex
-  gsl::span<const TPCClRefElem> mTPCTrackClIdx{};           ///< cluster refs for debugging
-  std::vector<std::array<FillVals, 2>> mBufferVals;         ///< buffer for multithreading
-  uint32_t mFirstTFOrbit{0};                                ///< first TF orbit
-  float mTimeWindowMUS{50};                                 ///< time window in mus for local mult estimate
-  float mMIPdEdx{50};                                       ///< MIP dEdx position for MIP/dEdx monitoring
-  std::vector<int> mNTracksWindow;                          ///< number of tracks in time window
-  std::vector<int> mNearestVtxTPC;                          ///< nearest vertex for tpc tracks
-  o2::tpc::VDriftHelper mTPCVDriftHelper{};                 ///< helper for v-drift
-  float mVDrift{2.64};                                      ///< v drift in mus
-  bool mUseQMax{false};                                     ///< use dedx qmax for MIP/dEdx monitoring
-  float mMaxSnp{0.85};                                      ///< max sinus phi for propagation
-  float mXCoarse{40};                                       ///< perform propagation with coarse steps up to this mx
-  float mSqrt{13600};                                       ///< centre of mass energy
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;    ///< info for CCDB request
+  const bool mDisableWriter{false};                          ///< flag if no ROOT output will be written
+  o2::base::Propagator::MatCorrType mMatType;                ///< material for propagation
+  int mPhiBins = SECTORSPERSIDE;                             ///< number of phi bins
+  int mTglBins{3};                                           ///< number of tgl bins
+  int mQPtBins{20};                                          ///< number of qPt bins
+  TimeSeriesITSTPC mBufferDCA;                               ///< buffer for integrate DCAs
+  std::vector<std::array<RobustAverage, 3>> mAvgADCAr;       ///< for averaging the DCAr for TPC and ITS-TPC tracks for A-side
+  std::vector<std::array<RobustAverage, 3>> mAvgCDCAr;       ///< for averaging the DCAr for TPC and ITS-TPC tracks for C-side
+  std::vector<std::array<RobustAverage, 3>> mAvgADCAz;       ///< for averaging the DCAz for TPC and ITS-TPC tracks for A-side
+  std::vector<std::array<RobustAverage, 3>> mAvgCDCAz;       ///< for averaging the DCAz for TPC and ITS-TPC tracks for C-side
+  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioA;  ///< for averaging MIP/dEdx
+  std::vector<std::array<RobustAverage, 2>> mMIPdEdxRatioC;  ///< for averaging MIP/dEdx
+  std::vector<std::array<RobustAverage, 2>> mTPCChi2A;       ///< for averaging chi2 TPC A
+  std::vector<std::array<RobustAverage, 2>> mTPCChi2C;       ///< for averaging chi2 TPC C
+  std::vector<std::array<RobustAverage, 2>> mTPCNClA;        ///< for averaging number of cluster A
+  std::vector<std::array<RobustAverage, 2>> mTPCNClC;        ///< for averaging number of cluster C
+  std::vector<std::array<RobustAverage, 3>> mAvgMeffA;       ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 3>> mAvgMeffC;       ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchA;  ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 3>> mAvgChi2MatchC;  ///< for matching efficiency ITS-TPC standalone + afterburner, standalone, afterburner
+  std::vector<std::array<RobustAverage, 10>> mLogdEdxA;      ///< for log dedx A side
+  std::vector<std::array<RobustAverage, 10>> mLogdEdxC;      ///< for log dedx C side
+  std::vector<std::array<RobustAverage, 2>> mITSPropertiesA; ///< mITS_NCl, mSqrtITSChi2_Ncl, mSqrtMatchChi2
+  std::vector<std::array<RobustAverage, 2>> mITSPropertiesC; ///< mITS_NCl, mSqrtITSChi2_Ncl, mSqrtMatchChi2
+  int mNMaxTracks{-1};                                       ///< maximum number of tracks to process
+  float mMinMom{1};                                          ///< minimum accepted momentum
+  int mMinNCl{80};                                           ///< minimum accepted number of clusters per track
+  float mMaxTgl{1};                                          ///< maximum eta
+  float mMaxQPt{5};                                          ///< max qPt bin
+  float mCoarseStep{1};                                      ///< coarse step during track propagation
+  float mFineStep{0.005};                                    ///< fine step during track propagation
+  float mCutDCA{5};                                          ///< cut on the abs(DCA-median)
+  float mCutRMS{5};                                          ///< sigma cut for mean,median calculation
+  float mRefXSec{108.475};                                   ///< reference lx position for sector information (default centre of IROC)
+  int mNThreads{1};                                          ///< number of parallel threads
+  float maxITSTPCDCAr{0.2};                                  ///< maximum abs DCAr value for ITS-TPC tracks
+  float maxITSTPCDCAz{10};                                   ///< maximum abs DCAz value for ITS-TPC tracks
+  float maxITSTPCDCAr_comb{0.2};                             ///< max abs DCA for ITS-TPC DCA to vertex
+  float maxITSTPCDCAz_comb{0.2};                             ///< max abs DCA for ITS-TPC DCA to vertex
+  gsl::span<const TPCClRefElem> mTPCTrackClIdx{};            ///< cluster refs for debugging
+  std::vector<std::array<FillVals, 2>> mBufferVals;          ///< buffer for multithreading
+  uint32_t mFirstTFOrbit{0};                                 ///< first TF orbit
+  float mTimeWindowMUS{50};                                  ///< time window in mus for local mult estimate
+  float mMIPdEdx{50};                                        ///< MIP dEdx position for MIP/dEdx monitoring
+  std::vector<int> mNTracksWindow;                           ///< number of tracks in time window
+  std::vector<int> mNearestVtxTPC;                           ///< nearest vertex for tpc tracks
+  o2::tpc::VDriftHelper mTPCVDriftHelper{};                  ///< helper for v-drift
+  float mVDrift{2.64};                                       ///< v drift in mus
+  bool mUseQMax{false};                                      ///< use dedx qmax for MIP/dEdx monitoring
+  float mMaxSnp{0.85};                                       ///< max sinus phi for propagation
+  float mXCoarse{40};                                        ///< perform propagation with coarse steps up to this mx
+  float mSqrt{13600};                                        ///< centre of mass energy
+  int mMultBins{20};                                         ///< multiplicity bins
+  int mMultMax{80000};                                       ///< maximum multiplicity
+  PIDResponse mPID;                                          ///< PID response
+  int mMinTracksPerVertex{5};                                ///< minimum number of tracks per vertex
+  float mMaxdEdxRatio{0.3};                                  ///< maximum abs dedx ratio: log(dedx_exp(pion)/dedx)
+  float mMaxdEdxRegionRatio{0.5};                            ///< maximum abs dedx region ratio: log(dedx_region/dedx)
 
   /// check if track passes coarse cuts
   bool acceptTrack(const TrackTPC& track) const
@@ -653,7 +791,7 @@ class TPCTimeSeries : public Task
     return true;
   }
 
-  void fillDCA(const gsl::span<const TrackTPC> tracksTPC, const gsl::span<const o2::dataformats::TrackTPCITS> tracksITSTPC, const gsl::span<const o2::dataformats::PrimaryVertex> vertices, const int iTrk, const int iThread, const std::unordered_map<unsigned int, std::array<int, 2>>& indicesITSTPC)
+  void fillDCA(const gsl::span<const TrackTPC> tracksTPC, const gsl::span<const o2::dataformats::TrackTPCITS> tracksITSTPC, const gsl::span<const o2::dataformats::PrimaryVertex> vertices, const int iTrk, const int iThread, const std::unordered_map<unsigned int, std::array<int, 2>>& indicesITSTPC, const gsl::span<const o2::its::TrackITS> tracksITS)
   {
     TrackTPC track = tracksTPC[iTrk];
 
@@ -683,10 +821,16 @@ class TPCTimeSeries : public Task
 
     const int tglBin = mTglBins * std::abs(trackTmp.getTgl()) / mMaxTgl + mPhiBins;
     const int phiBin = mPhiBins * trackTmp.getPhi() / o2::constants::math::TwoPI;
-    const int qPtBin = mPhiBins + mTglBins + mQPtBins * (trackTmp.getQ2Pt() + mMaxQPtBin) / (2 * mMaxQPtBin);
+
+    const int offsQPtBin = mPhiBins + mTglBins;
+    const int qPtBin = offsQPtBin + mQPtBins * (trackTmp.getQ2Pt() + mMaxQPt) / (2 * mMaxQPt);
+    const int localMult = mNTracksWindow[iTrk];
+
+    const int offsMult = offsQPtBin + mQPtBins;
+    const int multBin = offsMult + mMultBins * localMult / mMultMax;
     const int nBins = getNBins();
 
-    if ((phiBin < 0) || (phiBin > mPhiBins) || (tglBin < mPhiBins) || (tglBin > (mPhiBins + mTglBins)) || (qPtBin < (mPhiBins + mTglBins)) || (qPtBin > (mPhiBins + mTglBins + mQPtBins))) {
+    if ((phiBin < 0) || (phiBin > mPhiBins) || (tglBin < mPhiBins) || (tglBin > offsQPtBin) || (qPtBin < offsQPtBin) || (qPtBin > offsMult) || (multBin < offsMult) || (multBin > offsMult + mMultBins)) {
       return;
     }
 
@@ -736,13 +880,60 @@ class TPCTimeSeries : public Task
       const float dedxRatio = (dedx > 0) ? (mMIPdEdx / dedx) : -1;
       const float sqrtChi2TPC = (track.getChi2() > 0) ? std::sqrt(track.getChi2()) : 0;
       const float nClTPC = track.getNClusters();
-
-      if (track.hasCSideClustersOnly()) {
-        mBufferVals[iThread].front().emplace_back(Side::C, tglBin, phiBin, qPtBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC);
-      } else if (track.hasASideClustersOnly()) {
-        mBufferVals[iThread].front().emplace_back(Side::A, tglBin, phiBin, qPtBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC);
+      const float dedxRatioNorm = mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx;
+      float dedxNorm = (dedxRatioNorm > 0) ? std::log(mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx) : -1;
+      // restrict to specified range
+      if (std::abs(dedxNorm > mMaxdEdxRatio)) {
+        dedxNorm = -1;
       }
 
+      // get log(dedxRegion / dedx)
+      float dedxIROC = -1;
+      float dedxOROC1 = -1;
+      float dedxOROC2 = -1;
+      float dedxOROC3 = -1;
+      if (dedx > 0) {
+        dedxIROC = mUseQMax ? track.getdEdx().dEdxMaxIROC : track.getdEdx().dEdxTotIROC;
+        dedxOROC1 = mUseQMax ? track.getdEdx().dEdxMaxOROC1 : track.getdEdx().dEdxTotOROC1;
+        dedxOROC2 = mUseQMax ? track.getdEdx().dEdxMaxOROC2 : track.getdEdx().dEdxTotOROC2;
+        dedxOROC3 = mUseQMax ? track.getdEdx().dEdxMaxOROC3 : track.getdEdx().dEdxTotOROC3;
+        dedxIROC /= dedx;
+        dedxOROC1 /= dedx;
+        dedxOROC2 /= dedx;
+        dedxOROC3 /= dedx;
+        dedxIROC = (dedxIROC > 0) ? std::log(dedxIROC) : -1;
+        dedxOROC1 = (dedxOROC1 > 0) ? std::log(dedxOROC1) : -1;
+        dedxOROC2 = (dedxOROC2 > 0) ? std::log(dedxOROC2) : -1;
+        dedxOROC3 = (dedxOROC3 > 0) ? std::log(dedxOROC3) : -1;
+
+        // restrict to specified range
+        if (std::abs(dedxIROC > mMaxdEdxRegionRatio)) {
+          dedxIROC = -1;
+        }
+        if (std::abs(dedxOROC1 > mMaxdEdxRegionRatio)) {
+          dedxOROC1 = -1;
+        }
+        if (std::abs(dedxOROC2 > mMaxdEdxRegionRatio)) {
+          dedxOROC2 = -1;
+        }
+        if (std::abs(dedxOROC3 > mMaxdEdxRegionRatio)) {
+          dedxOROC3 = -1;
+        }
+      }
+
+      const int nClITS = hasITSTPC ? tracksITS[tracksITSTPC[idxITSTPC.front()].getRefITS().getIndex()].getNClusters() : -1;
+      float chi2ITS = hasITSTPC ? tracksITS[tracksITSTPC[idxITSTPC.front()].getRefITS().getIndex()].getChi2() : -1;
+      if ((chi2ITS > 0) && (nClITS > 0)) {
+        chi2ITS = std::sqrt(chi2ITS / nClITS);
+      }
+
+      if (track.hasCSideClustersOnly()) {
+        mBufferVals[iThread].front().emplace_back(Side::C, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC, dedxNorm, dedxIROC, dedxOROC1, dedxOROC2, dedxOROC3, nClITS, chi2ITS);
+      } else if (track.hasASideClustersOnly()) {
+        mBufferVals[iThread].front().emplace_back(Side::A, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, gID, chi2Match, hasITSTPC, dedxNorm, dedxIROC, dedxOROC1, dedxOROC2, dedxOROC3, nClITS, chi2ITS);
+      }
+
+      // make propagation for ITS-TPC Track
       // check if the track was assigned to ITS track
       o2::gpu::gpustd::array<float, 2> dcaITSTPC{0, 0};
       if (hasITSTPC) {
@@ -768,9 +959,9 @@ class TPCTimeSeries : public Task
             }
 
             if (track.hasCSideClustersOnly()) {
-              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::C, tglBin, phiBin, qPtBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
+              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::C, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
             } else if (track.hasASideClustersOnly()) {
-              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::A, tglBin, phiBin, qPtBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
+              mBufferVals[iThread].back().emplace_back_ITSTPC(Side::A, tglBin, phiBin, qPtBin, multBin, dca[0], dcaZFromDeltaTime, dcarW, dedxRatio, sqrtChi2TPC, nClTPC, dcaITSTPCTmp[0], dcaITSTPCTmp[1]);
             }
           }
         }
@@ -789,6 +980,8 @@ class TPCTimeSeries : public Task
           const auto& trkOrig = tracksTPC[iTrk];
           const bool isNearestVtx = (idxITSTPC.back() == -1); // is nearest vertex in case no vertex was found
           const float mx_ITS = hasITSTPC ? tracksITSTPC[idxITSTPC.front()].getX() : -1;
+          const int nClITS = hasITSTPC ? tracksITS[tracksITSTPC[idxITSTPC.front()].getRefITS().getIndex()].getNClusters() : -1;
+          const int chi2ITS = hasITSTPC ? tracksITS[tracksITSTPC[idxITSTPC.front()].getRefITS().getIndex()].getChi2() : -1;
           int typeSide = 2; // A- and C-Side cluster
           if (track.hasASideClustersOnly()) {
             typeSide = 0;
@@ -831,11 +1024,15 @@ class TPCTimeSeries : public Task
                                                                                      << "chi2=" << trkOrig.getChi2()
                                                                                      << "mX=" << trkOrig.getX()
                                                                                      << "mX_ITS=" << mx_ITS
+                                                                                     << "nClITS=" << nClITS
+                                                                                     << "chi2ITS=" << chi2ITS
                                                                                      // meta
                                                                                      << "mult=" << mNTracksWindow[iTrk]
                                                                                      << "time_window_mult=" << mTimeWindowMUS
                                                                                      << "firstTFOrbit=" << mFirstTFOrbit
                                                                                      << "mVDrift=" << mVDrift
+                                                                                     << "its_flag=" << int(gID)
+                                                                                     << "sqrtChi2Match=" << chi2Match
                                                                                      << "\n";
         }
       })
@@ -965,6 +1162,121 @@ class TPCTimeSeries : public Task
     }
   }
 
+  std::unordered_map<unsigned int, int> processVertices(const gsl::span<const o2::dataformats::PrimaryVertex> vertices, const gsl::span<const o2::dataformats::VtxTrackIndex> primMatchedTracks, const gsl::span<const o2::dataformats::VtxTrackRef> primMatchedTracksRef)
+  {
+    // storing collision vertex to ITS-TPC track index
+    std::unordered_map<unsigned int, int> indicesITSTPC_vtx; // ITS-TPC track index -> collision vertex ID
+
+    std::unordered_map<int, int> nContributors_ITS;    // ITS: vertex ID -> n contributors
+    std::unordered_map<int, int> nContributors_ITSTPC; // ITS-TPC: vertex ID -> n contributors
+
+    // loop over collisions
+    if (!vertices.empty()) {
+      for (const auto& ref : primMatchedTracksRef) {
+        // loop over ITS and ITS-TPC sources
+        const std::array<o2::dataformats::VtxTrackIndex::Source, 2> sources = {o2::dataformats::VtxTrackIndex::Source::ITSTPC, o2::dataformats::VtxTrackIndex::Source::ITS};
+        for (auto source : sources) {
+          const int vID = ref.getVtxID(); // vertex ID
+          const int firstEntry = ref.getFirstEntryOfSource(source);
+          const int nEntries = ref.getEntriesOfSource(source);
+          // loop over all tracks belonging to the vertex
+          for (int i = 0; i < nEntries; ++i) {
+            const auto& matchedTrk = primMatchedTracks[i + firstEntry];
+            bool pvCont = matchedTrk.isPVContributor();
+            if (pvCont) {
+              indicesITSTPC_vtx[matchedTrk] = vID;
+              if (source == o2::dataformats::VtxTrackIndex::Source::ITSTPC) {
+                ++nContributors_ITSTPC[vID];
+              } else if (matchedTrk.isTrackSource(o2::dataformats::VtxTrackIndex::Source::ITS)) {
+                ++nContributors_ITS[vID];
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // calculate statistics
+    std::array<RobustAverage, 4> avgVtxITS;
+    std::array<RobustAverage, 4> avgVtxITSTPC;
+    for (int i = 0; i < avgVtxITS.size(); ++i) {
+      avgVtxITS[i].reserve(vertices.size());
+      avgVtxITSTPC[i].reserve(vertices.size());
+    }
+    for (int ivtx = 0; ivtx < vertices.size(); ++ivtx) {
+      const auto& vtx = vertices[ivtx];
+      const float itsFrac = nContributors_ITS[ivtx] / static_cast<float>(vtx.getNContributors());
+      const float itstpcFrac = (nContributors_ITS[ivtx] + nContributors_ITSTPC[ivtx]) / static_cast<float>(vtx.getNContributors());
+
+      const float itsMin = 0.2;
+      const float itsMax = 0.8;
+      if ((itsFrac > itsMin) && (itsFrac < itsMax)) {
+        avgVtxITS[0].addValue(vtx.getX());
+        avgVtxITS[1].addValue(vtx.getY());
+        avgVtxITS[2].addValue(vtx.getZ());
+        avgVtxITS[3].addValue(vtx.getNContributors());
+      }
+
+      const float itstpcMax = 0.95;
+      if (itstpcFrac < itstpcMax) {
+        avgVtxITSTPC[0].addValue(vtx.getX());
+        avgVtxITSTPC[1].addValue(vtx.getY());
+        avgVtxITSTPC[2].addValue(vtx.getZ());
+        avgVtxITSTPC[3].addValue(vtx.getNContributors());
+      }
+    }
+
+    // ITS
+    mBufferDCA.nPrimVertices_ITS.front() = avgVtxITS[3].getValues().size();
+    mBufferDCA.nVertexContributors_ITS_Median.front() = avgVtxITS[3].getMedian();
+    mBufferDCA.nVertexContributors_ITS_RMS.front() = avgVtxITS[3].getStdDev();
+    mBufferDCA.vertexX_ITS_Median.front() = avgVtxITS[0].getMedian();
+    mBufferDCA.vertexY_ITS_Median.front() = avgVtxITS[1].getMedian();
+    mBufferDCA.vertexZ_ITS_Median.front() = avgVtxITS[2].getMedian();
+    mBufferDCA.vertexX_ITS_RMS.front() = avgVtxITS[0].getStdDev();
+    mBufferDCA.vertexY_ITS_RMS.front() = avgVtxITS[1].getStdDev();
+    mBufferDCA.vertexZ_ITS_RMS.front() = avgVtxITS[2].getStdDev();
+
+    // ITS-TPC
+    mBufferDCA.nPrimVertices_ITSTPC.front() = avgVtxITSTPC[3].getValues().size();
+    mBufferDCA.nVertexContributors_ITSTPC_Median.front() = avgVtxITSTPC[3].getMedian();
+    mBufferDCA.nVertexContributors_ITSTPC_RMS.front() = avgVtxITSTPC[3].getStdDev();
+    mBufferDCA.vertexX_ITSTPC_Median.front() = avgVtxITSTPC[0].getMedian();
+    mBufferDCA.vertexY_ITSTPC_Median.front() = avgVtxITSTPC[1].getMedian();
+    mBufferDCA.vertexZ_ITSTPC_Median.front() = avgVtxITSTPC[2].getMedian();
+    mBufferDCA.vertexX_ITSTPC_RMS.front() = avgVtxITSTPC[0].getStdDev();
+    mBufferDCA.vertexY_ITSTPC_RMS.front() = avgVtxITSTPC[1].getStdDev();
+    mBufferDCA.vertexZ_ITSTPC_RMS.front() = avgVtxITSTPC[2].getStdDev();
+
+    // quantiles and truncated mean
+    RobustAverage avg(vertices.size(), false);
+    for (const auto& vtx : vertices) {
+      if (vtx.getNContributors() > mMinTracksPerVertex) {
+        // transform by n^0.5 to get more flat distribution
+        avg.addValue(std::sqrt(vtx.getNContributors()));
+      }
+    }
+
+    // nPrimVertices_Quantiles
+    int sizeQ = mBufferDCA.nVertexContributors_Quantiles.size();
+    if (sizeQ >= 12) {
+      for (int q = 1; q <= 9; ++q) {
+        const float quantile = q * 0.1;
+        const int iq = q - 1;
+        const float val = avg.getQuantile(quantile, 1);
+        mBufferDCA.nVertexContributors_Quantiles[iq] = val * val;
+      }
+      const float tr0 = avg.getTrunctedMean(0.05, 0.95);
+      const float tr1 = avg.getTrunctedMean(0.1, 0.9);
+      const float tr2 = avg.getTrunctedMean(0.2, 0.8);
+      mBufferDCA.nVertexContributors_Quantiles[sizeQ - 3] = tr0 * tr0;
+      mBufferDCA.nVertexContributors_Quantiles[sizeQ - 2] = tr1 * tr1;
+      mBufferDCA.nVertexContributors_Quantiles[sizeQ - 1] = tr2 * tr2;
+    }
+
+    return indicesITSTPC_vtx;
+  }
+
   /// \return returns total number of stored values per TF
   int getNBins() const { return mBufferDCA.mTSTPC.getNBins(); }
 };
@@ -975,6 +1287,7 @@ o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("tracksITSTPC", "GLO", "TPCITS", 0, Lifetime::Timeframe);
   inputs.emplace_back("tracksTPC", header::gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("tracksITS", header::gDataOriginITS, "TRACKS", 0, Lifetime::Timeframe);
   GPUCA_DEBUG_STREAMER_CHECK(if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamTimeSeries)) {
     // request tpc clusters only in case the debug streamer is used for the cluster bit mask
     inputs.emplace_back("trackTPCClRefs", header::gDataOriginTPC, "CLUSREFS", 0, Lifetime::Timeframe);
@@ -1005,30 +1318,37 @@ o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, 
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<TPCTimeSeries>(ccdbRequest, disableWriter, matType)},
-    Options{{"min-momentum", VariantType::Float, 0.2f, {"Minimum momentum of the tracks"}},
-            {"min-cluster", VariantType::Int, 80, {"Minimum number of clusters of the tracks"}},
-            {"max-tgl", VariantType::Float, 1.1f, {"Maximum accepted tgl of the tracks"}},
-            {"max-qPt-bin", VariantType::Float, 5.f, {"Maximum abs(qPt) bin"}},
-            {"max-snp", VariantType::Float, 0.85f, {"Maximum sinus(phi) for propagation"}},
-            {"coarse-step", VariantType::Float, 5.f, {"Coarse step during track propagation"}},
-            {"fine-step", VariantType::Float, 2.f, {"Fine step during track propagation"}},
-            {"mX-coarse", VariantType::Float, 40.f, {"Perform coarse propagation up to this mx"}},
-            {"max-tracks", VariantType::Int, -1, {"Number of maximum tracks to process"}},
-            {"cut-DCA-median", VariantType::Float, 3.f, {"Cut on the DCA: abs(DCA-medianDCA)<cut-DCA-median"}},
-            {"cut-DCA-RMS", VariantType::Float, 3.f, {"Sigma cut on the DCA"}},
-            {"refX-for-sector", VariantType::Float, 108.475f, {"Reference local x position for the sector information (default centre of IROC)"}},
-            {"tgl-bins", VariantType::Int, 10, {"Number of tgl bins for time series variables"}},
-            {"phi-bins", VariantType::Int, 18, {"Number of phi bins for time series variables"}},
-            {"qPt-bins", VariantType::Int, 18, {"Number of qPt bins for time series variables"}},
-            {"threads", VariantType::Int, 4, {"Number of parallel threads"}},
-            {"max-ITS-TPC-DCAr", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks"}},
-            {"max-ITS-TPC-DCAz", VariantType::Float, 10.f, {"Maximum absolut DCAz value for ITS-TPC tracks - larger due to vertex spread"}},
-            {"max-ITS-TPC-DCAr_comb", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks to vertex for combined DCA"}},
-            {"max-ITS-TPC-DCAz_comb", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks to vertex for combined DCA"}},
-            {"MIP-dedx", VariantType::Float, 50.f, {"MIP dEdx for MIP/dEdx monitoring"}},
-            {"time-window-mult-mus", VariantType::Float, 50.f, {"Time window in micro s for multiplicity estimate"}},
-            {"use-qMax", VariantType::Bool, false, {"Using qMax for MIP/dedx monitoring"}},
-            {"sqrts", VariantType::Float, 13600.f, {"Centre of mass energy used for downsampling"}}}};
+    Options{
+      {"min-momentum", VariantType::Float, 0.2f, {"Minimum momentum of the tracks"}},
+      {"min-cluster", VariantType::Int, 80, {"Minimum number of clusters of the tracks"}},
+      {"max-tgl", VariantType::Float, 1.1f, {"Maximum accepted tgl of the tracks"}},
+      {"max-qPt", VariantType::Float, 5.f, {"Maximum abs(qPt) bin"}},
+      {"max-snp", VariantType::Float, 0.85f, {"Maximum sinus(phi) for propagation"}},
+      {"coarse-step", VariantType::Float, 5.f, {"Coarse step during track propagation"}},
+      {"fine-step", VariantType::Float, 2.f, {"Fine step during track propagation"}},
+      {"mX-coarse", VariantType::Float, 40.f, {"Perform coarse propagation up to this mx"}},
+      {"max-tracks", VariantType::Int, -1, {"Number of maximum tracks to process"}},
+      {"cut-DCA-median", VariantType::Float, 3.f, {"Cut on the DCA: abs(DCA-medianDCA)<cut-DCA-median"}},
+      {"cut-DCA-RMS", VariantType::Float, 3.f, {"Sigma cut on the DCA"}},
+      {"refX-for-sector", VariantType::Float, 108.475f, {"Reference local x position for the sector information (default centre of IROC)"}},
+      {"tgl-bins", VariantType::Int, 10, {"Number of tgl bins for time series variables"}},
+      {"phi-bins", VariantType::Int, 18, {"Number of phi bins for time series variables"}},
+      {"qPt-bins", VariantType::Int, 18, {"Number of qPt bins for time series variables"}},
+      {"mult-bins", VariantType::Int, 20, {"Number of multiplicity bins for time series variables"}},
+      {"mult-max", VariantType::Int, 80000, {"MAximum multiplicity bin"}},
+      {"threads", VariantType::Int, 4, {"Number of parallel threads"}},
+      {"max-ITS-TPC-DCAr", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks"}},
+      {"max-ITS-TPC-DCAz", VariantType::Float, 10.f, {"Maximum absolut DCAz value for ITS-TPC tracks - larger due to vertex spread"}},
+      {"max-ITS-TPC-DCAr_comb", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks to vertex for combined DCA"}},
+      {"max-ITS-TPC-DCAz_comb", VariantType::Float, 0.2f, {"Maximum absolut DCAr value for ITS-TPC tracks to vertex for combined DCA"}},
+      {"MIP-dedx", VariantType::Float, 50.f, {"MIP dEdx for MIP/dEdx monitoring"}},
+      {"time-window-mult-mus", VariantType::Float, 50.f, {"Time window in micro s for multiplicity estimate"}},
+      {"use-qMax", VariantType::Bool, false, {"Using qMax for MIP/dedx monitoring"}},
+      {"sqrts", VariantType::Float, 13600.f, {"Centre of mass energy used for downsampling"}},
+      {"min-tracks-per-vertex", VariantType::Int, 6, {"Minimum number of tracks per vertex required"}},
+      {"max-dedx-ratio", VariantType::Float, 0.3f, {"Maximum absolute log(dedx(pion)/dedx) ratio"}},
+      {"max-dedx-region-ratio", VariantType::Float, 0.5f, {"Maximum absolute log(dedx(region)/dedx) ratio"}},
+    }};
 }
 
 } // namespace tpc

--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1318,7 +1318,7 @@ class TPCTimeSeries : public Task
     const float dedxRatioNorm = mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx;
     float dedxNorm = (dedxRatioNorm > 0) ? std::log(mPID.getExpectedSignal(track, o2::track::PID::ID(o2::track::PID::Pion)) / dedx) : -1;
     // restrict to specified range
-    if (std::abs(dedxNorm > mMaxdEdxRatio)) {
+    if (std::abs(dedxNorm) > mMaxdEdxRatio) {
       dedxNorm = -1;
     }
 
@@ -1342,16 +1342,16 @@ class TPCTimeSeries : public Task
       dedxOROC3 = (dedxOROC3 > 0) ? std::log(dedxOROC3) : -1;
 
       // restrict to specified range
-      if (std::abs(dedxIROC > mMaxdEdxRegionRatio)) {
+      if (std::abs(dedxIROC) > mMaxdEdxRegionRatio) {
         dedxIROC = -1;
       }
-      if (std::abs(dedxOROC1 > mMaxdEdxRegionRatio)) {
+      if (std::abs(dedxOROC1) > mMaxdEdxRegionRatio) {
         dedxOROC1 = -1;
       }
-      if (std::abs(dedxOROC2 > mMaxdEdxRegionRatio)) {
+      if (std::abs(dedxOROC2) > mMaxdEdxRegionRatio) {
         dedxOROC2 = -1;
       }
-      if (std::abs(dedxOROC3 > mMaxdEdxRegionRatio)) {
+      if (std::abs(dedxOROC3) > mMaxdEdxRegionRatio) {
         dedxOROC3 = -1;
       }
     }


### PR DESCRIPTION
- fixing allocation of too much memory
- Adding multiplicity bins
- Adding meta data to output tree
- Adding monitoring of vertex: n contributors ITS / n contributors, n contributors (ITS + ITS-TPC) / n contributors, quantiles 0.1 -> 0.9, trucated mean
- Adding monitoring of dedxsqrt(ITSChi2/ncl ITS), ncl ITS,
- Adding nClITS, chi2ITS, trackID, sqrtChi2Match to debug streamer