### PR TITLE
OpenCL2: possibly fixup temporary extension of PATH for spirv creation

### DIFF
--- a/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
@@ -46,7 +46,7 @@ if(OPENCL2_ENABLED_SPIRV) # BUILD OpenCL2 intermediate code for SPIR-V target
   cmake_path(GET LLVM_SPIRV PARENT_PATH TMP_LLVM_SPIRV_PATH)
   add_custom_command(
       OUTPUT ${CL_BIN}.spirv
-      COMMAND ${CMAKE_COMMAND} -E env "PATH=${TMP_LLVM_SPIRV_PATH}:$ENV{PATH}" ${LLVM_CLANG}
+      COMMAND ${CMAKE_COMMAND} -E env "PATH=${TMP_LLVM_SPIRV_PATH}:\$PATH" ${LLVM_CLANG}
               -O0
               --target=spirv64
               ${OCL_FLAGS}

--- a/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
@@ -46,7 +46,7 @@ if(OPENCL2_ENABLED_SPIRV) # BUILD OpenCL2 intermediate code for SPIR-V target
   cmake_path(GET LLVM_SPIRV PARENT_PATH TMP_LLVM_SPIRV_PATH)
   add_custom_command(
       OUTPUT ${CL_BIN}.spirv
-      COMMAND PATH+=:${TMP_LLVM_SPIRV_PATH} ${LLVM_CLANG}
+      COMMAND ${CMAKE_COMMAND} -E env "PATH=${TMP_LLVM_SPIRV_PATH}:$ENV{PATH}" ${LLVM_CLANG}
               -O0
               --target=spirv64
               ${OCL_FLAGS}


### PR DESCRIPTION
@davidrohr 

Compilation broke on my machine with:
`PATH+=:/ssd_data/builds/gpu/sw/ubuntu2204_x86-64/Clang/v15.0.7-6/bin-safe: not found`

Does this do the same thing? I can swap the order `${TMP_LLVM_SPIRV_PATH}:$ENV{PATH}` if needed.