### PR TITLE
FT0: Use dead channel map in digitizer

### DIFF
--- a/Detectors/FIT/FDD/simulation/include/FDDSimulation/Digitizer.h
+++ b/Detectors/FIT/FDD/simulation/include/FDDSimulation/Digitizer.h
@@ -16,6 +16,7 @@
 #include "DataFormatsFDD/ChannelData.h"
 #include "DataFormatsFDD/Digit.h"
 #include "DataFormatsFDD/MCLabel.h"
+#include "DataFormatsFIT/DeadChannelMap.h"
 #include "FDDSimulation/Detector.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "FDDSimulation/DigitizationParameters.h"
@@ -87,6 +88,8 @@ class Digitizer
   void init();
   void finish();
 
+  void setDeadChannelMap(o2::fit::DeadChannelMap const* deadChannelMap) { mDeadChannelMap = deadChannelMap; };
+
  private:
   static constexpr int BCCacheMin = -1, BCCacheMax = 10, NBC2Cache = 1 + BCCacheMax - BCCacheMin;
 
@@ -124,6 +127,8 @@ class Digitizer
   static Double_t PMResponse(Double_t x);
   static Double_t PMResponse(Double_t* x, Double_t*);
   static Double_t SinglePhESpectrum(Double_t* x, Double_t* par);
+
+  o2::fit::DeadChannelMap const* mDeadChannelMap = nullptr;
 
   ClassDefNV(Digitizer, 4);
 };

