### PR TITLE
PDG: Remove XiCZero

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -56,7 +56,6 @@ enum Pdg {
   kXiB0 = 5232,
   kXiCCPlusPlus = 4422,
   kXiCPlus = 4232,
-  kXiCZero = 4132,
   kXiC0 = 4132,
   kDeuteron = 1000010020,
   kTriton = 1000010030,
@@ -93,7 +92,6 @@ constexpr double MassXi0 = 1.31486;
 constexpr double MassXiB0 = 5.7924;
 constexpr double MassXiCCPlusPlus = 3.59798;
 constexpr double MassXiCPlus = 2.4679;
-constexpr double MassXiCZero = 2.471;
 constexpr double MassXiC0 = 2.471;
 constexpr double MassDeuteron = 1.87561294257;
 constexpr double MassTriton = 2.80892113298;

--- a/Common/Constants/include/CommonConstants/make_pdg_header.py
+++ b/Common/Constants/include/CommonConstants/make_pdg_header.py
@@ -111,7 +111,6 @@ class Pdg(Enum):
     kXiB0 = 5232
     kXiCCPlusPlus = 4422
     kXiCPlus = 4232
-    kXiCZero = 4132
     kXiC0 = 4132
     kDeuteron = 1000010020
     kTriton = 1000010030


### PR DESCRIPTION
Replaced with XiC0
Requires https://github.com/AliceO2Group/O2Physics/pull/4045
@qgp 