### PR TITLE
AOD: Fix segfault when MC kinematics event is empty

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -301,7 +301,7 @@ class AODProducerWorkflowDPL : public Task
   // Mapping of eventID, sourceID, trackID to some integer.
   // The first two indices are not sparse whereas the trackID index is sparse which explains
   // the combination of vector and map
-  std::vector<std::vector<std::unordered_map<int, int>*>> mToStore;
+  std::vector<std::vector<std::unordered_map<int, int>>> mToStore;
   o2::steer::MCKinematicsReader* mMCKineReader = nullptr; //!
 
   // production metadata


### PR DESCRIPTION
Fixing a segfault problem, arising from the fact
that the kinematics events is empty.

AOD conversion now correctly handles this cornercase.

mToStore is refactored to **not use** pointers to maps so that we do not need to treat nullptr corner cases.

P.S. Simulation should probably make sure
that empty events are handled at an earlier stage.