### PR TITLE
svertexer tuning

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -97,6 +97,8 @@ class SVertexer
     GIndex gid{};
     VBracket vBracket{};
     float minR = 0; // track lowest point r
+    bool hasTPC = false;
+    uint8_t nITSclu = -1; // number of ITS clusters
   };
 
   SVertexer(bool enabCascades = true, bool enab3body = false) : mEnableCascades{enabCascades}, mEnable3BodyDecays{enab3body}

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include "GPUO2InterfaceRefit.h"
 #include "TPCFastTransform.h"
+#include "DataFormatsTPC/PIDResponse.h"
 
 namespace o2
 {
@@ -65,6 +66,7 @@ class SVertexer
   using Decay3BodyIndex = o2::dataformats::Decay3BodyIndex;
   using RRef = o2::dataformats::RangeReference<int, int>;
   using VBracket = o2::math_utils::Bracket<int>;
+  using PIDResponse = o2::tpc::PIDResponse;
 
   enum HypV0 { Photon,
                K0,
@@ -98,7 +100,7 @@ class SVertexer
     VBracket vBracket{};
     float minR = 0; // track lowest point r
     bool hasTPC = false;
-    uint8_t nITSclu = -1; // number of ITS clusters
+    bool compatibleProton = false; // dE/dx compatibility with proton hypothesis (FIXME: use better, uint8_t compat mask?)
   };
 
   SVertexer(bool enabCascades = true, bool enab3body = false) : mEnableCascades{enabCascades}, mEnable3BodyDecays{enab3body}
@@ -185,6 +187,9 @@ class SVertexer
   std::vector<DCAFitterN<2>> mFitterV0;
   std::vector<DCAFitterN<2>> mFitterCasc;
   std::vector<DCAFitterN<3>> mFitter3body;
+
+  PIDResponse mPIDresponse;
+
   int mNThreads = 1;
   int mNV0s = 0, mNCascades = 0, mN3Bodies = 0, mNStrangeTracks = 0;
   float mMinR2ToMeanVertex = 0;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -100,6 +100,7 @@ class SVertexer
     VBracket vBracket{};
     float minR = 0; // track lowest point r
     bool hasTPC = false;
+    uint8_t nITSclu = -1;
     bool compatibleProton = false; // dE/dx compatibility with proton hypothesis (FIXME: use better, uint8_t compat mask?)
   };
 

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,7 +95,8 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  uint8_t mITSSAminNclu = 6;             // require at least this many ITS clusters if no TPC info present
+  uint8_t mITSSAminNclu = 6;             // global requirement of at least this many ITS clusters if no TPC info present (N.B.: affects all secondary vertexing)
+  uint8_t mITSSAminNcluCascades = 6;     // require at least this many ITS clusters if no TPC info present for cascade finding. 
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
   bool mSkipTPCOnlyCascade = true;       // skip TPC only tracks when doing cascade finding
   bool mSkipTPCOnly3Body = true;         // skip TPC only tracks when doing cascade finding

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,9 +95,11 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  // cascade-specific selections 
-  uint8_t minNITSCluCascMesons = 6; // require at least this many ITS clusters for mesonic cascade daughters
-  bool requireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
+  uint8_t mITSSAminNclu = 6; // require at least this many ITS clusters if no TPC info present
+  bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
+  
+  // percent deviation from expected proton dEdx - to be replaced - estimated sigma from TPC for now 6%; a 6*sigma cut is therefore 36% = 0.36f. Any value above 1.0f will be ignored manually when checking.
+  float mFractiondEdxforCascBaryons = 0.36f; 
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -96,7 +96,7 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
   uint8_t mITSSAminNclu = 6;             // global requirement of at least this many ITS clusters if no TPC info present (N.B.: affects all secondary vertexing)
