### PR TITLE
Cells become track seeds

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -107,7 +107,7 @@ class GpuTimeFrameChunk
   int* getDeviceIndexTables(const int);
   Tracklet* getDeviceTracklets(const int);
   int* getDeviceTrackletsLookupTables(const int);
-  Cell* getDeviceCells(const int);
+  CellSeed* getDeviceCells(const int);
   int* getDeviceCellsLookupTables(const int);
   int* getDeviceRoadsLookupTables(const int);
   TimeFrameGPUParameters* getTimeFrameGPUParameters() const { return mTFGPUParams; }
@@ -117,7 +117,7 @@ class GpuTimeFrameChunk
   int* getDeviceNFoundCells() { return mNFoundCellsDevice; }
   int* getDeviceCellNeigboursLookupTables(const int);
   int* getDeviceCellNeighbours(const int);
-  Cell** getDeviceArrayCells() const { return mCellsDeviceArray; }
+  CellSeed** getDeviceArrayCells() const { return mCellsDeviceArray; }
   int** getDeviceArrayNeighboursCell() const { return mNeighboursCellDeviceArray; }
   int** getDeviceArrayNeighboursCellLUT() const { return mNeighboursCellLookupTablesDeviceArray; }
 
@@ -141,7 +141,7 @@ class GpuTimeFrameChunk
   std::array<int*, nLayers> mIndexTablesDevice;
   std::array<Tracklet*, nLayers - 1> mTrackletsDevice;
   std::array<int*, nLayers - 1> mTrackletsLookupTablesDevice;
-  std::array<Cell*, nLayers - 2> mCellsDevice;
+  std::array<CellSeed*, nLayers - 2> mCellsDevice;
   // Road<nLayers - 2>* mRoadsDevice;
   std::array<int*, nLayers - 2> mCellsLookupTablesDevice;
   std::array<int*, nLayers - 3> mNeighboursCellDevice;
@@ -149,7 +149,7 @@ class GpuTimeFrameChunk
   std::array<int*, nLayers - 2> mRoadsLookupTablesDevice;
 
   // These are to make them accessible using layer index
-  Cell** mCellsDeviceArray;
+  CellSeed** mCellsDeviceArray;
   int** mNeighboursCellDeviceArray;
   int** mNeighboursCellLookupTablesDeviceArray;
 
@@ -231,7 +231,7 @@ class TimeFrameGPU : public TimeFrame
   Cluster** getDeviceArrayClusters() const { return mClustersDeviceArray; }
   Cluster** getDeviceArrayUnsortedClusters() const { return mUnsortedClustersDeviceArray; }
   Tracklet** getDeviceArrayTracklets() const { return mTrackletsDeviceArray; }
-  Cell** getDeviceArrayCells() const { return mCellsDeviceArray; }
+  CellSeed** getDeviceArrayCells() const { return mCellsDeviceArray; }
   o2::track::TrackParCovF** getDeviceArrayTrackSeeds() { return mCellSeedsDeviceArray; }
   float** getDeviceArrayTrackSeedsChi2() { return mCellSeedsChi2DeviceArray; }
   void setDevicePropagator(const o2::base::PropagatorImpl<float>*) override;
@@ -262,8 +262,8 @@ class TimeFrameGPU : public TimeFrame
   Cluster** mUnsortedClustersDeviceArray;
   std::array<Tracklet*, nLayers - 1> mTrackletsDevice;
   Tracklet** mTrackletsDeviceArray;
-  std::array<Cell*, nLayers - 2> mCellsDevice;
-  Cell** mCellsDeviceArray;
+  std::array<CellSeed*, nLayers - 2> mCellsDevice;
+  CellSeed** mCellsDeviceArray;
   std::array<o2::track::TrackParCovF*, nLayers - 2> mCellSeedsDevice;
   o2::track::TrackParCovF** mCellSeedsDeviceArray;
   std::array<float*, nLayers - 2> mCellSeedsChi2Device;

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -117,7 +117,7 @@ void GpuTimeFrameChunk<nLayers>::allocate(const size_t nrof, Stream& stream)
       checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&(mTrackletsDevice[i])), sizeof(Tracklet) * mTFGPUParams->maxTrackletsPerCluster * mTFGPUParams->clustersPerROfCapacity * nrof, stream.get()));
       if (i < nLayers - 2) {
         checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&(mCellsLookupTablesDevice[i])), sizeof(int) * mTFGPUParams->validatedTrackletsCapacity * nrof, stream.get()));
