### PR TITLE
Remove default Lifetime::Timeframe when instanciating an Output

### DIFF
--- a/Detectors/AOD/src/AODMcProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODMcProducerWorkflowSpec.cxx
@@ -296,13 +296,13 @@ void AODMcProducerWorkflowDPL::run(ProcessingContext& pc)
     TString ROOTVersion = ROOT_RELEASE;
     mMetaDataKeys = {"DataType", "Run", "O2Version", "ROOTVersion", "RecoPassName", "AnchorProduction", "AnchorPassName", "LPMProductionTag"};
     mMetaDataVals = {dataType, "3", O2Version, ROOTVersion, mRecoPass, mAnchorProd, mAnchorPass, mLPMProdTag};
-    pc.outputs().snapshot(Output{"AMD", "AODMetadataKeys", 0, Lifetime::Timeframe}, mMetaDataKeys);
-    pc.outputs().snapshot(Output{"AMD", "AODMetadataVals", 0, Lifetime::Timeframe}, mMetaDataVals);
+    pc.outputs().snapshot(Output{"AMD", "AODMetadataKeys", 0}, mMetaDataKeys);
+    pc.outputs().snapshot(Output{"AMD", "AODMetadataVals", 0}, mMetaDataVals);
     mIsMDSent = true;
   }
 
-  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, tfNumber);
-  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
+  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0}, tfNumber);
+  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0}, "");
 
   pc.services().get<ControlService>().endOfStream();
   pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2241,11 +2241,11 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   TString ROOTVersion = ROOT_RELEASE;
   mMetaDataKeys = {"DataType", "Run", "O2Version", "ROOTVersion", "RecoPassName", "AnchorProduction", "AnchorPassName", "LPMProductionTag"};
   mMetaDataVals = {dataType, "3", O2Version, ROOTVersion, mRecoPass, mAnchorProd, mAnchorPass, mLPMProdTag};
-  pc.outputs().snapshot(Output{"AMD", "AODMetadataKeys", 0, Lifetime::Timeframe}, mMetaDataKeys);
-  pc.outputs().snapshot(Output{"AMD", "AODMetadataVals", 0, Lifetime::Timeframe}, mMetaDataVals);
+  pc.outputs().snapshot(Output{"AMD", "AODMetadataKeys", 0}, mMetaDataKeys);
+  pc.outputs().snapshot(Output{"AMD", "AODMetadataVals", 0}, mMetaDataVals);
 
-  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, tfNumber);
-  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
+  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0}, tfNumber);
+  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0}, "");
 
   mTimer.Stop();
 }

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVBadMapCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVBadMapCalibDevice.cxx
@@ -174,7 +174,7 @@ void CPVBadMapCalibDevice::sendOutput(DataAllocator& output)
     output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_BadChanMap", subSpec}, info);
   }
 
-  output.snapshot(o2::framework::Output{"CPV", "BADMAPCHANGE", 0, o2::framework::Lifetime::Timeframe}, mMapDiff);
+  output.snapshot(o2::framework::Output{"CPV", "BADMAPCHANGE", 0}, mMapDiff);
 }
 
 bool CPVBadMapCalibDevice::differFromCurrent()

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVGainCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVGainCalibDevice.cxx
@@ -143,7 +143,7 @@ void CPVGainCalibDevice::sendOutput(DataAllocator& output)
     fout.Close();
   }
   // Anyway send change to QC
-  output.snapshot(o2::framework::Output{"CPV", "GAINDIFF", 0, o2::framework::Lifetime::Timeframe}, mGainRatio);
+  output.snapshot(o2::framework::Output{"CPV", "GAINDIFF", 0}, mGainRatio);
 }
 
 void CPVGainCalibDevice::calculateGains()

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVPedestalCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVPedestalCalibDevice.cxx
@@ -118,7 +118,7 @@ void CPVPedestalCalibDevice::sendOutput(DataAllocator& output)
   }
   // Anyway send change to QC
   LOG(info) << "[CPVPedestalCalibDevice - run] Writing ";
-  output.snapshot(o2::framework::Output{"CPV", "PEDDIFF", 0, o2::framework::Lifetime::Timeframe}, mPedDiff);
+  output.snapshot(o2::framework::Output{"CPV", "PEDDIFF", 0}, mPedDiff);
 
   // Write pedestal distributions to calculate bad map
   std::string filename = mPath + "CPVPedestals.root";

--- a/Detectors/CPV/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterReaderSpec.cxx
@@ -44,10 +44,10 @@ void ClusterReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mClusters.size() << " Clusters in " << mTRs.size() << " TriggerRecords at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "CLUSTERS", 0, Lifetime::Timeframe}, mClusters);
-  pc.outputs().snapshot(Output{mOrigin, "CLUSTERTRIGRECS", 0, Lifetime::Timeframe}, mTRs);
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERS", 0}, mClusters);
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERTRIGRECS", 0}, mTRs);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "CLUSTERTRUEMC", 0, Lifetime::Timeframe}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERTRUEMC", 0}, mMCTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
@@ -49,14 +49,14 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
   if (!digits.size()) { // nothing to process
     LOG(info) << "ClusterizerSpec::run() : no digits; moving on";
     mOutputClusters.clear();
-    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
+    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERS", 0}, mOutputClusters);
     mOutputClusterTrigRecs.clear();
-    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRIGRECS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusterTrigRecs);
+    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRIGRECS", 0}, mOutputClusterTrigRecs);
     mCalibDigits.clear();
-    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CALIBDIGITS", 0, o2::framework::Lifetime::Timeframe}, mCalibDigits);
+    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CALIBDIGITS", 0}, mCalibDigits);
     if (mPropagateMC) {
       mOutputTruthCont.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0}, mOutputTruthCont);
     }
     return;
   }
@@ -73,12 +73,12 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
 
   LOG(debug) << "CPVClusterizer::run() : Received " << digitsTR.size() << " TR, calling clusterizer ...";
 
-  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
-  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRIGRECS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusterTrigRecs);
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERS", 0}, mOutputClusters);
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRIGRECS", 0}, mOutputClusterTrigRecs);
   if (mPropagateMC) {
-    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
+    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0}, mOutputTruthCont);
   }
-  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CALIBDIGITS", 0, o2::framework::Lifetime::Timeframe}, mCalibDigits);
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CALIBDIGITS", 0}, mCalibDigits);
   LOG(info) << "Finished, wrote  " << mOutputClusters.size() << " clusters, " << mOutputClusterTrigRecs.size() << "TR and " << mOutputTruthCont.getIndexedSize() << " Labels";
 }
 o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getClusterizerSpec(bool propagateMC)

--- a/Detectors/CPV/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/CPV/workflow/src/DigitReaderSpec.cxx
@@ -44,10 +44,10 @@ void DigitReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mDigits.size() << " Digits in " << mTRs.size() << " TriggerRecords at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
-  pc.outputs().snapshot(Output{mOrigin, "DIGITTRIGREC", 0, Lifetime::Timeframe}, mTRs);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0}, mDigits);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITTRIGREC", 0}, mTRs);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSMCTR", 0}, mMCTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
@@ -54,7 +54,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CPV", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CPV", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, triggers, clusters);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -136,11 +136,11 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       mOutputDigits.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mOutputDigits);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0}, mOutputDigits);
       mOutputTriggerRecords.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0}, mOutputTriggerRecords);
       mOutputHWErrors.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0, o2::framework::Lifetime::Timeframe}, mOutputHWErrors);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0}, mOutputHWErrors);
       return; // empty TF, nothing to process
     }
   }
@@ -272,11 +272,11 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
     if (skipTF) {
       // Send no digits
       mOutputDigits.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mOutputDigits);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0}, mOutputDigits);
       mOutputTriggerRecords.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0}, mOutputTriggerRecords);
       // Send errors
-      ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0, o2::framework::Lifetime::Timeframe}, mOutputHWErrors);
+      ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0}, mOutputHWErrors);
       return;
     }
   }
@@ -305,9 +305,9 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
   digitBuffer.clear();
 
   LOG(info) << "[CPVRawToDigitConverter - run] Sending " << mOutputDigits.size() << " digits in " << mOutputTriggerRecords.size() << "trigger records.";
-  ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mOutputDigits);
-  ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
-  ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0, o2::framework::Lifetime::Timeframe}, mOutputHWErrors);
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0}, mOutputDigits);
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0}, mOutputTriggerRecords);
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0}, mOutputHWErrors);
 }
 //_____________________________________________________________________________
 o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getRawToDigitConverterSpec(bool askDISTSTF, bool isPedestal, bool useBadChannelMap, bool useGainCalibration)

--- a/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
@@ -64,7 +64,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
       lumi = lumiPrev;
     }
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CTP", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CTP", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, digits, lumi);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -80,10 +80,10 @@ void RawDecoderSpec::run(framework::ProcessingContext& ctx)
   auto& inputs = ctx.inputs();
   auto dummyOutput = [&ctx, this]() {
     if (this->mDoDigits) {
-      ctx.outputs().snapshot(o2::framework::Output{"CTP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, this->mOutputDigits);
+      ctx.outputs().snapshot(o2::framework::Output{"CTP", "DIGITS", 0}, this->mOutputDigits);
     }
     if (this->mDoLumi) {
-      ctx.outputs().snapshot(o2::framework::Output{"CTP", "LUMI", 0, o2::framework::Lifetime::Timeframe}, this->mOutputLumiInfo);
+      ctx.outputs().snapshot(o2::framework::Output{"CTP", "LUMI", 0}, this->mOutputLumiInfo);
     }
   };
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
@@ -117,7 +117,7 @@ void RawDecoderSpec::run(framework::ProcessingContext& ctx)
   }
   if (mDoDigits) {
     LOG(info) << "[CTPRawToDigitConverter - run] Writing " << mOutputDigits.size() << " digits. IR rejected:" << mDecoder.getIRRejected() << " TCR rejected:" << mDecoder.getTCRRejected();
-    ctx.outputs().snapshot(o2::framework::Output{"CTP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mOutputDigits);
+    ctx.outputs().snapshot(o2::framework::Output{"CTP", "DIGITS", 0}, mOutputDigits);
   }
   if (mDoLumi) {
     uint32_t tfCountsT = 0;
@@ -157,7 +157,7 @@ void RawDecoderSpec::run(framework::ProcessingContext& ctx)
       mOutputLumiInfo.printInputs();
       LOGP(info, "Orbit {}: {}/{} counts inp1/inp2 in {}/{} HBFs -> lumi_inp1 = {:.3e}+-{:.3e} lumi_inp2 = {:.3e}+-{:.3e}", mOutputLumiInfo.orbit, mCountsT, mCountsV, mNHBIntegratedT, mNHBIntegratedV, mOutputLumiInfo.getLumi(), mOutputLumiInfo.getLumiError(), mOutputLumiInfo.getLumiFV0(), mOutputLumiInfo.getLumiFV0Error());
     }
-    ctx.outputs().snapshot(o2::framework::Output{"CTP", "LUMI", 0, o2::framework::Lifetime::Timeframe}, mOutputLumiInfo);
+    ctx.outputs().snapshot(o2::framework::Output{"CTP", "LUMI", 0}, mOutputLumiInfo);
   }
 }
 o2::framework::DataProcessorSpec o2::ctp::reco_workflow::getRawDecoderSpec(bool askDISTSTF, bool digits, bool lumi)

--- a/Detectors/CTP/workflowIO/src/DigitReaderSpec.cxx
+++ b/Detectors/CTP/workflowIO/src/DigitReaderSpec.cxx
@@ -76,8 +76,8 @@ void DigitReader::run(ProcessingContext& pc)
 
   mTree->GetEntry(ent);
   LOG(info) << "DigitReader pushes " << mDigits.size() << " digits at entry " << ent;
-  pc.outputs().snapshot(Output{"CTP", "DIGITS", 0, Lifetime::Timeframe}, mDigits);
-  pc.outputs().snapshot(Output{"CTP", "LUMI", 0, Lifetime::Timeframe}, mLumi);
+  pc.outputs().snapshot(Output{"CTP", "DIGITS", 0}, mDigits);
+  pc.outputs().snapshot(Output{"CTP", "LUMI", 0}, mLumi);
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Detectors/DCS/testWorkflow/src/DCSDataReplaySpec.cxx
+++ b/Detectors/DCS/testWorkflow/src/DCSDataReplaySpec.cxx
@@ -88,7 +88,7 @@ void DCSDataReplayer::run(o2::framework::ProcessingContext& pc)
 
   LOG(info)
     << "***************** TF " << tfid << " has generated " << dpcoms.size() << " DPs";
-  pc.outputs().snapshot(Output{"DCS", mDataDescription, 0, Lifetime::Timeframe}, dpcoms);
+  pc.outputs().snapshot(Output{"DCS", mDataDescription, 0}, dpcoms);
   mTFs++;
 }
 } // namespace

--- a/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
+++ b/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
@@ -153,7 +153,7 @@ void DCSRandomDataGenerator::run(o2::framework::ProcessingContext& pc)
   auto timeNow = std::chrono::system_clock::now();
   timingInfo.creation = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow.time_since_epoch()).count(); // in ms
 
-  pc.outputs().snapshot(Output{"DCS", mDataDescription, 0, Lifetime::Timeframe}, dpcoms);
+  pc.outputs().snapshot(Output{"DCS", mDataDescription, 0}, dpcoms);
   mTFs++;
 }
 } // namespace

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/PublisherSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/PublisherSpec.h
@@ -60,23 +60,22 @@ framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, uint3
 
   // a creator callback for the actual reader instance
   auto creator = [dto, tro, mco, subspec, propagateMC](const char* treename, const char* filename, int nofEvents, Reader::PublishingMode publishingMode, const char* branchname, const char* triggerbranchname, const char* mcbranchname) {
-    constexpr auto persistency = o2::framework::Lifetime::Timeframe;
     if (propagateMC) {
       return std::make_shared<Reader>(treename,
                                       filename,
                                       nofEvents,
                                       publishingMode,
-                                      Output{mco.origin, mco.description, subspec, persistency},
+                                      Output{mco.origin, mco.description, subspec},
                                       mcbranchname,
-                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subspec, persistency}, branchname},
-                                      Reader::BranchDefinition<TriggerInputType>{Output{tro.origin, tro.description, subspec, persistency}, triggerbranchname});
+                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subspec}, branchname},
+                                      Reader::BranchDefinition<TriggerInputType>{Output{tro.origin, tro.description, subspec}, triggerbranchname});
     } else {
       return std::make_shared<Reader>(treename,
                                       filename,
                                       nofEvents,
                                       publishingMode,
-                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subspec, persistency}, branchname},
-                                      Reader::BranchDefinition<TriggerInputType>{Output{tro.origin, tro.description, subspec, persistency}, triggerbranchname});
+                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subspec}, branchname},
+                                      Reader::BranchDefinition<TriggerInputType>{Output{tro.origin, tro.description, subspec}, triggerbranchname});
     }
   };
 

--- a/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
@@ -148,7 +148,7 @@ void AnalysisClusterSpec<InputType>::run(framework::ProcessingContext& ctx)
   }
 
   LOG(debug) << "[EMCALClusterizer - run] Writing " << mOutputAnaClusters->size() << " clusters ...";
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "ANALYSISCLUSTERS", 0, o2::framework::Lifetime::Timeframe}, *mOutputAnaClusters);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "ANALYSISCLUSTERS", 0}, *mOutputAnaClusters);
 }
 
 o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getAnalysisClusterSpec(bool useDigits)

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -161,10 +161,10 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
     ncellsTrigger = 0;
   }
   LOG(debug) << "[EMCALCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", mSubspecificationOut, o2::framework::Lifetime::Timeframe}, mOutputCells);
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSTRGR", mSubspecificationOut, o2::framework::Lifetime::Timeframe}, mOutputTriggers);
+  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", mSubspecificationOut}, mOutputCells);
+  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSTRGR", mSubspecificationOut}, mOutputTriggers);
   if (mPropagateMC) {
-    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", mSubspecificationOut, o2::framework::Lifetime::Timeframe}, mOutputLabels);
+    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", mSubspecificationOut}, mOutputLabels);
   }
 }
 

--- a/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
@@ -113,15 +113,15 @@ void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
   }
 
   // send recalibrated objects
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputcells);
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputtriggers);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", mOutputSubspec}, outputcells);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", mOutputSubspec}, outputtriggers);
   if (outputMCLabels.has_value()) {
     LOG(info) << "Timeframe: " << inputMCLabels->getIndexedSize() << " label entries read, " << outputMCLabels->getIndexedSize() << " label entries kept";
-    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSMCTR", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputMCLabels.value());
+    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSMCTR", mOutputSubspec}, outputMCLabels.value());
   }
   if (mLEDsettings == LEDEventSettings::REDIRECT) {
-    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", 10, o2::framework::Lifetime::Timeframe}, ledcells);
-    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", 10, o2::framework::Lifetime::Timeframe}, ledtriggers);
+    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", 10}, ledcells);
+    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", 10}, ledtriggers);
   }
 }
 

--- a/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
@@ -107,11 +107,11 @@ void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
     currentStartIndices = mOutputCellDigitIndices->size();
   }
   LOG(debug) << "[EMCALClusterizer - run] Writing " << mOutputClusters->size() << " clusters ...";
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, *mOutputClusters);
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "INDICES", 0, o2::framework::Lifetime::Timeframe}, *mOutputCellDigitIndices);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CLUSTERS", 0}, *mOutputClusters);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "INDICES", 0}, *mOutputCellDigitIndices);
 
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CLUSTERSTRGR", 0, o2::framework::Lifetime::Timeframe}, *mOutputTriggerRecord);
-  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "INDICESTRGR", 0, o2::framework::Lifetime::Timeframe}, *mOutputTriggerRecordIndices);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CLUSTERSTRGR", 0}, *mOutputTriggerRecord);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "INDICESTRGR", 0}, *mOutputTriggerRecordIndices);
   mTimer.Stop();
 }
 

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -140,15 +140,15 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
   mDigitizer.finish();
 
   // here we have all digits and we can send them to consumer (aka snapshot it onto output)
-  ctx.outputs().snapshot(Output{"EMC", "DIGITS", 0, Lifetime::Timeframe}, mDigitizer.getDigits());
-  ctx.outputs().snapshot(Output{"EMC", "TRGRDIG", 0, Lifetime::Timeframe}, mDigitizer.getTriggerRecords());
+  ctx.outputs().snapshot(Output{"EMC", "DIGITS", 0}, mDigitizer.getDigits());
+  ctx.outputs().snapshot(Output{"EMC", "TRGRDIG", 0}, mDigitizer.getTriggerRecords());
   if (ctx.outputs().isAllowed({"EMC", "DIGITSMCTR", 0})) {
-    ctx.outputs().snapshot(Output{"EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}, mDigitizer.getMCLabels());
+    ctx.outputs().snapshot(Output{"EMC", "DIGITSMCTR", 0}, mDigitizer.getMCLabels());
   }
   // EMCAL is always a triggering detector
   const o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::TRIGGERING;
   LOG(info) << "EMCAL: Sending ROMode= " << roMode << " to GRPUpdater";
-  ctx.outputs().snapshot(Output{"EMC", "ROMode", 0, Lifetime::Timeframe}, roMode);
+  ctx.outputs().snapshot(Output{"EMC", "ROMode", 0}, roMode);
   // Create CTP digits
   std::vector<o2::ctp::CTPInputDigit> triggerinputs;
   for (auto& trg : mDigitizer.getTriggerRecords()) {
@@ -161,7 +161,7 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
     nextdigit.inputsMask.set(0);
     triggerinputs.push_back(nextdigit);
   }
-  ctx.outputs().snapshot(Output{"EMC", "TRIGGERINPUT", 0, Lifetime::Timeframe}, triggerinputs);
+  ctx.outputs().snapshot(Output{"EMC", "TRIGGERINPUT", 0}, triggerinputs);
 
   timer.Stop();
   LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
@@ -52,7 +52,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
   auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
 
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"EMC", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"EMC", "CTFDATA", 0});
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -722,11 +722,11 @@ void RawToCellConverterSpec::handleMinorPageError(const RawReaderMemory::MinorEr
 void RawToCellConverterSpec::sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", mSubspecification, framework::Lifetime::Timeframe}, cells);
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", mSubspecification, framework::Lifetime::Timeframe}, triggers);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", mSubspecification}, cells);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", mSubspecification}, triggers);
   if (mCreateRawDataErrors) {
     LOG(debug) << "Sending " << decodingErrors.size() << " decoding errors";
-    ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", mSubspecification, framework::Lifetime::Timeframe}, decodingErrors);
+    ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", mSubspecification}, decodingErrors);
   }
 }
 

--- a/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
@@ -136,8 +136,8 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
   } // end of event loop
   // std::cout << "Finished cell loop" << std::endl;
 
-  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, tfNumber);
-  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
+  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0}, tfNumber);
+  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0}, "");
 
   mTimer.Stop();
 }

--- a/Detectors/EMCAL/workflow/src/emc-channel-data-producer.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-channel-data-producer.cxx
@@ -160,7 +160,7 @@ DataProcessorSpec generateData(const std::string nameRootFile, const std::string
         o2::pmr::vector<o2::emcal::TriggerRecord> TriggerOutput;
         TriggerOutput.emplace_back(0, 0, 0, CellOutput.size());
 
-        ctx.outputs().adoptContainer(Output{o2::header::gDataOriginEMC, "CELLS", 0, Lifetime::Timeframe}, std::move(CellOutput));
-        ctx.outputs().adoptContainer(Output{o2::header::gDataOriginEMC, "CELLSTRGR", 0, Lifetime::Timeframe}, std::move(TriggerOutput));
+        ctx.outputs().adoptContainer(Output{o2::header::gDataOriginEMC, "CELLS", 0}, std::move(CellOutput));
+        ctx.outputs().adoptContainer(Output{o2::header::gDataOriginEMC, "CELLSTRGR", 0}, std::move(TriggerOutput));
       }}};
 }

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RawReaderFDD.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RawReaderFDD.h
@@ -65,8 +65,8 @@ class RawReaderFDD : public RawReaderFDDBaseNorm
   }
   void makeSnapshot(o2::framework::ProcessingContext& pc)
   {
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFDD, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFDD, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFDD, "DIGITSBC", 0}, mVecDigits);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFDD, "DIGITSCH", 0}, mVecChannelData);
   }
   bool mDumpData;
   std::vector<Digit> mVecDigits;

--- a/Detectors/FIT/FDD/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/DigitReaderSpec.cxx
@@ -81,18 +81,18 @@ void DigitReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
 
   LOG(info) << "FDD DigitReader pushes " << digitsBC->size() << " digits";
-  pc.outputs().snapshot(Output{mOrigin, "DIGITSBC", 0, Lifetime::Timeframe}, *digitsBC);
-  pc.outputs().snapshot(Output{mOrigin, "DIGITSCH", 0, Lifetime::Timeframe}, *digitsCh);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITSBC", 0}, *digitsBC);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITSCH", 0}, *digitsCh);
 
   if (mUseMC) {
     // TODO: To be replaced with sending ConstMCTruthContainer as soon as reco workflow supports it
-    pc.outputs().snapshot(Output{mOrigin, "TRIGGERINPUT", 0, Lifetime::Timeframe}, *digitsTrig);
+    pc.outputs().snapshot(Output{mOrigin, "TRIGGERINPUT", 0}, *digitsTrig);
 
     std::vector<char> flatbuffer;
     mcTruthRootBuffer->copyandflatten(flatbuffer);
     o2::dataformats::MCTruthContainer<o2::fdd::MCLabel> mcTruth;
     mcTruth.restore_from(flatbuffer.data(), flatbuffer.size());
-    pc.outputs().snapshot(Output{mOrigin, "DIGITLBL", 0, Lifetime::Timeframe}, mcTruth);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITLBL", 0}, mcTruth);
   }
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
@@ -54,7 +54,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FDD", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FDD", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, digits, channels);
   if (mSelIR) {
     mCTFCoder.getIRFramesSelector().clear();

--- a/Detectors/FIT/FDD/workflow/src/RecPointReaderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/RecPointReaderSpec.cxx
@@ -51,8 +51,8 @@ void RecPointReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
 
   LOG(info) << "FDD RecPointReader pushes " << mRecPoints->size() << " recpoints with " << mChannelData->size() << " channels at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, *mRecPoints);
-  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0, Lifetime::Timeframe}, *mChannelData);
+  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0}, *mRecPoints);
+  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0}, *mChannelData);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/FIT/FDD/workflow/src/ReconstructorSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/ReconstructorSpec.cxx
@@ -54,8 +54,8 @@ void FDDReconstructorDPL::run(ProcessingContext& pc)
   }
   // do we ignore MC in this task?
   LOG(debug) << "FDD reconstruction pushes " << mRecPoints.size() << " RecPoints";
-  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, mRecPoints);
-  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0, Lifetime::Timeframe}, mRecChData);
+  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0}, mRecPoints);
+  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0}, mRecChData);
 }
 
 DataProcessorSpec getFDDReconstructorSpec(bool useMC)

--- a/Detectors/FIT/FT0/calibration/testWorkflow/FT0CalibSlewingCollectorSpec.h
+++ b/Detectors/FIT/FT0/calibration/testWorkflow/FT0CalibSlewingCollectorSpec.h
@@ -88,8 +88,8 @@ class FT0CalibCollectorDevice : public o2::framework::Task
       auto entries = collectedInfo.size();
       // this means that we are ready to send the output
       auto entriesPerChannel = mCollector->getEntriesPerChannel();
