### PR TITLE
Better pruning of events from Pythia8 and enable in HepMC

### DIFF
--- a/Generators/include/Generators/GeneratorHepMC.h
+++ b/Generators/include/Generators/GeneratorHepMC.h
@@ -31,6 +31,7 @@ namespace HepMC3
 class Reader;
 class GenEvent;
 class FourVector;
+class GenParticle;
 } // namespace HepMC3
 #endif
 
@@ -101,12 +102,22 @@ class GeneratorHepMC : public Generator, public GeneratorFileOrCmd
   /** Make our reader */
   bool makeReader();
 
+  /** Type of function to select particles to keep when pruning
+   * events */
+  typedef bool (*Select)(std::shared_ptr<const HepMC3::GenParticle>);
+  /** Prune event of particles that are not selected by passed
+   * function.  The event structure is preserved. */
+  void pruneEvent(Select select);
+
   /** HepMC interface **/
   uint64_t mEventsToSkip = 0;
+  /** HepMC event record version to expected.  Deprecated. */
   int mVersion = 0;
   std::shared_ptr<HepMC3::Reader> mReader;
   /** Event structure */
   HepMC3::GenEvent* mEvent = nullptr;
+  /** Option whether to prune event */
+  bool mPrune; //!
 
   ClassDefOverride(GeneratorHepMC, 1);
 

--- a/Generators/include/Generators/GeneratorHepMCParam.h
+++ b/Generators/include/Generators/GeneratorHepMCParam.h
@@ -30,9 +30,27 @@ namespace eventgen
  **/
 
 struct GeneratorHepMCParam : public o2::conf::ConfigurableParamHelper<GeneratorHepMCParam> {
+  /** Version number of event structure to decode.  Note, when reading
+   *  from a file, this key is ignored.  The interface will figure out
+   *  the version automatically.  When reading from a pipe, and the
+   *  command line writes HepMC version 2 format, then this parameter
+   *  should be set to 2 */
   int version = 0;
+  /** Number of events to skip at the start of the input */
   uint64_t eventsToSkip = 0;
+  /** Deprecated.  Set the name of the file to read from.  Use
+   * GeneratorFileOrCmd.fileNames instead. */
   std::string fileName = "";
+  /** Wether to prune the event tree.  If true, then only particles that are
+   *
+   * - beam particles (status == 4)
+   * - decayed (status == 2), or
+   * - final state (status == 1)
+   *
+   * are kept.  This reduces the event size.  How much depends on the
+   * event generator producing the event.  Use with caution, as it may
+   * corrupt the event record. */
+  bool prune = false;
   O2ParamDef(GeneratorHepMCParam, "HepMC");
 };
 

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -24,7 +24,63 @@ namespace eventgen
 
 /*****************************************************************/
 /*****************************************************************/
