### PR TITLE
Fix field regex to re-enable 2T sims

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -286,7 +286,7 @@ bool SimConfig::parseFieldString(std::string const& fieldstring, int& fieldvalue
 {
   // analyse field options
   // either: "ccdb" or +-2[U],+-5[U] and 0[U]; +-<intKGaus>U
-  std::regex re("(ccdb)|([+-]?[250]U?)");
+  std::regex re("(ccdb)|([+-]?([2-9]|[12][0-9]|20)U?)");
   if (!std::regex_match(fieldstring, re)) {
     LOG(error) << "Invalid field option";
     return false;

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -245,7 +245,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   // analyse field options
   // either: "ccdb" or +-2[U],+-5[U] and 0[U]; +-<intKGaus>U
   auto& fieldstring = vm["field"].as<std::string>();
-  std::regex re("(ccdb)|([+-]?[250]U?)");
+  std::regex re("(ccdb)|([+-]?([2-9]|[12][0-9]|20)U?)");
   if (!std::regex_match(fieldstring, re)) {
     LOG(error) << "Invalid field option";
     return false;


### PR DESCRIPTION
The regex check added to `SimConfig.cxx` makes it impossible to run simulations with 2T (that would be +20U or -20U) for ALICE 3 since that doesn't match the expected regex. This change allows for [+-] (a number from 2 to 20) U to work fine, as it did before this regex check was implemented. The effects of this change have been successfully tested already and should allow also for 1.0T and 1.5T fields. 