### PR TITLE
DPL Analysis: prevent warning

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2752,7 +2752,7 @@ class FilteredBase : public T
       this->copyIndexBindings(fresult);
       return fresult;
     }
-    auto start = offset;
+    auto start = static_cast<uint64_t>(offset);
     auto end = start + slice->num_rows();
     auto start_iterator = std::lower_bound(mSelectedRows.begin(), mSelectedRows.end(), start);
     auto stop_iterator = std::lower_bound(start_iterator, mSelectedRows.end(), end);


### PR DESCRIPTION
Prevents `non-constant-expression cannot be narrowed from type 'std::tuple_element<0, std::pair<long long, long long>>::type' (aka 'long long') to 'uint64_t' (aka 'unsigned long long') in initializer list` 