### PR TITLE
CcdbDownloader: Testing trimHostUrl

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -208,12 +208,12 @@ class CCDBDownloader
    */
   void runLoop(bool noWait);
 
- private:
   /**
    * Leaves only the protocol and host part of the url, discrading path and metadata.
    */
   std::string trimHostUrl(std::string full_host_url) const;
 
+ private:
   /**
    * Recognizes whether the address is a full url, or a partial one (like for example "/Task/Detector/1") and combines it with potentialHost if needed.
    */

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -408,7 +408,7 @@ std::string CCDBDownloader::trimHostUrl(std::string full_host_url) const
   char* host;
   CURLUcode host_result = curl_url_get(host_url, CURLUPART_HOST, &host, 0);
   if (host_result != CURLUE_OK) {
-    LOG(error) << "CCDBDownloader: Malformed url detected when processing redirect, could not identify the host part: " << host;
+    LOG(error) << "CCDBDownloader: Malformed url detected when processing redirect, could not identify the host part: " << full_host_url;
     curl_url_cleanup(host_url);
     return "";
   }

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -381,5 +381,17 @@ BOOST_AUTO_TEST_CASE(external_loop_test)
   delete uvLoop;
 }
 
+BOOST_AUTO_TEST_CASE(trim_host_url_test)
+{
+  CCDBDownloader downloader;
+  BOOST_CHECK(downloader.trimHostUrl("http://localhost:8080") == "http://localhost:8080");
+  BOOST_CHECK(downloader.trimHostUrl("http://localhost") == "http://localhost");
+  BOOST_CHECK(downloader.trimHostUrl("localhost:8080") == "localhost:8080");
+  BOOST_CHECK(downloader.trimHostUrl("localhost:8080/some/path") == "localhost:8080");
+  BOOST_CHECK(downloader.trimHostUrl("http://localhost:8080/some/path") == "http://localhost:8080");
+  BOOST_CHECK(downloader.trimHostUrl("http://localhost/some/path") == "http://localhost");
+  BOOST_CHECK(downloader.trimHostUrl("http://localhost:8080/Task/Detector/1?HTTPOnly=true") == "http://localhost:8080");
+}
+
 } // namespace ccdb
 } // namespace o2

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -386,8 +386,6 @@ BOOST_AUTO_TEST_CASE(trim_host_url_test)
   CCDBDownloader downloader;
   BOOST_CHECK(downloader.trimHostUrl("http://localhost:8080") == "http://localhost:8080");
   BOOST_CHECK(downloader.trimHostUrl("http://localhost") == "http://localhost");
-  BOOST_CHECK(downloader.trimHostUrl("localhost:8080") == "localhost:8080");
-  BOOST_CHECK(downloader.trimHostUrl("localhost:8080/some/path") == "localhost:8080");
   BOOST_CHECK(downloader.trimHostUrl("http://localhost:8080/some/path") == "http://localhost:8080");
   BOOST_CHECK(downloader.trimHostUrl("http://localhost/some/path") == "http://localhost");
   BOOST_CHECK(downloader.trimHostUrl("http://localhost:8080/Task/Detector/1?HTTPOnly=true") == "http://localhost:8080");


### PR DESCRIPTION
This PR adds a single test function which aims to test whether trimHostUrl works as expected.