### PR TITLE
TRD: Implementation of DCS Chamber Status processing and DPs update

### DIFF
--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -130,8 +130,8 @@ class DCSProcessor
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSEnv;      ///< environment parameters (temperatures, pressures, humidity)
   std::unordered_map<DPID, int> mTRDDCSRun;                       ///< run number (run type ignored)
   // LB: new DPs for Fed
-  std::array<int, constants::MAXCHAMBER> mTRDDCSFedChamberStatus;            ///< fed chamber status
-  std::array<string, constants::MAXCHAMBER> mTRDDCSFedCFGtag;                ///< fed config tag
+  std::array<int, constants::MAXCHAMBER> mTRDDCSFedChamberStatus; ///< fed chamber status
+  std::array<string, constants::MAXCHAMBER> mTRDDCSFedCFGtag;     ///< fed config tag
 
   // helper variables
   std::unordered_map<DPID, bool> mPids;                 ///< flag for each DP whether it has been processed at least once

--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -64,11 +64,10 @@ class DCSProcessor
   bool updateCurrentsDPsCCDB();
   bool updateEnvDPsCCDB();
   bool updateRunDPsCCDB();
-  // LB: new DPs for Fed and Cavern
+  // LB: new DPs for Fed
   bool updateFedChamberStatusDPsCCDB();
   bool updateFedCFGtagDPsCCDB();
   bool updateFedEnvTempDPsCCDB();
-  bool updateCavernDPsCCDB();
 
   // signal that the CCDB object for the voltages should be updated due to change exceeding threshold
   bool shouldUpdateVoltages() const { return mShouldUpdateVoltages; }
@@ -76,6 +75,17 @@ class DCSProcessor
   // LB: Only update ChamberStatus/CFGtag if both conditions are met (complete DPs and new run)
   bool shouldUpdateFedChamberStatus() const { return mFedChamberStatusCompleteDPs && mFirstRunEntryForFedChamberStatusUpdate; }
   bool shouldUpdateFedCFGtag() const { return mFedCFGtagCompleteDPs && mFirstRunEntryForFedCFGtagUpdate; }
