### PR TITLE
DPL: drop lifetime member from Output

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/FlatHisto1D.h
+++ b/DataFormats/common/include/CommonDataFormat/FlatHisto1D.h
@@ -34,7 +34,7 @@ namespace dataformats
   Fast 1D histo class which can be messages as
   FlatHisto1D<float> histo(nbins, xmin, xmax);
   histo.fill(...);
-  pc.outputs().snapshot(Output{"Origin", "Desc", 0, Lifetime::Timeframe}, histo.getBase());
+  pc.outputs().snapshot(Output{"Origin", "Desc", 0}, histo.getBase());
 
   and received (read only!) as
   const auto hdata = pc.inputs().get<gsl::span<float>>("histodata");

--- a/DataFormats/common/include/CommonDataFormat/FlatHisto2D.h
+++ b/DataFormats/common/include/CommonDataFormat/FlatHisto2D.h
@@ -35,7 +35,7 @@ namespace dataformats
   Fast 2D histo class which can be messages as
   FlatHisto2D<float> histo(nbinsX, xmin, xmax, nbinsY, ymin, ymax);
   histo.fill(...);
-  pc.outputs().snapshot(Output{"Origin", "Desc", 0, Lifetime::Timeframe}, histo.getBase());
+  pc.outputs().snapshot(Output{"Origin", "Desc", 0}, histo.getBase());
 
   and received (read only!) as
   const auto hdata = pc.inputs().get<gsl::span<float>>("histodata");

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/RawReaderFT0.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/RawReaderFT0.h
@@ -80,10 +80,10 @@ class RawReaderFT0 : public RawReaderFT0BaseNorm
   }
   void makeSnapshot(o2::framework::ProcessingContext& pc)
   {
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0}, mVecDigits);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0}, mVecChannelData);
     if constexpr (sUseTrgInput) {
-      pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "TRIGGERINPUT", 0, o2::framework::Lifetime::Timeframe}, mVecTriggerInput);
+      pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "TRIGGERINPUT", 0}, mVecTriggerInput);
     }
   }
   bool mDumpData;
@@ -136,11 +136,11 @@ class RawReaderFT0ext : public RawReaderFT0BaseExt
   }
   void makeSnapshot(o2::framework::ProcessingContext& pc)
   {
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSTRGEXT", 0, o2::framework::Lifetime::Timeframe}, mVecTrgExt);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0}, mVecDigits);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0}, mVecChannelData);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSTRGEXT", 0}, mVecTrgExt);
     if constexpr (sUseTrgInput) {
-      pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "TRIGGERINPUT", 0, o2::framework::Lifetime::Timeframe}, mVecTriggerInput);
+      pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "TRIGGERINPUT", 0}, mVecTriggerInput);
     }
   }
   bool mDumpData;

--- a/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
@@ -28,12 +28,11 @@ namespace ft0
 void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
 {
   auto t1 = std::chrono::high_resolution_clock::now();
-
   auto dummyOutput = [&pc, this]() {
     this->mVecDigits.resize(0);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0}, mVecDigits);
     this->mVecChannelData.resize(0);
-    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
+    pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0}, mVecChannelData);
   };
 
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
@@ -529,8 +528,8 @@ void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
     // Due to empty Digit container this dummy object will never participate in any further tasks.
     mVecChannelData.emplace_back();
   }
-  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
-  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0}, mVecDigits);
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0}, mVecChannelData);
   auto t2 = std::chrono::high_resolution_clock::now();
   auto delay = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
   LOG(debug) << "Decoder delay: " << delay.count();

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -97,11 +97,11 @@ class TOFDPLRecoWorkflowTask
     //           << " DIGITS TO " << mClustersArray.size() << " CLUSTERS";
 
     // send matching-info
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPC", 0}, mMatcher.getMatchedTrackVector());
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTOF", 0}, mMatcher.getMatchedTOFLabelsVector());
     }
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0}, mMatcher.getCalibVector());
     mTimer.Stop();
   }
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
@@ -251,7 +251,7 @@ void TPCResidualReader::run(ProcessingContext& pc)
   mTrackResiduals.closeOutputFile(); // FIXME remove when map output is handled properly
 
   // const auto& voxResArray = mTrackResiduals.getVoxelResults(); // array with one vector of results per sector
