### PR TITLE
Store ref vDrift with TPC residuals

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -284,8 +284,6 @@ class TrackInterpolation
   const SpacePointsCalibConfParam* mParams = nullptr;
   float mTPCTimeBinMUS{.2f};    ///< TPC time bin duration in us
   float mTPCVDriftRef = -1.;    ///< TPC nominal drift speed in cm/microseconds
-  float mTPCVDrift = -1.;       ///< TPC drift speed in cm/microseconds
-  float mTPCDriftTimeOffset = 0.;                    ///< TPC drift time bias in cm/mus
   float mTPCDriftTimeOffsetRef = 0.;                 ///< TPC nominal (e.g. at the start of run) drift time bias in cm/mus
   float mSqrtS{13600.f};                             ///< centre of mass energy set from LHC IF
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -1037,8 +1037,6 @@ void TrackInterpolation::reset()
 //______________________________________________
 void TrackInterpolation::setTPCVDrift(const o2::tpc::VDriftCorrFact& v)
 {
-  mTPCVDrift = v.getVDrift();
-  mTPCDriftTimeOffset = v.getTimeOffset();
   // Attention! For the refit we are using reference VDrift and TDriftOffest rather than high-rate calibrated, since we want to have fixed reference over the run
   if (v.refVDrift != mTPCVDriftRef) {
     mTPCVDriftRef = v.refVDrift;


### PR DESCRIPTION
So that the applied vDrift information is kept together with the unbinned residuals output.

+ minor optimization since orbit reset time never changes during a run it does not need to be queried for every TF