--- a/Detectors/FIT/FDD/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FDD/simulation/src/Digitizer.cxx
@@ -49,6 +49,13 @@ void Digitizer::process(const std::vector<o2::fdd::Hit>& hits,
   // LOG(info) << "Pulse";
   // Conversion of hits to the analogue pulse shape
   for (auto& hit : sorted_hits) {
+    int iChannel = hit.GetDetectorID();
+
+    // If the dead channel map is used, and the channel with ID 'hit_ch' is dead, don't process this hit.
+    if (mDeadChannelMap && !mDeadChannelMap->isChannelAlive(iChannel)) {
+      continue;
+    }
+
     if (hit.GetTime() > 20e3) {
       const int maxWarn = 10;
       static int warnNo = 0;
@@ -60,7 +67,6 @@ void Digitizer::process(const std::vector<o2::fdd::Hit>& hits,
     }
 
     std::array<o2::InteractionRecord, NBC2Cache> cachedIR;
-    int iChannel = hit.GetDetectorID();
     int nPhotoElectrons = simulateLightYield(iChannel, hit.GetNphot());
 
     double delayScintillator = mRndScintDelay.getNextValue();

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
@@ -13,6 +13,7 @@
 #define ALICEO2_FT0_DIGITIZER_H
 
 #include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsFIT/DeadChannelMap.h"
 #include "DataFormatsFT0/Digit.h"
 #include "DataFormatsFT0/ChannelData.h"
 #include "DataFormatsFT0/MCLabel.h"
@@ -73,6 +74,7 @@ class Digitizer
 
   void SetChannelOffset(o2::ft0::FT0ChannelTimeCalibrationObject const*
                           caliboffsets) { mCalibOffset = caliboffsets; };
+  void SetDeadChannelMap(o2::fit::DeadChannelMap const* deadChannelMap) { mDeadChannelMap = deadChannelMap; };
   double getTimeOffsetWrtBC() const { return mIntRecord.getTimeOffsetWrtBC(); }
 
   struct CFDOutput {
@@ -165,6 +167,7 @@ class Digitizer
                o2::dataformats::MCTruthContainer<o2::ft0::MCLabel>& labels);
 
   o2::ft0::FT0ChannelTimeCalibrationObject const* mCalibOffset = nullptr;
+  o2::fit::DeadChannelMap const* mDeadChannelMap = nullptr;
 
   ClassDefNV(Digitizer, 3);
 };

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
@@ -74,7 +74,7 @@ class Digitizer
 
   void SetChannelOffset(o2::ft0::FT0ChannelTimeCalibrationObject const*
                           caliboffsets) { mCalibOffset = caliboffsets; };
-  void SetDeadChannelMap(o2::fit::DeadChannelMap const* deadChannelMap) { mDeadChannelMap = deadChannelMap; };
+  void setDeadChannelMap(o2::fit::DeadChannelMap const* deadChannelMap) { mDeadChannelMap = deadChannelMap; };
   double getTimeOffsetWrtBC() const { return mIntRecord.getTimeOffsetWrtBC(); }
 
   struct CFDOutput {

--- a/Detectors/FIT/FT0/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Digitizer.cxx
@@ -204,8 +204,16 @@ void Digitizer::process(const std::vector<o2::ft0::HitType>* hits,
     if (hit.GetEnergyLoss() > 0) {
       continue;
     }
-    const auto& params = FT0DigParam::Instance();
+
     Int_t hit_ch = hit.GetDetectorID();
+
+    // If the dead channel map is used, and the channel with ID 'hit_ch' is dead, don't process this hit.
+    if (mDeadChannelMap && !mDeadChannelMap->isChannelAlive(hit_ch)) {
+      continue;
+    }
+
+    const auto& params = FT0DigParam::Instance();
+
     Bool_t is_A_side = (hit_ch < 4 * mGeometry.NCellsA);
     Float_t time_compensate = is_A_side ? params.mA_side_cable_cmps : params.mC_side_cable_cmps;
     Double_t hit_time = hit.GetTime() - time_compensate;
@@ -248,6 +256,9 @@ void Digitizer::storeBC(BCCache& bc,
     auto channel_begin = channel_end;
     channel_end = std::find_if(channel_begin, particles.end(),
                                [ipmt](BCCache::particle const& p) { return p.hit_ch != ipmt; });
+
+    // The hits between 'channel_begin' and 'channel_end' now contains all hits for channel 'ipmt'
+
     if (channel_end - channel_begin < params.mAmp_trsh) {
       continue;
     }

--- a/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
@@ -58,13 +58,19 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
     mDigitizer.init();
     mROMode = o2::parameters::GRPObject::ROMode(o2::parameters::GRPObject::TRIGGERING | (mDigitizer.isContinuous() ? o2::parameters::GRPObject::CONTINUOUS : o2::parameters::GRPObject::PRESENT));
     mDisableQED = ic.options().get<bool>("disable-qed");
+    mUseDeadChannelMap = !ic.options().get<bool>("disable-dead-channel-map");
+    mUpdateDeadChannelMap = mUseDeadChannelMap;
   }
 
   void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   {
     if (matcher == ConcreteDataMatcher("FT0", "TimeOffset", 0)) {
       mUpdateCCDB = false;
-      return;
+    }
+
+    // Initialize the dead channel map only once
+    if (matcher == ConcreteDataMatcher("FT0", "DeadChannelMap", 0)) {
+      mUpdateDeadChannelMap = false;
     }
   }
 
@@ -85,6 +91,13 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
       auto caliboffsets = pc.inputs().get<o2::ft0::FT0ChannelTimeCalibrationObject*>("ft0offsets");
       mDigitizer.SetChannelOffset(caliboffsets.get());
     }
+
+    // Initialize the dead channel map
+    if (mUpdateDeadChannelMap && mUseDeadChannelMap) {
+      auto deadChannelMap = pc.inputs().get<o2::fit::DeadChannelMap*>("ft0deadchannelmap");
+      mDigitizer.SetDeadChannelMap(deadChannelMap.get());
+    }
+
     // if there is nothing to do ... return
     if (timesview.size() == 0) {
       return;
@@ -158,6 +171,8 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
   bool mDisableQED = false;
   bool mUseCCDB = true;
   bool mUpdateCCDB = true;
+  bool mUseDeadChannelMap = true;
+  bool mUpdateDeadChannelMap = false;
   std::vector<TChain*> mSimChains;
 };
 
@@ -183,13 +198,18 @@ o2::framework::DataProcessorSpec getFT0DigitizerSpec(int channel, bool mctruth, 
                         Lifetime::Condition,
                         ccdbParamSpec("FT0/Calib/ChannelTimeOffset"));
   }
+  inputs.emplace_back("ft0deadchannelmap", "FT0", "DeadChannelMap", 0,
+                      Lifetime::Condition,
+                      ccdbParamSpec("FT0/Calib/DeadChannelMap", {}, -1));
+
   return DataProcessorSpec{
     "FT0Digitizer",
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<FT0DPLDigitizerTask>(useCCDB)},
     Options{{"pileup", VariantType::Int, 1, {"whether to run in continuous time mode"}},
-            {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
+            {"disable-qed", VariantType::Bool, false, {"disable QED handling"}},
+            {"disable-dead-channel-map", VariantType::Bool, false, {"Don't mask dead channels"}}}};
 }
 
 } // namespace ft0

--- a/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
@@ -18,6 +18,7 @@
 #include "Headers/DataHeader.h"
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "FT0Simulation/Digitizer.h"
+#include "DataFormatsFIT/DeadChannelMap.h"
 #include "DataFormatsFT0/ChannelData.h"
 #include "DataFormatsFT0/HitType.h"
 #include "DataFormatsFT0/Digit.h"
@@ -95,7 +96,7 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
     // Initialize the dead channel map
     if (mUpdateDeadChannelMap && mUseDeadChannelMap) {
       auto deadChannelMap = pc.inputs().get<o2::fit::DeadChannelMap*>("ft0deadchannelmap");
-      mDigitizer.SetDeadChannelMap(deadChannelMap.get());
+      mDigitizer.setDeadChannelMap(deadChannelMap.get());
     }
 
     // if there is nothing to do ... return
@@ -172,7 +173,7 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
   bool mUseCCDB = true;
   bool mUpdateCCDB = true;
   bool mUseDeadChannelMap = true;
-  bool mUpdateDeadChannelMap = false;
+  bool mUpdateDeadChannelMap = true;
   std::vector<TChain*> mSimChains;
 };
 


### PR DESCRIPTION
Enables the use of the dead channel map from CCDB in the FT0 digitizer as default. Hits in dead channels will not be processed. To disable checking the dead channel map, pass `--FT0Digitizer --disable-dead-channel-map` to the digitizer workflow.