-      output.snapshot(Output{o2::header::gDataOriginFT0, "COLLECTEDINFO", 0, Lifetime::Timeframe}, collectedInfo);
-      output.snapshot(Output{o2::header::gDataOriginFT0, "ENTRIESCH", 0, Lifetime::Timeframe}, entriesPerChannel);
+      output.snapshot(Output{o2::header::gDataOriginFT0, "COLLECTEDINFO", 0}, collectedInfo);
+      output.snapshot(Output{o2::header::gDataOriginFT0, "ENTRIESCH", 0}, entriesPerChannel);
       mCollector->initOutput(); // reset the output for the next round
     }
   }

--- a/Detectors/FIT/FT0/calibration/testWorkflow/FT0TimeSpectraProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/testWorkflow/FT0TimeSpectraProcessor-Workflow.cxx
@@ -101,7 +101,7 @@ class FT0TimeSpectraProcessor final : public o2::framework::Task
       }
     }
 
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "TIME_SPECTRA", 0, o2::framework::Lifetime::Timeframe}, timeSpectraInfoObject.getBase());
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "TIME_SPECTRA", 0}, timeSpectraInfoObject.getBase());
   }
 };
 

--- a/Detectors/FIT/FT0/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/DigitReaderSpec.cxx
@@ -64,13 +64,13 @@ void DigitReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(debug) << "FT0DigitReader pushed " << channels.size() << " channels in " << digits.size() << " digits";
-  pc.outputs().snapshot(Output{"FT0", "DIGITSBC", 0, Lifetime::Timeframe}, digits);
-  pc.outputs().snapshot(Output{"FT0", "DIGITSCH", 0, Lifetime::Timeframe}, channels);
+  pc.outputs().snapshot(Output{"FT0", "DIGITSBC", 0}, digits);
+  pc.outputs().snapshot(Output{"FT0", "DIGITSCH", 0}, channels);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"FT0", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
+    pc.outputs().snapshot(Output{"FT0", "DIGITSMCTR", 0}, labels);
   }
   if (mUseTrgInput) {
-    pc.outputs().snapshot(Output{"FT0", "TRIGGERINPUT", 0, Lifetime::Timeframe}, trgInput);
+    pc.outputs().snapshot(Output{"FT0", "TRIGGERINPUT", 0}, trgInput);
   }
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
@@ -55,7 +55,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
 
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FT0", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FT0", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, digits, channels);
   if (mSelIR) {
     mCTFCoder.getIRFramesSelector().clear();

--- a/Detectors/FIT/FT0/workflow/src/RecPointReaderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/RecPointReaderSpec.cxx
@@ -49,8 +49,8 @@ void RecPointReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
 
   LOG(debug) << "FT0 RecPointReader pushes " << mRecPoints->size() << " recpoints with " << mChannelData->size() << " channels at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, *mRecPoints);
-  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0, Lifetime::Timeframe}, *mChannelData);
+  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0}, *mRecPoints);
+  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0}, *mChannelData);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/FIT/FT0/workflow/src/ReconstructionSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ReconstructionSpec.cxx
@@ -74,8 +74,8 @@ void ReconstructionDPL::run(ProcessingContext& pc)
   mReco.processTF(digits, channels, mRecPoints, mRecChData);
   // do we ignore MC in this task?
   LOG(debug) << "FT0 reconstruction pushes " << mRecPoints.size() << " RecPoints";
-  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, mRecPoints);
-  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0, Lifetime::Timeframe}, mRecChData);
+  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0}, mRecPoints);
+  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0}, mRecChData);
 
   mTimer.Stop();
 }

--- a/Detectors/FIT/FV0/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/DigitReaderSpec.cxx
@@ -65,13 +65,13 @@ void DigitReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(debug) << "FV0DigitReader pushed " << channels.size() << " channels in " << digits.size() << " digits";
-  pc.outputs().snapshot(Output{"FV0", "DIGITSBC", 0, Lifetime::Timeframe}, digits);
-  pc.outputs().snapshot(Output{"FV0", "DIGITSCH", 0, Lifetime::Timeframe}, channels);
+  pc.outputs().snapshot(Output{"FV0", "DIGITSBC", 0}, digits);
+  pc.outputs().snapshot(Output{"FV0", "DIGITSCH", 0}, channels);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"FV0", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
+    pc.outputs().snapshot(Output{"FV0", "DIGITSMCTR", 0}, labels);
   }
   if (mUseTrgInput) {
-    pc.outputs().snapshot(Output{"FV0", "TRIGGERINPUT", 0, Lifetime::Timeframe}, trgInput);
+    pc.outputs().snapshot(Output{"FV0", "TRIGGERINPUT", 0}, trgInput);
   }
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
@@ -55,7 +55,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
 
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FV0", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FV0", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, digits, channels);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/FIT/FV0/workflow/src/RecPointReaderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/RecPointReaderSpec.cxx
@@ -49,8 +49,8 @@ void RecPointReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
 
   LOG(debug) << "FV0 RecPointReader pushes " << mRecPoints->size() << " recpoints with " << mChannelData->size() << " channels at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, *mRecPoints);
-  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0, Lifetime::Timeframe}, *mChannelData);
+  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0}, *mRecPoints);
+  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0}, *mChannelData);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/FIT/FV0/workflow/src/ReconstructionSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/ReconstructionSpec.cxx
@@ -68,8 +68,8 @@ void ReconstructionDPL::run(ProcessingContext& pc)
   }
 
   LOG(debug) << "FV0 reconstruction pushes " << mRecPoints.size() << " RecPoints";
-  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, mRecPoints);
-  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0, Lifetime::Timeframe}, mRecChData);
+  pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0}, mRecPoints);
+  pc.outputs().snapshot(Output{mOrigin, "RECCHDATA", 0}, mRecChData);
 
   mTimer.Stop();
 }

--- a/Detectors/FIT/workflow/include/FITWorkflow/RawReaderFIT.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/RawReaderFIT.h
@@ -165,28 +165,28 @@ class RawReaderFIT : public RawReaderType
   }
   void makeSnapshot(o2::framework::ProcessingContext& pc) const
   {
-    pc.outputs().snapshot(o2::framework::Output{mDataOrigin, Digit_t::sChannelNameDPL, 0, o2::framework::Lifetime::Timeframe}, mVecDigit);
+    pc.outputs().snapshot(o2::framework::Output{mDataOrigin, Digit_t::sChannelNameDPL, 0}, mVecDigit);
     if constexpr (sSubDigitExists) {
       std::apply([&](const auto&... subDigit) {
-        ((pc.outputs().snapshot(o2::framework::Output{mDataOrigin, (std::decay<decltype(subDigit)>::type::value_type::sChannelNameDPL), 0, o2::framework::Lifetime::Timeframe}, subDigit)), ...);
+        ((pc.outputs().snapshot(o2::framework::Output{mDataOrigin, (std::decay<decltype(subDigit)>::type::value_type::sChannelNameDPL), 0}, subDigit)), ...);
       },
                  mVecSubDigit);
     }
     if constexpr (sSingleSubDigitExists) {
       std::apply([&](const auto&... singleSubDigit) {
-        ((pc.outputs().snapshot(o2::framework::Output{mDataOrigin, (std::decay<decltype(singleSubDigit)>::type::value_type::sChannelNameDPL), 0, o2::framework::Lifetime::Timeframe}, singleSubDigit)), ...);
+        ((pc.outputs().snapshot(o2::framework::Output{mDataOrigin, (std::decay<decltype(singleSubDigit)>::type::value_type::sChannelNameDPL), 0}, singleSubDigit)), ...);
       },
                  mVecSingleSubDigit);
     }
     if constexpr (sUseTrgInput) {
-      pc.outputs().snapshot(o2::framework::Output{mDataOrigin, DetTrigInput_t::sChannelNameDPL, 0, o2::framework::Lifetime::Timeframe}, mVecTrgInput);
+      pc.outputs().snapshot(o2::framework::Output{mDataOrigin, DetTrigInput_t::sChannelNameDPL, 0}, mVecTrgInput);
     }
-    pc.outputs().snapshot(o2::framework::Output{mDataOrigin, "RawDataMetric", 0, o2::framework::Lifetime::Timeframe}, mVecRawDataMetric);
+    pc.outputs().snapshot(o2::framework::Output{mDataOrigin, "RawDataMetric", 0}, mVecRawDataMetric);
   }
   template <typename VecDigitType>
   auto& getRefVec(o2::framework::ProcessingContext& pc)
   {
-    auto& refVec = pc.outputs().make<VecDigitType>(o2::framework::Output{mDataOrigin, VecDigitType::value_type::sChannelNameDPL, 0, o2::framework::Lifetime::Timeframe});
+    auto& refVec = pc.outputs().make<VecDigitType>(o2::framework::Output{mDataOrigin, VecDigitType::value_type::sChannelNameDPL, 0});
     return refVec;
   }
   void enableEmptyTFprotection()

--- a/Detectors/FOCAL/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/FOCAL/workflow/src/RawDecoderSpec.cxx
@@ -274,10 +274,10 @@ void RawDecoderSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
 
 void RawDecoderSpec::sendOutput(framework::ProcessingContext& ctx)
 {
-  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "PADLAYERS", mOutputSubspec, framework::Lifetime::Timeframe}, mOutputPadLayers);
-  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "PIXELHITS", mOutputSubspec, framework::Lifetime::Timeframe}, mOutputPixelHits);
-  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "PIXELCHIPS", mOutputSubspec, framework::Lifetime::Timeframe}, mOutputPixelChips);
-  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "TRIGGERS", mOutputSubspec, framework::Lifetime::Timeframe}, mOutputTriggerRecords);
+  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "PADLAYERS", mOutputSubspec}, mOutputPadLayers);
+  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "PIXELHITS", mOutputSubspec}, mOutputPixelHits);
+  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "PIXELCHIPS", mOutputSubspec}, mOutputPixelChips);
+  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginFOC, "TRIGGERS", mOutputSubspec}, mOutputTriggerRecords);
 }
 
 void RawDecoderSpec::resetContainers()

--- a/Detectors/Filtering/src/FilteredTFReaderSpec.cxx
+++ b/Detectors/Filtering/src/FilteredTFReaderSpec.cxx
@@ -45,15 +45,15 @@ void FilteredTFReader::run(ProcessingContext& pc)
 
   LOG(info) << "Pushing filtered TF: " << mFiltTF.header.asString();
   // ITS
-  pc.outputs().snapshot(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, mFiltTF.ITSTrackROFs);
-  pc.outputs().snapshot(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe}, mFiltTF.ITSTracks);
-  pc.outputs().snapshot(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe}, mFiltTF.ITSClusterIndices);
+  pc.outputs().snapshot(Output{"ITS", "ITSTrackROF", 0}, mFiltTF.ITSTrackROFs);
+  pc.outputs().snapshot(Output{"ITS", "TRACKS", 0}, mFiltTF.ITSTracks);
+  pc.outputs().snapshot(Output{"ITS", "TRACKCLSID", 0}, mFiltTF.ITSClusterIndices);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, mFiltTF.ITSTrackMCTruth);
+    pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0}, mFiltTF.ITSTrackMCTruth);
   }
-  pc.outputs().snapshot(Output{"ITS", "CLUSTERSROF", 0, Lifetime::Timeframe}, mFiltTF.ITSClusterROFs);
-  pc.outputs().snapshot(Output{"ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe}, mFiltTF.ITSClusters);
-  pc.outputs().snapshot(Output{"ITS", "PATTERNS", 0, Lifetime::Timeframe}, mFiltTF.ITSClusterPatterns);
+  pc.outputs().snapshot(Output{"ITS", "CLUSTERSROF", 0}, mFiltTF.ITSClusterROFs);
+  pc.outputs().snapshot(Output{"ITS", "COMPCLUSTERS", 0}, mFiltTF.ITSClusters);
+  pc.outputs().snapshot(Output{"ITS", "PATTERNS", 0}, mFiltTF.ITSClusterPatterns);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/NoInpDummyOutSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/NoInpDummyOutSpec.cxx
@@ -47,7 +47,7 @@ void NoInpDummyOut::run(ProcessingContext& pc)
 {
   static int counter = 0;
   // send just once dummy output to trigger the ccdb-fetcher
-  pc.outputs().make<std::vector<char>>(Output{"GLO", "DUMMY_OUT", 0, Lifetime::Timeframe});
+  pc.outputs().make<std::vector<char>>(Output{"GLO", "DUMMY_OUT", 0});
   if (mLoops >= 0 && ++counter >= mLoops) {
     pc.services().get<o2::framework::ControlService>().endOfStream();
     pc.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);

--- a/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
@@ -71,7 +71,7 @@ void ITSTPCMatchingQCDevice::sendOutput(DataAllocator& output)
 
   TObjArray objar;
   mMatchITSTPCQC->getHistos(objar);
-  output.snapshot(Output{"GLO", "ITSTPCMATCHQC", 0, Lifetime::Sporadic}, objar);
+  output.snapshot(Output{"GLO", "ITSTPCMATCHQC", 0}, objar);
 
   TFile* f = new TFile(Form("outITSTPCmatchingQC.root"), "RECREATE");
   objar.Write("ObjArray", TObject::kSingleKey);

--- a/Detectors/GlobalTrackingWorkflow/readers/src/GlobalFwdTrackReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/GlobalFwdTrackReaderSpec.cxx
@@ -65,9 +65,9 @@ void GlobalFwdTrackReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " Global Forward tracks at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "GLFWD", 0, Lifetime::Timeframe}, mTracks);
+  pc.outputs().snapshot(Output{"GLO", "GLFWD", 0}, mTracks);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "GLFWD_MC", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{"GLO", "GLFWD_MC", 0}, mLabels);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/GlobalTrackingWorkflow/readers/src/IRFrameReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/IRFrameReaderSpec.cxx
@@ -63,7 +63,7 @@ void IRFrameReaderSpec::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(debug) << "Pushing " << mIRF.size() << " IR-frames in at entry " << ent;
-  pc.outputs().snapshot(Output{mDataOrigin, "IRFRAMES", mSubSpec, Lifetime::Timeframe}, mIRF);
+  pc.outputs().snapshot(Output{mDataOrigin, "IRFRAMES", mSubSpec}, mIRF);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/GlobalTrackingWorkflow/readers/src/MatchedMFTMCHReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/MatchedMFTMCHReaderSpec.cxx
@@ -65,7 +65,7 @@ void MatchMFTMCHReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " MFTMCH matches at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "MTC_MFTMCH", 0, Lifetime::Timeframe}, mTracks);
+  pc.outputs().snapshot(Output{"GLO", "MTC_MFTMCH", 0}, mTracks);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/GlobalTrackingWorkflow/readers/src/PrimaryVertexReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/PrimaryVertexReaderSpec.cxx
@@ -84,12 +84,12 @@ void PrimaryVertexReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mVerticesPtr->size() << " vertices at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "PVTX", 0, Lifetime::Timeframe}, mVertices);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTC", 0, Lifetime::Timeframe}, mPV2MatchIdx);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTCREFS", 0, Lifetime::Timeframe}, mPV2MatchIdxRef);
+  pc.outputs().snapshot(Output{"GLO", "PVTX", 0}, mVertices);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTC", 0}, mPV2MatchIdx);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTCREFS", 0}, mPV2MatchIdxRef);
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "PVTX_MCTR", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{"GLO", "PVTX_MCTR", 0}, mLabels);
   }
 
   if (mVerbose) {

--- a/Detectors/GlobalTrackingWorkflow/readers/src/SecondaryVertexReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/SecondaryVertexReaderSpec.cxx
@@ -93,15 +93,15 @@ void SecondaryVertexReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mV0s.size() << " V0s and " << mCascs.size() << " cascades at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "V0S_IDX", 0, Lifetime::Timeframe}, mV0sIdx);
-  pc.outputs().snapshot(Output{"GLO", "V0S", 0, Lifetime::Timeframe}, mV0s);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_V0REFS", 0, Lifetime::Timeframe}, mPV2V0Ref);
-  pc.outputs().snapshot(Output{"GLO", "CASCS_IDX", 0, Lifetime::Timeframe}, mCascsIdx);
-  pc.outputs().snapshot(Output{"GLO", "CASCS", 0, Lifetime::Timeframe}, mCascs);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_CASCREFS", 0, Lifetime::Timeframe}, mPV2CascRef);
-  pc.outputs().snapshot(Output{"GLO", "DECAYS3BODY_IDX", 0, Lifetime::Timeframe}, m3BodysIdx);
-  pc.outputs().snapshot(Output{"GLO", "DECAYS3BODY", 0, Lifetime::Timeframe}, m3Bodys);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_3BODYREFS", 0, Lifetime::Timeframe}, mPV23BodyRef);
+  pc.outputs().snapshot(Output{"GLO", "V0S_IDX", 0}, mV0sIdx);
+  pc.outputs().snapshot(Output{"GLO", "V0S", 0}, mV0s);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_V0REFS", 0}, mPV2V0Ref);
+  pc.outputs().snapshot(Output{"GLO", "CASCS_IDX", 0}, mCascsIdx);
+  pc.outputs().snapshot(Output{"GLO", "CASCS", 0}, mCascs);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_CASCREFS", 0}, mPV2CascRef);
+  pc.outputs().snapshot(Output{"GLO", "DECAYS3BODY_IDX", 0}, m3BodysIdx);
+  pc.outputs().snapshot(Output{"GLO", "DECAYS3BODY", 0}, m3Bodys);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_3BODYREFS", 0}, mPV23BodyRef);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/GlobalTrackingWorkflow/readers/src/StrangenessTrackingReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/StrangenessTrackingReaderSpec.cxx
@@ -76,14 +76,14 @@ void StrangenessTrackingReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mStrangeTrack.size() << " strange tracks at entry " << ent;
-  pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS", 0, Lifetime::Timeframe}, mStrangeTrack);
+  pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS", 0}, mStrangeTrack);
 
   if (mUseMC) {
     LOG(info) << "Pushing " << mStrangeTrackMC.size() << " strange tracks MC labels at entry " << ent;
-    pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS_MC", 0, Lifetime::Timeframe}, mStrangeTrackMC);
+    pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS_MC", 0}, mStrangeTrackMC);
   }
 
-  // pc.outputs().snapshot(Output{"GLO", "PVTX_V0REFS", 0, Lifetime::Timeframe}, mPV2V0Ref);
+  // pc.outputs().snapshot(Output{"GLO", "PVTX_V0REFS", 0}, mPV2V0Ref);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/GlobalTrackingWorkflow/readers/src/TrackCosmicsReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/TrackCosmicsReaderSpec.cxx
@@ -41,9 +41,9 @@ void TrackCosmicsReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " Cosmic Tracks at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "COSMICTRC", 0, Lifetime::Timeframe}, mTracks);
+  pc.outputs().snapshot(Output{"GLO", "COSMICTRC", 0}, mTracks);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "COSMICTRC_MC", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{"GLO", "COSMICTRC_MC", 0}, mLabels);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/GlobalTrackingWorkflow/readers/src/TrackTPCITSReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/TrackTPCITSReaderSpec.cxx
@@ -68,12 +68,12 @@ void TrackTPCITSReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " TPC-ITS matches at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "TPCITS", 0, Lifetime::Timeframe}, mTracks);
-  pc.outputs().snapshot(Output{"GLO", "TPCITSAB_REFS", 0, Lifetime::Timeframe}, mABTrkClusRefs);
-  pc.outputs().snapshot(Output{"GLO", "TPCITSAB_CLID", 0, Lifetime::Timeframe}, mABTrkClIDs);
+  pc.outputs().snapshot(Output{"GLO", "TPCITS", 0}, mTracks);
+  pc.outputs().snapshot(Output{"GLO", "TPCITSAB_REFS", 0}, mABTrkClusRefs);
+  pc.outputs().snapshot(Output{"GLO", "TPCITSAB_CLID", 0}, mABTrkClIDs);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "TPCITS_MC", 0, Lifetime::Timeframe}, mLabels);
-    pc.outputs().snapshot(Output{"GLO", "TPCITSAB_MC", 0, Lifetime::Timeframe}, mLabelsAB);
+    pc.outputs().snapshot(Output{"GLO", "TPCITS_MC", 0}, mLabels);
+    pc.outputs().snapshot(Output{"GLO", "TPCITSAB_MC", 0}, mLabelsAB);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -99,9 +99,9 @@ void CosmicsMatchingSpec::run(ProcessingContext& pc)
   updateTimeDependentParams(pc); // Make sure this is called after recoData.collectData, which may load some conditions
 
   mMatching.process(recoData);
-  pc.outputs().snapshot(Output{"GLO", "COSMICTRC", 0, Lifetime::Timeframe}, mMatching.getCosmicTracks());
+  pc.outputs().snapshot(Output{"GLO", "COSMICTRC", 0}, mMatching.getCosmicTracks());
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "COSMICTRC_MC", 0, Lifetime::Timeframe}, mMatching.getCosmicTracksLbl());
+    pc.outputs().snapshot(Output{"GLO", "COSMICTRC_MC", 0}, mMatching.getCosmicTracksLbl());
   }
   mTimer.Stop();
 }

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
@@ -92,18 +92,18 @@ void GlobalFwdMatchingDPL::run(ProcessingContext& pc)
   const auto& matchingParam = GlobalFwdMatchingParam::Instance();
 
   if (matchingParam.saveMode == kSaveTrainingData) {
-    pc.outputs().snapshot(Output{"GLO", "GLFWDMFT", 0, Lifetime::Timeframe}, mMatching.getMFTMatchingPlaneParams());
-    pc.outputs().snapshot(Output{"GLO", "GLFWDMCH", 0, Lifetime::Timeframe}, mMatching.getMCHMatchingPlaneParams());
-    pc.outputs().snapshot(Output{"GLO", "GLFWDINF", 0, Lifetime::Timeframe}, mMatching.getMFTMCHMatchInfo());
+    pc.outputs().snapshot(Output{"GLO", "GLFWDMFT", 0}, mMatching.getMFTMatchingPlaneParams());
+    pc.outputs().snapshot(Output{"GLO", "GLFWDMCH", 0}, mMatching.getMCHMatchingPlaneParams());
+    pc.outputs().snapshot(Output{"GLO", "GLFWDINF", 0}, mMatching.getMFTMCHMatchInfo());
   } else {
-    pc.outputs().snapshot(Output{"GLO", "GLFWD", 0, Lifetime::Timeframe}, mMatching.getMatchedFwdTracks());
+    pc.outputs().snapshot(Output{"GLO", "GLFWD", 0}, mMatching.getMatchedFwdTracks());
   }
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "GLFWD_MC", 0, Lifetime::Timeframe}, mMatching.getMatchLabels());
+    pc.outputs().snapshot(Output{"GLO", "GLFWD_MC", 0}, mMatching.getMatchLabels());
   }
   if (mMatchRootOutput) {
-    pc.outputs().snapshot(Output{"GLO", "MTC_MFTMCH", 0, Lifetime::Timeframe}, mMatching.getMFTMCHMatchInfo());
+    pc.outputs().snapshot(Output{"GLO", "MTC_MFTMCH", 0}, mMatching.getMFTMCHMatchInfo());
   }
   mTimer.Stop();
 }

--- a/Detectors/GlobalTrackingWorkflow/src/HMPMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/HMPMatcherSpec.cxx
@@ -128,9 +128,9 @@ void HMPMatcherSpec::run(ProcessingContext& pc)
 
   mMatcher.run(recoData);
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MATCHES", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector(o2::globaltracking::MatchHMP::trackType::CONSTR));
+  pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MATCHES", 0}, mMatcher.getMatchedTrackVector(o2::globaltracking::MatchHMP::trackType::CONSTR));
   if (mUseMC) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MCLABELS", 0, Lifetime::Timeframe}, mMatcher.getMatchedHMPLabelsVector(o2::globaltracking::MatchHMP::trackType::CONSTR));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MCLABELS", 0}, mMatcher.getMatchedHMPLabelsVector(o2::globaltracking::MatchHMP::trackType::CONSTR));
   }
 
   mTimer.Stop();

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -152,12 +152,12 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
     mVertexer.process(tracks, gids, ft0Data, vertices, vertexTrackIDs, v2tRefs, tracksMCInfo, lblVtx);
   }
 
-  pc.outputs().snapshot(Output{"GLO", "PVTX", 0, Lifetime::Timeframe}, vertices);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_CONTIDREFS", 0, Lifetime::Timeframe}, v2tRefs);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_CONTID", 0, Lifetime::Timeframe}, vertexTrackIDs);
+  pc.outputs().snapshot(Output{"GLO", "PVTX", 0}, vertices);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_CONTIDREFS"}, v2tRefs);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_CONTID", 0}, vertexTrackIDs);
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "PVTX_MCTR", 0, Lifetime::Timeframe}, lblVtx);
+    pc.outputs().snapshot(Output{"GLO", "PVTX_MCTR", 0}, lblVtx);
   }
 
   mTimer.Stop();

--- a/Detectors/GlobalTrackingWorkflow/src/StrangenessTrackingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/StrangenessTrackingSpec.cxx
@@ -75,11 +75,11 @@ void StrangenessTrackerSpec::run(framework::ProcessingContext& pc)
   mTracker.loadData(recoData);
   mTracker.prepareITStracks();
   mTracker.process();