-        checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&(mCellsDevice[i])), sizeof(Cell) * mTFGPUParams->maxNeighboursSize * nrof, stream.get()));
+        checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&(mCellsDevice[i])), sizeof(CellSeed) * mTFGPUParams->maxNeighboursSize * nrof, stream.get()));
         checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mRoadsLookupTablesDevice[i]), sizeof(int) * mTFGPUParams->maxNeighboursSize * nrof, stream.get()));
         if (i < nLayers - 3) {
           checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&(mNeighboursCellLookupTablesDevice[i])), sizeof(int) * mTFGPUParams->maxNeighboursSize * nrof, stream.get()));
@@ -140,12 +140,12 @@ void GpuTimeFrameChunk<nLayers>::allocate(const size_t nrof, Stream& stream)
   /// Invariant allocations
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mFoundTrackletsDevice), (nLayers - 1) * sizeof(int) * nrof, stream.get())); // No need to reset, we always read it after writing
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mNFoundCellsDevice), (nLayers - 2) * sizeof(int) * nrof, stream.get()));
-  checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mCellsDeviceArray), (nLayers - 2) * sizeof(Cell*), stream.get()));
+  checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mCellsDeviceArray), (nLayers - 2) * sizeof(CellSeed*), stream.get()));
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mNeighboursCellDeviceArray), (nLayers - 3) * sizeof(int*), stream.get()));
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mNeighboursCellLookupTablesDeviceArray), (nLayers - 3) * sizeof(int*), stream.get()));
 
   /// Copy pointers of allocated memory to regrouping arrays
-  checkGPUError(cudaMemcpyAsync(mCellsDeviceArray, mCellsDevice.data(), (nLayers - 2) * sizeof(Cell*), cudaMemcpyHostToDevice, stream.get()));
+  checkGPUError(cudaMemcpyAsync(mCellsDeviceArray, mCellsDevice.data(), (nLayers - 2) * sizeof(CellSeed*), cudaMemcpyHostToDevice, stream.get()));
   checkGPUError(cudaMemcpyAsync(mNeighboursCellDeviceArray, mNeighboursCellDevice.data(), (nLayers - 3) * sizeof(int*), cudaMemcpyHostToDevice, stream.get()));
   checkGPUError(cudaMemcpyAsync(mNeighboursCellLookupTablesDeviceArray, mNeighboursCellLookupTablesDevice.data(), (nLayers - 3) * sizeof(int*), cudaMemcpyHostToDevice, stream.get()));
 
@@ -199,7 +199,7 @@ size_t GpuTimeFrameChunk<nLayers>::computeScalingSizeBytes(const int nrof, const
   rofsize += 2 * sizeof(int) * config.clustersPerROfCapacity;                                                  // tracklets found per cluster (vertexer)
   rofsize += sizeof(unsigned char) * config.maxTrackletsPerCluster * config.clustersPerROfCapacity;            // used tracklets (vertexer)
   rofsize += (nLayers - 2) * sizeof(int) * config.validatedTrackletsCapacity;                                  // cells lookup tables
-  rofsize += (nLayers - 2) * sizeof(Cell) * config.maxNeighboursSize;                                          // cells
+  rofsize += (nLayers - 2) * sizeof(CellSeed) * config.maxNeighboursSize;                                      // cells
   rofsize += (nLayers - 3) * sizeof(int) * config.maxNeighboursSize;                                           // cell neighbours lookup tables
   rofsize += (nLayers - 3) * sizeof(int) * config.maxNeighboursSize;                                           // cell neighbours
   rofsize += sizeof(Road<nLayers - 2>) * config.maxRoadPerRofSize;                                             // roads
@@ -267,7 +267,7 @@ int* GpuTimeFrameChunk<nLayers>::getDeviceTrackletsLookupTables(const int layer)
 }
 
 template <int nLayers>
