### PR TITLE
CcdbApi: Removing copy and copy assignment constructor

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -64,6 +64,10 @@ class CcdbApi //: public DatabaseInterface
   /// \brief Default destructor
   virtual ~CcdbApi();
 
+  // Delete copy and copy assignment constructor
+  CcdbApi(const CcdbApi&) = delete;
+  void operator=(const CcdbApi&) = delete;
+
   const std::string getUniqueAgentID() const { return mUniqueAgentID; }
 
   static bool checkAlienToken();


### PR DESCRIPTION
Due to recent changes in CcdbApi the copy constructor no longer works, as it causes an error due mishandling the multi handle of CcdbDownloader.

Because of this I suggest deleting the copy and copy assignment constructors, to make using them an obvious error.