### PR TITLE
Fix TRD digit subspec to zero

### DIFF
--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
@@ -91,7 +91,7 @@ class PuseHeightDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getTRDPulseHeightSpec(GID::mask_t src, bool digitsFromReader)
+DataProcessorSpec getTRDPulseHeightSpec(GID::mask_t src)
 {
 
   std::vector<OutputSpec> outputs;
@@ -112,7 +112,7 @@ DataProcessorSpec getTRDPulseHeightSpec(GID::mask_t src, bool digitsFromReader)
   auto dataRequest = std::make_shared<DataRequest>();
   dataRequest->requestTracks(src, false);
   dataRequest->requestClusters(srcClu, false);
-  dataRequest->inputs.emplace_back("digits", "TRD", "DIGITS", digitsFromReader ? 1 : 0);
+  dataRequest->inputs.emplace_back("digits", "TRD", "DIGITS", 0);
 
   return DataProcessorSpec{
     "trd-pulseheight",

--- a/Detectors/TRD/workflow/io/src/TRDDigitReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDDigitReaderSpec.cxx
@@ -76,7 +76,7 @@ void TRDDigitReaderSpec::run(ProcessingContext& pc)
 DataProcessorSpec getTRDDigitReaderSpec(bool useMC, bool trigRec, int dataSubspec)
 {
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("TRD", "DIGITS", dataSubspec, Lifetime::Timeframe);
+  outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
   if (trigRec) {
     outputs.emplace_back("TRD", "TRKTRGRD", dataSubspec, Lifetime::Timeframe);
   }

--- a/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
@@ -74,7 +74,7 @@ o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth, bool inpFro
                                 "o2sim",
                                 // setting a custom callback for closing the writer
                                 MakeRootTreeWriterSpec::CustomClose(finishWriting),
-                                BranchDefinition<std::vector<o2::trd::Digit>>{InputSpec{"input", "TRD", "DIGITS", (inpFromDigitizer ? 1u : 0u)}, "TRDDigit"},
+                                BranchDefinition<std::vector<o2::trd::Digit>>{InputSpec{"input", "TRD", "DIGITS"}, "TRDDigit"},
                                 BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRKTRGRD", (inpFromDigitizer ? 1u : 0u)}, "TriggerRecord"},
                                 std::move(labelsdef))();
 }

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -209,7 +209,7 @@ o2::framework::DataProcessorSpec getTRDDigitizerSpec(int channel, bool mctruth)
   //  algorithmic description (here a lambda getting called once to setup the actual processing function)
   //  options that can be used for this processor (here: input file names where to take the hits)
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("TRD", "DIGITS", 1, Lifetime::Timeframe);
+  outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "TRKTRGRD", 1, Lifetime::Timeframe);
   if (mctruth) {
     outputs.emplace_back("TRD", "LABELS", 0, Lifetime::Timeframe);

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -343,7 +343,7 @@ o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(bool useMC, int digitDo
   std::vector<InputSpec> inputs;
   std::vector<OutputSpec> outputs;
 
-  inputs.emplace_back("digitinput", "TRD", "DIGITS", 1);
+  inputs.emplace_back("digitinput", "TRD", "DIGITS", 0);
   inputs.emplace_back("triggerrecords", "TRD", "TRKTRGRD", 1);
 
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -57,7 +57,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   if (configcontext.options().get<bool>("noise")) {
     if (enableRootInp) {
-      specs.emplace_back(o2::trd::getTRDDigitReaderSpec(false));
+      specs.emplace_back(o2::trd::getTRDDigitReaderSpec(false, true, 0));
     }
     int ddsCollectionIdx = configcontext.options().get<int>("calib-dds-collection-index");
     bool noiseCalibIsDummy = true;

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -118,9 +118,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   if (pulseHeight) {
     if (rootInput) {
-      specs.emplace_back(o2::trd::getTRDDigitReaderSpec(useMC));
+      specs.emplace_back(o2::trd::getTRDDigitReaderSpec(useMC, false));
     }
-    specs.emplace_back(o2::framework::getTRDPulseHeightSpec(srcTRD, rootInput));
+    specs.emplace_back(o2::framework::getTRDPulseHeightSpec(srcTRD));
   }
 
   // output devices

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -339,7 +339,7 @@ if [[ ! -z ${WORKFLOW_DETECTORS_USE_GLOBAL_READER} ]]; then
   has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --infile mchdigits.root"
   has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-clusters-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
   has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-preclusters-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
-  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow "$DISABLE_MC --digit-subspec 0 --disable-trigrec --hbfutils-config o2_tfidinfo.root"
+  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow "$DISABLE_MC --disable-trigrec --hbfutils-config o2_tfidinfo.root"
   has_detector TOF && has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "$DISABLE_MC --input-type digits --output-type NONE --hbfutils-config o2_tfidinfo.root"
 fi
 


### PR DESCRIPTION
Don't remember why I did it like this, but only the trigger records need some special treatment with different sub specs. The digits are only produced by the digitizer and therefore their sub spec can be fixed to zero.
The trigger records can be produced by the digitizer, the raw reader or the TRAP simulator and specifically when we do the TRAP simulation we need to request trigger records with sub spec 1 and dump them with sub spec 0 in order to add the tracklet range to them.
Ping @chiarazampolli this will interfere with your https://github.com/AliceO2Group/AliceO2/pull/12171 but after this is merged you don't need to modify the trd-tracking-workflow.cxx at all anymore.