-  uint8_t mITSSAminNcluCascades = 6;     // require at least this many ITS clusters if no TPC info present for cascade finding. 
+  uint8_t mITSSAminNcluCascades = 6;     // require at least this many ITS clusters if no TPC info present for cascade finding.
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
   bool mSkipTPCOnlyCascade = true;       // skip TPC only tracks when doing cascade finding
   bool mSkipTPCOnly3Body = true;         // skip TPC only tracks when doing cascade finding

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,11 +95,16 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  uint8_t mITSSAminNcluCascades = 6;     // require at least this many ITS clusters if no TPC info present
+  uint8_t mITSSAminNclu = 6;     // require at least this many ITS clusters if no TPC info present
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
+  bool mSkipTPCOnlyCascade = true; // skip TPC only tracks when doing cascade finding
+  bool mSkipTPCOnly3Body = true; // skip TPC only tracks when doing cascade finding
 
   // percent deviation from expected proton dEdx - to be replaced - estimated sigma from TPC for now 6%; a 6*sigma cut is therefore 36% = 0.36f. Any value above 1.0f will be ignored manually when checking.
   float mFractiondEdxforCascBaryons = 0.36f;
+  // default: average 2023 from C. Sonnabend, Nov 2023: ([0.217553   4.02762    0.00850178 2.33324    0.880904  ])
+  // to-do: grab from CCDB when available -> discussion with TPC experts, not available yet
+  float mBBpars[5] = {0.217553, 4.02762, 0.00850178, 2.33324, 0.880904};
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,11 +95,11 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  uint8_t mITSSAminNclu = 6; // require at least this many ITS clusters if no TPC info present
+  uint8_t mITSSAminNclu = 6;             // require at least this many ITS clusters if no TPC info present
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
-  
+
   // percent deviation from expected proton dEdx - to be replaced - estimated sigma from TPC for now 6%; a 6*sigma cut is therefore 36% = 0.36f. Any value above 1.0f will be ignored manually when checking.
-  float mFractiondEdxforCascBaryons = 0.36f; 
+  float mFractiondEdxforCascBaryons = 0.36f;
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,11 +95,11 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  uint8_t mITSSAminNclu = 6;             // require at least this many ITS clusters if no TPC info present
+  uint8_t mITSSAminNcluCascades = 6; // require at least this many ITS clusters if no TPC info present
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
-
+  
   // percent deviation from expected proton dEdx - to be replaced - estimated sigma from TPC for now 6%; a 6*sigma cut is therefore 36% = 0.36f. Any value above 1.0f will be ignored manually when checking.
-  float mFractiondEdxforCascBaryons = 0.36f;
+  float mFractiondEdxforCascBaryons = 0.36f; 
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,10 +95,10 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  uint8_t mITSSAminNclu = 6;     // require at least this many ITS clusters if no TPC info present
+  uint8_t mITSSAminNclu = 6;             // require at least this many ITS clusters if no TPC info present
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
-  bool mSkipTPCOnlyCascade = true; // skip TPC only tracks when doing cascade finding
-  bool mSkipTPCOnly3Body = true; // skip TPC only tracks when doing cascade finding
+  bool mSkipTPCOnlyCascade = true;       // skip TPC only tracks when doing cascade finding
+  bool mSkipTPCOnly3Body = true;         // skip TPC only tracks when doing cascade finding
 
   // percent deviation from expected proton dEdx - to be replaced - estimated sigma from TPC for now 6%; a 6*sigma cut is therefore 36% = 0.36f. Any value above 1.0f will be ignored manually when checking.
   float mFractiondEdxforCascBaryons = 0.36f;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -58,6 +58,7 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float maxDCAXYToMeanVertexV0Casc = 2.; ///< max DCA of V0 from beam line (mean vertex) for cascade V0 candidates
   float maxDCAXYToMeanVertex3bodyV0 = 2; ///< max DCA of V0 from beam line (mean vertex) for 3body V0 candidates
   float minPtV0 = 0.01;                  ///< v0 minimum pT
