### PR TITLE
TPC: Fix usage of derivative map for scaling of space-charge corrections

### DIFF
--- a/Detectors/Align/Workflow/include/AlignmentWorkflow/BarrelAlignmentSpec.h
+++ b/Detectors/Align/Workflow/include/AlignmentWorkflow/BarrelAlignmentSpec.h
@@ -21,12 +21,17 @@ using namespace o2::framework;
 
 namespace o2
 {
+namespace tpc
+{
+struct CorrectionMapsLoaderGloOpts;
+}
+
 namespace align
 {
 
 /// create a processor spec
 framework::DataProcessorSpec getBarrelAlignmentSpec(o2::dataformats::GlobalTrackID::mask_t srcMP, o2::dataformats::GlobalTrackID::mask_t src,
-                                                    o2::detectors::DetID::mask_t dets, o2::detectors::DetID::mask_t skipDetClusters, bool enableCosmic, int postproc, bool useMC, int lumiType);
+                                                    o2::detectors::DetID::mask_t dets, o2::detectors::DetID::mask_t skipDetClusters, bool enableCosmic, int postproc, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace align
 } // namespace o2

--- a/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
+++ b/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
@@ -358,7 +358,7 @@ void BarrelAlignmentSpec::endOfStream(EndOfStreamContext& ec)
   mDBGOut.reset();
 }
 
-DataProcessorSpec getBarrelAlignmentSpec(GTrackID::mask_t srcMP, GTrackID::mask_t src, DetID::mask_t dets, DetID::mask_t skipDetClusters, bool enableCosmic, int postprocess, bool useMC, int lumiType)
+DataProcessorSpec getBarrelAlignmentSpec(GTrackID::mask_t srcMP, GTrackID::mask_t src, DetID::mask_t dets, DetID::mask_t skipDetClusters, bool enableCosmic, int postprocess, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<OutputSpec> outputs;
   auto dataRequest = std::make_shared<DataRequest>();
@@ -383,7 +383,7 @@ DataProcessorSpec getBarrelAlignmentSpec(GTrackID::mask_t srcMP, GTrackID::mask_
     }
     if (src[DetID::TPC] && !skipDetClusters[DetID::TPC]) {
       o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-      o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, lumiType);
+      o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, sclOpts);
       loadTPCCalib = true;
     }
   }

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/CosmicsMatchingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/CosmicsMatchingSpec.h
@@ -20,11 +20,16 @@ using namespace o2::framework;
 
 namespace o2
 {
+namespace tpc
+{
+struct CorrectionMapsLoaderGloOpts;
+}
+
 namespace globaltracking
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getCosmicsMatchingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, int lumiType);
+framework::DataProcessorSpec getCosmicsMatchingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/SecondaryVertexingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/SecondaryVertexingSpec.h
@@ -20,11 +20,16 @@
 
 namespace o2
 {
+namespace tpc
+{
+struct CorrectionMapsLoaderGloOpts;
+}
+
 namespace vertexing
 {
 
 /// create a processor spec
-o2::framework::DataProcessorSpec getSecondaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool enableCasc, bool enable3body, bool enableStrangenesTracking, bool useMC, int lumiType);
+o2::framework::DataProcessorSpec getSecondaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool enableCasc, bool enable3body, bool enableStrangenesTracking, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace vertexing
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TOFMatcherSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TOFMatcherSpec.h
@@ -21,11 +21,15 @@ using namespace o2::framework;
 
 namespace o2
 {
+namespace tpc
+{
+struct CorrectionMapsLoaderGloOpts;
+}
 namespace globaltracking
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getTOFMatcherSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool useFIT, bool tpcRefit, bool strict, float extratolerancetrd, bool pushMatchable, int lumiType);
+framework::DataProcessorSpec getTOFMatcherSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool useFIT, bool tpcRefit, bool strict, float extratolerancetrd, bool pushMatchable, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
@@ -20,10 +20,14 @@ using namespace o2::framework;
 
 namespace o2
 {
+namespace tpc
+{
+struct CorrectionMapsLoaderGloOpts;
+}
 namespace globaltracking
 {
 /// create a processor spec
-framework::DataProcessorSpec getTPCITSMatchingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useFT0, bool calib, bool skipTPCOnly, bool useMC, int lumiType);
+framework::DataProcessorSpec getTPCITSMatchingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useFT0, bool calib, bool skipTPCOnly, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -172,7 +172,7 @@ void CosmicsMatchingSpec::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getCosmicsMatchingSpec(GTrackID::mask_t src, bool useMC, int lumiType)
+DataProcessorSpec getCosmicsMatchingSpec(GTrackID::mask_t src, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<OutputSpec> outputs;
   Options opts{
@@ -198,7 +198,7 @@ DataProcessorSpec getCosmicsMatchingSpec(GTrackID::mask_t src, bool useMC, int l
                                                               dataRequest->inputs,
                                                               true);
   o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, lumiType);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, sclOpts);
 
   return DataProcessorSpec{
     "cosmics-matcher",

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
@@ -33,6 +33,7 @@
 #include "TPCCalibration/CorrectionMapsLoader.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/DeviceSpec.h"
+#include "TPCCalibration/CorrectionMapsLoader.h"
 
 using namespace o2::framework;
 
@@ -201,7 +202,7 @@ void SecondaryVertexingSpec::updateTimeDependentParams(ProcessingContext& pc)
   pc.inputs().get<o2::dataformats::MeanVertexObject*>("meanvtx");
 }
 
-DataProcessorSpec getSecondaryVertexingSpec(GTrackID::mask_t src, bool enableCasc, bool enable3body, bool enableStrangenesTracking, bool useMC, int lumiType)
+DataProcessorSpec getSecondaryVertexingSpec(GTrackID::mask_t src, bool enableCasc, bool enable3body, bool enableStrangenesTracking, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<OutputSpec> outputs;
   Options opts{
@@ -231,7 +232,7 @@ DataProcessorSpec getSecondaryVertexingSpec(GTrackID::mask_t src, bool enableCas
                                                               true);
   if (src[GTrackID::TPC]) {
     o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-    o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, lumiType);
+    o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, sclOpts);
   }
   outputs.emplace_back("GLO", "V0S_IDX", 0, Lifetime::Timeframe);        // found V0s indices
   outputs.emplace_back("GLO", "V0S", 0, Lifetime::Timeframe);            // found V0s

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
@@ -237,7 +237,7 @@ void TOFMatcherSpec::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getTOFMatcherSpec(GID::mask_t src, bool useMC, bool useFIT, bool tpcRefit, bool strict, float extratolerancetrd, bool pushMatchable, int lumiType)
+DataProcessorSpec getTOFMatcherSpec(GID::mask_t src, bool useMC, bool useFIT, bool tpcRefit, bool strict, float extratolerancetrd, bool pushMatchable, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   uint32_t ss = o2::globaltracking::getSubSpec(strict ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
   Options opts;
@@ -260,7 +260,7 @@ DataProcessorSpec getTOFMatcherSpec(GID::mask_t src, bool useMC, bool useFIT, bo
                                                               dataRequest->inputs,
                                                               true);
   o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, lumiType);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, sclOpts);
   std::vector<OutputSpec> outputs;
   if (GID::includesSource(GID::TPC, src)) {
     outputs.emplace_back(o2::header::gDataOriginTOF, "MTC_TPC", ss, Lifetime::Timeframe);

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -196,7 +196,7 @@ void TPCITSMatchingDPL::updateTimeDependentParams(ProcessingContext& pc)
   }
 }
 
-DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool calib, bool skipTPCOnly, bool useMC, int lumiType)
+DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool calib, bool skipTPCOnly, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<OutputSpec> outputs;
   auto dataRequest = std::make_shared<DataRequest>();