-  pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS", 0, Lifetime::Timeframe}, mTracker.getStrangeTrackVec());
-  pc.outputs().snapshot(Output{"GLO", "CLUSUPDATES", 0, Lifetime::Timeframe}, mTracker.getClusAttachments());
+  pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS", 0}, mTracker.getStrangeTrackVec());
+  pc.outputs().snapshot(Output{"GLO", "CLUSUPDATES", 0}, mTracker.getClusAttachments());
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS_MC", 0, Lifetime::Timeframe}, mTracker.getStrangeTrackLabels());
+    pc.outputs().snapshot(Output{"GLO", "STRANGETRACKS_MC", 0}, mTracker.getStrangeTrackLabels());
   }
 
   mTimer.Stop();

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
@@ -171,8 +171,8 @@ void TOFMatcherSpec::run(ProcessingContext& pc)
   static pmr::vector<o2::MCCompLabel> dummyMCLab;
 
   if (isTPCused) {
-    auto& mtcInfo = pc.outputs().make<std::vector<o2::dataformats::MatchInfoTOF>>(Output{o2::header::gDataOriginTOF, "MTC_TPC", ss, Lifetime::Timeframe});
-    auto& mclabels = mUseMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{o2::header::gDataOriginTOF, "MCMTC_TPC", ss, Lifetime::Timeframe}) : dummyMCLab;
+    auto& mtcInfo = pc.outputs().make<std::vector<o2::dataformats::MatchInfoTOF>>(Output{o2::header::gDataOriginTOF, "MTC_TPC", ss});
+    auto& mclabels = mUseMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{o2::header::gDataOriginTOF, "MCMTC_TPC", ss}) : dummyMCLab;
     auto& tracksTPCTOF = pc.outputs().make<std::vector<o2::dataformats::TrackTPCTOF>>(OutputRef{"tpctofTracks", ss});
     auto nmatch = mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::TPC).size();
     LOG(debug) << (mDoTPCRefit ? "Refitting " : "Shifting Z for ") << nmatch << " matched TPC tracks with TOF time info";
@@ -180,48 +180,48 @@ void TOFMatcherSpec::run(ProcessingContext& pc)
   }
 
   if (isITSTPCused) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPC));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPC", 0}, mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPC));
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMTC_ITSTPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPC));
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMTC_ITSTPC", 0}, mMatcher.getMatchedTOFLabelsVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPC));
     }
   }
 
   if (isTPCTRDused) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_TPCTRD", ss, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::TPCTRD));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_TPCTRD", ss}, mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::TPCTRD));
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMTC_TPCTRD", ss, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector(o2::dataformats::MatchInfoTOFReco::TrackType::TPCTRD));
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMTC_TPCTRD", ss}, mMatcher.getMatchedTOFLabelsVector(o2::dataformats::MatchInfoTOFReco::TrackType::TPCTRD));
     }
   }
 
   if (isITSTPCTRDused) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPCTRD", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPCTRD));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPCTRD", 0}, mMatcher.getMatchedTrackVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPCTRD));
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMTC_ITSTPCTRD", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPCTRD));
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMTC_ITSTPCTRD", 0}, mMatcher.getMatchedTOFLabelsVector(o2::dataformats::MatchInfoTOFReco::TrackType::ITSTPCTRD));
     }
   }
 
   // TODO: TRD-matched tracks
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0}, mMatcher.getCalibVector());
 
   if (mPushMatchable) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_0", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(0));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_1", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(1));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_2", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(2));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_3", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(3));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_4", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(4));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_5", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(5));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_6", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(6));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_7", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(7));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_8", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(8));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_9", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(9));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_10", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(10));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_11", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(11));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_12", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(12));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_13", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(13));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_14", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(14));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_15", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(15));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_16", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(16));
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_17", 0, Lifetime::Timeframe}, mMatcher.getMatchedTracksPair(17));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_0", 0}, mMatcher.getMatchedTracksPair(0));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_1", 0}, mMatcher.getMatchedTracksPair(1));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_2", 0}, mMatcher.getMatchedTracksPair(2));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_3", 0}, mMatcher.getMatchedTracksPair(3));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_4", 0}, mMatcher.getMatchedTracksPair(4));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_5", 0}, mMatcher.getMatchedTracksPair(5));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_6", 0}, mMatcher.getMatchedTracksPair(6));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_7", 0}, mMatcher.getMatchedTracksPair(7));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_8", 0}, mMatcher.getMatchedTracksPair(8));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_9", 0}, mMatcher.getMatchedTracksPair(9));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_10", 0}, mMatcher.getMatchedTracksPair(10));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_11", 0}, mMatcher.getMatchedTracksPair(11));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_12", 0}, mMatcher.getMatchedTracksPair(12));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_13", 0}, mMatcher.getMatchedTracksPair(13));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_14", 0}, mMatcher.getMatchedTracksPair(14));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_15", 0}, mMatcher.getMatchedTracksPair(15));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_16", 0}, mMatcher.getMatchedTracksPair(16));
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHABLES_17", 0}, mMatcher.getMatchedTracksPair(17));
   }
 
   mTimer.Stop();

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -103,12 +103,12 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   static pmr::vector<o2::MCCompLabel> dummyMCLab, dummyMCLabAB;
   static pmr::vector<o2::dataformats::Triplet<float, float, float>> dummyCalib;
 
-  auto& matchedTracks = pc.outputs().make<std::vector<o2::dataformats::TrackTPCITS>>(Output{"GLO", "TPCITS", 0, Lifetime::Timeframe});
-  auto& ABTrackletRefs = pc.outputs().make<std::vector<o2::itsmft::TrkClusRef>>(Output{"GLO", "TPCITSAB_REFS", 0, Lifetime::Timeframe});
-  auto& ABTrackletClusterIDs = pc.outputs().make<std::vector<int>>(Output{"GLO", "TPCITSAB_CLID", 0, Lifetime::Timeframe});
-  auto& matchLabels = mUseMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"GLO", "TPCITS_MC", 0, Lifetime::Timeframe}) : dummyMCLab;
-  auto& ABTrackletLabels = mUseMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"GLO", "TPCITSAB_MC", 0, Lifetime::Timeframe}) : dummyMCLabAB;
-  auto& calib = mCalibMode ? pc.outputs().make<std::vector<o2::dataformats::Triplet<float, float, float>>>(Output{"GLO", "TPCITS_VDTGL", 0, Lifetime::Timeframe}) : dummyCalib;
+  auto& matchedTracks = pc.outputs().make<std::vector<o2::dataformats::TrackTPCITS>>(Output{"GLO", "TPCITS", 0});
+  auto& ABTrackletRefs = pc.outputs().make<std::vector<o2::itsmft::TrkClusRef>>(Output{"GLO", "TPCITSAB_REFS", 0});
+  auto& ABTrackletClusterIDs = pc.outputs().make<std::vector<int>>(Output{"GLO", "TPCITSAB_CLID", 0});
+  auto& matchLabels = mUseMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"GLO", "TPCITS_MC", 0}) : dummyMCLab;
+  auto& ABTrackletLabels = mUseMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"GLO", "TPCITSAB_MC", 0}) : dummyMCLabAB;
+  auto& calib = mCalibMode ? pc.outputs().make<std::vector<o2::dataformats::Triplet<float, float, float>>>(Output{"GLO", "TPCITS_VDTGL", 0}) : dummyCalib;
 
   mMatching.run(recoData, matchedTracks, ABTrackletRefs, ABTrackletClusterIDs, matchLabels, ABTrackletLabels, calib);
 

--- a/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
@@ -78,8 +78,8 @@ void VertexTrackMatcherSpec::run(ProcessingContext& pc)
 
   mMatcher.process(recoData, trackIndex, vtxRefs);
 
-  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTC", 0, Lifetime::Timeframe}, trackIndex);
-  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTCREFS", 0, Lifetime::Timeframe}, vtxRefs);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTC", 0}, trackIndex);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTCREFS", 0}, vtxRefs);
 
   mTimer.Stop();
   LOG(info) << "Made " << trackIndex.size() << " track associations for " << recoData.getPrimaryVertices().size()

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCDataFilter.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCDataFilter.cxx
@@ -107,10 +107,10 @@ void TPCDataFilter::run(ProcessingContext& pc)
 void TPCDataFilter::sendOutput(ProcessingContext& pc)
 {
 
-  pc.outputs().snapshot(Output{"TPC", "TRACKSF", 0, Lifetime::Timeframe}, mTracksFiltered);
-  pc.outputs().snapshot(Output{"TPC", "CLUSREFSF", 0, Lifetime::Timeframe}, mTrackClusIdxFiltered);
+  pc.outputs().snapshot(Output{"TPC", "TRACKSF", 0}, mTracksFiltered);
+  pc.outputs().snapshot(Output{"TPC", "CLUSREFSF", 0}, mTrackClusIdxFiltered);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBLF", 0, Lifetime::Timeframe}, mTPCTrkLabelsFiltered);
+    pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBLF", 0}, mTPCTrkLabelsFiltered);
   }
 
   o2::tpc::TPCSectorHeader clusterOutputSectorHeader{0};
@@ -118,7 +118,7 @@ void TPCDataFilter::sendOutput(ProcessingContext& pc)
   for (int i = 0; i < o2::tpc::constants::MAXSECTOR; i++) {
     clusterOutputSectorHeader.sectorBits = (1ul << i);
     o2::header::DataHeader::SubSpecificationType subspec = i;
-    char* buffer = pc.outputs().make<char>({o2::header::gDataOriginTPC, "CLUSTERNATIVEF", subspec, Lifetime::Timeframe, {clusterOutputSectorHeader}},
+    char* buffer = pc.outputs().make<char>({o2::header::gDataOriginTPC, "CLUSTERNATIVEF", subspec, {clusterOutputSectorHeader}},
                                            mClusFiltered.nClustersSector[i] * sizeof(*mClusFiltered.clustersLinear) + sizeof(o2::tpc::ClusterCountIndex))
                      .data();
     o2::tpc::ClusterCountIndex* outIndex = reinterpret_cast<o2::tpc::ClusterCountIndex*>(buffer);
@@ -138,7 +138,7 @@ void TPCDataFilter::sendOutput(ProcessingContext& pc)
       }
       o2::dataformats::ConstMCLabelContainer contflat;
       cont.flatten_to(contflat);
-      pc.outputs().snapshot({o2::header::gDataOriginTPC, "CLNATIVEMCLBLF", subspec, Lifetime::Timeframe, {clusterOutputSectorHeader}}, contflat);
+      pc.outputs().snapshot({o2::header::gDataOriginTPC, "CLNATIVEMCLBLF", subspec, {clusterOutputSectorHeader}}, contflat);
     }
   }
 }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -133,18 +133,18 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   LOGF(info, "TPC interpolation timing: Cpu: %.3e Real: %.3e s", mTimer.CpuTime(), mTimer.RealTime());
   if (SpacePointsCalibConfParam::Instance().writeUnfiltered) {
     // these are the residuals and tracks before outlier rejection; they are not used in production
-    pc.outputs().snapshot(Output{"GLO", "TPCINT_RES", 0, Lifetime::Timeframe}, mInterpolation.getClusterResidualsUnfiltered());
+    pc.outputs().snapshot(Output{"GLO", "TPCINT_RES", 0}, mInterpolation.getClusterResidualsUnfiltered());
     if (mSendTrackData) {
-      pc.outputs().snapshot(Output{"GLO", "TPCINT_TRK", 0, Lifetime::Timeframe}, mInterpolation.getReferenceTracksUnfiltered());
+      pc.outputs().snapshot(Output{"GLO", "TPCINT_TRK", 0}, mInterpolation.getReferenceTracksUnfiltered());
     }
   }
-  pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0, Lifetime::Timeframe}, mInterpolation.getClusterResiduals());
-  pc.outputs().snapshot(Output{"GLO", "TRKREFS", 0, Lifetime::Timeframe}, mInterpolation.getTrackDataCompact());
+  pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0}, mInterpolation.getClusterResiduals());
+  pc.outputs().snapshot(Output{"GLO", "TRKREFS", 0}, mInterpolation.getTrackDataCompact());
   if (mSendTrackData) {
-    pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0, Lifetime::Timeframe}, mInterpolation.getReferenceTracks());
+    pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0}, mInterpolation.getReferenceTracks());
   }
   if (mDebugOutput) {
-    pc.outputs().snapshot(Output{"GLO", "TRKDATAEXT", 0, Lifetime::Timeframe}, mInterpolation.getTrackDataExtended());
+    pc.outputs().snapshot(Output{"GLO", "TRKDATAEXT", 0}, mInterpolation.getTrackDataExtended());
   }
   mInterpolation.reset();
 }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCUnbinnedResidualReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCUnbinnedResidualReaderSpec.cxx
@@ -56,11 +56,11 @@ void TPCUnbinnedResidualReader::run(ProcessingContext& pc)
   assert(currEntry < mTreeIn->GetEntries()); // this should not happen
   mTreeIn->GetEntry(currEntry);
   LOG(info) << "Pushing " << mUnbinnedResid.size() << " unbinned residuals at entry " << currEntry;
-  pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0, Lifetime::Timeframe}, mUnbinnedResid);
-  pc.outputs().snapshot(Output{"GLO", "TRKREFS", 0, Lifetime::Timeframe}, mTrackDataCompact);
+  pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0}, mUnbinnedResid);
+  pc.outputs().snapshot(Output{"GLO", "TRKREFS", 0}, mTrackDataCompact);
   if (mTrackInput) {
     LOG(info) << "Pushing " << mTrackData.size() << " reference tracks for these residuals";
-    pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0, Lifetime::Timeframe}, mTrackData);
+    pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0}, mTrackData);
   }
 
   if (mTreeIn->GetReadEntry() + 1 >= mTreeIn->GetEntries()) {

--- a/Detectors/HMPID/workflow/src/ClustersReaderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/ClustersReaderSpec.cxx
@@ -71,8 +71,8 @@ void ClusterReaderTask::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
 
-  pc.outputs().snapshot(Output{"HMP", "CLUSTERS", 0, Lifetime::Timeframe}, mClustersFromFile);
-  pc.outputs().snapshot(Output{"HMP", "INTRECORDS1", 0, Lifetime::Timeframe}, mClusterTriggersFromFile);
+  pc.outputs().snapshot(Output{"HMP", "CLUSTERS", 0}, mClustersFromFile);
+  pc.outputs().snapshot(Output{"HMP", "INTRECORDS1", 0}, mClusterTriggersFromFile);
   mClustersReceived += mClustersFromFile.size();
   LOG(info) << "[HMPID ClusterReader - run() ] clusters  = " << mClustersFromFile.size();
 

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
@@ -87,8 +87,8 @@ void DataDecoderTask::run(framework::ProcessingContext& pc)
   //  decodeReadout(pc);
   // decodeRawFile(pc);
 
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mDigits);
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mIntReco);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "DIGITS", 0}, mDeco->mDigits);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS", 0}, mDeco->mIntReco);
 
   LOG(debug) << "Writing   Digitis=" << mDeco->mDigits.size() << "/" << mTotalDigits << " Frame=" << mTotalFrames << " IntRec " << mDeco->mIntReco;
   mExTimer.elapseMes("Decoding... Digits decoded = " + std::to_string(mTotalDigits) + " Frames received = " + std::to_string(mTotalFrames));

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
@@ -93,8 +93,8 @@ void DataDecoderTask2::run(framework::ProcessingContext& pc)
 
   // Output the Digits/Triggers vector
   orderTriggers();
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mDigits);
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS", 0, o2::framework::Lifetime::Timeframe}, mTriggers);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "DIGITS", 0}, mDeco->mDigits);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS", 0}, mTriggers);
 
   mExTimer.elapseMes("Decoding... Digits decoded = " + std::to_string(mTotalDigits) + " Frames received = " + std::to_string(mTotalFrames));
   return;

--- a/Detectors/HMPID/workflow/src/DigitsReaderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DigitsReaderSpec.cxx
@@ -115,8 +115,8 @@ void DigitReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
 
-  pc.outputs().snapshot(Output{"HMP", "DIGITS", 0, Lifetime::Timeframe}, mDigitsFromFile);
-  pc.outputs().snapshot(Output{"HMP", "INTRECORDS", 0, Lifetime::Timeframe}, mTriggersFromFile);
+  pc.outputs().snapshot(Output{"HMP", "DIGITS", 0}, mDigitsFromFile);
+  pc.outputs().snapshot(Output{"HMP", "INTRECORDS", 0}, mTriggersFromFile);
   mDigitsReceived += mDigitsFromFile.size();
   LOG(info) << "[HMPID DigitsReader - run() ] digits  = " << mDigitsFromFile.size();
 

--- a/Detectors/HMPID/workflow/src/DigitsToClustersSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DigitsToClustersSpec.cxx
@@ -116,8 +116,8 @@ void DigitsToClustersTask::run(framework::ProcessingContext& pc)
   mDigitsReceived += digits.size();
   mClustersReceived += clusters.size();
 
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, clusters);
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS1", 0, o2::framework::Lifetime::Timeframe}, clusterTriggers);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "CLUSTERS", 0}, clusters);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS1", 0}, clusterTriggers);
 
   mExTimer.elapseMes("Clusterization of Digits received = " + std::to_string(mDigitsReceived));
   mExTimer.elapseMes("Clusterization of Clusters received = " + std::to_string(mClustersReceived));

--- a/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
@@ -72,7 +72,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"HMP", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"HMP", "CTFDATA", 0});
 
   auto iosize = mCTFCoder.encode(buffer, triggers, digits);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);

--- a/Detectors/HMPID/workflow/src/HMPMatchedReaderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/HMPMatchedReaderSpec.cxx
@@ -62,9 +62,9 @@ void HMPMatchedReader::run(ProcessingContext& pc)
   mTree->GetEntry(currEntry);
   LOG(debug) << "Pushing " << mMatches.size() << " HMP matchings at entry " << currEntry;
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MATCHES", 0, Lifetime::Timeframe}, mMatches);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MATCHES", 0}, mMatches);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MCLABELS", 0, Lifetime::Timeframe}, mLabelHMP);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginHMP, "MCLABELS", 0}, mLabelHMP);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
+++ b/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
@@ -139,14 +139,14 @@ void TestDataReader::run(ProcessingContext& pc)
   if (mDiffFolderName.size() == 0) {
     cout << "No New Run -- No Need to Reset" << endl;
     mResetCommand = 0;
-    pc.outputs().snapshot(Output{"ITS", "TEST", 0, Lifetime::Timeframe}, mResetCommand);
+    pc.outputs().snapshot(Output{"ITS", "TEST", 0}, mResetCommand);
   }
 
   // New folders found, send the reset signal and reload configuration
   if (mDiffFolderName.size() > 0) {
     cout << "New Run Started -- Reset All Histograms" << endl;
     mResetCommand = 1;
-    pc.outputs().snapshot(Output{"ITS", "TEST", 0, Lifetime::Timeframe}, mResetCommand);
+    pc.outputs().snapshot(Output{"ITS", "TEST", 0}, mResetCommand);
     for (int i = 0; i < sNError; i++) {
       mErrors[i] = 0;
     }
@@ -264,11 +264,11 @@ void TestDataReader::run(ProcessingContext& pc)
         mErrorsVecTest.push_back(mErrors);
         mFileDone = 1;
         mFileInfo = mFileDone + mFileRemain * 10;
-        pc.outputs().snapshot(Output{"ITS", "Run", 0, Lifetime::Timeframe}, mRunNumber);
-        pc.outputs().snapshot(Output{"ITS", "File", 0, Lifetime::Timeframe}, mFileID);
-        pc.outputs().snapshot(Output{"ITS", "Error", 0, Lifetime::Timeframe}, mErrorsVecTest[0]);
-        pc.outputs().snapshot(Output{"ITS", "Finish", 0, Lifetime::Timeframe}, mFileInfo);
-        pc.outputs().snapshot(Output{"ITS", "DIGITS", 0, Lifetime::Timeframe}, mMultiDigitsTest);
+        pc.outputs().snapshot(Output{"ITS", "Run", 0}, mRunNumber);
+        pc.outputs().snapshot(Output{"ITS", "File", 0}, mFileID);
+        pc.outputs().snapshot(Output{"ITS", "Error", 0}, mErrorsVecTest[0]);
+        pc.outputs().snapshot(Output{"ITS", "Finish", 0}, mFileInfo);
+        pc.outputs().snapshot(Output{"ITS", "DIGITS", 0}, mMultiDigitsTest);
         mNewFileInj = 0;
         mErrorsVecTest.clear();
         mDigitsTest.clear();
@@ -422,10 +422,10 @@ void TestDataReader::run(ProcessingContext& pc)
 
     cout << "RunIDS = " << mRunNumber << "   FileIDS = " << mFileID << endl;
 
-    pc.outputs().snapshot(Output{"ITS", "Run", 0, Lifetime::Timeframe}, mRunNumber);
-    pc.outputs().snapshot(Output{"ITS", "File", 0, Lifetime::Timeframe}, mFileID);
+    pc.outputs().snapshot(Output{"ITS", "Run", 0}, mRunNumber);
+    pc.outputs().snapshot(Output{"ITS", "File", 0}, mFileID);
 
-    pc.outputs().snapshot(Output{"ITS", "Error", 0, Lifetime::Timeframe}, mErrorsVec[j]);
+    pc.outputs().snapshot(Output{"ITS", "Error", 0}, mErrorsVec[j]);
     mIndexPushEx = mIndexPush + mNDigits[j];
     LOG(debug) << "IndexPushEx = " << mIndexPushEx << "  mDigits.size() " << mDigits.size();
     if (mIndexPushEx > mDigits.size() - 5) {
@@ -436,11 +436,11 @@ void TestDataReader::run(ProcessingContext& pc)
 
     mFileInfo = mFileDone + mFileRemain * 10;
 
-    pc.outputs().snapshot(Output{"ITS", "Finish", 0, Lifetime::Timeframe}, mFileInfo);
+    pc.outputs().snapshot(Output{"ITS", "Finish", 0}, mFileInfo);
 
     LOG(debug) << "mIndexPush = " << mIndexPush << "    Chip ID Pushing " << mDigits[mIndexPush].getChipIndex();
 
-    pc.outputs().snapshot(Output{"ITS", "DIGITS", 0, Lifetime::Timeframe}, mMultiDigits);
+    pc.outputs().snapshot(Output{"ITS", "DIGITS", 0}, mMultiDigits);
 
     mMultiDigits.clear();
     mIndexPush = mIndexPush + mNDigits[j];
@@ -453,7 +453,7 @@ void TestDataReader::run(ProcessingContext& pc)
   //            << "mIndexPush = " << mIndexPush << "     mDigits.size() = " << mDigits.size();
   // while (mIndexPush < mDigits.size()) {
   // LOG(debug) << "mDigits.size() = " << mDigits.size();
-  //   pc.outputs().snapshot(Output{"ITS", "DIGITS", 0, Lifetime::Timeframe}, mDigits[mIndexPush++]);
+  //   pc.outputs().snapshot(Output{"ITS", "DIGITS", 0}, mDigits[mIndexPush++]);
   //   if (mIndexPush % 100000 == 0)
   //     LOG(debug) << "mIndexPush = " << mIndexPush << "    Chip ID Pushing " << mDigits[mIndexPush].getChipIndex();
   // }
@@ -483,7 +483,7 @@ void TestDataReader::run(ProcessingContext& pc)
     j = 0;
     mNDigits.clear();
     mFileDone = 1;
-    pc.outputs().snapshot(Output{"TST", "Finish", 0, Lifetime::Timeframe}, mFileDone);
+    pc.outputs().snapshot(Output{"TST", "Finish", 0}, mFileDone);
     PercentDone = 0;
     mErrorsVec.clear();
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -88,17 +88,17 @@ void ClustererDPL::run(ProcessingContext& pc)
     clusterLabels = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
   }
   mClusterer->process(mNThreads, reader, &clusCompVec, &clusPattVec, &clusROFVec, clusterLabels.get());
-  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
-  pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
+  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0}, clusCompVec);
+  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "PATTERNS", 0}, clusPattVec);
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, *clusterLabels.get()); // at the moment requires snapshot
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0}, *clusterLabels.get()); // at the moment requires snapshot
     std::vector<o2::itsmft::MC2ROFRecord> clusterMC2ROframes(mc2rofs.size());
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -95,7 +95,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
     physTriggers = pc.inputs().get<gsl::span<o2::itsmft::PhysTrigger>>("phystrig");
   }
 
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0}, rofsinput.begin(), rofsinput.end());
 
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
   gsl::span<itsmft::MC2ROFRecord const> mc2rofs;
@@ -116,11 +116,11 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   o2::its::ROframe event(0, 7);
   mVertexerPtr->adoptTimeFrame(mTimeFrame);
 
-  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
-  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
-  auto& tracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
-  auto& clusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
-  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0, Lifetime::Timeframe});
+  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0});
+  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0});
+  auto& tracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0});
+  auto& clusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0});
+  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0});
 
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
   int nBCPerTF = mTracker.getContinuousMode() ? alpParams.roFrameLengthInBC : alpParams.roFrameLengthTrig;
