### PR TITLE
STFDecoder accept new dataSpec format

### DIFF
--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -63,10 +63,11 @@ void STFDecoder<Mapping>::init(InitContext& ic)
     mDecoder = std::make_unique<RawPixelDecoder<Mapping>>();
     auto v0 = o2::utils::Str::tokenize(mInputSpec, ':');
     auto v1 = o2::utils::Str::tokenize(v0[1], '/');
+    auto v2 = o2::utils::Str::tokenize(v1[1], '?');
     header::DataOrigin dataOrig;
     header::DataDescription dataDesc;
     dataOrig.runtimeInit(v1[0].c_str());
-    dataDesc.runtimeInit(v1[1].c_str());
+    dataDesc.runtimeInit(v2[0].c_str());
     mDecoder->setUserDataOrigin(dataOrig);
     mDecoder->setUserDataDescription(dataDesc);
     mDecoder->init(); // is this no-op?


### PR DESCRIPTION
Running the ITS/MFT decoder with `--dataspec TF:MFT/RAWDATA_SMP?lifetime=sporadic` currently crashes, because the whole string `RAWDATA_SMP?lifetime=sporadic` is taken as description and that is too long.
In principle, one should use the framework function `auto input = o2::framework::select(mInputSpec.c_str());`. I tried, but didn't manage to get then the origin and description at runtime from the result. This failed:
```
mDecoder->setUserDataOrigin(std::get<o2::framework::ConcreteDataMatcher>(input[0].matcher).origin);
```
In any case. I noticed the decoder anyhow always uses Lifetime::Timeframe no matter what is specified so that clearly must be fixed for the sampled FLP processing: https://github.com/AliceO2Group/AliceO2/blob/6c01c46e0ae809b64d0cbfbd8abbc9cb9313060f/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx#L228

@shahor02 would you have time to change this or shall I give it a try?