### PR TITLE
Update of the ALPIDE Protocol Extension definitions for RU FW v1.22.0

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -34,46 +34,46 @@ struct ChipStat {
   };
 
   enum DecErrors : int {
-    BusyViolation,                // Busy violation
-    DataOverrun,                  // Data overrun
-    Fatal,                        // Fatal (?)
-    BusyOn,                       // Busy On
-    BusyOff,                      // Busy Off
-    TruncatedChipEmpty,           // Data was truncated after ChipEmpty
-    TruncatedChipHeader,          // Data was truncated after ChipHeader
-    TruncatedRegion,              // Data was truncated after Region record
-    TruncatedLondData,            // Data was truncated in the LongData record
-    WrongDataLongPattern,         // LongData pattern has highest bit set
-    NoDataFound,                  // Region is not followed by Short or Long data
-    UnknownWord,                  // Unknown word was seen
-    RepeatingPixel,               // Same pixel fired more than once
-    WrongRow,                     // Non-existing row decoded
-    APE_STRIP,                    // lane data stripped for this chip event (behaviour changed with RU FW v1.16.0, for general APE behaviour see  https://alice.its.cern.ch/jira/browse/O2-1717)
-    APE_RESERVED_F3,              // reserved F3
-    APE_DET_TIMEOUT,              // detector timeout (FATAL)
-    APE_OOT_START,                // 8b10b OOT (FATAL, start)
-    APE_PROTOCOL_ERROR,           // event protocol error marker (FATAL, start)
-    APE_LANE_FIFO_OVERFLOW_ERROR, // lane FIFO overflow error (FATAL)
-    APE_FSM_ERROR,                // FSM error (FATAL, SEU error, reached an unknown state)
-    APE_OCCUPANCY_RATE_LIMIT,     // pending detector events limit (FATAL)
-    APE_OCCUPANCY_RATE_LIMIT_2,   // pending detector events limit in packager(FATAL)
-    APE_LANE_PROTOCOL_ERROR,      // lane protocol error
-    APE_RESERVED_FC,              // reserved FC
-    APE_ERROR_NON_CRITICAL_BYTE,  // Error in non critical byte
-    APE_OOT_NON_CRITICAL,         // OOT non-critical
-    WrongDColOrder,               // DColumns non increasing
-    InterleavedChipData,          // Chip data interleaved on the cable
-    TruncatedBuffer,              // truncated buffer, 0 padding
-    TrailerAfterHeader,           // trailer seen after header w/o FE of FD set
-    FlushedIncomplete,            // ALPIDE MEB was flushed by the busy handling
-    StrobeExtended,               // ALPIDE received a second trigger while the strobe was still open
+    BusyViolation,                    // Busy violation
+    DataOverrun,                      // Data overrun
+    Fatal,                            // Fatal (ALPIDE trigger fifo overflow, trigger-event matching compromised)
+    BusyOn,                           // Busy On
+    BusyOff,                          // Busy Off
+    TruncatedChipEmpty,               // Data was truncated after ChipEmpty
+    TruncatedChipHeader,              // Data was truncated after ChipHeader
+    TruncatedRegion,                  // Data was truncated after Region record
+    TruncatedLondData,                // Data was truncated in the LongData record
+    WrongDataLongPattern,             // LongData pattern has highest bit set
+    NoDataFound,                      // Region is not followed by Short or Long data
+    UnknownWord,                      // Unknown word was seen
+    RepeatingPixel,                   // Same pixel fired more than once
+    WrongRow,                         // Non-existing row decoded
+    APE_STRIP_START,                  // 0xF2 - Lane data stripped for this chip event (behaviour changed with RU FW v1.16.0, for general APE behaviour see  https://alice.its.cern.ch/jira/browse/O2-1717)
+    APE_ILLEGAL_CHIPID,               // 0xF3 - Chip ID jumped downwards within an ROF on a OB module (FATAL)
+    APE_DET_TIMEOUT,                  // 0xF4 - Detector timeout (FATAL)
+    APE_OOT,                          // 0xF5 - 8b10b OOT (FATAL, start)
+    APE_PROTOCOL_ERROR,               // 0xF6 - Event protocol error marker (FATAL, start)
+    APE_LANE_FIFO_OVERFLOW_ERROR,     // 0xF7 - Lane FIFO overflow error (FATAL)
+    APE_FSM_ERROR,                    // 0xF8 - FSM error (FATAL, SEU error, reached an unknown state)
+    APE_PENDING_DETECTOR_EVENT_LIMIT, // 0xF9 - Pending detector events limit (FATAL)
+    APE_PENDING_LANE_EVENT_LIMIT,     // 0xFA - Pending detector events limit in packager (FATAL)
+    APE_O2N_ERROR,                    // 0xFB - Lane protocol error (FATAL)
+    APE_RATE_MISSING_TRG_ERROR,       // 0xFC - Received start of event before trigger (FATAL)
+    APE_PE_DATA_MISSING,              // 0xFD - Error in non critical byte
+    APE_OOT_DATA_MISSING,             // 0xFE - OOT non-critical
+    WrongDColOrder,                   // DColumns non increasing
+    InterleavedChipData,              // Chip data interleaved on the cable
+    TruncatedBuffer,                  // Truncated buffer, 0 padding
+    TrailerAfterHeader,               // Trailer seen after header w/o FE of FD set
+    FlushedIncomplete,                // ALPIDE MEB was flushed by the busy handling
+    StrobeExtended,                   // ALPIDE received a second trigger while the strobe was still open
     NErrorsDefined
   };
 
   static constexpr std::array<std::string_view, NErrorsDefined> ErrNames = {
     "BusyViolation flag ON",                        // BusyViolation
     "DataOverrun flag ON",                          // DataOverrun
-    "Fatal flag ON",                                // Fatal
+    "Fatal flag ON",                                // Fatal (ALPIDE trigger fifo overflow, trigger-event matching compromised)
     "BusyON",                                       // BusyOn
     "BusyOFF",                                      // BusyOff
     "Data truncated after ChipEmpty",               // TruncatedChipEmpty
@@ -85,23 +85,23 @@ struct ChipStat {
     "Unknown word",                                 // UnknownWord
     "Same pixel fired multiple times",              // RepeatingPixel
     "Non-existing row decoded",                     // WrongRow
-    "APE_STRIP",                                    // lane data stripped for this chip event (behaviour changed with RU FW v1.16.0, for general APE behaviour see  https://alice.its.cern.ch/jira/browse/O2-1717)
-    "APE_RESERVED_F3",                              // reserved F3
-    "APE_DET_TIMEOUT",                              // detector timeout (FATAL)
-    "APE_OOT_START",                                // 8b10b OOT (FATAL, start)
-    "APE_PROTOCOL_ERROR",                           // event event protocol error marker (FATAL, start)
-    "APE_LANE_FIFO_OVERFLOW_ERROR",                 // lane FIFO overflow error (FATAL)
-    "APE_FSM_ERROR",                                // FSM error (FATAL, SEU error, reached an unknown state)
-    "APE_OCCUPANCY_RATE_LIMIT",                     // pending detector events limit (FATAL)
-    "APE_OCCUPANCY_RATE_LIMIT_2",                   // pending detector events limit in packager(FATAL)
-    "APE_LANE_PROTOCOL_ERROR",                      // lane protocol error
-    "APE_RESERVED_FC",                              // reserved
-    "APE_ERROR_IN_NON_CRITICAL_BYTE",               // Error in non critical byte
-    "APE_OOT_NON_CRITICAL",                         // OOT non-critical
+    "APE_STRIP_START",                              // 0xF2 - Lane data stripped for this chip event (behaviour changed with RU FW v1.16.0, for general APE behaviour see  https://alice.its.cern.ch/jira/browse/O2-1717)
+    "APE_ILLEGAL_CHIPID",                           // 0xF3 - Chip ID jumped downwards within an ROF on a OB module (FATAL)
+    "APE_DET_TIMEOUT",                              // 0xF4 - Detector timeout (FATAL)
+    "APE_OOT",                                      // 0xF5 - 8b10b OOT (FATAL, start)
+    "APE_PROTOCOL_ERROR",                           // 0xF6 - Event protocol error marker (FATAL, start)
+    "APE_LANE_FIFO_OVERFLOW_ERROR",                 // 0xF7 - Lane FIFO overflow error (FATAL)
+    "APE_FSM_ERROR",                                // 0xF8 - FSM error (FATAL, SEU error, reached an unknown state)
+    "APE_PENDING_DETECTOR_EVENT_LIMIT",             // 0xF9 - Pending detector events limit (FATAL)
+    "APE_PENDING_LANE_EVENT_LIMIT",                 // 0xFA - Pending detector events limit in packager (FATAL)
+    "APE_O2N_ERROR",                                // 0xFB - Lane protocol error (FATAL)
+    "APE_RATE_MISSING_TRG_ERROR",                   // 0xFC - Received start of event before trigger (FATAL)
+    "APE_PE_DATA_MISSING",                          // 0xFD - Error in non critical byte
+    "APE_OOT_NON_CRITICAL",                         // 0xFE - OOT non-critical
     "DColumns non-increasing",                      // DColumns non increasing
     "Chip data interleaved on the cable",           // Chip data interleaved on the cable
-    "TruncatedBuffer",                              // truncated buffer, 0 padding
-    "TrailerAfterHeader",                           // trailer seen after header w/o FE of FD set
+    "TruncatedBuffer",                              // Truncated buffer, 0 padding
+    "TrailerAfterHeader",                           // Trailer seen after header w/o FE of FD set
     "FlushedIncomplete",                            // ALPIDE MEB was flushed by the busy handling
     "StrobeExtended"                                // ALPIDE received a second trigger while the strobe was still open
   };
@@ -109,7 +109,7 @@ struct ChipStat {
   static constexpr std::array<uint32_t, NErrorsDefined> ErrActions = {
     ErrActPropagate | ErrActDump, // Busy violation
     ErrActPropagate | ErrActDump, // Data overrun
-    ErrActPropagate | ErrActDump, // Fatal (?)
+    ErrActPropagate | ErrActDump, // Fatal (ALPIDE trigger fifo overflow, trigger-event matching compromised)
     ErrActNone,                   // Busy On
     ErrActNone,                   // Busy Off
     ErrActPropagate | ErrActDump, // Data was truncated after ChipEmpty
@@ -121,19 +121,19 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // Unknown word was seen
     ErrActPropagate,              // Same pixel fired more than once
     ErrActPropagate | ErrActDump, // Non-existing row decoded
-    ErrActPropagate | ErrActDump, // lane data stripped for this chip event (behaviour changed with RU FW v1.16.0, for general APE behaviour see  https://alice.its.cern.ch/jira/browse/O2-1717)
-    ErrActPropagate | ErrActDump, // reserved F3
-    ErrActPropagate | ErrActDump, // detector timeout (FATAL)
-    ErrActPropagate | ErrActDump, // 8b10b OOT (FATAL, start)
-    ErrActPropagate | ErrActDump, // event protocol error marker (FATAL, start)
-    ErrActPropagate | ErrActDump, // lane FIFO overflow error (FATAL)
-    ErrActPropagate | ErrActDump, // FSM error (FATAL, SEU error, reached an unknown state)
-    ErrActPropagate | ErrActDump, // pending detector events limit (FATAL)
-    ErrActPropagate | ErrActDump, // pending detector events limit in packager(FATAL)
-    ErrActPropagate | ErrActDump, // lane protocol error
-    ErrActPropagate | ErrActDump, // reserved FC
-    ErrActPropagate | ErrActDump, // Error in non critical byte
-    ErrActPropagate | ErrActDump, // OOT non-critical
+    ErrActPropagate | ErrActDump, // 0xF2 - Lane data stripped for this chip event (behaviour changed with RU FW v1.16.0, for general APE behaviour see  https://alice.its.cern.ch/jira/browse/O2-1717)
+    ErrActPropagate | ErrActDump, // 0xF3 - Chip ID jumped downwards within an ROF on a OB module (FATAL)
+    ErrActPropagate | ErrActDump, // 0xF4 - Detector timeout (FATAL)
+    ErrActPropagate | ErrActDump, // 0xF5 - 8b10b OOT (FATAL, start)
+    ErrActPropagate | ErrActDump, // 0xF6 - Event protocol error marker (FATAL, start)
+    ErrActPropagate | ErrActDump, // 0xF7 - Lane FIFO overflow error (FATAL)
+    ErrActPropagate | ErrActDump, // 0xF8 - FSM error (FATAL, SEU error, reached an unknown state)
+    ErrActPropagate | ErrActDump, // 0xF9 - Pending detector events limit (FATAL)
+    ErrActPropagate | ErrActDump, // 0xFA - Pending detector events limit in packager (FATAL)
+    ErrActPropagate | ErrActDump, // 0xFB - Lane protocol error (FATAL)
+    ErrActPropagate | ErrActDump, // 0xFC - Received start of event before trigger (FATAL)
+    ErrActPropagate | ErrActDump, // 0xFD - Error in non critical byte
+    ErrActPropagate | ErrActDump, // 0xFE - OOT non-critical
     ErrActPropagate | ErrActDump, // DColumns non increasing
     ErrActPropagate | ErrActDump, // Chip data interleaved on the cable
     ErrActPropagate | ErrActDump, // Truncated buffer while something was expected
@@ -156,7 +156,7 @@ struct ChipStat {
   static int getAPENonCritical(uint8_t c)
   {
     if (c == 0xfd || c == 0xfe) {
-      return APE_STRIP + c - 0xf2;
+      return APE_STRIP_START + c - 0xf2;
     }
     return -1;
   }
@@ -169,7 +169,7 @@ struct ChipStat {
       return -1;
     }
     ft = c >= 0xf2 && c <= 0xfe;
-    return APE_STRIP + c - 0xf2;
+    return APE_STRIP_START + c - 0xf2;
   }
   uint32_t getNErrors() const;
   uint32_t addErrors(uint32_t mask, uint16_t chID, int verbosity);


### PR DESCRIPTION
- Updated the names of the error markers inserted by the ITS Readout Unit into the ALPIDE data stream
- No logic changes as existing words have been repurposed (0xF3 and 0xFC)
- Preparation for the firmware version v1.22.0