### PR TITLE
Do not expose AODToHepMC.h to ROOT

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -107,7 +107,6 @@ endif()
 if(HepMC3_FOUND)
   list(APPEND headers include/Generators/GeneratorHepMC.h)
   list(APPEND headers include/Generators/GeneratorHepMCParam.h)
-  list(APPEND headers include/Generators/AODToHepMC.h)
 endif()
 
 o2_target_root_dictionary(Generators HEADERS ${headers})


### PR DESCRIPTION
Do not expose AODToHepMC.h to ROOT

This is needed to fix macOS builds. Apparently ROOT injects
some arrow incompatible system headers in the chain.
