### PR TITLE
GPU: Make O2 compile with C++20 + unrelated fixes

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -9,6 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
+#ifndef __HIPCC__
+#include "GPUReconstructionCUDADef.h" // This file should come first, if included
+#endif
+
 #include <thrust/fill.h>
 #include <thrust/execution_policy.h>
 
@@ -26,7 +30,6 @@
 
 #ifndef __HIPCC__
 #define THRUST_NAMESPACE thrust::cuda
-#include "GPUReconstructionCUDADef.h"
 #else
 #define THRUST_NAMESPACE thrust::hip
 // clang-format off

--- a/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
@@ -46,7 +46,7 @@ if(OPENCL2_ENABLED_SPIRV) # BUILD OpenCL2 intermediate code for SPIR-V target
   cmake_path(GET LLVM_SPIRV PARENT_PATH TMP_LLVM_SPIRV_PATH)
   add_custom_command(
       OUTPUT ${CL_BIN}.spirv
-      COMMAND ${CMAKE_COMMAND} -E env "PATH=${TMP_LLVM_SPIRV_PATH}:\$PATH" ${LLVM_CLANG}
+      COMMAND ${CMAKE_COMMAND} -E env "PATH=${TMP_LLVM_SPIRV_PATH}:\$$PATH" ${LLVM_CLANG}
               -O0
               --target=spirv64
               ${OCL_FLAGS}

--- a/GPU/GPUTracking/DataTypes/TPCPadBitMap.cxx
+++ b/GPU/GPUTracking/DataTypes/TPCPadBitMap.cxx
@@ -16,7 +16,6 @@
 
 #include "GPUTPCGeometry.h"
 #include "DataFormatsTPC/Constants.h"
-#include "TPCBase/CalDet.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
 
@@ -29,6 +28,9 @@ TPCPadBitMap::TPCPadBitMap()
     offset += geo.NPads(r);
   }
 }
+
+#ifndef GPUCA_STANDALONE
+#include "TPCBase/CalDet.h"
 
 TPCPadBitMap::TPCPadBitMap(const o2::tpc::CalDet<bool>& map) : TPCPadBitMap()
 {
@@ -44,3 +46,4 @@ void TPCPadBitMap::setFromMap(const o2::tpc::CalDet<bool>& map)
     }
   }
 }
+#endif

--- a/GPU/GPUTracking/DataTypes/TPCPadGainCalib.cxx
+++ b/GPU/GPUTracking/DataTypes/TPCPadGainCalib.cxx
@@ -16,7 +16,6 @@
 
 #include "GPUTPCGeometry.h"
 #include "DataFormatsTPC/Constants.h"
-#include "TPCBase/CalDet.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
 
@@ -29,6 +28,9 @@ TPCPadGainCalib::TPCPadGainCalib()
     offset += geo.NPads(r);
   }
 }
+
+#ifndef GPUCA_STANDALONE
+#include "TPCBase/CalDet.h"
 
 TPCPadGainCalib::TPCPadGainCalib(const o2::tpc::CalDet<float>& gainMap) : TPCPadGainCalib()
 {
@@ -51,3 +53,4 @@ void TPCPadGainCalib::setFromMap(const o2::tpc::CalDet<float>& gainMap, const bo
     }
   }
 }
+#endif

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 # Set Build and Compiler settings
 set(ALIGPU_BUILD_TYPE "Standalone")
 add_definitions(-DGPUCA_STANDALONE)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/GPU/Workflow/src/GPUWorkflowPipeline.cxx
+++ b/GPU/Workflow/src/GPUWorkflowPipeline.cxx
@@ -108,7 +108,7 @@ void GPURecoWorkflowSpec::enqueuePipelinedJob(GPUTrackingInOutPointers* ptrs, GP
   {
     std::unique_lock lk(mPipeline->mayInjectMutex);
     mPipeline->mayInjectCondition.wait(lk, [this, context]() { return mPipeline->mayInject && mPipeline->mayInjectTFId == context->mTFId; });
-    mPipeline->mayInjectTFId++;
+    mPipeline->mayInjectTFId = mPipeline->mayInjectTFId + 1;
     mPipeline->mayInject = false;
   }
   context->jobSubmitted = true;

--- a/dependencies/FindO2GPU.cmake
+++ b/dependencies/FindO2GPU.cmake
@@ -202,6 +202,8 @@ endif()
 
 # Detect and enable HIP
 if(ENABLE_HIP)
+  set(CMAKE_HIP_STANDARD 17)
+  set(CMAKE_HIP_STANDARD_REQUIRED TRUE)
   if(HIP_AMDGPUTARGET)
     set(AMDGPU_TARGETS "${HIP_AMDGPUTARGET}" CACHE STRING "AMD GPU targets to compile for" FORCE)
     set(GPU_TARGETS "${HIP_AMDGPUTARGET}" CACHE STRING "AMD GPU targets to compile for" FORCE)


### PR DESCRIPTION
@ktf : That should be all that is needed.
We'll get a couple of
```
2023-12-09@18:03:02:DEBUG:O2:O2:0: /usr/include/root/RConfigure.h:30:4: warning: "The C++ standard in this build does not match ROOT configuration (202002L); this might cause unexpected issues" [-W#warnings]
2023-12-09@18:03:02:DEBUG:O2:O2:0: #  warning "The C++ standard in this build does not match ROOT configuration (202002L); this might cause unexpected issues"
```
warnings, but that is unavoidablle until AMD has a ROCm release that works for us and that supports C++20.