### PR TITLE
Adding MFT cluster sizes to AO2D

### DIFF
--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -70,6 +70,47 @@ class TrackMFT : public o2::track::TrackParCovFwd
   const o2::track::TrackParCovFwd& getOutParam() const { return mOutParameters; }       ///< Returns track parameters fitted outwards
   void setOutParam(const o2::track::TrackParCovFwd parcov) { mOutParameters = parcov; } ///< Set track out parameters
 
+  void setClusterSize(int l, int size)
+  {
+    if (l >= 11) {
+      return;
+    }
+    if (size > 63) {
+      size = 63;
+    }
+    //mClusterSizes &= ~(0x3f << (l * 6));
+    //mClusterSizes |= (size << (l * 6));
+
+    mClusterSizes &= ~(0x3f << (l * 6));
+    mClusterSizes |= (static_cast<uint64_t>(size) << (l * 6));
+
+    std::cout << "l: " << l << ", size: " << size << ", mClusterSizes (binario): ";
+    uint64_t num = mClusterSizes;
+    for (int i = 63; i >= 0; --i) {
+      std::cout << ((num >> i) & 1);
+      if (i % 6 == 0) {
+        std::cout << ' ';
+      }
+    }
+    std::cout << ", mClusterSizes (decimale): " << mClusterSizes << std::endl;
+
+    //std::cout << "l = " << l << " ; size = " << size << std::endl; 
+    //std::cout << "mClusterSizes: " << static_cast<unsigned int>(mClusterSizes) << std::endl;
+  }
+
+  uint64_t getClusterSize(int l)
+  {
+    if (l >= 11) {
+      return 0;
+    }
+    return (mClusterSizes >> (l * 6)) & 0x3f;
+  }
+
+  uint64_t getClusterSizes() const
+  {
+    return mClusterSizes;
+  }
+
  private:
   Bool_t mIsCA = false; ///< Track finding method CA vs. LTF
 
@@ -79,8 +120,9 @@ class TrackMFT : public o2::track::TrackParCovFwd
 
   Double_t mSeedinvQPtFitChi2 = 0.; ///< Seed InvQPt Chi2 from FCF clusters X,Y positions
   Double_t mInvQPtSeed;             ///< Seed InvQPt from FCF clusters X,Y positions
+  uint64_t mClusterSizes = 0;
 
-  ClassDefNV(TrackMFT, 2);
+  ClassDefNV(TrackMFT, 3);
 };
 
 class TrackMFTExt : public TrackMFT

--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -78,8 +78,8 @@ class TrackMFT : public o2::track::TrackParCovFwd
     if (size > 63) {
       size = 63;
     }
-    //mClusterSizes &= ~(0x3f << (l * 6));
-    //mClusterSizes |= (size << (l * 6));
+    // mClusterSizes &= ~(0x3f << (l * 6));
+    // mClusterSizes |= (size << (l * 6));
 
     mClusterSizes &= ~(0x3f << (l * 6));
     mClusterSizes |= (static_cast<uint64_t>(size) << (l * 6));
@@ -94,8 +94,8 @@ class TrackMFT : public o2::track::TrackParCovFwd
     }
     std::cout << ", mClusterSizes (decimale): " << mClusterSizes << std::endl;
 
-    //std::cout << "l = " << l << " ; size = " << size << std::endl; 
-    //std::cout << "mClusterSizes: " << static_cast<unsigned int>(mClusterSizes) << std::endl;
+    // std::cout << "l = " << l << " ; size = " << size << std::endl;
+    // std::cout << "mClusterSizes: " << static_cast<unsigned int>(mClusterSizes) << std::endl;
   }
 
   uint64_t getClusterSize(int l)

--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -78,24 +78,9 @@ class TrackMFT : public o2::track::TrackParCovFwd
     if (size > 63) {
       size = 63;
     }
-    // mClusterSizes &= ~(0x3f << (l * 6));
-    // mClusterSizes |= (size << (l * 6));
 
     mClusterSizes &= ~(0x3f << (l * 6));
     mClusterSizes |= (static_cast<uint64_t>(size) << (l * 6));
-
-    std::cout << "l: " << l << ", size: " << size << ", mClusterSizes (binario): ";
-    uint64_t num = mClusterSizes;
-    for (int i = 63; i >= 0; --i) {
-      std::cout << ((num >> i) & 1);
-      if (i % 6 == 0) {
-        std::cout << ' ';
-      }
-    }
-    std::cout << ", mClusterSizes (decimale): " << mClusterSizes << std::endl;
-
-    // std::cout << "l = " << l << " ; size = " << size << std::endl;
-    // std::cout << "mClusterSizes: " << static_cast<unsigned int>(mClusterSizes) << std::endl;
   }
 
   uint64_t getClusterSize(int l)

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -391,6 +391,7 @@ class AODProducerWorkflowDPL : public Task
     float chi2 = 0.f;
     float pdca = 0.f;
     int nClusters = -1;
