### PR TITLE
CcdbApi: Ignoring local cache validity by default

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -161,7 +161,9 @@ void CcdbApi::init(std::string const& host)
     }
     snapshotReport = fmt::format("(cache snapshots to dir={}", mSnapshotCachePath);
   }
-  if (getenv("IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE")) {
+
+  const char* ignoreValidity = getenv("IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE");
+  if ((cachedir && !ignoreValidity) || (ignoreValidity && atoi(ignoreValidity) == 1)) {
     mPreferSnapshotCache = true;
     if (mSnapshotCachePath.empty()) {
       LOGP(fatal, "IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE is defined but the ALICEO2_CCDB_LOCALCACHE is not");


### PR DESCRIPTION
As a follow up to https://alice.its.cern.ch/jira/browse/O2-4437 I propose to treat the flag `IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE ` as if it were on by default, while still leaving the option to turn it off if desired via setting to 0.