### PR TITLE
ALICE3: Set color scheme to resemble LOI schema

### DIFF
--- a/Detectors/Upgrades/ALICE3/FCT/simulation/src/FCTLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/FCT/simulation/src/FCTLayer.cxx
@@ -105,8 +105,7 @@ void FCTLayer::createDiskLayer(TGeoVolume* motherVolume)
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
   layerVol->SetLineColor(kGreen + 3);
 
-  LOG(info)
-    << "Inserting " << sensVol->GetName() << " inside " << chipVol->GetName();
+  LOG(info) << "Inserting " << sensVol->GetName() << " inside " << chipVol->GetName();
   chipVol->AddNode(sensVol, 1, nullptr);
 
   LOG(info) << "Inserting " << chipVol->GetName() << " inside " << layerVol->GetName();

--- a/Detectors/Upgrades/ALICE3/FCT/simulation/src/FCTLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/FCT/simulation/src/FCTLayer.cxx
@@ -99,10 +99,14 @@ void FCTLayer::createDiskLayer(TGeoVolume* motherVolume)
   TGeoMedium* medAir = gGeoManager->GetMedium("FCT_AIR$");
 
   TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
+  sensVol->SetLineColor(kGreen + 3);
   TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
+  chipVol->SetLineColor(kGreen + 3);
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
+  layerVol->SetLineColor(kGreen + 3);
 
-  LOG(info) << "Inserting " << sensVol->GetName() << " inside " << chipVol->GetName();
+  LOG(info)
+    << "Inserting " << sensVol->GetName() << " inside " << chipVol->GetName();
   chipVol->AddNode(sensVol, 1, nullptr);
 
   LOG(info) << "Inserting " << chipVol->GetName() << " inside " << layerVol->GetName();

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -74,8 +74,11 @@ void FT3Layer::createLayer(TGeoVolume* motherVolume)
     TGeoMedium* medAir = gGeoManager->GetMedium("FT3_AIR$");
 
     TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
+    sensVol->SetLineColor(kBlue - 4);
     TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
+    chipVol->SetLineColor(kBlue - 4);
     TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
+    layerVol->SetLineColor(kBlue - 4);
 
     LOG(info) << "Inserting " << sensVol->GetName() << " inside " << chipVol->GetName();
     chipVol->AddNode(sensVol, 1, nullptr);

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Layer.cxx
@@ -51,9 +51,9 @@ void ITOFLayer::createLayer(TGeoVolume* motherVolume)
   TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
   TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
-  sensVol->SetLineColor(kAzure + 4);
-  chipVol->SetLineColor(kAzure + 4);
-  layerVol->SetLineColor(kAzure + 4);
+  sensVol->SetLineColor(kMagenta - 7);
+  chipVol->SetLineColor(kMagenta - 7);
+  layerVol->SetLineColor(kMagenta - 7);
 
   LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
   chipVol->AddNode(sensVol, 1, nullptr);
@@ -80,9 +80,9 @@ void OTOFLayer::createLayer(TGeoVolume* motherVolume)
   TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
   TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
-  sensVol->SetLineColor(kRed + 1);
-  chipVol->SetLineColor(kRed + 1);
-  layerVol->SetLineColor(kRed + 1);
+  sensVol->SetLineColor(kMagenta - 7);
+  chipVol->SetLineColor(kMagenta - 7);
+  layerVol->SetLineColor(kMagenta - 7);
 
   LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
   chipVol->AddNode(sensVol, 1, nullptr);
@@ -109,9 +109,9 @@ void FTOFLayer::createLayer(TGeoVolume* motherVolume)
   TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
   TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
-  sensVol->SetLineColor(kGreen + 2);
-  chipVol->SetLineColor(kGreen + 2);
-  layerVol->SetLineColor(kGreen + 2);
+  sensVol->SetLineColor(kMagenta - 7);
+  chipVol->SetLineColor(kMagenta - 7);
+  layerVol->SetLineColor(kMagenta - 7);
 
   LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
   chipVol->AddNode(sensVol, 1, nullptr);