-  // pc.outputs().snapshot(Output{"GLO", "VOXELRESULTS", 0, Lifetime::Timeframe}, voxResArray); // send results as one large vector?
+  // pc.outputs().snapshot(Output{"GLO", "VOXELRESULTS", 0}, voxResArray); // send results as one large vector?
 
   pc.services().get<ControlService>().endOfStream();
   pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);

--- a/Detectors/PHOS/calib/src/PHOSTurnonCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSTurnonCalibDevice.cxx
@@ -80,8 +80,8 @@ void PHOSTurnonCalibDevice::endOfStream(o2::framework::EndOfStreamContext& ec)
     LOG(alarm) << "Incorrect fit results";
   }
   // //Send result to QC
-  // ec.outputs().snapshot(o2::framework::Output{"PHS", "TRIGMAPDIFF", 0, o2::framework::Lifetime::Timeframe}, mTrigMapDiff);
-  // ec.outputs().snapshot(o2::framework::Output{"PHS", "TURNONDIFF", 0, o2::framework::Lifetime::Timeframe}, mTurnOnDiff);
+  // ec.outputs().snapshot(o2::framework::Output{"PHS", "TRIGMAPDIFF", 0}, mTrigMapDiff);
+  // ec.outputs().snapshot(o2::framework::Output{"PHS", "TURNONDIFF", 0}, mTurnOnDiff);
 }
 
 o2::framework::DataProcessorSpec o2::phos::getPHOSTurnonCalibDeviceSpec(bool useCCDB)

--- a/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
@@ -109,7 +109,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
         o2::tpc::TPCSectorHeader header{sector};
         header.activeSectors = processAttributes->activeSectors;
         // digit for now are transported per sector, not per lane
-        // pc.outputs().snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe, header},
+        // pc.outputs().snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(channel), header},
         pc.outputs().snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(sector), header},
                               const_cast<std::vector<o2::tpc::Digit>&>(digits));
       };

--- a/Detectors/Upgrades/ITS3/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/ClusterReaderSpec.cxx
@@ -53,14 +53,14 @@ void ClusterReader::run(ProcessingContext& pc)
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
   // To be fixed once the names-definition class is ready
-  pc.outputs().snapshot(Output{mOrigin, "CLUSTERSROF", 0, Lifetime::Timeframe}, mClusROFRec);
-  pc.outputs().snapshot(Output{mOrigin, "COMPCLUSTERS", 0, Lifetime::Timeframe}, mClusterCompArray);
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERSROF", 0}, mClusROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "COMPCLUSTERS", 0}, mClusterCompArray);
   if (mUsePatterns) {
-    pc.outputs().snapshot(Output{mOrigin, "PATTERNS", 0, Lifetime::Timeframe}, mPatternsArray);
+    pc.outputs().snapshot(Output{mOrigin, "PATTERNS", 0}, mPatternsArray);
   }
   if (mUseMC) {
-    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mClusterMCTruth);
-    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, mClusMC2ROFs);
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMCTR", 0}, mClusterMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMC2ROF", 0}, mClusMC2ROFs);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Framework/CCDBSupport/src/CCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/CCDBHelpers.cxx
@@ -185,7 +185,7 @@ auto populateCacheWith(std::shared_ptr<CCDBFetcherHelper> const& helper,
     LOGP(debug, "Fetching object for route {}", DataSpecUtils::describe(route.matcher));
     objCnt++;
     auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
-    Output output{concrete.origin, concrete.description, concrete.subSpec, route.matcher.lifetime};
+    Output output{concrete.origin, concrete.description, concrete.subSpec};
     auto&& v = allocator.makeVector<char>(output);
     std::map<std::string, std::string> metadata;
     std::map<std::string, std::string> headers;
@@ -343,7 +343,7 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
             checkValidity = true; // never skip check if the cache is empty
           }
           LOG(debug) << "checkValidity = " << checkValidity << " for TF " << timingInfo.timeslice;
