### PR TITLE
Optionally remap PIDforTracking assingments

### DIFF
--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -132,6 +132,7 @@ AddOptionRTC(mergerReadFromTrackerDirectly, char, 1, "", 0, "Forward data direct
 AddOptionRTC(dropSecondaryLegsInOutput, char, 1, "", 0, "Do not store secondary legs of looping track in TrackTPC")
 AddOptionRTC(enablePID, char, 1, "", 0, "Enable PID response")
 AddOptionRTC(PID_useNsigma, char, 1, "", 0, "Use nSigma instead of absolute distance in PID response")
+AddOptionArrayRTC(PID_remap, char, 9, (0, 1, 2, 3, 4, 5, 6, 7, 8), "", 0, "Remap Ipid to PID_reamp[Ipid] (no remap if<0)")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
@@ -145,7 +145,11 @@ GPUdii() void GPUTPCGMO2Output::Thread<GPUTPCGMO2Output::output>(int nBlocks, in
 
     if (merger.Param().par.dodEdx && merger.Param().rec.tpc.enablePID) {
       PIDResponse pidResponse{};
-      const auto pid = pidResponse.getMostProbablePID(oTrack, merger.Param().rec.tpc.PID_EKrangeMin, merger.Param().rec.tpc.PID_EKrangeMax, merger.Param().rec.tpc.PID_EPrangeMin, merger.Param().rec.tpc.PID_EPrangeMax, merger.Param().rec.tpc.PID_EDrangeMin, merger.Param().rec.tpc.PID_EDrangeMax, merger.Param().rec.tpc.PID_ETrangeMin, merger.Param().rec.tpc.PID_ETrangeMax, merger.Param().rec.tpc.PID_useNsigma, merger.Param().rec.tpc.PID_sigma);
+      auto pid = pidResponse.getMostProbablePID(oTrack, merger.Param().rec.tpc.PID_EKrangeMin, merger.Param().rec.tpc.PID_EKrangeMax, merger.Param().rec.tpc.PID_EPrangeMin, merger.Param().rec.tpc.PID_EPrangeMax, merger.Param().rec.tpc.PID_EDrangeMin, merger.Param().rec.tpc.PID_EDrangeMax, merger.Param().rec.tpc.PID_ETrangeMin, merger.Param().rec.tpc.PID_ETrangeMax, merger.Param().rec.tpc.PID_useNsigma, merger.Param().rec.tpc.PID_sigma);
+      auto pidRemap = merger.Param().rec.tpc.PID_remap[pid];
+      if (pidRemap >= 0) {
+        pid = pidRemap;
+      }
       oTrack.setPID(pid);
       oTrack.getParamOut().setPID(pid);
     }


### PR DESCRIPTION
e.g.
PIDREMAP="GPU_rec_tpc.PID_remap[0]=2;GPU_rec_tpc.PID_remap[2]=-1;GPU_rec_tpc.PID_remap[3]=2;GPU_rec_tpc.PID_remap[5]=4;GPU_rec_tpc.PID_remap[6]=4;" will convert PID response for
electron (0) to pion (2)
kaon (3) to pion
Deuteron (5) to proton (4)
Triron (6) to proton (4)
and leave the rest unchanged. Negative value (like GPU_rec_tpc.PID_remap[2]=-1) leave PID unchanged.

ping to @njacazio 