### PR TITLE
ctpdev: special digi for emc

### DIFF
--- a/DataFormats/Detectors/CTP/src/Configuration.cxx
+++ b/DataFormats/Detectors/CTP/src/Configuration.cxx
@@ -1060,7 +1060,7 @@ const std::vector<CTPInput> CTPInputsConfiguration::CTPInputsDefault =
     CTPInput("0DMC", "EMC", 14), CTPInput("0DJ1", "EMC", 41), CTPInput("0DG1", "EMC", 42), CTPInput("0DJ2", "EMC", 43), CTPInput("0DG2", "EMC", 44),
     CTPInput("0EMC", "EMC", 21), CTPInput("0EJ1", "EMC", 37), CTPInput("0EG1", "EMC", 38), CTPInput("0EJ2", "EMC", 39), CTPInput("0EG2", "EMC", 40),
     CTPInput("0PH0", "PHS", 22), CTPInput("1PHL", "PHS", 27), CTPInput("1PHH", "PHS", 28), CTPInput("1PHL", "PHM", 29),
-    CTPInput("1ZED", "ZDC", 25), CTPInput("1ZNC", "ZDC", 26), CTPInput("EMBA","EMC",48)};
+    CTPInput("1ZED", "ZDC", 25), CTPInput("1ZNC", "ZDC", 26), CTPInput("EMBA", "EMC", 48)};
 void CTPInputsConfiguration::initDefaultInputConfig()
 {
   defaultInputConfig.CTPInputs = CTPInputsConfiguration::CTPInputsDefault;

--- a/DataFormats/Detectors/CTP/src/Configuration.cxx
+++ b/DataFormats/Detectors/CTP/src/Configuration.cxx
@@ -1049,6 +1049,9 @@ void CTPInputsConfiguration::printStream(std::ostream& stream) const
     input.printStream(stream);
   }
 }
+//
+// EMBA - software generated input for EMC - Min Bias Accepted
+//
 const std::vector<CTPInput> CTPInputsConfiguration::CTPInputsDefault =
   {
     CTPInput("MT0A", "FT0", 1), CTPInput("MT0C", "FT0", 2), CTPInput("MTVX", "FT0", 3), CTPInput("MTSC", "FT0", 4), CTPInput("MTCE", "FT0", 5),
@@ -1057,7 +1060,7 @@ const std::vector<CTPInput> CTPInputsConfiguration::CTPInputsDefault =
     CTPInput("0DMC", "EMC", 14), CTPInput("0DJ1", "EMC", 41), CTPInput("0DG1", "EMC", 42), CTPInput("0DJ2", "EMC", 43), CTPInput("0DG2", "EMC", 44),
     CTPInput("0EMC", "EMC", 21), CTPInput("0EJ1", "EMC", 37), CTPInput("0EG1", "EMC", 38), CTPInput("0EJ2", "EMC", 39), CTPInput("0EG2", "EMC", 40),
     CTPInput("0PH0", "PHS", 22), CTPInput("1PHL", "PHS", 27), CTPInput("1PHH", "PHS", 28), CTPInput("1PHL", "PHM", 29),
-    CTPInput("1ZED", "ZDC", 25), CTPInput("1ZNC", "ZDC", 26)};
+    CTPInput("1ZED", "ZDC", 25), CTPInput("1ZNC", "ZDC", 26), CTPInput("EMBA","EMC",48)};
 void CTPInputsConfiguration::initDefaultInputConfig()
 {
   defaultInputConfig.CTPInputs = CTPInputsConfiguration::CTPInputsDefault;

--- a/Detectors/CTP/simulation/include/CTPSimulation/Digitizer.h
+++ b/Detectors/CTP/simulation/include/CTPSimulation/Digitizer.h
@@ -32,7 +32,6 @@ class Digitizer
   Digitizer() = default;
   ~Digitizer() = default;
   void setCCDBServer(const std::string& server) { mCCDBServer = server; }
-  void setEMCsim(int emcsim) { mEMCsim = emcsim; }
   std::vector<CTPDigit> process(const gsl::span<o2::ctp::CTPInputDigit> detinputs);
   void calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, std::bitset<CTP_NCLASSES>& classmask);
   void init();
