### PR TITLE
DPL Analysis: add PresliceOptional

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1178,7 +1178,6 @@ using Preslice = PresliceBase<T, false, true>;
 template <typename T>
 using PresliceOptional = PresliceBase<T, true, true>;
 
-
 } // namespace o2::framework
 
 namespace o2::soa

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -116,7 +116,12 @@ void notBoundTable(const char* tableName)
 
 void notFoundColumn(const char* label, const char* key)
 {
-  throw o2::framework::runtime_error_f(R"(Preslice not valid: table "%s" (or join based on it) does not have column "%s"")", label, key);
+  throw o2::framework::runtime_error_f(R"(Preslice not valid: table "%s" (or join based on it) does not have column "%s")", label, key);
+}
+
+void missingOptionalPreslice(const char* label, const char* key)
+{
+  throw o2::framework::runtime_error_f(R"(Optional Preslice with missing binding used: table "%s" (or join based on it) does not have column "%s")", label, key);
 }
 
 } // namespace o2::soa

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -145,7 +145,10 @@ struct KTask {
 
 struct LTask {
   SliceCache cache;
+  Preslice<aod::Tracks> perCol = aod::track::collisionId;
+  PresliceOptional<aod::Tracks> perPart = aod::mctracklabel::mcParticleId;
   PresliceUnsorted<aod::McCollisionLabels> perMcCol = aod::mccollisionlabel::mcCollisionId;
+  PresliceUnsortedOptional<aod::Collisions> perMcColopt = aod::mccollisionlabel::mcCollisionId;
   void process(aod::McCollision const&, soa::SmallGroups<soa::Join<aod::Collisions, aod::McCollisionLabels>> const&) {}
 };
 


### PR DESCRIPTION
* Optional `Preslice` declaration that does not fail if the column is missing from the table that is intended to be sliced. To be used with templated analysis tasks. 
* Further consolidates the functions that are used to slice tables to reduce code duplication. 
* Selection manipulations functions in `Filtered` are promoted to public from protected. 