### PR TITLE
PDG: Add XiC0 to replace XiCZero

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -57,6 +57,7 @@ enum Pdg {
   kXiCCPlusPlus = 4422,
   kXiCPlus = 4232,
   kXiCZero = 4132,
+  kXiC0 = 4132,
   kDeuteron = 1000010020,
   kTriton = 1000010030,
   kHelium3 = 1000020030,
@@ -93,6 +94,7 @@ constexpr double MassXiB0 = 5.7924;
 constexpr double MassXiCCPlusPlus = 3.59798;
 constexpr double MassXiCPlus = 2.4679;
 constexpr double MassXiCZero = 2.471;
+constexpr double MassXiC0 = 2.471;
 constexpr double MassDeuteron = 1.87561294257;
 constexpr double MassTriton = 2.80892113298;
 constexpr double MassHelium3 = 2.80839160743;

--- a/Common/Constants/include/CommonConstants/make_pdg_header.py
+++ b/Common/Constants/include/CommonConstants/make_pdg_header.py
@@ -112,6 +112,7 @@ class Pdg(Enum):
     kXiCCPlusPlus = 4422
     kXiCPlus = 4232
     kXiCZero = 4132
+    kXiC0 = 4132
     kDeuteron = 1000010020
     kTriton = 1000010030
     kHelium3 = 1000020030


### PR DESCRIPTION
Adding `XiC0` to replace `XiCZero` after renaming in O2Physics
@qgp