### PR TITLE
Add MCH clusters to AO2Ds

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -481,7 +481,7 @@ class AODProducerWorkflowDPL : public Task
   // * interaction time is for TOF information
   template <typename TracksCursorType, typename TracksCovCursorType, typename TracksExtraCursorType, typename AmbigTracksCursorType,
             typename MFTTracksCursorType, typename AmbigMFTTracksCursorType,
-            typename FwdTracksCursorType, typename FwdTracksCovCursorType, typename AmbigFwdTracksCursorType>
+            typename FwdTracksCursorType, typename FwdTracksCovCursorType, typename AmbigFwdTracksCursorType, typename FwdTrkClsCursorType>
   void fillTrackTablesPerCollision(int collisionID,
                                    std::uint64_t collisionBC,
                                    const o2::dataformats::VtxTrackRef& trackRef,
@@ -496,7 +496,11 @@ class AODProducerWorkflowDPL : public Task
                                    FwdTracksCursorType& fwdTracksCursor,
                                    FwdTracksCovCursorType& fwdTracksCovCursor,
                                    AmbigFwdTracksCursorType& ambigFwdTracksCursor,
+                                   FwdTrkClsCursorType& fwdTrkClsCursor,
                                    const std::map<uint64_t, int>& bcsMap);
+
+  template <typename FwdTrkClsCursorType>
+  void addClustersToFwdTrkClsTable(const o2::globaltracking::RecoContainer& recoData, FwdTrkClsCursorType& fwdTrkClsCursor, GIndex trackID, int fwdTrackId);
 
   void fillIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices, const o2::globaltracking::RecoContainer& data);
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1264,7 +1264,11 @@ void AODProducerWorkflowDPL::addClustersToFwdTrkClsTable(const o2::globaltrackin
     int last = mchTrack.getLastClusterIdx();
     for (int i = first; i <= last; i++) {
       const auto& cluster = mchClusters[i];
-      fwdTrkClsCursor(fwdTrackId, cluster.x, cluster.y, cluster.z, (((cluster.ey < 5.) & 0x1) << 12) | (((cluster.ex < 5.) & 0x1) << 11) | cluster.getDEId());
+      fwdTrkClsCursor(fwdTrackId,
+                      truncateFloatFraction(cluster.x, mMuonCl),
+                      truncateFloatFraction(cluster.y, mMuonCl),
+                      truncateFloatFraction(cluster.z, mMuonCl),
+                      (((cluster.ey < 5.) & 0x1) << 12) | (((cluster.ex < 5.) & 0x1) << 11) | cluster.getDEId());
     }
   }
 }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -744,7 +744,7 @@ DECLARE_SOA_TABLE(AmbiguousFwdTracks, "AOD", "AMBIGUOUSFWDTR", //! Table for Fwd
 
 using AmbiguousFwdTrack = AmbiguousFwdTracks::iterator;
 
-// Forward Tracks Cluster informationtrackclusters information
+// Forward Tracks Cluster information
 namespace fwdtrkcl
 {
 DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack); //! Track index

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -744,6 +744,32 @@ DECLARE_SOA_TABLE(AmbiguousFwdTracks, "AOD", "AMBIGUOUSFWDTR", //! Table for Fwd
 
 using AmbiguousFwdTrack = AmbiguousFwdTracks::iterator;
 
+// Forward Tracks Cluster informationtrackclusters information
+namespace fwdtrkcl
+{
+DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack); //! Track index
+DECLARE_SOA_COLUMN(X, x, float);              //! Cluster x coordinate
+DECLARE_SOA_COLUMN(Y, y, float);              //! Cluster y coordinate
+DECLARE_SOA_COLUMN(Z, z, float);              //! Cluster z coordinate
+DECLARE_SOA_COLUMN(ClInfo, clInfo, uint16_t); //! Encoded detection element of cluster and cluster type along x and y
+DECLARE_SOA_DYNAMIC_COLUMN(DEId, deId, [](uint16_t info) -> uint16_t { return (info & 0x7FF); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsGoodX, isGoodX, [](uint16_t info) -> bool { return ((info & 0x800) >> 11); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsGoodY, isGoodY, [](uint16_t info) -> bool { return ((info & 0x1000) >> 12); });
+} // namespace fwdtrkcl
+
+DECLARE_SOA_TABLE(FwdTrkCls, "AOD", "FWDTRKCL", //! Forward Track Cluster information
+                  o2::soa::Index<>,
+                  fwdtrkcl::FwdTrackId,
+                  fwdtrkcl::X,
+                  fwdtrkcl::Y,
+                  fwdtrkcl::Z,
+                  fwdtrkcl::ClInfo,
+                  fwdtrkcl::DEId<fwdtrkcl::ClInfo>,
+                  fwdtrkcl::IsGoodX<fwdtrkcl::ClInfo>,
+                  fwdtrkcl::IsGoodY<fwdtrkcl::ClInfo>);
+
+using FwdTrkCl = FwdTrkCls::iterator;
+
 // HMPID information
 namespace hmpid
 {

--- a/scripts/datamodel-doc/inputCard.xml
+++ b/scripts/datamodel-doc/inputCard.xml
@@ -106,7 +106,7 @@
           o2::aod::Tracks, o2::aod::TracksIU, o2::aod::TracksCov, o2::aod::TracksCovIU, o2::aod::TracksExtra, o2::aod::StoredTracks, o2::aod::StoredTracksIU, o2::aod::StoredTracksCov, o2::aod::StoredTracksCovIU, o2::aod::StoredTracksExtra, o2::aod::MFTTracks, o2::aod::StoredMFTTracks, o2::aod::FwdTracks, o2::aod::FwdTracksCov, o2::aod::StoredFwdTracks, o2::aod::StoredFwdTracksCov, o2::aod::AmbiguousTracks, o2::aod::AmbiguousMFTTracks, o2::aod::AmbiguousFwdTracks
         </category>
         <category name="Detectors">
-          o2::aod::FV0As, o2::aod::FT0s, o2::aod::FDDs, so2::aod::HMPIDs, o2::aod::Calos, o2::aod::CaloTriggers, o2::aod::Zdcs, o2::aod::FV0Cs, o2::aod::HMPIDs, o2::aod::CPVClusters
+          o2::aod::FV0As, o2::aod::FT0s, o2::aod::FDDs, so2::aod::HMPIDs, o2::aod::Calos, o2::aod::CaloTriggers, o2::aod::Zdcs, o2::aod::FV0Cs, o2::aod::HMPIDs, o2::aod::CPVClusters, o2::aod::FwdTrkCls
         </category>
         <category name="Strangeness">
           o2::aod::V0s, o2::aod::TransientV0s, o2::aod::StoredV0s, o2::aod::Cascades, o2::aod::TransientCascades, o2::aod::StoredCascades, o2::aod::Decays3Body


### PR DESCRIPTION
This is to add the MCH clusters to the AO2Ds. It will allow running the alignment but also applying a new alignment at the AO2D level without the need of a new reconstruction.
A new table FwdTrkCls is added to the AO2D, it contains the clusters associated to an MCH (standalone or matched to the MID). Each cluster is described by 3 floats (x, y, z coordinates), an uint16 encoding the Detection Element Id and the "cluster type" in the x and y directions, and an index to the FwdTracks table.
In practice, from a local test on a few CTF of a run of LHC23zs, this results in the addition of an average of 120 bytes per MCH track (12 bytes per cluster) for a total increase of the AO2D of 0.08%.