+  float minPtV0FromCascade = 0.3;        ///< v0 minimum pT for v0 to be used in cascading (lowest pT Run 2 lambda: 0.4)
   float maxTglV0 = 2.;                   ///< maximum tgLambda of V0
 
   float causalityRTolerance = 1.; ///< V0 radius cannot exceed its contributors minR by more than this value
@@ -93,6 +94,10 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float mTPCTrackMaxX = -1.f;     // don't use TPC standalone tracks with X exceeding this
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
+
+  // cascade-specific selections 
+  uint8_t minNITSCluCascMesons = 6; // require at least this many ITS clusters for mesonic cascade daughters
+  bool requireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -95,11 +95,11 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minTPCdEdx = 250;         // starting from this dEdx value, tracks with p > minMomTPCdEdx are always accepted
   float minMomTPCdEdx = 0.8;      // minimum p for tracks with dEdx > mMinTPCdEdx to be accepted
 
-  uint8_t mITSSAminNcluCascades = 6; // require at least this many ITS clusters if no TPC info present
+  uint8_t mITSSAminNcluCascades = 6;     // require at least this many ITS clusters if no TPC info present
   bool mRequireTPCforCascBaryons = true; // require that baryon daughter of cascade has TPC
-  
+
   // percent deviation from expected proton dEdx - to be replaced - estimated sigma from TPC for now 6%; a 6*sigma cut is therefore 36% = 0.36f. Any value above 1.0f will be ignored manually when checking.
-  float mFractiondEdxforCascBaryons = 0.36f; 
+  float mFractiondEdxforCascBaryons = 0.36f;
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -503,7 +503,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
       // get Nclusters in the ITS if available
       uint8_t nITSclu = -1;
       auto itsGID = recoData.getITSContributorGID(tvid);
-      if (itsGID.getSource()==GIndex::ITS && isITSloaded) {
+      if (itsGID.getSource() == GIndex::ITS && isITSloaded) {
         auto& itsTrack = recoData.getITSTrack(itsGID);
         nITSclu = itsTrack.getNumberOfClusters();
       }

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -606,7 +606,8 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   // check tight lambda mass only
   bool goodLamForCascade = false, goodALamForCascade = false;
   bool usesTPCOnly = (seedP.hasTPC && seedP.nITSclu < 1) || (seedN.hasTPC && seedN.nITSclu < 1);
-  if (ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mSkipTPCOnlyCascade || !usesTPCOnly)) {
+  bool usesShortITSOnly = (!seedP.hasTPC && seedP.nITSclu < mSVParams->mITSSAminNcluCascades) || (!seedN.hasTPC && seedN.nITSclu < mSVParams->mITSSAminNcluCascades);
+  if (ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mSkipTPCOnlyCascade || !usesTPCOnly) && !usesShortITSOnly) {
     if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
       goodLamForCascade = true;
     }
@@ -774,6 +775,10 @@ int SVertexer::checkCascades(const V0Index& v0Idx, const V0& v0, float rv0, std:
       continue; // skip the track used by V0
     }
     auto& bach = tracks[it];
+    
+    if (!bach.hasTPC && bach.nITSclu < mSVParams->mITSSAminNcluCascades) {
+      continue; // reject short ITS-only
+    }
 
     if (bach.vBracket.getMin() > v0vlist.getMax()) {
       LOG(debug) << "Skipping";

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -503,7 +503,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
       // get Nclusters in the ITS if available
       uint8_t nITSclu = -1;
       auto itsGID = recoData.getITSContributorGID(tvid);
-      if (itsGID.isIndexSet() && isITSloaded) {
+      if (itsGID.getSource()==GIndex::ITS && isITSloaded) {
         auto& itsTrack = recoData.getITSTrack(itsGID);
         nITSclu = itsTrack.getNumberOfClusters();
       }

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -515,7 +515,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         continue;
       }
 
-      if( !hasTPC && nITSclu < mSVParams->mITSSAminNclu ){ 
+      if (!hasTPC && nITSclu < mSVParams->mITSSAminNclu) {
         continue; // reject short ITS-only
       }
 
@@ -605,7 +605,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   }
   // check tight lambda mass only
   bool goodLamForCascade = false, goodALamForCascade = false;
-  bool usesTPCOnly = (seedP.hasTPC && seedP.nITSclu<1) || (seedN.hasTPC && seedN.nITSclu<1);
+  bool usesTPCOnly = (seedP.hasTPC && seedP.nITSclu < 1) || (seedN.hasTPC && seedN.nITSclu < 1);
   if (ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mSkipTPCOnlyCascade || !usesTPCOnly)) {
     if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
       goodLamForCascade = true;

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -302,7 +302,7 @@ void SVertexer::updateTimeDependentParams()
     ft.setBz(bz);
   }
 