-
+/** Interface to the Pythia8 event generator.  This generator is
+ * configured by configuration files (e.g.,
+ * `Generators/share/egconfig/pythia8_inel.cfg` for the type of
+ * events to generate.
+ *
+ * The above file, for example, contains
+ *
+ * @verbatim
+ * ### Beams, proton-proton collisions at sqrt(s)=14TeV
+ * Beams:idA 2212                  # proton
+ * Beams:idB 2212                  # proton
+ * Beams:eCM 14000.                # GeV
+ *
+ * ### Processes, min-bias inelastic events
+ * SoftQCD:inelastic on            # all inelastic processes
+ *
+ * ### Decays. Only decay until 1cm/c - corresponding to (physical) primaries
+ * ParticleDecays:limitTau0 on
+ * ParticleDecays:tau0Max 10.
+ * @endverbatim
+ *
+ * The configuration file to read is initially set in
+ * `GeneratorFactory`, but an additional configuration file can be
+ * specified with the configuration key `GeneratorPythia8::config`.
+ *
+ * If the configuration key `GeneratorPythia8::includePartonEvent` is
+ * set to false (default), then the event is pruned.  That is, all
+ * particles that are not
+ *
+ * - beam particles (HepMC status = 4),
+ * - decayed particles (HepMC status = 2), nor
+ * - final state partcles (HepMC status = 1)
+ *
+ * are removed from the event before passing on to the simulation.
+ * The event structure is kept, so that we have a well-formed event
+ * structure.  This reduces the event size by roughly 30%.
+ *
+ * If the configuration key `GeneratorPythia8::includePartonEvent` is
+ * true, then the full event is kept, including intermediate partons
+ * such as gluons, pomerons, diffractive hadrons, and so on.
+ *
+ * In the future, the way to prune events may become more flexible.
+ * For example, we could have the configuration keys
+ *
+ * - GeneratorPythia8::onlyStatus a list of HepMC status codes to accept
+ * - GeneratorPythia8::onlyPDGs a list of PDG particle codes to accept
+ *
+ * The configuration key `GeneratorPythia8::hooksFileName` allows the
+ * definition of a Pythia8 user hook.  See for example
+ * `Generators/share/egconfig/pythia8_userhooks_charm.C`.  The file
+ * specified is interpreted via ROOT (i.e., a ROOT script), and the
+ * function name set via the configuration key
+ * `GeneratorPythia8::hooksFuncName` (default `pythia8_user_hooks`) is
+ * executed.  That function must return a pointer to a
+ * `Pythia8::UserHooks` object (see the Pythia8 manual for more on
+ * this).
+ */
 class GeneratorPythia8 : public Generator
 {
 
@@ -36,47 +92,69 @@ class GeneratorPythia8 : public Generator
   /** destructor **/
   ~GeneratorPythia8() override = default;
 
+  /** @{
+      @name methods to override **/
   /** Initialize the generator if needed **/
   Bool_t Init() override;
-
-  /** methods to override **/
+  /** Generate a single event */
   Bool_t generateEvent() override;
+  /** Import particles from Pythia onto the simulation event stack */
   Bool_t importParticles() override { return importParticles(mPythia.event); };
+  /** @} */
 
-  /** setters **/
+  /** @{
+   * @name setters **/
+  /** Set Pythia8 configuration file to read */
   void setConfig(std::string val) { mConfig = val; };
+  /**
+   * Set the ROOT script file name that defines a Pythia8::UserHooks
+   * object */
   void setHooksFileName(std::string val) { mHooksFileName = val; };
+  /** Function in ROOT script that returns a pointer to a
+   * Pythia8::UserHooks object */
   void setHooksFuncName(std::string val) { mHooksFuncName = val; };
-  void setUserHooks(Pythia8::UserHooks* hooks)
-  {
-#if PYTHIA_VERSION_INTEGER < 8300
-    mPythia.setUserHooksPtr(hooks);
-#else
-    mPythia.setUserHooksPtr(std::shared_ptr<Pythia8::UserHooks>(hooks));
-#endif
-  }
+  /** Set the user hooks (defined in a Pythia8::UserHooks object) for
+   * the event generator. */
+  void setUserHooks(Pythia8::UserHooks* hooks);
+  /** @} */
 
-  /** methods **/
+  /** @{
+   * @name Configuration methods **/
+  /** Read a Pythia8 configuration string */
   bool readString(std::string val) { return mPythia.readString(val, true); };
+  /** Read a Pythia8 configuration file */
   bool readFile(std::string val) { return mPythia.readFile(val, true); };
+  /** @} */
 
-  /** utilities **/
+  /** @{
+   * @name Utilities **/
+  /** Get number of binary collisions.  Note that this method deviates
+   * from how the Pythia authors count number of binary collisions */
   void getNcoll(int& nColl)
   {
     getNcoll(mPythia.info, nColl);
   };
+  /** Get number of participants.  Note that this method deviates
+   * from how the Pythia authors count number of participants */
   void getNpart(int& nPart)
   {
     getNpart(mPythia.info, nPart);
   };
+  /** Get number of participants, split by nucleon type and origin.
+   * Note that this method deviates from how the Pythia authors count
+   * number of participants */
   void getNpart(int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg)
   {
     getNpart(mPythia.info, nProtonProj, nNeutronProj, nProtonTarg, nNeutronTarg);
   };
+  /** Get number of nuclei remnants, split by nucleon type and origin. */
   void getNremn(int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg)
   {
     getNremn(mPythia.event, nProtonProj, nNeutronProj, nProtonTarg, nNeutronTarg);
   };
+  /** Get number of spectators, split by nucleon type and origin.
+   * Note that this method deviates from how the Pythia authors count
+   * number of spectators */
   void getNfreeSpec(int& nFreenProj, int& nFreepProj, int& nFreenTarg, int& nFreepTarg)
   {
     getNfreeSpec(mPythia.info, nFreenProj, nFreepProj, nFreenTarg, nFreepTarg);
@@ -88,27 +166,101 @@ class GeneratorPythia8 : public Generator
   /** operator= **/
   GeneratorPythia8& operator=(const GeneratorPythia8&);
 
-  /** methods that can be overridded **/
+  /** @{
+   * @name Some function definitions
+   */
+  /** Select particles when pruning event */
+  typedef bool (*Select)(const Pythia8::Particle& particle);
+  /** Get relatives (mothers or daughters) of a particle */
+  typedef std::vector<int> (*GetRelatives)(const Pythia8::Particle&);
+  /** Set relatives (mothers or daughters) of a particle */
+  typedef void (*SetRelatives)(Pythia8::Particle&, int, int);
+  /** Get range of relatives (mothers or daughters) of a particle */
+  typedef std::pair<int, int> (*FirstLastRelative)(const Pythia8::Particle&);
+  /** @} */
+
+  /** @{
+   * @name Methods that can be overridded **/
+  /** Update the event header.  This propagates all sorts of
+   * information from Pythia8 to the simulation event header,
+   * including parton distribution function parameters, event weight,
+   * cross-section information, heavy-ion collision information, and
+   * so on. */
   void updateHeader(o2::dataformats::MCEventHeader* eventHeader) override;
+  /** @} */
 
-  /** internal methods **/
-  Bool_t importParticles(Pythia8::Event const& event);
-
-  /** utilities **/
+  /** @{
+   * @name Internal methods **/
+  /** Import particles from Pythia onto the simulation stack */
+  Bool_t importParticles(Pythia8::Event& event);
+  /** Prune an event.  Only particles for which the function select
+   * returns true are kept in the event record.  The structure of the
+   * event is preserved, meaning that particles will point back to
+   * their ultimate (selected) mothers and, if select preserves the
+   * beam particles, the ultimate collision interaction. */
+  void pruneEvent(Pythia8::Event& event, Select select);
+  /** Investigate relatives (mothers or daughters) for particles to
+   * keep when pruning an event.  This checks the current particle,
+   * identified by index, if any of its relatives (either mothers or
+   * daughters) are to be kept.  If a relative is to be kept, then
+   * that is added to an internal list.  If a relative is _not_ to be
+   * kept, then that relatives relatives are queried (recursive call).
+   * The result of the recursive call is a list of relatives to the
+   * current particle which are to be kept.  These are then also added
+   * to the internal list.  The relatives that are found to be kept
+   * are then set to be relatives of the current particle.  Note that
+   * this member function modifies the relatives of the passed
+   * particle, and thus modifies the passed event structure.
+   * Calculations are cached. */
+  void investigateRelatives(Pythia8::Event& event,                   // Event
+                            const std::map<size_t, size_t>& old2New, // Map from old to new idx
+                            size_t index,                            // Current particle
+                            std::vector<bool>& done,                 // cache flag
+                            GetRelatives getter,                     // get relatives
+                            SetRelatives setter,                     // set relatives
+                            FirstLastRelative firstLast,             // get first and last relative
+                            const std::string& what,                 // what are we looking for
+                            const std::string& ind = "");            // logging indent
+  /** @{
+   * @name utilities **/
+  /** Select from ancestor. Fills the output event with all particles
+   * related to an ancestor of the input event
+   *
+   * Starting from ancestor, select all daughters (and their daughters
+   * recursively), and store them in the output event.
+   **/
   void selectFromAncestor(int ancestor, Pythia8::Event& inputEvent, Pythia8::Event& outputEvent);
+  /** Get number of binary collisions.  Note that this method deviates
+   * from how the Pythia authors count number of binary collisions */
   void getNcoll(const Pythia8::Info& info, int& nColl);
+  /** Get number of participants.  Note that this method deviates
+   * from how the Pythia authors count number of participants */
   void getNpart(const Pythia8::Info& info, int& nPart);
+  /** Get number of participants, split by nucleon type and origin.
+   * Note that this method deviates from how the Pythia authors count
+   * number of participants */
   void getNpart(const Pythia8::Info& info, int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg);
+  /** Get number of nuclei remnants, split by nucleon type and origin. */
   void getNremn(const Pythia8::Event& event, int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg);
+  /** Get number of spectators, split by nucleon type and origin.
+   * Note that this method deviates from how the Pythia authors count
+   * number of spectators */
   void getNfreeSpec(const Pythia8::Info& info, int& nFreenProj, int& nFreepProj, int& nFreenTarg, int& nFreepTarg);
+  /** @} */
 
   /** Pythia8 **/
   Pythia8::Pythia mPythia; //!
 
-  /** configuration **/
+  /** @{
+   * @name Configurations */
+  /** configuration file to read **/
   std::string mConfig;
+  /** ROOT script defining a Pythia8::UserHooks object */
   std::string mHooksFileName;
+  /** Function in `mHooksFileName` to execute to return pointer to
+   * Pythia8::UserHooks object */
   std::string mHooksFuncName;
+  /** @} */
 
   ClassDefOverride(GeneratorPythia8, 1);
 
@@ -121,3 +273,6 @@ class GeneratorPythia8 : public Generator
 } // namespace o2
 
 #endif /* ALICEO2_EVENTGEN_GENERATORPYTHIA8_H_ */
+//
+// EOF
+//

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -212,15 +212,15 @@ class GeneratorPythia8 : public Generator
    * this member function modifies the relatives of the passed
    * particle, and thus modifies the passed event structure.
    * Calculations are cached. */
-  void investigateRelatives(Pythia8::Event& event,                   // Event
-                            const std::map<size_t, size_t>& old2New, // Map from old to new idx
-                            size_t index,                            // Current particle
-                            std::vector<bool>& done,                 // cache flag
-                            GetRelatives getter,                     // get relatives
-                            SetRelatives setter,                     // set relatives
-                            FirstLastRelative firstLast,             // get first and last relative
-                            const std::string& what,                 // what are we looking for
-                            const std::string& ind = "");            // logging indent
+  void investigateRelatives(Pythia8::Event& event,           // Event
+                            const std::vector<int>& old2New, // Map from old to new idx
+                            size_t index,                    // Current particle
+                            std::vector<bool>& done,         // cache flag
+                            GetRelatives getter,             // get relatives
+                            SetRelatives setter,             // set relatives
+                            FirstLastRelative firstLast,     // get first and last relative
+                            const std::string& what,         // what are we looking for
+                            const std::string& ind = "");    // logging indent
   /** @{
    * @name utilities **/
   /** Select from ancestor. Fills the output event with all particles

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -215,8 +215,8 @@ void GeneratorHepMC::pruneEvent(Select select)
     event.remove_vertex(vtx);
   }
 
-  LOG(debug) << "HepMC events was pruned from " << oldSize 
-	     << " particles to " << event.particles().size()
+  LOG(debug) << "HepMC events was pruned from " << oldSize
+             << " particles to " << event.particles().size()
              << " particles and " << event.vertices().size()
              << " vertices";
 }

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -84,6 +84,7 @@ void GeneratorHepMC::setup(const GeneratorFileOrCmdParam& param0,
   }
 
   mVersion = param.version;
+  mPrune = param.prune;
   setEventsToSkip(param.eventsToSkip);
 
   if (param.version != 0 and mCmd.empty()) {
@@ -121,10 +122,122 @@ Bool_t GeneratorHepMC::generateEvent()
 }
 
 /*****************************************************************/
+void GeneratorHepMC::pruneEvent(Select select)
+{
+  HepMC3::GenEvent& event = *mEvent;
+
+  auto particles = event.particles();
+  auto vertices = event.vertices();
+  std::set<HepMC3::GenParticlePtr> toRemove;
+
+  LOG(debug) << "HepMC events has " << particles.size()
+             << " particles and " << vertices.size()
+             << " vertices" << std::endl;
+
+  size_t nSelect = 0;
+  for (size_t i = 0; i < particles.size(); ++i) {
+    auto particle = particles[i];
+    if (select(particle)) {
+      nSelect++;
+      continue;
+    }
+
+    // Remove particle from the event
+    toRemove.insert(particle);
+    LOG(debug) << " Remove " << std::setw(3) << particle->id();
+
+    auto endVtx = particle->end_vertex();
+    auto prdVtx = particle->production_vertex();
+    if (endVtx) {
+      // Disconnect this particle from its out going vertex
+      endVtx->remove_particle_in(particle);
+      LOG(debug) << " end " << std::setw(3) << endVtx->id();
+
+      if (prdVtx and prdVtx->id() != endVtx->id()) {
+        auto outbound = endVtx->particles_out();
+        auto inbound = endVtx->particles_in();
+        LOG(debug) << " prd " << std::setw(3) << prdVtx->id() << " "
+                   << std::setw(3) << outbound.size() << " out "
+                   << " "
+                   << std::setw(3) << inbound.size() << " in ";
+
+        // Other out-bound particles of the end vertex are attached as
+        // out-going to the production vertex of this particle.
+        for (auto outgoing : outbound) {
+          // This should also detach the particle from its old
+          // end-vertex.
+          if (outgoing) {
+            auto ee = outgoing->end_vertex();
+            if (not ee or ee->id() != prdVtx->id()) {
+              prdVtx->add_particle_out(outgoing);
+            }
+            LOG(debug) << "  " << std::setw(3) << outgoing->id();
+          }
+        }
+
+        // Other incoming particles to the end vertex of this
+        // particles are attached incoming particles to the production
+        // vertex of this particle.
+        for (auto incoming : inbound) {
+          if (incoming) {
+            auto pp = incoming->production_vertex();
+            if (not pp or pp->id() != prdVtx->id()) {
+              prdVtx->add_particle_in(incoming);
+            }
+
+            LOG(debug) << "  " << std::setw(3) << incoming->id();
+          }
+        }
+      }
+    }
+    if (prdVtx) {
+      prdVtx->remove_particle_out(particle);
+    }
+  }
+
+  LOG(debug) << "Selected " << nSelect << " particles\n"
+             << "Removing " << toRemove.size() << " particles";
+  for (auto particle : toRemove) {
+    event.remove_particle(particle);
+  }
+
+  std::list<HepMC3::GenVertexPtr> remVtx;
+  for (auto vtx : event.vertices()) {
+    if (not vtx or
+        (vtx->particles_out().empty() and
+         vtx->particles_in().empty())) {
+      remVtx.push_back(vtx);
+    }
+  }
+  LOG(debug) << "Removing " << remVtx.size() << " vertexes";
+  for (auto vtx : remVtx) {
+    event.remove_vertex(vtx);
+  }
+
+  LOG(debug) << "HepMC events has " << event.particles().size()
+             << " particles and " << event.vertices().size()
+             << " vertices";
+}
+
+/*****************************************************************/
 
 Bool_t GeneratorHepMC::importParticles()
 {
   /** import particles **/
+  if (mPrune) {
+    auto select = [](HepMC3::ConstGenParticlePtr particle) {
+      switch (particle->status()) {
+        case 1: // Final st
+        case 2: // Decayed
+        case 4: // Beam
+          return true;
+      }
+      // To also keep diffractive particles
+      // if (particle->pid() == 9902210) return true;
+      return false;
+    };
+    pruneEvent(select);
+  }
 
   /** loop over particles **/
   auto particles = mEvent->particles();
@@ -132,24 +245,10 @@ Bool_t GeneratorHepMC::importParticles()
 
     /** get particle information **/
     auto particle = particles.at(i);
-    auto pdg = particle->pid();
-    auto st = particle->status();
     auto momentum = particle->momentum();
     auto vertex = particle->production_vertex()->position();
-    auto parents = particle->parents();   // less efficient than via vertex
-    auto children = particle->children(); // less efficient than via vertex
-
-    /** get momentum information **/
-    auto px = momentum.x();
-    auto py = momentum.y();
-    auto pz = momentum.z();
-    auto et = momentum.t();
-
-    /** get vertex information **/
-    auto vx = vertex.x();
-    auto vy = vertex.y();
-    auto vz = vertex.z();
-    auto vt = vertex.t();
+    auto parents = particle->parents();
+    auto children = particle->children();
 
     /** get mother information **/
     auto m1 = parents.empty() ? -1 : parents.front()->id() - 1;
@@ -160,8 +259,23 @@ Bool_t GeneratorHepMC::importParticles()
     auto d2 = children.empty() ? -1 : children.back()->id() - 1;
 
     /** add to particle vector **/
-    mParticles.push_back(TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt));
-    o2::mcutils::MCGenHelper::encodeParticleStatusAndTracking(mParticles.back(), st == 1);
+    mParticles.push_back(TParticle(particle->pid(),            // Particle type
+                                   particle->status(),         // Status code
+                                   m1,                         // First mother
+                                   m2,                         // Second mother
+                                   d1,                         // First daughter
+                                   d2,                         // Last daughter
+                                   momentum.x(),               // X-momentum
+                                   momentum.y(),               // Y-momentum
+                                   momentum.z(),               // Z-momentum
+                                   momentum.t(),               // Energy
+                                   vertex.x(),                 // Production X
+                                   vertex.y(),                 // Production Y
+                                   vertex.z(),                 // Production Z
+                                   vertex.t()));               // Production time
+    o2::mcutils::MCGenHelper::encodeParticleStatusAndTracking( //
+      mParticles.back(),                                       // Add to back
+      particle->status() == 1);                                // only final state are to be propagated
 
   } /** end of loop over particles **/
 

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -128,7 +128,7 @@ void GeneratorHepMC::pruneEvent(Select select)
 
   auto particles = event.particles();
   auto vertices = event.vertices();