+    uint64_t mftClusterSizes = 0u;
     float chi2matchmchmid = -1.0;
     float chi2matchmchmft = -1.0;
     float matchscoremchmft = -1.0;

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -360,14 +360,6 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
   }
   trackTime -= bcOfTimeRef * o2::constants::lhc::LHCBunchSpacingNS;
 
-  std::cout << "Final track cluster sizes : " << track.getClusterSizes() << std::endl;
-  std::cout << "Unpacked cluster size = ";
-  auto clSizeTest = track.getClusterSizes();
-  for (int i = 0; i < 10; ++i) {
-    int size = (clSizeTest >> (i * 6)) & 0x3f;
-    std::cout << size << " , ";
-  }
-  std::cout << "VALIDATION = " << track.getClusterSizes() << std::endl;
   mftTracksCursor(collisionID,
                   track.getX(),
                   track.getY(),

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -360,6 +360,14 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
   }
   trackTime -= bcOfTimeRef * o2::constants::lhc::LHCBunchSpacingNS;
 
+  std::cout << "Final track cluster sizes : " << track.getClusterSizes() << std::endl;
+  std::cout << "Unpacked cluster size = ";
+  auto clSizeTest = track.getClusterSizes();
+  for (int i = 0; i < 10; ++i) {
+    int size = (clSizeTest >> (i * 6)) & 0x3f;
+    std::cout << size << " , ";
+  }
+  std::cout << "VALIDATION = " << track.getClusterSizes() << std::endl;
   mftTracksCursor(collisionID,
                   track.getX(),
                   track.getY(),
@@ -368,6 +376,7 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
                   truncateFloatFraction(track.getTanl(), mTrackTgl),
                   truncateFloatFraction(track.getInvQPt(), mTrack1Pt),
                   track.getNumberOfPoints(),
+                  track.getClusterSizes(),
                   truncateFloatFraction(track.getTrackChi2(), mTrackChi2),
                   truncateFloatFraction(trackTime, mTrackTime),
                   truncateFloatFraction(trackTimeRes, mTrackTimeError));

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
@@ -54,6 +54,8 @@ class ROframe
 
   std::vector<Cluster>& getClustersInLayer(Int_t layerId) { return mClusters[layerId]; }
 
+  std::vector<Int_t>& getClusterSizes() { return mClusterSizes; }
+
   const MCCompLabel& getClusterLabels(Int_t layerId, const Int_t clusterId) const { return mClusterLabels[layerId][clusterId]; }
 
   const Int_t getClusterExternalIndex(Int_t layerId, const Int_t clusterId) const { return mClusterExternalIndices[layerId][clusterId]; }
@@ -70,6 +72,7 @@ class ROframe
   }
   void addClusterLabelToLayer(Int_t layer, const MCCompLabel label) { mClusterLabels[layer].emplace_back(label); }
   void addClusterExternalIndexToLayer(Int_t layer, const Int_t idx) { mClusterExternalIndices[layer].push_back(idx); }
+  void addClusterSizeToLayer(const Int_t clusterSize) { mClusterSizes.push_back(clusterSize); }
 
   void addTrack(bool isCA = false)
   {
@@ -90,6 +93,7 @@ class ROframe
     }
     mTracks.clear();
     mRoads.clear();
+    mClusterSizes.clear();
   }
 
   const Int_t getNClustersInLayer(Int_t layerId) const { return mClusters[layerId].size(); }
@@ -100,6 +104,7 @@ class ROframe
   std::array<std::vector<Int_t>, constants::mft::LayersNumber> mClusterExternalIndices;
   std::vector<T> mTracks;
   std::vector<Road> mRoads;
+  std::vector<Int_t> mClusterSizes;
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -81,7 +81,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
       locXYZ = dict->getClusterCoordinates(c, patt, false);
       clusterSize = patt.getNPixels();
     }
-    //std::cout << "----------------------> Cluster Size = " << clusterSize << std::endl;
+    // std::cout << "----------------------> Cluster Size = " << clusterSize << std::endl;
     if (skip_ROF) { // Skip filtered-out ROFs after processing pattIt
       clusterId++;
       continue;

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -81,7 +81,6 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
       locXYZ = dict->getClusterCoordinates(c, patt, false);
       clusterSize = patt.getNPixels();
     }
-    // std::cout << "----------------------> Cluster Size = " << clusterSize << std::endl;
     if (skip_ROF) { // Skip filtered-out ROFs after processing pattIt
       clusterId++;
       continue;

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -191,14 +191,21 @@ void TrackerDPL::run(ProcessingContext& pc)
   };
 
   // snippet to convert found tracks to final output tracks with separate cluster indices