-  // TPC dE/dx usage information 
+  // TPC dE/dx usage information
   // default: average 2023 from C. Sonnabend, Nov 2023: ([0.217553   4.02762    0.00850178 2.33324    0.880904  ])
   // to-do: grab from CCDB when available -> discussion with TPC experts, not available yet
   const float bbPars[] = {0.217553, 4.02762, 0.00850178, 2.33324, 0.880904};
@@ -499,7 +499,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         auto protonId = o2::track::PID::Proton;
         float dEdxExpected = mPIDresponse.getExpectedSignal(tpcTrack, protonId);
         float fracDevProton = std::abs((dEdxTPC - dEdxExpected) / dEdxExpected);
-        if(fracDevProton<mSVParams->mFractiondEdxforCascBaryons){ 
+        if (fracDevProton < mSVParams->mFractiondEdxforCascBaryons) {
           compatibleWithProton = true;
         }
       }
@@ -519,7 +519,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         continue;
       }
 
-      if(!hasTPC && nITSclu < mSVParams->mITSSAminNclu){
+      if (!hasTPC && nITSclu < mSVParams->mITSSAminNclu) {
         continue; // reject track if no TPC && below minimum N ITS clusters
       }
 
@@ -612,7 +612,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
     goodLamForCascade = true;
   }
-  if (mV0Hyps[AntiLambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && ptV0 > mSVParams->minPtV0FromCascade &&(!mSVParams->mRequireTPCforCascBaryons || seedN.hasTPC && seedN.compatibleProton)) {
+  if (mV0Hyps[AntiLambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mRequireTPCforCascBaryons || seedN.hasTPC && seedN.compatibleProton)) {
     goodALamForCascade = true;
   }
 

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -302,7 +302,7 @@ void SVertexer::updateTimeDependentParams()
     ft.setBz(bz);
   }
 
-  // TPC dE/dx usage information 
+  // TPC dE/dx usage information
   // default: average 2023 from C. Sonnabend, Nov 2023: ([0.217553   4.02762    0.00850178 2.33324    0.880904  ])
   // to-do: grab from CCDB when available -> discussion with TPC experts, not available yet
   const float bbPars[] = {0.217553, 4.02762, 0.00850178, 2.33324, 0.880904};
@@ -499,7 +499,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         auto protonId = o2::track::PID::Proton;
         float dEdxExpected = mPIDresponse.getExpectedSignal(tpcTrack, protonId);
         float fracDevProton = std::abs((dEdxTPC - dEdxExpected) / dEdxExpected);
-        if(fracDevProton<mSVParams->mFractiondEdxforCascBaryons){ 
+        if (fracDevProton < mSVParams->mFractiondEdxforCascBaryons) {
           compatibleWithProton = true;
         }
       }
@@ -605,7 +605,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   }
   // check tight lambda mass only
   bool goodLamForCascade = false, goodALamForCascade = false;
-  if( ptV0 > mSVParams->minPtV0FromCascade && seedP.nITSclu >= mSVParams->mITSSAminNcluCascades && seedN.nITSclu >= mSVParams->mITSSAminNcluCascades ){
+  if (ptV0 > mSVParams->minPtV0FromCascade && seedP.nITSclu >= mSVParams->mITSSAminNcluCascades && seedN.nITSclu >= mSVParams->mITSSAminNcluCascades) {
     if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
       goodLamForCascade = true;
     }
@@ -613,7 +613,6 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
       goodALamForCascade = true;
     }
   }