@@ -239,7 +239,7 @@ DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool 
     {"debug-tree-flags", VariantType::Int, 0, {"DebugFlagTypes bit-pattern for debug tree"}}};
 
   o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, lumiType);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, sclOpts);
 
   return DataProcessorSpec{
     "itstpc-track-matcher",

--- a/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/TPCTrackStudy.h
+++ b/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/TPCTrackStudy.h
@@ -19,10 +19,15 @@
 #include "MathUtils/detail/Bracket.h"
 #include "DataFormatsTPC/ClusterNative.h"
 
+namespace o2::tpc
+{
+struct CorrectionMapsLoaderGloOpts;
+}
+
 namespace o2::trackstudy
 {
 /// create a processor spec
-o2::framework::DataProcessorSpec getTPCTrackStudySpec(o2::dataformats::GlobalTrackID::mask_t srcTracks, o2::dataformats::GlobalTrackID::mask_t srcClus, bool useMC, int lumyType);
+o2::framework::DataProcessorSpec getTPCTrackStudySpec(o2::dataformats::GlobalTrackID::mask_t srcTracks, o2::dataformats::GlobalTrackID::mask_t srcClus, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace o2::trackstudy
 

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
@@ -404,7 +404,7 @@ void TPCTrackStudySpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   }
 }
 
-DataProcessorSpec getTPCTrackStudySpec(GTrackID::mask_t srcTracks, GTrackID::mask_t srcClusters, bool useMC, int lumyType)
+DataProcessorSpec getTPCTrackStudySpec(GTrackID::mask_t srcTracks, GTrackID::mask_t srcClusters, bool useMC, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<OutputSpec> outputs;
   Options opts{
@@ -428,7 +428,7 @@ DataProcessorSpec getTPCTrackStudySpec(GTrackID::mask_t srcTracks, GTrackID::mas
                                                               dataRequest->inputs,
                                                               true);
   o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, lumyType);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs, opts, sclOpts);
 
   return DataProcessorSpec{
     "tpc-track-study",

--- a/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
@@ -20,6 +20,7 @@
 #include "DetectorsBase/DPLWorkflowUtils.h"
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "TPCCalibration/CorrectionMapsLoader.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -39,9 +40,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of track sources to use"}},
     {"cluster-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of cluster sources to use"}},
-    {"lumi-type", o2::framework::VariantType::Int, 0, {"1 = require CTP lumi for TPC correction scaling, 2 = require TPC scalers for TPC correction scaling"}},
     {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::tpc::CorrectionMapsLoader::addGlobalOptions(options);
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -59,17 +60,17 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  auto lumiType = configcontext.options().get<int>("lumi-type");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
+  auto sclOpt = o2::tpc::CorrectionMapsLoader::parseGlobalOptions(configcontext.options());
   GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
   GID::mask_t srcCls = allowedSourcesClus & GID::getSourcesMask(configcontext.options().get<std::string>("cluster-sources"));
-  if (lumiType == 1) {
+  if (sclOpt.lumiType == 1) {
     srcTrc = srcTrc | GID::getSourcesMask("CTP");
     srcCls = srcCls | GID::getSourcesMask("CTP");
   }
   o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, useMC);
   o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC); // P-vertex is always needed
-  specs.emplace_back(o2::trackstudy::getTPCTrackStudySpec(srcTrc, srcCls, useMC, lumiType));
+  specs.emplace_back(o2::trackstudy::getTPCTrackStudySpec(srcTrc, srcCls, useMC, sclOpt));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);

--- a/Detectors/TPC/base/include/TPCBase/CDBInterface.h
+++ b/Detectors/TPC/base/include/TPCBase/CDBInterface.h
@@ -89,6 +89,8 @@ enum class CDBType {
                        ///
   CalTimeSeries,       ///< integrated DCAs for longer time interval
   CalScaler,           ///< Scaler from IDCs or combined estimator
+                       ///
+  CorrMapParam,        ///< parameters for CorrectionMapsLoader configuration
 };
 
 /// Upload intervention type