-  std::set<HepMC3::GenParticlePtr> toRemove;
+  std::list<HepMC3::GenParticlePtr> toRemove;
 
   LOG(debug) << "HepMC events has " << particles.size()
              << " particles and " << vertices.size()
@@ -143,7 +143,7 @@ void GeneratorHepMC::pruneEvent(Select select)
     }
 
     // Remove particle from the event
-    toRemove.insert(particle);
+    toRemove.push_back(particle);
     LOG(debug) << " Remove " << std::setw(3) << particle->id();
 
     auto endVtx = particle->end_vertex();
@@ -197,6 +197,7 @@ void GeneratorHepMC::pruneEvent(Select select)
 
   LOG(debug) << "Selected " << nSelect << " particles\n"
              << "Removing " << toRemove.size() << " particles";
+  size_t oldSize = particles.size();
   for (auto particle : toRemove) {
     event.remove_particle(particle);
   }
@@ -214,7 +215,8 @@ void GeneratorHepMC::pruneEvent(Select select)
     event.remove_vertex(vtx);
   }
 
-  LOG(debug) << "HepMC events has " << event.particles().size()
+  LOG(debug) << "HepMC events was pruned from " << oldSize 
+	     << " particles to " << event.particles().size()
              << " particles and " << event.vertices().size()
              << " vertices";
 }

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -279,13 +279,13 @@ void GeneratorPythia8::investigateRelatives(Pythia8::Event& event,
     auto grandRelatives = firstLast(relative);
     int grandRelative1 = grandRelatives.first;
     int grandRelative2 = grandRelatives.second;
-    assert (grandRelative1 != invalid);
-    assert (grandRelative2 != -invalid);
+    assert(grandRelative1 != invalid);
+    assert(grandRelative2 != -invalid);
     if (grandRelative1 > 0) {
-      addId(newRelatives,grandRelative1);
+      addId(newRelatives, grandRelative1);
     }
     if (grandRelative2 > 0) {
-      addId(newRelatives,grandRelative2);
+      addId(newRelatives, grandRelative2);
     }
     LOG(debug) << ind << " "
                << what << " "
@@ -454,10 +454,12 @@ void GeneratorPythia8::pruneEvent(Pythia8::Event& event, Select select)
         // We also need to take all the daughters of this shared
         // mother and reister those.
         auto& otherMother = pruned[otherMotherIdx];
-	int otherDaughter1 = otherMother.daughter1();
-	int otherDaughter2 = otherMother.daughter2();
-	if (otherDaughter1 > 0) addId(allDaughters,otherDaughter1);
-	if (otherDaughter2 > 0) addId(allDaughters,otherDaughter2);
+        int otherDaughter1 = otherMother.daughter1();
+        int otherDaughter2 = otherMother.daughter2();
+        if (otherDaughter1 > 0)
+          addId(allDaughters, otherDaughter1);
+        if (otherDaughter2 > 0)
+          addId(allDaughters, otherDaughter2);
       }
       // At this point, we have added all mothers of current
       // daughter, and all daughters of those mothers.

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -28,6 +28,7 @@
 
 #include <iostream>
 #include <unordered_map>
