### PR TITLE
DPL: mark dummy sink as resilient to expendable task failures

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -599,9 +599,8 @@ DataProcessorSpec CommonDataProcessors::getDummySink(std::vector<InputSpec> cons
     .options = !rateLimitingChannelConfig.empty() ? std::vector<ConfigParamSpec>{{"channel-config", VariantType::String, // raw input channel
                                                                                   rateLimitingChannelConfig,
                                                                                   {"Out-of-band channel config"}}}
-                                                  : std::vector<ConfigParamSpec>()
-
-  };
+                                                  : std::vector<ConfigParamSpec>(),
+    .labels = {{"resilient"}}};
 }
 
 AlgorithmSpec CommonDataProcessors::wrapWithRateLimiting(AlgorithmSpec spec)


### PR DESCRIPTION
DPL: mark dummy sink as resilient to expendable task failures