@@ -151,6 +153,8 @@ const std::unordered_map<CDBType, const std::string> CDBTypeMap{
   // time series
   {CDBType::CalTimeSeries, "TPC/Calib/TimeSeries"},
   {CDBType::CalScaler, "TPC/Calib/Scaler"},
+  // correction maps loader params
+  {CDBType::CorrMapParam, "TPC/Calib/CorrMapParam"},
 };
 
 /// Poor enum reflection ...

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -53,6 +53,7 @@ o2_add_library(TPCCalibration
                        src/TPCFastSpaceChargeCorrectionHelper.cxx
                        src/CalculatedEdx.cxx
                        src/TPCScaler.cxx
+                       src/CorrMapParam.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL
@@ -105,7 +106,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/SACCCDBHelper.h
                                   include/TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h
                                   include/TPCCalibration/CalculatedEdx.h
-                                  include/TPCCalibration/TPCScaler.h)
+                                  include/TPCCalibration/TPCScaler.h
+                                  include/TPCCalibration/CorrMapParam.h)
 
 o2_add_test_root_macro(macro/comparePedestalsAndNoise.C
                        PUBLIC_LINK_LIBRARIES O2::TPCBase

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrMapParam.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrMapParam.h
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CorrMapParam.h
+/// \brief Implementation of the parameter class for the CorrectionMapsLoader options
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_TPC_CORRMAP_PARAM_H_
+#define ALICEO2_TPC_CORRMAP_PARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+struct CorrMapParam : public o2::conf::ConfigurableParamHelper<CorrMapParam> {
+  float lumiInst = 0.;       // override instantaneous lumi (if > 0) for TPC corr.map scaling, disable corrections if < 0"
+  float lumiMean = 0.;       // override TPC corr.map mean lumi (if > 0), disable corrections if < 0
+  float lumiMeanRef = 0.;    // override TPC corr.mapRef mean lumi (if > 0)"
+  float lumiInstFactor = 1.; // scaling to apply to instantaneous lumi from CTP (but not corrmap-lumi-inst)
+  int ctpLumiSource = 0;     // CTP lumi source: 0 = LumiInfo.getLumi(), 1 = LumiInfo.getLumiAlt()
+
+  O2ParamDef(CorrMapParam, "TPCCorrMap");
+};
+} // namespace tpc
+
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::tpc::CorrMapParam> : std::true_type {
+};
+} // namespace framework
+
+} // namespace o2
+
+#endif // ALICEO2_TPC_CORRMAP_PARAM_H_

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -57,9 +57,8 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
   void copySettings(const CorrectionMapsLoader& src);
 
   static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, const CorrectionMapsLoaderGloOpts& gloOpts);
-  static void addOptions(std::vector<o2::framework::ConfigParamSpec>& options);
   static void addGlobalOptions(std::vector<o2::framework::ConfigParamSpec>& options);
-
+  static void addOptions(std::vector<o2::framework::ConfigParamSpec>& options);
   static CorrectionMapsLoaderGloOpts parseGlobalOptions(const o2::framework::ConfigParamRegistry& opts);
 
  protected:

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -30,11 +30,17 @@ class ProcessingContext;
 class ConcreteDataMatcher;
 class InputSpec;
 class ConfigParamSpec;
+class ConfigParamRegistry;
 class InitContext;
 } // namespace framework
 
 namespace tpc
 {
+
+struct CorrectionMapsLoaderGloOpts {
+  int lumiType = 0;
+  int lumiMode = 0;
+};
 
 class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
 {
@@ -50,8 +56,11 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
   void init(o2::framework::InitContext& ic);
   void copySettings(const CorrectionMapsLoader& src);
 
-  static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, int lumiScaleType, int lumiScaleMode = 0);
+  static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, const CorrectionMapsLoaderGloOpts& gloOpts);
   static void addOptions(std::vector<o2::framework::ConfigParamSpec>& options);
+  static void addGlobalOptions(std::vector<o2::framework::ConfigParamSpec>& options);
+
+  static CorrectionMapsLoaderGloOpts parseGlobalOptions(const o2::framework::ConfigParamRegistry& opts);
 
  protected:
   static void addOption(std::vector<o2::framework::ConfigParamSpec>& options, o2::framework::ConfigParamSpec&& osp);

--- a/Detectors/TPC/calibration/src/CorrMapParam.cxx
+++ b/Detectors/TPC/calibration/src/CorrMapParam.cxx
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CorrMapParam.cxx
+/// \brief Implementation of the parameter class for the CorrectionMapsLoader options
+/// \author ruben.shahoyan@cern.ch
+
+#include "TPCCalibration/CorrMapParam.h"
+
+O2ParamImpl(o2::tpc::CorrMapParam);

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -26,6 +26,8 @@
 #pragma link C++ class o2::tpc::DigitDump;
 #pragma link C++ class o2::tpc::DigitDumpParam;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::DigitDumpParam> + ;
+#pragma link C++ class o2::tpc::CorrMapParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::CorrMapParam> + ;
 #pragma link C++ class o2::tpc::CalibPadGainTracks + ;
 #pragma link C++ class o2::tpc::FastHisto < float> + ;
 #pragma link C++ class o2::tpc::FastHisto < unsigned int> + ;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -85,7 +85,8 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,           
                                     bool selIR = false,
                                     bool filteredInp = false,
                                     int lumiScaleType = 0,
