### PR TITLE
DPL: add edge validation support after topology generation

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -259,9 +259,11 @@ DataProcessorSpec CommonDataProcessors::getOutputObjHistSink(std::vector<OutputO
   };
 
   char const* name = "internal-dpl-aod-global-analysis-file-sink";
+  // Lifetime is sporadic because we do not ask each analysis task to send its
+  // results every timeframe.
   DataProcessorSpec spec{
     .name = name,
-    .inputs = {InputSpec("x", DataSpecUtils::dataDescriptorMatcherFrom(header::DataOrigin{"ATSK"}))},
+    .inputs = {InputSpec("x", DataSpecUtils::dataDescriptorMatcherFrom(header::DataOrigin{"ATSK"}), Lifetime::Sporadic)},
     .algorithm = {writerFunction},
   };
 

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1072,6 +1072,8 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
 
   WorkflowHelpers::constructGraph(workflow, logicalEdges, outputs, availableForwardsInfo);
 
+  WorkflowHelpers::validateEdges(workflow, logicalEdges, outputs);
+
   // We need to instanciate one device per (me, timeIndex) in the
   // DeviceConnectionEdge. For each device we need one new binding
   // server per (me, other) -> port Moreover for each (me, other,

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -227,6 +227,14 @@ struct WorkflowHelpers {
 
   /// returns only dangling outputs
   static std::vector<InputSpec> computeDanglingOutputs(WorkflowSpec const& workflow);
+
+  /// Validate that the nodes at the ends of the edges of the graph
+  /// are actually compatible with each other.
+  /// For example we should make sure that Lifetime::Timeframe inputs of
+  /// one node is not connected to an Output of Lifetime::Sporadic of another node.
+  static void validateEdges(WorkflowSpec const& workflow,
+                            std::vector<DeviceConnectionEdge> const& edges,
+                            std::vector<OutputSpec> const& outputs);
 };
 
 } // namespace o2::framework


### PR DESCRIPTION
DPL: add edge validation support after topology generation

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12242).
* #12306
* #12305
* __->__ #12242