### PR TITLE
DPL: Improve debugging of bad topologies.

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -2590,6 +2590,11 @@ std::string debugTopoInfo(std::vector<DataProcessorSpec> const& specs,
   for (auto& d : specs) {
     out << "- " << d.name << std::endl;
   }
+  out << "digraph G {\n";
+  for (auto& e : edges) {
+    out << fmt::format("  \"{}\" -> \"{}\"\n", specs[e.first].name, specs[e.second].name);
+  }
+  out << "}\n";
   return out.str();
 }
 


### PR DESCRIPTION
DPL: Improve debugging of bad topologies.

Print dependency as graphviz digraph when topological sort fails.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12315).
* #12316
* __->__ #12315