+  // LB: Env DPs have no alias pattern, processor uses this function to identify if alias is Env
+  bool isAliasFromEnvDP(const char* dpalias) const
+  {
+    std::vector<std::string> envaliases = {"CavernTemperature", "temperature_P2_external", "AtmosPressure", "UXC2Humidity"};
+    for (const auto& envalias : envaliases) {
+      if (std::strstr(dpalias, envalias.c_str()) != nullptr) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   // allow access to the CCDB objects from DPL processor
   CcdbObjectInfo& getccdbGasDPsInfo() { return mCcdbGasDPsInfo; }
@@ -86,7 +96,6 @@ class DCSProcessor
   CcdbObjectInfo& getccdbFedChamberStatusDPsInfo() { return mCcdbFedChamberStatusDPsInfo; }
   CcdbObjectInfo& getccdbFedCFGtagDPsInfo() { return mCcdbFedCFGtagDPsInfo; }
   CcdbObjectInfo& getccdbFedEnvTempDPsInfo() { return mCcdbFedEnvTempDPsInfo; }
-  CcdbObjectInfo& getccdbCavernDPsInfo() { return mCcdbCavernDPsInfo; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDGasDPsInfo() const { return mTRDDCSGas; }
   const std::unordered_map<DPID, float>& getTRDVoltagesDPsInfo() const { return mTRDDCSVoltages; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDCurrentsDPsInfo() const { return mTRDDCSCurrents; }
@@ -95,7 +104,6 @@ class DCSProcessor
   const std::unordered_map<DPID, int>& getTRDFedChamberStatusDPsInfo() const { return mTRDDCSFedChamberStatus; }
   const std::unordered_map<DPID, string>& getTRDFedCFGtagDPsInfo() const { return mTRDDCSFedCFGtag; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDFedEnvTempDPsInfo() const { return mTRDDCSFedEnvTemp; }
-  const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDCavernDPsInfo() const { return mTRDDCSCavern; }
 
   // settings
   void setCurrentTS(TFType tf) { mCurrentTS = tf; }
@@ -109,11 +117,10 @@ class DCSProcessor
   void clearCurrentsDPsInfo();
   void clearEnvDPsInfo();
   void clearRunDPsInfo();
-  // LB: new DPs for Fed and Cavern
+  // LB: new DPs for Fed
   void clearFedChamberStatusDPsInfo();
   void clearFedCFGtagDPsInfo();
   void clearFedEnvTempDPsInfo();
-  void clearCavernDPsInfo();
 
   // helper functions
   int getChamberIdFromAlias(const char* alias) const;
@@ -123,13 +130,12 @@ class DCSProcessor
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSGas;      ///< gas DPs (CO2, O2, H20 and from the chromatograph CO2, N2, Xe)
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSCurrents; ///< anode and drift currents
   std::unordered_map<DPID, float> mTRDDCSVoltages;                ///< anode and drift voltages
-  std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSEnv;      ///< environment parameters (temperatures, pressures)
+  std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSEnv;      ///< environment parameters (temperatures, pressures, humidity)
   std::unordered_map<DPID, int> mTRDDCSRun;                       ///< run number (run type ignored)
-  // LB: new DPs for Fed and Cavern
+  // LB: new DPs for Fed
   std::unordered_map<DPID, int> mTRDDCSFedChamberStatus;            ///< fed chamber status
   std::unordered_map<DPID, string> mTRDDCSFedCFGtag;                ///< fed config tag
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSFedEnvTemp; ///< fed env temperature
-  std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSCavern;     ///< cavern humidity, pressure
 
   // helper variables
   std::unordered_map<DPID, bool> mPids;                 ///< flag for each DP whether it has been processed at least once
@@ -139,11 +145,10 @@ class DCSProcessor
   CcdbObjectInfo mCcdbCurrentsDPsInfo;
   CcdbObjectInfo mCcdbEnvDPsInfo;
   CcdbObjectInfo mCcdbRunDPsInfo;
-  // LB: new DPs for Fed and Cavern
+  // LB: new DPs for Fed
   CcdbObjectInfo mCcdbFedChamberStatusDPsInfo;
   CcdbObjectInfo mCcdbFedCFGtagDPsInfo;
   CcdbObjectInfo mCcdbFedEnvTempDPsInfo;
-  CcdbObjectInfo mCcdbCavernDPsInfo;
 
   TFType mGasStartTS;      ///< the time stamp of the first TF which was processesd for the current GAS CCDB object
   TFType mVoltagesStartTS; ///< the time stamp of the first TF which was processesd for the current voltages CCDB object
@@ -151,22 +156,20 @@ class DCSProcessor
   TFType mEnvStartTS;
   TFType mRunStartTS;
   TFType mRunEndTS;
-  // LB: new DPs for Fed and Cavern
+  // LB: new DPs for Fed
   TFType mFedChamberStatusStartTS;
   TFType mFedCFGtagStartTS;
   TFType mFedEnvTempStartTS;
-  TFType mCavernStartTS;
   TFType mCurrentTS{0}; ///< the time stamp of the TF currently being processed
   bool mGasStartTSset{false};
   bool mVoltagesStartTSSet{false};
   bool mCurrentsStartTSSet{false};
   bool mEnvStartTSSet{false};
   bool mRunStartTSSet{false};
-  // LB: new DPs for Fed and Cavern
+  // LB: new DPs for Fed
   bool mFedChamberStatusStartTSSet{false};
   bool mFedCFGtagStartTSSet{false};
   bool mFedEnvTempStartTSSet{false};
-  bool mCavernStartTSSet{false};
   std::bitset<constants::MAXCHAMBER> mVoltageSet{};
   bool mShouldUpdateVoltages{false};
   bool mShouldUpdateRun{false};

--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -67,7 +67,6 @@ class DCSProcessor
   // LB: new DPs for Fed
   bool updateFedChamberStatusDPsCCDB();
   bool updateFedCFGtagDPsCCDB();
-  bool updateFedEnvTempDPsCCDB();
 
   // signal that the CCDB object for the voltages should be updated due to change exceeding threshold
   bool shouldUpdateVoltages() const { return mShouldUpdateVoltages; }
@@ -95,15 +94,13 @@ class DCSProcessor
   CcdbObjectInfo& getccdbRunDPsInfo() { return mCcdbRunDPsInfo; }
   CcdbObjectInfo& getccdbFedChamberStatusDPsInfo() { return mCcdbFedChamberStatusDPsInfo; }
   CcdbObjectInfo& getccdbFedCFGtagDPsInfo() { return mCcdbFedCFGtagDPsInfo; }
-  CcdbObjectInfo& getccdbFedEnvTempDPsInfo() { return mCcdbFedEnvTempDPsInfo; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDGasDPsInfo() const { return mTRDDCSGas; }
   const std::unordered_map<DPID, float>& getTRDVoltagesDPsInfo() const { return mTRDDCSVoltages; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDCurrentsDPsInfo() const { return mTRDDCSCurrents; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDEnvDPsInfo() const { return mTRDDCSEnv; }
   const std::unordered_map<DPID, int>& getTRDRunDPsInfo() const { return mTRDDCSRun; }
-  const std::unordered_map<DPID, int>& getTRDFedChamberStatusDPsInfo() const { return mTRDDCSFedChamberStatus; }
-  const std::unordered_map<DPID, string>& getTRDFedCFGtagDPsInfo() const { return mTRDDCSFedCFGtag; }
-  const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDFedEnvTempDPsInfo() const { return mTRDDCSFedEnvTemp; }
+  const std::array<int, constants::MAXCHAMBER>& getTRDFedChamberStatusDPsInfo() const { return mTRDDCSFedChamberStatus; }
+  const std::array<string, constants::MAXCHAMBER>& getTRDFedCFGtagDPsInfo() const { return mTRDDCSFedCFGtag; }
 
   // settings
   void setCurrentTS(TFType tf) { mCurrentTS = tf; }
@@ -121,7 +118,6 @@ class DCSProcessor
   // LB: new DPs for Fed
   void clearFedChamberStatusDPsInfo();
   void clearFedCFGtagDPsInfo();
-  void clearFedEnvTempDPsInfo();
 
   // helper functions
   int getChamberIdFromAlias(const char* alias) const;
@@ -134,9 +130,8 @@ class DCSProcessor
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSEnv;      ///< environment parameters (temperatures, pressures, humidity)
   std::unordered_map<DPID, int> mTRDDCSRun;                       ///< run number (run type ignored)
   // LB: new DPs for Fed
-  std::unordered_map<DPID, int> mTRDDCSFedChamberStatus;            ///< fed chamber status
-  std::unordered_map<DPID, string> mTRDDCSFedCFGtag;                ///< fed config tag
-  std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSFedEnvTemp; ///< fed env temperature
+  std::array<int, constants::MAXCHAMBER> mTRDDCSFedChamberStatus;            ///< fed chamber status
+  std::array<string, constants::MAXCHAMBER> mTRDDCSFedCFGtag;                ///< fed config tag
 
   // helper variables
   std::unordered_map<DPID, bool> mPids;                 ///< flag for each DP whether it has been processed at least once
@@ -149,7 +144,6 @@ class DCSProcessor
   // LB: new DPs for Fed
   CcdbObjectInfo mCcdbFedChamberStatusDPsInfo;
   CcdbObjectInfo mCcdbFedCFGtagDPsInfo;
-  CcdbObjectInfo mCcdbFedEnvTempDPsInfo;
 
   TFType mGasStartTS;      ///< the time stamp of the first TF which was processesd for the current GAS CCDB object
   TFType mVoltagesStartTS; ///< the time stamp of the first TF which was processesd for the current voltages CCDB object
@@ -160,7 +154,6 @@ class DCSProcessor
   // LB: new DPs for Fed
   TFType mFedChamberStatusStartTS;
   TFType mFedCFGtagStartTS;
-  TFType mFedEnvTempStartTS;
   TFType mCurrentTS{0}; ///< the time stamp of the TF currently being processed
   bool mGasStartTSset{false};
   bool mVoltagesStartTSSet{false};
@@ -170,7 +163,6 @@ class DCSProcessor
   // LB: new DPs for Fed
   bool mFedChamberStatusStartTSSet{false};
   bool mFedCFGtagStartTSSet{false};
-  bool mFedEnvTempStartTSSet{false};
   std::bitset<constants::MAXCHAMBER> mVoltageSet{};
   bool mShouldUpdateVoltages{false};
   bool mShouldUpdateRun{false};

--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -110,6 +110,7 @@ class DCSProcessor
   void setVerbosity(int v) { mVerbosity = v; }
   void setMaxCounterAlarmFed(int alarmfed) { mFedAlarmCounterMax = alarmfed; }
   void setFedMinimunDPsForUpdate(int minupdatefed) { mFedMinimunDPsForUpdate = minupdatefed; }
+  void setUVariationTriggerForUpdate(float utrigger) { mUVariationTriggerForUpdate = utrigger; }
 
   // reset methods
   void clearGasDPsInfo();
@@ -188,6 +189,7 @@ class DCSProcessor
   int mVerbosity{0};
   int mFedAlarmCounterMax{1};
   int mFedMinimunDPsForUpdate{522};
+  float mUVariationTriggerForUpdate{1.0};
 
   ClassDefNV(DCSProcessor, 0);
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -187,7 +187,7 @@ class DCSProcessor
   // settings
   int mVerbosity{0};
   int mFedAlarmCounterMax{1};
-  int mFedMinimunDPsForUpdate{540};
+  int mFedMinimunDPsForUpdate{522};
 
   ClassDefNV(DCSProcessor, 0);
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -124,7 +124,7 @@ class DCSProcessor
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSCurrents; ///< anode and drift currents
   std::unordered_map<DPID, float> mTRDDCSVoltages;                ///< anode and drift voltages
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSEnv;      ///< environment parameters (temperatures, pressures)
-  std::unordered_map<DPID, int> mTRDDCSRun;                       ///< run number and run type
+  std::unordered_map<DPID, int> mTRDDCSRun;                       ///< run number (run type ignored)
   // LB: new DPs for Fed and Cavern
   std::unordered_map<DPID, int> mTRDDCSFedChamberStatus;            ///< fed chamber status
   std::unordered_map<DPID, string> mTRDDCSFedCFGtag;                ///< fed config tag

--- a/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
+++ b/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
@@ -30,17 +30,28 @@ int makeTRDCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   std::vector<std::string> aliasesFloat;
   std::vector<std::string> aliasesInt;
   std::vector<std::string> aliasesString;
+
+  // Gas DPs
   aliasesFloat.insert(aliasesFloat.end(), {"trd_gasCO2", "trd_gasH2O", "trd_gasO2"});
   aliasesFloat.insert(aliasesFloat.end(), {"trd_gaschromatographCO2", "trd_gaschromatographN2", "trd_gaschromatographXe"});
-  aliasesFloat.insert(aliasesFloat.end(), {"trd_hvAnodeImon[00..539]", "trd_hvAnodeUmon[00..539]", "trd_hvDriftImon[00..539]", "trd_hvDriftUmon[00..539]"});
-  aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvTempCavern", "trd_aliEnvTempP2"});
-  aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvPressure00", "trd_aliEnvPressure01", "trd_aliEnvPressure02"});
-  aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo"});
 
-  // New DPs
-  aliasesFloat.insert(aliasesFloat.end(), {"UXC2Humidity", "CavernAtmosPressure", "trd_envTemp[00..539]"});
+  // Current and Voltages DPs
+  aliasesFloat.insert(aliasesFloat.end(), {"trd_hvAnodeImon[00..539]", "trd_hvAnodeUmon[00..539]", "trd_hvDriftImon[00..539]", "trd_hvDriftUmon[00..539]"});
+
+  // FED DPs
+  aliasesFloat.insert(aliasesFloat.end(), {"trd_envTemp[00..539]"});
   aliasesInt.insert(aliasesInt.end(), {"trd_chamberStatus[00..539]"});
   aliasesString.insert(aliasesString.end(), {"trd_CFGtag[00..539]"});
+
+  // Environment DPs
+  aliasesFloat.insert(aliasesFloat.end(), {"CavernTemperature", "temperature_P2_external"});
+  aliasesFloat.insert(aliasesFloat.end(), {"CavernAtmosPressure", "SurfaceAtmosPressure", "CavernAtmosPressure2"});
+  aliasesFloat.insert(aliasesFloat.end(), {"UXC2Humidity"});
+
+  // Run DPs
+  aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo"});
+
+  // Ignorded DPs: trd_fed_runType, trd_gasOverpressure*
 
   DPID dpidTmp;
   for (const auto& ali : o2::dcs::expandAliases(aliasesFloat)) {

--- a/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
+++ b/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
@@ -35,10 +35,12 @@ int makeTRDCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   aliasesFloat.insert(aliasesFloat.end(), {"trd_hvAnodeImon[00..539]", "trd_hvAnodeUmon[00..539]", "trd_hvDriftImon[00..539]", "trd_hvDriftUmon[00..539]"});
   aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvTempCavern", "trd_aliEnvTempP2"});
   aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvPressure00", "trd_aliEnvPressure01", "trd_aliEnvPressure02"});
-  aliasesInt.insert(aliasesInt.end(), {"trd_runNo", "trd_runType"});
-  // aliasesFloat.insert(aliasesFloat.end(), {"trd_cavernHumidity", "trd_fedEnvTemp[00..539]"});
-  // aliasesInt.insert(aliasesInt.end(), {"trd_fedChamberStatus[00..539]"});
-  // aliasesString.insert(aliasesString.end(), {"trd_fedCFGtag[00..539]"});
+  aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo", "trd_runType"});
+
+  // New DPs
+  aliasesFloat.insert(aliasesFloat.end(), {"UXC2Humidity", "CavernAtmosPressure", "trd_envTemp[00..539]"});
+  aliasesInt.insert(aliasesInt.end(), {"trd_chamberStatus[00..539]"});
+  aliasesString.insert(aliasesString.end(), {"trd_CFGtag[00..539]"});
 
   DPID dpidTmp;
   for (const auto& ali : o2::dcs::expandAliases(aliasesFloat)) {

--- a/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
+++ b/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
@@ -39,7 +39,6 @@ int makeTRDCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   aliasesFloat.insert(aliasesFloat.end(), {"trd_hvAnodeImon[00..539]", "trd_hvAnodeUmon[00..539]", "trd_hvDriftImon[00..539]", "trd_hvDriftUmon[00..539]"});
 
   // FED DPs
-  aliasesFloat.insert(aliasesFloat.end(), {"trd_envTemp[00..539]"});
   aliasesInt.insert(aliasesInt.end(), {"trd_chamberStatus[00..539]"});
   aliasesString.insert(aliasesString.end(), {"trd_CFGtag[00..539]"});
 
@@ -51,7 +50,7 @@ int makeTRDCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   // Run DPs
   aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo"});
 
-  // Ignorded DPs: trd_fed_runType, trd_gasOverpressure*
+  // Ignorded DPs: trd_fed_runType, trd_envTemp[00..539], trd_gasOverpressure*
 
   DPID dpidTmp;
   for (const auto& ali : o2::dcs::expandAliases(aliasesFloat)) {

--- a/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
+++ b/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
@@ -35,7 +35,7 @@ int makeTRDCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   aliasesFloat.insert(aliasesFloat.end(), {"trd_hvAnodeImon[00..539]", "trd_hvAnodeUmon[00..539]", "trd_hvDriftImon[00..539]", "trd_hvDriftUmon[00..539]"});
   aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvTempCavern", "trd_aliEnvTempP2"});
   aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvPressure00", "trd_aliEnvPressure01", "trd_aliEnvPressure02"});
-  aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo", "trd_runType"});
+  aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo"});
 
   // New DPs
   aliasesFloat.insert(aliasesFloat.end(), {"UXC2Humidity", "CavernAtmosPressure", "trd_envTemp[00..539]"});

--- a/Detectors/TRD/calibration/macros/readTRDDCSentries.C
+++ b/Detectors/TRD/calibration/macros/readTRDDCSentries.C
@@ -31,6 +31,7 @@ void readTRDDCSentries(std::string ccdb = "http://localhost:8080", long ts = -1)
   ccdbmgr.setURL(ccdb.c_str()); // comment out this line to read from production CCDB instead of a local one, or adapt ccdb string
   if (ts < 0) {
     ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    std::cout << "Timestamp: " << ts << std::endl;
   }
   ccdbmgr.setTimestamp(ts);
 
@@ -58,6 +59,46 @@ void readTRDDCSentries(std::string ccdb = "http://localhost:8080", long ts = -1)
     std::cout << entry.first << std::endl;
     entry.second.print();
   }
+  std::cout << std::endl;
+
+  // LB: also read FedChamberStatus and FedCFGtag for testing
+  // There seems to be an issue with the validity timestamp of Run DPs, ignoring them at the moment
+  // Access FedChamberStatus DPs
+  auto calchamberstatus = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, int>>("TRD/Calib/DCSDPsFedChamberStatus");
+
+  std::cout << "Print all objects from the map (DCSDPsFedChamberStatus), together with their DataPointIdentifier:" << std::endl;
+  for (const auto& entry : *calchamberstatus) {
+    std::cout << "id =  " << entry.first << ",\tvalue =  " << entry.second << std::endl;
+  }
+  std::cout << std::endl;
+
+  // Access FedCFGtag DPs
+  auto calcfgtag = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, string>>("TRD/Calib/DCSDPsFedCFGtag");
+
+  std::cout << "Print all objects from the map (DCSDPsFedCFGtag), together with their DataPointIdentifier:" << std::endl;
+  for (const auto& entry : *calcfgtag) {
+    std::cout << "id =  " << entry.first << ",\tvalue =  " << entry.second << std::endl;
+  }
+  std::cout << std::endl;
+
+  // Access FedEnvTemp DPs
+  auto calfedenvtemp = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo>>("TRD/Calib/DCSDPsFedEnvTemp");
+
+  for (const auto& entry : *calfedenvtemp) {
+    std::cout << entry.first << std::endl;
+    entry.second.print();
+    std::cout << std::endl;
+  }
+
+  // Access Cavern DPs
+  auto calcavern = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo>>("TRD/Calib/DCSDPsCavern");
+
+  for (const auto& entry : *calcavern) {
+    std::cout << entry.first << std::endl;
+    entry.second.print();
+    std::cout << std::endl;
+  }
+
   std::cout << std::endl;
 
   return;

--- a/Detectors/TRD/calibration/macros/readTRDDCSentries.C
+++ b/Detectors/TRD/calibration/macros/readTRDDCSentries.C
@@ -58,8 +58,8 @@ void readTRDDCSentries(std::string ccdb = "http://localhost:8080", long ts = -1)
   for (const auto& entry : *cal) {
     std::cout << entry.first << std::endl;
     entry.second.print();
+    std::cout << std::endl;
   }
-  std::cout << std::endl;
 
   // LB: also read FedChamberStatus and FedCFGtag for testing
   // There seems to be an issue with the validity timestamp of Run DPs, ignoring them at the moment
@@ -90,16 +90,14 @@ void readTRDDCSentries(std::string ccdb = "http://localhost:8080", long ts = -1)
     std::cout << std::endl;
   }
 
-  // Access Cavern DPs
-  auto calcavern = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo>>("TRD/Calib/DCSDPsCavern");
+  // Access Env DPs
+  auto calenv = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo>>("TRD/Calib/DCSDPsEnv");
 
-  for (const auto& entry : *calcavern) {
+  for (const auto& entry : *calenv) {
     std::cout << entry.first << std::endl;
     entry.second.print();
     std::cout << std::endl;
   }
-
-  std::cout << std::endl;
 
   return;
 }

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -214,7 +214,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
             // LB: two different flags as they reset separately, after upload of CCDB, for each object
             mFirstRunEntryForFedChamberStatusUpdate = true;
             mFirstRunEntryForFedCFGtagUpdate = true;
-	    // LB: reset alarm counters
+            // LB: reset alarm counters
             mFedChamberStatusAlarmCounter = 0;
             mFedCFGtagAlarmCounter = 0;
             mRunEndTS = mCurrentTS;
@@ -235,8 +235,8 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
           mFedChamberStatusStartTS = mCurrentTS;
           mFedChamberStatusStartTSSet = true;
         }
-	
-	// LB: for ChamberStatus, grab the chamber number from alias
+
+        // LB: for ChamberStatus, grab the chamber number from alias
         int chamberId = getChamberIdFromAlias(dpid.get_alias());
         auto& dpInfoFedChamberStatus = mTRDDCSFedChamberStatus[chamberId];
         if (etime != mLastDPTimeStamps[dpid]) {
@@ -244,7 +244,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
             // If value changes after processing and DPs should not be updated, log change as warning (for now)
             if (mPids[dpid] && !(mFedChamberStatusCompleteDPs && mFirstRunEntryForFedChamberStatusUpdate)) {
               // Issue an alarm if counter is lower than maximum, warning otherwise
-	      // LB: set both to warnings, conditions are kept if future changes are needed
+              // LB: set both to warnings, conditions are kept if future changes are needed
               if (mFedChamberStatusAlarmCounter < mFedAlarmCounterMax) {
                 LOG(warn) << "ChamberStatus change " << dpid.get_alias() << " : " << dpInfoFedChamberStatus << " -> " << o2::dcs::getValue<int>(dpcom) << ", run = " << mCurrentRunNumber;
                 mFedChamberStatusAlarmCounter++;
@@ -267,7 +267,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
           mFedCFGtagStartTSSet = true;
         }
 
-	// LB: for CFGtag, grab the chamber number from alias
+        // LB: for CFGtag, grab the chamber number from alias
         int chamberId = getChamberIdFromAlias(dpid.get_alias());
         auto& dpInfoFedCFGtag = mTRDDCSFedCFGtag[chamberId];
         if (etime != mLastDPTimeStamps[dpid]) {

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -686,7 +686,7 @@ void DCSProcessor::clearRunDPsInfo()
 
 void DCSProcessor::clearFedChamberStatusDPsInfo()
 {
-  mTRDDCSFedChamberStatus.clear();
+  // mTRDDCSFedChamberStatus should not be cleared after upload giving alarm/warn logic
   mFedChamberStatusStartTSSet = false;
   mFedChamberStatusCompleteDPs = false;
   mFirstRunEntryForFedChamberStatusUpdate = false;
@@ -704,7 +704,7 @@ void DCSProcessor::clearFedChamberStatusDPsInfo()
 
 void DCSProcessor::clearFedCFGtagDPsInfo()
 {
-  mTRDDCSFedCFGtag.clear();
+  // mTRDDCSFedCFGtag should not be cleared after upload giving alarm/warn logic
   mFedCFGtagStartTSSet = false;
   mFedCFGtagCompleteDPs = false;
   mFirstRunEntryForFedCFGtagUpdate = false;

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -52,7 +52,7 @@ int DCSProcessor::process(const gsl::span<const DPCOM> dps)
     mapin[it.id] = it.data;
 
     // LB: check if all ChamberStatus/CFGtag DPs were sent in dps
-    // if counter is equal to 540 => all DPs were sent
+    // if counter is equal to mFedMinimunDPsForUpdate (522) => all DPs were sent
     if (std::strstr(it.id.get_alias(), "trd_chamberStatus") != nullptr) {
       ChamberStatusDPsCounter++;
     } else if (std::strstr(it.id.get_alias(), "trd_CFGtag") != nullptr) {

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -168,7 +168,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
         if (etime != mLastDPTimeStamps[dpid]) {
           int chamberId = getChamberIdFromAlias(dpid.get_alias());
           if (mVoltageSet.test(chamberId)) {
-            if (std::fabs(dpInfoVoltages - o2::dcs::getValue<double>(dpcom)) > 1.f) {
+            if (std::fabs(dpInfoVoltages - o2::dcs::getValue<double>(dpcom)) > mUVariationTriggerForUpdate) {
               // trigger update of voltage CCDB object
               mShouldUpdateVoltages = true;
               // OS: this will still overwrite the current voltage value of the object going into the CCDB

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -43,12 +43,41 @@ int DCSProcessor::process(const gsl::span<const DPCOM> dps)
     LOG(info) << "\n\n\nProcessing new TF\n-----------------";
   }
 
-  if (mVerbosity > 1) {
-    std::unordered_map<DPID, DPVAL> mapin;
-    for (auto& it : dps) {
-      mapin[it.id] = it.data;
-    }
+  // LB: setup counters for ChamberStatus/CFGtag logic
+  int ChamberStatusDPsCounter = 0;
+  int CFGtagDPsCounter = 0;
 
+  std::unordered_map<DPID, DPVAL> mapin;
+  for (auto& it : dps) {
+    mapin[it.id] = it.data;
+
+    // LB: check if all ChamberStatus/CFGtag DPs were sent in dps
+    // if counter is equal to 540 => all DPs were sent
+    if (std::strstr(it.id.get_alias(), "trd_chamberStatus") != nullptr) {
+      ChamberStatusDPsCounter++;
+    } else if (std::strstr(it.id.get_alias(), "trd_CFGtag") != nullptr) {
+      CFGtagDPsCounter++;
+    }
+  }
+
+  if (ChamberStatusDPsCounter >= mFedMinimunDPsForUpdate) {
+    mFedChamberStatusCompleteDPs = true;
+    if (mVerbosity > 1) {
+      LOG(info) << "Minimum number of required DPs (" << mFedMinimunDPsForUpdate << ") for ChamberStatus update were found.";
+    }
+  }
+  if (CFGtagDPsCounter >= mFedMinimunDPsForUpdate) {
+    mFedCFGtagCompleteDPs = true;
+    if (mVerbosity > 1) {
+      LOG(info) << "Minimum number of required DPs (" << mFedMinimunDPsForUpdate << ") for CFGtag update were found.";
+    }
+  }
+  if (mVerbosity > 1) {
+    LOG(info) << "Number of ChamberStatus DPs = " << ChamberStatusDPsCounter;
+    LOG(info) << "Number of CFGtag DPs = " << CFGtagDPsCounter;
+  }
+
+  if (mVerbosity > 1) {
     for (auto& it : mPids) {
       const auto& el = mapin.find(it.first);
       if (el == mapin.end()) {
@@ -96,8 +125,10 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
   }
   auto flags = dpcom.data.get_flags();
   if (processFlags(flags, dpid.get_alias()) == 0) {
+    auto etime = dpcom.data.get_epoch_time();
+
+    // DPs are sorted by type variable
     if (type == DPVAL_DOUBLE) {
-      auto etime = dpcom.data.get_epoch_time();
 
       // check if DP is one of the gas values
       if (std::strstr(dpid.get_alias(), "trd_gas") != nullptr) {
@@ -163,42 +194,117 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
           mLastDPTimeStamps[dpid] = etime;
         }
       }
+
+      if (std::strstr(dpid.get_alias(), "trd_envTemp") != nullptr) { // DP is trd_envTemp
+        if (!mFedEnvTempStartTSSet) {
+          mFedEnvTempStartTS = mCurrentTS;
+          mFedEnvTempStartTSSet = true;
+        }
+        auto& dpInfoFedEnvTemp = mTRDDCSFedEnvTemp[dpid];
+        if (dpInfoFedEnvTemp.nPoints == 0 || etime != mLastDPTimeStamps[dpid]) {
+          // only add data point in case last one was not already read before
+          dpInfoFedEnvTemp.addPoint(o2::dcs::getValue<double>(dpcom), etime);
+          mLastDPTimeStamps[dpid] = etime;
+        }
+      }
+
+      // DP is UXC2Humidity or CavernAtmosPressure
+      if (std::strstr(dpid.get_alias(), "UXC2Humidity") != nullptr || std::strstr(dpid.get_alias(), "CavernAtmos") != nullptr) {
+        if (!mCavernStartTSSet) {
+          mCavernStartTS = mCurrentTS;
+          mCavernStartTSSet = true;
+        }
+        auto& dpInfoCavern = mTRDDCSCavern[dpid];
+        if (dpInfoCavern.nPoints == 0 || etime != mLastDPTimeStamps[dpid]) {
+          // only add data point in case last one was not already read before
+          dpInfoCavern.addPoint(o2::dcs::getValue<double>(dpcom), etime);
+          mLastDPTimeStamps[dpid] = etime;
+        }
+      }
     }
+
     if (type == DPVAL_INT) {
-      if (std::strstr(dpid.get_alias(), "trd_runNo") != nullptr) { // DP is trd_runNo
+      if (std::strstr(dpid.get_alias(), "trd_fed_runNo") != nullptr) { // DP is trd_fed_runNo
         if (!mRunStartTSSet) {
           mRunStartTS = mCurrentTS;
           mRunStartTSSet = true;
         }
+
         auto& runNumber = mTRDDCSRun[dpid];
-        if (mPids[dpid] && runNumber != o2::dcs::getValue<int32_t>(dpcom)) {
-          LOGF(info, "Run number has already been processed and the new one %i differs from the old one %i", runNumber, o2::dcs::getValue<int32_t>(dpcom));
-          mShouldUpdateRun = true;
-          mRunEndTS = mCurrentTS;
-        } else {
-          runNumber = o2::dcs::getValue<int32_t>(dpcom);
+
+        // LB: Check if new value is a valid run number (0 = cleared variable)
+        if (o2::dcs::getValue<int32_t>(dpcom) > 0) {
+          // If value has changed from previous one, new run has begun and update
+          if (o2::dcs::getValue<int32_t>(dpcom) != mCurrentRunNumber) {
+            LOG(info) << "New run number " << o2::dcs::getValue<int32_t>(dpcom) << " differs from the old one " << mCurrentRunNumber;
+            mShouldUpdateRun = true;
+            // LB: two different flags as they reset separately, after upload of CCDB, for each object
+            mFirstRunEntryForFedChamberStatusUpdate = true;
+            mFirstRunEntryForFedCFGtagUpdate = true;
+            mRunEndTS = mCurrentTS;
+          }
+
+          // LB: Save current run number
+          mCurrentRunNumber = o2::dcs::getValue<int32_t>(dpcom);
+          // Save to mTRDDCSRun
+          runNumber = mCurrentRunNumber;
         }
-      } else if (std::strstr(dpid.get_alias(), "trd_runType") != nullptr) { // DP is trd_runType
-        if (!mRunStartTSSet) {
-          mRunStartTS = mCurrentTS;
-          mRunStartTSSet = true;
+
+        if (mVerbosity > 2) {
+          LOG(info) << "Current Run Number: " << mCurrentRunNumber;
         }
-        auto& runType = mTRDDCSRun[dpid];
-        if (mPids[dpid] && runType != o2::dcs::getValue<int32_t>(dpcom)) {
-          LOGF(info, "Run type has already been processed and the new one %i differs from the old one %i", runType, o2::dcs::getValue<int32_t>(dpcom));
-          mShouldUpdateRun = true;
-          mRunEndTS = mCurrentTS;
-        } else {
-          runType = o2::dcs::getValue<int32_t>(dpcom);
+
+      } else if (std::strstr(dpid.get_alias(), "trd_chamberStatus") != nullptr) { // DP is trd_chamberStatus
+        if (!mFedChamberStatusStartTSSet) {
+          mFedChamberStatusStartTS = mCurrentTS;
+          mFedChamberStatusStartTSSet = true;
+        }
+
+        auto& dpInfoFedChamberStatus = mTRDDCSFedChamberStatus[dpid];
+        if (etime != mLastDPTimeStamps[dpid]) {
+          if (dpInfoFedChamberStatus != o2::dcs::getValue<int>(dpcom)) {
+            // If value changes after processing and DPs should not be updated, log change as warning (for now)
+            if (mPids[dpid] && !(mFedChamberStatusCompleteDPs && mFirstRunEntryForFedChamberStatusUpdate)) {
+              // Issue an alarm if counter is lower than maximum, warning otherwise
+              if (mFedChamberStatusAlarmCounter < mFedAlarmCounterMax) {
+                LOG(alarm) << "ChamberStatus change " << dpid.get_alias() << " : " << dpInfoFedChamberStatus << " -> " << o2::dcs::getValue<int>(dpcom) << ", run = " << mCurrentRunNumber;
+                mFedChamberStatusAlarmCounter++;
+              } else if (mVerbosity > 0) {
+                LOG(warn) << "ChamberStatus change " << dpid.get_alias() << " : " << dpInfoFedChamberStatus << " -> " << o2::dcs::getValue<int>(dpcom) << ", run = " << mCurrentRunNumber;
+              }
+            }
+          }
+
+          dpInfoFedChamberStatus = o2::dcs::getValue<int>(dpcom);
+          mLastDPTimeStamps[dpid] = etime;
         }
       }
     }
 
     if (type == DPVAL_STRING) {
-      if (std::strstr(dpid.get_alias(), "trd_fedCFGtag") != nullptr) { // DP is trd_fedCFGtag
-        auto cfgTag = o2::dcs::getValue<std::string>(dpcom);
-        if (mVerbosity > 1) {
-          LOG(info) << "CFG tag " << dpid.get_alias() << " is " << cfgTag;
+      if (std::strstr(dpid.get_alias(), "trd_CFGtag") != nullptr) { // DP is trd_CFGtag
+        if (!mFedCFGtagStartTSSet) {
+          mFedCFGtagStartTS = mCurrentTS;
+          mFedCFGtagStartTSSet = true;
+        }
+
+        auto& dpInfoFedCFGtag = mTRDDCSFedCFGtag[dpid];
+        if (etime != mLastDPTimeStamps[dpid]) {
+          if (dpInfoFedCFGtag != o2::dcs::getValue<string>(dpcom)) {
+            // If value changes after processing and DPs should not be updated, log change as warning (for now)
+            if (mPids[dpid] && !(mFedCFGtagCompleteDPs && mFirstRunEntryForFedCFGtagUpdate)) {
+              // Issue an alarm if counter is lower than maximum, warning otherwise
+              if (mFedCFGtagAlarmCounter < mFedAlarmCounterMax) {
+                LOG(alarm) << "CFGtag change " << dpid.get_alias() << " : " << dpInfoFedCFGtag << " -> " << o2::dcs::getValue<string>(dpcom) << ", run = " << mCurrentRunNumber;
+                mFedCFGtagAlarmCounter++;
+              } else if (mVerbosity > 0) {
+                LOG(warn) << "CFGtag change " << dpid.get_alias() << " : " << dpInfoFedCFGtag << " -> " << o2::dcs::getValue<string>(dpcom) << ", run = " << mCurrentRunNumber;
+              }
+            }
+          }
+
+          dpInfoFedCFGtag = o2::dcs::getValue<std::string>(dpcom);
+          mLastDPTimeStamps[dpid] = etime;
         }
       }
     }
@@ -349,7 +455,7 @@ bool DCSProcessor::updateVoltagesDPsCCDB()
           retVal = true;
         }
         if (mVerbosity > 1) {
-          LOG(info) << "PID = " << it.first.get_alias() << " Value = " << mTRDDCSVoltages[it.first];
+          LOG(info) << "PID = " << it.first.get_alias() << ". Value = " << mTRDDCSVoltages[it.first];
         }
       }
     }
@@ -375,7 +481,7 @@ bool DCSProcessor::updateEnvDPsCCDB()
         if (it.second == true) { // we processed the DP at least 1x
           retVal = true;
         }
-        if (mVerbosity > 0) {
+        if (mVerbosity > 1) {
           LOG(info) << "PID = " << it.first.get_alias();
           mTRDDCSEnv[it.first].print();
         }
@@ -398,8 +504,8 @@ bool DCSProcessor::updateRunDPsCCDB()
 
   for (const auto& it : mPids) {
     const auto& type = it.first.get_type();
-    if (type == o2::dcs::DPVAL_DOUBLE) {
-      if (std::strstr(it.first.get_alias(), "trd_run") != nullptr) {
+    if (type == o2::dcs::DPVAL_INT) {
+      if (std::strstr(it.first.get_alias(), "trd_fed_run") != nullptr) {
         if (it.second == true) { // we processed the DP at least 1x
           retVal = true;
         }
@@ -410,8 +516,134 @@ bool DCSProcessor::updateRunDPsCCDB()
     }
   }
   std::map<std::string, std::string> md;
-  md["responsible"] = "Ole Schmidt";
+  md["responsible"] = "Leonardo Barreto";
+  // Redundancy for testing, this object is updated after run ended, so need to write old run number, not current
+  // md["runNumber"] = std::to_string(mFinishedRunNumber);
   o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSRun, mCcdbRunDPsInfo, "TRD/Calib/DCSDPsRun", md, mRunStartTS, mRunEndTS);
+
+  // LB: Deactivated upload of Run DPs to CCDB even if processed
+  // To turn it back on just comment the next line
+  retVal = false;
+  return retVal;
+}
+
+bool DCSProcessor::updateFedChamberStatusDPsCCDB()
+{
+  // here we create the object containing the fedChamberStatus data points to then be sent to CCDB
+  LOG(info) << "Preparing CCDB object for TRD fedChamberStatus DPs";
+
+  bool retVal = false; // set to 'true' in case at least one DP for run has been processed
+
+  for (const auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_INT) {
+      if (std::strstr(it.first.get_alias(), "trd_chamberStatus") != nullptr) {
+        if (it.second == true) { // we processed the DP at least 1x
+          retVal = true;
+        }
+        if (mVerbosity > 1) {
+          LOG(info) << "PID = " << it.first.get_alias() << ". Value = " << mTRDDCSFedChamberStatus[it.first];
+        }
+      }
+    }
+  }
+
+  std::map<std::string, std::string> md;
+  md["responsible"] = "Leonardo Barreto";
+  md["runNumber"] = std::to_string(mCurrentRunNumber);
+  // TODO: define mFedStartTS and mFedEndTS, use same setup as env for now
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSFedChamberStatus, mCcdbFedChamberStatusDPsInfo, "TRD/Calib/DCSDPsFedChamberStatus", md, mFedChamberStatusStartTS, mFedChamberStatusStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
+
+  return retVal;
+}
+
+bool DCSProcessor::updateFedCFGtagDPsCCDB()
+{
+  // here we create the object containing the fedCFGtag data points to then be sent to CCDB
+  LOG(info) << "Preparing CCDB object for TRD fedCFGtag DPs";
+
+  bool retVal = false; // set to 'true' in case at least one DP for run has been processed
+
+  for (const auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_STRING) {
+      if (std::strstr(it.first.get_alias(), "trd_CFGtag") != nullptr) {
+        if (it.second == true) { // we processed the DP at least 1x
+          retVal = true;
+        }
+        if (mVerbosity > 1) {
+          LOG(info) << "PID = " << it.first.get_alias() << ". Value = " << mTRDDCSFedCFGtag[it.first];
+        }
+      }
+    }
+  }
+
+  std::map<std::string, std::string> md;
+  md["responsible"] = "Leonardo Barreto";
+  md["runNumber"] = std::to_string(mCurrentRunNumber);
+  // TODO: define mFedStartTS and mFedEndTS, use same setup as env for now
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSFedCFGtag, mCcdbFedCFGtagDPsInfo,
+                                                "TRD/Calib/DCSDPsFedCFGtag", md, mFedCFGtagStartTS, mFedCFGtagStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
+
+  return retVal;
+}
+
+bool DCSProcessor::updateFedEnvTempDPsCCDB()
+{
+  // here we create the object containing the fedEnvTemp data points to then be sent to CCDB
+  LOG(info) << "Preparing CCDB object for TRD fedEnvTemp DPs";
+
+  bool retVal = false; // set to 'true' in case at least one DP for run has been processed
+
+  for (const auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_DOUBLE) {
+      if (std::strstr(it.first.get_alias(), "trd_envTemp") != nullptr) {
+        if (it.second == true) { // we processed the DP at least 1x
+          retVal = true;
+        }
+        if (mVerbosity > 1) {
+          LOG(info) << "PID = " << it.first.get_alias();
+          mTRDDCSFedEnvTemp[it.first].print();
+        }
+      }
+    }
+  }
+
+  std::map<std::string, std::string> md;
+  md["responsible"] = "Leonardo Barreto";
+  // TODO: define mFedStartTS and mFedEndTS, use same setup as env for now
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSFedEnvTemp, mCcdbFedEnvTempDPsInfo,
+                                                "TRD/Calib/DCSDPsFedEnvTemp", md, mFedEnvTempStartTS, mFedEnvTempStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
+
+  return retVal;
+}
+
+bool DCSProcessor::updateCavernDPsCCDB()
+{
+  // here we create the object containing the cavern data points to then be sent to CCDB
+  LOG(info) << "Preparing CCDB object for TRD cavern DPs";
+
+  bool retVal = false; // set to 'true' in case at least one DP for env has been processed
+
+  for (const auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_DOUBLE) {
+      if (std::strstr(it.first.get_alias(), "UXC2Humidity") != nullptr || std::strstr(it.first.get_alias(), "CavernAtmos") != nullptr) {
+        if (it.second == true) { // we processed the DP at least 1x
+          retVal = true;
+        }
+        if (mVerbosity > 1) {
+          LOG(info) << "PID = " << it.first.get_alias();
+          mTRDDCSCavern[it.first].print();
+        }
+      }
+    }
+  }
+  std::map<std::string, std::string> md;
+  md["responsible"] = "Leonardo Barreto";
+  // TODO: define mCavernStartTS and mCavernEndTS, use same setup as env for now
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSCavern, mCcdbCavernDPsInfo, "TRD/Calib/DCSDPsCavern", md, mCavernStartTS, mCavernStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
 
   return retVal;
 }
@@ -453,7 +685,6 @@ void DCSProcessor::clearGasDPsInfo()
   // reset the data and the gas CCDB object itself
   mTRDDCSGas.clear();
   mGasStartTSset = false; // the next object will be valid from the first processed time stamp
-
   // reset the 'processed' flags for the gas DPs
   for (auto& it : mPids) {
     const auto& type = it.first.get_type();
@@ -469,7 +700,7 @@ void DCSProcessor::clearEnvDPsInfo()
 {
   mTRDDCSEnv.clear();
   mEnvStartTSSet = false;
-  // reset the 'processed' flags for the gas DPs
+  // reset the 'processed' flags for the env DPs
   for (auto& it : mPids) {
     const auto& type = it.first.get_type();
     if (type == o2::dcs::DPVAL_DOUBLE) {
@@ -485,11 +716,77 @@ void DCSProcessor::clearRunDPsInfo()
   mTRDDCSRun.clear();
   mRunStartTSSet = false;
   mShouldUpdateRun = false;
-  // reset the 'processed' flags for the gas DPs
+  // reset the 'processed' flags for the run DPs
+  for (auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_INT) {
+      if (std::strstr(it.first.get_alias(), "trd_fed_run") != nullptr) {
+        it.second = false;
+      }
+    }
+  }
+}
+
+void DCSProcessor::clearFedChamberStatusDPsInfo()
+{
+  mTRDDCSFedChamberStatus.clear();
+  mFedChamberStatusStartTSSet = false;
+  mFedChamberStatusCompleteDPs = false;
+  mFirstRunEntryForFedChamberStatusUpdate = false;
+  mFedChamberStatusAlarmCounter = 0;
+  // reset the 'processed' flags for the fed DPs
+  for (auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_INT) {
+      if (std::strstr(it.first.get_alias(), "trd_chamberStatus") != nullptr) {
+        it.second = false;
+      }
+    }
+  }
+}
+
+void DCSProcessor::clearFedCFGtagDPsInfo()
+{
+  mTRDDCSFedCFGtag.clear();
+  mFedCFGtagStartTSSet = false;
+  mFedCFGtagCompleteDPs = false;
+  mFirstRunEntryForFedCFGtagUpdate = false;
+  mFedCFGtagAlarmCounter = 0;
+  // reset the 'processed' flags for the fed DPs
+  for (auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_STRING) {
+      if (std::strstr(it.first.get_alias(), "trd_CFGtag") != nullptr) {
+        it.second = false;
+      }
+    }
+  }
+}
+
+void DCSProcessor::clearFedEnvTempDPsInfo()
+{
+  mTRDDCSFedEnvTemp.clear();
+  mFedEnvTempStartTSSet = false;
+  // reset the 'processed' flags for the fed DPs
   for (auto& it : mPids) {
     const auto& type = it.first.get_type();
     if (type == o2::dcs::DPVAL_DOUBLE) {
-      if (std::strstr(it.first.get_alias(), "trd_run") != nullptr) {
+      if (std::strstr(it.first.get_alias(), "trd_envTemp") != nullptr) {
+        it.second = false;
+      }
+    }
+  }
+}
+
+void DCSProcessor::clearCavernDPsInfo()
+{
+  mTRDDCSCavern.clear();
+  mCavernStartTSSet = false;
+  // reset the 'processed' flags for the fed DPs
+  for (auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::DPVAL_DOUBLE) {
+      if (std::strstr(it.first.get_alias(), "UXC2Humidity") != nullptr || std::strstr(it.first.get_alias(), "CavernAtmos") != nullptr) {
         it.second = false;
       }
     }

--- a/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
+++ b/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
@@ -107,7 +107,7 @@ class TRDDCSDataProcessor : public o2::framework::Task
       aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvTempCavern", "trd_aliEnvTempP2"});
       aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvPressure00", "trd_aliEnvPressure01", "trd_aliEnvPressure02"});
       aliasesFloat.insert(aliasesFloat.end(), {"UXC2Humidity", "CavernAtmosPressure", "trd_envTemp[00..539]"});
-      aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo", "trd_fed_runType"});
+      aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo"});
       aliasesInt.insert(aliasesInt.end(), {"trd_chamberStatus[00..539]"});
       aliasesString.insert(aliasesString.end(), {"trd_CFGtag[00..539]"});
 

--- a/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
+++ b/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
@@ -73,6 +73,18 @@ class TRDDCSDataProcessor : public o2::framework::Task
       LOG(error) << "TRD DPs update interval set to zero seconds --> changed to 1800s";
       mEnvDPsUpdateInterval = 1800;
     }
+    // LB: FedEnvTemp DPs, only update every 30 minutes
+    mFedEnvTempDPsUpdateInterval = ic.options().get<int64_t>("DPs-update-interval-fedenv");
+    if (mFedEnvTempDPsUpdateInterval == 0) {
+      LOG(error) << "TRD DPs update interval set to zero seconds --> changed to 1800s";
+      mFedEnvTempDPsUpdateInterval = 1800;
+    }
+    // LB: Cavern DPs, only update every 2 hours
+    mCavernDPsUpdateInterval = ic.options().get<int64_t>("DPs-update-interval-cavern");
+    if (mCavernDPsUpdateInterval == 0) {
+      LOG(error) << "TRD DPs update interval set to zero seconds --> changed to 7200s";
+      mCavernDPsUpdateInterval = 7200;
+    }
     bool useCCDBtoConfigure = ic.options().get<bool>("use-ccdb-to-configure");
     if (useCCDBtoConfigure) {
       LOG(info) << "Configuring via CCDB";
@@ -94,10 +106,10 @@ class TRDDCSDataProcessor : public o2::framework::Task
       aliasesFloat.insert(aliasesFloat.end(), {"trd_hvAnodeImon[00..539]", "trd_hvAnodeUmon[00..539]", "trd_hvDriftImon[00..539]", "trd_hvDriftUmon[00..539]"});
       aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvTempCavern", "trd_aliEnvTempP2"});
       aliasesFloat.insert(aliasesFloat.end(), {"trd_aliEnvPressure00", "trd_aliEnvPressure01", "trd_aliEnvPressure02"});
-      // aliasesFloat.insert(aliasesFloat.end(), {"trd_cavernHumidity", "trd_fedEnvTemp[00..539]"});
-      aliasesInt.insert(aliasesInt.end(), {"trd_runNo", "trd_runType"});
-      // aliasesInt.insert(aliasesInt.end(), {"trd_fedChamberStatus[00..539]"});
-      // aliasesString.insert(aliasesString.end(), {"trd_fedCFGtag[00..539]"});
+      aliasesFloat.insert(aliasesFloat.end(), {"UXC2Humidity", "CavernAtmosPressure", "trd_envTemp[00..539]"});
+      aliasesInt.insert(aliasesInt.end(), {"trd_fed_runNo", "trd_fed_runType"});
+      aliasesInt.insert(aliasesInt.end(), {"trd_chamberStatus[00..539]"});
+      aliasesString.insert(aliasesString.end(), {"trd_CFGtag[00..539]"});
 
       for (const auto& i : o2::dcs::expandAliases(aliasesFloat)) {
         vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
@@ -116,16 +128,40 @@ class TRDDCSDataProcessor : public o2::framework::Task
     }
 
     mProcessor = std::make_unique<o2::trd::DCSProcessor>();
-    int verbosity = ic.options().get<bool>("processor-verbosity");
+    int verbosity = ic.options().get<int>("processor-verbosity");
     if (verbosity > 0) {
       LOG(info) << "Using verbose mode for TRD DCS processor";
       mProcessor->setVerbosity(verbosity);
     }
+
+    // LB: set maximum number of alarms in change in FedChamberStatus and FedCFGtag
+    int alarmfed = ic.options().get<int>("DPs-max-counter-alarm-fed");
+    if (alarmfed >= 0) {
+      LOG(info) << "Setting max number of alarms in FED objects changes to " << alarmfed;
+      mProcessor->setMaxCounterAlarmFed(alarmfed);
+    } else {
+      LOG(info) << "Invalid max number of alarms in FED objects changes " << alarmfed << ", using default value of 1";
+    }
+
+    // LB: set minimum number of DPs in DCS Processor to update ChamberStatus/CFGtag
+    int minupdatefed = ic.options().get<int>("DPs-min-counter-update-fed");
+    if (minupdatefed >= 0 && minupdatefed <= 540) {
+      LOG(info) << "Setting min number of DPs to update ChamberStatus/CFGtag to " << minupdatefed;
+      mProcessor->setFedMinimunDPsForUpdate(minupdatefed);
+    } else {
+      LOG(info) << "Invalid min number of DPs to update ChamberStatus/CFGtag " << alarmfed << ", using default value of 540";
+    }
+
     mProcessor->init(vect);
     mTimerGas = std::chrono::high_resolution_clock::now();
     mTimerVoltages = mTimerGas;
     mTimerCurrents = mTimerGas;
     mTimerEnv = mTimerGas;
+    // LB: new DPs for Fed and Cavern
+    mTimerFedChamberStatus = mTimerGas;
+    mTimerFedCFGtag = mTimerGas;
+    mTimerFedEnvTemp = mTimerGas;
+    mTimerCavern = mTimerGas;
 
     mReportTiming = ic.options().get<bool>("report-timing") || verbosity > 0;
   }
@@ -169,6 +205,29 @@ class TRDDCSDataProcessor : public o2::framework::Task
       mTimerEnv = timeNow;
     }
 
+    // LB: processing logic for FedChamberStatus and FedCFGtag
+    if (mProcessor->shouldUpdateFedChamberStatus()) {
+      sendDPsoutputFedChamberStatus(pc.outputs());
+    }
+
+    if (mProcessor->shouldUpdateFedCFGtag()) {
+      sendDPsoutputFedCFGtag(pc.outputs());
+    }
+
+    // LB: new DP for FedEnvTemp
+    auto elapsedTimeFedEnvTemp = timeNow - mTimerFedEnvTemp; // in ns
+    if (elapsedTimeFedEnvTemp.count() * 1e-9 >= mFedEnvTempDPsUpdateInterval) {
+      sendDPsoutputFedEnvTemp(pc.outputs());
+      mTimerFedEnvTemp = timeNow;
+    }
+
+    // LB: new DP for Cavern
+    auto elapsedTimeCavern = timeNow - mTimerCavern; // in ns
+    if (elapsedTimeCavern.count() * 1e-9 >= mCavernDPsUpdateInterval) {
+      sendDPsoutputCavern(pc.outputs());
+      mTimerCavern = timeNow;
+    }
+
     if (mProcessor->shouldUpdateRun()) {
       sendDPsoutputRun(pc.outputs());
     }
@@ -185,6 +244,11 @@ class TRDDCSDataProcessor : public o2::framework::Task
     sendDPsoutputCurrents(ec.outputs());
     sendDPsoutputEnv(ec.outputs());
     sendDPsoutputRun(ec.outputs());
+    // LB: new DPs for Fed and Cavern
+    sendDPsoutputFedChamberStatus(ec.outputs());
+    sendDPsoutputFedCFGtag(ec.outputs());
+    sendDPsoutputFedEnvTemp(ec.outputs());
+    sendDPsoutputCavern(ec.outputs());
   }
 
  private:
@@ -194,11 +258,22 @@ class TRDDCSDataProcessor : public o2::framework::Task
   std::chrono::high_resolution_clock::time_point mTimerVoltages;
   std::chrono::high_resolution_clock::time_point mTimerCurrents;
   std::chrono::high_resolution_clock::time_point mTimerEnv;
+  // LB: new DPs for Fed and Cavern
+  std::chrono::high_resolution_clock::time_point mTimerFedChamberStatus;
+  std::chrono::high_resolution_clock::time_point mTimerFedCFGtag;
+  std::chrono::high_resolution_clock::time_point mTimerFedEnvTemp;
+  std::chrono::high_resolution_clock::time_point mTimerCavern;
+
   int64_t mGasDPsUpdateInterval;
   int64_t mVoltagesDPsUpdateInterval;
   int64_t mCurrentsDPsUpdateInterval;
   int64_t mMinUpdateIntervalU;
   int64_t mEnvDPsUpdateInterval;
+  // LB: new DPs for Fed and Cavern
+  int64_t mFedChamberStatusDPsUpdateInterval;
+  int64_t mFedCFGtagDPsUpdateInterval;
+  int64_t mFedEnvTempDPsUpdateInterval;
+  int64_t mCavernDPsUpdateInterval;
 
   void sendDPsoutputVoltages(DataAllocator& output)
   {
@@ -289,6 +364,87 @@ class TRDDCSDataProcessor : public o2::framework::Task
       mProcessor->clearRunDPsInfo();
     } else {
       auto& info = mProcessor->getccdbRunDPsInfo();
+      // LOG(info) << "Not sending object " << info.getPath() << "/" << info.getFileName() << " since no DPs were processed for it";
+      LOG(info) << "Not sending object " << info.getPath() << "/" << info.getFileName() << " as upload of Run DPs was deactivated";
+    }
+  }
+
+  // LB: new DP for FedChamberStatus
+  //________________________________________________________________
+  void sendDPsoutputFedChamberStatus(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration object for DPs
+    if (mProcessor->updateFedChamberStatusDPsCCDB()) {
+      const auto& payload = mProcessor->getTRDFedChamberStatusDPsInfo();
+      auto& info = mProcessor->getccdbFedChamberStatusDPsInfo();
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+      LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_ChamberStat", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_ChamberStat", 0}, info);
+      mProcessor->clearFedChamberStatusDPsInfo();
+    } else {
+      auto& info = mProcessor->getccdbFedChamberStatusDPsInfo();
+      LOG(info) << "Not sending object " << info.getPath() << "/" << info.getFileName() << " since no DPs were processed for it";
+    }
+  }
+
+  // LB: new DP for FedCFGtag
+  //________________________________________________________________
+  void sendDPsoutputFedCFGtag(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration object for DPs
+    if (mProcessor->updateFedCFGtagDPsCCDB()) {
+      const auto& payload = mProcessor->getTRDFedCFGtagDPsInfo();
+      auto& info = mProcessor->getccdbFedCFGtagDPsInfo();
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+      LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_CFGtag", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_CFGtag", 0}, info);
+      mProcessor->clearFedCFGtagDPsInfo();
+    } else {
+      auto& info = mProcessor->getccdbFedCFGtagDPsInfo();
+      LOG(info) << "Not sending object " << info.getPath() << "/" << info.getFileName() << " since no DPs were processed for it";
+    }
+  }
+
+  // LB: new DP for FedEnvTemp
+  //________________________________________________________________
+  void sendDPsoutputFedEnvTemp(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration object for DPs
+    if (mProcessor->updateFedEnvTempDPsCCDB()) {
+      const auto& payload = mProcessor->getTRDFedEnvTempDPsInfo();
+      auto& info = mProcessor->getccdbFedEnvTempDPsInfo();
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+      LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_FedTemp", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_FedTemp", 0}, info);
+      mProcessor->clearFedEnvTempDPsInfo();
+    } else {
+      auto& info = mProcessor->getccdbFedEnvTempDPsInfo();
+      LOG(info) << "Not sending object " << info.getPath() << "/" << info.getFileName() << " since no DPs were processed for it";
+    }
+  }
+
+  // LB: new DP for Cavern
+  //________________________________________________________________
+  void sendDPsoutputCavern(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration object for DPs
+    if (mProcessor->updateCavernDPsCCDB()) {
+      const auto& payload = mProcessor->getTRDCavernDPsInfo();
+      auto& info = mProcessor->getccdbCavernDPsInfo();
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+      LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_DCSCavernDPs", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_DCSCavernDPs", 0}, info);
+      mProcessor->clearCavernDPsInfo();
+    } else {
+      auto& info = mProcessor->getccdbCavernDPsInfo();
       LOG(info) << "Not sending object " << info.getPath() << "/" << info.getFileName() << " since no DPs were processed for it";
     }
   }
@@ -314,6 +470,16 @@ DataProcessorSpec getTRDDCSDataProcessorSpec()
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_DCSRunDPs"});
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_DCSEnvDPs"});
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_DCSEnvDPs"});
+  // LB: new DPs for Fed and Cavern
+  // Must use reduced names due to initializer string cannot exceed descriptor size in Data Format
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_ChamberStat"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_ChamberStat"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_CFGtag"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_CFGtag"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_FedTemp"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_FedTemp"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TRD_DCSCavernDPs"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TRD_DCSCavernDPs"});
 
   return DataProcessorSpec{
     "trd-dcs-data-processor",
@@ -328,7 +494,11 @@ DataProcessorSpec getTRDDCSDataProcessorSpec()
             {"DPs-update-interval-voltages", VariantType::Int64, 600ll, {"Interval (in s) after which to update the DPs CCDB entry for voltage parameters"}},
             {"DPs-update-interval-env", VariantType::Int64, 1800ll, {"Interval (in s) after which to update the DPs CCDB entry for environment parameters"}},
             {"DPs-min-update-interval-voltages", VariantType::Int64, 120ll, {"Minimum range to be covered by voltage CCDB object"}},
-            {"DPs-update-interval-gas", VariantType::Int64, 900ll, {"Interval (in s) after which to update the DPs CCDB entry for gas parameters"}}}};
+            {"DPs-update-interval-gas", VariantType::Int64, 900ll, {"Interval (in s) after which to update the DPs CCDB entry for gas parameters"}},
+            {"DPs-update-interval-fedenv", VariantType::Int64, 1800ll, {"Interval (in s) after which to update the DPs CCDB entry for front end device environment parameters"}},
+            {"DPs-update-interval-cavern", VariantType::Int64, 7200ll, {"Interval (in s) after which to update the DPs CCDB entry for cavern parameters"}},
+            {"DPs-max-counter-alarm-fed", VariantType::Int, 1, {"Maximum number of alarms after FedChamberStatus and FedCFGtag changes, following changes are logged as warnings"}},
+            {"DPs-min-counter-update-fed", VariantType::Int, 540, {"Minimum number of DPs to update FedChamberStatus and FedCFGtag objects"}}}};
 }
 
 } // namespace framework

--- a/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
+++ b/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
@@ -148,6 +148,15 @@ class TRDDCSDataProcessor : public o2::framework::Task
       LOG(info) << "Invalid min number of DPs to update ChamberStatus/CFGtag " << alarmfed << ", using default value of 522";
     }
 
+    // LB: set minimum voltage variation to update Anode/DriftUmon
+    int utrigger = ic.options().get<int>("DPs-voltage-variation-trigger");
+    if (utrigger > 0) {
+      LOG(info) << "Setting voltage variation trigger of DPs to update Anode/DriftUMon to " << utrigger;
+      mProcessor->setUVariationTriggerForUpdate(utrigger);
+    } else {
+      LOG(info) << "Invalid voltage variation trigger of DPs to update Anode/DriftUMon to " << utrigger << ", using default value of 1 V";
+    }
+
     mProcessor->init(vect);
     mTimerGas = std::chrono::high_resolution_clock::now();
     mTimerVoltages = mTimerGas;
@@ -457,6 +466,7 @@ DataProcessorSpec getTRDDCSDataProcessorSpec()
             {"DPs-update-interval-voltages", VariantType::Int64, 600ll, {"Interval (in s) after which to update the DPs CCDB entry for voltage parameters"}},
             {"DPs-update-interval-env", VariantType::Int64, 1800ll, {"Interval (in s) after which to update the DPs CCDB entry for environment parameters"}},
             {"DPs-min-update-interval-voltages", VariantType::Int64, 120ll, {"Minimum range to be covered by voltage CCDB object"}},
+            {"DPs-voltage-variation-trigger", VariantType::Int64, 1ll, {"Voltage variation trigger for upload of CCDB object"}},
             {"DPs-update-interval-gas", VariantType::Int64, 900ll, {"Interval (in s) after which to update the DPs CCDB entry for gas parameters"}},
             {"DPs-update-interval-fedenv", VariantType::Int64, 1800ll, {"Interval (in s) after which to update the DPs CCDB entry for front end device environment parameters"}},
             {"DPs-max-counter-alarm-fed", VariantType::Int, 1, {"Maximum number of alarms after FedChamberStatus and FedCFGtag changes, following changes are logged as warnings"}},

--- a/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
+++ b/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
@@ -145,7 +145,7 @@ class TRDDCSDataProcessor : public o2::framework::Task
       LOG(info) << "Setting min number of DPs to update ChamberStatus/CFGtag to " << minupdatefed;
       mProcessor->setFedMinimunDPsForUpdate(minupdatefed);
     } else {
-      LOG(info) << "Invalid min number of DPs to update ChamberStatus/CFGtag " << alarmfed << ", using default value of 540";
+      LOG(info) << "Invalid min number of DPs to update ChamberStatus/CFGtag " << alarmfed << ", using default value of 522";
     }
 
     mProcessor->init(vect);
@@ -460,7 +460,7 @@ DataProcessorSpec getTRDDCSDataProcessorSpec()
             {"DPs-update-interval-gas", VariantType::Int64, 900ll, {"Interval (in s) after which to update the DPs CCDB entry for gas parameters"}},
             {"DPs-update-interval-fedenv", VariantType::Int64, 1800ll, {"Interval (in s) after which to update the DPs CCDB entry for front end device environment parameters"}},
             {"DPs-max-counter-alarm-fed", VariantType::Int, 1, {"Maximum number of alarms after FedChamberStatus and FedCFGtag changes, following changes are logged as warnings"}},
-            {"DPs-min-counter-update-fed", VariantType::Int, 540, {"Minimum number of DPs to update FedChamberStatus and FedCFGtag objects"}}}};
+            {"DPs-min-counter-update-fed", VariantType::Int, 522, {"Minimum number of DPs to update FedChamberStatus and FedCFGtag objects"}}}};
 }
 
 } // namespace framework