+#include <numeric>
 
 namespace o2
 {
@@ -142,6 +143,16 @@ Bool_t GeneratorPythia8::Init()
 }
 
 /*****************************************************************/
+void GeneratorPythia8::setUserHooks(Pythia8::UserHooks* hooks)
+{
+#if PYTHIA_VERSION_INTEGER < 8300
+  mPythia.setUserHooksPtr(hooks);
+#else
+  mPythia.setUserHooksPtr(std::shared_ptr<Pythia8::UserHooks>(hooks));
+#endif
+}
+
+/*****************************************************************/
 
 Bool_t
   GeneratorPythia8::generateEvent()
@@ -185,177 +196,333 @@ Bool_t
 }
 
 /*****************************************************************/
+void GeneratorPythia8::investigateRelatives(Pythia8::Event& event,
+                                            const std::map<size_t, size_t>& old2New,
+                                            size_t index,
+                                            std::vector<bool>& done,
+                                            GetRelatives getter,
+                                            SetRelatives setter,
+                                            FirstLastRelative firstLast,
+                                            const std::string& what,
+                                            const std::string& ind)
+{
+  // Utility to find new index, or -1 if not found
+  auto findNew = [old2New](size_t old) -> int {
+    auto iter = old2New.find(old);
+    return iter == old2New.end() ? -1 : iter->second;
+  };
+  int newIdx = findNew(index);
+  int hepmc = event[index].statusHepMC();
+
+  LOG(debug) << ind
+             << index << " -> "
+             << newIdx << " (" << hepmc << ") ";
+  if (done[index]) {
+    LOG(debug) << ind << " already done";
+    return;
+  }
+
+  // Our list of new relatives
+  using IdList = std::set<int>;
+  IdList newRelatives;
+
+  // Utility to add id
+  auto addId = [](IdList& l, size_t id) { l.insert(id); };
+  // Get particle and relatives
+  auto& particle = event[index];
+  auto relatives = getter(particle);
+
+  LOG(debug) << ind << " Check " << what << "s ["
+             << std::setw(3) << firstLast(particle).first << ","
+             << std::setw(3) << firstLast(particle).second << "] "
+             << relatives.size();
+
+  for (auto relativeIdx : relatives) {
+    int newRelative = findNew(relativeIdx);
+    if (newRelative >= 0) {
+      // If this relative is to be kept, then append to list of new
+      // relatives.
+      LOG(debug) << ind << " "
+                 << what << " "
+                 << relativeIdx << " -> "
+                 << newRelative << " to be kept" << std::endl;
+      addId(newRelatives, newRelative);
+      continue;
+    }
+    LOG(debug) << ind << " "
+               << what << " "
+               << relativeIdx << " not to be kept "
+               << (done[relativeIdx] ? "already done" : "to be done")
+               << std::endl;
+
+    // Below is code for when the relative is not to be kept
+    auto& relative = event[relativeIdx];
+    if (not done[relativeIdx]) {
+      // IF the relative hasn't been processed yet, do so now
+      investigateRelatives(event,       // Event
+                           old2New,     // Map from old to new
+                           relativeIdx, // current particle index
+                           done,        // cache flag
+                           getter,      // get mother relatives
+                           setter,      // set mother relatives
+                           firstLast,   // get first and last
+                           what,        // what we're looking at
+                           ind + "  "); // Logging indent
+    }
+
+    // If this relative was already done, then get its relatives and
+    // add them to the list of new relatives.
+    LOG(debug) << ind << " "
+               << what << " "
+               << relativeIdx << " gave new relatives ";
+    for (auto grandRelative : getter(relative)) {
+      LOG(debug) << ind << "  " << grandRelative;
+      addId(newRelatives, grandRelative);
+    }
+  }
+  LOG(debug) << ind << " Got " << newRelatives.size() << " new "
+             << what << "s ";
+
+  if (newRelatives.size() > 0) {
+    size_t newRelative1 = *std::min_element(newRelatives.begin(),
+                                            newRelatives.end());
+    size_t newRelative2 = *std::max_element(newRelatives.begin(),
+                                            newRelatives.end());
+    setter(particle, newRelative1, newRelative2);
+    LOG(debug) << ind << " " << what << "s: "
+               << firstLast(particle).first << " ("
+               << newRelative1 << "),"
+               << firstLast(particle).second << " ("
+               << newRelative2 << ")";
+
+  } else {
+    setter(particle, 0, 0);
+  }
+  done[index] = true;
+}
+
+/*****************************************************************/
+void GeneratorPythia8::pruneEvent(Pythia8::Event& event, Select select)
+{
+  // Mapping from old to new index.
+  std::map<size_t, size_t> old2new;
+
+  // Particle 0 is a system particle, and we will skip that in the
+  // following.
+  size_t newId = 0;
+
+  // Loop over particles and store those we need
+  for (size_t i = 1; i < event.size(); i++) {
+    auto& particle = event[i];
+    if (select(particle)) {
+      ++newId;
+      old2new[i] = newId;
+    }
+  }
+  // Utility to find new index, or -1 if not found
+  auto findNew = [old2new](size_t old) -> int {
+    auto iter = old2new.find(old);
+    return iter == old2new.end() ? -1 : iter->second;
+  };
+
+  // First loop, investigate mothers - from the bottom
+  auto getMothers = [](const Pythia8::Particle& particle) { return particle.motherList(); };
+  auto setMothers = [](Pythia8::Particle& particle, int m1, int m2) { particle.mothers(m1, m2); };
+  auto firstLastMothers = [](const Pythia8::Particle& particle) { return std::make_pair(particle.mother1(), particle.mother2()); };
+
+  std::vector<bool> motherDone(event.size(), false);
+  for (size_t i = 1; i < event.size(); ++i) {
+    investigateRelatives(event,            // Event
+                         old2new,          // Map from old to new
+                         i,                // current particle index
+                         motherDone,       // cache flag
+                         getMothers,       // get mother relatives
+                         setMothers,       // set mother relatives
+                         firstLastMothers, // get first and last
+                         "mother");        // what we're looking at
+  }
+
+  // Second loop, investigate daughters - from the top
+  auto getDaughters = [](const Pythia8::Particle& particle) {
+    // In case of |status|==13 (diffractive), we cannot use
+    // Pythia8::Particle::daughterList as it will give more than
+    // just the immediate daughters. In that cae, we do it
+    // ourselves.
+    if (std::abs(particle.status()) == 13) {
+      int d1 = particle.daughter1();
+      int d2 = particle.daughter2();
+      if (d1 == 0 and d2 == 0) {
+        return std::vector<int>();
+      }
+      if (d2 == 0) {
+        return std::vector<int>{d1};
+      }
+      if (d2 > d1) {
+        std::vector<int> ret(d2-d1+1);
+        std::iota(ret.begin(), ret.end(), d1);
+        return ret;
+      }
+      return std::vector<int>{d2,d1};
+    }
+    return particle.daughterList(); };
+  auto setDaughters = [](Pythia8::Particle& particle, int d1, int d2) { particle.daughters(d1, d2); };
+  auto firstLastDaughters = [](const Pythia8::Particle& particle) { return std::make_pair(particle.daughter1(), particle.daughter2()); };
+
+  std::vector<bool> daughterDone(event.size(), false);
+  for (size_t i = event.size() - 1; i > 0; --i) {
+    investigateRelatives(event,              // Event
+                         old2new,            // Map from old to new
+                         i,                  // current particle index
+                         daughterDone,       // cache flag
+                         getDaughters,       // get mother relatives
+                         setDaughters,       // set mother relatives
+                         firstLastDaughters, // get first and last
+                         "daughter");        // what we're looking at
+  }
+
+  // Make a pruned event
+  Pythia8::Event pruned;
+  pruned.init("Pruned event", &mPythia.particleData);
+  pruned.reset();
+
+  for (size_t i = 1; i < event.size(); i++) {
+    int newIdx = findNew(i);
+    if (newIdx < 0) {
+      continue;
+    }
+
+    auto particle = event[i];
+    int realIdx = pruned.append(particle);
+    assert(realIdx == newIdx);
+  }
+
+  // We may have that two or more mothers share some daughters, but
+  // that one or more mothers have more daughters than the other
+  // mothers, and hence not all daughters point back to all mothers.
+  // This can happen, for example, if a beam particle radiates
+  // on-shell particles before an interaction with any daughters
+  // from the other mothers.  Thus, we need to take care of that or
+  // the event record will be corrupted.
+  //
+  // What we do is that for all particles, we look up the daughters.
+  // Then for each daughter, we check the mothers of those
+  // daughters.  If this list of mothers include other mothers than
+  // the currently investigated mother, we must change the mothers
+  // of the currently investigated daughters.
+  std::vector<bool> shareDone(pruned.size(), false);
+  for (size_t i = 1; i < pruned.size(); i++) {
+    if (shareDone[i]) {
+      continue;
+    }
+
+    auto& particle = pruned[i];
+    auto daughters = particle.daughterList();
+    std::set<size_t> allDaughters;
+    std::set<size_t> allMothers;
+    allMothers.insert(i);
+    for (auto daughterIdx : daughters) {
+      // Add this daughter to set of all daughters
+      allDaughters.insert(daughterIdx);
+      auto& daughter = pruned[daughterIdx];
+      auto otherMothers = daughter.motherList();
+      for (auto otherMotherIdx : otherMothers) {
+        // Add this mother to set of all mothers.  That is, take all
+        // mothers of the current daughter of the current particle
+        // and store that.  In this way, we register mothers that
+        // share a daughter with the current particle.
+        allMothers.insert(otherMotherIdx);
+        // We also need to take all the daughters of this shared
+        // mother and reister those.
+        auto& otherMother = pruned[otherMotherIdx];
+        auto otherDaughters = otherMother.daughterList();
+        allDaughters.insert(otherDaughters.begin(), otherDaughters.end());
+      }
+      // At this point, we have added all mothers of current
+      // daughter, and all daughters of those mothers.
+    }
+    // At this point, we have all mothers that share daughters with
+    // the current particle, and we have all of the daughters
+    // too.
+    //
+    // We can now update the daughter information on all mothers
+    size_t minDaughter = *std::min_element(allDaughters.begin(),
+                                           allDaughters.end());
+    size_t maxDaughter = *std::max_element(allDaughters.begin(),
+                                           allDaughters.end());
+    for (auto motherIdx : allMothers) {
+      shareDone[motherIdx] = true;
+      pruned[motherIdx].daughters(minDaughter, maxDaughter);
+    }
+    // We can now update the mother information on all daughters
+    size_t minMother = *std::min_element(allMothers.begin(),
+                                         allMothers.end());
+    size_t maxMother = *std::max_element(allMothers.begin(),
+                                         allMothers.end());
+    for (auto daughterIdx : allDaughters) {
+      pruned[daughterIdx].mothers(minMother, maxMother);
+    }
+  }
+
+  LOG(info) << "Pythia event was pruned from " << event.size()
+            << " to " << pruned.size() << " particles";
+  // Assign our pruned event to the event passed in
+  event = pruned;
+}
+
+/*****************************************************************/
 
 Bool_t