-          Output output{"CTP", "OrbitReset", 0, Lifetime::Condition};
+          Output output{"CTP", "OrbitReset", 0};
           Long64_t newOrbitResetTime = orbitResetTime;
           auto&& v = allocator.makeVector<char>(output);
           const auto& api = helper->getAPI(path);

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -28,7 +28,6 @@ struct Output {
   header::DataOrigin origin;
   header::DataDescription description;
   header::DataHeader::SubSpecificationType subSpec = 0;
-  enum Lifetime lifetime = Lifetime::Timeframe;
   header::Stack metaHeader = {};
 
   Output(header::DataOrigin o, header::DataDescription d) : origin(o), description(d) {}
@@ -38,19 +37,8 @@ struct Output {
   {
   }
 
-  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l)
-    : origin(o), description(d), subSpec(s), lifetime(l)
-  {
-  }
-
   Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, header::Stack&& stack)
     : origin(o), description(d), subSpec(s), metaHeader(std::move(stack))
-  {
-  }
-
-  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l,
-         header::Stack&& stack)
-    : origin(o), description(d), subSpec(s), lifetime(l), metaHeader(std::move(stack))
   {
   }
 
@@ -65,7 +53,6 @@ struct Output {
     : origin(rhs.origin),
       description(rhs.description),
       subSpec(rhs.subSpec),
-      lifetime(rhs.lifetime),
       metaHeader(std::move(rhs.metaHeader))
   {
   }
@@ -77,16 +64,14 @@ struct Output {
     origin = rhs.origin;
     description = rhs.description;
     subSpec = rhs.subSpec;
-    lifetime = rhs.lifetime;
     metaHeader = std::move(rhs.metaHeader);
     return *this;
   }
 
   bool operator==(const Output& that) const
   {
-    return origin == that.origin && description == that.description && subSpec == that.subSpec &&
-           lifetime == that.lifetime;
-  };
+    return origin == that.origin && description == that.description && subSpec == that.subSpec;
+  }
 };
 
 } // namespace o2

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -425,7 +425,7 @@ o2::framework::ServiceSpec CommonServices::ccdbSupportSpec()
           if (concrete.subSpec == 0) {
             continue;
           }
-          auto& stfDist = pc.outputs().make<o2::header::STFHeader>(Output{concrete.origin, concrete.description, concrete.subSpec, output.matcher.lifetime});
+          auto& stfDist = pc.outputs().make<o2::header::STFHeader>(Output{concrete.origin, concrete.description, concrete.subSpec});
           stfDist.id = timingInfo.timeslice;
           stfDist.firstOrbit = timingInfo.firstTForbit;
           stfDist.runNumber = timingInfo.runNumber;

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -294,7 +294,7 @@ Output DataAllocator::getOutputByBind(OutputRef&& ref)
     if (allowedOutputRoutes[ri].matcher.binding.value == ref.label) {
       auto spec = allowedOutputRoutes[ri].matcher;
       auto dataType = DataSpecUtils::asConcreteDataTypeMatcher(spec);
-      return Output{dataType.origin, dataType.description, ref.subSpec, spec.lifetime, std::move(ref.headerStack)};
+      return Output{dataType.origin, dataType.description, ref.subSpec, std::move(ref.headerStack)};
     }
   }
   std::string availableRoutes;
@@ -342,7 +342,7 @@ void DataAllocator::cookDeadBeef(const Output& spec)
   // We get the output route from the original spec, but we send it
   // using the binding of the deadbeef subSpecification.
   RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
