### PR TITLE
Fix TrackParam rotate function

### DIFF
--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
@@ -198,6 +198,7 @@ class GPUTPCGMMerger : public GPUProcessor
   void MergedTrackStreamerInternal(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode, float weight, float frac);
   void MergedTrackStreamer(const GPUTPCGMBorderTrack& b1, const GPUTPCGMBorderTrack& b2, const char* name, int slice1, int slice2, int mergeMode, float weight, float frac);
   const GPUTPCGMBorderTrack& MergedTrackStreamerFindBorderTrack(const GPUTPCGMBorderTrack* tracks, int N, int trackId);
+  void DebugRefitMergedTrack(const GPUTPCGMMergedTrack& track);
 #endif
 
  private:

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -1152,6 +1152,7 @@ GPUd() void GPUTPCGMTrackParam::RefitTrack(GPUTPCGMMergedTrack& GPUrestrict() tr
     track.SetLastX(xx * cosA - yy * sinA);
     track.SetLastY(xx * sinA + yy * cosA);
     track.SetLastZ(zz);
+    // merger->DebugRefitMergedTrack(track);
   }
 }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -1168,7 +1168,7 @@ GPUd() void GPUTPCGMTrackParam::Rotate(float alpha)
   float j2 = cosPhi / cosPhi0;
   mX = x0 * cA + mP[0] * sA;
   mP[0] = -x0 * sA + mP[0] * cA;
-  mP[2] = sinPhi + j2;
+  mP[2] = sinPhi;
   mC[0] *= j0 * j0;
   mC[1] *= j0;
   mC[3] *= j0;


### PR DESCRIPTION
Not sure how the `+ j2` ended up there. Fortunately that fast function is used only sparsely since normally the rotation including the track linearization model is used... but a small fraction of TPC tracks have incorrect SinPhi after the track fit.