### PR TITLE
New version of the track fitting

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -92,8 +92,8 @@ class TrackITS : public o2::track::TrackParCov
 
   bool isBetter(const TrackITS& best, float maxChi2) const;
 
-  o2::track::TrackParCov& getParamIn() { return *this; }
-  const o2::track::TrackParCov& getParamIn() const { return *this; }
+  GPUhdi() o2::track::TrackParCov& getParamIn() { return *this; }
+  GPUhdi() const o2::track::TrackParCov& getParamIn() const { return *this; }
 
   GPUhdi() o2::track::TrackParCov& getParamOut() { return mParamOut; }
   GPUhdi() const o2::track::TrackParCov& getParamOut() const { return mParamOut; }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -46,7 +46,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   GPUd() TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
                                        const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true, const PID pid = PID::Pion);
 
-  GPUdDefault() TrackParametrizationWithError(const TrackParametrizationWithError& src) = default;
+  GPUhdDefault() TrackParametrizationWithError(const TrackParametrizationWithError& src) = default;
   GPUdDefault() TrackParametrizationWithError(TrackParametrizationWithError&& src) = default;
   GPUhdDefault() TrackParametrizationWithError& operator=(const TrackParametrizationWithError& src) = default;
   GPUhdDefault() TrackParametrizationWithError& operator=(TrackParametrizationWithError&& src) = default;

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -198,7 +198,9 @@ class TimeFrameGPU : public TimeFrame
   void loadTrackSeedsDevice();
   void loadTrackSeedsChi2Device();
   void loadRoadsDevice();
-  void createTrackITSExtDevice();
+  void loadTrackSeedsDevice(std::vector<CellSeed>&);
+  void createTrackITSExtDevice(const std::vector<CellSeed>& seeds);
+  void createTrackITSExtDevice(); // deprecated
   void downloadTrackITSExtDevice();
   void initDeviceChunks(const int, const int);
   template <Task task>
@@ -232,6 +234,7 @@ class TimeFrameGPU : public TimeFrame
   Cluster** getDeviceArrayUnsortedClusters() const { return mUnsortedClustersDeviceArray; }
   Tracklet** getDeviceArrayTracklets() const { return mTrackletsDeviceArray; }
   CellSeed** getDeviceArrayCells() const { return mCellsDeviceArray; }
+  CellSeed* getDeviceTrackSeeds() { return mTrackSeedsDevice; }
   o2::track::TrackParCovF** getDeviceArrayTrackSeeds() { return mCellSeedsDeviceArray; }
   float** getDeviceArrayTrackSeedsChi2() { return mCellSeedsChi2DeviceArray; }
   void setDevicePropagator(const o2::base::PropagatorImpl<float>*) override;
@@ -263,6 +266,7 @@ class TimeFrameGPU : public TimeFrame
   std::array<Tracklet*, nLayers - 1> mTrackletsDevice;
   Tracklet** mTrackletsDeviceArray;
   std::array<CellSeed*, nLayers - 2> mCellsDevice;
+  CellSeed* mTrackSeedsDevice;
   CellSeed** mCellsDeviceArray;
   std::array<o2::track::TrackParCovF*, nLayers - 2> mCellSeedsDevice;
   o2::track::TrackParCovF** mCellSeedsDeviceArray;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -92,7 +92,9 @@ class CellSeed final : public o2::track::TrackParCovF
   GPUhd() int getSecondClusterIndex() const { return mClusters[getUserField() + 1]; };
   GPUhd() int getThirdClusterIndex() const { return mClusters[getUserField() + 2]; };
   GPUhd() int getFirstTrackletIndex() const { return mTracklets[0]; };
+  GPUhd() void setFirstTrackletIndex(int trkl) { mTracklets[0] = trkl; };
   GPUhd() int getSecondTrackletIndex() const { return mTracklets[1]; };
