### PR TITLE
Also write cathode in the generated json file with MID mapping for muonview

### DIFF
--- a/Detectors/MUON/MID/GlobalMapping/exe/global-mapper.cxx
+++ b/Detectors/MUON/MID/GlobalMapping/exe/global-mapper.cxx
@@ -51,6 +51,8 @@ void stripsInfo2json(const std::vector<o2::mid::ExtendedMappingInfo>& infos, con
     writer.Int(infos[idx].lineId);
     writer.Key("stripId");
     writer.Int(infos[idx].stripId);
+    writer.Key("cathode");
+    writer.Int(infos[idx].cathode);
     writer.Key("locId");
     writer.Int(infos[idx].locId);
     writer.Key("locIdDcs");


### PR DESCRIPTION
This should simplify the retrieval of information (e.g. in muonview)