### PR TITLE
Attach CTP digits reader to tpc-reco-workflow for --lumi-type 1

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -52,6 +52,7 @@ o2_add_library(TPCWorkflow
                                      O2::TPCCalibration O2::TPCSimulation
                                      O2::TPCQC O2::DetectorsCalibration
                                      O2::TPCReaderWorkflow
+                                     O2::CTPWorkflowIO
                PRIVATE_LINK_LIBRARIES O2::GPUTracking # For the Zero Suppression includes
                                       O2::GPUWorkflow
            )

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -43,7 +43,7 @@
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
 #include "TPCReaderWorkflow/TriggerReaderSpec.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
-
+#include "CTPWorkflowIO/DigitReaderSpec.h"
 #include <string>
 #include <stdexcept>
 #include <fstream>
@@ -174,6 +174,9 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
   }};
 
   if (!disableRootInput || inputType == InputType::PassThrough) {
+    if (sclOpts.lumiType == 1) { // need CTP digits (lumi) reader
+      specs.emplace_back(o2::ctp::getDigitsReaderSpec(false));
+    }
     // The OutputSpec of the PublisherSpec is configured depending on the input
     // type. Note that the configuration of the dispatch trigger in the main file
     // needs to be done in accordance. This means, if a new input option is added


### PR DESCRIPTION
@sawenzel nominally this will make o2-tpc-reco-workflow work when --lumy-type 1 (i.e. CTP lumi) is requested.
It will attach in this case the CTP digits reader to the inputs. 
But there is one problem in the MC: the CTP does not simulate lumi counters therefore provided lumi will be always 0, leading to the correction with the reference map only.
And even if CTP starts to simulate lumi (though in pbpb this would require ZDC inputs with EM signals simulated) I doubt it will precisely match the systematic of the lumi scale stored in the map.
In fact, one should 1st decide what lumi will be used to simulate the distortions. In case we use some constant lumi, it is worth to ignore the `--lumi-type <>` option and instead impose the same ad hoc fixed "instantaneous" lumi as used in the simulation (at the moment via `--corrmap-lumi-inst <lumi>`, once https://github.com/AliceO2Group/AliceO2/pull/12264 is merged: via `TPCCorrMap.instLumi` configurable).