-                                    int deadMapSources = -1);
+                                    int deadMapSources = -1,
+                                    int lumiScaleMode = 0);
 
 void cleanupCallback();
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -30,6 +30,7 @@ struct InputSpec;
 }
 namespace tpc
 {
+struct CorrectionMapsLoaderGloOpts;
 
 namespace reco_workflow
 {
@@ -71,22 +72,21 @@ enum struct OutputType { Digits,
 using CompletionPolicyData = std::vector<framework::InputSpec>;
 
 /// create the workflow for TPC reconstruction
-framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
-                                    std::vector<int> const& tpcSectors,           //
-                                    unsigned long tpcSectorMask,                  //
-                                    std::vector<int> const& laneConfiguration,    //
-                                    bool propagateMC = true, unsigned nLanes = 1, //
-                                    std::string const& cfgInput = "digitizer",    //
-                                    std::string const& cfgOutput = "tracks",      //
-                                    bool disableRootInput = false,                //
-                                    int caClusterer = 0,                          //
+framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,                    //
+                                    std::vector<int> const& tpcSectors,                  //
+                                    unsigned long tpcSectorMask,                         //
+                                    std::vector<int> const& laneConfiguration,           //
+                                    const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts, //
+                                    bool propagateMC = true, unsigned nLanes = 1,        //
+                                    std::string const& cfgInput = "digitizer",           //
+                                    std::string const& cfgOutput = "tracks",             //
+                                    bool disableRootInput = false,                       //
+                                    int caClusterer = 0,                                 //
                                     int zsOnTheFly = 0,
                                     bool askDISTSTF = true,
                                     bool selIR = false,
                                     bool filteredInp = false,
-                                    int lumiScaleType = 0,
-                                    int deadMapSources = -1,
-                                    int lumiScaleMode = 0);
+                                    int deadMapSources = -1);
 
 void cleanupCallback();
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -240,12 +240,15 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, const bool debug, const bool useLastExtractedMapAsReference, const std::string polynomialsFile, bool disablePolynomialsCCDB, int lumiType)
+DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, const bool debug, const bool useLastExtractedMapAsReference, const std::string polynomialsFile, bool disablePolynomialsCCDB, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("trackTPC", gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPCClRefs", gDataOriginTPC, "CLUSREFS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{gDataOriginTPC, "CLUSTERNATIVE"}, Lifetime::Timeframe);
+  if (sclOpts.lumiType == 1) {
+    inputs.emplace_back("CTPLumi", "CTP", "LUMI", 0, Lifetime::Timeframe);
+  }
 
   if (!polynomialsFile.empty()) {
     disablePolynomialsCCDB = true;
@@ -282,7 +285,7 @@ DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, c
     {"useEveryNthTF", VariantType::Int, 10, {"Using only a fraction of the data: 1: Use every TF, 10: Use only every tenth TF."}},
     {"maxTracksPerTF", VariantType::Int, 10000, {"Maximum number of processed tracks per TF (-1 for processing all tracks)"}},
   };
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs, opts, lumiType);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs, opts, sclOpts);
 
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
                                                                 false,                          // GRPECS=true

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -42,6 +42,7 @@
 #include "DataFormatsTPC/ZeroSuppression.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
 #include "TPCReaderWorkflow/TriggerReaderSpec.h"
+#include "TPCCalibration/CorrectionMapsLoader.h"
 
 #include <string>
 #include <stdexcept>
@@ -97,8 +98,8 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"tpc-triggers", OutputType::TPCTriggers}};
 
 framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, unsigned long tpcSectorMask, std::vector<int> const& laneConfiguration,
-                                    bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput, bool disableRootInput,
-                                    int caClusterer, int zsOnTheFly, bool askDISTSTF, bool selIR, bool filteredInp, int lumiScaleType, int deadMapSources, int lumiScaleMode)
+                                    const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts, bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput, bool disableRootInput,
+                                    int caClusterer, int zsOnTheFly, bool askDISTSTF, bool selIR, bool filteredInp, int deadMapSources)
 {
   InputType inputType;
   try {
@@ -440,8 +441,8 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
   if (runGPUReco) {
     o2::gpu::GPURecoWorkflowSpec::Config cfg;
     cfg.runTPCTracking = true;
-    cfg.lumiScaleType = lumiScaleType;
-    cfg.lumiScaleMode = lumiScaleMode;
+    cfg.lumiScaleType = sclOpts.lumiType;
+    cfg.lumiScaleMode = sclOpts.lumiMode;
     cfg.decompressTPC = decompressTPC;
     cfg.decompressTPCFromROOT = decompressTPC && inputType == InputType::CompClusters;
     cfg.caClusterer = caClusterer;

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -98,7 +98,7 @@ const std::unordered_map<std::string, OutputType> OutputMap{
 
 framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, unsigned long tpcSectorMask, std::vector<int> const& laneConfiguration,
                                     bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput, bool disableRootInput,
-                                    int caClusterer, int zsOnTheFly, bool askDISTSTF, bool selIR, bool filteredInp, int lumiScaleType, int deadMapSources)
+                                    int caClusterer, int zsOnTheFly, bool askDISTSTF, bool selIR, bool filteredInp, int lumiScaleType, int deadMapSources, int lumiScaleMode)
 {
   InputType inputType;
   try {
@@ -441,6 +441,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     o2::gpu::GPURecoWorkflowSpec::Config cfg;
     cfg.runTPCTracking = true;
     cfg.lumiScaleType = lumiScaleType;
+    cfg.lumiScaleMode = lumiScaleMode;
     cfg.decompressTPC = decompressTPC;
     cfg.decompressTPCFromROOT = decompressTPC && inputType == InputType::CompClusters;
     cfg.caClusterer = caClusterer;

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -23,6 +23,7 @@
 #include "Framework/ConcreteDataMatcher.h"
 #include "TPCWorkflow/RecoWorkflow.h"
 #include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
+#include "TPCCalibration/CorrectionMapsLoader.h"
 #include "Framework/CustomWorkflowTerminationHook.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "Algorithm/RangeTokenizer.h"
@@ -68,11 +69,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCHwClusterer.peakChargeThreshold=4;...')"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
     {"filtered-input", VariantType::Bool, false, {"Filtered tracks, clusters input, prefix dataDescriptors with F"}},
-    {"lumi-type", o2::framework::VariantType::Int, 0, {"1 = require CTP lumi for TPC correction scaling, 2 = require TPC scalers for TPC correction scaling"}},
     {"select-ir-frames", VariantType::Bool, false, {"Subscribe and filter according to external IR Frames"}},
     {"tpc-deadMap-sources", VariantType::Int, -1, {"Sources to consider for TPC dead channel map creation; -1=all, 0=deactivated"}},
-    {"corrmap-lumi-mode", o2::framework::VariantType::Int, 0, {"scaling mode: (default) 0 = static + scale * full; 1 = full + scale * derivative"}},
   };
+  o2::tpc::CorrectionMapsLoader::addGlobalOptions(options);
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -141,7 +141,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   std::vector<int> laneConfiguration = tpcSectors; // Currently just a copy of the tpcSectors, why?
   auto nLanes = cfgc.options().get<int>("tpc-lanes");
   auto inputType = cfgc.options().get<std::string>("input-type");
-  auto lumiType = cfgc.options().get<int>("lumi-type");
+
   // depending on whether to dispatch early (prompt) and on the input type, we
   // set the matcher. Note that this has to be in accordance with the OutputSpecs
   // configured for the PublisherSpec
@@ -168,10 +168,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     gTpcSectorMask |= (1ul << s);
   }
   bool doMC = not cfgc.options().get<bool>("disable-mc");
+  auto sclOpt = o2::tpc::CorrectionMapsLoader::parseGlobalOptions(cfgc.options());
   auto wf = o2::tpc::reco_workflow::getWorkflow(&gPolicyData,                                      //
                                                 tpcSectors,                                        // sector configuration
                                                 gTpcSectorMask,                                    // same as bitmask
                                                 laneConfiguration,                                 // lane configuration
+                                                sclOpt,                                            // scaling options
                                                 doMC,                                              //
                                                 nLanes,                                            //
                                                 inputType,                                         //
@@ -182,9 +184,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                                 !cfgc.options().get<bool>("ignore-dist-stf"),      //
                                                 cfgc.options().get<bool>("select-ir-frames"),
                                                 cfgc.options().get<bool>("filtered-input"),
-                                                lumiType,
-                                                cfgc.options().get<int>("tpc-deadMap-sources"),
-                                                cfgc.options().get<int>("corrmap-lumi-mode"));
+                                                cfgc.options().get<int>("tpc-deadMap-sources"));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -71,6 +71,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"lumi-type", o2::framework::VariantType::Int, 0, {"1 = require CTP lumi for TPC correction scaling, 2 = require TPC scalers for TPC correction scaling"}},
     {"select-ir-frames", VariantType::Bool, false, {"Subscribe and filter according to external IR Frames"}},
     {"tpc-deadMap-sources", VariantType::Int, -1, {"Sources to consider for TPC dead channel map creation; -1=all, 0=deactivated"}},