@@ -201,8 +201,8 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   LOG(info) << "ITSCookedTracker pushed " << tracks.size() << " tracks and " << vertices.size() << " vertices";
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, trackLabels);
-    pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
+    pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0}, trackLabels);
+    pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0}, mc2rofs);
   }
   mTimer.Stop();
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSGeneratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSGeneratorSpec.cxx
@@ -117,7 +117,7 @@ void ITSDCSDataGenerator::run(o2::framework::ProcessingContext& pc)
   auto timeNow = std::chrono::system_clock::now();
   timingInfo.creation = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow.time_since_epoch()).count(); // in ms
 
-  pc.outputs().snapshot(Output{"ITS", mDataDescription, 0, Lifetime::Timeframe}, dpcoms);
+  pc.outputs().snapshot(Output{"ITS", mDataDescription, 0}, dpcoms);
   mTFs++;
 }
 } // namespace

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackReaderSpec.cxx
@@ -44,14 +44,14 @@ void TrackReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " track in " << mROFRec.size() << " ROFs at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "ITSTrackROF", 0, Lifetime::Timeframe}, mROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0, Lifetime::Timeframe}, mTracks);
-  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0, Lifetime::Timeframe}, mClusInd);
-  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe}, mVertices);
-  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "ITSTrackROF", 0}, mROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0}, mTracks);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0}, mClusInd);
+  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0}, mVertices);
+  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0}, mVerticesROFRec);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
-    pc.outputs().snapshot(Output{mOrigin, "VERTICESMCTR", 0, Lifetime::Timeframe}, mMCVertTruth);
+    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "VERTICESMCTR", 0}, mMCVertTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -150,8 +150,8 @@ void TrackerDPL::run(ProcessingContext& pc)
   }
 
   auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
-  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0, Lifetime::Timeframe});
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0}, rofsinput.begin(), rofsinput.end());
+  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0});
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
 
   irFrames.reserve(rofs.size());
@@ -164,19 +164,19 @@ void TrackerDPL::run(ProcessingContext& pc)
   if (mIsMC) {
     labels = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("itsmclabels").release();
     // get the array as read-only span, a snapshot is sent forward
-    pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe}, pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("ITSMC2ROframes"));
+    pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0}, pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("ITSMC2ROframes"));
     LOG(info) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
   }
 
-  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
-  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
-  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
-  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
+  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0});
+  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0});
+  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0});
+  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0});
 
   // MC
   static pmr::vector<o2::MCCompLabel> dummyMCLabTracks, dummyMCLabVerts;
-  auto& allTrackLabels = mIsMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}) : dummyMCLabTracks;
-  auto& allVerticesLabels = mIsMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "VERTICESMCTR", 0, Lifetime::Timeframe}) : dummyMCLabVerts;
+  auto& allTrackLabels = mIsMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "TRACKSMCTR", 0}) : dummyMCLabTracks;
+  auto& allVerticesLabels = mIsMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "VERTICESMCTR", 0}) : dummyMCLabVerts;
 
   std::uint32_t roFrame = 0;
 

--- a/Detectors/ITSMFT/ITS/workflow/src/VertexReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/VertexReaderSpec.cxx
@@ -41,8 +41,8 @@ void VertexReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mVerticesPtr->size() << " vertices in " << mVerticesROFRecPtr->size()
             << " ROFs at entry " << ent;
-  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe}, mVertices);
-  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
+  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0}, mVertices);
+  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0}, mVerticesROFRec);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -89,17 +89,17 @@ void ClustererDPL::run(ProcessingContext& pc)
     clusterLabels = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
   }
   mClusterer->process(mNThreads, reader, &clusCompVec, &clusPattVec, &clusROFVec, clusterLabels.get());
-  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
-  pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
+  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0}, clusCompVec);
+  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "PATTERNS", 0}, clusPattVec);
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, *clusterLabels.get()); // at the moment requires snapshot
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0}, *clusterLabels.get()); // at the moment requires snapshot
     std::vector<o2::itsmft::MC2ROFRecord> clusterMC2ROframes(mc2rofs.size());
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackReaderSpec.cxx
@@ -45,11 +45,11 @@ void TrackReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " track in " << mROFRec.size() << " ROFs at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "MFTTrackROF", 0, Lifetime::Timeframe}, mROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0, Lifetime::Timeframe}, mTracks);
-  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0, Lifetime::Timeframe}, mClusInd);
+  pc.outputs().snapshot(Output{mOrigin, "MFTTrackROF", 0}, mROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0}, mTracks);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0}, mClusInd);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0}, mMCTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -72,7 +72,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   // the output vector however is created directly inside the message memory thus avoiding copy by
   // snapshot
   auto rofsinput = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "MFTTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "MFTTrackROF", 0}, rofsinput.begin(), rofsinput.end());
 
   ROFFilter filter = [](const o2::itsmft::ROFRecord& r) { return true; };
 
@@ -104,12 +104,12 @@ void TrackerDPL::run(ProcessingContext& pc)
     LOG(info) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
   }
 
-  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"MFT", "TRACKCLSID", 0, Lifetime::Timeframe});
+  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"MFT", "TRACKCLSID", 0});
   std::vector<o2::MCCompLabel> trackLabels;
   std::vector<o2::MCCompLabel> allTrackLabels;
   std::vector<o2::mft::TrackLTF> tracks;
   std::vector<o2::mft::TrackLTFL> tracksL;
-  auto& allTracksMFT = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
+  auto& allTracksMFT = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0});
 
   std::uint32_t roFrameId = 0;
   int nROFs = rofs.size();
@@ -327,8 +327,8 @@ void TrackerDPL::run(ProcessingContext& pc)
   LOG(info) << "MFTTracker pushed " << allTracksMFT.size() << " tracks";
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"MFT", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
-    pc.outputs().snapshot(Output{"MFT", "TRACKSMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
+    pc.outputs().snapshot(Output{"MFT", "TRACKSMCTR", 0}, allTrackLabels);
+    pc.outputs().snapshot(Output{"MFT", "TRACKSMC2ROF", 0}, mc2rofs);
   }
 
   mTimer[SWTot].Stop();

--- a/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
@@ -58,18 +58,18 @@ void ClusterReader::run(ProcessingContext& pc)
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
   // To be fixed once the names-definition class is ready
-  pc.outputs().snapshot(Output{mOrigin, "CLUSTERSROF", 0, Lifetime::Timeframe}, mClusROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "COMPCLUSTERS", 0, Lifetime::Timeframe}, mClusterCompArray);
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERSROF", 0}, mClusROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "COMPCLUSTERS", 0}, mClusterCompArray);
   if (mUsePatterns) {
-    pc.outputs().snapshot(Output{mOrigin, "PATTERNS", 0, Lifetime::Timeframe}, mPatternsArray);
+    pc.outputs().snapshot(Output{mOrigin, "PATTERNS", 0}, mPatternsArray);
   }
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mClusterMCTruth);
-    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, mClusMC2ROFs);
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMCTR", 0}, mClusterMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMC2ROF", 0}, mClusMC2ROFs);
   }
   if (mTriggerOut) {
     std::vector<o2::itsmft::PhysTrigger> dummyTrig;
-    pc.outputs().snapshot(Output{mOrigin, "PHYSTRIG", 0, Lifetime::Timeframe}, dummyTrig);
+    pc.outputs().snapshot(Output{mOrigin, "PHYSTRIG", 0}, dummyTrig);
   }
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
@@ -74,20 +74,20 @@ void DigitReader::run(ProcessingContext& pc)
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
   // To be fixed once the names-definition class is ready
-  pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0, Lifetime::Timeframe}, mDigROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, mDigROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0}, mDigits);
   if (mUseCalib) {
-    pc.outputs().snapshot(Output{mOrigin, "GBTCALIB", 0, Lifetime::Timeframe}, mCalib);
+    pc.outputs().snapshot(Output{mOrigin, "GBTCALIB", 0}, mCalib);
   }
   if (mTriggerOut) {
     std::vector<o2::itsmft::PhysTrigger> dummyTrig;
-    pc.outputs().snapshot(Output{mOrigin, "PHYSTRIG", 0, Lifetime::Timeframe}, dummyTrig);
+    pc.outputs().snapshot(Output{mOrigin, "PHYSTRIG", 0}, dummyTrig);
   }
   if (mUseMC) {
-    auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe});
+    auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
     plabels->copyandflatten(sharedlabels);
     delete plabels;
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0, Lifetime::Timeframe}, mDigMC2ROFs);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, mDigMC2ROFs);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
@@ -56,7 +56,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{mOrigin, "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{mOrigin, "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, rofs, compClusters, pspan, mPattIdConverter, mStrobeLength);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -139,7 +139,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
   std::vector<Digit> digVec;
   std::vector<GBTCalibData> calVec;
   std::vector<ROFRecord> digROFVec;
-  auto& chipStatus = pc.outputs().make<std::vector<char>>(Output{orig, "CHIPSSTATUS", 0, Lifetime::Timeframe}, (size_t)Mapping::getNChips());
+  auto& chipStatus = pc.outputs().make<std::vector<char>>(Output{orig, "CHIPSSTATUS", 0}, (size_t)Mapping::getNChips());
 
   try {
     mDecoder->startNewTF(pc.inputs());
@@ -202,29 +202,29 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     }
   }
   if (mDoDigits) {
-    pc.outputs().snapshot(Output{orig, "DIGITS", 0, Lifetime::Timeframe}, digVec);
-    pc.outputs().snapshot(Output{orig, "DIGITSROF", 0, Lifetime::Timeframe}, digROFVec);
+    pc.outputs().snapshot(Output{orig, "DIGITS", 0}, digVec);
+    pc.outputs().snapshot(Output{orig, "DIGITSROF", 0}, digROFVec);
     mEstNDig = std::max(mEstNDig, size_t(digVec.size() * 1.2));
     mEstNROF = std::max(mEstNROF, size_t(digROFVec.size() * 1.2));
     if (mDoCalibData) {
-      pc.outputs().snapshot(Output{orig, "GBTCALIB", 0, Lifetime::Timeframe}, calVec);
+      pc.outputs().snapshot(Output{orig, "GBTCALIB", 0}, calVec);
       mEstNCalib = std::max(mEstNCalib, size_t(calVec.size() * 1.2));
     }
   }
 
   if (mDoClusters) { // we are not obliged to create vectors which are not requested, but other devices might not know the options of this one
-    pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-    pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
-    pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
+    pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0}, clusCompVec);
+    pc.outputs().snapshot(Output{orig, "PATTERNS", 0}, clusPattVec);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0}, clusROFVec);
     mEstNClus = std::max(mEstNClus, size_t(clusCompVec.size() * 1.2));
     mEstNClusPatt = std::max(mEstNClusPatt, size_t(clusPattVec.size() * 1.2));
     mEstNROF = std::max(mEstNROF, size_t(clusROFVec.size() * 1.2));
   }
-  auto& linkErrors = pc.outputs().make<std::vector<GBTLinkDecodingStat>>(Output{orig, "LinkErrors", 0, Lifetime::Timeframe});
-  auto& decErrors = pc.outputs().make<std::vector<ChipError>>(Output{orig, "ChipErrors", 0, Lifetime::Timeframe});
+  auto& linkErrors = pc.outputs().make<std::vector<GBTLinkDecodingStat>>(Output{orig, "LinkErrors", 0});
+  auto& decErrors = pc.outputs().make<std::vector<ChipError>>(Output{orig, "ChipErrors", 0});
   mDecoder->collectDecodingErrors(linkErrors, decErrors);
 
-  pc.outputs().snapshot(Output{orig, "PHYSTRIG", 0, Lifetime::Timeframe}, mDecoder->getExternalTriggers());
+  pc.outputs().snapshot(Output{orig, "PHYSTRIG", 0}, mDecoder->getExternalTriggers());
 
   if (mDumpOnError != int(GBTLink::RawDataDumps::DUMP_NONE)) {
     mDecoder->produceRawDataDumps(mDumpOnError, pc.services().get<o2::framework::TimingInfo>());

--- a/Detectors/MUON/MCH/IO/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MCH/IO/src/DigitReaderSpec.cxx
@@ -54,18 +54,18 @@ class DigitsReaderDeviceDPL
       mReader = std::make_unique<RootTreeReader>("o2sim", filename.c_str(), -1,
                                                  RootTreeReader::PublishingMode::Single,
                                                  RootTreeReader::BranchDefinition<std::vector<Digit>>{
-                                                   Output{header::gDataOriginMCH, mDescriptions[0], 0, Lifetime::Timeframe}, "MCHDigit"},
+                                                   Output{header::gDataOriginMCH, mDescriptions[0], 0}, "MCHDigit"},
                                                  RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
-                                                   Output{header::gDataOriginMCH, mDescriptions[1], 0, Lifetime::Timeframe}, "MCHROFRecords"},
+                                                   Output{header::gDataOriginMCH, mDescriptions[1], 0}, "MCHROFRecords"},
                                                  RootTreeReader::BranchDefinition<dataformats::MCTruthContainer<MCCompLabel>>{
-                                                   Output{header::gDataOriginMCH, mDescriptions[2], 0, Lifetime::Timeframe}, "MCHMCLabels"});
+                                                   Output{header::gDataOriginMCH, mDescriptions[2], 0}, "MCHMCLabels"});
     } else {
       mReader = std::make_unique<RootTreeReader>("o2sim", filename.c_str(), -1,
                                                  RootTreeReader::PublishingMode::Single,
                                                  RootTreeReader::BranchDefinition<std::vector<Digit>>{
-                                                   Output{header::gDataOriginMCH, mDescriptions[0], 0, Lifetime::Timeframe}, "MCHDigit"},
+                                                   Output{header::gDataOriginMCH, mDescriptions[0], 0}, "MCHDigit"},
                                                  RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
-                                                   Output{header::gDataOriginMCH, mDescriptions[1], 0, Lifetime::Timeframe}, "MCHROFRecords"});
+                                                   Output{header::gDataOriginMCH, mDescriptions[1], 0}, "MCHROFRecords"});
     }
   }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.cxx
@@ -139,7 +139,7 @@ class TrackAtVertexTask
     }
 
     // create the output message
-    auto msgOut = pc.outputs().make<char>(Output{"MCH", "TRACKSATVERTEX", 0, Lifetime::Timeframe},
+    auto msgOut = pc.outputs().make<char>(Output{"MCH", "TRACKSATVERTEX", 0},
                                           mTracksAtVtx.size() * sizeof(int) + nTracksTot * sizeof(TrackAtVtxStruct));
 
     // write the tracks

--- a/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
@@ -72,7 +72,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"MCH", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"MCH", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, rofs, digits);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();

--- a/Detectors/MUON/MID/Workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ClusterizerSpec.cxx
@@ -99,13 +99,13 @@ class ClusterizerDeviceDPL
       // Clear the index correlations that will be used in the next cluster processing
       mCorrelation.clear();
 
-      pc.outputs().snapshot(of::Output{"MID", "CLUSTERSLABELS", 0, of::Lifetime::Timeframe}, mClusterLabeler.getContainer());
+      pc.outputs().snapshot(of::Output{"MID", "CLUSTERSLABELS", 0}, mClusterLabeler.getContainer());
       LOG(debug) << "Sent " << mClusterLabeler.getContainer().getIndexedSize() << " indexed clusters";
     }
 
-    pc.outputs().snapshot(of::Output{"MID", "CLUSTERS", 0, of::Lifetime::Timeframe}, mClusterizer.getClusters());
+    pc.outputs().snapshot(of::Output{"MID", "CLUSTERS", 0}, mClusterizer.getClusters());
     LOG(debug) << "Sent " << mClusterizer.getClusters().size() << " clusters";
-    pc.outputs().snapshot(of::Output{"MID", "CLUSTERSROF", 0, of::Lifetime::Timeframe}, mClusterizer.getROFRecords());
+    pc.outputs().snapshot(of::Output{"MID", "CLUSTERSROF", 0}, mClusterizer.getROFRecords());
     LOG(debug) << "Sent " << mClusterizer.getROFRecords().size() << " ROF";
 
     mTimer += std::chrono::high_resolution_clock::now() - tStart;

--- a/Detectors/MUON/MID/Workflow/src/ColumnDataSpecsUtils.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ColumnDataSpecsUtils.cxx
@@ -127,7 +127,7 @@ std::vector<framework::Output> buildOutputs(std::vector<framework::OutputSpec> o
   std::vector<framework::Output> outputs;
   for (auto& outSpec : outputSpecs) {
     auto matcher = framework::DataSpecUtils::asConcreteDataMatcher(outSpec);
-    outputs.emplace_back(framework::Output{matcher.origin, matcher.description, matcher.subSpec, framework::Lifetime::Timeframe});
+    outputs.emplace_back(framework::Output{matcher.origin, matcher.description, matcher.subSpec});
   }
   return outputs;
 }

--- a/Detectors/MUON/MID/Workflow/src/DecodedDataAggregatorSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DecodedDataAggregatorSpec.cxx
@@ -60,8 +60,8 @@ class DecodedDataAggregatorDeviceDPL
 
     for (o2::header::DataHeader::SubSpecificationType subSpec = 0; subSpec < 3; ++subSpec) {
       EventType evtType = static_cast<EventType>(subSpec);
-      pc.outputs().snapshot(of::Output{o2::header::gDataOriginMID, "DATA", subSpec, of::Lifetime::Timeframe}, mAggregator.getData(evtType));
-      pc.outputs().snapshot(of::Output{o2::header::gDataOriginMID, "DATAROF", subSpec, of::Lifetime::Timeframe}, mAggregator.getROFRecords(evtType));
+      pc.outputs().snapshot(of::Output{o2::header::gDataOriginMID, "DATA", subSpec}, mAggregator.getData(evtType));
+      pc.outputs().snapshot(of::Output{o2::header::gDataOriginMID, "DATAROF", subSpec}, mAggregator.getROFRecords(evtType));
     }
 
     mTimer += std::chrono::high_resolution_clock::now() - tStart;

--- a/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
@@ -55,19 +55,19 @@ class DigitsReaderDeviceDPL
       mReader = std::make_unique<RootTreeReader>("o2sim", filename.c_str(), -1,
                                                  RootTreeReader::PublishingMode::Single,
                                                  RootTreeReader::BranchDefinition<std::vector<ColumnData>>{
-                                                   Output{header::gDataOriginMID, mDescriptions[0], 0, Lifetime::Timeframe}, "MIDDigit"},
+                                                   Output{header::gDataOriginMID, mDescriptions[0], 0}, "MIDDigit"},
                                                  RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
-                                                   Output{header::gDataOriginMID, mDescriptions[1], 0, Lifetime::Timeframe}, "MIDROFRecords"},
+                                                   Output{header::gDataOriginMID, mDescriptions[1], 0}, "MIDROFRecords"},
                                                  RootTreeReader::BranchDefinition<dataformats::MCTruthContainer<MCLabel>>{
-                                                   Output{header::gDataOriginMID, mDescriptions[2], 0, Lifetime::Timeframe}, "MIDDigitMCLabels"},
+                                                   Output{header::gDataOriginMID, mDescriptions[2], 0}, "MIDDigitMCLabels"},
                                                  &mPublishDigits);
     } else {
       mReader = std::make_unique<RootTreeReader>("o2sim", filename.c_str(), -1,
                                                  RootTreeReader::PublishingMode::Single,
                                                  RootTreeReader::BranchDefinition<std::vector<ColumnData>>{
-                                                   Output{header::gDataOriginMID, mDescriptions[0], 0, Lifetime::Timeframe}, "MIDDigit"},
+                                                   Output{header::gDataOriginMID, mDescriptions[0], 0}, "MIDDigit"},
                                                  RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
-                                                   Output{header::gDataOriginMID, mDescriptions[1], 0, Lifetime::Timeframe}, "MIDROFRecords"},
+                                                   Output{header::gDataOriginMID, mDescriptions[1], 0}, "MIDROFRecords"},
                                                  &mPublishDigits);
     }
   }

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -66,9 +66,9 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   size_t insize = 0;
   for (uint32_t it = 0; it < NEvTypes; it++) {
     insize += cols[it].size() * sizeof(o2::mid::ColumnData);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATA", it, Lifetime::Timeframe}, cols[it]);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATA", it}, cols[it]);
     insize += rofs[it].size() * sizeof(o2::mid::ROFRecord);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATAROF", it, Lifetime::Timeframe}, rofs[it]);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATAROF", it}, rofs[it]);
   }
   iosize.rawIn = insize;
   pc.outputs().snapshot({"ctfrep", 0}, iosize);

--- a/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
@@ -83,7 +83,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   // build references for looping over the data in BC increasing direction
   tfData.buildReferences(mCTFCoder.getIRFramesSelector());
 
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{header::gDataOriginMID, "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{header::gDataOriginMID, "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, tfData);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   iosize.rawIn = insize;

--- a/Detectors/MUON/MID/Workflow/src/MaskMakerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/MaskMakerSpec.cxx
@@ -117,7 +117,7 @@ class MaskMakerDeviceDPL
     if (mCounterSinceReset >= mNReset) {
       for (size_t itype = 0; itype < 2; ++itype) {
         auto masks = o2::mid::makeMasks(mScalers[itype], mCounterSinceReset, mThreshold, mRefMasks);
-        pc.outputs().snapshot(of::Output{header::gDataOriginMID, "MASKS", static_cast<header::DataHeader::SubSpecificationType>(itype + 1), of::Lifetime::Timeframe}, masks);
+        pc.outputs().snapshot(of::Output{header::gDataOriginMID, "MASKS", static_cast<header::DataHeader::SubSpecificationType>(itype + 1)}, masks);
       }
       mCounterSinceReset = 0;
       for (auto& scaler : mScalers) {

--- a/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
@@ -82,8 +82,8 @@ class RawGBTDecoderDeviceDPL
 
     mTimerAlgo += std::chrono::high_resolution_clock::now() - tAlgoStart;
 
-    pc.outputs().snapshot(o2::framework::Output{header::gDataOriginMID, "DECODED", dh->subSpecification, o2::framework::Lifetime::Timeframe}, data);
-    pc.outputs().snapshot(o2::framework::Output{header::gDataOriginMID, "DECODEDROF", dh->subSpecification, o2::framework::Lifetime::Timeframe}, rofRecords);
+    pc.outputs().snapshot(o2::framework::Output{header::gDataOriginMID, "DECODED", dh->subSpecification}, data);
+    pc.outputs().snapshot(o2::framework::Output{header::gDataOriginMID, "DECODEDROF", dh->subSpecification}, rofRecords);
 
     mTimer += std::chrono::high_resolution_clock::now() - tStart;
     mNROFs += rofRecords.size();

--- a/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
@@ -80,20 +80,20 @@ class TrackerDeviceDPL
     if (mIsMC) {
       std::unique_ptr<const o2::dataformats::MCTruthContainer<MCClusterLabel>> labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<MCClusterLabel>*>("mid_clusterlabels");
       mTrackLabeler.process(mTracker->getClusters(), tracks, *labels);
-      pc.outputs().snapshot(of::Output{"MID", "TRACKLABELS", 0, of::Lifetime::Timeframe}, mTrackLabeler.getTracksLabels());
+      pc.outputs().snapshot(of::Output{"MID", "TRACKLABELS", 0}, mTrackLabeler.getTracksLabels());
       LOG(debug) << "Sent " << mTrackLabeler.getTracksLabels().size() << " indexed tracks.";
-      pc.outputs().snapshot(of::Output{"MID", "TRCLUSLABELS", 0, of::Lifetime::Timeframe}, mTrackLabeler.getTrackClustersLabels());
+      pc.outputs().snapshot(of::Output{"MID", "TRCLUSLABELS", 0}, mTrackLabeler.getTrackClustersLabels());
       LOG(debug) << "Sent " << mTrackLabeler.getTrackClustersLabels().getIndexedSize() << " indexed track clusters.";
     }
 
-    pc.outputs().snapshot(of::Output{"MID", "TRACKS", 0, of::Lifetime::Timeframe}, tracks);
+    pc.outputs().snapshot(of::Output{"MID", "TRACKS", 0}, tracks);
     LOG(debug) << "Sent " << tracks.size() << " tracks.";
-    pc.outputs().snapshot(of::Output{"MID", "TRACKCLUSTERS", 0, of::Lifetime::Timeframe}, mTracker->getClusters());
+    pc.outputs().snapshot(of::Output{"MID", "TRACKCLUSTERS", 0}, mTracker->getClusters());
     LOG(debug) << "Sent " << mTracker->getClusters().size() << " track clusters.";
 
-    pc.outputs().snapshot(of::Output{"MID", "TRACKROFS", 0, of::Lifetime::Timeframe}, mTracker->getTrackROFRecords());
+    pc.outputs().snapshot(of::Output{"MID", "TRACKROFS", 0}, mTracker->getTrackROFRecords());
     LOG(debug) << "Sent " << mTracker->getTrackROFRecords().size() << " ROFs.";
-    pc.outputs().snapshot(of::Output{"MID", "TRCLUSROFS", 0, of::Lifetime::Timeframe}, mTracker->getClusterROFRecords());
+    pc.outputs().snapshot(of::Output{"MID", "TRCLUSROFS", 0}, mTracker->getClusterROFRecords());
     LOG(debug) << "Sent " << mTracker->getClusterROFRecords().size() << " ROFs.";
 
     mTimer += std::chrono::high_resolution_clock::now() - tStart;

--- a/Detectors/MUON/MID/Workflow/src/ZeroSuppressionSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ZeroSuppressionSpec.cxx
@@ -90,7 +90,7 @@ class ZeroSuppressionDeviceDPL
     }
 
     if (mUseMC) {
-      pc.outputs().snapshot(of::Output{header::gDataOriginMID, "DATALABELS", 0, of::Lifetime::Timeframe}, outMCContainer);
+      pc.outputs().snapshot(of::Output{header::gDataOriginMID, "DATALABELS", 0}, outMCContainer);
     }
   }
 

