### PR TITLE
TPC PID response: Added an option to use nSigma

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/PIDResponse.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/PIDResponse.h
@@ -98,24 +98,26 @@ GPUd() o2::track::PID::ID PIDResponse::getMostProbablePID(const TrackTPC& track,
 
   auto id = o2::track::PID::Electron;
   float distanceMin = 0.;
+  float dEdxExpected = getExpectedSignal(track, id);
   if (PID_useNsigma) {
     // using nSigma
-    distanceMin = o2::gpu::GPUCommonMath::Abs((dEdx - getExpectedSignal(track, id)) / (PID_sigma * getExpectedSignal(track, id)));
+    distanceMin = o2::gpu::GPUCommonMath::Abs((dEdx - dEdxExpected) / (PID_sigma * dEdxExpected));
   } else {
     // using absolute distance
-    distanceMin = o2::gpu::GPUCommonMath::Abs(dEdx - getExpectedSignal(track, id));
+    distanceMin = o2::gpu::GPUCommonMath::Abs(dEdx - dEdxExpected);
   }
 
   // calculate the distance to the expected dEdx signals
   // start from Pion to exlude Muons
   for (o2::track::PID::ID i = o2::track::PID::Pion; i < o2::track::PID::NIDs; i++) {
     float distance = 0.;
+    dEdxExpected = getExpectedSignal(track, i);
     if (PID_useNsigma) {
       // using nSigma
-      distance = o2::gpu::GPUCommonMath::Abs((dEdx - getExpectedSignal(track, i)) / (PID_sigma * getExpectedSignal(track, i)));
+      distance = o2::gpu::GPUCommonMath::Abs((dEdx - dEdxExpected) / (PID_sigma * dEdxExpected));
     } else {
       // using absolute distance
-      distance = o2::gpu::GPUCommonMath::Abs(dEdx - getExpectedSignal(track, i));
+      distance = o2::gpu::GPUCommonMath::Abs(dEdx - dEdxExpected);
     }
     if (distance < distanceMin) {
       id = i;

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/PIDResponse.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/PIDResponse.h
@@ -58,7 +58,7 @@ class PIDResponse
   GPUd() float getExpectedSignal(const TrackTPC& track, const o2::track::PID::ID id) const;
 
   /// get most probable PID of the track
-  GPUd() o2::track::PID::ID getMostProbablePID(const TrackTPC& track, float PID_EKrangeMin, float PID_EKrangeMax, float PID_EPrangeMin, float PID_EPrangeMax, float PID_EDrangeMin, float PID_EDrangeMax, float PID_ETrangeMin, float PID_ETrangeMax) const;
+  GPUd() o2::track::PID::ID getMostProbablePID(const TrackTPC& track, float PID_EKrangeMin, float PID_EKrangeMax, float PID_EPrangeMin, float PID_EPrangeMax, float PID_EDrangeMin, float PID_EDrangeMax, float PID_ETrangeMin, float PID_ETrangeMax, char PID_useNsigma, float PID_sigma) const;
 
  private:
   float mBetheBlochParams[5] = {0.19310481, 4.26696118, 0.00522579, 2.38124907, 0.98055396}; // BBAleph average fit parameters
@@ -88,7 +88,7 @@ GPUd() float PIDResponse::getExpectedSignal(const TrackTPC& track, const o2::tra
 }
 
 // get most probable PID
-GPUd() o2::track::PID::ID PIDResponse::getMostProbablePID(const TrackTPC& track, float PID_EKrangeMin, float PID_EKrangeMax, float PID_EPrangeMin, float PID_EPrangeMax, float PID_EDrangeMin, float PID_EDrangeMax, float PID_ETrangeMin, float PID_ETrangeMax) const
+GPUd() o2::track::PID::ID PIDResponse::getMostProbablePID(const TrackTPC& track, float PID_EKrangeMin, float PID_EKrangeMax, float PID_EPrangeMin, float PID_EPrangeMax, float PID_EDrangeMin, float PID_EDrangeMax, float PID_ETrangeMin, float PID_ETrangeMax, char PID_useNsigma, float PID_sigma) const
 {
   const float dEdx = track.getdEdx().dEdxTotTPC;
 
@@ -97,12 +97,26 @@ GPUd() o2::track::PID::ID PIDResponse::getMostProbablePID(const TrackTPC& track,
   }
 
   auto id = o2::track::PID::Electron;
-  float distanceMin = o2::gpu::GPUCommonMath::Abs(dEdx - getExpectedSignal(track, id));
+  float distanceMin = 0.;
+  if (PID_useNsigma) {
+    // using nSigma
+    distanceMin = o2::gpu::GPUCommonMath::Abs((dEdx - getExpectedSignal(track, id)) / (PID_sigma * getExpectedSignal(track, id)));
+  } else {
+    // using absolute distance
+    distanceMin = o2::gpu::GPUCommonMath::Abs(dEdx - getExpectedSignal(track, id));
+  }
 
   // calculate the distance to the expected dEdx signals
   // start from Pion to exlude Muons
   for (o2::track::PID::ID i = o2::track::PID::Pion; i < o2::track::PID::NIDs; i++) {
-    const float distance = o2::gpu::GPUCommonMath::Abs(dEdx - getExpectedSignal(track, i));
+    float distance = 0.;
+    if (PID_useNsigma) {
+      // using nSigma
+      distance = o2::gpu::GPUCommonMath::Abs((dEdx - getExpectedSignal(track, i)) / (PID_sigma * getExpectedSignal(track, i)));
+    } else {
+      // using absolute distance
+      distance = o2::gpu::GPUCommonMath::Abs(dEdx - getExpectedSignal(track, i));
+    }
     if (distance < distanceMin) {
       id = i;
       distanceMin = distance;

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -68,6 +68,7 @@ AddOptionRTC(PID_EDrangeMin, float, 1.88f, "", 0, "min P of electron/d BB bands 
 AddOptionRTC(PID_EDrangeMax, float, 1.98f, "", 0, "max P of electron/d BB bands crossing")
 AddOptionRTC(PID_ETrangeMin, float, 2.84f, "", 0, "min P of electron/t BB bands crossing")
 AddOptionRTC(PID_ETrangeMax, float, 2.94f, "", 0, "max P of electron/t BB bands crossing")
+AddOptionRTC(PID_sigma, float, 0.06f, "", 0, "relative sigma for PID in combination with PID_useNsigma")
 AddOptionRTC(extraClusterErrorEdgeY2, float, 0.35f, "", 0, "Additive extra cluster error for Y2 if edge flag set")
 AddOptionRTC(extraClusterErrorEdgeZ2, float, 0.15f, "", 0, "Additive extra cluster error for Z2 if edge flag set")
 AddOptionRTC(extraClusterErrorSingleY2, float, 0.2f, "", 0, "Additive extra cluster error for Y2 if edge single set")
@@ -130,6 +131,7 @@ AddOptionRTC(loopInterpolationInExtraPass, char, -1, "", 0, "Perform loop interp
 AddOptionRTC(mergerReadFromTrackerDirectly, char, 1, "", 0, "Forward data directly from tracker to merger on GPU")
 AddOptionRTC(dropSecondaryLegsInOutput, char, 1, "", 0, "Do not store secondary legs of looping track in TrackTPC")
 AddOptionRTC(enablePID, char, 1, "", 0, "Enable PID response")
+AddOptionRTC(PID_useNsigma, char, 1, "", 0, "Use nSigma instead of absolute distance in PID response")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
@@ -145,7 +145,7 @@ GPUdii() void GPUTPCGMO2Output::Thread<GPUTPCGMO2Output::output>(int nBlocks, in
 
     if (merger.Param().par.dodEdx && merger.Param().rec.tpc.enablePID) {
       PIDResponse pidResponse{};
-      const auto pid = pidResponse.getMostProbablePID(oTrack, merger.Param().rec.tpc.PID_EKrangeMin, merger.Param().rec.tpc.PID_EKrangeMax, merger.Param().rec.tpc.PID_EPrangeMin, merger.Param().rec.tpc.PID_EPrangeMax, merger.Param().rec.tpc.PID_EDrangeMin, merger.Param().rec.tpc.PID_EDrangeMax, merger.Param().rec.tpc.PID_ETrangeMin, merger.Param().rec.tpc.PID_ETrangeMax);
+      const auto pid = pidResponse.getMostProbablePID(oTrack, merger.Param().rec.tpc.PID_EKrangeMin, merger.Param().rec.tpc.PID_EKrangeMax, merger.Param().rec.tpc.PID_EPrangeMin, merger.Param().rec.tpc.PID_EPrangeMax, merger.Param().rec.tpc.PID_EDrangeMin, merger.Param().rec.tpc.PID_EDrangeMax, merger.Param().rec.tpc.PID_ETrangeMin, merger.Param().rec.tpc.PID_ETrangeMax, merger.Param().rec.tpc.PID_useNsigma, merger.Param().rec.tpc.PID_sigma);
       oTrack.setPID(pid);
       oTrack.getParamOut().setPID(pid);
     }


### PR DESCRIPTION
Added an option to use nSigma instead of absolute distance to the expected dEdx in PID response. 

PID_sigma is a configurable parameter for a constant relative sigma.
PID_useNsigma is a configurable parameter to enable/disable the use of nSigma in PID response. 

![image](https://github.com/AliceO2Group/AliceO2/assets/48834043/d170008d-bea4-4f82-bd71-04e1ec470922)