-  auto copyTracks = [](auto& new_tracks, auto& allTracks, auto& allClusIdx) {
+  auto copyTracks = [](auto& new_tracks, auto& allTracks, auto& allClusIdx, auto& allClusterSizes) {
     for (auto& trc : new_tracks) {
       trc.setExternalClusterIndexOffset(allClusIdx.size());
       int ncl = trc.getNumberOfPoints();
       for (int ic = 0; ic < ncl; ic++) {
         auto externalClusterID = trc.getExternalClusterIndex(ic);
+        trc.setClusterSize(ic, allClusterSizes[ic]);
         allClusIdx.push_back(externalClusterID);
       }
+      std::cout << "Writing the cluster size per track = ";
+      for (int ic = 0; ic < ncl; ic++) {
+        std::cout << allClusterSizes[ic] << " , ";
+      }
+      std::cout << std::endl;
+      std::cout << "----------------------------" << std::endl;
       allTracks.emplace_back(trc);
     }
   };
@@ -252,8 +259,9 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (auto& rofData : roFrameVec[i]) {
         int ntracksROF = 0, firstROFTrackEntry = allTracksMFT.size();
         tracks.swap(rofData.getTracks());
+        auto clusterSizes = rofData.getClusterSizes();
         ntracksROF = tracks.size();
-        copyTracks(tracks, allTracksMFT, allClusIdx);
+        copyTracks(tracks, allTracksMFT, allClusIdx, clusterSizes);
 
         rof->setFirstEntry(firstROFTrackEntry);
         rof->setNEntries(ntracksROF);
@@ -312,7 +320,8 @@ void TrackerDPL::run(ProcessingContext& pc)
         int ntracksROF = 0, firstROFTrackEntry = allTracksMFT.size();
         tracksL.swap(rofData.getTracks());
         ntracksROF = tracksL.size();
-        copyTracks(tracksL, allTracksMFT, allClusIdx);
+        auto clusterSizes = rofData.getClusterSizes();
+        copyTracks(tracksL, allTracksMFT, allClusIdx, clusterSizes);
         rof->setFirstEntry(firstROFTrackEntry);
         rof->setNEntries(ntracksROF);
         *rof++;

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -200,12 +200,6 @@ void TrackerDPL::run(ProcessingContext& pc)
         trc.setClusterSize(ic, allClusterSizes[ic]);
         allClusIdx.push_back(externalClusterID);
       }
-      std::cout << "Writing the cluster size per track = ";
-      for (int ic = 0; ic < ncl; ic++) {
-        std::cout << allClusterSizes[ic] << " , ";
-      }
-      std::cout << std::endl;
-      std::cout << "----------------------------" << std::endl;
       allTracks.emplace_back(trc);
     }
   };

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -506,6 +506,7 @@ DECLARE_SOA_COLUMN(Phi, phi, float);                                            
 DECLARE_SOA_COLUMN(Tgl, tgl, float);                                                         //! TrackParFwd parameter tan(\lamba); (\lambda = 90 - \theta_{polar})
 DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float);                                             //! TrackParFwd parameter: charged inverse transverse momentum; (q/pt)
 DECLARE_SOA_COLUMN(NClusters, nClusters, int8_t);                                            //! Number of clusters
+DECLARE_SOA_COLUMN(MFTClusterSizes, mftClusterSizes, uint64_t);                              //! Cluster sizes per track and per layer
 DECLARE_SOA_COLUMN(Chi2, chi2, float);                                                       //! Track chi^2
 DECLARE_SOA_COLUMN(PDca, pDca, float);                                                       //! PDca for MUONStandalone
 DECLARE_SOA_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float);                                   //! RAtAbsorberEnd for MUONStandalone tracks and GlobalMuonTrackstracks
@@ -608,7 +609,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
 DECLARE_SOA_TABLE_FULL(StoredMFTTracks, "MFTTracks", "AOD", "MFTTRACK", //!
                        o2::soa::Index<>, fwdtrack::CollisionId,
                        fwdtrack::X, fwdtrack::Y, fwdtrack::Z, fwdtrack::Phi, fwdtrack::Tgl,
-                       fwdtrack::Signed1Pt, fwdtrack::NClusters,
+                       fwdtrack::Signed1Pt, fwdtrack::NClusters, fwdtrack::MFTClusterSizes,
                        fwdtrack::Px<fwdtrack::Pt, fwdtrack::Phi>,
                        fwdtrack::Py<fwdtrack::Pt, fwdtrack::Phi>,
                        fwdtrack::Pz<fwdtrack::Pt, fwdtrack::Tgl>,


### PR DESCRIPTION
Inclusion of the MFT cluster sizes into the to MFTTracks table
Presented at the WP4 + 14 meeting: 
https://indico.cern.ch/event/1347068/contributions/5670560/attachments/2750869/4788066/mft_pid.pdf