### PR TITLE
 DPL: add temporary workaround to disable lifetime check via env variable @davidrohr

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -1257,7 +1257,11 @@ void WorkflowHelpers::validateEdges(WorkflowSpec const& workflow,
                                     std::vector<DeviceConnectionEdge> const& edges,
                                     std::vector<OutputSpec> const& outputs)
 {
-  std::vector<Validator> defaultValidators = {validateExpendable, validateLifetime};
+  static bool disableLifetimeCheck = getenv("DPL_WORKAROUND_DO_NOT_CHECK_FOR_CORRECT_WORKFLOW_LIFETIMES") && atoi(getenv("DPL_WORKAROUND_DO_NOT_CHECK_FOR_CORRECT_WORKFLOW_LIFETIMES"));
+  std::vector<Validator> defaultValidators = {validateExpendable};
+  if (!disableLifetimeCheck) {
+    defaultValidators.emplace_back(validateLifetime);
+  }
   std::stringstream errors;
   // Iterate over all the edges.
   // Get the input lifetime and the output lifetime.

--- a/Utilities/ShmManager/src/ShmManager.cxx
+++ b/Utilities/ShmManager/src/ShmManager.cxx
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
       "regions", value<vector<string>>(&regions)->multitoken()->composing(), "Regions, as <id>,<size> <id>,<size>,<numaid> <id>,<size>,<numaid> ...")(
       "nozero", value<bool>(&nozero)->default_value(false)->implicit_value(true), "Do not zero segments after initialization")(
       "check-presence", value<bool>(&checkPresence)->default_value(true)->implicit_value(true), "Check periodically if configured segments/regions are still present, and cleanup and leave if they are not")(
-      "refcount-segment-size", value<uint64_t>(&refcount_segment_size)->default_value(0), "Shm id")(
+      "refcount-segment-size", value<uint64_t>(&refcount_segment_size)->default_value(0), "Size in bytes of refCount segment (global setting affecting all unmanaged regions)")(
       "help,h", "Print help");
 
     variables_map vm;


### PR DESCRIPTION
@martenole @ktf: I propose we do this temporarily instead of #12371