-Cell* GpuTimeFrameChunk<nLayers>::getDeviceCells(const int layer)
+CellSeed* GpuTimeFrameChunk<nLayers>::getDeviceCells(const int layer)
 {
   return mCellsDevice[layer];
 }
@@ -555,45 +555,15 @@ template <int nLayers>
 void TimeFrameGPU<nLayers>::loadCellsDevice()
 {
   for (auto iLayer{0}; iLayer < nLayers - 2; ++iLayer) {
-    LOGP(debug, "gpu-transfer: loading {} cells on layer {}, for {} MB.", mCells[iLayer].size(), iLayer, mCells[iLayer].size() * sizeof(Cell) / MB);
-    allocMemAsync(reinterpret_cast<void**>(&mCellsDevice[iLayer]), mCells[iLayer].size() * sizeof(Cell), nullptr, getExtAllocator());
+    LOGP(debug, "gpu-transfer: loading {} cell seeds on layer {}, for {} MB.", mCells[iLayer].size(), iLayer, mCells[iLayer].size() * sizeof(CellSeed) / MB);
+    allocMemAsync(reinterpret_cast<void**>(&mCellsDevice[iLayer]), mCells[iLayer].size() * sizeof(CellSeed), nullptr, getExtAllocator());
     // Register and move data
-    checkGPUError(cudaHostRegister(mCells[iLayer].data(), mCells[iLayer].size() * sizeof(Cell), cudaHostRegisterPortable));
-    checkGPUError(cudaMemcpyAsync(mCellsDevice[iLayer], mCells[iLayer].data(), mCells[iLayer].size() * sizeof(Cell), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
+    checkGPUError(cudaHostRegister(mCells[iLayer].data(), mCells[iLayer].size() * sizeof(CellSeed), cudaHostRegisterPortable));
+    checkGPUError(cudaMemcpyAsync(mCellsDevice[iLayer], mCells[iLayer].data(), mCells[iLayer].size() * sizeof(CellSeed), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
   }
-  allocMemAsync(reinterpret_cast<void**>(&mCellsDeviceArray), (nLayers - 2) * sizeof(Cell*), nullptr, getExtAllocator());
-  checkGPUError(cudaHostRegister(mCellsDevice.data(), (nLayers - 2) * sizeof(Cell*), cudaHostRegisterPortable));
-  checkGPUError(cudaMemcpyAsync(mCellsDeviceArray, mCellsDevice.data(), (nLayers - 2) * sizeof(Cell*), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
-}
-
-template <int nLayers>
-void TimeFrameGPU<nLayers>::loadTrackSeedsDevice()
-{
-  for (auto iLayer{0}; iLayer < nLayers - 2; ++iLayer) {
-    LOGP(debug, "gpu-transfer: loading {} seeds on layer {}, for {} MB.", mCellSeeds[iLayer].size(), iLayer, mCellSeeds[iLayer].size() * sizeof(o2::track::TrackParCovF) / MB);
-    allocMemAsync(reinterpret_cast<void**>(&mCellSeedsDevice[iLayer]), mCellSeeds[iLayer].size() * sizeof(o2::track::TrackParCovF), nullptr, getExtAllocator());
-    // Register and move data
-    checkGPUError(cudaHostRegister(mCellSeeds[iLayer].data(), mCellSeeds[iLayer].size() * sizeof(o2::track::TrackParCovF), cudaHostRegisterPortable));
-    checkGPUError(cudaMemcpyAsync(mCellSeedsDevice[iLayer], mCellSeeds[iLayer].data(), mCellSeeds[iLayer].size() * sizeof(o2::track::TrackParCovF), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
-  }
-  allocMemAsync(reinterpret_cast<void**>(&mCellSeedsDeviceArray), (nLayers - 2) * sizeof(o2::track::TrackParCovF*), nullptr, getExtAllocator());
-  checkGPUError(cudaHostRegister(mCellSeedsDevice.data(), (nLayers - 2) * sizeof(o2::track::TrackParCovF*), cudaHostRegisterPortable));
-  checkGPUError(cudaMemcpyAsync(mCellSeedsDeviceArray, mCellSeedsDevice.data(), (nLayers - 2) * sizeof(o2::track::TrackParCovF*), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
-}
-
-template <int nLayers>
-void TimeFrameGPU<nLayers>::loadTrackSeedsChi2Device()
-{
-  for (auto iLayer{0}; iLayer < nLayers - 2; ++iLayer) {
-    LOGP(debug, "gpu-transfer: loading {} seeds' chi2 on layer {}, for {} MB.", mCellSeedsChi2[iLayer].size(), iLayer, mCellSeedsChi2[iLayer].size() * sizeof(float) / MB);
-    allocMemAsync(reinterpret_cast<void**>(&mCellSeedsChi2Device[iLayer]), mCellSeedsChi2[iLayer].size() * sizeof(float), nullptr, getExtAllocator());
-    // Register and move data
-    checkGPUError(cudaHostRegister(mCellSeedsChi2[iLayer].data(), mCellSeedsChi2[iLayer].size() * sizeof(float), cudaHostRegisterPortable));
-    checkGPUError(cudaMemcpyAsync(mCellSeedsChi2Device[iLayer], mCellSeedsChi2[iLayer].data(), mCellSeedsChi2[iLayer].size() * sizeof(float), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
-  }
-  allocMemAsync(reinterpret_cast<void**>(&mCellSeedsChi2DeviceArray), (nLayers - 2) * sizeof(float*), nullptr, getExtAllocator());
-  checkGPUError(cudaHostRegister(mCellSeedsChi2Device.data(), (nLayers - 2) * sizeof(float*), cudaHostRegisterPortable));
-  checkGPUError(cudaMemcpyAsync(mCellSeedsChi2DeviceArray, mCellSeedsChi2Device.data(), (nLayers - 2) * sizeof(float*), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
+  allocMemAsync(reinterpret_cast<void**>(&mCellsDeviceArray), (nLayers - 2) * sizeof(CellSeed*), nullptr, getExtAllocator());
+  checkGPUError(cudaHostRegister(mCellsDevice.data(), (nLayers - 2) * sizeof(CellSeed*), cudaHostRegisterPortable));
+  checkGPUError(cudaMemcpyAsync(mCellsDeviceArray, mCellsDevice.data(), (nLayers - 2) * sizeof(CellSeed*), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
 }
 
 template <int nLayers>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -75,33 +75,36 @@ GPUdi() Cell::Cell(const int firstClusterIndex, const int secondClusterIndex, co
   // Nothing to do
 }
 
-class CellSeed final : public o2::track::TrackParCovF {
-  public:
-    GPUhd() CellSeed() = default;
-    GPUd() CellSeed(int innerL, int cl0, int cl1, int cl2, int trkl0, int trkl1, o2::track::TrackParCovF& tpc, float chi2) : o2::track::TrackParCovF{tpc}, mChi2{chi2} {
-      setUserField(innerL);
-      mClusters[innerL + 0] = cl0;
-      mClusters[innerL + 1] = cl1;
-      mClusters[innerL + 2] = cl2;
-      mTracklets[0] = trkl0;
-      mTracklets[1] = trkl1;
+class CellSeed final : public o2::track::TrackParCovF
+{
+ public:
+  GPUhd() CellSeed() = default;
+  GPUd() CellSeed(int innerL, int cl0, int cl1, int cl2, int trkl0, int trkl1, o2::track::TrackParCovF& tpc, float chi2) : o2::track::TrackParCovF{tpc}, mChi2{chi2}, mLevel{1}
+  {
+    setUserField(innerL);
+    mClusters[innerL + 0] = cl0;
+    mClusters[innerL + 1] = cl1;
+    mClusters[innerL + 2] = cl2;
+    mTracklets[0] = trkl0;
+    mTracklets[1] = trkl1;
+  }
+  GPUhd() int getFirstClusterIndex() const { return mClusters[getUserField()]; };
+  GPUhd() int getSecondClusterIndex() const { return mClusters[getUserField() + 1]; };
+  GPUhd() int getThirdClusterIndex() const { return mClusters[getUserField() + 2]; };
+  GPUhd() int getFirstTrackletIndex() const { return mTracklets[0]; };
+  GPUhd() int getSecondTrackletIndex() const { return mTracklets[1]; };
+  GPUhd() int getChi2() const { return mChi2; };
+  GPUhd() void setChi2(float chi2) { mChi2 = chi2; };
+  GPUhd() int getLevel() const { return mLevel; };
+  GPUhd() void setLevel(int level) { mLevel = level; };
+  GPUhd() int* getLevelPtr() { return &mLevel; }
+  GPUhd() int* getClusters() { return mClusters; }
 
-    }
-    GPUhd() int getFirstClusterIndex() const { return mClusters[getUserField()]; };
-    GPUhd() int getSecondClusterIndex() const { return mClusters[getUserField() + 1]; };
-    GPUhd() int getThirdClusterIndex() const { return mClusters[getUserField() + 2]; };
-    GPUhd() int getFirstTrackletIndex() const { return mTracklets[0]; };
-    GPUhd() int getSecondTrackletIndex() const { return mTracklets[1]; };
-    GPUhd() int getLevel() const { return mLevel; };
-    GPUhd() void setLevel(const int level) { mLevel = level; };
-    GPUhd() int* getLevelPtr() { return &mLevel; }
-    GPUhd() int* getClusters() { return mClusters; }
-
-  private:
-    int mClusters[7] = {-1, -1, -1, -1, -1, -1, -1};
-    int mTracklets[2] = {-1, -1};
-    int mLevel = 0;
-    float mChi2 = 0.f;
+ private:
+  int mClusters[7] = {-1, -1, -1, -1, -1, -1, -1};
+  int mTracklets[2] = {-1, -1};
+  int mLevel = 0;
+  float mChi2 = 0.f;
 };
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -75,6 +75,35 @@ GPUdi() Cell::Cell(const int firstClusterIndex, const int secondClusterIndex, co
   // Nothing to do
 }
 
+class CellSeed final : public o2::track::TrackParCovF {
+  public:
+    GPUhd() CellSeed() = default;
+    GPUd() CellSeed(int innerL, int cl0, int cl1, int cl2, int trkl0, int trkl1, o2::track::TrackParCovF& tpc, float chi2) : o2::track::TrackParCovF{tpc}, mChi2{chi2} {
+      setUserField(innerL);
+      mClusters[innerL + 0] = cl0;
+      mClusters[innerL + 1] = cl1;
+      mClusters[innerL + 2] = cl2;
+      mTracklets[0] = trkl0;
+      mTracklets[1] = trkl1;
+
+    }
+    GPUhd() int getFirstClusterIndex() const { return mClusters[getUserField()]; };
+    GPUhd() int getSecondClusterIndex() const { return mClusters[getUserField() + 1]; };
+    GPUhd() int getThirdClusterIndex() const { return mClusters[getUserField() + 2]; };
+    GPUhd() int getFirstTrackletIndex() const { return mTracklets[0]; };
+    GPUhd() int getSecondTrackletIndex() const { return mTracklets[1]; };
+    GPUhd() int getLevel() const { return mLevel; };
+    GPUhd() void setLevel(const int level) { mLevel = level; };
+    GPUhd() int* getLevelPtr() { return &mLevel; }
+    GPUhd() int* getClusters() { return mClusters; }
+
+  private:
+    int mClusters[7] = {-1, -1, -1, -1, -1, -1, -1};
+    int mTracklets[2] = {-1, -1};
+    int mLevel = 0;
+    float mChi2 = 0.f;
+};
+
 } // namespace its
 } // namespace o2
 #endif /* TRACKINGITSU_INCLUDE_CACELL_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -163,9 +163,7 @@ class TimeFrame
   std::vector<std::vector<Cluster>>& getClusters();
   std::vector<std::vector<Cluster>>& getUnsortedClusters();
   int getClusterROF(int iLayer, int iCluster);
-  std::vector<std::vector<Cell>>& getCells();
-  std::vector<std::vector<o2::track::TrackParCovF>>& getCellSeeds();
-  std::vector<std::vector<float>>& getCellSeedsChi2() { return mCellSeedsChi2; }
+  std::vector<std::vector<CellSeed>>& getCells();
 
   std::vector<std::vector<int>>& getCellsLookupTable();
   std::vector<std::vector<int>>& getCellsNeighbours();
@@ -272,7 +270,7 @@ class TimeFrame
   ExternalAllocator* mAllocator = nullptr;
   std::vector<std::vector<Cluster>> mUnsortedClusters;
   std::vector<std::vector<Tracklet>> mTracklets;
-  std::vector<std::vector<Cell>> mCells;
+  std::vector<std::vector<CellSeed>> mCells;
   std::vector<std::vector<o2::track::TrackParCovF>> mCellSeeds;
   std::vector<std::vector<float>> mCellSeedsChi2;
   std::vector<Road<5>> mRoads;
@@ -577,9 +575,7 @@ inline std::vector<std::vector<Cluster>>& TimeFrame::getUnsortedClusters()
   return mUnsortedClusters;
 }
 
-inline std::vector<std::vector<Cell>>& TimeFrame::getCells() { return mCells; }
-
-inline std::vector<std::vector<o2::track::TrackParCovF>>& TimeFrame::getCellSeeds() { return mCellSeeds; }
+inline std::vector<std::vector<CellSeed>>& TimeFrame::getCells() { return mCells; }
 
 inline std::vector<std::vector<int>>& TimeFrame::getCellsLookupTable()
 {
@@ -645,9 +641,10 @@ inline int TimeFrame::getNumberOfTracklets() const
   return nTracklets;
 }
 
-inline int TimeFrame::getNumberOfNeighbours() const {
+inline int TimeFrame::getNumberOfNeighbours() const
+{
   int n{0};
-  for (auto & l : mCellsNeighbours) {
+  for (auto& l : mCellsNeighbours) {
     n += l.size();
   }
   return n;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -179,6 +179,7 @@ class TimeFrame
   int getNumberOfClusters() const;
   int getNumberOfCells() const;
   int getNumberOfTracklets() const;
+  int getNumberOfNeighbours() const;
   size_t getNumberOfTracks() const;
   size_t getNumberOfUsedClusters() const;
 
@@ -642,6 +643,14 @@ inline int TimeFrame::getNumberOfTracklets() const
     nTracklets += layer.size();
   }
   return nTracklets;
+}
+
+inline int TimeFrame::getNumberOfNeighbours() const {
+  int n{0};
+  for (auto & l : mCellsNeighbours) {
+    n += l.size();
+  }
+  return n;
 }
 
 inline size_t TimeFrame::getNumberOfTracks() const

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -262,8 +262,6 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     mTracksLabel.resize(mNrof);
     mLinesLabels.resize(mNrof);
     mCells.resize(trkParam.CellsPerRoad());
-    mCellSeeds.resize(trkParam.CellsPerRoad());
-    mCellSeedsChi2.resize(trkParam.CellsPerRoad());
     mCellsLookupTable.resize(trkParam.CellsPerRoad() - 1);
     mCellsNeighbours.resize(trkParam.CellsPerRoad() - 1);
     mCellsNeighboursLUT.resize(trkParam.CellsPerRoad() - 1);
@@ -397,8 +395,6 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     mTrackletLabels[iLayer].clear();
     if (iLayer < (int)mCells.size()) {
       mCells[iLayer].clear();
-      mCellSeeds[iLayer].clear();
-      mCellSeedsChi2[iLayer].clear();
       mTrackletsLookupTable[iLayer].clear();
       mTrackletsLookupTable[iLayer].resize(mClusters[iLayer + 1].size(), 0);
       mCellLabels[iLayer].clear();

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -131,6 +131,7 @@ void Tracker::clustersToTracksHybrid(std::function<void(std::string s)> logger, 
       break;
     }
     total += evaluateTask(&Tracker::findCellsNeighboursHybrid, "Hybrid Neighbour finding", logger, iteration);
+    logger(fmt::format("\t- Number of Neighbours: {}", mTimeFrame->getNumberOfNeighbours()));
     total += evaluateTask(&Tracker::findRoadsHybrid, "Hybrid Road finding", logger, iteration);
     logger(fmt::format("\t- Number of Roads: {}", mTimeFrame->getRoads().size()));
     total += evaluateTask(&Tracker::findTracksHybrid, "Hybrid Track fitting", logger, iteration);

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -236,7 +236,7 @@ void Tracker::computeRoadsMClabels()
         }
       }
 
-      const Cell& currentCell{mTimeFrame->getCells()[iCell][currentCellIndex]};
+      const CellSeed& currentCell{mTimeFrame->getCells()[iCell][currentCellIndex]};
 
       if (isFirstRoadCell) {
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -76,6 +76,7 @@ void Tracker::clustersToTracks(std::function<void(std::string s)> logger, std::f
     }
 
     total += evaluateTask(&Tracker::findCellsNeighbours, "Neighbour finding", logger, iteration);
+    logger(fmt::format("\t- Number of neighbours: {}", mTimeFrame->getNumberOfNeighbours()));
     total += evaluateTask(&Tracker::findRoads, "Road finding", logger, iteration);
     logger(fmt::format("\t- Number of Roads: {}", mTimeFrame->getRoads().size()));
     total += evaluateTask(&Tracker::findTracks, "Track finding", logger);

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -347,11 +347,8 @@ void TrackerTraits::computeLayerCells(const int iteration)
           if (!good) {
             continue;
           }
-          tf->getCells()[iLayer].emplace_back(
-            currentTracklet.firstClusterIndex, nextTracklet.firstClusterIndex, nextTracklet.secondClusterIndex,
-            iTracklet, iNextTracklet);
-          tf->getCellSeeds()[iLayer].emplace_back(track);
-          tf->getCellSeedsChi2()[iLayer].emplace_back(chi2);
+          tf->getCells()[iLayer].emplace_back(iLayer, currentTracklet.firstClusterIndex, nextTracklet.firstClusterIndex, nextTracklet.secondClusterIndex,
+                                              iTracklet, iNextTracklet, track, chi2);
         }
       }
     }
@@ -403,16 +400,14 @@ void TrackerTraits::findCellsNeighbours(const int iteration)
 
     for (int iCell{0}; iCell < layerCellsNum; ++iCell) {
 
-      const Cell& currentCell{mTimeFrame->getCells()[iLayer][iCell]};
-      const auto& currentCellSeed{mTimeFrame->getCellSeeds()[iLayer][iCell]};
-      const int nextLayerTrackletIndex{currentCell.getSecondTrackletIndex()};
+      const auto& currentCellSeed{mTimeFrame->getCells()[iLayer][iCell]};
+      const int nextLayerTrackletIndex{currentCellSeed.getSecondTrackletIndex()};
       const int nextLayerFirstCellIndex{mTimeFrame->getCellsLookupTable()[iLayer][nextLayerTrackletIndex]};
       const int nextLayerLastCellIndex{mTimeFrame->getCellsLookupTable()[iLayer][nextLayerTrackletIndex + 1]};
       for (int iNextCell{nextLayerFirstCellIndex}; iNextCell < nextLayerLastCellIndex; ++iNextCell) {
 
-        Cell& nextCell{mTimeFrame->getCells()[iLayer + 1][iNextCell]};
-        auto nextCellSeed{mTimeFrame->getCellSeeds()[iLayer + 1][iNextCell]}; /// copy
-        if (nextCell.getFirstTrackletIndex() != nextLayerTrackletIndex) {
+        auto nextCellSeed{mTimeFrame->getCells()[iLayer + 1][iNextCell]}; /// copy
+        if (nextCellSeed.getFirstTrackletIndex() != nextLayerTrackletIndex) {
           break;
         }
 
@@ -433,10 +428,10 @@ void TrackerTraits::findCellsNeighbours(const int iteration)
 
         mTimeFrame->getCellsNeighboursLUT()[iLayer][iNextCell]++;
         cellsNeighbours.push_back(std::make_pair(iCell, iNextCell));
-        const int currentCellLevel{currentCell.getLevel()};
+        const int currentCellLevel{currentCellSeed.getLevel()};
 
-        if (currentCellLevel >= nextCell.getLevel()) {
-          nextCell.setLevel(currentCellLevel + 1);
+        if (currentCellLevel >= nextCellSeed.getLevel()) {
+          mTimeFrame->getCells()[iLayer + 1][iNextCell].setLevel(currentCellLevel + 1);
         }
       }
     }
@@ -460,7 +455,7 @@ void TrackerTraits::findRoads(const int iteration)
     for (int iLayer{mTrkParams[iteration].CellsPerRoad() - 1}; iLayer >= minimumLevel; --iLayer) {
       const int levelCellsNum{static_cast<int>(mTimeFrame->getCells()[iLayer].size())};
       for (int iCell{0}; iCell < levelCellsNum; ++iCell) {
-        Cell& currentCell{mTimeFrame->getCells()[iLayer][iCell]};
+        CellSeed& currentCell{mTimeFrame->getCells()[iLayer][iCell]};
         if (currentCell.getLevel() != iLevel) {
           continue;
         }
@@ -476,7 +471,7 @@ void TrackerTraits::findRoads(const int iteration)
         bool isFirstValidNeighbour = true;
         for (int iNeighbourCell{startNeighbourId}; iNeighbourCell < endNeighbourId; ++iNeighbourCell) {
           const int neighbourCellId = mTimeFrame->getCellsNeighbours()[iLayer - 1][iNeighbourCell];
-          const Cell& neighbourCell = mTimeFrame->getCells()[iLayer - 1][neighbourCellId];
+          const CellSeed& neighbourCell = mTimeFrame->getCells()[iLayer - 1][neighbourCellId];
           if (iLevel - 1 != neighbourCell.getLevel()) {
             continue;
           }
@@ -567,11 +562,8 @@ void TrackerTraits::findTracks()
       }
     }
 
-    TrackITSExt temporaryTrack{mTimeFrame->getCellSeeds()[lastCellLevel][lastCellIndex]};
-    // if (ri < 5) {
-    //   temporaryTrack.print();
-    // }
-    temporaryTrack.setChi2(mTimeFrame->getCellSeedsChi2()[lastCellLevel][lastCellIndex]);
+    TrackITSExt temporaryTrack{mTimeFrame->getCells()[lastCellLevel][lastCellIndex]};
+    temporaryTrack.setChi2(mTimeFrame->getCells()[lastCellLevel][lastCellIndex].getChi2());
     for (size_t iC = 0; iC < clusters.size(); ++iC) {
       temporaryTrack.setExternalClusterIndex(iC, clusters[iC], clusters[iC] != constants::its::UnusedIndex);
     }
@@ -971,7 +963,7 @@ track::TrackParCov TrackerTraits::buildTrackSeed(const Cluster& cluster1, const 
 
 void TrackerTraits::traverseCellsTree(const int currentCellId, const int currentLayerId)
 {
-  Cell& currentCell{mTimeFrame->getCells()[currentLayerId][currentCellId]};
+  CellSeed& currentCell{mTimeFrame->getCells()[currentLayerId][currentCellId]};
   const int currentCellLevel = currentCell.getLevel();
 
   mTimeFrame->getRoads().back().addCell(currentLayerId, currentCellId);
@@ -982,7 +974,7 @@ void TrackerTraits::traverseCellsTree(const int currentCellId, const int current
     const int endNeighbourId = mTimeFrame->getCellsNeighboursLUT()[currentLayerId - 1][currentCellId];
     for (int iNeighbourCell{startNeighbourId}; iNeighbourCell < endNeighbourId; ++iNeighbourCell) {
       const int neighbourCellId = mTimeFrame->getCellsNeighbours()[currentLayerId - 1][iNeighbourCell];
-      const Cell& neighbourCell = mTimeFrame->getCells()[currentLayerId - 1][neighbourCellId];
+      const CellSeed& neighbourCell = mTimeFrame->getCells()[currentLayerId - 1][neighbourCellId];
 
       if (currentCellLevel - 1 != neighbourCell.getLevel()) {
         continue;


### PR DESCRIPTION
The result of the tracking is not changed by this PR, this is simply done to lay down the foundation for the complete overhaul of the track fitting to reduce the memory footprint and CPU consumption of the ITS tracking