--- a/Detectors/PHOS/calib/src/PHOSBadMapCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSBadMapCalibDevice.cxx
@@ -177,7 +177,7 @@ void PHOSBadMapCalibDevice::sendOutput(DataAllocator& output)
 
   // Send change to QC
   LOG(info) << "[PHOSBadMapCalibDevice - run] Sending QC ";
-  output.snapshot(o2::framework::Output{"PHS", "BADMAPDIFF", 0, o2::framework::Lifetime::Timeframe}, mBadMapDiff);
+  output.snapshot(o2::framework::Output{"PHS", "BADMAPDIFF", 0}, mBadMapDiff);
 }
 
 bool PHOSBadMapCalibDevice::calculateBadMap()

--- a/Detectors/PHOS/calib/src/PHOSHGLGRatioCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSHGLGRatioCalibDevice.cxx
@@ -229,7 +229,7 @@ void PHOSHGLGRatioCalibDevice::sendOutput(DataAllocator& output)
   }
   // Anyway send change to QC
   LOG(info) << "[PHOSHGLGRatioCalibDevice - sendOutput] Sending QC ";
-  output.snapshot(o2::framework::Output{"PHS", "CALIBDIFF", 0, o2::framework::Lifetime::Timeframe}, mRatioDiff);
+  output.snapshot(o2::framework::Output{"PHS", "CALIBDIFF", 0}, mRatioDiff);
 }
 
 DataProcessorSpec o2::phos::getHGLGRatioCalibSpec(bool useCCDB, bool forceUpdate)

--- a/Detectors/PHOS/calib/src/PHOSPedestalCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSPedestalCalibDevice.cxx
@@ -135,7 +135,7 @@ void PHOSPedestalCalibDevice::sendOutput(DataAllocator& output)
   }
   // Anyway send change to QC
   LOG(info) << "[PHOSPedestalCalibDevice - run] Sending QC ";
-  output.snapshot(o2::framework::Output{"PHS", "CALIBDIFF", 0, o2::framework::Lifetime::Timeframe}, mPedDiff);
+  output.snapshot(o2::framework::Output{"PHS", "CALIBDIFF", 0}, mPedDiff);
 }
 
 void PHOSPedestalCalibDevice::calculatePedestals()

--- a/Detectors/PHOS/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/CellConverterSpec.cxx
@@ -44,12 +44,12 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   auto digitsTR = ctx.inputs().get<std::vector<o2::phos::TriggerRecord>>("digitTriggerRecords");
   if (!digitsTR.size()) { // nothing to process
     mOutputCells.clear();
-    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
+    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", 0}, mOutputCells);
     mOutputCellTrigRecs.clear();
-    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputCellTrigRecs);
+    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", 0}, mOutputCellTrigRecs);
     if (mPropagateMC) {
       mOutputTruthCont.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
+      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLSMCTR", 0}, mOutputTruthCont);
     }
     return;
   }
@@ -128,10 +128,10 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   }
   LOG(info) << "[PHOSCellConverter - run] Writing " << mOutputCells.size() << " cells, " << mOutputCellTrigRecs.size() << " Trig Records " << mOutputTruthCont.getNElements() << " PHOS labels ";
 
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputCellTrigRecs);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", 0}, mOutputCells);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", 0}, mOutputCellTrigRecs);
   if (mPropagateMC) {
-    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
+    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLSMCTR", 0}, mOutputTruthCont);
   }
 }
 

--- a/Detectors/PHOS/workflow/src/CellReaderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/CellReaderSpec.cxx
@@ -44,10 +44,10 @@ void CellReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mCells.size() << " Cells in " << mTRs.size() << " TriggerRecords at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "CELLS", 0, Lifetime::Timeframe}, mCells);
-  pc.outputs().snapshot(Output{mOrigin, "CELLTRIGREC", 0, Lifetime::Timeframe}, mTRs);
+  pc.outputs().snapshot(Output{mOrigin, "CELLS", 0}, mCells);
+  pc.outputs().snapshot(Output{mOrigin, "CELLTRIGREC", 0}, mTRs);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "CELLSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "CELLSMCTR", 0}, mMCTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/PHOS/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/PHOS/workflow/src/ClusterizerSpec.cxx
@@ -78,16 +78,16 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
     auto digitsTR = ctx.inputs().get<std::vector<o2::phos::TriggerRecord>>("digitTriggerRecords");
     if (!digitsTR.size()) { // nothing to process
       mOutputClusters.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
+      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERS", 0}, mOutputClusters);
       if (mFullCluOutput) {
         mOutputCluElements.clear();
-        ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUELEMENTS", 0, o2::framework::Lifetime::Timeframe}, mOutputCluElements);
+        ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUELEMENTS", 0}, mOutputCluElements);
       }
       mOutputClusterTrigRecs.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputClusterTrigRecs);
+      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRIGREC", 0}, mOutputClusterTrigRecs);
       if (mPropagateMC) {
         mOutputTruthCont.clear();
-        ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
+        ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRUEMC", 0}, mOutputTruthCont);
       }
       return;
     }
@@ -120,13 +120,13 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
   } else {
     LOG(debug) << "[PHOSClusterizer - run] Writing " << mOutputClusters.size() << " clusters and " << mOutputClusterTrigRecs.size() << " TR";
   }
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERS", 0}, mOutputClusters);
   if (mFullCluOutput) {
-    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUELEMENTS", 0, o2::framework::Lifetime::Timeframe}, mOutputCluElements);
+    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUELEMENTS", 0}, mOutputCluElements);
   }
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputClusterTrigRecs);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRIGREC", 0}, mOutputClusterTrigRecs);
   if (mPropagateMC) {
-    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
+    ctx.outputs().snapshot(o2::framework::Output{"PHS", "CLUSTERTRUEMC", 0}, mOutputTruthCont);
   }
 }
 

--- a/Detectors/PHOS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/DigitReaderSpec.cxx
@@ -44,10 +44,10 @@ void DigitReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mDigits.size() << " Digits in " << mTRs.size() << " TriggerRecords at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
-  pc.outputs().snapshot(Output{mOrigin, "DIGITTRIGREC", 0, Lifetime::Timeframe}, mTRs);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0}, mDigits);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITTRIGREC", 0}, mTRs);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSMCTR", 0}, mMCTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
@@ -54,7 +54,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"PHS", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"PHS", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, triggers, cells);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/PHOS/workflow/src/EventBuilderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EventBuilderSpec.cxx
@@ -178,8 +178,8 @@ void EventBuilderSpec::run(framework::ProcessingContext& ctx)
     }
   }
 
-  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginPHS, "CELLS", 0, framework::Lifetime::Timeframe}, outputCells);
-  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginPHS, "CELLTRIGREC", 0, framework::Lifetime::Timeframe}, outputTriggers);
+  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginPHS, "CELLS", 0}, outputCells);
+  ctx.outputs().snapshot(framework::Output{o2::header::gDataOriginPHS, "CELLTRIGREC", 0}, outputTriggers);
 }
 
 o2::framework::DataProcessorSpec o2::phos::getEventBuilderSpec()

--- a/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
@@ -108,11 +108,11 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       mOutputCells.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", mflpId, o2::framework::Lifetime::Timeframe}, mOutputCells);
+      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", mflpId}, mOutputCells);
       mOutputTriggerRecords.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", mflpId, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
+      ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", mflpId}, mOutputTriggerRecords);
       mOutputHWErrors.clear();
-      ctx.outputs().snapshot(o2::framework::Output{"PHS", "RAWHWERRORS", 0, o2::framework::Lifetime::Timeframe}, mOutputHWErrors);
+      ctx.outputs().snapshot(o2::framework::Output{"PHS", "RAWHWERRORS", 0}, mOutputHWErrors);
       if (mFillChi2) {
         mOutputFitChi.clear();
         ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLFITQA", 0, o2::framework::Lifetime::QA}, mOutputFitChi);
@@ -290,9 +290,9 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   mLastSize = 1.1 * mOutputCells.size();
 
   LOG(debug) << "[PHOSRawToCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", mflpId, o2::framework::Lifetime::Timeframe}, mOutputCells);
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", mflpId, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
-  ctx.outputs().snapshot(o2::framework::Output{"PHS", "RAWHWERRORS", 0, o2::framework::Lifetime::Timeframe}, mOutputHWErrors);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", mflpId}, mOutputCells);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLTRIGREC", mflpId}, mOutputTriggerRecords);
+  ctx.outputs().snapshot(o2::framework::Output{"PHS", "RAWHWERRORS", 0}, mOutputHWErrors);
   if (mFillChi2) {
     ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLFITQA", 0, o2::framework::Lifetime::QA}, mOutputFitChi);
   }

--- a/Detectors/PHOS/workflow/src/ReaderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/ReaderSpec.cxx
@@ -58,7 +58,6 @@ DataProcessorSpec getDigitsReaderSpec(bool propagateMC)
       processAttributes->terminateOnEod = ic.options().get<bool>("terminate-on-eod");
       processAttributes->finished = false;
       processAttributes->datatype = "PHOSDigit";
-      constexpr auto persistency = Lifetime::Timeframe;
       o2::header::DataHeader::SubSpecificationType subSpec = 0;
       if (propagateMC) {
         processAttributes->reader = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
@@ -66,19 +65,19 @@ DataProcessorSpec getDigitsReaderSpec(bool propagateMC)
                                                                      nofEvents,        // number of entries to publish
                                                                      publishingMode,
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::Digit>>{
-                                                                       Output{"PHS", "DIGITS", subSpec, persistency}, "PHOSDigit"},
+                                                                       Output{"PHS", "DIGITS", subSpec}, "PHOSDigit"},
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::TriggerRecord>>{
-                                                                       Output{"PHS", "DIGITTRIGREC", subSpec, persistency}, "PHOSDigitTrigRecords"},
-                                                                     Output{"PHS", "DIGITSMCTR", subSpec, persistency}, "PHOSDigitMCTruth"); // name of mc label branch
+                                                                       Output{"PHS", "DIGITTRIGREC", subSpec}, "PHOSDigitTrigRecords"},
+                                                                     Output{"PHS", "DIGITSMCTR", subSpec}, "PHOSDigitMCTruth"); // name of mc label branch
       } else {
         processAttributes->reader = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
                                                                      filename.c_str(), // input file name
                                                                      nofEvents,        // number of entries to publish
                                                                      publishingMode,
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::Digit>>{
-                                                                       Output{"PHS", "DIGITS", subSpec, persistency}, "PHOSDigit"},
+                                                                       Output{"PHS", "DIGITS", subSpec}, "PHOSDigit"},
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::TriggerRecord>>{
-                                                                       Output{"PHS", "DIGITTRIGREC", subSpec, persistency}, "PHOSDigitTrigRecords"});
+                                                                       Output{"PHS", "DIGITTRIGREC", subSpec}, "PHOSDigitTrigRecords"});
       }
     }
 
@@ -156,7 +155,6 @@ DataProcessorSpec getCellReaderSpec(bool propagateMC)
       processAttributes->terminateOnEod = ic.options().get<bool>("terminate-on-eod");
       processAttributes->finished = false;
       processAttributes->datatype = "PHOSCell";
-      constexpr auto persistency = Lifetime::Timeframe;
       o2::header::DataHeader::SubSpecificationType subSpec = 0;
       if (propagateMC) {
         processAttributes->reader = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
@@ -164,10 +162,10 @@ DataProcessorSpec getCellReaderSpec(bool propagateMC)
                                                                      nofEvents,        // number of entries to publish
                                                                      publishingMode,
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::Cell>>{
-                                                                       Output{"PHS", "CELLS", subSpec, persistency}, "PHOSCell"},
+                                                                       Output{"PHS", "CELLS", subSpec}, "PHOSCell"},
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::TriggerRecord>>{
-                                                                       Output{"PHS", "CELLTRIGREC", subSpec, persistency}, "PHOSCellTrigRec"},
-                                                                     Output{"PHS", "CELLSMCTR", subSpec, persistency},
+                                                                       Output{"PHS", "CELLTRIGREC", subSpec}, "PHOSCellTrigRec"},
+                                                                     Output{"PHS", "CELLSMCTR", subSpec},
                                                                      "PHOSCellTrueMC"); // name of mc label branch
       } else {
         processAttributes->reader = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
@@ -175,9 +173,9 @@ DataProcessorSpec getCellReaderSpec(bool propagateMC)
                                                                      nofEvents,        // number of entries to publish
                                                                      publishingMode,
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::Cell>>{
-                                                                       Output{"PHS", "CELLS", subSpec, persistency}, "PHOSCell"},
+                                                                       Output{"PHS", "CELLS", subSpec}, "PHOSCell"},
                                                                      RootTreeReader::BranchDefinition<std::vector<o2::phos::TriggerRecord>>{
-                                                                       Output{"PHS", "CELLTRIGREC", subSpec, persistency}, "PHOSCellTrigRec"});
+                                                                       Output{"PHS", "CELLTRIGREC", subSpec}, "PHOSCellTrigRec"});
       }
     }
 

--- a/Detectors/PHOS/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/PHOS/workflow/src/StandaloneAODProducerSpec.cxx
@@ -136,8 +136,8 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
   } // end of event loop
   // std::cout << "Finished cell loop" << std::endl;
 
-  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, tfNumber);
-  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
+  pc.outputs().snapshot(Output{"TFN", "TFNumber", 0}, tfNumber);
+  pc.outputs().snapshot(Output{"TFF", "TFFilename", 0}, "");
 
   mTimer.Stop();
 }

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
@@ -113,8 +113,8 @@ class TOFCalibCollectorDevice : public o2::framework::Task
       auto entries = collectedInfo.size();
       // this means that we are ready to send the output
       auto entriesPerChannel = mCollector->getEntriesPerChannel();
-      output.snapshot(Output{o2::header::gDataOriginTOF, "COLLECTEDINFO", 0, Lifetime::Timeframe}, collectedInfo);
-      output.snapshot(Output{o2::header::gDataOriginTOF, "ENTRIESCH", 0, Lifetime::Timeframe}, entriesPerChannel);
+      output.snapshot(Output{o2::header::gDataOriginTOF, "COLLECTEDINFO", 0}, collectedInfo);
+      output.snapshot(Output{o2::header::gDataOriginTOF, "ENTRIESCH", 0}, entriesPerChannel);
       mCollector->initOutput(); // reset the output for the next round
     }
   }

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -109,18 +109,18 @@ void CompressedDecodingTask::postData(ProcessingContext& pc)
   // LOG(info) << "TOF: N tof window decoded = " << n_tof_window << "(orbits = " << n_orbits << ") with " << digit_size << " digits";
 
   // add digits in the output snapshot
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe}, *alldigits);
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe}, *row);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITS", 0}, *alldigits);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0}, *row);
 
   std::vector<uint8_t>& patterns = mDecoder.getPatterns();
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe}, patterns);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0}, patterns);
 
   std::vector<uint64_t>& errors = mDecoder.getErrors();
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ERRORS", 0, Lifetime::Timeframe}, errors);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ERRORS", 0}, errors);
 
   DigitHeader& digitH = mDecoder.getDigitHeader();
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITHEADER", 0, Lifetime::Timeframe}, digitH);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITHEADER", 0}, digitH);
 
   auto diagnosticFrequency = mDecoder.getDiagnosticFrequency();
   diagnosticFrequency.setTimeStamp(mCreationTime / 1000);
@@ -130,7 +130,7 @@ void CompressedDecodingTask::postData(ProcessingContext& pc)
   diagnosticFrequency.setTFIDInfo(tfinfo);
 
   //diagnosticFrequency.print();
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIAFREQ", 0, Lifetime::Timeframe}, diagnosticFrequency);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIAFREQ", 0}, diagnosticFrequency);
 
   mDecoder.clear();
 

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -81,7 +81,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   o2::dataformats::TFIDInfo tfinfo;
   o2::base::TFIDInfoHelper::fillTFIDInfo(pc, tfinfo);
   diagnostic.setTFIDInfo(tfinfo);
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIAFREQ", 0, Lifetime::Timeframe}, diagnostic);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIAFREQ", 0}, diagnostic);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
   LOG(info) << "Decoded " << digits.size() << " digits in " << row.size() << " ROF, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -55,7 +55,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{o2::header::gDataOriginTOF, "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, rofs, compDigits, pspan);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -224,25 +224,25 @@ class TOFDPLClustererTask
     }
 
     // send clusters
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERS", 0, Lifetime::Timeframe}, mClustersArray);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMULT", 0, Lifetime::Timeframe}, mMultPerLongBC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERS", 0}, mClustersArray);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMULT", 0}, mMultPerLongBC);
     // send labels
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mClsLabels);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0}, mClsLabels);
     }
 
     if (mIsCalib) {
       std::vector<CalibInfoCluster>* clusterCalInfo = mClusterer.getInfoFromCluster();
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCALCLUS", 0, Lifetime::Timeframe}, *clusterCalInfo);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCALCLUS", 0}, *clusterCalInfo);
     }
 
     if (mIsCosmic) {
       std::vector<CosmicInfo>* cosmicInfo = mCosmicProcessor.getCosmicInfo();
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCOSMICS", 0, Lifetime::Timeframe}, *cosmicInfo);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCOSMICS", 0}, *cosmicInfo);
       std::vector<CalibInfoTrackCl>* cosmicTrack = mCosmicProcessor.getCosmicTrack();
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKCOS", 0, Lifetime::Timeframe}, *cosmicTrack);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKCOS", 0}, *cosmicTrack);
       std::vector<int>* cosmicTrackSize = mCosmicProcessor.getCosmicTrackSize();
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKSIZE", 0, Lifetime::Timeframe}, *cosmicTrackSize);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKSIZE", 0}, *cosmicTrackSize);
     }
 
     mTimer.Stop();

--- a/Detectors/TOF/workflowIO/src/CalibClusReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/CalibClusReaderSpec.cxx
@@ -39,13 +39,13 @@ void CalibClusReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(debug) << "Pushing " << mPclusInfos->size() << " TOF clusters calib info at entry " << ent;
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCALCLUS", 0, Lifetime::Timeframe}, mClusInfos);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCALCLUS", 0}, mClusInfos);
 
   if (mIsCosmics) {
     LOG(debug) << "Pushing " << mPcosmicInfo->size() << " TOF cosmics info at entry " << ent;
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCOSMICS", 0, Lifetime::Timeframe}, mCosmicInfo);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKCOS", 0, Lifetime::Timeframe}, mCosmicTrack);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKSIZE", 0, Lifetime::Timeframe}, mCosmicTrackSize);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOCOSMICS", 0}, mCosmicInfo);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKCOS", 0}, mCosmicTrack);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "INFOTRACKSIZE", 0}, mCosmicTrackSize);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/TOF/workflowIO/src/CalibInfoReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/CalibInfoReaderSpec.cxx
@@ -90,9 +90,9 @@ void CalibInfoReader::run(ProcessingContext& pc)
       LOG(debug) << "Current entry " << mCurrentEntry;
       LOG(debug) << "Send " << mVect.size() << " calib infos";
 
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, mTOFTPC ? ddCalib_tpc : ddCalib, 0, Lifetime::Timeframe}, mVect);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, mTOFTPC ? ddCalib_tpc : ddCalib, 0}, mVect);
 
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, ddDia, 0, Lifetime::Timeframe}, mDia);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, ddDia, 0}, mDia);
       usleep(100);
     }
     mGlobalEntry++;

--- a/Detectors/TOF/workflowIO/src/ClusterReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/ClusterReaderSpec.cxx
@@ -44,10 +44,10 @@ void ClusterReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(debug) << "Pushing " << mClustersPtr->size() << " TOF clusters at entry " << ent;
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERS", 0, Lifetime::Timeframe}, mClusters);
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMULT", 0, Lifetime::Timeframe}, mClustersMult);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERS", 0}, mClusters);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMULT", 0}, mClustersMult);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0}, mLabels);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/TOF/workflowIO/src/DigitReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/DigitReaderSpec.cxx
@@ -81,18 +81,18 @@ void DigitReader::run(ProcessingContext& pc)
     mDiagnostic = mFiller.getDiagnosticFrequency();
 
     // add digits loaded in the output snapshot
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe}, mRow);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe}, mPatterns);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIAFREQ", 0, Lifetime::Timeframe}, mDiagnostic);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITS", 0}, mDigits);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0}, mRow);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0}, mPatterns);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIAFREQ", 0}, mDiagnostic);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITSMCTR", 0, Lifetime::Timeframe}, mLabels);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITSMCTR", 0}, mLabels);
     }
 
     static o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::CONTINUOUS;
 
     LOG(debug) << "TOF: Sending ROMode= " << roMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe}, roMode);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0}, roMode);
   } else {
     LOG(error) << "Cannot read the TOF digits !";
     return;

--- a/Detectors/TOF/workflowIO/src/TOFMatchedReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/TOFMatchedReaderSpec.cxx
@@ -74,12 +74,12 @@ void TOFMatchedReader::run(ProcessingContext& pc)
   LOG(debug) << "Pushing " << mMatches.size() << " TOF matchings at entry " << currEntry;
 
   uint32_t tpcMatchSS = o2::globaltracking::getSubSpec(mSubSpecStrict && (!mMode) ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, ddMatchInfo[mMode], tpcMatchSS, Lifetime::Timeframe}, mMatches);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, ddMatchInfo[mMode], tpcMatchSS}, mMatches);
   if (mReadTracks && (!mMode)) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "TOFTRACKS_TPC", tpcMatchSS, Lifetime::Timeframe}, mTracks);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "TOFTRACKS_TPC", tpcMatchSS}, mTracks);
   }
   if (mUseMC) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, ddMCMatchTOF[mMode], tpcMatchSS, Lifetime::Timeframe}, mLabelTOF);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, ddMCMatchTOF[mMode], tpcMatchSS}, mLabelTOF);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFLPIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFLPIDCSpec.h
@@ -195,14 +195,14 @@ class TPCFLPIDCDevice : public o2::framework::Task
 
     fill1DIDCs(cru);
     LOGP(debug, "Sending 1D-IDCs to EPNs of size {} and weights of size {}", mOneDIDCs.first.size(), mOneDIDCs.second.size());
-    output.snapshot(Output{gDataOriginTPC, getDataDescription1DIDCEPN(), subSpec, Lifetime::Timeframe}, mOneDIDCs.first);
-    output.snapshot(Output{gDataOriginTPC, getDataDescription1DIDCEPNWeights(), subSpec, Lifetime::Timeframe}, mOneDIDCs.second);
+    output.snapshot(Output{gDataOriginTPC, getDataDescription1DIDCEPN(), subSpec}, mOneDIDCs.first);
+    output.snapshot(Output{gDataOriginTPC, getDataDescription1DIDCEPNWeights(), subSpec}, mOneDIDCs.second);
   }
 
   void sendOutput(DataAllocator& output, const uint32_t cru)
   {
     const header::DataHeader::SubSpecificationType subSpec{cru << 7};
-    output.adoptContainer(Output{gDataOriginTPC, getDataDescriptionIDCGroup(CRU(cru).side()), subSpec, Lifetime::Timeframe}, std::move(mIDCs[cru]));
+    output.adoptContainer(Output{gDataOriginTPC, getDataDescriptionIDCGroup(CRU(cru).side()), subSpec}, std::move(mIDCs[cru]));
   }
 
   void fill1DIDCs(const uint32_t cru)

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformEPNSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformEPNSpec.h
@@ -120,7 +120,7 @@ class TPCFourierTransformEPNSpec : public o2::framework::Task
 
   void sendOutput(DataAllocator& output, const Side side)
   {
-    output.snapshot(Output{gDataOriginTPC, getDataDescription(), header::DataHeader::SubSpecificationType{side}, Lifetime::Timeframe}, mIDCFourierTransform.getFourierCoefficients().getFourierCoefficients());
+    output.snapshot(Output{gDataOriginTPC, getDataDescription(), header::DataHeader::SubSpecificationType{side}}, mIDCFourierTransform.getFourierCoefficients().getFourierCoefficients());
   }
 };
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCIntegrateIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCIntegrateIDCSpec.h
@@ -92,14 +92,14 @@ class TPCIntegrateIDCDevice : public o2::framework::Task
     for (const auto& idcs : mIDCs[sector].get()) {
       const header::DataHeader::SubSpecificationType subSpec{cru << 7};
       if (mIDCFormat == IDCFormat::Sim) {
-        output.snapshot(Output{gDataOriginTPC, getDataDescription(mIDCFormat), subSpec, Lifetime::Timeframe}, idcs);
+        output.snapshot(Output{gDataOriginTPC, getDataDescription(mIDCFormat), subSpec}, idcs);
       } else {
         // TODO
         // convert to format from thorsten here
         // send.......
         // DUMMY FOR NOW
         // const TPCCRUHeader cruheader{cru, mIntegrationIntervalsPerTF};
-        output.snapshot(Output{gDataOriginTPC, getDataDescription(mIDCFormat), subSpec, Lifetime::Timeframe}, idcs);
+        output.snapshot(Output{gDataOriginTPC, getDataDescription(mIDCFormat), subSpec}, idcs);
       }
       ++cru;
     }