-
 
   // apply mass selections for 3-body decay
   bool good3bodyV0Hyp = false;

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -302,7 +302,7 @@ void SVertexer::updateTimeDependentParams()
     ft.setBz(bz);
   }
 
-  // TPC dE/dx usage information
+  // TPC dE/dx usage information 
   // default: average 2023 from C. Sonnabend, Nov 2023: ([0.217553   4.02762    0.00850178 2.33324    0.880904  ])
   // to-do: grab from CCDB when available -> discussion with TPC experts, not available yet
   const float bbPars[] = {0.217553, 4.02762, 0.00850178, 2.33324, 0.880904};
@@ -499,7 +499,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         auto protonId = o2::track::PID::Proton;
         float dEdxExpected = mPIDresponse.getExpectedSignal(tpcTrack, protonId);
         float fracDevProton = std::abs((dEdxTPC - dEdxExpected) / dEdxExpected);
-        if (fracDevProton < mSVParams->mFractiondEdxforCascBaryons) {
+        if(fracDevProton<mSVParams->mFractiondEdxforCascBaryons){ 
           compatibleWithProton = true;
         }
       }
@@ -519,13 +519,9 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         continue;
       }
 
-      if (!hasTPC && nITSclu < mSVParams->mITSSAminNclu) {
-        continue; // reject track if no TPC && below minimum N ITS clusters
-      }
-
       int posneg = trc.getSign() < 0 ? 1 : 0;
       float r = std::sqrt(trc.getX() * trc.getX() + trc.getY() * trc.getY());
-      mTracksPool[posneg].emplace_back(TrackCand{trc, tvid, {iv, iv}, r, hasTPC, compatibleWithProton});
+      mTracksPool[posneg].emplace_back(TrackCand{trc, tvid, {iv, iv}, r, hasTPC, nITSclu, compatibleWithProton});
       if (tvid.getSource() == GIndex::TPC) { // constrained TPC track?
         correctTPCTrack(mTracksPool[posneg].back(), mTPCTracksArray[tvid], -1, -1);
       }
@@ -609,12 +605,15 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   }
   // check tight lambda mass only
   bool goodLamForCascade = false, goodALamForCascade = false;
-  if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
-    goodLamForCascade = true;
+  if( ptV0 > mSVParams->minPtV0FromCascade && seedP.nITSclu >= mSVParams->mITSSAminNcluCascades && seedN.nITSclu >= mSVParams->mITSSAminNcluCascades ){
+    if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
+      goodLamForCascade = true;
+    }
+    if (mV0Hyps[AntiLambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedN.hasTPC && seedN.compatibleProton)) {
+      goodALamForCascade = true;
+    }
   }
-  if (mV0Hyps[AntiLambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && ptV0 > mSVParams->minPtV0FromCascade && (!mSVParams->mRequireTPCforCascBaryons || seedN.hasTPC && seedN.compatibleProton)) {
-    goodALamForCascade = true;
-  }
+
 
   // apply mass selections for 3-body decay
   bool good3bodyV0Hyp = false;

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -775,7 +775,7 @@ int SVertexer::checkCascades(const V0Index& v0Idx, const V0& v0, float rv0, std:
       continue; // skip the track used by V0
     }
     auto& bach = tracks[it];
-    
+
     if (!bach.hasTPC && bach.nITSclu < mSVParams->mITSSAminNcluCascades) {
       continue; // reject short ITS-only
     }

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -605,7 +605,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   }
   // check tight lambda mass only
   bool goodLamForCascade = false, goodALamForCascade = false;