-  auto deadBeefOutput = Output{spec.origin, spec.description, 0xdeadbeef, Lifetime::Timeframe};
+  auto deadBeefOutput = Output{spec.origin, spec.description, 0xdeadbeef};
   auto headerMessage = headerMessageFromOutput(deadBeefOutput, routeIndex, header::gSerializationMethodNone, 0);
 
   addPartToContext(proxy.createOutputMessage(routeIndex, 0), deadBeefOutput, header::gSerializationMethodNone);

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -45,7 +45,7 @@ using namespace o2::framework;
 // this function is only used to do the static checks for API return types
 void doTypeChecks()
 {
-  const Output output{"TST", "DUMMY", 0, Lifetime::Timeframe};
+  const Output output{"TST", "DUMMY", 0};
   // we require references to objects owned by allocator context
   static_assert(std::is_lvalue_reference<decltype(std::declval<DataAllocator>().make<int>(output))>::value);
   static_assert(std::is_lvalue_reference<decltype(std::declval<DataAllocator>().make<std::string>(output, "test"))>::value);
@@ -83,24 +83,24 @@ DataProcessorSpec getSourceSpec()
     // picked by the framework is no serialization
     test::MetaHeader meta1{42};
     test::MetaHeader meta2{23};
-    pc.outputs().snapshot(Output{"TST", "MESSAGEABLE", 0, Lifetime::Timeframe, {meta1, meta2}}, a);
-    pc.outputs().snapshot(Output{"TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe},
+    pc.outputs().snapshot(Output{"TST", "MESSAGEABLE", 0, {meta1, meta2}}, a);
+    pc.outputs().snapshot(Output{"TST", "MSGBLEROOTSRLZ", 0},
                           o2::framework::ROOTSerialized<decltype(a)>(a));
     // class Polymorphic is not messageable, so the serialization type is deduced
     // from the fact that the type has a dictionary and can be ROOT-serialized.
-    pc.outputs().snapshot(Output{"TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe}, b);
+    pc.outputs().snapshot(Output{"TST", "ROOTNONTOBJECT", 0}, b);
     // vector of ROOT serializable class
-    pc.outputs().snapshot(Output{"TST", "ROOTVECTOR", 0, Lifetime::Timeframe}, c);
+    pc.outputs().snapshot(Output{"TST", "ROOTVECTOR", 0}, c);
     // deque of simple types
-    pc.outputs().snapshot(Output{"TST", "DEQUE", 0, Lifetime::Timeframe}, testDequePayload);
+    pc.outputs().snapshot(Output{"TST", "DEQUE", 0}, testDequePayload);
     // likewise, passed anonymously with char type and class name
     o2::framework::ROOTSerialized<char, const char> d(*((char*)&c), "vector<o2::test::Polymorphic>");
-    pc.outputs().snapshot(Output{"TST", "ROOTSERLZDVEC", 0, Lifetime::Timeframe}, d);
+    pc.outputs().snapshot(Output{"TST", "ROOTSERLZDVEC", 0}, d);
     // vector of ROOT serializable class wrapped with TClass info as hint
     auto* cl = TClass::GetClass(typeid(decltype(c)));
     ASSERT_ERROR(cl != nullptr);
     o2::framework::ROOTSerialized<char, TClass> e(*((char*)&c), cl);
-    pc.outputs().snapshot(Output{"TST", "ROOTSERLZDVEC2", 0, Lifetime::Timeframe}, e);
+    pc.outputs().snapshot(Output{"TST", "ROOTSERLZDVEC2", 0}, e);
     // test the 'make' methods
     pc.outputs().make<o2::test::TriviallyCopyable>(OutputRef{"makesingle", 0}) = a;
     auto& multi = pc.outputs().make<o2::test::TriviallyCopyable>(OutputRef{"makespan", 0}, 3);
@@ -111,7 +111,7 @@ DataProcessorSpec getSourceSpec()
     // test the adopt method
     auto freefct = [](void* data, void* hint) {}; // simply ignore the cleanup for the test
     static std::string teststring = "adoptchunk";
-    pc.outputs().adoptChunk(Output{"TST", "ADOPTCHUNK", 0, Lifetime::Timeframe}, teststring.data(), teststring.length(), freefct, nullptr);
+    pc.outputs().adoptChunk(Output{"TST", "ADOPTCHUNK", 0}, teststring.data(), teststring.length(), freefct, nullptr);
     // test resizable data chunk, initial size 0 and grow
     auto& growchunk = pc.outputs().newChunk(OutputRef{"growchunk", 0}, 0);
     growchunk.resize(sizeof(o2::test::TriviallyCopyable));
@@ -307,7 +307,7 @@ DataProcessorSpec getSinkSpec()
     ASSERT_ERROR((object12[0] == o2::test::TriviallyCopyable{42, 23, 0xdead}));
     ASSERT_ERROR((object12[1] == o2::test::TriviallyCopyable{10, 20, 0xacdc}));
     // forward the read-only span on a different route
-    pc.outputs().snapshot(Output{"TST", "MSGABLVECTORCPY", 0, Lifetime::Timeframe}, object12);
+    pc.outputs().snapshot(Output{"TST", "MSGABLVECTORCPY", 0}, object12);
 
     LOG(info) << "extracting TNamed object from input13";
     auto object13 = pc.inputs().get<TNamed*>("input13");

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -64,7 +64,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
                     << *input.spec << ": " << *((int*)input.payload);
          auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
          //auto& data = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
-         auto& data = ctx.outputs().make<int>(Output{"TST", "PREPROC", dataheader->subSpecification, Lifetime::Timeframe});
+         auto& data = ctx.outputs().make<int>(Output{"TST", "PREPROC", dataheader->subSpecification});
          ASSERT_ERROR(ctx.inputs().get<int>(input.spec->binding.c_str()) == parallelContext.index1D());
          data = parallelContext.index1D();
        }
@@ -85,10 +85,10 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
          // TODO: there is a bug in the API for using OutputRef, returns an rvalue which can not be bound to
          // lvalue reference
          //auto& data = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
-         auto& data = ctx.outputs().make<int>(Output{"TST", "DATA", dataheader->subSpecification, Lifetime::Timeframe});
+         auto& data = ctx.outputs().make<int>(Output{"TST", "DATA", dataheader->subSpecification});
          data = ctx.inputs().get<int>(input.spec->binding.c_str());
          //auto& meta = ctx.outputs().make<int>(OutputRef{"metadt", dataheader->subSpecification});
-         auto& meta = ctx.outputs().make<int>(Output{"TST", "META", dataheader->subSpecification, Lifetime::Timeframe});
+         auto& meta = ctx.outputs().make<int>(Output{"TST", "META", dataheader->subSpecification});
          meta = dataheader->subSpecification;
        }
      }}},