@@ -40,7 +39,6 @@ class Digitizer
   // CTP configuration
   std::string mCCDBServer = o2::base::NameConf::getCCDBServer();
   CTPConfiguration* mCTPConfiguration = nullptr;
-  int mEMCsim = 0;
   ClassDefNV(Digitizer, 2);
 };
 } // namespace ctp

--- a/Detectors/CTP/simulation/include/CTPSimulation/Digitizer.h
+++ b/Detectors/CTP/simulation/include/CTPSimulation/Digitizer.h
@@ -32,6 +32,7 @@ class Digitizer
   Digitizer() = default;
   ~Digitizer() = default;
   void setCCDBServer(const std::string& server) { mCCDBServer = server; }
+  void setEMCsim(int emcsim) { mEMCsim = emcsim; }
   std::vector<CTPDigit> process(const gsl::span<o2::ctp::CTPInputDigit> detinputs);
   void calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, std::bitset<CTP_NCLASSES>& classmask);
   void init();
@@ -39,6 +40,7 @@ class Digitizer
   // CTP configuration
   std::string mCCDBServer = o2::base::NameConf::getCCDBServer();
   CTPConfiguration* mCTPConfiguration = nullptr;
+  int mEMCsim = 0;
   ClassDefNV(Digitizer, 2);
 };
 } // namespace ctp

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -70,7 +70,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
         }
         case o2::detectors::DetID::EMC: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
-            uint64_t mask = (inp->iputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
+            uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             if (mask) {
               inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
             }

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -70,9 +70,9 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
         }
         case o2::detectors::DetID::EMC: {
           uint64_t inpmaske = inp->inputsMask.to_ullong();
-          if ( inpmaske & detInputName2Mask["MBA"]) {
-              inpmaskcoll |= std::bitset<CTP_NINPUTS>(CTP_NINPUTS - 1);
-              inpmaske &= ~(1ull < detInputName2Mask["MBA"]);
+          if (inpmaske & detInputName2Mask["MBA"]) {
+            inpmaskcoll |= std::bitset<CTP_NINPUTS>(CTP_NINPUTS - 1);
+            inpmaske &= ~(1ull < detInputName2Mask["MBA"]);
           }
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
             uint64_t mask = inpmaske & detInputName2Mask[ctpinp.name];
@@ -126,8 +126,8 @@ void Digitizer::calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, st
     tvxMBemc != tcl.name.find("C0TVX-A-NOPF-EMC") != std::string::npos;
     tvxMBemc != tcl.name.find("C0TVX-C-NOPF-EMC") != std::string::npos;
     tvxMBemc != tcl.name.find("C0TVX-E-NOPF-EMC") != std::string::npos;
-    tvxMBemc != tcl.name.find("minbias_TVX_L0") != std::string::npos;  // 2022
-    if(tvxMBemc && ctpinpmask[CTP_NINPUTS - 1]) {
+    tvxMBemc != tcl.name.find("minbias_TVX_L0") != std::string::npos; // 2022
+    if (tvxMBemc && ctpinpmask[CTP_NINPUTS - 1]) {
       classmask |= (1 << tcl.classMask);
       LOG(info) << "adding MBA:" << tcl.name;
     } else {

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -69,8 +69,8 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           break;
         }
         case o2::detectors::DetID::EMC: {
-          uint64_t inpmaskdebug = 1;
-          // uint64_t inpmaskdebug = (inp->inputsMask).to_ullong();
+          // uint64_t inpmaskdebug = 1;
+          uint64_t inpmaskdebug = (inp->inputsMask).to_ullong();
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
             uint64_t mask = inpmaskdebug & detInputName2Mask[ctpinp.name];
             // uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -27,7 +27,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
   std::map<o2::detectors::DetID::ID, std::vector<CTPInput>> det2ctpinp = mCTPConfiguration->getDet2InputMap();
   // To be taken from config database ?
   std::map<std::string, uint64_t> detInputName2Mask =
-    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10},{"MBA",0x1},{"0EMC",0x2},{"0DMC",0x4}};
+    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10}, {"MBA", 0x1}, {"0EMC", 0x2}, {"0DMC", 0x4}};
 
   // pre-sorting detector inputs per interaction record
   std::map<o2::InteractionRecord, std::vector<const CTPInputDigit*>> predigits;