--- a/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
+++ b/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
@@ -35,7 +35,6 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_chamberStatus[00..539]", 1, 5});
   dphints.emplace_back(o2::dcs::test::DataPointHint<std::string>{"trd_CFGtag[00..539]", "foo", "bar"});
   // FIXME if I put a longer string here, e.g. "cf2_krypton_tb30:r5927" then dcs-random-data-generator crashes (std::bad_alloc or std::length_error)
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_envTemp[00..539]", 10., 40.});
 
   // Env parameters (temperatures, pressures, humidity)
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"CavernTemperature", 0, 100.});

--- a/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
+++ b/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
@@ -45,7 +45,6 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"UXC2Humidity", 0, 100.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"CavernAtmosPressure", 800, 1000.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_fed_runNo", 254, 255});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_runType", 1, 3});
 
   return o2::framework::WorkflowSpec{o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "TRD")};
 }

--- a/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
+++ b/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
@@ -32,19 +32,20 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvDriftUmon[00..539]", 2249., 2250.});
 
   // temperatures, pressures, config and other
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<std::string>{"trd_fedCFGtag[00..539]", "foo", "bar"});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<std::string>{"trd_CFGtag[00..539]", "foo", "bar"});
   // FIXME if I put a longer string here, e.g. "cf2_krypton_tb30:r5927" then dcs-random-data-generator crashes (std::bad_alloc or std::length_error)
 
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_fedChamberStatus[00..539]", 0, 255});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_fedEnvTemp[00..539]", 10., 40.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_chamberStatus[00..539]", 1, 5});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_envTemp[00..539]", 10., 40.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvTempCavern", 0, 100.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvTempP2", 0, 100.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvPressure00", 0, 100.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvPressure01", 0, 100.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvPressure02", 0, 100.});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_cavernHumidity", 0, 100.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_runNo", 254, 255});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_runType", 254, 255});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"UXC2Humidity", 0, 100.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"CavernAtmosPressure", 800, 1000.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_fed_runNo", 254, 255});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_runType", 1, 3});
 
   return o2::framework::WorkflowSpec{o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "TRD")};
 }

