### PR TITLE
Fix build under new Xcode on MacOS Sonoma

### DIFF
--- a/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
@@ -284,7 +284,7 @@ void AltroDecoder::readTRUDigits(short absId, int payloadSize)
     currentsample += bunchlength + 2;
   }
   truDigitPack dp = {0};
-  dp.mHeader = 1;
+  dp.mHeader = -1;
   dp.mAmp = maxAmp;
   dp.mTime = timeBin;
   int chId = (absId - Mapping::NCHANNELS - 1) % 224;


### PR DESCRIPTION
This is triggered by `-Werror,-Wsingle-bit-bitfield-constant-conversion`, since we run with `-Werror` in CI.

@peressounko @kharlov Please let me know what you think! Alternatively, you might prefer to declare the `mHeader` field (and possibly others in the same struct?) as `uint32` instead of the current (signed) `int32`.