### PR TITLE
Add asArrowTable() to Partition

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -551,6 +551,11 @@ struct Partition {
     expressions::updatePlaceholders(filter, context);
   }
 
+  [[nodiscard]] std::shared_ptr<arrow::Table> asArrowTable() const
+  {
+    return mFiltered->asArrowTable();
+  }
+
   o2::soa::Filtered<T>* operator->()
   {
     return mFiltered.get();


### PR DESCRIPTION
Bug reported on Mattermost: not possible to do grouped combinations on partitioned tables, which also prevents mixing on partitioned collisions.
This fixes the problem, tested locally. I will later submit a PR with the "unit test" in O2Physics/Tutorials.

