### PR TITLE
o2sim_mctracks_to_aod: fix mother/daughter IDs for more than one event per timeframe

### DIFF
--- a/run/o2sim_mctracks_to_aod.cxx
+++ b/run/o2sim_mctracks_to_aod.cxx
@@ -50,6 +50,7 @@ struct MctracksToAod {
     }
     // TODO: include BC simulation
     auto bcCounter = 0UL;
+    int trackCounter = 0;
     for (auto i = 0U; i < Nparts; ++i) {
       auto record = sampler.generateCollisionTime();
       auto mcheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader", i);
@@ -118,19 +119,19 @@ struct MctracksToAod {
         int daughters[2];
 
         if (mctrack.getMotherTrackId() >= 0) {
-          mothers.push_back(mctrack.getMotherTrackId());
+          mothers.push_back(mctrack.getMotherTrackId() + trackCounter);
         }
         if (mctrack.getSecondMotherTrackId() >= 0) {
-          mothers.push_back(mctrack.getSecondMotherTrackId());
+          mothers.push_back(mctrack.getSecondMotherTrackId() + trackCounter);
         }
         daughters[0] = -1;
         daughters[1] = -1;
         if (mctrack.getFirstDaughterTrackId() >= 0 && mctrack.getLastDaughterTrackId() >= 0) {
-          daughters[0] = mctrack.getFirstDaughterTrackId();
-          daughters[1] = mctrack.getLastDaughterTrackId();
+          daughters[0] = mctrack.getFirstDaughterTrackId() + trackCounter;
+          daughters[1] = mctrack.getLastDaughterTrackId() + trackCounter;
         } else if (mctrack.getFirstDaughterTrackId() >= 0) {
-          daughters[0] = mctrack.getFirstDaughterTrackId();
-          daughters[1] = mctrack.getLastDaughterTrackId();
+          daughters[0] = mctrack.getFirstDaughterTrackId() + trackCounter;
+          daughters[1] = mctrack.getLastDaughterTrackId() + trackCounter;
         }
         int PdgCode = mctrack.GetPdgCode();
         int statusCode = 0;
@@ -169,6 +170,7 @@ struct MctracksToAod {
                     z,
                     t);
       }
+      trackCounter = trackCounter + mctracks.size();
     }
     ++timeframe;
     pc.outputs().snapshot(Output{"TFF", "TFFilename", 0}, "");


### PR DESCRIPTION
Mother/daughter IDs from individual events need to be shifted by the number of tracks already in that timeframe