### PR TITLE
Restore propagation of CCDB download failure error

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -54,7 +54,6 @@ typedef struct DownloaderRequestData {
   std::string userAgent;
 
   std::function<bool(std::string)> localContentCallback;
-  bool errorflag = false;
 } DownloaderRequestData;
 #endif
 

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1490,12 +1490,6 @@ void CcdbApi::scheduleDownload(RequestContext& requestContext, size_t* requestCo
   auto data = new DownloaderRequestData(); // Deleted in transferFinished of CCDBDownloader.cxx
   data->hoPair.object = &requestContext.dest;
 
-  auto signalError = [&chunk = requestContext.dest, &errorflag = data->errorflag]() {
-    chunk.clear();
-    chunk.reserve(1);
-    errorflag = true;
-  };
-
   std::function<bool(std::string)> localContentCallback = [this, &requestContext](std::string url) {
     return this->loadLocalContentToMemory(requestContext.dest, url);
   };


### PR DESCRIPTION
So that the end user (BasicCCDBManager or DPL CCDBHelper) can decide further steps.