### PR TITLE
Optional detailed report on the BasicCCDBManager cache

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -542,7 +542,7 @@ class CcdbApi //: public DatabaseInterface
    * @param tcl The TClass object describing the serialized type
    * @return raw pointer to created object
    */
-  void* downloadFilesystemContent(std::string const& fullUrl, std::type_info const& tinfo) const;
+  void* downloadFilesystemContent(std::string const& fullUrl, std::type_info const& tinfo, std::map<string, string>* headers) const;
 
   // initialize the TGrid (Alien connection)
   bool initTGrid() const;

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -72,9 +72,15 @@ std::string CCDBManagerInstance::getSummaryString() const
   return res;
 }
 
-void CCDBManagerInstance::endOfStream()
+void CCDBManagerInstance::report(bool longrep)
 {
   LOG(info) << "CCDBManager summary: " << getSummaryString();
+  if (longrep && mCachingEnabled) {
+    LOGP(info, "CCDB cache miss/hit/failures");
+    for (const auto& obj : mCache) {
+      LOGP(info, "  {}: {}/{}/{} ({}-{} bytes)", obj.first, obj.second.fetches, obj.second.queries - obj.second.fetches - obj.second.failures, obj.second.failures, obj.second.minSize, obj.second.maxSize);
+    }
+  }
 }
 
 } // namespace ccdb

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -54,7 +54,7 @@ std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(int runnumber, b
 
 std::string CCDBManagerInstance::getSummaryString() const
 {
-  std::string res = fmt::format("{} queries", mQueries);
+  std::string res = fmt::format("{} queries, {} bytes", mQueries, fmt::group_digits(mFetchedSize));
   if (mCachingEnabled) {
     res += fmt::format(" for {} objects", mCache.size());
   }

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -529,6 +529,10 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
             (*requestData->headers)["Error"] = "An error occurred during retrieval";
           }
           LOGP(alarm, "Curl request to {}, response code: {}", url, httpCode);
+        } else {
+          if (requestData->headers && requestData->headers->find("fileSize") == requestData->headers->end()) {
+            (*requestData->headers)["fileSize"] = fmt::format("{}", requestData->hoPair.object ? requestData->hoPair.object->size() : 0);
+          }
         }
         --(*performData->requestsLeft);
         delete requestData;

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -832,6 +832,9 @@ void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info 
     if ((isSnapshotMode() || mPreferSnapshotCache) && headers->find("ETag") == headers->end()) { // generate dummy ETag to profit from the caching
       (*headers)["ETag"] = filename;
     }
+    if (headers->find("fileSize") == headers->end()) {
+      (*headers)["fileSize"] = fmt::format("{}", f.GetEND());
+    }
   }
   return extractFromTFile(f, tcl);
 }
@@ -857,7 +860,7 @@ bool CcdbApi::initTGrid() const
   return mAlienInstance != nullptr;
 }
 
-void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info const& tinfo) const
+void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info const& tinfo, std::map<string, string>* headers) const
 {
   if ((url.find("alien:/", 0) != std::string::npos) && !initTGrid()) {
     return nullptr;
@@ -867,6 +870,9 @@ void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info 
   if (memfile) {
     auto cl = tinfo2TClass(tinfo);
     auto content = extractFromTFile(*memfile, cl);
+    if (headers && headers->find("fileSize") == headers->end()) {
+      (*headers)["fileSize"] = fmt::format("{}", memfile->GetEND());
+    }
     delete memfile;
     return content;
   }
@@ -902,7 +908,7 @@ void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string con
 
   // let's see first of all if the url is something specific that curl cannot handle
   if ((url.find("alien:/", 0) != std::string::npos) || (url.find("file:/", 0) != std::string::npos)) {
-    return downloadFilesystemContent(url, tinfo);
+    return downloadFilesystemContent(url, tinfo, headers);
   }
   // add other final cases here
   // example root://
@@ -933,6 +939,9 @@ void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string con
     if (200 <= response_code && response_code < 300) {
       // good response and the content is directly provided and should have been dumped into "chunk"
       content = interpretAsTMemFileAndExtract(chunk.memory, chunk.size, tinfo);
+      if (headers && headers->find("fileSize") == headers->end()) {
+        (*headers)["fileSize"] = fmt::format("{}", chunk.size);
+      }
     } else if (response_code == 304) {
       // this means the object exist but I am not serving
       // it since it's already in your possession
@@ -1772,6 +1781,9 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& p
     }
     if ((isSnapshotMode() || mPreferSnapshotCache) && localHeaders->find("ETag") == localHeaders->end()) { // generate dummy ETag to profit from the caching
       (*localHeaders)["ETag"] = path;
+    }
+    if (localHeaders->find("fileSize") == localHeaders->end()) {
+      (*localHeaders)["fileSize"] = fmt::format("{}", memFile.GetEND());
     }
   }
   return;


### PR DESCRIPTION
@ktf @jgrosseo this PR extends the report of the BasicCCDBManager statistics to the same detailed level as produced by the DPL CCDBHelper. One should explicitly call `BasicCCDBManager::instance().report(true)` to have the extended report, by default only the old summary string is printed:
```
auto& cc = o2::ccdb::BasicCCDBManager::instance();
cc.get<o2::parameters::GRPECSObject>("GLO/Config/GRPECS");
cc.setTimestamp(17021636063139);
cc.get<o2::parameters::GRPECSObject>("GLO/Config/GRPECS"); // fails as the timestamp is bogus;
cc.setTimestamp(1702163606313);
cc.get<o2::parameters::GRPECSObject>("GLO/Config/GRPECS");
cc.get<o2::parameters::GRPECSObject>("GLO/Config/GRPECS");
cc.get<o2::parameters::GRPECSObject>("GLO/Config/GRPECS");
cc.get<TGeoManager>("GLO/Config/Geometry");
cc.get<TGeoManager>("GLO/Config/Geometry");

cc.report(true);
```
```
[INFO] CCDBManager summary: 7 queries for 2 objects, 3 good fetches (and 0 failed ones) in 4,009 ms, instance: alicrs02-1702170696-lhV1VF
[INFO] CCDB cache miss/hit/failures
[INFO]   GLO/Config/Geometry: 1/1/0 (1883722-1883722 bytes)
[INFO]   GLO/Config/GRPECS: 2/2/1 (1809-1820 bytes)
```
Let me know what exactly you want to send to the monitoring, I will prepare a getter for corresponding `Metric`.