### PR TITLE
[EMCAL-1105, EMCAL-687] Reject EMCAL trigger classes for incomplete events

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -30,6 +30,7 @@
 #include "ZDCBase/Constants.h"
 #include "GlobalTracking/MatchGlobalFwd.h"
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -252,6 +253,7 @@ class AODProducerWorkflowDPL : public Task
   TString mRecoPass{""};
   TStopwatch mTimer;
   bool mEMCselectLeading{false};
+  uint64_t mEMCALTrgClassMask = 0;
 
   // unordered map connects global indices and table indices of barrel tracks
   std::unordered_map<GIndex, int> mGIDToTableID;
@@ -541,6 +543,8 @@ class AODProducerWorkflowDPL : public Task
   void fillCaloTable(TCaloCursor& caloCellCursor, TCaloTRGCursor& caloTRGCursor,
                      TMCCaloLabelCursor& mcCaloCellLabelCursor, const std::map<uint64_t, int>& bcsMap,
                      const o2::globaltracking::RecoContainer& data);
+
+  std::set<uint64_t> filterEMCALIncomplete(const gsl::span<const o2::emcal::TriggerRecord> triggers);
 };
 
 /// create a processor spec


### PR DESCRIPTION
Incomplete events (data from at least one link missing) are rejected in the synchronous reconstruction, and instead a trigger record with a dedicated bit and no payload is store in the CTF. CTP trigger classes
triggering the EMC cluster for the corresponding BCs need to be removed since the corresponding payload is not available.