### PR TITLE
DPL: cleanups

### DIFF
--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -13,6 +13,7 @@
 #include "Framework/DataMatcherWalker.h"
 #include "Framework/VariantHelpers.h"
 #include "Framework/RuntimeError.h"
+#include "Headers/DataHeaderHelpers.h"
 
 #include <fmt/format.h>
 #include <cstring>

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -12,10 +12,9 @@
 #include "Framework/DataDescriptorMatcher.h"
 #include "Framework/DataMatcherWalker.h"
 #include "Framework/VariantHelpers.h"
-#include "Framework/Logger.h"
 #include "Framework/RuntimeError.h"
-#include "Headers/DataHeaderHelpers.h"
 
+#include <fmt/format.h>
 #include <cstring>
 #include <cinttypes>
 #include <regex>
@@ -516,7 +515,7 @@ DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(ConcreteDataMatch
         SubSpecificationTypeValueMatcher{concrete.subSpec},
         std::make_unique<DataDescriptorMatcher>(DataDescriptorMatcher::Op::Just,
                                                 StartTimeValueMatcher{ContextRef{0}})))};
-  return std::move(matchEverything);
+  return matchEverything;
 }
 
 DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(ConcreteDataTypeMatcher const& dataType)
@@ -526,10 +525,10 @@ DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(ConcreteDataTypeM
     DescriptionValueMatcher{dataType.description.as<std::string>()},
     std::make_unique<DataDescriptorMatcher>(DataDescriptorMatcher::Op::Just,
                                             StartTimeValueMatcher{ContextRef{0}}));
-  return std::move(DataDescriptorMatcher(
+  return DataDescriptorMatcher(
     DataDescriptorMatcher::Op::And,
     OriginValueMatcher{dataType.origin.as<std::string>()},
-    std::move(timeDescriptionMatcher)));
+    std::move(timeDescriptionMatcher));
 }
 
 DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(header::DataOrigin const& origin)
@@ -547,7 +546,7 @@ DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(header::DataOrigi
         SubSpecificationTypeValueMatcher{ContextRef{2}},
         std::make_unique<DataDescriptorMatcher>(DataDescriptorMatcher::Op::Just,
                                                 StartTimeValueMatcher{ContextRef{0}})))};
-  return std::move(matchOnlyOrigin);
+  return matchOnlyOrigin;
 }
 
 DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(header::DataDescription const& description)
@@ -565,7 +564,7 @@ DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(header::DataDescr
         SubSpecificationTypeValueMatcher{ContextRef{2}},
         std::make_unique<DataDescriptorMatcher>(DataDescriptorMatcher::Op::Just,
                                                 StartTimeValueMatcher{ContextRef{0}})))};
-  return std::move(matchOnlyOrigin);
+  return matchOnlyOrigin;
 }
 
 std::optional<framework::ConcreteDataMatcher> DataSpecUtils::optionalConcreteDataMatcherFrom(data_matcher::DataDescriptorMatcher const& matcher)

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -11,7 +11,6 @@
 #include "WorkflowHelpers.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/AODReaderHelpers.h"
-#include "Framework/ChannelMatching.h"
 #include "Framework/ConfigParamsHelper.h"
 #include "Framework/CommonDataProcessors.h"
 #include "Framework/ConfigContext.h"
@@ -21,13 +20,10 @@
 #include "Framework/ControlService.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/StringHelpers.h"
-#include "Framework/CommonMessageBackends.h"
 #include "Framework/ChannelSpecHelpers.h"
-#include "Framework/ExternalFairMQDeviceProxy.h"
 #include "Framework/Plugins.h"
 #include "Framework/DataTakingContext.h"
 #include "Framework/DefaultsHelpers.h"
-#include "ArrowSupport.h"
 
 #include "Headers/DataHeader.h"
 #include <algorithm>
@@ -61,25 +57,25 @@ std::vector<TopoIndexInfo>
   using EdgeIndex = int;
   // Create the index which will be returned.
   std::vector<TopoIndexInfo> index(nodeCount);
-  for (auto wi = 0; wi < nodeCount; ++wi) {
+  for (auto wi = 0; static_cast<size_t>(wi) < nodeCount; ++wi) {
     index[wi] = {wi, 0};
   }
   std::vector<EdgeIndex> remainingEdgesIndex(edgesCount);
-  for (EdgeIndex ei = 0; ei < edgesCount; ++ei) {
+  for (EdgeIndex ei = 0; static_cast<size_t>(ei) < edgesCount; ++ei) {
     remainingEdgesIndex[ei] = ei;
   }
 
   // Create a vector where at each position we have true
   // if the vector has dependencies, false otherwise
   std::vector<bool> nodeDeps(nodeCount, false);
-  for (EdgeIndex ei = 0; ei < edgesCount; ++ei) {
+  for (EdgeIndex ei = 0; static_cast<size_t>(ei) < edgesCount; ++ei) {
     nodeDeps[*(edgeOut + ei * stride)] = true;
   }
 
   // We start with all those which do not have any dependencies
   // They are layer 0.
   std::list<TopoIndexInfo> L;
-  for (auto ii = 0; ii < index.size(); ++ii) {
+  for (auto ii = 0; static_cast<size_t>(ii) < index.size(); ++ii) {
     if (nodeDeps[ii] == false) {
       L.push_back({ii, 0});
     }

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -13,10 +13,8 @@
 
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
-#include "Framework/ForwardRoute.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataOutputDirector.h"
-#include "Framework/DataProcessorInfo.h"
 
 #include <cstddef>
 #include <vector>


### PR DESCRIPTION
@ktf 
This removes unused includes, redundant `std::move`s and signed/unsigned comparison warnings.