--- a/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
+++ b/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
@@ -31,19 +31,21 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvDriftImon[00..539]", 0, 50.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvDriftUmon[00..539]", 2249., 2250.});
 
-  // temperatures, pressures, config and other
+  // FED parameters
+  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_chamberStatus[00..539]", 1, 5});
   dphints.emplace_back(o2::dcs::test::DataPointHint<std::string>{"trd_CFGtag[00..539]", "foo", "bar"});
   // FIXME if I put a longer string here, e.g. "cf2_krypton_tb30:r5927" then dcs-random-data-generator crashes (std::bad_alloc or std::length_error)
-
-  dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_chamberStatus[00..539]", 1, 5});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_envTemp[00..539]", 10., 40.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvTempCavern", 0, 100.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvTempP2", 0, 100.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvPressure00", 0, 100.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvPressure01", 0, 100.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_aliEnvPressure02", 0, 100.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"UXC2Humidity", 0, 100.});
+
+  // Env parameters (temperatures, pressures, humidity)
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"CavernTemperature", 0, 100.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"temperature_P2_external", 0, 100.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"CavernAtmosPressure", 800, 1000.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"SurfaceAtmosPressure", 800, 1000.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"CavernAtmosPressure2", 800, 1000.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"UXC2Humidity", 0, 100.});
+
+  // Run parameters
   dphints.emplace_back(o2::dcs::test::DataPointHint<int32_t>{"trd_fed_runNo", 254, 255});
 
   return o2::framework::WorkflowSpec{o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "TRD")};


### PR DESCRIPTION
## Main goal
Add the processing logic of TRD chamber status and config tags data points, setup othe DCS DPs for processing.

The proposed procedure is: after a new run begins, first instances of `trd_chamberStatus` and `trd_CFGtag` get written to CCDB with run number as metadata. Following changes should be logged as alarm (first change), then warnings.

Modification and organization of other DCS DPs, such as temperatures, pressures, humidity (environment).

---

Relevant JIRA: https://alice.its.cern.ch/jira/browse/TRD-109
See previous PR for more information: https://github.com/AliceO2Group/AliceO2/pull/12079