### PR TITLE
Discard ITS/MFT ROFs with impossible IRs

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -633,9 +633,9 @@ bool MatchTPCITS::prepareITSData()
   for (int irof = 0; irof < nROFs; irof++) {
     const auto& rofRec = mITSTrackROFRec[irof];
     long nBC = rofRec.getBCData().differenceInBC(mStartIR);
-    if (nBC > maxBCs) {
+    if (nBC > maxBCs || nBC < 0) {
       if (++errCount < MaxErrors2Report) {
-        LOGP(alarm, "ITS ROF#{} start is not compatible with TF 1st orbit {} and TF length of {} HBFs",
+        LOGP(alarm, "ITS ROF#{} start {} is not compatible with TF 1st orbit {} or TF length of {} HBFs",
              irof, rofRec.getBCData().asString(), mStartIR.asString(), nHBF);
       }
       break;

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -36,6 +36,7 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
   }
   auto autoDecode = reader.getDecodeNextAuto();
   int rofcount{0};
+  o2::InteractionRecord lastIR{};
   do {
     if (autoDecode) {
       reader.setDecodeNextAuto(false); // internally do not autodecode
@@ -46,6 +47,15 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
     if (reader.getInteractionRecord().isDummy()) {
       continue; // No IR info was found
     }
+    if (!lastIR.isDummy() && lastIR >= reader.getInteractionRecord()) {
+      const int MaxErrLog = 2;
+      static int errLocCount = 0;
+      if (errLocCount++ < MaxErrLog) {
+        LOGP(warn, "Impossible ROF IR {}, does not exceed previous {}, discarding in clusterization", reader.getInteractionRecord().asString(), lastIR.asString());
+      }
+      continue;
+    }
+    lastIR = reader.getInteractionRecord();
     // pre-fetch all non-empty chips of current ROF
     ChipPixelData* curChipData = nullptr;
     mFiredChipsPtr.clear();


### PR DESCRIPTION
Alpide Raw decoder, clusterizer and ITS-TPC matcher will skip ROFs with IR preceding or equal previous ROF IR (or TF 1st IR)