@@ -145,7 +145,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
           if (multiplicities[pipeline] == 0) {
             continue;
           }
-          ctx.outputs().make<int>(Output{"TST", "TRIGGER", subspecs[index], Lifetime::Timeframe}) = pipeline;
+          ctx.outputs().make<int>(Output{"TST", "TRIGGER", subspecs[index]}) = pipeline;
           multiplicities[pipeline++]--;
           if (pipeline >= nPipelines) {
             pipeline = 0;

--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -45,7 +45,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
             }
             // there is nothing to do, simply stop the workflow but we have to send at least one message
             // to make sure that the callback of the consumer is called
-            ctx.outputs().make<int>(Output{"TST", "TEST", 0, Lifetime::Timeframe}) = 42;
+            ctx.outputs().make<int>(Output{"TST", "TEST", 0}) = 42;
             ctx.services().get<ControlService>().endOfStream();
             *isReady = true;
           };

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -85,9 +85,9 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       // since the snapshot copy is ready for sending it is scheduled but held back
       // because of the CompletionPolicy trigger matcher. This message will be
       // sent together with the second message.
-      outputs.snapshot(Output{"PROD", "CHANNEL", subspec, Lifetime::Timeframe}, subspec);
+      outputs.snapshot(Output{"PROD", "CHANNEL", subspec}, subspec);
       device.waitFor(100);
-      outputs.snapshot(Output{"PROD", "TRIGGER", subspec, Lifetime::Timeframe}, subspec);
+      outputs.snapshot(Output{"PROD", "TRIGGER", subspec}, subspec);
       device.waitFor(100);
     }
     control.endOfStream();
@@ -106,7 +106,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       LOG(info) << "processing " << input.spec->binding << " " << data;
       // check if the channel binding starts with 'trigger'
       if (input.spec->binding.find("trigger") == 0) {
-        pc.outputs().make<MyDataType>(Output{"PROC", "CHANNEL", data, Lifetime::Timeframe}) = data;
+        pc.outputs().make<MyDataType>(Output{"PROC", "CHANNEL", data}) = data;
       }
       nActiveInputs++;
     }

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -240,7 +240,7 @@ TEST_CASE("TestSoAIntegration")
 
 TEST_CASE("TestDataAllocatorReturnType")
 {
-  const Output output{"TST", "DUMMY", 0, Lifetime::Timeframe};
+  const Output output{"TST", "DUMMY", 0};
 }
 
 TEST_CASE("TestPodInjestion")