@@ -69,9 +69,9 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           break;
         }
         case o2::detectors::DetID::EMC: {
-          if(mEMCsim == 0) {
-            if(inp->inputsMask.to_ullong() & detInputName2Mask["MBA"]) {
-              inpmaskcoll != std::bitset<CTP_NINPUTS>(CTP_NINPUTS-1);
+          if (mEMCsim == 0) {
+            if (inp->inputsMask.to_ullong() & detInputName2Mask["MBA"]) {
+              inpmaskcoll != std::bitset<CTP_NINPUTS>(CTP_NINPUTS - 1);
             }
           } else {
             for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
@@ -122,7 +122,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
 void Digitizer::calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, std::bitset<CTP_NCLASSES>& classmask)
 {
   classmask = 0;
-  if(mEMCsim != 0) {
+  if (mEMCsim != 0) {
     for (auto const& tcl : mCTPConfiguration->getCTPClasses()) {
       if (tcl.descriptor->getInputsMask() & ctpinpmask.to_ullong()) {
         classmask |= (1 << tcl.classMask);
@@ -130,13 +130,13 @@ void Digitizer::calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, st
     }
   } else {
     for (auto const& tcl : mCTPConfiguration->getCTPClasses()) {
-      if(tcl.name.find("EMC") == std::string::npos) {
+      if (tcl.name.find("EMC") == std::string::npos) {
         if (tcl.descriptor->getInputsMask() & ctpinpmask.to_ullong()) {
           classmask |= (1 << tcl.classMask);
           LOG(info) << "adding NOT MBA:" << tcl.name;
         }
       } else {
-        if( (tcl.name.find("CTVXEMC-B-NOPF-EMC") != std::string::npos) && ctpinpmask[CTP_NINPUTS-1]) {
+        if ((tcl.name.find("CTVXEMC-B-NOPF-EMC") != std::string::npos) && ctpinpmask[CTP_NINPUTS - 1]) {
           classmask |= (1 << tcl.classMask);
           LOG(info) << "adding MBA:" << tcl.name;
         }

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -27,7 +27,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
   std::map<o2::detectors::DetID::ID, std::vector<CTPInput>> det2ctpinp = mCTPConfiguration->getDet2InputMap();
   // To be taken from config database ?
   std::map<std::string, uint64_t> detInputName2Mask =
-    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10}, {"MBA", 0x1}, {"0EMC", 0x2}, {"0DMC", 0x4}};
+    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10}, {"EMBA", 0x1}, {"0EMC", 0x2}, {"0DMC", 0x4}};
 
   // pre-sorting detector inputs per interaction record
   std::map<o2::InteractionRecord, std::vector<const CTPInputDigit*>> predigits;
@@ -69,13 +69,8 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           break;
         }
         case o2::detectors::DetID::EMC: {
-          uint64_t inpmaske = inp->inputsMask.to_ullong();
-          if (inpmaske & detInputName2Mask["MBA"]) {
-            inpmaskcoll |= std::bitset<CTP_NINPUTS>(CTP_NINPUTS - 1);
-            inpmaske &= ~(1ull < detInputName2Mask["MBA"]);
-          }
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
-            uint64_t mask = inpmaske & detInputName2Mask[ctpinp.name];
+            uint64_t mask = (inpmask->iputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             if (mask) {
               inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
             }

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -70,7 +70,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
         }
         case o2::detectors::DetID::EMC: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
-            uint64_t mask = (inpmask->iputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
+            uint64_t mask = (inp->iputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             if (mask) {
               inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
             }

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -70,15 +70,15 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
         }
         case o2::detectors::DetID::EMC: {
           uint64_t inpmaskdebug = 1;
-          //uint64_t inpmaskdebug = (inp->inputsMask).to_ullong();
+          // uint64_t inpmaskdebug = (inp->inputsMask).to_ullong();
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
             uint64_t mask = inpmaskdebug & detInputName2Mask[ctpinp.name];
-            //uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
+            // uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             if (mask) {
               inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
             }
           }
-          LOG(info) << "EMC input mask:" <<  inpmaskcoll;
+          LOG(info) << "EMC input mask:" << inpmaskcoll;
           break;
         }
         case o2::detectors::DetID::PHS: {
@@ -104,8 +104,8 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           LOG(error) << "CTP Digitizer: unknown detector:" << inp->detector;
           break;
       }
-      //inpmaskcoll.reset();  // debug
-      //inpmaskcoll[47] = 1;  // debug
+      // inpmaskcoll.reset();  // debug
+      // inpmaskcoll[47] = 1;  // debug
     } // end loop over trigger input for this interaction
     if (inpmaskcoll.to_ullong()) {
       // we put the trigger only when non-trivial
@@ -128,7 +128,7 @@ void Digitizer::calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, st
     tvxMBemc |= tcl.name.find("C0TVX-A-NOPF-EMC") != std::string::npos;
     tvxMBemc |= tcl.name.find("C0TVX-C-NOPF-EMC") != std::string::npos;
     tvxMBemc |= tcl.name.find("C0TVX-E-NOPF-EMC") != std::string::npos;
-    if(tcl.cluster->name == "emc") {
+    if (tcl.cluster->name == "emc") {
       tvxMBemc |= tcl.name.find("minbias_TVX_L0") != std::string::npos; // 2022
     }
     if (tvxMBemc && ctpinpmask[CTP_NINPUTS - 1]) {

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -27,7 +27,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
   std::map<o2::detectors::DetID::ID, std::vector<CTPInput>> det2ctpinp = mCTPConfiguration->getDet2InputMap();
   // To be taken from config database ?
   std::map<std::string, uint64_t> detInputName2Mask =
-    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10}};
+    {{"MVBA", 1}, {"MVOR", 2}, {"MVNC", 4}, {"MVCH", 8}, {"MVIR", 0x10}, {"MT0A", 1}, {"MT0C", 2}, {"MTSC", 4}, {"MTCE", 8}, {"MTVX", 0x10}, {"0U0A", 1}, {"0U0C", 2}, {"0USC", 4}, {"0UCE", 8}, {"0UVX", 0x10},{"MBA",0x1},{"0EMC",0x2},{"0DMC",0x4}};
 
   // pre-sorting detector inputs per interaction record
   std::map<o2::InteractionRecord, std::vector<const CTPInputDigit*>> predigits;
@@ -69,10 +69,16 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
           break;
         }
         case o2::detectors::DetID::EMC: {
-          for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
-            uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-            if (mask) {
-              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+          if(mEMCsim == 0) {
+            if(inp->inputsMask.to_ullong() & detInputName2Mask["MBA"]) {
+              inpmaskcoll != std::bitset<CTP_NINPUTS>(CTP_NINPUTS-1);
+            }
+          } else {
+            for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
+              uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
+              if (mask) {
+                inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
+              }
             }
           }
           break;
@@ -116,11 +122,28 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
 void Digitizer::calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, std::bitset<CTP_NCLASSES>& classmask)
 {
   classmask = 0;
-  for (auto const& tcl : mCTPConfiguration->getCTPClasses()) {
-    if (tcl.descriptor->getInputsMask() & ctpinpmask.to_ullong()) {
-      classmask |= (1 << tcl.classMask);
+  if(mEMCsim != 0) {
+    for (auto const& tcl : mCTPConfiguration->getCTPClasses()) {
+      if (tcl.descriptor->getInputsMask() & ctpinpmask.to_ullong()) {
+        classmask |= (1 << tcl.classMask);
+      }
+    }
+  } else {
+    for (auto const& tcl : mCTPConfiguration->getCTPClasses()) {
+      if(tcl.name.find("EMC") == std::string::npos) {
+        if (tcl.descriptor->getInputsMask() & ctpinpmask.to_ullong()) {
+          classmask |= (1 << tcl.classMask);
+          LOG(info) << "adding NOT MBA:" << tcl.name;
+        }
+      } else {
+        if( (tcl.name.find("CTVXEMC-B-NOPF-EMC") != std::string::npos) && ctpinpmask[CTP_NINPUTS-1]) {
+          classmask |= (1 << tcl.classMask);
+          LOG(info) << "adding MBA:" << tcl.name;
+        }
+      }
     }
   }
+  LOG(info) << "class mask:" << classmask;
 }
 void Digitizer::init()
 {

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -71,7 +71,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
         case o2::detectors::DetID::EMC: {
           if (mEMCsim == 0) {
             if (inp->inputsMask.to_ullong() & detInputName2Mask["MBA"]) {
-              inpmaskcoll != std::bitset<CTP_NINPUTS>(CTP_NINPUTS - 1);
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(CTP_NINPUTS - 1);
             }
           } else {
             for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -70,9 +70,9 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     }
     // emc
     if (std::find(mDetList.begin(), mDetList.end(), o2::detectors::DetID::EMC) != mDetList.end()) {
-      auto emcinputs = pc.inputs().get<gsl::span<o2::fv0::DetTrigInput>>("emc");
+      auto emcinputs = pc.inputs().get<gsl::span<o2::ctp::CTPInputDigit>>("emc");
       for (const auto& inp : emcinputs) {
-        finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::EMC});
+        finputs.emplace_back(inp);
       }
     }
     gsl::span<CTPInputDigit> ginputs(finputs);

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -40,6 +40,9 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   void initDigitizerTask(framework::InitContext& ic) override
   {
     mDigitizer.init();
+    int emcsim = ic.options().get<int>("emcsim-option");
+    mDigitizer.setEMCsim(emcsim);
+    LOG(info) << "emcsim:" << emcsim;
   }
   void run(framework::ProcessingContext& pc)
   {
@@ -87,6 +90,9 @@ o2::framework::DataProcessorSpec getCTPDigitizerSpec(int channel, std::vector<o2
   if (std::find(detList.begin(), detList.end(), o2::detectors::DetID::FV0) != detList.end()) {
     inputs.emplace_back("fv0", "FV0", "TRIGGERINPUT", 0, Lifetime::Timeframe);
   }
+  if (std::find(detList.begin(), detList.end(), o2::detectors::DetID::EMC) != detList.end()) {
+    inputs.emplace_back("emc", "EMC", "TRIGGERINPUT", 0, Lifetime::Timeframe);
+  }
   output.emplace_back("CTP", "DIGITS", 0, Lifetime::Timeframe);
   output.emplace_back("CTP", "ROMode", 0, Lifetime::Timeframe);
   return DataProcessorSpec{
@@ -95,7 +101,8 @@ o2::framework::DataProcessorSpec getCTPDigitizerSpec(int channel, std::vector<o2
     output,
     AlgorithmSpec{adaptFromTask<CTPDPLDigitizerTask>()},
     Options{{"pileup", VariantType::Int, 1, {"whether to run in continuous time mode"}},
-            {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
+            {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}},
+            {"emcsim-option", VariantType::Int, 0, {"0 - MinBias from EMC, TVX ignored, 1 - MinBias from TVX"}}}};
 }
 } // namespace ctp
 } // namespace o2

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -54,23 +54,26 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     o2::globaltracking::RecoContainer recoData;
     recoData.collectData(pc, *mDataRequest.get());
     std::vector<o2::ctp::CTPInputDigit> finputs;
+    TStopwatch timer;
+    timer.Start();
+    LOG(info) << "CALLING CTP DIGITIZATION";
+    // Input order: T0, V0, ... but O need also position of inputs DETInputs
+    // fv0
     auto ft0inputs = pc.inputs().get<gsl::span<o2::ft0::DetTrigInput>>("ft0");
+    for (const auto& inp : ft0inputs) {
+      finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::FT0});
+    }
+    // fv0
     auto fv0inputs = pc.inputs().get<gsl::span<o2::fv0::DetTrigInput>>("fv0");
+    for (const auto& inp : fv0inputs) {
+      finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::FV0});
+    }
+    // emc
     if (mDataRequest->isRequested("emc")) {
       auto emcinputs = pc.inputs().get<gsl::span<o2::fv0::DetTrigInput>>("emc");
       for (const auto& inp : emcinputs) {
         finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::EMC});
       }
-    }
-    TStopwatch timer;
-    timer.Start();
-    LOG(info) << "CALLING CTP DIGITIZATION";
-    // Input order: T0, V0, ... but O need also position of inputs DETInputs
-    for (const auto& inp : ft0inputs) {
-      finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::FT0});
-    }
-    for (const auto& inp : fv0inputs) {
-      finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::FV0});
     }
     gsl::span<CTPInputDigit> ginputs(finputs);
     auto digits = mDigitizer.process(ginputs);

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -46,9 +46,9 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   void run(framework::ProcessingContext& pc)
   {
     // read collision context from input
-    //auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
-    //const bool withQED = context->isQEDProvided();
-    //auto& timesview = context->getEventRecords(withQED);
+    // auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
+    // const bool withQED = context->isQEDProvided();
+    // auto& timesview = context->getEventRecords(withQED);
     // read ctp inputs from input
 
     o2::globaltracking::RecoContainer recoData;
@@ -56,7 +56,7 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     std::vector<o2::ctp::CTPInputDigit> finputs;
     auto ft0inputs = pc.inputs().get<gsl::span<o2::ft0::DetTrigInput>>("ft0");
     auto fv0inputs = pc.inputs().get<gsl::span<o2::fv0::DetTrigInput>>("fv0");
-    if( mDataRequest->isRequested("emc")) {
+    if (mDataRequest->isRequested("emc")) {
       auto emcinputs = pc.inputs().get<gsl::span<o2::fv0::DetTrigInput>>("emc");
       for (const auto& inp : emcinputs) {
         finputs.emplace_back(CTPInputDigit{inp.mIntRecord, inp.mInputs, o2::detectors::DetID::EMC});

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -40,9 +40,6 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   void initDigitizerTask(framework::InitContext& ic) override
   {
     mDigitizer.init();
-    int emcsim = ic.options().get<int>("emcsim-option");
-    mDigitizer.setEMCsim(emcsim);
-    LOG(info) << "emcsim:" << emcsim;
   }
   void run(framework::ProcessingContext& pc)
   {
@@ -101,8 +98,7 @@ o2::framework::DataProcessorSpec getCTPDigitizerSpec(int channel, std::vector<o2
     output,
     AlgorithmSpec{adaptFromTask<CTPDPLDigitizerTask>()},
     Options{{"pileup", VariantType::Int, 1, {"whether to run in continuous time mode"}},
-            {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}},
-            {"emcsim-option", VariantType::Int, 0, {"0 - MinBias from EMC, TVX ignored, 1 - MinBias from TVX"}}}};
+            {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
 }
 } // namespace ctp
 } // namespace o2


### PR DESCRIPTION
Reject trigger classes for the EMCAL cluster which were rejected by EMCAL digitisation

Triggers are rejected in the EMCAL digitisation if the readout was either active due to a 
previous trigger (pileup) or busy.