### PR TITLE
Add TrackQA table

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -494,6 +494,21 @@ namespace aod
 using FullTracks = soa::Join<Tracks, TracksExtra>;
 using FullTrack = FullTracks::iterator;
 
+namespace trackqa
+{
+// TRACKQA TABLE COLUMNS
+DECLARE_SOA_INDEX_COLUMN(Track, track); //! track to which this QA information belongs
+DECLARE_SOA_COLUMN(DCAR, dcaR, uint16_t); //!
+DECLARE_SOA_COLUMN(DCAZ, dcaZ, uint16_t); //!
+DECLARE_SOA_COLUMN(ClusterByteMask, clusterByteMask, uint8_t); //!
+DECLARE_SOA_COLUMN(TPCSignalPerRegion, tpcSignalPerRegion, uint8_t); //!
+} // namespace trackqa
+
+DECLARE_SOA_TABLE(TracksQA, "AOD", "TRACKQA", //! Run 2 cascade table
+o2::soa::Index<>, trackqa::TrackId, trackqa::DCAR, trackqa::DCAZ, trackqa::ClusterByteMask, trackqa::TPCSignalPerRegion);
+
+using TrackQA = TracksQA::iterator;
+
 namespace fwdtrack
 {
 // FwdTracks and MFTTracks Columns definitions


### PR DESCRIPTION
Adds a track QA table with an index to the track the QA information belongs to. This table is to be downsampled at filling time (to at most 10% of the size of the track table) such that it does not occupy large amounts of disk space