--- a/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/PublisherSpec.h
+++ b/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/PublisherSpec.h
@@ -62,22 +62,21 @@ framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool 
 
   // a creator callback for the actual reader instance
   auto creator = [dto, mco, propagateMC](const char* treename, const char* filename, int nofEvents, Reader::PublishingMode publishingMode, o2::header::DataHeader::SubSpecificationType subSpec, const char* branchname, const char* mcbranchname, Reader::SpecialPublishHook* publishhook = nullptr) {
-    constexpr auto persistency = o2::framework::Lifetime::Timeframe;
     if (propagateMC) {
       return std::make_shared<Reader>(treename,
                                       filename,
                                       nofEvents,
                                       publishingMode,
-                                      Output{mco.origin, mco.description, subSpec, persistency},
+                                      Output{mco.origin, mco.description, subSpec},
                                       mcbranchname,
-                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subSpec, persistency}, branchname},
+                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subSpec}, branchname},
                                       publishhook);
     } else {
       return std::make_shared<Reader>(treename,
                                       filename,
                                       nofEvents,
                                       publishingMode,
-                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subSpec, persistency}, branchname},
+                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, subSpec}, branchname},
                                       publishhook);
     }
   };

--- a/Detectors/TPC/workflow/readers/src/PublisherSpec.cxx
+++ b/Detectors/TPC/workflow/readers/src/PublisherSpec.cxx
@@ -204,9 +204,9 @@ DataProcessorSpec createPublisherSpec(PublisherConf const& config, bool propagat
         header.sectorBits = 0;
         header.activeSectors = processAttributes->activeSectors;
         for (auto const& subSpec : processAttributes->zeroLengthOutputs) {
-          pc.outputs().make<char>({dto.origin, dto.description, subSpec, Lifetime::Timeframe, {header}});
+          pc.outputs().make<char>({dto.origin, dto.description, subSpec, {header}});
           if (pc.outputs().isAllowed({mco.origin, mco.description, subSpec})) {
-            pc.outputs().make<char>({mco.origin, mco.description, subSpec, Lifetime::Timeframe, {header}});
+            pc.outputs().make<char>({mco.origin, mco.description, subSpec, {header}});
           }
         }
       }

--- a/Detectors/TPC/workflow/readers/src/TrackReaderSpec.cxx
+++ b/Detectors/TPC/workflow/readers/src/TrackReaderSpec.cxx
@@ -68,10 +68,10 @@ void TrackReader::run(ProcessingContext& pc)
     }
   }
 
-  pc.outputs().snapshot(Output{"TPC", "TRACKS", 0, Lifetime::Timeframe}, mTracksOut);
-  pc.outputs().snapshot(Output{"TPC", "CLUSREFS", 0, Lifetime::Timeframe}, mCluRefVecOut);
+  pc.outputs().snapshot(Output{"TPC", "TRACKS", 0}, mTracksOut);
+  pc.outputs().snapshot(Output{"TPC", "CLUSREFS", 0}, mCluRefVecOut);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe}, mMCTruthOut);
+    pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBL", 0}, mMCTruthOut);
   }
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/TPC/workflow/readers/src/TriggerReaderSpec.cxx
+++ b/Detectors/TPC/workflow/readers/src/TriggerReaderSpec.cxx
@@ -36,7 +36,7 @@ void TriggerReader::run(ProcessingContext& pc)
   auto ent = mTree->GetReadEntry() + 1;
   mTree->GetEntry(ent);
 
-  pc.outputs().snapshot(Output{"TPC", "TRIGGERWORDS", 0, Lifetime::Timeframe}, *mTrig);
+  pc.outputs().snapshot(Output{"TPC", "TRIGGERWORDS", 0}, *mTrig);
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Detectors/TPC/workflow/src/ChunkedDigitPublisher.cxx
+++ b/Detectors/TPC/workflow/src/ChunkedDigitPublisher.cxx
@@ -111,8 +111,7 @@ auto makePublishBuffer(framework::ProcessingContext& pc, int sector, uint64_t ac
 
   o2::tpc::TPCSectorHeader header{sector};
   header.activeSectors = activeSectors;
-  return &pc.outputs().make<T>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe,
-                                      header});
+  return &pc.outputs().make<T>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(sector), header});
 }
 
 template <>
@@ -138,7 +137,7 @@ void publishBuffer<MCTruthContainer>(framework::ProcessingContext& pc, int secto
   LabelType* sharedlabels;
 #pragma omp critical
   sharedlabels = &pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(
-    Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe, header});
+    Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(sector), header});
 
   accum->flatten_to(*sharedlabels);
   delete accum;

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -88,7 +88,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
           o2::header::Stack actual{*sectorHeaderMC};
           std::swap(mcHeaderStack, actual);
           if (sectorHeaderMC->sector() < 0) {
-            pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, Lifetime::Timeframe, std::move(mcHeaderStack)}, fanSpec);
+            pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, std::move(mcHeaderStack)}, fanSpec);
           }
         }
       }
@@ -97,7 +97,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
         o2::header::Stack actual{*sectorHeader};
         std::swap(rawHeaderStack, actual);
         if (sectorHeader->sector() < 0) {
-          pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack)}, fanSpec);
+          pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, std::move(rawHeaderStack)}, fanSpec);
           return;
         }
       }
@@ -167,7 +167,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       // containers are created for clusters and MC labels per (sector,globalPadRow) address
       char* outputBuffer = nullptr;
       auto outputAllocator = [&pc, &fanSpec, &outputBuffer, &rawHeaderStack](size_t size) -> char* {
-        outputBuffer = pc.outputs().newChunk(Output{gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack)}, size).data();
+        outputBuffer = pc.outputs().newChunk(Output{gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, std::move(rawHeaderStack)}, size).data();
         return outputBuffer;
       };
       MCLabelContainer mcout;
@@ -188,7 +188,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
         // serialize the complete list of MC label containers
         ConstMCLabelContainer labelsFlat;
         mcout.flatten_to(labelsFlat);
-        pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, Lifetime::Timeframe, std::move(mcHeaderStack)}, labelsFlat);
+        pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, std::move(mcHeaderStack)}, labelsFlat);
       }
     };
 

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -81,9 +81,9 @@ DataProcessorSpec getClustererSpec(bool sendMC)
         // forward the control information
         // FIXME define and use flags in TPCSectorHeader
         o2::tpc::TPCSectorHeader header{sector};
-        pc.outputs().snapshot(Output{gDataOriginTPC, "CLUSTERHW", fanSpec, Lifetime::Timeframe, {header}}, fanSpec);
+        pc.outputs().snapshot(Output{gDataOriginTPC, "CLUSTERHW", fanSpec, {header}}, fanSpec);
         if (DataRefUtils::isValid(mclabelref)) {
-          pc.outputs().snapshot(Output{gDataOriginTPC, "CLUSTERHWMCLBL", fanSpec, Lifetime::Timeframe, {header}}, fanSpec);
+          pc.outputs().snapshot(Output{gDataOriginTPC, "CLUSTERHWMCLBL", fanSpec, {header}}, fanSpec);
         }
         return;
       }
@@ -131,12 +131,12 @@ DataProcessorSpec getClustererSpec(bool sendMC)
       }
       // FIXME: that should be a case for pmr, want to send the content of the vector as a binary
       // block by using move semantics
-      auto outputPages = pc.outputs().make<ClusterHardwareContainer8kb>(Output{gDataOriginTPC, "CLUSTERHW", fanSpec, Lifetime::Timeframe, {*sectorHeader}}, clusterArray.size());
+      auto outputPages = pc.outputs().make<ClusterHardwareContainer8kb>(Output{gDataOriginTPC, "CLUSTERHW", fanSpec, {*sectorHeader}}, clusterArray.size());
       std::copy(clusterArray.begin(), clusterArray.end(), outputPages.begin());
       if (DataRefUtils::isValid(mclabelref)) {
         ConstMCLabelContainer mcflat;
         mctruthArray.flatten_to(mcflat);
-        pc.outputs().snapshot(Output{gDataOriginTPC, "CLUSTERHWMCLBL", fanSpec, Lifetime::Timeframe, {*sectorHeader}}, mcflat);
+        pc.outputs().snapshot(Output{gDataOriginTPC, "CLUSTERHWMCLBL", fanSpec, {*sectorHeader}}, mcflat);
       }
     };
 

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -133,7 +133,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto triggers = pc.inputs().get<gsl::span<o2::tpc::TriggerInfoDLBZS>>("trigger");
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TPC", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TPC", "CTFDATA", 0});
   std::vector<bool> rejectHits, rejectTracks, rejectTrackHits, rejectTrackHitsReduced;
   CompressedClusters clustersFiltered = clusters;
   std::vector<std::pair<std::vector<unsigned int>, std::vector<unsigned short>>> tmpBuffer(std::max<int>(mNThreads, 1));

--- a/Detectors/TPC/workflow/src/KryptonClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/KryptonClustererSpec.cxx
@@ -75,7 +75,7 @@ class KrBoxClusterFinderDevice : public o2::framework::Task
   {
     o2::tpc::TPCSectorHeader header{sector};
     header.activeSectors = (0x1 << sector);
-    output.snapshot(Output{gDataOriginTPC, "KRCLUSTERS", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe, header}, clusters);
+    output.snapshot(Output{gDataOriginTPC, "KRCLUSTERS", static_cast<SubSpecificationType>(sector), header}, clusters);
   }
 };
 

--- a/Detectors/TPC/workflow/src/KryptonRawFilterSpec.cxx
+++ b/Detectors/TPC/workflow/src/KryptonRawFilterSpec.cxx
@@ -223,7 +223,7 @@ class KrRawFilterDevice : public o2::framework::Task
   {
     o2::tpc::TPCSectorHeader header{sector};
     header.activeSectors = (0x1 << sector);
-    output.snapshot(Output{gDataOriginTPC, "FILTERDIG", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe, header}, digits);
+    output.snapshot(Output{gDataOriginTPC, "FILTERDIG", static_cast<SubSpecificationType>(sector), header}, digits);
   }
 };
 

--- a/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
@@ -110,7 +110,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
         header.activeSectors = processAttributes->activeSectors;
         // digit for now are transported per sector, not per lane
         // pc.outputs().snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe, header},
-        pc.outputs().snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe, header},
+        pc.outputs().snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(sector), header},
                               const_cast<std::vector<o2::tpc::Digit>&>(digits));
       };
 

--- a/Detectors/TPC/workflow/src/MIPTrackFilterSpec.cxx
+++ b/Detectors/TPC/workflow/src/MIPTrackFilterSpec.cxx
@@ -141,7 +141,7 @@ void MIPTrackFilterDevice::run(ProcessingContext& pc)
   mMIPTracks.clear();
 }
 
-void MIPTrackFilterDevice::sendOutput(DataAllocator& output) { output.snapshot(Output{header::gDataOriginTPC, "MIPS", 0, Lifetime::Timeframe}, mMIPTracks); }
+void MIPTrackFilterDevice::sendOutput(DataAllocator& output) { output.snapshot(Output{header::gDataOriginTPC, "MIPS", 0}, mMIPTracks); }
 
 void MIPTrackFilterDevice::endOfStream(EndOfStreamContext& eos)
 {

--- a/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
@@ -226,10 +226,10 @@ class TPCDigitDumpDevice : public o2::framework::Task
       o2::tpc::TPCSectorHeader header{isector};
       header.activeSectors = mActiveSectors;
       // digit for now are transported per sector, not per lane
-      output.snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(isector), Lifetime::Timeframe, header},
+      output.snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(isector), header},
                       mDigitDump.getDigits(isector));
       if (mSendCEdigits) {
-        output.snapshot(Output{"TPC", "CEDIGITS", static_cast<SubSpecificationType>(isector), Lifetime::Timeframe, header},
+        output.snapshot(Output{"TPC", "CEDIGITS", static_cast<SubSpecificationType>(isector), header},
                         ceDigits[isector]);
       }
     }

--- a/Detectors/TPC/workflow/src/SACProcessorSpec.cxx
+++ b/Detectors/TPC/workflow/src/SACProcessorSpec.cxx
@@ -129,8 +129,8 @@ class SACProcessorDevice : public Task
 
   void sendData(DataAllocator& output)
   {
-    output.snapshot(Output{"TPC", "REFTIMESAC", 0, Lifetime::Timeframe}, mDecoder.getDecodedData().referenceTime);
-    output.snapshot(Output{"TPC", "DECODEDSAC", 0, Lifetime::Timeframe}, mDecoder.getDecodedData().getGoodData());
+    output.snapshot(Output{"TPC", "REFTIMESAC", 0}, mDecoder.getDecodedData().referenceTime);
+    output.snapshot(Output{"TPC", "DECODEDSAC", 0}, mDecoder.getDecodedData().getGoodData());
     mDecoder.clearDecodedData();
   }
 

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -133,8 +133,8 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool outR
       }
       o2::tpc::TPCSectorHeader sh{0};
       gsl::span<ZeroSuppressedContainer8kb> outp(&page[0], offset);
-      pc.outputs().snapshot(Output{gDataOriginTPC, "TPCZS", 0, Lifetime::Timeframe, sh}, outp);
-      pc.outputs().snapshot(Output{gDataOriginTPC, "ZSSIZES", 0, Lifetime::Timeframe, sh}, sizes);
+      pc.outputs().snapshot(Output{gDataOriginTPC, "TPCZS", 0, sh}, outp);
+      pc.outputs().snapshot(Output{gDataOriginTPC, "ZSSIZES", 0, sh}, sizes);
 
       if (outRaw) {
         // ===| set up raw writer |===================================================
@@ -301,7 +301,7 @@ DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& tpcSectors)
       for (int i = 0; i < NSectors; i++) {
         LOG(info) << "digits in sector " << i << " : " << outDigits[i].size();
         o2::tpc::TPCSectorHeader sh{i};
-        pc.outputs().snapshot(Output{gDataOriginTPC, "DIGITS", (unsigned int)i, Lifetime::Timeframe, sh}, outDigits[i]);
+        pc.outputs().snapshot(Output{gDataOriginTPC, "DIGITS", (unsigned int)i, sh}, outDigits[i]);
       }
     };
     return processingFct;

--- a/Detectors/TPC/workflow/test/test_ft_EPN_Aggregator.cxx
+++ b/Detectors/TPC/workflow/test/test_ft_EPN_Aggregator.cxx
@@ -243,7 +243,7 @@ DataProcessorSpec generateIDCsCRU(int lane, const unsigned int maxTFs, const std
               }
             }
           }
-          ctx.outputs().adoptContainer(Output{gDataOriginTPC, TPCIntegrateIDCDevice::getDataDescription(TPCIntegrateIDCDevice::IDCFormat::Sim), o2::header::DataHeader::SubSpecificationType{icru << 7}, Lifetime::Timeframe}, std::move(idcs));
+          ctx.outputs().adoptContainer(Output{gDataOriginTPC, TPCIntegrateIDCDevice::getDataDescription(TPCIntegrateIDCDevice::IDCFormat::Sim), o2::header::DataHeader::SubSpecificationType{icru << 7}}, std::move(idcs));
         }
 
         if (delay) {

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -77,16 +77,16 @@ void EventRecordContainer::sendData(o2::framework::ProcessingContext& pc, bool g
     counters.push_back(event.getCounters());
   }
 
-  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "DIGITS", 0, o2::framework::Lifetime::Timeframe}, digits);
-  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "TRACKLETS", 0, o2::framework::Lifetime::Timeframe}, tracklets);
-  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0, o2::framework::Lifetime::Timeframe}, triggers);
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "DIGITS", 0}, digits);
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "TRACKLETS", 0}, tracklets);
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0}, triggers);
   if (generatestats) {
     accumulateStats();
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mTFStats.mTFIDInfo);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "RAWSTATS", 0, o2::framework::Lifetime::Timeframe}, mTFStats);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "RAWSTATS", 0}, mTFStats);
   }
   if (sendLinkStats) {
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "LINKSTATS", 0, o2::framework::Lifetime::Timeframe}, counters);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "LINKSTATS", 0}, counters);
   }
 
   std::chrono::duration<double, std::micro> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/KrClustererSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/KrClustererSpec.h
@@ -67,8 +67,8 @@ void TRDKrClustererDevice::run(ProcessingContext& pc)
   LOGP(info, "Found {} Kr clusters in {} input trigger records. Timing: CPU: {}, Real: {}",
        mKrClFinder.getKrClusters().size(), triggerRecords.size(), timer.CpuTime(), timer.RealTime());
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "KRCLUSTER", 0, Lifetime::Timeframe}, mKrClFinder.getKrClusters());
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGKRCLS", 0, Lifetime::Timeframe}, mKrClFinder.getKrTrigRecs());
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "KRCLUSTER", 0}, mKrClFinder.getKrClusters());
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGKRCLS", 0}, mKrClFinder.getKrTrigRecs());
 }
 
 void TRDKrClustererDevice::endOfStream(EndOfStreamContext& ec)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
@@ -63,7 +63,7 @@ class TRDGlobalTrackingQC : public Task
     mQC.reset();
     mQC.setInput(recoData);
     mQC.run();
-    pc.outputs().snapshot(Output{"TRD", "TRACKINGQC", 0, Lifetime::Timeframe}, mQC.getTrackQC());
+    pc.outputs().snapshot(Output{"TRD", "TRACKINGQC", 0}, mQC.getTrackQC());
   }
   void endOfStream(framework::EndOfStreamContext& ec) final {}
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
@@ -52,7 +52,7 @@ class PuseHeightDevice : public o2::framework::Task
     }
     if (mRunStopRequested) {
       std::vector<PHData> mPHValues{}; // the calibration expects data at every TF, so inject dummy
-      pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHT", 0, Lifetime::Timeframe}, mPHValues);
+      pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHT", 0}, mPHValues);
       return;
     }
     RecoContainer recoData;
@@ -61,7 +61,7 @@ class PuseHeightDevice : public o2::framework::Task
     mPulseHeight->setInput(recoData, &digits);
     mPulseHeight->reset();
     mPulseHeight->process();
-    pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHT", 0, Lifetime::Timeframe}, mPulseHeight->getPHData());
+    pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHT", 0}, mPulseHeight->getPHData());
     if (pc.transitionState() == TransitionHandlingState::Requested) {
       LOG(info) << "Run stop requested, finalizing";
       mRunStopRequested = true;

--- a/Detectors/TRD/workflow/io/src/TRDCalibReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibReaderSpec.cxx
@@ -53,7 +53,7 @@ void TRDCalibReader::run(ProcessingContext& pc)
   assert(currEntry < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(currEntry);
   LOG(info) << "Pushing angular residual histograms filled with " << mAngResids.getNEntries() << " entries at tree entry " << currEntry;
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "ANGRESHISTS", 0, Lifetime::Timeframe}, mAngResids);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "ANGRESHISTS", 0}, mAngResids);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/TRD/workflow/io/src/TRDDigitReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDDigitReaderSpec.cxx
@@ -58,13 +58,13 @@ void TRDDigitReaderSpec::run(ProcessingContext& pc)
   assert(currEntry < mTreeDigits->GetEntries()); // this should not happen
   mTreeDigits->GetEntry(currEntry);
   LOGP(info, "Pushing {} digits for tree entry {}", mDigits.size(), currEntry);
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "DIGITS", mSubSpec, Lifetime::Timeframe}, mDigits);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "DIGITS", mSubSpec}, mDigits);
   if (mUseTriggerRecords) {
     LOGP(info, "Pushing {} trigger records for tree entry {}", mTriggerRecords.size(), currEntry);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", mSubSpec, Lifetime::Timeframe}, mTriggerRecords);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", mSubSpec}, mTriggerRecords);
   }
   if (mUseMC) {
-    auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{o2::header::gDataOriginTRD, "LABELS", 0, Lifetime::Timeframe});
+    auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{o2::header::gDataOriginTRD, "LABELS", 0});
     mLabels->copyandflatten(sharedlabels);
   }
   if (mTreeDigits->GetReadEntry() + 1 >= mTreeDigits->GetEntries()) {

--- a/Detectors/TRD/workflow/io/src/TRDPHReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDPHReaderSpec.cxx
@@ -54,7 +54,7 @@ void TRDPHReader::run(ProcessingContext& pc)
   mTree->GetEntry(currEntry);
 
   LOG(info) << "Pushing vector of PH values filled with " << mPHValues.size() << " entries at tree entry " << currEntry;
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "PULSEHEIGHT", 0, Lifetime::Timeframe}, mPHValues);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "PULSEHEIGHT", 0}, mPHValues);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
@@ -50,18 +50,18 @@ void TRDTrackReader::run(ProcessingContext& pc)
 
   if (mMode == Mode::TPCTRD) {
     uint32_t ss = o2::globaltracking::getSubSpec(mSubSpecStrict ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_TPC", ss, Lifetime::Timeframe}, mTracks);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_TPC", ss, Lifetime::Timeframe}, mTrigRec);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_TPC", ss}, mTracks);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_TPC", ss}, mTrigRec);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", ss, Lifetime::Timeframe}, mLabelsMatch);
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", ss, Lifetime::Timeframe}, mLabelsTrd);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", ss}, mLabelsMatch);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", ss}, mLabelsTrd);
     }
   } else if (mMode == Mode::ITSTPCTRD) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0, Lifetime::Timeframe}, mTracks);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe}, mTrigRec);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0}, mTracks);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0}, mTrigRec);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe}, mLabelsMatch);
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe}, mLabelsTrd);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0}, mLabelsMatch);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0}, mLabelsTrd);
     }
   }
 

--- a/Detectors/TRD/workflow/io/src/TRDTrackletReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackletReaderSpec.cxx
@@ -72,20 +72,20 @@ void TRDTrackletReader::run(ProcessingContext& pc)
   mTreeTrklt->GetEntry(currEntry);
   LOG(info) << "Pushing " << mTriggerRecords.size() << " TRD trigger records at entry " << currEntry;
   LOG(info) << "Pushing " << mTracklets.size() << " uncalibrated TRD tracklets for these trigger records";
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe}, mTracklets);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRACKLETS", 0}, mTracklets);
   if (mUseTrackletTransform) {
     assert(mTreeTrklt->GetEntries() == mTreeCTrklt->GetEntries());
     mTreeCTrklt->GetEntry(currEntry);
     LOG(info) << "Pushing " << mTrackletsCal.size() << " calibrated TRD tracklets for these trigger records";
     LOG(info) << "Pushing " << mTrigRecMask.size() << " flags for the given TRD trigger records";
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "CTRACKLETS", 0, Lifetime::Timeframe}, mTrackletsCal);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRIGRECMASK", 0, Lifetime::Timeframe}, mTrigRecMask);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "CTRACKLETS", 0}, mTrackletsCal);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRIGRECMASK", 0}, mTrigRecMask);
   }
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe}, mTriggerRecords);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0}, mTriggerRecords);
   if (mUseMC) {
     LOG(info) << "Pushing " << mLabels.getNElements() << " TRD tracklet labels";
-    pc.outputs().snapshot(Output{"TRD", "TRKLABELS", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{"TRD", "TRKLABELS", 0}, mLabels);
   }
 
   if (mTreeTrklt->GetReadEntry() + 1 >= mTreeTrklt->GetEntries()) {

--- a/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
@@ -76,7 +76,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TRD", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TRD", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, triggers, tracklets, digits);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -177,17 +177,17 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     LOGF(info, "TRD digitization timing: Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
 
     LOG(info) << "TRD: Sending " << digitsAccum.size() << " digits";
-    pc.outputs().snapshot(Output{"TRD", "DIGITS", 1, Lifetime::Timeframe}, digitsAccum);
+    pc.outputs().snapshot(Output{"TRD", "DIGITS", 1}, digitsAccum);
     if (mctruth) {
       LOG(info) << "TRD: Sending " << labelsAccum.getNElements() << " labels";
       // we are flattening the labels and write to managed shared memory container for further communication
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TRD", "LABELS", 0, Lifetime::Timeframe});
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TRD", "LABELS", 0});
       labelsAccum.flatten_to(sharedlabels);
     }
     LOG(info) << "TRD: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"TRD", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"TRD", "ROMode", 0}, mROMode);
     LOG(info) << "TRD: Sending trigger records";
-    pc.outputs().snapshot(Output{"TRD", "TRKTRGRD", 1, Lifetime::Timeframe}, triggers);
+    pc.outputs().snapshot(Output{"TRD", "TRKTRGRD", 1}, triggers);
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     finished = true;

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -496,19 +496,19 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
 
   uint32_t ss = o2::globaltracking::getSubSpec(mStrict ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
   if (GTrackID::includesSource(GTrackID::Source::ITSTPC, mTrkMask)) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0, Lifetime::Timeframe}, tracksOutITSTPC);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe}, trackTrigRecITSTPC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0}, tracksOutITSTPC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0}, trackTrigRecITSTPC);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe}, matchLabelsITSTPC);
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe}, trdLabelsITSTPC);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0}, matchLabelsITSTPC);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0}, trdLabelsITSTPC);
     }
   }
   if (GTrackID::includesSource(GTrackID::Source::TPC, mTrkMask)) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_TPC", ss, Lifetime::Timeframe}, tracksOutTPC);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_TPC", ss, Lifetime::Timeframe}, trackTrigRecTPC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_TPC", ss}, tracksOutTPC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_TPC", ss}, trackTrigRecTPC);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", ss, Lifetime::Timeframe}, matchLabelsTPC);
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", ss, Lifetime::Timeframe}, trdLabelsTPC);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", ss}, matchLabelsTPC);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", ss}, trdLabelsTPC);
     }
   }
 

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -113,8 +113,8 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
 
   LOGF(info, "Found %lu tracklets in %lu trigger records. Applied filter for ITS IR frames: %i. Transformed %i tracklets.", tracklets.size(), trigRecs.size(), mTrigRecFilterActive, nTrackletsTransformed);
 