+  GPUhd() void setSecondTrackletIndex(int trkl) { mTracklets[1] = trkl; };
   GPUhd() int getChi2() const { return mChi2; };
   GPUhd() void setChi2(float chi2) { mChi2 = chi2; };
   GPUhd() int getLevel() const { return mLevel; };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -78,7 +78,8 @@ GPUdi() Cell::Cell(const int firstClusterIndex, const int secondClusterIndex, co
 class CellSeed final : public o2::track::TrackParCovF
 {
  public:
-  GPUhd() CellSeed() = default;
+  GPUhdDefault() CellSeed() = default;
+  GPUhdDefault() CellSeed(const CellSeed&) = default;
   GPUd() CellSeed(int innerL, int cl0, int cl1, int cl2, int trkl0, int trkl1, o2::track::TrackParCovF& tpc, float chi2) : o2::track::TrackParCovF{tpc}, mChi2{chi2}, mLevel{1}
   {
     setUserField(innerL);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -102,6 +102,7 @@ class CellSeed final : public o2::track::TrackParCovF
   GPUhd() void setLevel(int level) { mLevel = level; };
   GPUhd() int* getLevelPtr() { return &mLevel; }
   GPUhd() int* getClusters() { return mClusters; }
+  GPUhd() int getCluster(int i) const { return mClusters[i]; }
 
  private:
   int mClusters[7] = {-1, -1, -1, -1, -1, -1, -1};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -67,6 +67,7 @@ class TrackerTraits
   virtual void findShortPrimaries();
   virtual void setBz(float bz);
   virtual bool trackFollowing(TrackITSExt* track, int rof, bool outward, const int iteration);
+  virtual void processNeighbours(int iLayer, int iLevel, const std::vector<CellSeed>& currentCellSeed, const std::vector<int>& currentCellId, std::vector<CellSeed>& updatedCellSeed, std::vector<int>& updatedCellId);
 
   void UpdateTrackingParameters(const std::vector<TrackingParameters>& trkPars);
   TimeFrame* getTimeFrame() { return mTimeFrame; }

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -78,9 +78,9 @@ void Tracker::clustersToTracks(std::function<void(std::string s)> logger, std::f
     total += evaluateTask(&Tracker::findCellsNeighbours, "Neighbour finding", logger, iteration);
     logger(fmt::format("\t- Number of neighbours: {}", mTimeFrame->getNumberOfNeighbours()));
     total += evaluateTask(&Tracker::findRoads, "Road finding", logger, iteration);
-    logger(fmt::format("\t- Number of Roads: {}", mTimeFrame->getRoads().size()));
-    total += evaluateTask(&Tracker::findTracks, "Track finding", logger);
     logger(fmt::format("\t- Number of Tracks: {}", mTimeFrame->getNumberOfTracks()));
+    // total += evaluateTask(&Tracker::findTracks, "Track finding", logger);
+    // logger(fmt::format("\t- Number of Tracks: {}", mTimeFrame->getNumberOfTracks()));
     total += evaluateTask(&Tracker::extendTracks, "Extending tracks", logger, iteration);
   }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -132,9 +132,9 @@ void Tracker::clustersToTracksHybrid(std::function<void(std::string s)> logger, 
     }
     total += evaluateTask(&Tracker::findCellsNeighboursHybrid, "Hybrid Neighbour finding", logger, iteration);
     logger(fmt::format("\t- Number of Neighbours: {}", mTimeFrame->getNumberOfNeighbours()));
-    total += evaluateTask(&Tracker::findRoadsHybrid, "Hybrid Road finding", logger, iteration);
-    logger(fmt::format("\t- Number of Roads: {}", mTimeFrame->getRoads().size()));
-    total += evaluateTask(&Tracker::findTracksHybrid, "Hybrid Track fitting", logger, iteration);
+    total += evaluateTask(&Tracker::findRoadsHybrid, "Hybrid Track finding", logger, iteration);
+    logger(fmt::format("\t- Number of Tracks: {}", mTimeFrame->getNumberOfTracks()));
+    // total += evaluateTask(&Tracker::findTracksHybrid, "Hybrid Track fitting", logger, iteration);
   }
 }
 


### PR DESCRIPTION
Hi @shahor02,

this is the new version of the ITS tracker fitting. The output is almost the same (we found 1 track more per 100k tracks)  as the old one. I did not check how this interact with the rest of the reconstruction, but from the benchmark on two TF of a 20kHz CTF I see that this consume half of the memory it used to and it takes less than half of the time to process them. See the plot here:

![comparison](https://github.com/AliceO2Group/AliceO2/assets/2094113/3340fa6c-bf8b-4d67-b477-8fe163eddd1b)

Let me know if I should check something in particular.
Cheers,
Max

P.S. This is now with no multithreading, that will come in the next few days.