+    {"corrmap-lumi-mode", o2::framework::VariantType::Int, 0, {"scaling mode: (default) 0 = static + scale * full; 1 = full + scale * derivative"}},
   };
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -182,7 +183,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                                 cfgc.options().get<bool>("select-ir-frames"),
                                                 cfgc.options().get<bool>("filtered-input"),
                                                 lumiType,
-                                                cfgc.options().get<int>("tpc-deadMap-sources"));
+                                                cfgc.options().get<int>("tpc-deadMap-sources"),
+                                                cfgc.options().get<int>("corrmap-lumi-mode"));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -101,7 +101,7 @@ class TRDGlobalTracking : public o2::framework::Task
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict /* = false*/, bool withPID /* = false*/, PIDPolicy policy /* = PIDPolicy::DEFAULT*/, int lumiType /* = 0*/);
+framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict /* = false*/, bool withPID /* = false*/, PIDPolicy policy /* = PIDPolicy::DEFAULT*/, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -800,7 +800,7 @@ void TRDGlobalTracking::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, bool trigRecFilterActive, bool strict, bool withPID, PIDPolicy policy, int lumiType)
+DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, bool trigRecFilterActive, bool strict, bool withPID, PIDPolicy policy, const o2::tpc::CorrectionMapsLoaderGloOpts& sclOpts)
 {
   std::vector<OutputSpec> outputs;
   uint32_t ss = o2::globaltracking::getSubSpec(strict ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
@@ -829,7 +829,7 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, boo
                                                               true);
   o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
   Options opts;
-  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs, opts, lumiType);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(inputs, opts, sclOpts);
 
   // Request PID policy data
   if (withPID) {

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
@@ -78,5 +78,5 @@ void CorrectionMapsHelper::setCorrMapRef(std::unique_ptr<TPCFastTransform>&& m)
 //________________________________________________________
 void CorrectionMapsHelper::reportScaling()
 {
-  LOGP(info, "InstLumiOverride={}, LumiScaleType={} -> instLumi={}, meanLumi={} -> LumiScale={}, lumiScaleMode={}", getInstLumiOverride(), getLumiScaleType(), getInstLumi(), getMeanLumi(), getLumiScale(), getLumiScaleMode());
+  LOGP(info, "Map scaling update: InstLumiOverride={}, LumiScaleType={} -> instLumi={}, meanLumi={} -> LumiScale={}, lumiScaleMode={}", getInstLumiOverride(), getLumiScaleType(), getInstLumi(), getMeanLumi(), getLumiScale(), getLumiScaleMode());
 }

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
@@ -26,6 +26,7 @@ void CorrectionMapsHelper::clear()
   mUpdatedFlags = 0;
   mInstLumi = 0.f;
   mMeanLumi = 0.f;
+  mMeanLumiRef = 0.f;
 }
 
 void CorrectionMapsHelper::setOwner(bool v)

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -80,6 +80,13 @@ class CorrectionMapsHelper
     }
   }
 