--- a/Framework/Utils/include/DPLUtils/RootTreeReader.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeReader.h
@@ -51,11 +51,11 @@ struct DefaultKey {
   enum Lifetime lifetime = Lifetime::Timeframe;
 
   DefaultKey(const Output& desc)
-    : origin(desc.origin), description(desc.description), subSpec(desc.subSpec), lifetime(desc.lifetime)
+    : origin(desc.origin), description(desc.description), subSpec(desc.subSpec)
   {
   }
 
-  operator Output() const { return Output{origin, description, subSpec, lifetime}; }
+  operator Output() const { return Output{origin, description, subSpec}; }
 };
 } // namespace rtr
 
@@ -302,7 +302,7 @@ class GenericRootTreeReader
       }
 
       auto snapshot = [&context, &stackcreator](const KeyType& key, const auto& object) {
-        context.outputs().snapshot(Output{key.origin, key.description, key.subSpec, key.lifetime, std::move(stackcreator())}, object);
+        context.outputs().snapshot(Output{key.origin, key.description, key.subSpec, std::move(stackcreator())}, object);
       };
 
       char* data = nullptr;
@@ -310,7 +310,7 @@ class GenericRootTreeReader
       mBranch->GetEntry(entry);
 
       // execute hook if it was registered; if this return true do not proceed further
-      if (mPublishHook != nullptr && (*mPublishHook).hook(mName, context, Output{mKey.origin, mKey.description, mKey.subSpec, mKey.lifetime, std::move(stackcreator())}, data)) {
+      if (mPublishHook != nullptr && (*mPublishHook).hook(mName, context, Output{mKey.origin, mKey.description, mKey.subSpec, std::move(stackcreator())}, data)) {
 
       }
       // try to figureout when we need to do something special

--- a/Framework/Utils/src/Utils.cxx
+++ b/Framework/Utils/src/Utils.cxx
@@ -28,7 +28,7 @@ namespace workflows
 Output getOutput(const o2f::OutputSpec outputSpec)
 {
   auto concrete = DataSpecUtils::asConcreteDataMatcher(outputSpec);
-  return Output{concrete.origin, concrete.description, concrete.subSpec, outputSpec.lifetime};
+  return Output{concrete.origin, concrete.description, concrete.subSpec};
 }
 
 // This method can convert a vector of OutputSpec into a vector of Output.

--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -67,11 +67,10 @@ DataProcessorSpec getSourceSpec()
       testFile->Close();
     }
 
-    constexpr auto persistency = Lifetime::Transient;
     auto reader = std::make_shared<RootTreeReader>("testtree",       // tree name
                                                    fileName.c_str(), // input file name
-                                                   RootTreeReader::BranchDefinition<std::vector<o2::test::TriviallyCopyable>>{Output{"TST", "ARRAYOFMSGBL", 0, persistency}, "msgblarray"},
-                                                   Output{"TST", "ARRAYOFDATA", 0, persistency},
+                                                   RootTreeReader::BranchDefinition<std::vector<o2::test::TriviallyCopyable>>{Output{"TST", "ARRAYOFMSGBL", 0}, "msgblarray"},
+                                                   Output{"TST", "ARRAYOFDATA", 0},
                                                    "dataarray",
                                                    RootTreeReader::PublishingMode::Single);
 

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -143,7 +143,7 @@ DataProcessorSpec getSourceSpec()
       o2::test::Polymorphic a(*counter);
       pc.outputs().snapshot(OutputRef{"output", 0}, a);
       pc.outputs().snapshot(OutputRef{"output", 1}, a);
-      int& metadata = pc.outputs().make<int>(Output{"TST", "METADATA", 0, Lifetime::Timeframe});
+      int& metadata = pc.outputs().make<int>(Output{"TST", "METADATA", 0});
       metadata = *counter;
       *counter = *counter + 1;
       if (*counter >= sTreeSize) {


### PR DESCRIPTION
DPL: drop lifetime member from Output

This is apparently not really used for anything and in general not passed
correctly. Lifetime is a static property of the data flow, so it does not
make sense to have it on a per message basis.