@@ -141,9 +141,9 @@ void BTOFLayer::createLayer(TGeoVolume* motherVolume)
   TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
   TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
-  sensVol->SetLineColor(kGreen + 2);
-  chipVol->SetLineColor(kGreen + 2);
-  layerVol->SetLineColor(kGreen + 2);
+  sensVol->SetLineColor(kMagenta - 7);
+  chipVol->SetLineColor(kMagenta - 7);
+  layerVol->SetLineColor(kMagenta - 7);
 
   LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
   chipVol->AddNode(sensVol, 1, nullptr);

--- a/Detectors/Upgrades/ALICE3/Passive/src/Pipe.cxx
+++ b/Detectors/Upgrades/ALICE3/Passive/src/Pipe.cxx
@@ -103,7 +103,7 @@ void Alice3Pipe::ConstructGeometry()
   // Strategy used here is to use a composite shape where shapes of TRK layers are subtracted to the vacuum volume
   TGeoTube* outerBeTube = new TGeoTube("OUT_PIPEsh", mBeOuterPipeRmin, mBeOuterPipeRmin + mBeOuterPipeThick, mOuterIpHLength);
   TGeoVolume* outerBeTubeVolume = new TGeoVolume("OUT_PIPE", outerBeTube, kMedBe);
-  outerBeTubeVolume->SetLineColor(kBlue);
+  outerBeTubeVolume->SetLineColor(kGreen - 9);
 
   TGeoTube* outerBerylliumTubeVacuumBase = new TGeoTube("OUT_PIPEVACUUM_BASEsh", mBeInnerPipeRmin + mBeInnerPipeThick, mBeOuterPipeRmin, mOuterIpHLength); // Vacuum filling for outer pipe
   TGeoCompositeShape* outerBerylliumTubeVacuumComposite;                                                                                                   // Composite volume to subctract to vacuum
@@ -155,7 +155,7 @@ void Alice3Pipe::ConstructGeometry()
   TGeoTube* innerBeTube =
     new TGeoTube("INN_PIPEsh", mBeInnerPipeRmin, mBeInnerPipeRmin + mBeInnerPipeThick, mInnerIpHLength);
   TGeoVolume* innerBeTubeVolume = new TGeoVolume("INN_PIPE", innerBeTube, kMedBe);
-  innerBeTubeVolume->SetLineColor(kRed);
+  innerBeTubeVolume->SetLineColor(kGreen - 9);
 
   TGeoTube* berylliumTubeVacuum =
     new TGeoTube("INN_PIPEVACUUMsh", 0., mBeInnerPipeRmin, mInnerIpHLength);

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKLayer.cxx
@@ -51,8 +51,11 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
   TGeoMedium* medAir = gGeoManager->GetMedium("TRK_AIR$");
 
   TGeoVolume* sensVol = new TGeoVolume(sensName.c_str(), sensor, medSi);
+  sensVol->SetLineColor(kBlue - 4);
   TGeoVolume* chipVol = new TGeoVolume(chipName.c_str(), chip, medSi);
+  chipVol->SetLineColor(kBlue - 4);
   TGeoVolume* layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
+  layerVol->SetLineColor(kBlue - 4);
 
   LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
   chipVol->AddNode(sensVol, 1, nullptr);


### PR DESCRIPTION
Minor adjustment to make ALICE 3 detectors share same color code as LoI schemes:
See:
![Screenshot 2023-09-14 at 12 54 30](https://github.com/AliceO2Group/AliceO2/assets/4990252/b849da6c-e2cf-47c3-9e77-b3f1014726f6)

vs

![Screenshot 2023-11-09 at 14 55 12](https://github.com/AliceO2Group/AliceO2/assets/4990252/466f97b1-f2fa-43a4-9f1f-ccc1a7a1cc80)