+  void setMeanLumiRef(float v)
+  {
+    if (v != mMeanLumi) {
+      mMeanLumiRef = v;
+    }
+  }
+
   void setLumiScaleMode(int v)
   {
     if (v != mLumiScaleMode) {
@@ -93,7 +100,8 @@ class CorrectionMapsHelper
     if (mMeanLumi < 0.f || mInstLumi < 0.f) {
       mLumiScale = -1.f;
     } else if (mLumiScaleMode == 1) {
-      mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi - 1. : 0.f;
+      mLumiScale = mMeanLumiRef ? (mInstLumi - mMeanLumi) / mMeanLumiRef : 0.f;
+      LOGP(info, "mInstLumi: {}  mMeanLumi: {} mMeanLumiRef: {}", mInstLumi, mMeanLumi, mMeanLumiRef);
     } else {
       mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
     }
@@ -105,6 +113,8 @@ class CorrectionMapsHelper
 
   GPUd() float getInstLumi() const { return mInstLumi; }
   GPUd() float getMeanLumi() const { return mMeanLumi; }
+  GPUd() float getMeanLumiRef() const { return mMeanLumiRef; }
+
   GPUd() float getLumiScale() const { return mLumiScale; }
   GPUd() int getLumiScaleMode() const { return mLumiScaleMode; }
 
@@ -127,7 +137,9 @@ class CorrectionMapsHelper
   int getLumiScaleType() const { return mLumiScaleType; }
 
   void setMeanLumiOverride(float f) { mMeanLumiOverride = f; }
+  void setMeanLumiRefOverride(float f) { mMeanLumiRefOverride = f; }
   float getMeanLumiOverride() const { return mMeanLumiOverride; }
+  float getMeanLumiRefOverride() const { return mMeanLumiRefOverride; }
 
   void setInstLumiOverride(float f) { mInstLumiOverride = f; }
   float getInstLumiOverride() const { return mInstLumiOverride; }
@@ -143,14 +155,16 @@ class CorrectionMapsHelper
   int mUpdatedFlags = 0;
   float mInstLumi = 0.;                                         // instanteneous luminosity (a.u)
   float mMeanLumi = 0.;                                         // mean luminosity of the map (a.u)
+  float mMeanLumiRef = 0.;                                      // mean luminosity of the ref map (a.u)
   float mLumiScale = 0.;                                        // precalculated mInstLumi/mMeanLumi
   int mLumiScaleMode = 0;                                       // scaling-mode of the correciton maps
   float mMeanLumiOverride = -1.f;                               // optional value to override mean lumi
+  float mMeanLumiRefOverride = -1.f;                            // optional value to override ref mean lumi
   float mInstLumiOverride = -1.f;                               // optional value to override inst lumi
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMap{nullptr};    // current transform
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapRef{nullptr}; // reference transform
 #ifndef GPUCA_ALIROOT_LIB
-  ClassDefNV(CorrectionMapsHelper, 3);
+  ClassDefNV(CorrectionMapsHelper, 4);
 #endif
 };
 

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -101,7 +101,7 @@ class CorrectionMapsHelper
       mLumiScale = -1.f;
     } else if (mLumiScaleMode == 1) {
       mLumiScale = mMeanLumiRef ? (mInstLumi - mMeanLumi) / mMeanLumiRef : 0.f;
-      LOGP(info, "mInstLumi: {}  mMeanLumi: {} mMeanLumiRef: {}", mInstLumi, mMeanLumi, mMeanLumiRef);
+      LOGP(debug, "mInstLumi: {}  mMeanLumi: {} mMeanLumiRef: {}", mInstLumi, mMeanLumi, mMeanLumiRef);
     } else {
       mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
     }

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -1088,7 +1088,8 @@ Inputs GPURecoWorkflowSpec::inputs()
     inputs.emplace_back("tpcthreshold", gDataOriginTPC, "PADTHRESHOLD", 0, Lifetime::Condition, ccdbParamSpec("TPC/Config/FEEPad"));
     o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
     Options optsDummy;
-    mCalibObjects.mFastTransformHelper->requestCCDBInputs(inputs, optsDummy, mSpecConfig.lumiScaleType, mSpecConfig.lumiScaleMode); // option filled here is lost
+    o2::tpc::CorrectionMapsLoaderGloOpts gloOpts{mSpecConfig.lumiScaleType, mSpecConfig.lumiScaleMode};
+    mCalibObjects.mFastTransformHelper->requestCCDBInputs(inputs, optsDummy, gloOpts); // option filled here is lost
   }
   if (mSpecConfig.decompressTPC) {
     inputs.emplace_back(InputSpec{"input", ConcreteDataTypeMatcher{gDataOriginTPC, mSpecConfig.decompressTPCFromROOT ? o2::header::DataDescription("COMPCLUSTERS") : o2::header::DataDescription("COMPCLUSTERSFLAT")}, Lifetime::Timeframe});

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -53,6 +53,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, zsonthefly, clustersnative, compressed-clusters-root, compressed-clusters-ctf, trd-tracklets"}},
     {"output-type", VariantType::String, "tracks", {"clustersnative, tracks, compressed-clusters-ctf, qa, no-shared-cluster-map, send-clusters-per-sector, trd-tracks, error-qa, tpc-triggers"}},
     {"lumi-type", VariantType::Int, 0, {"1 = require CTP lumi for TPC correction scaling, 2 = require TPC scalers for TPC correction scaling"}},
+    {"corrmap-lumi-mode", VariantType::Int, 0, {"scaling mode: (default) 0 = static + scale * full; 1 = full + scale * derivative"}},
     {"disable-root-input", VariantType::Bool, true, {"disable root-files input reader"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
@@ -137,6 +138,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   auto inputType = cfgc.options().get<std::string>("input-type");
   auto lumiType = cfgc.options().get<int>("lumi-type");
+  auto lumiMode = cfgc.options().get<int>("corrmap-lumi-mode");
   bool doMC = !cfgc.options().get<bool>("disable-mc");
 
   o2::conf::ConfigurableParam::updateFromFile(cfgc.options().get<std::string>("configFile"));
@@ -158,6 +160,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   GPURecoWorkflowSpec::Config cfg;
   cfg.runTPCTracking = true;
   cfg.lumiScaleType = lumiType;
+  cfg.lumiScaleMode = lumiMode;
   cfg.decompressTPC = isEnabled(inputTypes, ioType::CompClustCTF);
   cfg.decompressTPCFromROOT = isEnabled(inputTypes, ioType::CompClustROOT);
   cfg.zsDecoder = isEnabled(inputTypes, ioType::ZSRaw);

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -28,6 +28,7 @@
 #include "Algorithm/RangeTokenizer.h"
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "TPCCalibration/CorrectionMapsLoader.h"
 
 #include <unordered_map>
 #include <numeric>
@@ -52,7 +53,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, zsonthefly, clustersnative, compressed-clusters-root, compressed-clusters-ctf, trd-tracklets"}},
     {"output-type", VariantType::String, "tracks", {"clustersnative, tracks, compressed-clusters-ctf, qa, no-shared-cluster-map, send-clusters-per-sector, trd-tracks, error-qa, tpc-triggers"}},
-    {"lumi-type", VariantType::Int, 0, {"1 = require CTP lumi for TPC correction scaling, 2 = require TPC scalers for TPC correction scaling"}},
     {"corrmap-lumi-mode", VariantType::Int, 0, {"scaling mode: (default) 0 = static + scale * full; 1 = full + scale * derivative"}},
     {"disable-root-input", VariantType::Bool, true, {"disable root-files input reader"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
@@ -62,6 +62,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"enableDoublePipeline", VariantType::Bool, false, {"enable GPU double pipeline mode"}},
     {"tpc-deadMap-sources", VariantType::Int, -1, {"Sources to consider for TPC dead channel map creation; -1=all, 0=deactivated"}},
   };
+  o2::tpc::CorrectionMapsLoader::addGlobalOptions(options);
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -137,10 +138,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   std::iota(tpcSectors.begin(), tpcSectors.end(), 0);
 
   auto inputType = cfgc.options().get<std::string>("input-type");
-  auto lumiType = cfgc.options().get<int>("lumi-type");
-  auto lumiMode = cfgc.options().get<int>("corrmap-lumi-mode");
   bool doMC = !cfgc.options().get<bool>("disable-mc");
-
+  auto sclOpt = o2::tpc::CorrectionMapsLoader::parseGlobalOptions(cfgc.options());
   o2::conf::ConfigurableParam::updateFromFile(cfgc.options().get<std::string>("configFile"));
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2gpurecoworkflow_configuration.ini");
@@ -159,8 +158,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   GPURecoWorkflowSpec::Config cfg;
   cfg.runTPCTracking = true;
-  cfg.lumiScaleType = lumiType;
-  cfg.lumiScaleMode = lumiMode;
+  cfg.lumiScaleType = sclOpt.lumiType;
+  cfg.lumiScaleMode = sclOpt.lumiMode;
   cfg.decompressTPC = isEnabled(inputTypes, ioType::CompClustCTF);
   cfg.decompressTPCFromROOT = isEnabled(inputTypes, ioType::CompClustROOT);
   cfg.zsDecoder = isEnabled(inputTypes, ioType::ZSRaw);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -88,6 +88,8 @@ EMCRAW2C_CONFIG=
 PHS_CONFIG=
 MCH_CONFIG_KEY=
 CTP_CONFIG=
+TPC_CORR_OPT=
+TPC_CORR_KEY=
 INTERACTION_TAG_CONFIG_KEY=
 : ${STRTRACKING:=}
 : ${ITSEXTRAERR:=}
@@ -269,22 +271,19 @@ GPU_CONFIG_SELF="--severity $SEVERITY_TPC"
 
 parse_TPC_CORR_SCALING()
 {
-ASK_CTP_LUMI_GPU=
-local restOpt=
 while [[ $# -gt 0 ]]; do
+  echo $1
   case "$1" in
-    --lumi-type=*) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --lumi-type ${1#*=}"; shift 1;;
-    --lumi-type) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --lumi-type ${2}"; shift 2;;
-    --corrmap-lumi-mode=*) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --corrmap-lumi-mode ${1#*=}"; shift 1;;
-    --corrmap-lumi-mode) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --corrmap-lumi-mode ${2}"; shift 2;;
-    *) restOpt+=" $1"; shift 1;;
+    --lumi-type=*) TPC_CORR_OPT+=" --lumi-type ${1#*=}"; shift 1;;
+    --lumi-type) TPC_CORR_OPT+=" --lumi-type ${2}"; shift 2;;
+    --corrmap-lumi-mode=*) TPC_CORR_OPT+=" --corrmap-lumi-mode ${1#*=}"; shift 1;;
+    --corrmap-lumi-mode) TPC_CORR_OPT+=" --corrmap-lumi-mode ${2}"; shift 2;;
+    *) TPC_CORR_KEY+="$1;"; shift 1;;
   esac
 done
