### PR TITLE
CcdbDownloader: Fixing malformed url appearing when CcdbApi is redirected to another host

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -210,12 +210,22 @@ class CCDBDownloader
 
  private:
   /**
+   * Leaves only the protocol and host part of the url, discrading path and metadata.
+   */
+  std::string trimHostUrl(std::string full_host_url) const;
+
+  /**
+   * Recognizes whether the address is a full url, or a partial one (like for example "/Task/Detector/1") and combines it with potentialHost if needed.
+   */
+  std::string prepareRedirectedURL(std::string address, std::string potentialHost) const;
+
+  /**
    * Returns a vector of possible content locations based on the redirect headers.
    *
    * @param baseUrl Content path.
    * @param headerMap Map containing response headers.
    */
-  std::vector<std::string> getLocations(std::string baseUrl, std::multimap<std::string, std::string>* headerMap) const;
+  std::vector<std::string> getLocations(std::multimap<std::string, std::string>* headerMap) const;
 
   std::string mUserAgentId = "CCDBDownloader";
   /**
@@ -284,6 +294,7 @@ class CCDBDownloader
   } PerformData;
 #endif
 
+
   /**
    * Called by CURL in order to close a socket. It will be called by CURL even if a timeout timer closed the socket beforehand.
    *
@@ -293,14 +304,17 @@ class CCDBDownloader
   static void closesocketCallback(void* clientp, curl_socket_t item);
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
+  // Returns a new location string or an empty string if all locations under current host have been accessedd
+  std::string getNewLocation(PerformData* performData, std::vector<std::string>& locations) const;
+
   // Reschedules the transfer to be performed with a different host.
   void tryNewHost(PerformData* performData, CURL* easy_handle);
 
   // Retrieves content from either alien, cvmfs or local storage using a callback to CCDBApi.
-  void getLocalContent(PerformData* performData, std::string& newUrl, std::string& newLocation, bool& contentRetrieved, std::vector<std::string>& locations);
+  void getLocalContent(PerformData* performData, std::string& newLocation, bool& contentRetrieved, std::vector<std::string>& locations);
 
   // Continues a transfer via a http redirect.
-  void httpRedirect(PerformData* performData, std::string& newUrl, std::string& newLocation, CURL* easy_handle);
+  void httpRedirect(PerformData* performData, std::string& newLocation, CURL* easy_handle);
 
   // Continues a transfer via a redirect. The redirect can point to a local file, alien file or a http address.
   void followRedirect(PerformData* performData, CURL* easy_handle, std::vector<std::string>& locations, bool& rescheduled, bool& contentRetrieved);

--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -294,7 +294,6 @@ class CCDBDownloader
   } PerformData;
 #endif
 
-
   /**
    * Called by CURL in order to close a socket. It will be called by CURL even if a timeout timer closed the socket beforehand.
    *

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -401,10 +401,10 @@ void CCDBDownloader::followRedirect(PerformData* performData, CURL* easy_handle,
 
 std::string CCDBDownloader::trimHostUrl(std::string full_host_url) const
 {
-  CURLU *host_url = curl_url();
+  CURLU* host_url = curl_url();
   curl_url_set(host_url, CURLUPART_URL, full_host_url.c_str(), 0);
   // Get host part
-  char *host;
+  char* host;
   CURLUcode host_result = curl_url_get(host_url, CURLUPART_HOST, &host, 0);
   std::string host_name;
   if (host_result == CURLUE_OK) {
@@ -417,7 +417,7 @@ std::string CCDBDownloader::trimHostUrl(std::string full_host_url) const
     return "";
   }
   // Get scheme (protocol) part
-  char *scheme;
+  char* scheme;
   CURLUcode scheme_result = curl_url_get(host_url, CURLUPART_SCHEME, &scheme, 0);
   curl_url_cleanup(host_url);
   if (scheme_result == CURLUE_OK) {
@@ -436,9 +436,9 @@ std::string CCDBDownloader::prepareRedirectedURL(std::string address, std::strin
     return address;
   }
   // Check if URL contains a scheme (protocol)
-  CURLU *redirected_url = curl_url();
+  CURLU* redirected_url = curl_url();
   curl_url_set(redirected_url, CURLUPART_URL, address.c_str(), 0);
-  char *scheme;
+  char* scheme;
   CURLUcode scheme_result = curl_url_get(redirected_url, CURLUPART_SCHEME, &scheme, 0);
   curl_free(scheme);
   curl_url_cleanup(redirected_url);

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -354,40 +354,101 @@ void CCDBDownloader::tryNewHost(PerformData* performData, CURL* easy_handle)
   mHandlesToBeAdded.push_back(easy_handle);
 }
 
-void CCDBDownloader::getLocalContent(PerformData* performData, std::string& newUrl, std::string& newLocation, bool& contentRetrieved, std::vector<std::string>& locations)
+void CCDBDownloader::getLocalContent(PerformData* performData, std::string& newLocation, bool& contentRetrieved, std::vector<std::string>& locations)
 {
   auto requestData = performData->requestData;
-  newUrl = newLocation;
-  LOG(debug) << "Redirecting to local content " << newUrl << "\n";
-  if (requestData->localContentCallback(newUrl)) {
+  LOG(debug) << "Redirecting to local content " << newLocation << "\n";
+  if (requestData->localContentCallback(newLocation)) {
     contentRetrieved = true;
   } else {
     // Prepare next redirect url
-    newLocation = (performData->locInd < locations.size()) ? locations.at(performData->locInd) : "";
-    performData->locInd++;
+    newLocation = getNewLocation(performData, locations);
   }
 }
 
-void CCDBDownloader::httpRedirect(PerformData* performData, std::string& newUrl, std::string& newLocation, CURL* easy_handle)
+std::string CCDBDownloader::getNewLocation(PerformData* performData, std::vector<std::string>& locations) const
 {
   auto requestData = performData->requestData;
-  newUrl = requestData->hosts.at(performData->hostInd) + newLocation;
-  LOG(debug) << "Trying content location " << newUrl;
-  curl_easy_setopt(easy_handle, CURLOPT_URL, newUrl.c_str());
+  if (performData->locInd < locations.size()) {
+    std::string newLocation = locations.at(performData->locInd++);
+    std::string hostUrl = requestData->hosts.at(performData->hostInd);
+    std::string newUrl = prepareRedirectedURL(newLocation, hostUrl);
+    return newUrl;
+  } else {
+    return "";
+  }
+}
+
+void CCDBDownloader::httpRedirect(PerformData* performData, std::string& newLocation, CURL* easy_handle)
+{
+  auto requestData = performData->requestData;
+  LOG(debug) << "Trying content location " << newLocation;
+  curl_easy_setopt(easy_handle, CURLOPT_URL, newLocation.c_str());
   mHandlesToBeAdded.push_back(easy_handle);
 }
 
 void CCDBDownloader::followRedirect(PerformData* performData, CURL* easy_handle, std::vector<std::string>& locations, bool& rescheduled, bool& contentRetrieved)
 {
-  std::string newLocation = locations.at(performData->locInd++);
-  std::string newUrl;
+  std::string newLocation = getNewLocation(performData, locations);
   if (newLocation.find("alien:/", 0) != std::string::npos || newLocation.find("file:/", 0) != std::string::npos) {
-    getLocalContent(performData, newUrl, newLocation, contentRetrieved, locations);
+    getLocalContent(performData, newLocation, contentRetrieved, locations);
   }
   if (!contentRetrieved && newLocation != "") {
-    httpRedirect(performData, newUrl, newLocation, easy_handle);
+    httpRedirect(performData, newLocation, easy_handle);
     rescheduled = true;
   }
+}
+
+std::string CCDBDownloader::trimHostUrl(std::string full_host_url) const
+{
+  CURLU *host_url = curl_url();
+  curl_url_set(host_url, CURLUPART_URL, full_host_url.c_str(), 0);
+  // Get host part
+  char *host;
+  CURLUcode host_result = curl_url_get(host_url, CURLUPART_HOST, &host, 0);
+  std::string host_name;
+  if (host_result == CURLUE_OK) {
+    // Host part present
+    host_name = host;
+    curl_free(host);
+  } else {
+    LOG(error) << "CCDBDownloader: Malformed url detected when processing redirect, could not identify the host part: " << host;
+    curl_url_cleanup(host_url);
+    return "";
+  }
+  // Get scheme (protocol) part
+  char *scheme;
+  CURLUcode scheme_result = curl_url_get(host_url, CURLUPART_SCHEME, &scheme, 0);
+  curl_url_cleanup(host_url);
+  if (scheme_result == CURLUE_OK) {
+    // If protocol present combine with host
+    curl_free(scheme);
+    return scheme + std::string("://") + host_name;
+  } else {
+    return host_name;
+  }
+}
+
+std::string CCDBDownloader::prepareRedirectedURL(std::string address, std::string potentialHost) const
+{
+  // If it is an alien or local address it does not need preparation
+  if (address.find("alien:/") != std::string::npos || address.find("file:/") != std::string::npos) {
+    return address;
+  }
+  // Check if URL contains a scheme (protocol)
+  CURLU *redirected_url = curl_url();
+  curl_url_set(redirected_url, CURLUPART_URL, address.c_str(), 0);
+  char *scheme;
+  CURLUcode scheme_result = curl_url_get(redirected_url, CURLUPART_SCHEME, &scheme, 0);
+  curl_free(scheme);
+  curl_url_cleanup(redirected_url);
+  if (scheme_result == CURLUE_OK) {
+    // The redirected_url contains a scheme (protocol) so there is no need for preparation
+    return address;
+  }
+  // If the address doesn't contain a scheme it means it is a relative url. We need to append it to the trimmed host url
+  // The host url must be trimmed from it's path (if it ends in one) as otherwise the redirection url would be appended after said path
+  return trimHostUrl(potentialHost) + address;
 }
 
 void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
@@ -426,7 +487,7 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
       LOG(debug) << "Transfer for " << url << " finished with code " << httpCode << "\n";
 
       // Get alternative locations for the same host
-      auto locations = getLocations(requestData->hosts.at(performData->hostInd), &(requestData->hoPair.header));
+      auto locations = getLocations(&(requestData->hoPair.header));
 
       // React to received http code
       if (404 == httpCode) {
@@ -549,16 +610,12 @@ CURLcode CCDBDownloader::perform(CURL* handle)
   return batchBlockingPerform(handleVector).back();
 }
 
-std::vector<std::string> CCDBDownloader::getLocations(std::string baseUrl, std::multimap<std::string, std::string>* headerMap) const
+std::vector<std::string> CCDBDownloader::getLocations(std::multimap<std::string, std::string>* headerMap) const
 {
   std::vector<std::string> locs;
   auto iter = headerMap->find("Location");
   if (iter != headerMap->end()) {
-    if (iter->second.find("/", 0) != std::string::npos) {
-      locs.push_back(iter->second);
-    } else {
-      locs.push_back(baseUrl + iter->second);
-    }
+    locs.push_back(iter->second);
   }
   // add alternative locations (not yet included)
   auto iter2 = headerMap->find("Content-Location");
@@ -566,11 +623,7 @@ std::vector<std::string> CCDBDownloader::getLocations(std::string baseUrl, std::
     auto range = headerMap->equal_range("Content-Location");
     for (auto it = range.first; it != range.second; ++it) {
       if (std::find(locs.begin(), locs.end(), it->second) == locs.end()) {
-        if (it->second.find("alien", 0) != std::string::npos) {
-          locs.push_back(it->second);
-        } else {
-          locs.push_back(baseUrl + it->second);
-        }
+        locs.push_back(it->second);
       }
     }
   }


### PR DESCRIPTION
This commit adds a `prepareRedirectedURL` function which assures that the host address will not be added unnecessarily and that the path will be correctly appended to the host url.

This is a follow up to https://github.com/AliceO2Group/AliceO2/pull/12182
