### PR TITLE
DPL: keep dropping data while in ready, unless a new state was requested

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -119,7 +119,6 @@ class DataProcessingDevice : public fair::mq::Device
   /// Handle to wake up the main loop from other threads
   /// e.g. when FairMQ notifies some callback in an asynchronous way
   uv_async_t* mAwakeHandle = nullptr;
-  int64_t mCleanupCount = -1;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -107,15 +107,15 @@ class DataProcessingDevice : public fair::mq::Device
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
 
-  uint64_t mLastSlowMetricSentTimestamp = 0;         /// The timestamp of the last time we sent slow metrics
-  uint64_t mLastMetricFlushedTimestamp = 0;          /// The timestamp of the last time we actually flushed metrics
-  uint64_t mBeginIterationTimestamp = 0;             /// The timestamp of when the current ConditionalRun was started
+  uint64_t mLastSlowMetricSentTimestamp = 0;             /// The timestamp of the last time we sent slow metrics
+  uint64_t mLastMetricFlushedTimestamp = 0;              /// The timestamp of the last time we actually flushed metrics
+  uint64_t mBeginIterationTimestamp = 0;                 /// The timestamp of when the current ConditionalRun was started
   std::vector<fair::mq::RegionInfo> mPendingRegionInfos; /// A list of the region infos not yet notified.
   std::mutex mRegionInfoMutex;
-  ProcessingPolicies mProcessingPolicies;                        /// User policies related to data processing
-  bool mWasActive = false;                                       /// Whether or not the device was active at last iteration.
-  std::vector<uv_work_t> mHandles;                               /// Handles to use to schedule work.
-  std::vector<TaskStreamInfo> mStreams;                          /// Information about the task running in the associated mHandle.
+  ProcessingPolicies mProcessingPolicies; /// User policies related to data processing
+  bool mWasActive = false;                /// Whether or not the device was active at last iteration.
+  std::vector<uv_work_t> mHandles;        /// Handles to use to schedule work.
+  std::vector<TaskStreamInfo> mStreams;   /// Information about the task running in the associated mHandle.
   /// Handle to wake up the main loop from other threads
   /// e.g. when FairMQ notifies some callback in an asynchronous way
   uv_async_t* mAwakeHandle = nullptr;

--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <map>
 #include <utility>
+#include <atomic>
 
 typedef struct uv_loop_s uv_loop_t;
 typedef struct uv_timer_s uv_timer_t;
@@ -59,6 +60,7 @@ struct DeviceState {
   std::vector<InputChannelInfo> inputChannelInfos;
   StreamingState streaming = StreamingState::Streaming;
   bool quitRequested = false;
+  std::atomic<int64_t> cleanupCount = -1;
 
   /// ComputingQuotaOffers which have not yet been
   /// evaluated by the ComputingQuotaEvaluator


### PR DESCRIPTION
DPL: keep dropping data while in ready, unless a new state was requested

For some reason, before we were dropping data only for 5 seconds.
To be seen if this was needed to prevent some timeout by ECS / ODC.

This has now changed to keep dropping data until the "cleanup" property
changes or until there is a NewStatePending().