-TPC_CORR_SCALING_GPU=$restOpt
 }
 
 parse_TPC_CORR_SCALING $TPC_CORR_SCALING
-GPU_CONFIG_SELF+=" $TPC_CORR_SCALING_GPU "
 
 if [[ $GPUTYPE != "CPU" && $(ulimit -e) -ge 25 && ${O2_GPU_WORKFLOW_NICE:-} == 1 ]]; then
   GPU_CONFIG_SELF+=" --child-driver 'nice -n -5'"
@@ -474,14 +473,14 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Common reconstruction workflows
-(has_detector_reco TPC || has_detector_ctf TPC) && ! has_detector_from_global_reader TPC && add_W o2-gpu-reco-workflow "--gpu-reconstruction \"$GPU_CONFIG_SELF\" $ASK_CTP_LUMI_GPU --input-type=$GPU_INPUT $DISABLE_MC --output-type $GPU_OUTPUT --pipeline gpu-reconstruction:${N_TPCTRK:-1},gpu-reconstruction-prepare:${N_TPCTRK:-1} $GPU_CONFIG" "GPU_global.deviceType=$GPUTYPE;GPU_proc.debugLevel=0;$GPU_CONFIG_KEY;$TRACKTUNETPCINNER"
+(has_detector_reco TPC || has_detector_ctf TPC) && ! has_detector_from_global_reader TPC && add_W o2-gpu-reco-workflow "--gpu-reconstruction \"$GPU_CONFIG_SELF\" --input-type=$GPU_INPUT $DISABLE_MC --output-type $GPU_OUTPUT $TPC_CORR_OPT --pipeline gpu-reconstruction:${N_TPCTRK:-1},gpu-reconstruction-prepare:${N_TPCTRK:-1} $GPU_CONFIG" "GPU_global.deviceType=$GPUTYPE;GPU_proc.debugLevel=0;$GPU_CONFIG_KEY;$TRACKTUNETPCINNER;$TPC_CORR_KEY"
 (has_detector_reco TOF || has_detector_ctf TOF) && ! has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "$TOF_CONFIG --input-type $TOF_INPUT --output-type $TOF_OUTPUT $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N tof-compressed-decoder TOF RAW 1),$(get_N TOFClusterer TOF REST 1)"
 has_detector_reco ITS && ! has_detector_from_global_reader ITS && add_W o2-its-reco-workflow "--trackerCA $ITS_CONFIG $DISABLE_MC $DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N its-tracker ITS REST 1 ITSTRK)" "$ITS_CONFIG_KEY;$ITSMFT_STROBES;$ITSEXTRAERR"
 has_detector_reco FT0 && ! has_detector_from_global_reader FT0 && add_W o2-ft0-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N ft0-reconstructor FT0 REST 1)"
 has_detector_reco TRD && ! has_detector_from_global_reader TRD && add_W o2-trd-tracklet-transformer "--disable-irframe-reader $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_FILTER_CONFIG --pipeline $(get_N TRDTRACKLETTRANSFORMER TRD REST 1 TRDTRKTRANS)"