-  GeneratorPythia8::importParticles(Pythia8::Event const& event)
+  GeneratorPythia8::importParticles(Pythia8::Event& event)
 {
   /** import particles **/
 
-  // the right moment to filter out unwanted stuff (like parton-level event information)
+  // The right moment to filter out unwanted stuff (like parton-level
+  // event information) Here, we aim to filter out everything before
+  // hadronization with the motivation to reduce the size of the MC
+  // event record in the AOD.
+  if (not GeneratorPythia8Param::Instance().includePartonEvent) {
 
-  std::unique_ptr<Pythia8::Event> hadronLevelEvent;
-  auto eventToRead = &event;
-
-  // The right moment to filter out unwanted stuff (like parton-level event information)
-  // Here, we aim to filter out everything before hadronization with the motivation to reduce the
-  // size of the MC event record in the AOD.
-  if (!GeneratorPythia8Param::Instance().includePartonEvent) {
-
-    // lambda performing the actual filtering
-    auto getHadronLevelEvent = [](Pythia8::Event const& event, Pythia8::Event& hadronLevelEvent) {
-      std::unordered_map<int, int> old_to_new;
-      std::vector<Pythia8::Particle> filtered;
-      // push the system particle
-      filtered.push_back(event[0]);
-
-      // Iterate over all particles and keep those that appear in hadronization phase
-      // (should be mostly those with HepMC statuses 1 and 2)
-      // we go from 1 since 0 is system as whole
-      for (int i = 1; i < event.size(); ++i) {
-        auto& p = event[i];
-        if (p.statusHepMC() == 1 || p.statusHepMC() == 2) {
-          filtered.push_back(p);
-          old_to_new[i] = filtered.size() - 1;
-        }
+    // Select pythia particles
+    auto particleSelect = [](const Pythia8::Particle& particle) {
+      switch (particle.statusHepMC()) {
+        case 1: // Final st
+        case 2: // Decayed
+        case 4: // Beam
+          return true;
       }
-
-      // helper lambda to lookup new index in filtered event - returns new id or -1 if not succesfull
-      auto lookupNew = [&old_to_new](int oldid) {
-        auto iter = old_to_new.find(oldid);
-        if (iter == old_to_new.end()) {
-          return -1;
-        }
-        return iter->second;
-      };
-
-      std::vector<int> childbuffer;
-
-      // a lambda to check/assert size on children
-      auto checkChildrenSize = [&childbuffer](int expected) {
-        if (expected != childbuffer.size()) {
-          LOG(error) << "Transcribed children list does not have expected size " << expected << " but " << childbuffer.size();
-        }
-      };
-
-      // second pass to fix parent / children mappings
-      for (int i = 1; i < filtered.size(); ++i) {
-        auto& p = filtered[i];
-        // get old daughters --> lookup their new position and fix
-        auto originaldaughterids = p.daughterList();
-
-        // this checks if all children have been copied over to filtered
-        childbuffer.clear();
-        for (auto& oldid : originaldaughterids) {
-          auto newid = lookupNew(oldid);
-          if (newid == -1) {
-            LOG(error) << "Pythia8 remapping error - original index not known " << oldid;
-          } else {
-            childbuffer.push_back(newid);
-          }
-        }
-
-        // fix children
-        // analyse the cases (see Pythia8 documentation)
-        auto d1 = p.daughter1();
-        auto d2 = p.daughter2();
-        if (d1 == 0 && d2 == 0) {
-          // there is no offsprint --> nothing to do
-          checkChildrenSize(0);
-        } else if (d1 == d2 && d1 != 0) {
-          // carbon copy ... should not happend here
-          checkChildrenSize(1);
-          p.daughters(childbuffer[0], childbuffer[0]);
-        } else if (d1 > 0 && d2 == 0) {
-          checkChildrenSize(1);
-          p.daughters(childbuffer[0], 0);
-        } else if (d2 != 0 && d2 > d1) {
-          // multiple decay products ... adjacent in the event
-          checkChildrenSize(d2 - d1 + 1);
-          p.daughters(lookupNew(d1), lookupNew(d2));
-        } else if (d2 != 0 && d2 < d1) {
-          // 2 distinct products ... not adjacent to each other
-          checkChildrenSize(2);
-          p.daughters(lookupNew(d1), lookupNew(d2));
-        }
-
-        // fix mothers
-        auto m1 = p.mother1();
-        auto m2 = p.mother2();
-        if (m1 == 0 && m2 == 0) {
-          // nothing to be done
-        } else if (m1 > 0 && m2 == m1) {
-          // carbon copy
-          auto tmp = lookupNew(m1);
-          if (tmp != -1) {
-            p.mothers(tmp, tmp);
-          } else {
-            // delete mother link since no longer available
-            p.mothers(0, 0);
-          }
-        } else if (m1 > 0 && m2 == 0) {
-          // the "normal" mother case, where it is meaningful to speak of one single mother to several products, in a shower or decay;
-          auto tmp = lookupNew(m1);
-          if (tmp != -1) {
-            p.mothers(tmp, tmp);
-          } else {
-            // delete mother link since no longer available
-            p.mothers(0, 0);
-          }
-        } else if (m1 < m2 && m1 > 0) {
-          // mother1 < mother2, both > 0,
-          // case for abs(status) = 81 - 86: primary hadrons produced from
-          // the fragmentation of a string spanning the range from mother1 to mother2,
-          // so that all partons in this range should be considered mothers;
-          // and analogously for abs(status) = 101 - 106, the formation of R-hadrons;
-
-          // here we simply delete the mothers
-          p.mothers(0, 0);
-          // verify that these shouldn't be in the list anyway
-          if (lookupNew(m1) != -1 || lookupNew(m2) != -1) {
-            LOG(warn) << "Indexing looks weird for primary hadron cases";
-          }
-        } else {
-          LOG(warn) << "Unsupported / unexpected mother reindexing. Code needs more treatment";
-        }
-        // append this to the Pythia event
-        hadronLevelEvent.append(p);
-      }
+      // For example to keep diffractive particles
+      // if (particle.id() == 9902210) return true;
+      return false;
     };
 
-    hadronLevelEvent.reset(new Pythia8::Event);
-    hadronLevelEvent->init("Hadron Level event record", &mPythia.particleData);
-
-    hadronLevelEvent->reset();
-
-    getHadronLevelEvent(event, *hadronLevelEvent);
-
-    hadronLevelEvent->list();
-    eventToRead = hadronLevelEvent.get();
-    LOG(info) << "The pythia event has been reduced from size " << event.size()
-              << " to " << hadronLevelEvent->size() << " by pre-hadronization pruning";
+    pruneEvent(event, particleSelect);
   }
 
   /* loop over particles */
-  //  auto weight = mPythia.info.weight(); // TBD: use weights
-  auto nParticles = eventToRead->size();
-  for (Int_t iparticle = 1; iparticle < nParticles; iparticle++) { // first particle is system
-    auto particle = (*eventToRead)[iparticle];
+  auto nParticles = event.size();
+  for (Int_t iparticle = 1; iparticle < nParticles; iparticle++) {
+    // first particle is system
+    auto particle = event[iparticle];
     auto pdg = particle.id();
-    auto st = o2::mcgenstatus::MCGenStatusEncoding(particle.statusHepMC(), particle.status()).fullEncoding;
-    auto px = particle.px();
-    auto py = particle.py();
-    auto pz = particle.pz();
-    auto et = particle.e();
-    auto vx = particle.xProd();
-    auto vy = particle.yProd();
-    auto vz = particle.zProd();
-    auto vt = particle.tProd();
-    auto m1 = particle.mother1() - 1;
-    auto m2 = particle.mother2() - 1;
-    auto d1 = particle.daughter1() - 1;
-    auto d2 = particle.daughter2() - 1;
-    mParticles.push_back(TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt));
-    mParticles.back().SetBit(ParticleStatus::kToBeDone, particle.statusHepMC() == 1);
+    auto st = o2::mcgenstatus::MCGenStatusEncoding(particle.statusHepMC(), //
+                                                   particle.status())      //
+                .fullEncoding;
+    mParticles.push_back(TParticle(particle.id(),            // Particle type
+                                   st,                       // status
+                                   particle.mother1() - 1,   // first mother
+                                   particle.mother2() - 1,   // second mother
+                                   particle.daughter1() - 1, // first daughter
+                                   particle.daughter2() - 1, // second daughter
+                                   particle.px(),            // X-momentum
+                                   particle.py(),            // Y-momentum
+                                   particle.pz(),            // Z-momentum
+                                   particle.e(),             // Energy
+                                   particle.xProd(),         // Production X
+                                   particle.yProd(),         // Production Y
+                                   particle.zProd(),         // Production Z
+                                   particle.tProd()));       // Production t
+    mParticles.back().SetBit(ParticleStatus::kToBeDone,      //
+                             particle.statusHepMC() == 1);
   }
 
   /** success **/

--- a/run/SimExamples/HepMC/README.md
+++ b/run/SimExamples/HepMC/README.md
@@ -113,6 +113,22 @@ via `--configKeyValues`
 - `HepMC.eventsToSkip=number` a number events to skip at the beginning
   of each file read.
 
+- `HepMC.prune=boolean` if true, then prune events of particles that
+  are not
+  - beam particles (status = 4),
+  - decayed (status = 2), nor
+  - final state (status = 1)
+
+  This reduces the event size. How much depend on the event
+  generator. Use with caution, as it can potentially corrupt the event
+  structure (though measures are taken to minimise that risk).
+
+  In the future, we may want more granular control of which particles
+  to keep.  For example, we could have the keys
+
+  - `HepMC.keepStatus=list-of-status-codes`
+  - `HepMC.keepPDGs=list-of-pdg-numbers`
+
 - `HepMC.version` - when reading the events from files, this option is
    no longer needed.  The code itself figures out which format version
    the input file is in. If executing a child process through

--- a/run/SimExamples/Pythia8/README.md
+++ b/run/SimExamples/Pythia8/README.md
@@ -1,0 +1,256 @@
+<!-- doxy
+\page refrunSimExamplesPythia Example of generating Pythia events
+/doxy -->
+
+Pythia8 is the only event generator guarantied to be included into O2.
+This is because it is used for decays in the simulations.
+
+The event generator is selected by
+
+    o2-sim -g pythia8 ...
+
+Pythia8 is heavily [documented](https://pythia8.org) at its
+web-site. Please refer to that documentation for more.
+
+## Configuration keys
+
+Configuration keys are specified by
+
+    o2-sim --configKeyValues "comma-separated-list-of-pairs"
+
+for example
+
+    o2-sim -g pythia8 \
+      --configKeyValues "GeneratorPythia8.config=myconfig.cfg"
+
+Available configuration keys for Pythia8 are
+
+- `GeneratorPythia8.config=filename` Specifies the configuration file
+  for Pythia8 to read.  The
+  [format](https://pythia.org/latest-manual/SettingsScheme.html) and
+  [settings](https://pythia.org/latest-manual) are heavily documented
+  at the Pythia web-site.  Note, if a predefined configuration is
+  selected (e.g, `pythia8pp`) - see below - then the file specified
+  here will be read _after_ the default configuration.
+- `GeneratorPythia8.hooksFileName=script-file-name` Specifies a ROOT
+  script to be executed to define a `Pythia8::UserHooks` (see
+  [documentation](https://pythia.org/latest-manual/UserHooks.html))
+  object. See for example
+  `${O2_ROOT}/share/Generators/egconfig/pythia8_userhooks_charm.C`.
+- `GeneratorPythia8.hooksFuncname=function-name` Specifies the
+  function in `GeneratorPythia8::hooksFileName` to call.  This
+  function _must_ return a pointer to a `Pythia8::UserHooks`
+  object. See for example
+  `${O2_ROOT}/share/Generators/egconfig/pythia8_userhooks_charm.C`. The
+  default value is `pythia8_userhooks`.
+- `GeneratorPythia8.includePartonEvent=boolean` If `false` (default),
+  prune the events for particles that are _not_
+  - beam particles (HepMC status = 4),
+  - decayed (HepMC status = 2), nor
+  - final state (HepMC status = 1) This reduces the size of the events
+  by roughly 30%. Note that setting this option to `false` _may_
+  corrupt the events, and it should be used with caution.  If `true`,
+  then the whole event is stored.
+
+## Predefined configurations
+
+The class `o2::eventgen::GeneratorFactory` (which parses the `o2-sim
+-g` option) has a number of predefined configurations of Pythia. These
+are listed below together with their configuration file (read from
+`${O2_ROOT}/share/Generators/egconfig/').
+
+- `alldet` (`pythia8_inel.cfg`) pp at 14 TeV, min. bias inelastic
+  collisions, with an additional muon box generator in the MUON arm
+  acceptance.
+- `pythia8inel` (`pythia8_inel.cfg`) pp at 14 TeV, min. bias inelastic
+  collisions.
+- `pythia8hf` (`pythia8_hf.cfg`) pp at 14 TeV, with hard c-cbar and
+  b-bar processes turned on.
+- `pythia8powheg` (`pythia8_powheg.cfg`) pp at 13 TeV using POWHEG
+  parton distribution functions (via LHEF files).
+- `pythia8hi` (`pythia8_hi.cfg`) Pb-Pb at 5.52 TeV using the Angantyr
+  model.
+
+## Alternative
+
+Rather than using the built-in Pythia8 event generator, we can also
+use an external application that writes HepMC output.  For example
+
+    /*
+       g++ -std=c++17 -I${PYTHIA8_ROOT}/include \
+       -I${HEPMC3_ROOT}/include \
+       pythia.cc -o pythia \
+       -L${PYTHIA8_ROOT} -L${HEPMC3_ROOT}/lib \
+       -Wl,-rpath,${PYTHIA8_ROOT}/lib \
+       -Wl,-rpath,${HEPMC3_ROOT}/lib \
+       -lHepMC3 \
+       -lpythia8
+    */
+    #include <HepMC3/WriterAscii.h>
+    #include <Pythia8/Pythia.h>
+    #include <Pythia8Plugins/HepMC3.h>
+    #include <string>
+    #include <fstream>
+
+    struct BasePythia {
+      Pythia8::Pythia _pythia{"",false};
+      int             _seed = -1;
+      std::string     _config;
+      void silence() {
+        _pythia.readString("Print:quiet                      = on");
+        _pythia.readString("Init:showAllSettings             = off");
+        _pythia.readString("Stat:showProcessLevel            = off");
+        _pythia.readString("Init:showAllParticleData         = off");
+        _pythia.readString("Init:showChangedParticleData     = off");
+        _pythia.readString("Init:showChangedSettings         = off");
+        _pythia.readString("Init:showMultipartonInteractions = off");
+      }
+      void seed() {
+        _pythia.readString("Random:setSeed = "
+                   +std::string(_seed >= 0 ? "yes" : "no"));
+        _pythia.readString("Random:seed = "+std::to_string(_seed));
+      }
+      virtual void configure() = 0;
+      void init()  {
+        silence();
+        seed();
+        configure();
+        if (not _config.empty()) _pythia.readFile(_config);
+        _pythia.init();
+      }
+      bool loop(size_t nev, const std::string& filename) {
+        std::ofstream*         file = (filename == "-" or filename.empty()
+                                       ? nullptr
+                                       : new std::ofstream(filename.c_str()));
+        std::ostream&           out  = file ? *file : std::cout;
+        HepMC3::GenEvent        event;
+        HepMC3::WriterAscii     writer(out);
+        HepMC3::Pythia8ToHepMC3 converter;
+
+        for (size_t iev = 0; iev < nev; ++iev) {
+          if (not _pythia.next()) return false;
+          event    .clear();
+          converter.fill_next_event(_pythia,event);
+          writer   .write_event(event);
+        }
+        if (file) {
+          file->close();
+          delete file;
+        }
+        return true;
+      }
+    };
+
+    struct Pythia : BasePythia {
+      void configure() {
+        _pythia.readString("Beams:idA                = 2212");
+        _pythia.readString("Beams:idB                = 2212");
+        _pythia.readString("Beams:eCM                = 5020.");
+        _pythia.readString("SoftQCD:inelastic        = on");
+        _pythia.readString("ParticleDecays:limitTau0 = on");
+        _pythia.readString("ParticleDecays:tau0Max   = 10");
+        _pythia.readString("Tune:ee                  = 7");
+        _pythia.readString("Tune:pp                  = 14");
+      }
+    };
+
+    struct Angantyr : BasePythia {
+      enum Model {
+        fixed = 0,
+        random = 1,
+        opacity = 2
+      } _model = fixed;
+      float _bMax = 15;
+      virtual void configure() {
+        _pythia.readString("Angantyr::CollisionModel = "+std::to_string(_model));
+        _pythia.readString("HeavyIon:showInit        = off");
+        _pythia.readString("HeavyIon:SigFitPrint     = off");
+        _pythia.readString("HeavyIon:SigFitDefPar    = 0,0,0,0,0,0,0,0,0");
+        _pythia.readString("HeavyIon:SigFitNGen      = 20");
+        _pythia.readString("HeavyIon:bWidth          = "+std::to_string(_bMax));
+      }
+    };
+
+    struct PbPb : Angantyr {
+      void configure() {
+        Angantyr::configure();
+        _pythia.readString("Beams:idA                = 1000822080");
+        _pythia.readString("Beams:idB                = 1000822080");
+        _pythia.readString("Beams:eCM                = 5020.");
+        _pythia.readString("Beams:frameType          = 1");
+        _pythia.readString("ParticleDecays:limitTau0 = on");
+        _pythia.readString("ParticleDecays:tau0Max   = 10");
+      }
+    };
+
+    struct pPb : Angantyr {
+      void configure() {
+        Angantyr::configure();
+        _pythia.readString("Beams:idA                = 2212");
+        _pythia.readString("Beams:idB                = 1000822080");
+        _pythia.readString("Beams:eA                 = 7000.");
+        _pythia.readString("Beams:eB                 = 2760.");
+        _pythia.readString("Beams:frameType          = 1");
+        _pythia.readString("ParticleDecays:limitTau0 = on");
+        _pythia.readString("ParticleDecays:tau0Max   = 10");
+      }
+    };
+
+    int main(int argc, char** argv) {
+      int seed           = -1;
+      int nev            = 10;
+      std::string output = "-";
+      std::string system = "pp";
+      std::string config = "";
+      for (int i = 1; i < argc; i++) {
+        if (argv[i][0] == '-') {
+          switch (argv[i][1]) {
+          case 's': seed   = std::stoi(argv[++i]); break;
+          case 'n': nev    = std::stoi(argv[++i]); break;
+          case 'o': output = argv[++i]; break;
+          case 'c': config = argv[++i]; break;
+          case 'h':
+        std::cout << "Usage: " << argv[0] << " [OPTIONS] [SYSTEM]\n\n"
+              << "Options:\n"
+              << "  -h           This help\n"
+              << "  -n NUMBER    Number of events\n"
+              << "  -o FILE      Output file\n"
+              << "  -s SEED      Random number seed\n"
+              << "  -c FILE      Configuratio file\n\n"
+              << "Systems (all at sqrt(s)=5.02TeV):\n"
+              << "  pp, p-Pb, or Pb-Pb\n"
+              << std::endl;
+        return 0;
+          default:
+        std::cerr << "Unknown option: " << argv[i] << std::endl;
+        return 1;
+          }
+        } else
+          system = argv[i];
+      }
+
+      BasePythia* eg = nullptr;
+      if (system == "pp")    eg = new Pythia;
+      if (system == "p-Pb")  eg = new pPb;
+      if (system == "Pb-Pb") eg = new PbPb;
+      if (not eg) {
+        std::cerr << "Unknown system: " << system << std::endl;
+        return 1;
+      }
+      eg->_seed   = seed;
+      eg->_config = config;
+      eg->init();
+      bool ret = eg->loop(nev, output);
+
+      delete eg;
+
+      return ret ? 0 : 1;
+    }
+
+The above program sets up a relative generic event generator that uses
+Pythia and writes the results to either file or standard output in the
+HepMC format.  This can be used with the generator `hepmc` as f.ex.
+
+    o2-sim -g hepmc \
+      --configKeyValues="GeneratorFileOrCmd.cmd=./pythia pPb"
+

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -5,6 +5,7 @@
 # Simulation Examples
 
 <!-- doxy
+* \subpage refrunSimExamplesPythia8
 * \subpage refrunSimExamplesHF_Embedding_Pythia8
 * \subpage refrunSimExamplesSignal_ImpactB
 * \subpage refrunSimExamplesTrigger_ImpactB_Pythia8


### PR DESCRIPTION
This commit
- Fixes the pruning of events in `GeneratorPythia8`.  The old implementation had a number of problems

  - Beam particles (HepMC status = 4) was _not_ kept
  - The event structure was _not_ preserved.  That meant that the event would be split into many disjoint trees.  Thus, subsequent passes over the event would not be able to tie things together.  This was especially a problem when converting the event to HepMC (via AOD) since the events would not be complete.
- Added the option to prune events read in via `GeneratorHepMC`.  The configuration key `HepMC.prune=true` will enable this mode (off by default).

By _pruning_, I mean that all particles that are _not_
- beam particles (HepMC status = 4),
- decayed (HepMC status = 2), nor
- final state (HepMC status = 1) are removed from the event.  When we do that, it is extremely important to connect up particles so that we have a consistent event structure. For example, we may remove a gluon from the tree.  In that case, we must take care to move all child particles to the proper node in the tree, or the children will be disjoint from the rest of the event.

This patch also adds Doxygen documentation to `GeneratorPythia8`, as well as a new `run/SimExamples/Pythia8/README.md` file.