### PR TITLE
TPC: Speed up SACs, improved error messages, fix stream alignment

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/SACDecoder.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/SACDecoder.h
@@ -233,6 +233,8 @@ class Decoder
 
   uint32_t mDebugLevel{0}; ///< Amount of debug information to print
 
+  uint32_t decodeTimeStamp(const char* data);
+
   /// \return status message: 1 = good, 0 = data length too short, -1 = decoding error
   int decodeChannels(DecodedDataFE& sacs, size_t& carry, int feid);
   void decode(int feid);


### PR DESCRIPTION
* Speed up using custom hex string to int convertion, some orders of magnitude
* Add packet position information in error messages
* Fix false error message in initial string alignment
* Fix wrong error message in packet count check overflowing 16bit boundary