-has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_W o2-tpcits-match-workflow "$DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $SEND_ITSTPC_DTGL  $TPC_CORR_SCALING --nthreads $ITSTPC_THREADS --pipeline $(get_N itstpc-track-matcher MATCH REST $ITSTPC_THREADS TPCITS)" "$ITSTPC_CONFIG_KEY;$INTERACTION_TAG_CONFIG_KEY;$ITSMFT_STROBES;$ITSEXTRAERR"
-has_detector_reco TRD && [[ ! -z "$TRD_SOURCES" ]] && add_W o2-trd-global-tracking "$DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_CONFIG $TRD_FILTER_CONFIG $TPC_CORR_SCALING --track-sources $TRD_SOURCES --pipeline $(get_N trd-globaltracking_TPC_ITS-TPC_ TRD REST 1 TRDTRK),$(get_N trd-globaltracking_TPC_FT0_ITS-TPC_ TRD REST 1 TRDTRK),$(get_N trd-globaltracking_TPC_FT0_ITS-TPC_CTP_ TRD REST 1 TRDTRK)" "$TRD_CONFIG_KEY;$INTERACTION_TAG_CONFIG_KEY;$ITSMFT_STROBES;$ITSEXTRAERR"
-has_detector_reco TOF && [[ ! -z "$TOF_SOURCES" ]] && add_W o2-tof-matcher-workflow "$DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TPC_CORR_SCALING --track-sources $TOF_SOURCES --pipeline $(get_N tof-matcher TOF REST 1 TOFMATCH)" "$ITSMFT_STROBES;$ITSEXTRAERR"
+has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_W o2-tpcits-match-workflow "$DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $SEND_ITSTPC_DTGL  $TPC_CORR_OPT --nthreads $ITSTPC_THREADS --pipeline $(get_N itstpc-track-matcher MATCH REST $ITSTPC_THREADS TPCITS)" "$ITSTPC_CONFIG_KEY;$INTERACTION_TAG_CONFIG_KEY;$ITSMFT_STROBES;$ITSEXTRAERR;$TPC_CORR_KEY"
+has_detector_reco TRD && [[ ! -z "$TRD_SOURCES" ]] && add_W o2-trd-global-tracking "$DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_CONFIG $TRD_FILTER_CONFIG $TPC_CORR_OPT --track-sources $TRD_SOURCES --pipeline $(get_N trd-globaltracking_TPC_ITS-TPC_ TRD REST 1 TRDTRK),$(get_N trd-globaltracking_TPC_FT0_ITS-TPC_ TRD REST 1 TRDTRK),$(get_N trd-globaltracking_TPC_FT0_ITS-TPC_CTP_ TRD REST 1 TRDTRK)" "$TRD_CONFIG_KEY;$INTERACTION_TAG_CONFIG_KEY;$ITSMFT_STROBES;$ITSEXTRAERR;$TPC_CORR_KEY"
+has_detector_reco TOF && [[ ! -z "$TOF_SOURCES" ]] && add_W o2-tof-matcher-workflow "$DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TPC_CORR_OPT --track-sources $TOF_SOURCES --pipeline $(get_N tof-matcher TOF REST 1 TOFMATCH)" "$ITSMFT_STROBES;$ITSEXTRAERR;$TPC_CORR_KEY"
 has_detectors TPC && [[ -z "$DISABLE_ROOT_OUTPUT" && "${SKIP_TPC_CLUSTERSTRACKS_OUTPUT:-}" != 1 ]] && ! has_detector_from_global_reader TPC && add_W o2-tpc-reco-workflow "--input-type pass-through --output-type clusters,tpc-triggers,tracks,send-clusters-per-sector $DISABLE_MC"
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -526,7 +525,7 @@ has_detector_reco MCH && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output 
 has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-primary-vertexing-workflow "$DISABLE_MC $DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $PVERTEX_CONFIG --pipeline $(get_N primary-vertexing MATCH REST 1 PRIMVTX),$(get_N pvertex-track-matching MATCH REST 1 PRIMVTXMATCH)" "${PVERTEXING_CONFIG_KEY};${INTERACTION_TAG_CONFIG_KEY};"
 
 if [[ $BEAMTYPE != "cosmic" ]] && has_detectors_reco ITS && has_detector_matching SECVTX && [[ ! -z "$SVERTEXING_SOURCES" ]]; then
-  add_W o2-secondary-vertexing-workflow "$DISABLE_MC $STRTRACKING $DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $TPC_CORR_SCALING --vertexing-sources $SVERTEXING_SOURCES --threads $SVERTEX_THREADS --pipeline $(get_N secondary-vertexing MATCH REST $SVERTEX_THREADS SECVTX)"
+  add_W o2-secondary-vertexing-workflow "$DISABLE_MC $STRTRACKING $DISABLE_ROOT_INPUT $DISABLE_ROOT_OUTPUT $TPC_CORR_OPT --vertexing-sources $SVERTEXING_SOURCES --threads $SVERTEX_THREADS --pipeline $(get_N secondary-vertexing MATCH REST $SVERTEX_THREADS SECVTX)" "$TPC_CORR_KEY"
   SECTVTX_ON="1"
 else
   SECTVTX_ON="0"

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -273,8 +273,10 @@ ASK_CTP_LUMI_GPU=
 local restOpt=
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --lumi-type=*) ASK_CTP_LUMI_GPU=" --lumi-type ${1#*=}"; [[ ${1#*=} == "2" ]] && NEED_TPC_SCALERS_WF=1; shift 1;;
-    --lumi-type) ASK_CTP_LUMI_GPU=" --lumi-type ${2}"; [[ ${2} == "2" ]] && NEED_TPC_SCALERS_WF=1; shift 2;;
+    --lumi-type=*) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --lumi-type ${1#*=}"; shift 1;;
+    --lumi-type) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --lumi-type ${2}"; shift 2;;
+    --corrmap-lumi-mode=*) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --corrmap-lumi-mode ${1#*=}"; shift 1;;
+    --corrmap-lumi-mode) ASK_CTP_LUMI_GPU="${ASK_CTP_LUMI_GPU} --corrmap-lumi-mode ${2}"; shift 2;;
     *) restOpt+=" $1"; shift 1;;
   esac
 done


### PR DESCRIPTION
- add option to override lumi of reference map (reference map can be the derivative map)

- changing definition of scaling when using the derivative map: The derivative map is defined as "map_high_IR - map_low_IR". The stored lumi of the derivative map should correspond to "<Lumi_high_IR> - <Lumi_low_IR>"

- Changing condition when scaling is used: for the derivative map the scaling is negative, when the inst_lumi < mean_lumi