-  pc.outputs().snapshot(Output{"TRD", "CTRACKLETS", 0, Lifetime::Timeframe}, calibratedTracklets);
-  pc.outputs().snapshot(Output{"TRD", "TRIGRECMASK", 0, Lifetime::Timeframe}, trigRecBitfield);
+  pc.outputs().snapshot(Output{"TRD", "CTRACKLETS", 0}, calibratedTracklets);
+  pc.outputs().snapshot(Output{"TRD", "TRIGRECMASK", 0}, trigRecBitfield);
 }
 
 void TRDTrackletTransformerSpec::updateTimeDependentParams(ProcessingContext& pc)

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -328,11 +328,11 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   LOG(info) << "Digit Sorting took: " << std::chrono::duration_cast<std::chrono::milliseconds>(sortTime).count() << "ms";
   LOG(info) << "Processing time for parallel region: " << std::chrono::duration_cast<std::chrono::milliseconds>(parallelTime).count() << "ms";
 
-  pc.outputs().snapshot(Output{"TRD", "TRACKLETS", 0, Lifetime::Timeframe}, tracklets);
-  pc.outputs().snapshot(Output{"TRD", "TRKTRGRD", 0, Lifetime::Timeframe}, triggerRecords);
-  pc.outputs().snapshot(Output{"TRD", "DIGITS", 0, Lifetime::Timeframe}, digitsOut);
+  pc.outputs().snapshot(Output{"TRD", "TRACKLETS", 0}, tracklets);
+  pc.outputs().snapshot(Output{"TRD", "TRKTRGRD", 0}, triggerRecords);
+  pc.outputs().snapshot(Output{"TRD", "DIGITS", 0}, digitsOut);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"TRD", "TRKLABELS", 0, Lifetime::Timeframe}, lblTracklets);
+    pc.outputs().snapshot(Output{"TRD", "TRKLABELS", 0}, lblTracklets);
   }
 
   LOG(debug) << "TRD Trap Simulator Device exiting";

--- a/Detectors/TRD/workflow/src/TrackBasedCalibSpec.cxx
+++ b/Detectors/TRD/workflow/src/TrackBasedCalibSpec.cxx
@@ -75,12 +75,12 @@ void TRDTrackBasedCalibDevice::run(ProcessingContext& pc)
 
   if (mDoVdExBCalib) {
     mCalibrator.calculateAngResHistos();
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "ANGRESHISTS", 0, Lifetime::Timeframe}, mCalibrator.getAngResHistos());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "ANGRESHISTS", 0}, mCalibrator.getAngResHistos());
   }
 
   if (mDoGainCalib) {
     mCalibrator.calculateGainCalibObjs();
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "GAINCALIBHISTS", 0, Lifetime::Timeframe}, mCalibrator.getGainCalibHistos());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "GAINCALIBHISTS", 0}, mCalibrator.getGainCalibHistos());
   }
 
   mCalibrator.reset();

--- a/Detectors/Upgrades/ITS3/workflow/src/ClustererSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/ClustererSpec.cxx
@@ -109,17 +109,17 @@ void ClustererDPL::run(ProcessingContext& pc)
     clusterLabels = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
   }
   mClusterer->process(mNThreads, reader, &clusCompVec, mPatterns ? &clusPattVec : nullptr, &clusROFVec, clusterLabels.get());
-  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
-  pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
+  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0}, clusCompVec);
+  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "PATTERNS", 0}, clusPattVec);
 
   if (mUseMC) {
-    pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, *clusterLabels.get()); // at the moment requires snapshot
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0}, *clusterLabels.get()); // at the moment requires snapshot
     std::vector<o2::itsmft::MC2ROFRecord> clusterMC2ROframes(mc2rofs.size());
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF

--- a/Detectors/Upgrades/ITS3/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/DigitReaderSpec.cxx
@@ -71,17 +71,17 @@ void DigitReader::run(ProcessingContext& pc)
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
   // To be fixed once the names-definition class is ready
-  pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0, Lifetime::Timeframe}, mDigROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigits);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, mDigROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0}, mDigits);
   if (mUseCalib) {
-    pc.outputs().snapshot(Output{mOrigin, "GBTCALIB", 0, Lifetime::Timeframe}, mCalib);
+    pc.outputs().snapshot(Output{mOrigin, "GBTCALIB", 0}, mCalib);
   }
 
   if (mUseMC) {
-    auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe});
+    auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
     plabels->copyandflatten(sharedlabels);
     delete plabels;
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0, Lifetime::Timeframe}, mDigMC2ROFs);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, mDigMC2ROFs);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackReaderSpec.cxx
@@ -44,14 +44,14 @@ void TrackReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " track in " << mROFRec.size() << " ROFs at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "IT3TrackROF", 0, Lifetime::Timeframe}, mROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0, Lifetime::Timeframe}, mTracks);
-  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0, Lifetime::Timeframe}, mClusInd);
-  pc.outputs().snapshot(Output{"IT3", "VERTICES", 0, Lifetime::Timeframe}, mVertices);
-  pc.outputs().snapshot(Output{"IT3", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "IT3TrackROF", 0}, mROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0}, mTracks);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0}, mClusInd);
+  pc.outputs().snapshot(Output{"IT3", "VERTICES", 0}, mVertices);
+  pc.outputs().snapshot(Output{"IT3", "VERTICESROF", 0}, mVerticesROFRec);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
-    pc.outputs().snapshot(Output{mOrigin, "VERTICESMCTR", 0, Lifetime::Timeframe}, mMCVertTruth);
+    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "VERTICESMCTR", 0}, mMCVertTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -171,9 +171,9 @@ void TrackerDPL::run(ProcessingContext& pc)
   // the output vector however is created directly inside the message memory thus avoiding copy by
   // snapshot
   auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"IT3", "IT3TrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"IT3", "IT3TrackROF", 0}, rofsinput.begin(), rofsinput.end());
 
-  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"IT3", "IRFRAMES", 0, Lifetime::Timeframe});
+  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"IT3", "IRFRAMES", 0});
 
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
   int nBCPerTF = alpParams.roFrameLengthInBC;
@@ -189,15 +189,15 @@ void TrackerDPL::run(ProcessingContext& pc)
     LOG(info) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
   }
 
-  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"IT3", "TRACKCLSID", 0, Lifetime::Timeframe});
+  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"IT3", "TRACKCLSID", 0});
   std::vector<o2::MCCompLabel> trackLabels;
   std::vector<MCCompLabel> verticesLabels;
-  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"IT3", "TRACKS", 0, Lifetime::Timeframe});
+  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"IT3", "TRACKS", 0});
   std::vector<o2::MCCompLabel> allTrackLabels;
   std::vector<o2::MCCompLabel> allVerticesLabels;
 
-  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"IT3", "VERTICESROF", 0, Lifetime::Timeframe});
-  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"IT3", "VERTICES", 0, Lifetime::Timeframe});
+  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"IT3", "VERTICESROF", 0});
+  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"IT3", "VERTICES", 0});
 
   TimeFrame* timeFrame = mChainITS->GetITSTimeframe();
   timeFrame->resizeVectors(mNLayers);
@@ -314,9 +314,9 @@ void TrackerDPL::run(ProcessingContext& pc)
       LOGP(info, "ITS3Tracker pushed {} track labels", allTrackLabels.size());
       LOGP(info, "ITS3Tracker pushed {} vertex labels", allVerticesLabels.size());
 
-      pc.outputs().snapshot(Output{"IT3", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
-      pc.outputs().snapshot(Output{"IT3", "VERTICESMCTR", 0, Lifetime::Timeframe}, allVerticesLabels);
-      pc.outputs().snapshot(Output{"IT3", "IT3TrackMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
+      pc.outputs().snapshot(Output{"IT3", "TRACKSMCTR", 0}, allTrackLabels);
+      pc.outputs().snapshot(Output{"IT3", "VERTICESMCTR", 0}, allVerticesLabels);
+      pc.outputs().snapshot(Output{"IT3", "IT3TrackMC2ROF", 0}, mc2rofs);
     }
   }
   mTimer.Stop();

--- a/Detectors/Upgrades/ITS3/workflow/src/VertexReaderSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/VertexReaderSpec.cxx
@@ -41,8 +41,8 @@ void VertexReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mVerticesPtr->size() << " vertices in " << mVerticesROFRecPtr->size()
             << " ROFs at entry " << ent;
-  pc.outputs().snapshot(Output{"IT3", "VERTICES", 0, Lifetime::Timeframe}, mVertices);
-  pc.outputs().snapshot(Output{"IT3", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
+  pc.outputs().snapshot(Output{"IT3", "VERTICES", 0}, mVertices);
+  pc.outputs().snapshot(Output{"IT3", "VERTICESROF", 0}, mVerticesROFRec);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -117,15 +117,15 @@ void SVertexer::produceOutput(o2::framework::ProcessingContext& pc)
   std::sort(nbodySortID.begin(), nbodySortID.end(), [](const vid& a, const vid& b) { return a.vtxID < b.vtxID; });
 
   // dpl output
-  auto& v0sIdx = pc.outputs().make<std::vector<V0Index>>(o2f::Output{"GLO", "V0S_IDX", 0, o2f::Lifetime::Timeframe});
-  auto& cascsIdx = pc.outputs().make<std::vector<CascadeIndex>>(o2f::Output{"GLO", "CASCS_IDX", 0, o2f::Lifetime::Timeframe});
-  auto& body3Idx = pc.outputs().make<std::vector<Decay3BodyIndex>>(o2f::Output{"GLO", "DECAYS3BODY_IDX", 0, o2f::Lifetime::Timeframe});
-  auto& fullv0s = pc.outputs().make<std::vector<V0>>(o2f::Output{"GLO", "V0S", 0, o2f::Lifetime::Timeframe});
-  auto& fullcascs = pc.outputs().make<std::vector<Cascade>>(o2f::Output{"GLO", "CASCS", 0, o2f::Lifetime::Timeframe});
-  auto& full3body = pc.outputs().make<std::vector<Decay3Body>>(o2f::Output{"GLO", "DECAYS3BODY", 0, o2f::Lifetime::Timeframe});
-  auto& v0Refs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_V0REFS", 0, o2f::Lifetime::Timeframe});
-  auto& cascRefs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_CASCREFS", 0, o2f::Lifetime::Timeframe});
-  auto& vtx3bodyRefs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_3BODYREFS", 0, o2f::Lifetime::Timeframe});
+  auto& v0sIdx = pc.outputs().make<std::vector<V0Index>>(o2f::Output{"GLO", "V0S_IDX", 0});
+  auto& cascsIdx = pc.outputs().make<std::vector<CascadeIndex>>(o2f::Output{"GLO", "CASCS_IDX", 0});
+  auto& body3Idx = pc.outputs().make<std::vector<Decay3BodyIndex>>(o2f::Output{"GLO", "DECAYS3BODY_IDX", 0});
+  auto& fullv0s = pc.outputs().make<std::vector<V0>>(o2f::Output{"GLO", "V0S", 0});
+  auto& fullcascs = pc.outputs().make<std::vector<Cascade>>(o2f::Output{"GLO", "CASCS", 0});
+  auto& full3body = pc.outputs().make<std::vector<Decay3Body>>(o2f::Output{"GLO", "DECAYS3BODY", 0});
+  auto& v0Refs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_V0REFS", 0});
+  auto& cascRefs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_CASCREFS", 0});
+  auto& vtx3bodyRefs = pc.outputs().make<std::vector<RRef>>(o2f::Output{"GLO", "PVTX_3BODYREFS", 0});
 
   // sorted V0s
   v0sIdx.reserve(mNV0s);
@@ -214,8 +214,8 @@ void SVertexer::produceOutput(o2::framework::ProcessingContext& pc)
       }
     }
 
-    auto& strTracksOut = pc.outputs().make<std::vector<o2::dataformats::StrangeTrack>>(o2f::Output{"GLO", "STRANGETRACKS", 0, o2f::Lifetime::Timeframe});
-    auto& strClustOut = pc.outputs().make<std::vector<o2::strangeness_tracking::ClusAttachments>>(o2f::Output{"GLO", "CLUSUPDATES", 0, o2f::Lifetime::Timeframe});
+    auto& strTracksOut = pc.outputs().make<std::vector<o2::dataformats::StrangeTrack>>(o2f::Output{"GLO", "STRANGETRACKS", 0});
+    auto& strClustOut = pc.outputs().make<std::vector<o2::strangeness_tracking::ClusAttachments>>(o2f::Output{"GLO", "CLUSUPDATES", 0});
     o2::pmr::vector<o2::MCCompLabel> mcLabsOut;
     strTracksOut.resize(mNStrangeTracks);
     strClustOut.resize(mNStrangeTracks);
@@ -239,7 +239,7 @@ void SVertexer::produceOutput(o2::framework::ProcessingContext& pc)
     }
 
     if (mStrTracker->getMCTruthOn()) {
-      auto& strTrMCLableOut = pc.outputs().make<std::vector<o2::MCCompLabel>>(o2f::Output{"GLO", "STRANGETRACKS_MC", 0, o2f::Lifetime::Timeframe});
+      auto& strTrMCLableOut = pc.outputs().make<std::vector<o2::MCCompLabel>>(o2f::Output{"GLO", "STRANGETRACKS_MC", 0});
       strTrMCLableOut.swap(mcLabsOut);
     }
   }

--- a/Detectors/ZDC/calib/src/InterCalibEPNSpec.cxx
+++ b/Detectors/ZDC/calib/src/InterCalibEPNSpec.cxx
@@ -101,16 +101,16 @@ void InterCalibEPNSpec::run(ProcessingContext& pc)
   mWorker.process(bcrec, energy, tdc, info);
 
   // Send intermediate calibration data and histograms
-  o2::framework::Output output("ZDC", "INTERCALIBDATA", 0, Lifetime::Timeframe);
+  o2::framework::Output output("ZDC", "INTERCALIBDATA", 0);
   pc.outputs().snapshot(output, mWorker.mData);
   for (int ih = 0; ih < (2 * InterCalibData::NH); ih++) {
     if (mWorker.mH[ih] != nullptr) {
-      o2::framework::Output output("ZDC", "INTER_1DH", ih, Lifetime::Timeframe);
+      o2::framework::Output output("ZDC", "INTER_1DH", ih);
       pc.outputs().snapshot(output, mWorker.mH[ih]->getBase());
     }
   }
   for (int ih = 0; ih < InterCalibData::NH; ih++) {
-    o2::framework::Output output("ZDC", "INTER_2DH", ih, Lifetime::Timeframe);
+    o2::framework::Output output("ZDC", "INTER_2DH", ih);
     pc.outputs().snapshot(output, mWorker.mC[ih]->getBase());
   }
 }

--- a/Detectors/ZDC/calib/src/TDCCalibEPNSpec.cxx
+++ b/Detectors/ZDC/calib/src/TDCCalibEPNSpec.cxx
@@ -114,10 +114,10 @@ void TDCCalibEPNSpec::run(ProcessingContext& pc)
     if (mVerbosity > DbgMedium && mModTF > 0) {
       LOG(info) << "Send intermediate calibration data mProcessed=" << mProcessed << " >= mModTF=" << mModTF;
     }
-    o2::framework::Output output("ZDC", "TDCCALIBDATA", 0, Lifetime::Timeframe);
+    o2::framework::Output output("ZDC", "TDCCALIBDATA", 0);
     pc.outputs().snapshot(output, mWorker.mData);
     for (int ih = 0; ih < TDCCalibData::NTDC; ih++) {
-      o2::framework::Output output("ZDC", "TDC_1DH", ih, Lifetime::Timeframe);
+      o2::framework::Output output("ZDC", "TDC_1DH", ih);
       pc.outputs().snapshot(output, mWorker.mTDC[ih]->getBase());
     }
     mWorker.clear();

--- a/Detectors/ZDC/calib/src/WaveformCalibEPNSpec.cxx
+++ b/Detectors/ZDC/calib/src/WaveformCalibEPNSpec.cxx
@@ -107,7 +107,7 @@ void WaveformCalibEPNSpec::run(ProcessingContext& pc)
   mWorker.process(bcrec, energy, tdc, info, wave);
 
   // Send intermediate calibration data
-  o2::framework::Output output("ZDC", "WAVECALIBDATA", 0, Lifetime::Timeframe);
+  o2::framework::Output output("ZDC", "WAVECALIBDATA", 0);
   pc.outputs().snapshot(output, mWorker.mData);
 }
 

--- a/Detectors/ZDC/raw/include/ZDCRaw/RawReaderZDC.h
+++ b/Detectors/ZDC/raw/include/ZDCRaw/RawReaderZDC.h
@@ -95,9 +95,9 @@ class RawReaderZDC
 
   void makeSnapshot(o2::framework::ProcessingContext& pc)
   {
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginZDC, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mDigitsBC);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginZDC, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mDigitsCh);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginZDC, "DIGITSPD", 0, o2::framework::Lifetime::Timeframe}, mOrbitData);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginZDC, "DIGITSBC", 0}, mDigitsBC);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginZDC, "DIGITSCH", 0}, mDigitsCh);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginZDC, "DIGITSPD", 0}, mOrbitData);
   }
 };
 } // namespace zdc

--- a/Detectors/ZDC/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitReaderSpec.cxx
@@ -69,11 +69,11 @@ void DigitReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "ZDCDigitReader pushed " << zdcOrbitData.size() << " orbits with " << zdcBCData.size() << " bcs and " << zdcChData.size() << " digits";
-  pc.outputs().snapshot(Output{"ZDC", "DIGITSPD", 0, Lifetime::Timeframe}, zdcOrbitData);
-  pc.outputs().snapshot(Output{"ZDC", "DIGITSBC", 0, Lifetime::Timeframe}, zdcBCData);
-  pc.outputs().snapshot(Output{"ZDC", "DIGITSCH", 0, Lifetime::Timeframe}, zdcChData);
+  pc.outputs().snapshot(Output{"ZDC", "DIGITSPD", 0}, zdcOrbitData);
+  pc.outputs().snapshot(Output{"ZDC", "DIGITSBC", 0}, zdcBCData);
+  pc.outputs().snapshot(Output{"ZDC", "DIGITSCH", 0}, zdcChData);
   if (mUseMC) {
-    pc.outputs().snapshot(Output{"ZDC", "DIGITSLBL", 0, Lifetime::Timeframe}, labels);
+    pc.outputs().snapshot(Output{"ZDC", "DIGITSLBL", 0}, labels);
   }
   uint64_t nextEntry = mTree->GetReadEntry() + 1;
   if (nextEntry >= mTree->GetEntries() || (mLastEntry >= 0 && nextEntry > mLastEntry)) {

--- a/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
@@ -264,11 +264,11 @@ void DigitRecoSpec::run(ProcessingContext& pc)
   }
   // TODO: rate information for all channels
   // TODO: summary of reconstruction to be collected by DQM?
-  pc.outputs().snapshot(Output{"ZDC", "BCREC", 0, Lifetime::Timeframe}, recEvent.mRecBC);
-  pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0, Lifetime::Timeframe}, recEvent.mEnergy);
-  pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0, Lifetime::Timeframe}, recEvent.mTDCData);
-  pc.outputs().snapshot(Output{"ZDC", "INFO", 0, Lifetime::Timeframe}, recEvent.mInfo);
-  pc.outputs().snapshot(Output{"ZDC", "WAVE", 0, Lifetime::Timeframe}, recEvent.mWaveform);
+  pc.outputs().snapshot(Output{"ZDC", "BCREC", 0}, recEvent.mRecBC);
+  pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0}, recEvent.mEnergy);
+  pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0}, recEvent.mTDCData);
+  pc.outputs().snapshot(Output{"ZDC", "INFO", 0}, recEvent.mInfo);
+  pc.outputs().snapshot(Output{"ZDC", "WAVE", 0}, recEvent.mWaveform);
   mTimer.Stop();
 }
 

--- a/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
@@ -58,7 +58,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
 
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"ZDC", "CTFDATA", 0, Lifetime::Timeframe});
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"ZDC", "CTFDATA", 0});
   auto iosize = mCTFCoder.encode(buffer, bcdata, chans, peds);
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {

--- a/Detectors/ZDC/workflow/src/RecEventReaderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/RecEventReaderSpec.cxx
@@ -49,10 +49,10 @@ void RecEventReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
 
   LOG(info) << "ZDC RecEventReader pushes " << mBCRecData->size() << " events with " << mBCRecData->size() << " energy, " << mZDCTDCData->size() << " TDC and " << mZDCInfo->size() << " info records at entry " << ent;
-  pc.outputs().snapshot(Output{"ZDC", "BCREC", 0, Lifetime::Timeframe}, *mBCRecData);
-  pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0, Lifetime::Timeframe}, *mZDCEnergy);
-  pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0, Lifetime::Timeframe}, *mZDCTDCData);
-  pc.outputs().snapshot(Output{"ZDC", "INFO", 0, Lifetime::Timeframe}, *mZDCInfo);
+  pc.outputs().snapshot(Output{"ZDC", "BCREC", 0}, *mBCRecData);
+  pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0}, *mZDCEnergy);
+  pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0}, *mZDCTDCData);
+  pc.outputs().snapshot(Output{"ZDC", "INFO", 0}, *mZDCInfo);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();

--- a/Detectors/ZDC/workflow/src/RecoReaderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/RecoReaderSpec.cxx
@@ -64,10 +64,10 @@ void RecoReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "ZDCRecoReader pushed " << RecBC.size() << " b.c. " << Energy.size() << " Energies " << TDCData.size() << " TDCs " << Info.size() << " Infos";
-  pc.outputs().snapshot(Output{"ZDC", "BCREC", 0, Lifetime::Timeframe}, RecBC);
-  pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0, Lifetime::Timeframe}, Energy);
-  pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0, Lifetime::Timeframe}, TDCData);
-  pc.outputs().snapshot(Output{"ZDC", "INFO", 0, Lifetime::Timeframe}, Info);
+  pc.outputs().snapshot(Output{"ZDC", "BCREC", 0}, RecBC);
+  pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0}, Energy);
+  pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0}, TDCData);
+  pc.outputs().snapshot(Output{"ZDC", "INFO", 0}, Info);
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -43,6 +43,11 @@ struct Output {
   {
   }
 
+  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, header::Stack&& stack)
+    : origin(o), description(d), subSpec(s), metaHeader(std::move(stack))
+  {
+  }
+
   Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l,
          header::Stack&& stack)
     : origin(o), description(d), subSpec(s), lifetime(l), metaHeader(std::move(stack))

--- a/GPU/Workflow/src/GPUWorkflowITS.cxx
+++ b/GPU/Workflow/src/GPUWorkflowITS.cxx
@@ -134,8 +134,8 @@ int GPURecoWorkflowSpec::runITSTracking(o2::framework::ProcessingContext& pc)
 
   auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
 
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
-  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0, Lifetime::Timeframe});
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0}, rofsinput.begin(), rofsinput.end());
+  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0});
   irFrames.reserve(rofs.size());
 
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
@@ -148,19 +148,19 @@ int GPURecoWorkflowSpec::runITSTracking(o2::framework::ProcessingContext& pc)
   if (mSpecConfig.processMC) {
     labels = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("itsmclabels").release();
     // get the array as read-only span, a snapshot is sent forward
-    pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe}, pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("ITSMC2ROframes"));
+    pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0}, pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("ITSMC2ROframes"));
     LOG(info) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
   }
 
-  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
-  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
-  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
-  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
+  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0});
+  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0});
+  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0});
+  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0});
 
   // MC
   static pmr::vector<o2::MCCompLabel> dummyMCLabTracks, dummyMCLabVerts;
-  auto& allTrackLabels = mSpecConfig.processMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}) : dummyMCLabTracks;
-  auto& allVerticesLabels = mSpecConfig.processMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "VERTICESMCTR", 0, Lifetime::Timeframe}) : dummyMCLabVerts;
+  auto& allTrackLabels = mSpecConfig.processMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "TRACKSMCTR", 0}) : dummyMCLabTracks;
+  auto& allVerticesLabels = mSpecConfig.processMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "VERTICESMCTR", 0}) : dummyMCLabVerts;
 
   std::uint32_t roFrame = 0;
 