-  if (ptV0 > mSVParams->minPtV0FromCascade && seedP.nITSclu >= mSVParams->mITSSAminNcluCascades && seedN.nITSclu >= mSVParams->mITSSAminNcluCascades) {
+  if( ptV0 > mSVParams->minPtV0FromCascade && (seedP.hasTPC || seedP.nITSclu >= mSVParams->mITSSAminNcluCascades) && (seedN.hasTPC || seedN.nITSclu >= mSVParams->mITSSAminNcluCascades) ){
     if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
       goodLamForCascade = true;
     }
@@ -773,6 +773,10 @@ int SVertexer::checkCascades(const V0Index& v0Idx, const V0& v0, float rv0, std:
       continue; // skip the track used by V0
     }
     auto& bach = tracks[it];
+
+    if( !bach.hasTPC && bach.nITSclu < mSVParams->mITSSAminNcluCascades ){ 
+      continue; 
+    }
 
     if (bach.vBracket.getMin() > v0vlist.getMax()) {
       LOG(debug) << "Skipping";

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -605,7 +605,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   }
   // check tight lambda mass only
   bool goodLamForCascade = false, goodALamForCascade = false;
-  if( ptV0 > mSVParams->minPtV0FromCascade && (seedP.hasTPC || seedP.nITSclu >= mSVParams->mITSSAminNcluCascades) && (seedN.hasTPC || seedN.nITSclu >= mSVParams->mITSSAminNcluCascades) ){
+  if (ptV0 > mSVParams->minPtV0FromCascade && (seedP.hasTPC || seedP.nITSclu >= mSVParams->mITSSAminNcluCascades) && (seedN.hasTPC || seedN.nITSclu >= mSVParams->mITSSAminNcluCascades)) {
     if (mV0Hyps[Lambda].checkTight(p2Pos, p2Neg, p2V0, ptV0) && (!mSVParams->mRequireTPCforCascBaryons || seedP.hasTPC) && seedP.compatibleProton) {
       goodLamForCascade = true;
     }
@@ -774,8 +774,8 @@ int SVertexer::checkCascades(const V0Index& v0Idx, const V0& v0, float rv0, std:
     }
     auto& bach = tracks[it];
 
-    if( !bach.hasTPC && bach.nITSclu < mSVParams->mITSSAminNcluCascades ){ 
-      continue; 
+    if (!bach.hasTPC && bach.nITSclu < mSVParams->mITSSAminNcluCascades) {
+      continue;
     }
 
     if (bach.vBracket.getMin() > v0vlist.getMax()) {


### PR DESCRIPTION
This draft PR implements the following parameters: 
* `minPtV0FromCascade` allows for a minimum pT for a V0 to be considered for cascading. Default value is 0.3 GeV/c; this is even aggressive since Lambda analysis in pp in Run 2 stopped at 0.4 GeV/c. 
* `mITSSAminNclu` when dealing with tracks with no TPC information (i.e. ITS only), require a minimum number of ITS clusters to have been used in tracking. Default value of 6 to allow only for exceptionally long tracks. (Will have no impact if all sec vertexer sources include TPC)
* `mRequireTPCforCascBaryons`: when deciding if a certain V0 is to be considered for cascade finding, require that the V0 prong with charge opposite to the bachelor has TPC signal. This is usually a safe bet because Lambda decays deposit most of the momentum into the proton daughter and we anyway typically want to resort to dE/dx selections of that proton. 
* `mFractiondEdxforCascBaryons`: in addition to the previous selection, if this parameter is below `1.0f`, will utilize the `o2::tpc::PIDResponse` O2 class + a standard set of 2023-averaged BB parameters for checking the compatibility of the V0 baryon daughter with a proton. This parameter, if below `1.0f`, is the fraction of the expected `dE/dx` to be used as threshold. TPC PID in tracking currently uses 6%; therefore, a 6-sigma selection is equivalent to setting this parameter to `0.36f`. 
(Tuning still happening, but PR created for discussion already)

Corresponding JIRA discussion: https://alice.its.cern.ch/jira/browse/O2-4382