### PR TITLE
FIT: Make digitizer config params non-static to make them usable

### DIFF
--- a/Detectors/FIT/FT0/base/include/FT0Base/FT0DigParam.h
+++ b/Detectors/FIT/FT0/base/include/FT0Base/FT0DigParam.h
@@ -37,17 +37,17 @@ struct FT0DigParam : o2::conf::ConfigurableParamHelper<FT0DigParam> {
   float mMip_in_V = 7;       // MIP to mV
   float mPe_in_mip = 0.004;  // invserse Np.e. in MIP 1./250.
   float mCfdShift = 1.66;    // ns
-  float mCFDShiftPos = 1.47; //// shift positive part of CFD signal; distance between 0.3 of max amplitude  to max
+  float mCFDShiftPos = 1.47; // shift positive part of CFD signal; distance between 0.3 of max amplitude  to max
   float mCFDdeadTime = 15.6; // ns
   float mCharge2amp = 0.22;
-  float mNoiseVar = 0.1;                               // noise level
-  float mNoisePeriod = 1 / 0.9;                        // GHz low frequency noise period;
-  static constexpr short mTime_trg_gate = 153;         // #channels as in TCM as in Pilot beams ('OR gate' setting in TCM tab in ControlServer)
-  static constexpr float mAmpThresholdForReco = 5;     // only channels with amplitude higher will participate in calibration and collision time: 0.3 MIP
-  static constexpr short mTimeThresholdForReco = 1000; // only channels with time below will participate in calibration and collision time
+  float mNoiseVar = 0.1;              // noise level
+  float mNoisePeriod = 1 / 0.9;       // GHz low frequency noise period;
+  short mTime_trg_gate = 153;         // #channels as in TCM as in Pilot beams ('OR gate' setting in TCM tab in ControlServer)
+  float mAmpThresholdForReco = 5;     // only channels with amplitude higher will participate in calibration and collision time: 0.3 MIP
+  short mTimeThresholdForReco = 1000; // only channels with time below will participate in calibration and collision time
 
-  static constexpr float mMV_2_Nchannels = 2.2857143;          // amplitude channel 7 mV ->16channels
-  static constexpr float mMV_2_NchannelsInverse = 0.437499997; // inverse amplitude channel 7 mV ->16channels
+  float mMV_2_Nchannels = 2.2857143;          // amplitude channel 7 mV ->16channels
+  float mMV_2_NchannelsInverse = 0.437499997; // inverse amplitude channel 7 mV ->16channels
 
   O2ParamDef(FT0DigParam, "FT0DigParam");
 };

--- a/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
+++ b/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
@@ -61,14 +61,14 @@ struct FV0DigParam : o2::conf::ConfigurableParamHelper<FV0DigParam> {
   float mCFD_trsh = 3.;                                                          // [mV]
   float getCFDTrshInAdc() const { return mCFD_trsh * getChannelsPerMilivolt(); } // [ADC channels]
   /// Parameters for trigger simulation
-  bool useMaxChInAdc = true;                           // default = true
-  int adcChargeCenThr = 3 * 498;                       // threshold value of ADC charge for Central trigger
-  int adcChargeSCenThr = 1 * 498;                      // threshold value of ADC charge for Semi-central trigger
-  int maxCountInAdc = 4095;                            // to take care adc ADC overflow
-  short mTime_trg_gate = 153;                          // #channels as in TCM as in Pilot beams ('OR gate' setting in TCM tab in ControlServer)
-  uint8_t defaultChainQtc = 0x48;                      // only 2 flags are set by default in simulation: kIsCFDinADCgate and kIsEventInTVDC
-  static constexpr float mAmpThresholdForReco = 24;    // only channels with amplitude higher will participate in calibration and collision time
-  static constexpr short mTimeThresholdForReco = 1000; // only channels with time below will participate in calibration and collision time
+  bool useMaxChInAdc = true;          // default = true
+  int adcChargeCenThr = 3 * 498;      // threshold value of ADC charge for Central trigger
+  int adcChargeSCenThr = 1 * 498;     // threshold value of ADC charge for Semi-central trigger
+  int maxCountInAdc = 4095;           // to take care adc ADC overflow
+  short mTime_trg_gate = 153;         // #channels as in TCM as in Pilot beams ('OR gate' setting in TCM tab in ControlServer)
+  uint8_t defaultChainQtc = 0x48;     // only 2 flags are set by default in simulation: kIsCFDinADCgate and kIsEventInTVDC
+  float mAmpThresholdForReco = 24;    // only channels with amplitude higher will participate in calibration and collision time
+  short mTimeThresholdForReco = 1000; // only channels with time below will participate in calibration and collision time
 
   O2ParamDef(FV0DigParam, "FV0DigParam");
 };


### PR DESCRIPTION
Some digitizer configurable parameters were set as `static constexpr`, this makes them unusable as *configurable* parameters so I removed those specifiers.