--- a/GPU/Workflow/src/GPUWorkflowPipeline.cxx
+++ b/GPU/Workflow/src/GPUWorkflowPipeline.cxx
@@ -177,7 +177,7 @@ int GPURecoWorkflowSpec::handlePipeline(ProcessingContext& pc, GPUTrackingInOutP
     ptrs.tpcZS = &tpcZS;
   }
   if (mSpecConfig.enableDoublePipeline == 2) {
-    auto prepareBuffer = pc.outputs().make<DataAllocator::UninitializedVector<char>>(Output{gDataOriginGPU, "PIPELINEPREPARE", 0, Lifetime::Timeframe}, 0u);
+    auto prepareBuffer = pc.outputs().make<DataAllocator::UninitializedVector<char>>(Output{gDataOriginGPU, "PIPELINEPREPARE", 0}, 0u);
 
     size_t ptrsTotal = 0;
     const void* firstPtr = nullptr;

--- a/Steer/DigitizerWorkflow/src/CPVDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CPVDigitizerSpec.cxx
@@ -171,15 +171,15 @@ void DigitizerSpec::run(framework::ProcessingContext& pc)
   }
   LOG(debug) << "Have " << mLabels.getNElements() << " CPV labels ";
   // here we have all digits and we can send them to consumer (aka snapshot it onto output)
-  pc.outputs().snapshot(Output{"CPV", "DIGITS", 0, Lifetime::Timeframe}, mDigitsOut);
-  pc.outputs().snapshot(Output{"CPV", "DIGITTRIGREC", 0, Lifetime::Timeframe}, triggers);
+  pc.outputs().snapshot(Output{"CPV", "DIGITS", 0}, mDigitsOut);
+  pc.outputs().snapshot(Output{"CPV", "DIGITTRIGREC", 0}, triggers);
   if (pc.outputs().isAllowed({"CPV", "DIGITSMCTR", 0})) {
-    pc.outputs().snapshot(Output{"CPV", "DIGITSMCTR", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{"CPV", "DIGITSMCTR", 0}, mLabels);
   }
   // CPV is always a triggered detector
   const o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::PRESENT;
   LOG(debug) << "CPV: Sending ROMode= " << roMode << " to GRPUpdater";
-  pc.outputs().snapshot(Output{"CPV", "ROMode", 0, Lifetime::Timeframe}, roMode);
+  pc.outputs().snapshot(Output{"CPV", "ROMode", 0}, roMode);
 
   timer.Stop();
   LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CTPDigitizerSpec.cxx
@@ -79,9 +79,9 @@ class CTPDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     auto digits = mDigitizer.process(ginputs);
     // send out to next stage
     LOG(info) << "CTP DIGITS being sent.";
-    pc.outputs().snapshot(Output{"CTP", "DIGITS", 0, Lifetime::Timeframe}, digits);
+    pc.outputs().snapshot(Output{"CTP", "DIGITS", 0}, digits);
     LOG(info) << "CTP PRESENT being sent.";
-    pc.outputs().snapshot(Output{"CTP", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"CTP", "ROMode", 0}, mROMode);
     timer.Stop();
     LOG(info) << "CTP Digitization took " << timer.CpuTime() << "s";
   }

--- a/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
@@ -120,17 +120,17 @@ class FDDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     mDigitizer.flush(mDigitsBC, mDigitsCh, mDigitsTrig, labels);
 
     // send out to next stage
-    pc.outputs().snapshot(Output{"FDD", "DIGITSBC", 0, Lifetime::Timeframe}, mDigitsBC);
-    pc.outputs().snapshot(Output{"FDD", "DIGITSCH", 0, Lifetime::Timeframe}, mDigitsCh);
-    pc.outputs().snapshot(Output{"FDD", "TRIGGERINPUT", 0, Lifetime::Timeframe}, mDigitsTrig);
+    pc.outputs().snapshot(Output{"FDD", "DIGITSBC", 0}, mDigitsBC);
+    pc.outputs().snapshot(Output{"FDD", "DIGITSCH", 0}, mDigitsCh);
+    pc.outputs().snapshot(Output{"FDD", "TRIGGERINPUT", 0}, mDigitsTrig);
     if (pc.outputs().isAllowed({"FDD", "DIGITLBL", 0})) {
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::fdd::MCLabel>>(Output{"FDD", "DIGITLBL", 0, Lifetime::Timeframe});
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::fdd::MCLabel>>(Output{"FDD", "DIGITLBL", 0});
       labels.flatten_to(sharedlabels);
       labels.clear_andfreememory();
     }
 
     LOG(info) << "FDD: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"FDD", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"FDD", "ROMode", 0}, mROMode);
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
@@ -138,14 +138,14 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
     mDigitizer.flush_all(mDigitsBC, mDigitsCh, mDigitsTrig, labels);
 
     // send out to next stage
-    pc.outputs().snapshot(Output{"FT0", "DIGITSBC", 0, Lifetime::Timeframe}, mDigitsBC);
-    pc.outputs().snapshot(Output{"FT0", "DIGITSCH", 0, Lifetime::Timeframe}, mDigitsCh);
-    pc.outputs().snapshot(Output{"FT0", "TRIGGERINPUT", 0, Lifetime::Timeframe}, mDigitsTrig);
+    pc.outputs().snapshot(Output{"FT0", "DIGITSBC", 0}, mDigitsBC);
+    pc.outputs().snapshot(Output{"FT0", "DIGITSCH", 0}, mDigitsCh);
+    pc.outputs().snapshot(Output{"FT0", "TRIGGERINPUT", 0}, mDigitsTrig);
     if (pc.outputs().isAllowed({"FT0", "DIGITSMCTR", 0})) {
-      pc.outputs().snapshot(Output{"FT0", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
+      pc.outputs().snapshot(Output{"FT0", "DIGITSMCTR", 0}, labels);
     }
     LOG(info) << "FT0: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"FT0", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"FT0", "ROMode", 0}, mROMode);
 
     timer.Stop();
     LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Steer/DigitizerWorkflow/src/FV0DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FV0DigitizerSpec.cxx
@@ -102,14 +102,14 @@ class FV0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
     LOG(info) << "FV0: Sending " << mDigitsBC.size() << " digitsBC and " << mDigitsCh.size() << " digitsCh.";
 
     // send out to next stage
-    pc.outputs().snapshot(Output{"FV0", "DIGITSBC", 0, Lifetime::Timeframe}, mDigitsBC);
-    pc.outputs().snapshot(Output{"FV0", "DIGITSCH", 0, Lifetime::Timeframe}, mDigitsCh);
-    pc.outputs().snapshot(Output{"FV0", "TRIGGERINPUT", 0, Lifetime::Timeframe}, mDigitsTrig);
+    pc.outputs().snapshot(Output{"FV0", "DIGITSBC", 0}, mDigitsBC);
+    pc.outputs().snapshot(Output{"FV0", "DIGITSCH", 0}, mDigitsCh);
+    pc.outputs().snapshot(Output{"FV0", "TRIGGERINPUT", 0}, mDigitsTrig);
     if (pc.outputs().isAllowed({"FV0", "DIGITLBL", 0})) {
-      pc.outputs().snapshot(Output{"FV0", "DIGITLBL", 0, Lifetime::Timeframe}, mLabels);
+      pc.outputs().snapshot(Output{"FV0", "DIGITLBL", 0}, mLabels);
     }
     LOG(info) << "FV0: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"FV0", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"FV0", "ROMode", 0}, mROMode);
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -132,13 +132,13 @@ class HMPIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     flushDigitsAndLabels();
 
     // send out to next stage
-    pc.outputs().snapshot(Output{"HMP", "DIGITS", 0, Lifetime::Timeframe}, digitsAccum);
-    pc.outputs().snapshot(Output{"HMP", "INTRECORDS", 0, Lifetime::Timeframe}, mIntRecord);
+    pc.outputs().snapshot(Output{"HMP", "DIGITS", 0}, digitsAccum);
+    pc.outputs().snapshot(Output{"HMP", "INTRECORDS", 0}, mIntRecord);
     if (pc.outputs().isAllowed({"HMP", "DIGITLBL", 0})) {
-      pc.outputs().snapshot(Output{"HMP", "DIGITLBL", 0, Lifetime::Timeframe}, labelAccum);
+      pc.outputs().snapshot(Output{"HMP", "DIGITLBL", 0}, labelAccum);
     }
     LOG(info) << "HMP: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"HMP", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"HMP", "ROMode", 0}, mROMode);
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Steer/DigitizerWorkflow/src/ITS3DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITS3DigitizerSpec.cxx
@@ -143,7 +143,7 @@ class ITS3DPLDigitizerTask : BaseDPLDigitizer
     mDigitizer.setMCLabels(&mLabels);
 
     // digits are directly put into DPL owned resource
-    auto& digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe});
+    auto& digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{mOrigin, "DIGITS", 0});
 
     auto accumulate = [this, &digitsAccum]() {
       // accumulate result of single event processing, called after processing every event supplied
@@ -216,17 +216,17 @@ class ITS3DPLDigitizerTask : BaseDPLDigitizer
 
     // here we have all digits and labels and we can send them to consumer (aka snapshot it onto output)
 
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0, Lifetime::Timeframe}, mROFRecordsAccum);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, mROFRecordsAccum);
     if (mWithMCTruth) {
-      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0, Lifetime::Timeframe}, mMC2ROFRecordsAccum);
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe});
+      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, mMC2ROFRecordsAccum);
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
       mLabelsAccum.flatten_to(sharedlabels);
       // free space of existing label containers
       mLabels.clear_andfreememory();
       mLabelsAccum.clear_andfreememory();
     }
     LOG(info) << mID.getName() << ": Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{mOrigin, "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{mOrigin, "ROMode", 0}, mROMode);
 
     timer.Stop();
     LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -82,7 +82,7 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     mDigitizer.setMCLabels(&mLabels);
 
     // digits are directly put into DPL owned resource
-    auto& digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe});
+    auto& digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{mOrigin, "DIGITS", 0});
 
     auto accumulate = [this, &digitsAccum]() {
       // accumulate result of single event processing, called after processing every event supplied
@@ -160,17 +160,17 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
 
     // here we have all digits and labels and we can send them to consumer (aka snapshot it onto output)
 
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0, Lifetime::Timeframe}, mROFRecordsAccum);
+    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, mROFRecordsAccum);
     if (mWithMCTruth) {
-      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0, Lifetime::Timeframe}, mMC2ROFRecordsAccum);
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0, Lifetime::Timeframe});
+      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, mMC2ROFRecordsAccum);
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
       mLabelsAccum.flatten_to(sharedlabels);
       // free space of existing label containers
       mLabels.clear_andfreememory();
       mLabelsAccum.clear_andfreememory();
     }
     LOG(info) << mID.getName() << ": Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{mOrigin, "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{mOrigin, "ROMode", 0}, mROMode);
 
     timer.Stop();
     LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -111,12 +111,12 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     dataformats::MCLabelContainer labels{};
     auto nPileup = mDigitizer->digitize(rofs, digits, labels);
 
-    pc.outputs().snapshot(Output{"MCH", "DIGITS", 0, Lifetime::Timeframe}, digits);
-    pc.outputs().snapshot(Output{"MCH", "DIGITROFS", 0, Lifetime::Timeframe}, rofs);
+    pc.outputs().snapshot(Output{"MCH", "DIGITS", 0}, digits);
+    pc.outputs().snapshot(Output{"MCH", "DIGITROFS", 0}, rofs);
     if (pc.outputs().isAllowed({"MCH", "DIGITSLABELS", 0})) {
-      pc.outputs().snapshot(Output{"MCH", "DIGITSLABELS", 0, Lifetime::Timeframe}, labels);
+      pc.outputs().snapshot(Output{"MCH", "DIGITSLABELS", 0}, labels);
     }
-    pc.outputs().snapshot(Output{"MCH", "ROMode", 0, Lifetime::Timeframe},
+    pc.outputs().snapshot(Output{"MCH", "ROMode", 0},
                           DigitizerParam::Instance().continuous ? o2::parameters::GRPObject::CONTINUOUS : o2::parameters::GRPObject::TRIGGERING);
 
     // we should be only called once; tell DPL that this process is ready to exit

--- a/Steer/DigitizerWorkflow/src/MCTruthReaderSpec.h
+++ b/Steer/DigitizerWorkflow/src/MCTruthReaderSpec.h
@@ -61,7 +61,7 @@ class MCTruthReaderTask : public o2::framework::Task
       br->GetEntry(0);
 
       // publish the labels in a const shared memory container
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TST", "LABELS2", 0, Lifetime::Timeframe});
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TST", "LABELS2", 0});
       iocontainer->copyandflatten(sharedlabels);
 
     } else {
@@ -74,7 +74,7 @@ class MCTruthReaderTask : public o2::framework::Task
       LOG(info) << "MCCONTAINER CHECK" << mccontainer->getNElements();
 
       // publish the original labels
-      pc.outputs().snapshot(Output{"TST", "LABELS2", 0, Lifetime::Timeframe}, *mccontainer);
+      pc.outputs().snapshot(Output{"TST", "LABELS2", 0}, *mccontainer);
     }
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
@@ -54,12 +54,12 @@ class MCTruthSourceTask : public o2::framework::Task
     if (mNew) {
       LOG(info) << "New serialization";
       // we need to flatten it and write to managed shared memory container
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TST", "LABELS", 0, Lifetime::Timeframe});
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TST", "LABELS", 0});
       container.flatten_to(sharedlabels);
       sleep(1);
     } else {
       LOG(info) << "Old serialization";
-      pc.outputs().snapshot({"TST", "LABELS", 0, Lifetime::Timeframe}, container);
+      pc.outputs().snapshot({"TST", "LABELS", 0}, container);
       sleep(1);
     }
 

--- a/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
@@ -84,7 +84,7 @@ class MCTruthWriterTask : public o2::framework::Task
     }
     if (mIO) {
       // this triggers the reader process
-      pc.outputs().snapshot({"TST", "TRIGGERREAD", 0, Lifetime::Timeframe}, labelfilename);
+      pc.outputs().snapshot({"TST", "TRIGGERREAD", 0}, labelfilename);
     }
 
     // we should be only called once; tell DPL that this process is ready to exit

--- a/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
@@ -117,13 +117,13 @@ class MIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     mDigitsMerger.process(digitsAccum, labelsAccum, rofRecords);
 
     LOG(debug) << "MID: Sending " << digitsAccum.size() << " digits.";
-    pc.outputs().snapshot(Output{"MID", "DIGITS", 0, Lifetime::Timeframe}, mDigitsMerger.getColumnData());
-    pc.outputs().snapshot(Output{"MID", "DIGITSROF", 0, Lifetime::Timeframe}, mDigitsMerger.getROFRecords());
+    pc.outputs().snapshot(Output{"MID", "DIGITS", 0}, mDigitsMerger.getColumnData());
+    pc.outputs().snapshot(Output{"MID", "DIGITSROF", 0}, mDigitsMerger.getROFRecords());
     if (pc.outputs().isAllowed({"MID", "DIGITLABELS", 0})) {
-      pc.outputs().snapshot(Output{"MID", "DIGITLABELS", 0, Lifetime::Timeframe}, mDigitsMerger.getMCContainer());
+      pc.outputs().snapshot(Output{"MID", "DIGITLABELS", 0}, mDigitsMerger.getMCContainer());
     }
     LOG(debug) << "MID: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"MID", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"MID", "ROMode", 0}, mROMode);
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Steer/DigitizerWorkflow/src/PHOSDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/PHOSDigitizerSpec.cxx
@@ -160,16 +160,16 @@ void DigitizerSpec::run(framework::ProcessingContext& pc)
   }
   LOG(debug) << "Have " << mLabels.getNElements() << " PHOS labels ";
   // here we have all digits and we can send them to consumer (aka snapshot it onto output)
-  pc.outputs().snapshot(Output{"PHS", "DIGITS", 0, Lifetime::Timeframe}, mDigitsOut);
-  pc.outputs().snapshot(Output{"PHS", "DIGITTRIGREC", 0, Lifetime::Timeframe}, triggers);
+  pc.outputs().snapshot(Output{"PHS", "DIGITS", 0}, mDigitsOut);
+  pc.outputs().snapshot(Output{"PHS", "DIGITTRIGREC", 0}, triggers);
   if (pc.outputs().isAllowed({"PHS", "DIGITSMCTR", 0})) {
-    pc.outputs().snapshot(Output{"PHS", "DIGITSMCTR", 0, Lifetime::Timeframe}, mLabels);
+    pc.outputs().snapshot(Output{"PHS", "DIGITSMCTR", 0}, mLabels);
   }
 
   // PHOS is always a triggering detector
   const o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::TRIGGERING;
   LOG(debug) << "PHOS: Sending ROMode= " << roMode << " to GRPUpdater";
-  pc.outputs().snapshot(Output{"PHS", "ROMode", 0, Lifetime::Timeframe}, roMode);
+  pc.outputs().snapshot(Output{"PHS", "ROMode", 0}, roMode);
 
   timer.Stop();
   LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -259,21 +259,21 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     LOG(info) << "Post " << digitsVector->size() << " digits in " << readoutwindow->size() << " RO windows";
 
     // here we have all digits and we can send them to consumer (aka snapshot it onto output)
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe}, *digitsVector);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITS", 0}, *digitsVector);
     if (pc.outputs().isAllowed({o2::header::gDataOriginTOF, "DIGITSMCTR", 0})) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITSMCTR", 0, Lifetime::Timeframe}, *mcLabVecOfVec);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITSMCTR", 0}, *mcLabVecOfVec);
     }
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe}, *readoutwindow);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0}, *readoutwindow);
 
     // send empty pattern from digitizer (it may change in future)
     std::vector<uint8_t>& patterns = mDigitizer->getPatterns();
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe}, patterns);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0}, patterns);
 
     DigitHeader& digitH = mDigitizer->getDigitHeader();
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITHEADER", 0, Lifetime::Timeframe}, digitH);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITHEADER", 0}, digitH);
 
     LOG(info) << "TOF: Sending ROMode= " << roMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe}, roMode);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0}, roMode);
 
     timer.Stop();
     LOG(info) << "Digitization took " << timer.CpuTime() << "s";

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -282,7 +282,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       auto roMode = isContinuous ? o2::parameters::GRPObject::CONTINUOUS : o2::parameters::GRPObject::PRESENT;
       LOG(info) << "TPC: Sending ROMode= " << (mDigitizer.isContinuousReadout() ? "Continuous" : "Triggered")
                 << " to GRPUpdater from channel " << dh->subSpecification;
-      pc.outputs().snapshot(Output{"TPC", "ROMode", 0, Lifetime::Timeframe}, roMode);
+      pc.outputs().snapshot(Output{"TPC", "ROMode", 0}, roMode);
     }
     mWriteGRP = false;
 
@@ -309,7 +309,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
         return ContainerType(nullptr);
       } else {
         // default case
-        return &pc.outputs().make<std::vector<o2::tpc::Digit>>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe, header});
+        return &pc.outputs().make<std::vector<o2::tpc::Digit>>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(dh->subSpecification), header});
       }
     };
     // lambda that snapshots the common mode vector to be sent out; prepares and attaches header with sector information
@@ -318,8 +318,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       header.activeSectors = activeSectors;
       if (!mInternalWriter) {
         // note that snapshoting only works with non-const references (to be fixed?)
-        pc.outputs().snapshot(Output{"TPC", "COMMONMODE", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
-                                     header},
+        pc.outputs().snapshot(Output{"TPC", "COMMONMODE", static_cast<SubSpecificationType>(dh->subSpecification), header},
                               const_cast<std::vector<o2::tpc::CommonMode>&>(commonMode));
       }
     };
@@ -329,7 +328,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       header.activeSectors = activeSectors;
       if (mWithMCTruth) {
         if (!mInternalWriter) {
-          auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe, header});
+          auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(dh->subSpecification), header});
           labels.flatten_to(sharedlabels);
         }
       }
@@ -340,8 +339,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       header.activeSectors = activeSectors;
       if (!mInternalWriter) {
         LOG(info) << "TPC: Send TRIGGERS for sector " << sector << " channel " << dh->subSpecification << " | size " << events.size();
-        pc.outputs().snapshot(Output{"TPC", "DIGTRIGGERS", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
-                                     header},
+        pc.outputs().snapshot(Output{"TPC", "DIGTRIGGERS", static_cast<SubSpecificationType>(dh->subSpecification), header},
                               const_cast<std::vector<DigiGroupRef>&>(events));
       }
     };

--- a/Steer/DigitizerWorkflow/src/ZDCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ZDCDigitizerSpec.cxx
@@ -147,15 +147,15 @@ class ZDCDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     mDigitizer.Finalize(mDigitsBC, mOrbitData);
 
     // send out to next stage
-    pc.outputs().snapshot(Output{"ZDC", "DIGITSBC", 0, Lifetime::Timeframe}, mDigitsBC);
-    pc.outputs().snapshot(Output{"ZDC", "DIGITSCH", 0, Lifetime::Timeframe}, mDigitsCh);
-    pc.outputs().snapshot(Output{"ZDC", "DIGITSPD", 0, Lifetime::Timeframe}, mOrbitData);
+    pc.outputs().snapshot(Output{"ZDC", "DIGITSBC", 0}, mDigitsBC);
+    pc.outputs().snapshot(Output{"ZDC", "DIGITSCH", 0}, mDigitsCh);
+    pc.outputs().snapshot(Output{"ZDC", "DIGITSPD", 0}, mOrbitData);
     if (pc.outputs().isAllowed({"ZDC", "DIGITSLBL", 0})) {
-      pc.outputs().snapshot(Output{"ZDC", "DIGITSLBL", 0, Lifetime::Timeframe}, mLabels);
+      pc.outputs().snapshot(Output{"ZDC", "DIGITSLBL", 0}, mLabels);
     }
 
     LOG(info) << "ZDC: Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{"ZDC", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    pc.outputs().snapshot(Output{"ZDC", "ROMode", 0}, mROMode);
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Utilities/DataSampling/src/DataSamplingPolicy.cxx
+++ b/Utilities/DataSampling/src/DataSamplingPolicy.cxx
@@ -128,7 +128,7 @@ Output DataSamplingPolicy::prepareOutput(const ConcreteDataMatcher& input, Lifet
   auto result = mPaths.find(input);
   if (result != mPaths.end()) {
     auto dataType = DataSpecUtils::asConcreteDataTypeMatcher(result->second);
-    return Output{dataType.origin, dataType.description, input.subSpec, lifetime};
+    return Output{dataType.origin, dataType.description, input.subSpec};
   } else {
     return Output{header::gDataOriginInvalid, header::gDataDescriptionInvalid};
   }

--- a/Utilities/DataSampling/src/Dispatcher.cxx
+++ b/Utilities/DataSampling/src/Dispatcher.cxx
@@ -114,7 +114,6 @@ void Dispatcher::run(ProcessingContext& ctx)
               routeAsConcreteDataType.origin,
               routeAsConcreteDataType.description,
               partInputHeader->subSpecification,
-              part.spec->lifetime,
               std::move(headerStack)};
             send(ctx.outputs(), part, output);
           }

--- a/run/dpl_eventgen.cxx
+++ b/run/dpl_eventgen.cxx
@@ -69,8 +69,8 @@ struct GeneratorTask {
     for (auto i = 0; i < std::min((int)aggregate, nEvents - eventCounter); ++i) {
       mctracks.clear();
       genservice.generateEvent_MCTracks(mctracks, mcheader);
-      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0, Lifetime::Timeframe}, mcheader);
-      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0, Lifetime::Timeframe}, mctracks);
+      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0}, mcheader);
+      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0}, mctracks);
       ++eventCounter;
     }
     // report number of TFs injected for the rate limiter to work

--- a/run/o2sim_hepmc_publisher.cxx
+++ b/run/o2sim_hepmc_publisher.cxx
@@ -135,8 +135,8 @@ struct O2simHepmcPublisher {
       }
 
       // add to the message
-      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0, Lifetime::Timeframe}, mcHeader);
-      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0, Lifetime::Timeframe}, mcTracks);
+      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0}, mcHeader);
+      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0}, mcTracks);
       mcTracks.clear();
       ++eventCounter;
     }

--- a/run/o2sim_kine_publisher.cxx
+++ b/run/o2sim_kine_publisher.cxx
@@ -44,8 +44,8 @@ struct O2simKinePublisher {
     for (auto i = 0; i < std::min((int)aggregate, nEvents - eventCounter); ++i) {
       auto mcevent = mcKinReader->getMCEventHeader(0, eventCounter);
       auto mctracks = mcKinReader->getTracks(0, eventCounter);
-      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0, Lifetime::Timeframe}, mcevent);
-      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0, Lifetime::Timeframe}, mctracks);
+      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0}, mcevent);
+      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0}, mctracks);
       ++eventCounter;
     }
     // report number of TFs injected for the rate limiter to work

--- a/run/o2sim_mctracks_to_aod.cxx
+++ b/run/o2sim_mctracks_to_aod.cxx
@@ -171,8 +171,8 @@ struct MctracksToAod {
       }
     }
     ++timeframe;
-    pc.outputs().snapshot(Output{"TFF", "TFFilename", 0, Lifetime::Timeframe}, "");
-    pc.outputs().snapshot(Output{"TFN", "TFNumber", 0, Lifetime::Timeframe}, timeframe);
+    pc.outputs().snapshot(Output{"TFF", "TFFilename", 0}, "");
+    pc.outputs().snapshot(Output{"TFN", "TFNumber", 0}, timeframe);
   }
 };
 


### PR DESCRIPTION
Remove default Lifetime::Timeframe when instanciating an Output

This lifetime field will be removed soon, and this is unambiguous, because
it's in any case the default.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12399).
* #12401
* #12400
* __->__ #12399