### PR TITLE
TPC: Adding possibility to correct for V-shape distortions

### DIFF
--- a/Detectors/Align/Workflow/src/barrel-alignment-workflow.cxx
+++ b/Detectors/Align/Workflow/src/barrel-alignment-workflow.cxx
@@ -19,6 +19,7 @@
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
 #include "TPCWorkflow/ClusterSharingMapSpec.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
 #include "TOFWorkflowIO/ClusterReaderSpec.h"
 #include "TOFWorkflowIO/TOFMatchedReaderSpec.h"
@@ -145,6 +146,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
     // write the configuration used for the workflow
     o2::conf::ConfigurableParam::writeINI("o2_barrel_alignment_configuration.ini");
+  }
+
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
   }
 
   specs.emplace_back(o2::align::getBarrelAlignmentSpec(srcMP, src, dets, skipDetClusters, enableCosmic, postprocess, useMC, sclOpt));

--- a/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
@@ -17,6 +17,7 @@
 #include "ITSMFTWorkflow/ClusterReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 #include "TPCWorkflow/ClusterSharingMapSpec.h"
 #include "TOFWorkflowIO/ClusterReaderSpec.h"
 #include "TOFWorkflowIO/TOFMatchedReaderSpec.h"
@@ -101,6 +102,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   GID::mask_t srcCl = src;
   GID::mask_t dummy;
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
   specs.emplace_back(o2::globaltracking::getCosmicsMatchingSpec(src, useMC, sclOpt));
 
   o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, src, src, src, useMC, dummy); // clusters MC is not needed

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -17,6 +17,7 @@
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 #include "ITSWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 #include "TOFWorkflowIO/TOFMatchedReaderSpec.h"
 #include "TOFWorkflowIO/ClusterReaderSpec.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
@@ -96,7 +97,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     src = src | GID::getSourcesMask("CTP");
   }
   WorkflowSpec specs;
-
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
   specs.emplace_back(o2::vertexing::getSecondaryVertexingSpec(src, enableCasc, enable3body, enableStrTr, enableCCDBParams, useMC, sclOpt));
 
   // only TOF clusters are needed if TOF is involved, no clusters MC needed

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -33,6 +33,7 @@
 #include "TSystem.h"
 #include "DetectorsBase/DPLWorkflowUtils.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 
 using namespace o2::framework;
 using DetID = o2::detectors::DetID;
@@ -167,7 +168,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       specs.push_back(s);
     }
   }
-
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
   specs.emplace_back(o2::globaltracking::getTOFMatcherSpec(src, useMC, useFIT, refitTPCTOF, strict, extratolerancetrd, writeMatchable, sclOpt, nLanes)); // doTPCrefit not yet supported (need to load TPC clusters?)
 
   if (!disableRootOut) {

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "TPCWorkflow/ClusterSharingMapSpec.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 #include "GlobalTrackingWorkflow/TPCITSMatchingSpec.h"
 #include "GlobalTrackingWorkflow/TrackWriterTPCITSSpec.h"
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
@@ -87,6 +88,9 @@ WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcont
   }
 
   o2::framework::WorkflowSpec specs;
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
   specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(srcL, useFT0, calib, !GID::includesSource(GID::TPC, src), useMC, sclOpt));
 
   if (!configcontext.options().get<bool>("disable-root-output")) {

--- a/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_library(GlobalTrackingStudy
                                      O2::GlobalTrackingWorkflowHelpers
                                      O2::DataFormatsGlobalTracking
                                      O2::DetectorsVertexing
+                                     O2::TPCWorkflow
                                      O2::SimulationDataFormat)
 
 o2_add_executable(study-workflow

--- a/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
@@ -21,6 +21,7 @@
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -70,6 +71,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, useMC);
   o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC); // P-vertex is always needed
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
   specs.emplace_back(o2::trackstudy::getTPCTrackStudySpec(srcTrc, srcCls, useMC, sclOpt));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit

--- a/Detectors/TPC/base/include/TPCBase/CDBTypes.h
+++ b/Detectors/TPC/base/include/TPCBase/CDBTypes.h
@@ -79,6 +79,7 @@ enum class CDBType {
   CalTimeSeries,       ///< integrated DCAs for longer time interval
   CalScaler,           ///< Scaler from IDCs or combined estimator
   CalScalerWeights,    ///< Weights for scalers
+  CalMShape,           ///< calibration object for M-shape distortions
                        ///
   CorrMapParam,        ///< parameters for CorrectionMapsLoader configuration
                        ///
@@ -144,6 +145,7 @@ const std::unordered_map<CDBType, const std::string> CDBTypeMap{
   {CDBType::CalTimeSeries, "TPC/Calib/TimeSeries"},
   {CDBType::CalScaler, "TPC/Calib/Scaler"},
   {CDBType::CalScalerWeights, "TPC/Calib/ScalerWeights"},
+  {CDBType::CalMShape, "TPC/Calib/MShapePotential"},
   // correction maps loader params
   {CDBType::CorrMapParam, "TPC/Calib/CorrMapParam"},
   // distortion maps

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -54,6 +54,7 @@ o2_add_library(TPCCalibration
                        src/CalculatedEdx.cxx
                        src/TPCScaler.cxx
                        src/CorrMapParam.cxx
+                       src/TPCMShapeCorrection.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL
@@ -107,7 +108,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h
                                   include/TPCCalibration/CalculatedEdx.h
                                   include/TPCCalibration/TPCScaler.h
-                                  include/TPCCalibration/CorrMapParam.h)
+                                  include/TPCCalibration/CorrMapParam.h
+                                  include/TPCCalibration/TPCMShapeCorrection.h)
 
 o2_add_test_root_macro(macro/comparePedestalsAndNoise.C
                        PUBLIC_LINK_LIBRARIES O2::TPCBase

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -38,8 +38,14 @@ namespace tpc
 {
 
 struct CorrectionMapsLoaderGloOpts {
-  int lumiType = 0;
-  int lumiMode = 0;
+  int lumiType = 0; ///< 0: no scaling, 1: CTP, 2: IDC
+  int lumiMode = 0; ///< 0: classical scaling, 1: Using of the derivative map, 2: Using of the derivative map for MC
+  bool enableMShapeCorrection = false;
+
+  bool needTPCScalersWorkflow() const
+  {
+    return lumiType == 2 || enableMShapeCorrection;
+  }
 };
 
 class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
@@ -55,6 +61,7 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
   void updateVDrift(float vdriftCorr, float vdrifRef, float driftTimeOffset = 0);
   void init(o2::framework::InitContext& ic);
   void copySettings(const CorrectionMapsLoader& src);
+  void updateInverse(); /// recalculate inverse correction
 
   static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, const CorrectionMapsLoaderGloOpts& gloOpts);
   static void addGlobalOptions(std::vector<o2::framework::ConfigParamSpec>& options);
@@ -67,6 +74,7 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
 
   float mInstLumiFactor = 1.0; // multiplicative factor for inst. lumi
   int mCTPLumiSource = 0;      // 0: main, 1: alternative CTP lumi source
+  std::unique_ptr<GPUCA_NAMESPACE::gpu::TPCFastTransform> mCorrMapMShape{nullptr};
 #endif
 };
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h
@@ -97,6 +97,12 @@ class TPCFastSpaceChargeCorrectionHelper
 
   void testGeometry(const TPCFastTransformGeo& geo) const;
 
+  /// initialise inverse transformation
+  void initInverse(o2::gpu::TPCFastSpaceChargeCorrection& correction, bool prn);
+
+  /// initialise inverse transformation from linear combination of several input corrections
+  void initInverse(std::vector<o2::gpu::TPCFastSpaceChargeCorrection*>& corrections, const std::vector<float>& scaling, bool prn);
+
  private:
   /// geometry initialization
   void initGeometry();
@@ -106,9 +112,6 @@ class TPCFastSpaceChargeCorrectionHelper
 
   /// initialise max drift length
   void initMaxDriftLength(o2::gpu::TPCFastSpaceChargeCorrection& correction, bool prn);
-
-  /// initialise inverse transformation
-  void initInverse(o2::gpu::TPCFastSpaceChargeCorrection& correction, bool prn);
 
   static TPCFastSpaceChargeCorrectionHelper* sInstance; ///< singleton instance
   bool mIsInitialized = 0;                              ///< initialization flag

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCMShapeCorrection.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCMShapeCorrection.h
@@ -1,0 +1,117 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TPCMShapeCorrection.h
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_TPCMSHAPECORRECTION
+#define ALICEO2_TPC_TPCMSHAPECORRECTION
+
+#include "DataFormatsTPC/Defs.h"
+#include <vector>
+
+class TTree;
+
+namespace o2::tpc
+{
+
+/// arbitrary boundary potential at the IFC
+struct BoundaryPotentialIFC {
+  /// add boundary potential at given z coordinate
+  void addValue(float potential, float z)
+  {
+    mPotential.emplace_back(potential);
+    mZPosition.emplace_back(z);
+  }
+  std::vector<float> mPotential; ///< boundary potential
+  std::vector<float> mZPosition; ///< z-position of the delta potential
+  ClassDefNV(BoundaryPotentialIFC, 1);
+};
+
+/// struct containing all M-Shape boundary potentials
+struct TPCMShape {
+  /// get time of last stored boundary potential
+  double getStartTimeMS() const { return mTimeMS.front(); }
+
+  /// get time of first stored boundary potential
+  double getEndTimeMS() const { return mTimeMS.back(); }
+
+  /// adding boundary potential for given timestamp
+  void addBoundaryPotentialIFC(const BoundaryPotentialIFC& pot, double time)
+  {
+    mTimeMS.emplace_back(time);
+    mBoundaryPotentialIFC.emplace_back(pot);
+  }
+
+  std::vector<double> mTimeMS;                             ///< time of the boundary potential
+  std::vector<BoundaryPotentialIFC> mBoundaryPotentialIFC; ///< definition of boundary potential
+  int mZ{129};                                             ///< number of vertices for boundary potential in z direction
+  int mR{129};                                             ///< number of vertices for boundary potential in radial direction
+  int mPhi{5};                                             ///< number of vertices for boundary potential in phi direction
+  int mBField{5};                                          ///< B-Field
+  ClassDefNV(TPCMShape, 1);
+};
+
+/*
+Class for storing the scalers (obtained from DCAs) which are used to correct for the M-shape distortions
+*/
+
+class TPCMShapeCorrection
+{
+ public:
+  /// default constructor
+  TPCMShapeCorrection() = default;
+
+  /// \return returns run number for which this object is valid
+  void setRun(int run) { mRun = run; }
+
+  /// dump this object to a file
+  /// \param file output file
+  /// \param name name of the output object
+  void dumpToFile(const char* file, const char* name);
+
+  /// load from input file (which were written using the dumpToFile method)
+  /// \param inpf input file
+  /// \param name name of the object in the file
+  void loadFromFile(const char* inpf, const char* name);
+
+  /// set this object from input tree
+  void setFromTree(TTree& tpcMShapeTree);
+
+  /// set maximum delta time when searching for nearest boundary potential
+  float setMaxDeltaTimeMS(float deltaTMS) { return mMaxDeltaTimeMS = deltaTMS; }
+
+  /// adding M-shapes
+  void setMShapes(const TPCMShape& mshapes) { mMShapes = mshapes; }
+
+  /// \return returns run number for which this object is valid
+  int getRun() const { return mRun; }
+
+  /// \return returns M-shape boundary potential for given timestamp
+  /// \param timestamp timestamp for which the boundary potential is queried
+  BoundaryPotentialIFC getBoundaryPotential(const double timestamp) const;
+
+  /// \return returns sampling time of the stored values
+  float getMaxDeltaTimeMS() const { return mMaxDeltaTimeMS; }
+
+  /// \return returns all stored M-shapes
+  const auto& getMShapes() const { return mMShapes; }
+
+ private:
+  int mRun{};                 ///< run for which this object is valid
+  float mMaxDeltaTimeMS = 50; ///< sampling time of the M-shape scalers
+  TPCMShape mMShapes;         ///< vector containing the M-shapes
+
+  ClassDefNV(TPCMShapeCorrection, 1);
+};
+
+} // namespace o2::tpc
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCScaler.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCScaler.h
@@ -50,8 +50,8 @@ class TPCScaler
   /// \return returns number of stored TPC scaler values
   int getNValues(o2::tpc::Side side) const { return (side == o2::tpc::Side::A ? mScalerA.size() : mScalerC.size()); }
 
-  /// set the parameters for the coefficients of the polynomial
-  /// \param params parameter for the coefficients
+  /// set TPC scalers
+  /// \param values scaling values
   void setScaler(const std::vector<float>& values, const o2::tpc::Side side) { (side == o2::tpc::Side::A ? (mScalerA = values) : (mScalerC = values)); }
 
   /// \return returns ion drift time in ms
@@ -72,6 +72,19 @@ class TPCScaler
   /// dump this object to a file
   /// \param file output file
   void dumpToFile(const char* file, const char* name);
+
+  /// dump this object to a file for a given time range
+  /// \param file output file
+  /// \param startTime start time stamp in ms of the dumped object
+  /// \param endTime end time stamp in ms of the dumped object (if endTimeMS=-1 the end of the stored data is used)
+  void dumpToFile(const char* file, const char* name, double startTimeMS, double endTimeMS);
+
+  /// dump this object to several file each containing the scalers for n minutes
+  /// \param file output file
+  /// \param minutesPerObject minutes each output file is covering
+  /// \param marginMS additional margin to the beginning of each object (should be >= getIonDriftTimeMS())
+  /// \param marginCCDBMinutes margin for CCDB timestamp
+  void dumpToFileSlices(const char* file, const char* name, int minutesPerObject, float marginMS = 500, float marginCCDBMinutes = 1);
 
   /// load parameters from input file (which were written using the writeToFile method)
   /// \param inpf input file
@@ -113,6 +126,11 @@ class TPCScaler
 
   /// \return returns duration in ms for which the scalers are defined
   float getDurationMS(o2::tpc::Side side) const { return mIntegrationTimeMS * getNValues(side); }
+
+  /// clamp scaler values
+  /// \param minThreshold minimum accepted scaler value
+  /// \param maxThreshold maximum accepted scaler value
+  void clampScalers(float minThreshold, float maxThreshold, Side side);
 
   /// setting the weights for the scalers
   void setScalerWeights(const TPCScalerWeights& weights) { mScalerWeights = weights; }

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -114,4 +114,7 @@
 #pragma link C++ class o2::tpc::CalculatedEdx + ;
 #pragma link C++ class o2::tpc::TPCScaler + ;
 #pragma link C++ struct o2::tpc::TPCScalerWeights + ;
+#pragma link C++ class o2::tpc::TPCMShapeCorrection + ;
+#pragma link C++ struct o2::tpc::TPCMShape + ;
+#pragma link C++ struct o2::tpc::BoundaryPotentialIFC + ;
 #endif

--- a/Detectors/TPC/calibration/src/TPCMShapeCorrection.cxx
+++ b/Detectors/TPC/calibration/src/TPCMShapeCorrection.cxx
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  TPCMShapeCorrection.cxx
+/// \brief Definition of TPCMShapeCorrection class
+///
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#include "TPCCalibration/TPCMShapeCorrection.h"
+#include <TFile.h>
+#include <TTree.h>
+#include "Framework/Logger.h"
+
+using namespace o2::tpc;
+
+void TPCMShapeCorrection::dumpToFile(const char* file, const char* name)
+{
+  TFile out(file, "RECREATE");
+  TTree tree(name, name);
+  tree.SetAutoSave(0);
+  tree.Branch("TPCMShapeCorrection", this);
+  tree.Fill();
+  out.WriteObject(&tree, name);
+}
+
+void TPCMShapeCorrection::loadFromFile(const char* inpf, const char* name)
+{
+  TFile out(inpf, "READ");
+  TTree* tree = (TTree*)out.Get(name);
+  setFromTree(*tree);
+}
+
+void TPCMShapeCorrection::setFromTree(TTree& tpcMShapeTree)
+{
+  TPCMShapeCorrection* mshapeTmp = this;
+  tpcMShapeTree.SetBranchAddress("TPCMShapeCorrection", &mshapeTmp);
+  const int entries = tpcMShapeTree.GetEntries();
+  if (entries > 0) {
+    tpcMShapeTree.GetEntry(0);
+  } else {
+    LOGP(error, "TPCMShapeCorrection not found in input file");
+  }
+  tpcMShapeTree.SetBranchAddress("TPCMShapeCorrection", nullptr);
+}
+
+BoundaryPotentialIFC TPCMShapeCorrection::getBoundaryPotential(const double timestamp) const
+{
+  const auto& time = mMShapes.mTimeMS;
+  // find closest stored M-Shape
+  const auto lower = std::lower_bound(time.begin(), time.end(), timestamp);
+  const int idx = std::distance(time.begin(), lower);
+  if ((idx > 0) && (idx < time.size())) {
+    // if idx > 0 check preceeding value
+    double diff1 = std::abs(timestamp - *lower);
+    double diff2 = std::abs(timestamp - *(lower - 1));
+    if (diff2 < diff1) {
+      if (diff2 < mMaxDeltaTimeMS) {
+        return mMShapes.mBoundaryPotentialIFC[idx - 1];
+      }
+    } else {
+      if (diff1 < mMaxDeltaTimeMS) {
+        return mMShapes.mBoundaryPotentialIFC[idx];
+      }
+    }
+  }
+  return BoundaryPotentialIFC{};
+}

--- a/Detectors/TPC/spacecharge/include/TPCSpaceCharge/SpaceCharge.h
+++ b/Detectors/TPC/spacecharge/include/TPCSpaceCharge/SpaceCharge.h
@@ -40,6 +40,11 @@ namespace parameters
 class GRPMagField;
 }
 
+namespace utils
+{
+class TreeStreamRedirector;
+}
+
 namespace tpc
 {
 
@@ -373,6 +378,9 @@ class SpaceCharge
   int getBField() const { return mBField.getBField(); }
 
   const auto& getPotential(const Side side) const& { return mPotential[side]; }
+
+  /// setting the potential directly for given vertex
+  void setPotential(int iz, int ir, int iphi, Side side, float val);
 
   /// get the space charge density for given coordinate
   /// \param z global z coordinate
@@ -1189,6 +1197,12 @@ class SpaceCharge
   float getMeanLumi() const { return mMeta.meanLumi; }
   void setMeanLumi(float lumi) { mMeta.meanLumi = lumi; }
   void initAfterReadingFromFile();
+
+  /// get DCA in RPhi for high pt track
+  /// \param tgl tgl of the track
+  /// \param nPoints number of points used to calculate the DCAr
+  /// \param pcstream if provided debug output is being created
+  float getDCAr(float tgl, const int nPoints, const float phi, o2::utils::TreeStreamRedirector* pcstream = nullptr) const;
 
  private:
   ParamSpaceCharge mParamGrid{};                                                                          ///< parameters of the grid on which the calculations are performed

--- a/Detectors/TPC/spacecharge/src/PoissonSolver.cxx
+++ b/Detectors/TPC/spacecharge/src/PoissonSolver.cxx
@@ -46,7 +46,7 @@ void PoissonSolver<DataT>::poissonSolver3D(DataContainer& matricesV, const DataC
   auto stop = timer::now();
   std::chrono::duration<float> time = stop - start;
   const float totalTime = time.count();
-  LOGP(info, "poissonSolver3D took {}s", totalTime);
+  LOGP(detail, "poissonSolver3D took {}s", totalTime);
 }
 
 template <typename DataT>
@@ -88,7 +88,7 @@ void PoissonSolver<DataT>::poissonMultiGrid2D(DataContainer& matricesV, const Da
 
   const int nLoop = std::max(nGridRow, nGridCol); // Calculate the number of nLoop for the binary expansion
 
-  LOGP(info, "{}", fmt::format("PoissonMultiGrid2D: nGridRow={}, nGridCol={}, nLoop={}, nMGCycle={}", nGridRow, nGridCol, nLoop, MGParameters::nMGCycle));
+  LOGP(detail, "{}", fmt::format("PoissonMultiGrid2D: nGridRow={}, nGridCol={}, nLoop={}, nMGCycle={}", nGridRow, nGridCol, nLoop, MGParameters::nMGCycle));
 
   unsigned int iOne = 1; // index
   unsigned int jOne = 1; // index
@@ -132,7 +132,7 @@ void PoissonSolver<DataT>::poissonMultiGrid2D(DataContainer& matricesV, const Da
   /// full multi grid
   if (MGParameters::cycleType == CycleType::FCycle) {
 
-    LOGP(info, "PoissonMultiGrid2D: Do full cycle");
+    LOGP(detail, "PoissonMultiGrid2D: Do full cycle");
     // FMG
     // 1) Relax on the coarsest grid
     iOne /= 2;
@@ -170,7 +170,7 @@ void PoissonSolver<DataT>::poissonMultiGrid2D(DataContainer& matricesV, const Da
     }
   } else if (MGParameters::cycleType == CycleType::VCycle) {
     // 2. VCycle
-    LOGP(info, "PoissonMultiGrid2D: Do V cycle");
+    LOGP(detail, "PoissonMultiGrid2D: Do V cycle");
 
     int gridFrom = 1;
     int gridTo = nLoop;
@@ -202,7 +202,7 @@ void PoissonSolver<DataT>::poissonMultiGrid2D(DataContainer& matricesV, const Da
 template <typename DataT>
 void PoissonSolver<DataT>::poissonMultiGrid3D2D(DataContainer& matricesV, const DataContainer& matricesCharge, const int symmetry)
 {
-  LOGP(info, "{}", fmt::format("PoissonMultiGrid3D2D: in Poisson Solver 3D multiGrid semi coarsening mParamGrid.NRVertices={}, cols={}, mParamGrid.NPhiVertices={}", mParamGrid.NZVertices, mParamGrid.NRVertices, mParamGrid.NPhiVertices));
+  LOGP(detail, "{}", fmt::format("PoissonMultiGrid3D2D: in Poisson Solver 3D multiGrid semi coarsening mParamGrid.NRVertices={}, cols={}, mParamGrid.NPhiVertices={}", mParamGrid.NZVertices, mParamGrid.NRVertices, mParamGrid.NPhiVertices));
 
   // Check that the number of mParamGrid.NRVertices and mParamGrid.NZVertices is suitable for a binary expansion
   if (!isPowerOfTwo((mParamGrid.NRVertices - 1))) {
@@ -352,7 +352,7 @@ void PoissonSolver<DataT>::poissonMultiGrid3D(DataContainer& matricesV, const Da
   const DataT gridSpacingZ = getSpacingZ();
   const DataT ratioZ = gridSpacingR * gridSpacingR / (gridSpacingZ * gridSpacingZ); // ratio_{Z} = gridSize_{r} / gridSize_{z}
 
-  LOGP(info, "{}", fmt::format("PoissonMultiGrid3D: in Poisson Solver 3D multi grid full coarsening  mParamGrid.NRVertices={}, cols={}, mParamGrid.NPhiVertices={}", mParamGrid.NRVertices, mParamGrid.NZVertices, mParamGrid.NPhiVertices));
+  LOGP(detail, "{}", fmt::format("PoissonMultiGrid3D: in Poisson Solver 3D multi grid full coarsening  mParamGrid.NRVertices={}, cols={}, mParamGrid.NPhiVertices={}", mParamGrid.NRVertices, mParamGrid.NZVertices, mParamGrid.NPhiVertices));
 
   // Check that the number of mParamGrid.NRVertices and mParamGrid.NZVertices is suitable for a binary expansion
   if (!isPowerOfTwo((mParamGrid.NRVertices - 1))) {
@@ -390,7 +390,7 @@ void PoissonSolver<DataT>::poissonMultiGrid3D(DataContainer& matricesV, const Da
     nnPhi /= 2;
   }
 
-  LOGP(info, "{}", fmt::format("PoissonMultiGrid3D: nGridRow={}, nGridCol={}, nGridPhi={}", nGridRow, nGridCol, nGridPhi));
+  LOGP(detail, "{}", fmt::format("PoissonMultiGrid3D: nGridRow={}, nGridCol={}, nGridPhi={}", nGridRow, nGridCol, nGridPhi));
   const int nLoop = std::max({nGridRow, nGridCol, nGridPhi}); // Calculate the number of nLoop for the binary expansion
 
   // Vector for storing multi grid array
@@ -462,7 +462,7 @@ void PoissonSolver<DataT>::poissonMultiGrid3D(DataContainer& matricesV, const Da
       tPhiSlice = kOne == 1 ? mParamGrid.NPhiVertices : mParamGrid.NPhiVertices / kOne;
       tPhiSlice = tPhiSlice < nnPhi ? nnPhi : tPhiSlice;
 
-      LOGP(info, "{}", fmt::format("PoissonMultiGrid3D: Restrict3D, tnRRow={}, tnZColumn={}, newPhiSlice={}, oldPhiSlice={}", tnRRow, tnZColumn, tPhiSlice, otPhiSlice));
+      LOGP(detail, "{}", fmt::format("PoissonMultiGrid3D: Restrict3D, tnRRow={}, tnZColumn={}, newPhiSlice={}, oldPhiSlice={}", tnRRow, tnZColumn, tPhiSlice, otPhiSlice));
       restrict3D(tvChargeFMG[count - 1], tvChargeFMG[count - 2], tnRRow, tnZColumn, tPhiSlice, otPhiSlice);
       // copy boundary values of V
       restrictBoundary3D(tvArrayV[count - 1], tvArrayV[count - 2], tnRRow, tnZColumn, tPhiSlice, otPhiSlice);
@@ -535,7 +535,7 @@ void PoissonSolver<DataT>::poissonMultiGrid3D(DataContainer& matricesV, const Da
         const DataT convergenceError = getConvergenceError(tvArrayV[count], tvPrevArrayV[count]);
         // if already converge just break move to finer grid
         if (convergenceError <= sConvergenceError) {
-          LOGP(info, "Cycle converged. Continue to next cycle...");
+          LOGP(detail, "Cycle converged. Continue to next cycle...");
           break;
         }
         if (count <= 1 && !(mgCycle % 10)) {
@@ -544,7 +544,7 @@ void PoissonSolver<DataT>::poissonMultiGrid3D(DataContainer& matricesV, const Da
           const float totalTime = time.count();
           const float timePerCycle = totalTime / (mgCycle + 1);
           const float remaining = timePerCycle * (MGParameters::nMGCycle - mgCycle);
-          LOGP(info, "Cycle {} out of {} for current V cycle {}. Processed time {}s with {}s per cycle. Max remaining time for current cycle {}s. Convergence {} > {}", mgCycle, MGParameters::nMGCycle, count, time.count(), timePerCycle, remaining, convergenceError, sConvergenceError);
+          LOGP(detail, "Cycle {} out of {} for current V cycle {}. Processed time {}s with {}s per cycle. Max remaining time for current cycle {}s. Convergence {} > {}", mgCycle, MGParameters::nMGCycle, count, time.count(), timePerCycle, remaining, convergenceError, sConvergenceError);
         }
         if (mgCycle == (MGParameters::nMGCycle - 1)) {
           LOGP(warning, "Cycle {} did not convergence! Current convergence error is larger than expected convergence error: {} > {}", mgCycle, convergenceError, sConvergenceError);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCScalerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCScalerSpec.h
@@ -19,7 +19,7 @@ namespace o2
 namespace tpc
 {
 
-o2::framework::DataProcessorSpec getTPCScalerSpec(bool enableWeights);
+o2::framework::DataProcessorSpec getTPCScalerSpec(bool enableIDCs, bool enableMShape);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
@@ -26,6 +26,7 @@
 #include "TTree.h"
 #include "TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h"
 #include "TPCSpaceCharge/SpaceCharge.h"
+#include "CommonUtils/TreeStreamRedirector.h"
 
 using namespace o2::framework;
 

--- a/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
@@ -22,7 +22,10 @@
 #include "TPCBase/CDBInterface.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "TPCCalibration/TPCScaler.h"
+#include "TPCCalibration/TPCMShapeCorrection.h"
 #include "TTree.h"
+#include "TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h"
+#include "TPCSpaceCharge/SpaceCharge.h"
 
 using namespace o2::framework;
 
@@ -34,40 +37,124 @@ namespace tpc
 class TPCScalerSpec : public Task
 {
  public:
-  TPCScalerSpec(std::shared_ptr<o2::base::GRPGeomRequest> req, bool enableWeights) : mCCDBRequest(req), mEnableWeights(enableWeights){};
+  TPCScalerSpec(std::shared_ptr<o2::base::GRPGeomRequest> req, bool enableIDCs, bool enableMShape) : mCCDBRequest(req), mEnableIDCs(enableIDCs), mEnableMShape(enableMShape){};
 
   void init(framework::InitContext& ic) final
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
     mIonDriftTimeMS = ic.options().get<float>("ion-drift-time");
     mMaxTimeWeightsMS = ic.options().get<float>("max-time-for-weights");
+    mMShapeScalingFac = ic.options().get<float>("m-shape-scaling-factor");
+    mEnableWeights = !(ic.options().get<bool>("disableWeights"));
+    const bool enableStreamer = ic.options().get<bool>("enableStreamer");
+    const int mshapeThreads = ic.options().get<int>("n-threads");
+    mKnotsYMshape = ic.options().get<int>("n-knots-y");
+    mKnotsZMshape = ic.options().get<int>("n-knots-z");
+    TPCFastSpaceChargeCorrectionHelper::instance()->setNthreads(mshapeThreads);
+    o2::tpc::SpaceCharge<double>::setNThreads(mshapeThreads);
+
+    if (enableStreamer) {
+      mStreamer = std::make_unique<o2::utils::TreeStreamRedirector>("M_Shape.root", "recreate");
+    }
+  }
+
+  void endOfStream(EndOfStreamContext& eos) final
+  {
+    if (mStreamer) {
+      mStreamer->Close();
+    }
   }
 
   void run(ProcessingContext& pc) final
   {
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-    if (pc.inputs().isValid("tpcscaler")) {
+    if (mEnableIDCs && pc.inputs().isValid("tpcscaler")) {
       pc.inputs().get<TTree*>("tpcscaler");
     }
 
-    if (mEnableWeights) {
+    if (mEnableWeights && mEnableIDCs) {
       if (pc.inputs().isValid("tpcscalerw")) {
         pc.inputs().get<TPCScalerWeights*>("tpcscalerw");
       }
     }
-
-    if (pc.services().get<o2::framework::TimingInfo>().runNumber != mTPCScaler.getRun()) {
-      LOGP(error, "Run number {} of processed data and run number {} of loaded TPC scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mTPCScaler.getRun());
+    if (mEnableMShape && pc.inputs().isValid("mshape")) {
+      pc.inputs().get<TTree*>("mshape");
     }
 
     const auto orbitResetTimeMS = o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS();
     const auto firstTFOrbit = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
     const double timestamp = orbitResetTimeMS + firstTFOrbit * o2::constants::lhc::LHCOrbitMUS * 0.001;
-    float scalerA = mTPCScaler.getMeanScaler(timestamp, o2::tpc::Side::A);
-    float scalerC = mTPCScaler.getMeanScaler(timestamp, o2::tpc::Side::C);
-    float meanScaler = (scalerA + scalerC) / 2;
-    LOGP(info, "Publishing TPC scaler: {}", meanScaler);
-    pc.outputs().snapshot(Output{header::gDataOriginTPC, "TPCSCALER"}, meanScaler);
+
+    if (mEnableMShape) {
+      if (pc.services().get<o2::framework::TimingInfo>().runNumber != mMShapeTPCScaler.getRun()) {
+        LOGP(error, "Run number {} of processed data and run number {} of loaded TPC M-shape scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mMShapeTPCScaler.getRun());
+      }
+
+      const auto& boundaryPotential = mMShapeTPCScaler.getBoundaryPotential(timestamp);
+      if (!boundaryPotential.mPotential.empty()) {
+        LOGP(info, "Calculating M-shape correction from input boundary potential");
+        const Side side = Side::A;
+        o2::tpc::SpaceCharge<double> sc = o2::tpc::SpaceCharge<double>(mMShapeTPCScaler.getMShapes().mBField, mMShapeTPCScaler.getMShapes().mZ, mMShapeTPCScaler.getMShapes().mR, mMShapeTPCScaler.getMShapes().mPhi);
+        for (int iz = 0; iz < mMShapeTPCScaler.getMShapes().mZ; ++iz) {
+          for (int iphi = 0; iphi < mMShapeTPCScaler.getMShapes().mPhi; ++iphi) {
+            const float pot = mMShapeScalingFac * boundaryPotential.mPotential[iz];
+            sc.setPotential(iz, 0, iphi, side, pot);
+          }
+        }
+
+        sc.poissonSolver(side);
+        sc.calcEField(side);
+        sc.calcGlobalCorrections(sc.getElectricFieldsInterpolator(side));
+
+        std::function<void(int, double, double, double, double&, double&, double&)> getCorrections = [&sc = sc](const int roc, double x, double y, double z, double& dx, double& dy, double& dz) {
+          Side side = roc < 18 ? Side::A : Side::C;
+          if (side == Side::C) {
+            dx = 0;
+            dy = 0;
+            dz = 0;
+          } else {
+            sc.getCorrections(x, y, z, side, dx, dy, dz);
+          }
+        };
+
+        std::unique_ptr<TPCFastSpaceChargeCorrection> spCorrection = TPCFastSpaceChargeCorrectionHelper::instance()->createFromGlobalCorrection(getCorrections, mKnotsYMshape, mKnotsZMshape);
+        std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0, *spCorrection));
+        pc.outputs().snapshot(Output{header::gDataOriginTPC, "TPCMSHAPE"}, *fastTransform);
+      } else {
+        // send empty dummy object
+        LOGP(info, "Sending default (no) M-shape correction");
+        auto fastTransform = o2::tpc::TPCFastTransformHelperO2::instance()->create(0);
+        pc.outputs().snapshot(Output{header::gDataOriginTPC, "TPCMSHAPE"}, *fastTransform);
+      }
+
+      if (mStreamer) {
+        (*mStreamer) << "treeMShape"
+                     << "firstTFOrbit=" << firstTFOrbit
+                     << "timestamp=" << timestamp
+                     << "boundaryPotential=" << boundaryPotential
+                     << "mMShapeScalingFac=" << mMShapeScalingFac
+                     << "\n";
+      }
+    }
+
+    if (mEnableIDCs) {
+      if (pc.services().get<o2::framework::TimingInfo>().runNumber != mTPCScaler.getRun()) {
+        LOGP(error, "Run number {} of processed data and run number {} of loaded TPC scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mTPCScaler.getRun());
+      }
+      float scalerA = mTPCScaler.getMeanScaler(timestamp, o2::tpc::Side::A);
+      float scalerC = mTPCScaler.getMeanScaler(timestamp, o2::tpc::Side::C);
+      float meanScaler = (scalerA + scalerC) / 2;
+      LOGP(info, "Publishing TPC scaler: {} for timestamp: {}, firstTFOrbit: {}", meanScaler, timestamp, firstTFOrbit);
+      pc.outputs().snapshot(Output{header::gDataOriginTPC, "TPCSCALER"}, meanScaler);
+      if (mStreamer) {
+        (*mStreamer) << "treeIDC"
+                     << "scalerA=" << scalerA
+                     << "scalerC=" << scalerC
+                     << "firstTFOrbit=" << firstTFOrbit
+                     << "timestamp=" << timestamp
+                     << "\n";
+      }
+    }
   }
 
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
@@ -99,15 +186,26 @@ class TPCScalerSpec : public Task
         overWriteIntegrationTime();
       }
     }
+    if (matcher == ConcreteDataMatcher(o2::header::gDataOriginTPC, "MSHAPEPOTCCDB", 0)) {
+      LOGP(info, "Updating M-shape TPC scaler");
+      mMShapeTPCScaler.setFromTree(*((TTree*)obj));
+    }
   }
 
  private:
-  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest; ///< info for CCDB request
-  const bool mEnableWeights{false};                       ///< use weights for TPC scalers
-  TPCScalerWeights mScalerWeights{};                      ///< scaler weights
-  float mIonDriftTimeMS{-1};                              ///< ion drift time
-  float mMaxTimeWeightsMS{500};                           ///< maximum integration time when weights are used
-  TPCScaler mTPCScaler;                                   ///< tpc scaler
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;     ///< info for CCDB request
+  const bool mEnableIDCs{true};                               ///< enable IDCs
+  const bool mEnableMShape{false};                            ///< enable v shape scalers
+  bool mEnableWeights{false};                                 ///< use weights for TPC scalers
+  TPCScalerWeights mScalerWeights{};                          ///< scaler weights
+  float mIonDriftTimeMS{-1};                                  ///< ion drift time
+  float mMaxTimeWeightsMS{500};                               ///< maximum integration time when weights are used
+  TPCScaler mTPCScaler;                                       ///< tpc scaler
+  float mMShapeScalingFac{0};                                 ///< scale m-shape scalers with this value
+  TPCMShapeCorrection mMShapeTPCScaler;                       ///< TPC M-shape scalers
+  int mKnotsYMshape{4};                                       ///< number of knots used for the spline object for M-Shape distortions
+  int mKnotsZMshape{4};                                       ///< number of knots used for the spline object for M-Shape distortions
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mStreamer; ///< streamer
 
   void overWriteIntegrationTime()
   {
@@ -123,12 +221,17 @@ class TPCScalerSpec : public Task
   }
 };
 
-o2::framework::DataProcessorSpec getTPCScalerSpec(bool enableWeights)
+o2::framework::DataProcessorSpec getTPCScalerSpec(bool enableIDCs, bool enableMShape)
 {
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("tpcscaler", o2::header::gDataOriginTPC, "TPCSCALERCCDB", 0, Lifetime::Condition, ccdbParamSpec(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::CalScaler), {}, 1)); // time-dependent
-  if (enableWeights) {
+  if (enableIDCs) {
+    LOGP(info, "Publishing IDC scalers for space-charge distortion fluctuation correction");
+    inputs.emplace_back("tpcscaler", o2::header::gDataOriginTPC, "TPCSCALERCCDB", 0, Lifetime::Condition, ccdbParamSpec(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::CalScaler), {}, 1));          // time-dependent
     inputs.emplace_back("tpcscalerw", o2::header::gDataOriginTPC, "TPCSCALERWCCDB", 0, Lifetime::Condition, ccdbParamSpec(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::CalScalerWeights), {}, 0)); // non time-dependent
+  }
+  if (enableMShape) {
+    LOGP(info, "Publishing M-shape correction map");
+    inputs.emplace_back("mshape", o2::header::gDataOriginTPC, "MSHAPEPOTCCDB", 0, Lifetime::Condition, ccdbParamSpec(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::CalMShape), {}, 1)); // time-dependent
   }
 
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
@@ -140,16 +243,27 @@ o2::framework::DataProcessorSpec getTPCScalerSpec(bool enableWeights)
                                                                 inputs);
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(o2::header::gDataOriginTPC, "TPCSCALER", 0, Lifetime::Timeframe);
+  if (enableIDCs) {
+    outputs.emplace_back(o2::header::gDataOriginTPC, "TPCSCALER", 0, Lifetime::Timeframe);
+  }
+  if (enableMShape) {
+    outputs.emplace_back(o2::header::gDataOriginTPC, "TPCMSHAPE", 0, Lifetime::Timeframe);
+  }
 
   return DataProcessorSpec{
     "tpc-scaler",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCScalerSpec>(ccdbRequest, enableWeights)},
+    AlgorithmSpec{adaptFromTask<TPCScalerSpec>(ccdbRequest, enableIDCs, enableMShape)},
     Options{
       {"ion-drift-time", VariantType::Float, -1.f, {"Overwrite ion drift time if a value >0 is provided"}},
-      {"max-time-for-weights", VariantType::Float, 500.f, {"Maximum possible integration time in ms when weights are used"}}}};
+      {"max-time-for-weights", VariantType::Float, 500.f, {"Maximum possible integration time in ms when weights are used"}},
+      {"m-shape-scaling-factor", VariantType::Float, 1.f, {"Scale M-shape scaler with this value"}},
+      {"disableWeights", VariantType::Bool, false, {"Disable weights for TPC scalers"}},
+      {"enableStreamer", VariantType::Bool, false, {"Enable streaming of M-shape scalers"}},
+      {"n-threads", VariantType::Int, 4, {"Number of threads used for the M-shape correction"}},
+      {"n-knots-y", VariantType::Int, 4, {"Number of knots in y-direction used for the M-shape correction"}},
+      {"n-knots-z", VariantType::Int, 4, {"Number of knots in z-direction used for the M-shape correction"}}}};
 }
 
 } // namespace tpc

--- a/Detectors/TPC/workflow/src/tpc-calib-gainmap-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calib-gainmap-tracks.cxx
@@ -21,6 +21,7 @@
 #include "TPCWorkflow/TPCCalibPadGainTracksSpec.h"
 #include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 
 using namespace o2::framework;
 
@@ -63,6 +64,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const std::string polynomialsFile = config.options().get<std::string>("polynomialsFile");
   const auto disablePolynomialsCCDB = config.options().get<bool>("disablePolynomialsCCDB");
   const auto sclOpt = o2::tpc::CorrectionMapsLoader::parseGlobalOptions(config.options());
-  WorkflowSpec workflow{getTPCCalibPadGainTracksSpec(publishAfterTFs, debug, useLastExtractedMapAsReference, polynomialsFile, disablePolynomialsCCDB, sclOpt)};
+  WorkflowSpec workflow;
+  if (sclOpt.needTPCScalersWorkflow()) {
+    workflow.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
+  workflow.emplace_back(o2::tpc::getTPCCalibPadGainTracksSpec(publishAfterTFs, debug, useLastExtractedMapAsReference, polynomialsFile, disablePolynomialsCCDB, sclOpt));
   return workflow;
 }

--- a/Detectors/TPC/workflow/src/tpc-scaler.cxx
+++ b/Detectors/TPC/workflow/src/tpc-scaler.cxx
@@ -23,7 +23,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<ConfigParamSpec> options{
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
-    {"disableWeights", VariantType::Bool, false, {"Disable weights for TPC scalers"}}};
+    {"enable-M-shape-correction", VariantType::Bool, false, {"Enable M-shape distortion correction"}},
+    {"disable-IDC-scalers", VariantType::Bool, false, {"Disable TPC scalers for space-charge distortion fluctuation correction"}}};
+
   std::swap(workflowOptions, options);
 }
 
@@ -33,7 +35,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
 {
   WorkflowSpec workflow;
   o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
-  const bool enableWeights = !(config.options().get<bool>("disableWeights"));
-  workflow.emplace_back(o2::tpc::getTPCScalerSpec(enableWeights));
+  const auto enableMShape = config.options().get<bool>("enable-M-shape-correction");
+  const auto enableIDCs = !config.options().get<bool>("disable-IDC-scalers");
+  workflow.emplace_back(o2::tpc::getTPCScalerSpec(enableIDCs, enableMShape));
   return workflow;
 }

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -25,6 +25,7 @@
 #include "TRDWorkflow/TRDPulseHeightSpec.h"
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
+#include "TPCWorkflow/TPCScalerSpec.h"
 
 using namespace o2::framework;
 using GTrackID = o2::dataformats::GlobalTrackID;
@@ -112,6 +113,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // processing devices
   o2::framework::WorkflowSpec specs;
+  if (sclOpt.needTPCScalersWorkflow() && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpt.lumiType == 2, sclOpt.enableMShapeCorrection));
+  }
   specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC, srcTRD, trigRecFilterActive, strict, pid, policy, sclOpt));
   if (vdexb || gain) {
     specs.emplace_back(o2::trd::getTRDTrackBasedCalibSpec(srcTRD, vdexb, gain));

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -216,6 +216,7 @@ template <template <typename T> class S>
 struct GPUCalibObjectsTemplate { // use only pointers on PODs or flat objects here
   typename S<TPCFastTransform>::type* fastTransform = nullptr;
   typename S<TPCFastTransform>::type* fastTransformRef = nullptr;
+  typename S<TPCFastTransform>::type* fastTransformMShape = nullptr;
   typename S<CorrectionMapsHelper>::type* fastTransformHelper = nullptr;
   typename S<o2::base::MatLayerCylSet>::type* matLUT = nullptr;
   typename S<o2::trd::GeometryFlat>::type* trdGeometry = nullptr;

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -416,6 +416,13 @@ void GPUChainTracking::UpdateGPUCalibObjects(int stream, const GPUCalibObjectsCo
     mFlatObjectsShadow.mCalibObjects.fastTransform->setActualBufferAddress(mFlatObjectsShadow.mTpcTransformBuffer);
     mFlatObjectsShadow.mCalibObjects.fastTransform->setFutureBufferAddress(mFlatObjectsDevice.mTpcTransformBuffer);
   }
+  if (processors()->calibObjects.fastTransformMShape && (ptrMask == nullptr || ptrMask->fastTransformMShape)) {
+    memcpy((void*)mFlatObjectsShadow.mCalibObjects.fastTransformMShape, (const void*)processors()->calibObjects.fastTransformMShape, sizeof(*processors()->calibObjects.fastTransformMShape));
+    memcpy((void*)mFlatObjectsShadow.mTpcTransformMShapeBuffer, (const void*)processors()->calibObjects.fastTransformMShape->getFlatBufferPtr(), processors()->calibObjects.fastTransformMShape->getFlatBufferSize());
+    mFlatObjectsShadow.mCalibObjects.fastTransformMShape->clearInternalBufferPtr();
+    mFlatObjectsShadow.mCalibObjects.fastTransformMShape->setActualBufferAddress(mFlatObjectsShadow.mTpcTransformMShapeBuffer);
+    mFlatObjectsShadow.mCalibObjects.fastTransformMShape->setFutureBufferAddress(mFlatObjectsDevice.mTpcTransformMShapeBuffer);
+  }
   if (processors()->calibObjects.fastTransformRef && (ptrMask == nullptr || ptrMask->fastTransformRef)) {
     memcpy((void*)mFlatObjectsShadow.mCalibObjects.fastTransformRef, (const void*)processors()->calibObjects.fastTransformRef, sizeof(*processors()->calibObjects.fastTransformRef));
     memcpy((void*)mFlatObjectsShadow.mTpcTransformRefBuffer, (const void*)processors()->calibObjects.fastTransformRef->getFlatBufferPtr(), processors()->calibObjects.fastTransformRef->getFlatBufferSize());
@@ -427,6 +434,7 @@ void GPUChainTracking::UpdateGPUCalibObjects(int stream, const GPUCalibObjectsCo
     memcpy((void*)mFlatObjectsShadow.mCalibObjects.fastTransformHelper, (const void*)processors()->calibObjects.fastTransformHelper, sizeof(*processors()->calibObjects.fastTransformHelper));
     mFlatObjectsShadow.mCalibObjects.fastTransformHelper->setCorrMap(mFlatObjectsShadow.mCalibObjects.fastTransform);
     mFlatObjectsShadow.mCalibObjects.fastTransformHelper->setCorrMapRef(mFlatObjectsShadow.mCalibObjects.fastTransformRef);
+    mFlatObjectsShadow.mCalibObjects.fastTransformHelper->setCorrMapMShape(mFlatObjectsShadow.mCalibObjects.fastTransformMShape);
   }
 #ifdef GPUCA_HAVE_O2HEADERS
   if (processors()->calibObjects.dEdxCalibContainer && (ptrMask == nullptr || ptrMask->dEdxCalibContainer)) {
@@ -519,6 +527,10 @@ void* GPUChainTracking::GPUTrackingFlatObjects::SetPointersFlatObjects(void* mem
   if (mChainTracking->processors()->calibObjects.fastTransformRef) {
     computePointerWithAlignment(mem, mCalibObjects.fastTransformRef, 1);
     computePointerWithAlignment(mem, mTpcTransformRefBuffer, mChainTracking->processors()->calibObjects.fastTransformRef->getFlatBufferSize());
+  }
+  if (mChainTracking->processors()->calibObjects.fastTransformMShape) {
+    computePointerWithAlignment(mem, mCalibObjects.fastTransformMShape, 1);
+    computePointerWithAlignment(mem, mTpcTransformMShapeBuffer, mChainTracking->processors()->calibObjects.fastTransformMShape->getFlatBufferSize());
   }
   if (mChainTracking->processors()->calibObjects.fastTransformHelper) {
     computePointerWithAlignment(mem, mCalibObjects.fastTransformHelper, 1);

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -206,6 +206,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
     GPUCalibObjects mCalibObjects;
     char* mTpcTransformBuffer = nullptr;
     char* mTpcTransformRefBuffer = nullptr;
+    char* mTpcTransformMShapeBuffer = nullptr;
     char* mdEdxSplinesBuffer = nullptr;
     char* mMatLUTBuffer = nullptr;
     short mMemoryResFlat = -1;
@@ -262,6 +263,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   // Ptr to detector / calibration objects
   std::unique_ptr<TPCFastTransform> mTPCFastTransformU;              // Global TPC fast transformation object
   std::unique_ptr<TPCFastTransform> mTPCFastTransformRefU;           // Global TPC fast transformation ref object
+  std::unique_ptr<TPCFastTransform> mTPCFastTransformMShapeU;        // Global TPC fast transformation for M-shape object
   std::unique_ptr<CorrectionMapsHelper> mTPCFastTransformHelperU;    // Global TPC fast transformation helper object
   std::unique_ptr<TPCPadGainCalib> mTPCPadGainCalibU;                // TPC gain calibration and cluster finder parameters
   std::unique_ptr<TPCZSLinkMapping> mTPCZSLinkMappingU;              // TPC Mapping data required by ZS Link decoder

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -309,6 +309,11 @@ void GPUChainTracking::DumpSettings(const char* dir)
     f += "tpctransformref.dump";
     DumpFlatObjectToFile(processors()->calibObjects.fastTransformRef, f.c_str());
   }
+  if (processors()->calibObjects.fastTransformMShape != nullptr) {
+    f = dir;
+    f += "tpctransformmshape.dump";
+    DumpFlatObjectToFile(processors()->calibObjects.fastTransformMShape, f.c_str());
+  }
   if (processors()->calibObjects.fastTransformHelper != nullptr) {
     f = dir;
     f += "tpctransformhelper.dump";
@@ -355,11 +360,16 @@ void GPUChainTracking::ReadSettings(const char* dir)
   mTPCFastTransformRefU = ReadFlatObjectFromFile<TPCFastTransform>(f.c_str());
   processors()->calibObjects.fastTransformRef = mTPCFastTransformRefU.get();
   f = dir;
+  f += "tpctransformmshape.dump";
+  mTPCFastTransformMShapeU = ReadFlatObjectFromFile<TPCFastTransform>(f.c_str());
+  processors()->calibObjects.fastTransformMShape = mTPCFastTransformMShapeU.get();
+  f = dir;
   f += "tpctransformhelper.dump";
   mTPCFastTransformHelperU = ReadStructFromFile<CorrectionMapsHelper>(f.c_str());
   if ((processors()->calibObjects.fastTransformHelper = mTPCFastTransformHelperU.get())) {
     mTPCFastTransformHelperU->setCorrMap(mTPCFastTransformU.get());
     mTPCFastTransformHelperU->setCorrMapRef(mTPCFastTransformRefU.get());
+    mTPCFastTransformHelperU->setCorrMapMShape(mTPCFastTransformMShapeU.get());
   }
   f = dir;
   f += "tpcpadgaincalib.dump";

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
@@ -98,5 +98,5 @@ void CorrectionMapsHelper::setCorrMapMShape(std::unique_ptr<TPCFastTransform>&& 
 //________________________________________________________
 void CorrectionMapsHelper::reportScaling()
 {
-  LOGP(info, "Map scaling update: InstLumiOverride={}, LumiScaleType={} -> instLumi={}, meanLumiRef={}, meanLumi={} -> LumiScale={}, lumiScaleMode={}", getInstLumiOverride(), getLumiScaleType(), getInstLumi(), getMeanLumiRef(), getMeanLumi(), getLumiScale(), getLumiScaleMode());
+  LOGP(info, "Map scaling update: InstLumiOverride={}, LumiScaleType={} -> instLumi={}, meanLumiRef={}, meanLumi={} -> LumiScale={}, lumiScaleMode={}, is M-Shape map valid: {}, is M-Shape default: {}", getInstLumiOverride(), getLumiScaleType(), getInstLumi(), getMeanLumiRef(), getMeanLumi(), getLumiScale(), getLumiScaleMode(), (mCorrMapMShape != nullptr), isCorrMapMShapeDummy());
 }

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
@@ -20,13 +20,16 @@ void CorrectionMapsHelper::clear()
   if (mOwner) {
     delete mCorrMap;
     delete mCorrMapRef;
+    delete mCorrMapMShape;
   }
   mCorrMap = nullptr;
   mCorrMapRef = nullptr;
+  mCorrMapMShape = nullptr;
   mUpdatedFlags = 0;
   mInstLumi = 0.f;
   mMeanLumi = 0.f;
   mMeanLumiRef = 0.f;
+  mScaleInverse = false;
 }
 
 void CorrectionMapsHelper::setOwner(bool v)
@@ -55,6 +58,14 @@ void CorrectionMapsHelper::setCorrMapRef(TPCFastTransform* m)
   mCorrMapRef = m;
 }
 
+void CorrectionMapsHelper::setCorrMapMShape(TPCFastTransform* m)
+{
+  if (mOwner) {
+    delete mCorrMapMShape;
+  }
+  mCorrMapMShape = m;
+}
+
 //________________________________________________________
 void CorrectionMapsHelper::setCorrMap(std::unique_ptr<TPCFastTransform>&& m)
 {
@@ -75,8 +86,17 @@ void CorrectionMapsHelper::setCorrMapRef(std::unique_ptr<TPCFastTransform>&& m)
   mCorrMapRef = m.release();
 }
 
+void CorrectionMapsHelper::setCorrMapMShape(std::unique_ptr<TPCFastTransform>&& m)
+{
+  if (!mOwner) {
+    throw std::runtime_error("we must not take the ownership from a unique ptr if mOwnerMShape is not set");
+  }
+  delete mCorrMapMShape;
+  mCorrMapMShape = m.release();
+}
+
 //________________________________________________________
 void CorrectionMapsHelper::reportScaling()
 {
-  LOGP(info, "Map scaling update: InstLumiOverride={}, LumiScaleType={} -> instLumi={}, meanLumi={} -> LumiScale={}, lumiScaleMode={}", getInstLumiOverride(), getLumiScaleType(), getInstLumi(), getMeanLumi(), getLumiScale(), getLumiScaleMode());
+  LOGP(info, "Map scaling update: InstLumiOverride={}, LumiScaleType={} -> instLumi={}, meanLumiRef={}, meanLumi={} -> LumiScale={}, lumiScaleMode={}", getInstLumiOverride(), getLumiScaleType(), getInstLumi(), getMeanLumiRef(), getMeanLumi(), getLumiScale(), getLumiScaleMode());
 }

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -38,31 +38,33 @@ class CorrectionMapsHelper
 
   GPUd() void Transform(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime = 0) const
   {
-    mCorrMap->Transform(slice, row, pad, time, x, y, z, vertexTime, mCorrMapRef, mLumiScale, mLumiScaleMode);
+    mCorrMap->Transform(slice, row, pad, time, x, y, z, vertexTime, mCorrMapRef, mCorrMapMShape, mLumiScale, 1, mLumiScaleMode);
   }
 
   GPUd() void TransformXYZ(int slice, int row, float& x, float& y, float& z) const
   {
-    mCorrMap->TransformXYZ(slice, row, x, y, z, mCorrMapRef, mLumiScale, mLumiScaleMode);
+    mCorrMap->TransformXYZ(slice, row, x, y, z, mCorrMapRef, mCorrMapMShape, mLumiScale, 1, mLumiScaleMode);
   }
 
   GPUd() void InverseTransformYZtoX(int slice, int row, float y, float z, float& x) const
   {
-    mCorrMap->InverseTransformYZtoX(slice, row, y, z, x, mCorrMapRef, mLumiScale, mLumiScaleMode);
+    mCorrMap->InverseTransformYZtoX(slice, row, y, z, x, mCorrMapRef, mCorrMapMShape, (mScaleInverse ? mLumiScale : 0), (mScaleInverse ? 1 : 0), mLumiScaleMode);
   }
 
   GPUd() void InverseTransformYZtoNominalYZ(int slice, int row, float y, float z, float& ny, float& nz) const
   {
-    mCorrMap->InverseTransformYZtoNominalYZ(slice, row, y, z, ny, nz, mCorrMapRef, mLumiScale, mLumiScaleMode);
+    mCorrMap->InverseTransformYZtoNominalYZ(slice, row, y, z, ny, nz, mCorrMapRef, mCorrMapMShape, (mScaleInverse ? mLumiScale : 0), (mScaleInverse ? 1 : 0), mLumiScaleMode);
   }
 
   GPUd() const GPUCA_NAMESPACE::gpu::TPCFastTransform* getCorrMap() const { return mCorrMap; }
   GPUd() const GPUCA_NAMESPACE::gpu::TPCFastTransform* getCorrMapRef() const { return mCorrMapRef; }
+  GPUd() const GPUCA_NAMESPACE::gpu::TPCFastTransform* getCorrMapMShape() const { return mCorrMapMShape; }
 
   bool getOwner() const { return mOwner; }
 
   void setCorrMap(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
   void setCorrMapRef(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
+  void setCorrMapMShape(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
   void reportScaling();
   void setInstLumi(float v, bool report = true)
   {
@@ -121,20 +123,25 @@ class CorrectionMapsHelper
   bool isUpdated() const { return mUpdatedFlags != 0; }
   bool isUpdatedMap() const { return (mUpdatedFlags & UpdateFlags::MapBit) != 0; }
   bool isUpdatedMapRef() const { return (mUpdatedFlags & UpdateFlags::MapRefBit) != 0; }
+  bool isUpdatedMapMShape() const { return (mUpdatedFlags & UpdateFlags::MapMShapeBit) != 0; }
   bool isUpdatedLumi() const { return (mUpdatedFlags & UpdateFlags::LumiBit) != 0; }
   void setUpdatedMap() { mUpdatedFlags |= UpdateFlags::MapBit; }
   void setUpdatedMapRef() { mUpdatedFlags |= UpdateFlags::MapRefBit; }
+  void setUpdatedMapMShape() { mUpdatedFlags |= UpdateFlags::MapMShapeBit; }
   void setUpdatedLumi() { mUpdatedFlags |= UpdateFlags::LumiBit; }
 
 #if !defined(GPUCA_GPUCODE_DEVICE) && defined(GPUCA_NOCOMPAT)
   void setCorrMap(std::unique_ptr<GPUCA_NAMESPACE::gpu::TPCFastTransform>&& m);
   void setCorrMapRef(std::unique_ptr<GPUCA_NAMESPACE::gpu::TPCFastTransform>&& m);
+  void setCorrMapMShape(std::unique_ptr<GPUCA_NAMESPACE::gpu::TPCFastTransform>&& m);
 #endif
   void setOwner(bool v);
   void acknowledgeUpdate() { mUpdatedFlags = 0; }
 
   void setLumiScaleType(int v) { mLumiScaleType = v; }
   int getLumiScaleType() const { return mLumiScaleType; }
+  void enableMShapeCorrection(bool v) { mEnableMShape = v; }
+  bool getUseMShapeCorrection() const { return mEnableMShape; }
 
   void setMeanLumiOverride(float f) { mMeanLumiOverride = f; }
   void setMeanLumiRefOverride(float f) { mMeanLumiRefOverride = f; }
@@ -146,26 +153,32 @@ class CorrectionMapsHelper
 
   int getUpdateFlags() const { return mUpdatedFlags; }
 
+  bool getScaleInverse() const { return mScaleInverse; }
+
  protected:
   enum UpdateFlags { MapBit = 0x1,
                      MapRefBit = 0x2,
-                     LumiBit = 0x4 };
-  bool mOwner = false;    // is content of pointers owned by the helper
+                     LumiBit = 0x4,
+                     MapMShapeBit = 0x10 };
+  bool mOwner = false; // is content of pointers owned by the helper
   // these 2 are global options, must be set by the workflow global options
   int mLumiScaleType = -1; // require CTP Lumi for mInstLumi
   int mLumiScaleMode = -1; // scaling-mode of the correciton maps
   int mUpdatedFlags = 0;
-  float mInstLumi = 0.;                                         // instanteneous luminosity (a.u)
-  float mMeanLumi = 0.;                                         // mean luminosity of the map (a.u)
-  float mMeanLumiRef = 0.;                                      // mean luminosity of the ref map (a.u)
-  float mLumiScale = 0.;                                        // precalculated mInstLumi/mMeanLumi
-  float mMeanLumiOverride = -1.f;                               // optional value to override mean lumi
-  float mMeanLumiRefOverride = -1.f;                            // optional value to override ref mean lumi
-  float mInstLumiOverride = -1.f;                               // optional value to override inst lumi
-  GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMap{nullptr};    // current transform
-  GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapRef{nullptr}; // reference transform
+  float mInstLumi = 0.;                                            // instanteneous luminosity (a.u)
+  float mMeanLumi = 0.;                                            // mean luminosity of the map (a.u)
+  float mMeanLumiRef = 0.;                                         // mean luminosity of the ref map (a.u)
+  float mLumiScale = 0.;                                           // precalculated mInstLumi/mMeanLumi
+  float mMeanLumiOverride = -1.f;                                  // optional value to override mean lumi
+  float mMeanLumiRefOverride = -1.f;                               // optional value to override ref mean lumi
+  float mInstLumiOverride = -1.f;                                  // optional value to override inst lumi
+  bool mEnableMShape = false;                                      ///< use v shape correction
+  bool mScaleInverse{false};                                       // if set to false the inverse correction is already scaled and will not scaled again
+  GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMap{nullptr};       // current transform
+  GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapRef{nullptr};    // reference transform
+  GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapMShape{nullptr}; // correction map for v-shape distortions on A-side
 #ifndef GPUCA_ALIROOT_LIB
-  ClassDefNV(CorrectionMapsHelper, 4);
+  ClassDefNV(CorrectionMapsHelper, 5);
 #endif
 };
 

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -155,6 +155,16 @@ class CorrectionMapsHelper
 
   bool getScaleInverse() const { return mScaleInverse; }
 
+  /// return returns if the correction map for the M-shape correction is a dummy spline object
+  GPUd() bool isCorrMapMShapeDummy() const
+  {
+    if (mCorrMapMShape) {
+      // just check for the first spline the number of knots which are 4 in case of default spline object
+      return mCorrMapMShape->getCorrection().getSpline(0, 0).getNumberOfKnots() == 4;
+    }
+    return true;
+  }
+
  protected:
   enum UpdateFlags { MapBit = 0x1,
                      MapRefBit = 0x2,

--- a/GPU/TPCFastTransformation/TPCFastTransform.h
+++ b/GPU/TPCFastTransformation/TPCFastTransform.h
@@ -182,8 +182,8 @@ class TPCFastTransform : public FlatObject
   /// Transforms raw TPC coordinates to local XYZ withing a slice
   /// taking calibration + alignment into account.
   ///
-  GPUd() void Transform(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime = 0, const TPCFastTransform* ref = nullptr, float scale = 0.f, int scaleMode = 0) const;
-  GPUd() void TransformXYZ(int slice, int row, float& x, float& y, float& z, const TPCFastTransform* ref = nullptr, float scale = 0.f, int scaleMode = 0) const;
+  GPUd() void Transform(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime = 0, const TPCFastTransform* ref = nullptr, const TPCFastTransform* ref2 = nullptr, float scale = 0.f, float scale2 = 0.f, int scaleMode = 0) const;
+  GPUd() void TransformXYZ(int slice, int row, float& x, float& y, float& z, const TPCFastTransform* ref = nullptr, const TPCFastTransform* ref2 = nullptr, float scale = 0.f, float scale2 = 0.f, int scaleMode = 0) const;
 
   /// Transformation in the time frame
   GPUd() void TransformInTimeFrame(int slice, int row, float pad, float time, float& x, float& y, float& z, float maxTimeBin) const;
@@ -193,13 +193,13 @@ class TPCFastTransform : public FlatObject
   GPUd() void InverseTransformInTimeFrame(int slice, int row, float /*x*/, float y, float z, float& pad, float& time, float maxTimeBin) const;
 
   /// Inverse transformation: Transformed Y and Z -> transformed X
-  GPUd() void InverseTransformYZtoX(int slice, int row, float y, float z, float& x, const TPCFastTransform* ref = nullptr, float scale = 0.f, int scaleMode = 0) const;
+  GPUd() void InverseTransformYZtoX(int slice, int row, float y, float z, float& x, const TPCFastTransform* ref = nullptr, const TPCFastTransform* ref2 = nullptr, float scale = 0.f, float scale2 = 0.f, int scaleMode = 0) const;
 
   /// Inverse transformation: Transformed Y and Z -> Y and Z, transformed w/o space charge correction
-  GPUd() void InverseTransformYZtoNominalYZ(int slice, int row, float y, float z, float& ny, float& nz, const TPCFastTransform* ref = nullptr, float scale = 0.f, int scaleMode = 0) const;
+  GPUd() void InverseTransformYZtoNominalYZ(int slice, int row, float y, float z, float& ny, float& nz, const TPCFastTransform* ref = nullptr, const TPCFastTransform* ref2 = nullptr, float scale = 0.f, float scale2 = 0.f, int scaleMode = 0) const;
 
   /// Inverse transformation: Transformed X, Y and Z -> X, Y and Z, transformed w/o space charge correction
-  GPUd() void InverseTransformXYZtoNominalXYZ(int slice, int row, float x, float y, float z, float& nx, float& ny, float& nz, const TPCFastTransform* ref = nullptr, float scale = 0.f, int scaleMode = 0) const;
+  GPUd() void InverseTransformXYZtoNominalXYZ(int slice, int row, float x, float y, float z, float& nx, float& ny, float& nz, const TPCFastTransform* ref = nullptr, const TPCFastTransform* ref2 = nullptr, float scale = 0.f, float scale2 = 0.f, int scaleMode = 0) const;
 
   /// Ideal transformation with Vdrift only - without calibration
   GPUd() void TransformIdeal(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime) const;
@@ -339,7 +339,7 @@ class TPCFastTransform : public FlatObject
   /// Correction of (x,u,v) with tricubic interpolator on a regular grid
   TPCSlowSpaceChargeCorrection* mCorrectionSlow{nullptr}; ///< reference space charge corrections
 
-  GPUd() void TransformInternal(int slice, int row, float& u, float& v, float& x, const TPCFastTransform* ref, float scale, int scaleMode) const;
+  GPUd() void TransformInternal(int slice, int row, float& u, float& v, float& x, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const;
 
 #ifndef GPUCA_ALIROOT_LIB
   ClassDefNV(TPCFastTransform, 3);
@@ -444,7 +444,7 @@ GPUdi() void TPCFastTransform::getTOFcorrection(int slice, int /*row*/, float x,
   dz = sideC ? dv : -dv;
 }
 
-GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, float& v, float& x, const TPCFastTransform* ref, float scale, int scaleMode) const
+GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, float& v, float& x, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const
 {
   if (mApplyCorrection) {
     float dx = 0.f, du = 0.f, dv = 0.f;
@@ -484,6 +484,13 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
             dv = dvRef * scale + dv;
           }
         }
+        if (ref2) {
+          float dxRef, duRef, dvRef;
+          ref2->mCorrection.getCorrection(slice, row, u, v, dxRef, duRef, dvRef);
+          dx = dxRef * scale2 + dx;
+          du = duRef * scale2 + du;
+          dv = dvRef * scale2 + dv;
+        }
       }
     }
     GPUCA_DEBUG_STREAMER_CHECK(if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamFastTransform)) {
@@ -499,15 +506,29 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
       float lxT = x + dx;
       getGeometry().convUVtoLocal(slice, uCorr, vCorr, lyT, lzT);
 
+      float invYZtoXScaled;
+      InverseTransformYZtoX(slice, row, lyT, lzT, invYZtoXScaled, ref, ref2, scale, scale2, scaleMode);
+
       float invYZtoX;
-      InverseTransformYZtoX(slice, row, lyT, lzT, invYZtoX, ref, scale, scaleMode);
+      InverseTransformYZtoX(slice, row, lyT, lzT, invYZtoX);
 
       float YZtoNominalY;
       float YZtoNominalZ;
-      InverseTransformYZtoNominalYZ(slice, row, lyT, lzT, YZtoNominalY, YZtoNominalZ, ref, scale, scaleMode);
+      InverseTransformYZtoNominalYZ(slice, row, lyT, lzT, YZtoNominalY, YZtoNominalZ);
+
+      float YZtoNominalYScaled;
+      float YZtoNominalZScaled;
+      InverseTransformYZtoNominalYZ(slice, row, lyT, lzT, YZtoNominalYScaled, YZtoNominalZScaled, ref, ref2, scale, scale2, scaleMode);
 
       float dxRef, duRef, dvRef;
-      ref->mCorrection.getCorrection(slice, row, u, v, dxRef, duRef, dvRef);
+      if (ref) {
+        ref->mCorrection.getCorrection(slice, row, u, v, dxRef, duRef, dvRef);
+      }
+
+      float dxRef2, duRef2, dvRef2;
+      if (ref2) {
+        ref2->mCorrection.getCorrection(slice, row, u, v, dxRef2, duRef2, dvRef2);
+      }
 
       float dxOrig, duOrig, dvOrig;
       mCorrection.getCorrection(slice, row, u, v, dxOrig, duOrig, dvOrig);
@@ -520,6 +541,9 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
                                                                                          << "dxRef=" << dxRef
                                                                                          << "duRef=" << duRef
                                                                                          << "dvRef=" << dvRef
+                                                                                         << "dxRef2=" << dxRef2
+                                                                                         << "duRef2=" << duRef2
+                                                                                         << "dvRef2=" << dvRef2
                                                                                          << "dx=" << dx
                                                                                          << "du=" << du
                                                                                          << "dv=" << dv
@@ -528,6 +552,7 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
                                                                                          << "row=" << row
                                                                                          << "slice=" << slice
                                                                                          << "scale=" << scale
+                                                                                         << "scale2=" << scale2
                                                                                          // original local coordinates
                                                                                          << "ly=" << ly
                                                                                          << "lz=" << lz
@@ -542,8 +567,11 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
                                                                                          << "gz=" << gz
                                                                                          // some transformations which are applied
                                                                                          << "invYZtoX=" << invYZtoX
+                                                                                         << "invYZtoXScaled=" << invYZtoXScaled
                                                                                          << "YZtoNominalY=" << YZtoNominalY
+                                                                                         << "YZtoNominalYScaled=" << YZtoNominalYScaled
                                                                                          << "YZtoNominalZ=" << YZtoNominalZ
+                                                                                         << "YZtoNominalZScaled=" << YZtoNominalZScaled
                                                                                          << "scaleMode=" << scaleMode
                                                                                          << "\n";
     })
@@ -554,18 +582,18 @@ GPUdi() void TPCFastTransform::TransformInternal(int slice, int row, float& u, f
   }
 }
 
-GPUdi() void TPCFastTransform::TransformXYZ(int slice, int row, float& x, float& y, float& z, const TPCFastTransform* ref, float scale, int scaleMode) const
+GPUdi() void TPCFastTransform::TransformXYZ(int slice, int row, float& x, float& y, float& z, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const
 {
   float u, v;
   getGeometry().convLocalToUV(slice, y, z, u, v);
-  TransformInternal(slice, row, u, v, x, ref, scale, scaleMode);
+  TransformInternal(slice, row, u, v, x, ref, ref2, scale, scale2, scaleMode);
   getGeometry().convUVtoLocal(slice, u, v, y, z);
   float dzTOF = 0;
   getTOFcorrection(slice, row, x, y, z, dzTOF);
   z += dzTOF;
 }
 
-GPUdi() void TPCFastTransform::Transform(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime, const TPCFastTransform* ref, float scale, int scaleMode) const
+GPUdi() void TPCFastTransform::Transform(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const
 {
   /// _______________ The main method: cluster transformation _______________________
   ///
@@ -582,7 +610,7 @@ GPUdi() void TPCFastTransform::Transform(int slice, int row, float pad, float ti
   float u = 0, v = 0;
   convPadTimeToUV(slice, row, pad, time, u, v, vertexTime);
 
-  TransformInternal(slice, row, u, v, x, ref, scale, scaleMode);
+  TransformInternal(slice, row, u, v, x, ref, ref2, scale, scale2, scaleMode);
 
   getGeometry().convUVtoLocal(slice, u, v, y, z);
 
@@ -746,7 +774,7 @@ GPUdi() float TPCFastTransform::getMaxDriftTime(int slice) const
   return maxTime;
 }
 
-GPUdi() void TPCFastTransform::InverseTransformYZtoX(int slice, int row, float y, float z, float& x, const TPCFastTransform* ref, float scale, int scaleMode) const
+GPUdi() void TPCFastTransform::InverseTransformYZtoX(int slice, int row, float y, float z, float& x, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const
 {
   /// Transformation y,z -> x
   float u = 0, v = 0;
@@ -763,6 +791,11 @@ GPUdi() void TPCFastTransform::InverseTransformYZtoX(int slice, int row, float y
         ref->mCorrection.getCorrectionInvCorrectedX(slice, row, u, v, xr);
         x = (xr - getGeometry().getRowInfo(row).x) * scale + x; // xr=mGeo.getRowInfo(row).x + dx;
       }
+    }
+    if (ref2 && (scale2 != 0)) {
+      float xr;
+      ref2->mCorrection.getCorrectionInvCorrectedX(slice, row, u, v, xr);
+      x = (xr - getGeometry().getRowInfo(row).x) * scale + x; // xr=mGeo.getRowInfo(row).x + dx;
     }
   } else {
     x = mCorrection.getGeometry().getRowInfo(row).x; // corrections are disabled
@@ -781,7 +814,7 @@ GPUdi() void TPCFastTransform::InverseTransformYZtoX(int slice, int row, float y
   })
 }
 
-GPUdi() void TPCFastTransform::InverseTransformYZtoNominalYZ(int slice, int row, float y, float z, float& ny, float& nz, const TPCFastTransform* ref, float scale, int scaleMode) const
+GPUdi() void TPCFastTransform::InverseTransformYZtoNominalYZ(int slice, int row, float y, float z, float& ny, float& nz, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const
 {
   /// Transformation y,z -> x
   float u = 0, v = 0, un = 0, vn = 0;
@@ -797,6 +830,12 @@ GPUdi() void TPCFastTransform::InverseTransformYZtoNominalYZ(int slice, int row,
       } else if ((scale != 0) && ((scaleMode == 1) || (scaleMode == 2))) {
         float unr = 0, vnr = 0;
         ref->mCorrection.getCorrectionInvUV(slice, row, u, v, unr, vnr);
+        un = (unr - u) * scale + un; // unr = u - duv[0];
+        vn = (vnr - v) * scale + vn;
+      }
+      if (ref2 && (scale != 0)) {
+        float unr = 0, vnr = 0;
+        ref2->mCorrection.getCorrectionInvUV(slice, row, u, v, unr, vnr);
         un = (unr - u) * scale + un; // unr = u - duv[0];
         vn = (vnr - v) * scale + vn;
       }
@@ -824,7 +863,7 @@ GPUdi() void TPCFastTransform::InverseTransformYZtoNominalYZ(int slice, int row,
   })
 }
 
-GPUdi() void TPCFastTransform::InverseTransformXYZtoNominalXYZ(int slice, int row, float x, float y, float z, float& nx, float& ny, float& nz, const TPCFastTransform* ref, float scale, int scaleMode) const
+GPUdi() void TPCFastTransform::InverseTransformXYZtoNominalXYZ(int slice, int row, float x, float y, float z, float& nx, float& ny, float& nz, const TPCFastTransform* ref, const TPCFastTransform* ref2, float scale, float scale2, int scaleMode) const
 {
   /// Inverse transformation: Transformed X, Y and Z -> X, Y and Z, transformed w/o space charge correction
   int row2 = row + 1;
@@ -835,8 +874,8 @@ GPUdi() void TPCFastTransform::InverseTransformXYZtoNominalXYZ(int slice, int ro
   float nx2, ny2, nz2; // nominal coordinates for row2
   nx1 = getGeometry().getRowInfo(row).x;
   nx2 = getGeometry().getRowInfo(row2).x;
-  InverseTransformYZtoNominalYZ(slice, row, y, z, ny1, nz1, ref, scale, scaleMode);
-  InverseTransformYZtoNominalYZ(slice, row2, y, z, ny2, nz2, ref, scale, scaleMode);
+  InverseTransformYZtoNominalYZ(slice, row, y, z, ny1, nz1, ref, ref2, scale, scale2, scaleMode);
+  InverseTransformYZtoNominalYZ(slice, row2, y, z, ny2, nz2, ref, ref2, scale, scale2, scaleMode);
   float c1 = (nx2 - nx) / (nx2 - nx1);
   float c2 = (nx - nx1) / (nx2 - nx1);
   nx = x;

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -104,6 +104,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   struct Config {
     int itsTriggerType = 0;
     int lumiScaleMode = 0;
+    bool enableMShape = false;
     int enableDoublePipeline = 0;
     int tpcDeadMapSources = -1;
     bool decompressTPC = false;
@@ -148,6 +149,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   struct calibObjectStruct {
     std::unique_ptr<TPCFastTransform> mFastTransform;
     std::unique_ptr<TPCFastTransform> mFastTransformRef;
+    std::unique_ptr<TPCFastTransform> mFastTransformMShape;
     std::unique_ptr<o2::tpc::CorrectionMapsLoader> mFastTransformHelper;
     std::unique_ptr<TPCPadGainCalib> mTPCPadGainCalib;
     std::unique_ptr<o2::tpc::CalibdEdxContainer> mdEdxCalibContainer;

--- a/GPU/Workflow/include/GPUWorkflow/O2GPUDPLDisplay.h
+++ b/GPU/Workflow/include/GPUWorkflow/O2GPUDPLDisplay.h
@@ -70,6 +70,7 @@ class O2GPUDPLDisplaySpec : public o2::framework::Task
   std::unique_ptr<GPUSettingsO2> mConfParam;
   std::unique_ptr<TPCFastTransform> mFastTransform;
   std::unique_ptr<TPCFastTransform> mFastTransformRef;
+  std::unique_ptr<TPCFastTransform> mFastTransformMShape;
   std::unique_ptr<o2::tpc::CorrectionMapsLoader> mFastTransformHelper;
   std::unique_ptr<o2::trd::GeometryFlat> mTrdGeo;
   std::unique_ptr<o2::itsmft::TopologyDictionary> mITSDict;

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -250,6 +250,7 @@ void GPURecoWorkflowSpec::init(InitContext& ic)
 
     mConfig->configCalib.fastTransform = mCalibObjects.mFastTransformHelper->getCorrMap();
     mConfig->configCalib.fastTransformRef = mCalibObjects.mFastTransformHelper->getCorrMapRef();
+    mConfig->configCalib.fastTransformMShape = mCalibObjects.mFastTransformHelper->getCorrMapMShape();
     mConfig->configCalib.fastTransformHelper = mCalibObjects.mFastTransformHelper.get();
     if (mConfig->configCalib.fastTransform == nullptr) {
       throw std::invalid_argument("GPU workflow: initialization of the TPC transformation failed");
@@ -1088,7 +1089,7 @@ Inputs GPURecoWorkflowSpec::inputs()
     inputs.emplace_back("tpcthreshold", gDataOriginTPC, "PADTHRESHOLD", 0, Lifetime::Condition, ccdbParamSpec("TPC/Config/FEEPad"));
     o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
     Options optsDummy;
-    o2::tpc::CorrectionMapsLoaderGloOpts gloOpts{mSpecConfig.lumiScaleType, mSpecConfig.lumiScaleMode};
+    o2::tpc::CorrectionMapsLoaderGloOpts gloOpts{mSpecConfig.lumiScaleType, mSpecConfig.lumiScaleMode, mSpecConfig.enableMShape};
     mCalibObjects.mFastTransformHelper->requestCCDBInputs(inputs, optsDummy, gloOpts); // option filled here is lost
   }
   if (mSpecConfig.decompressTPC) {

--- a/GPU/Workflow/src/O2GPUDPLDisplay.cxx
+++ b/GPU/Workflow/src/O2GPUDPLDisplay.cxx
@@ -68,10 +68,13 @@ void O2GPUDPLDisplaySpec::init(InitContext& ic)
   mFastTransformHelper.reset(new o2::tpc::CorrectionMapsLoader());
   mFastTransform = std::move(TPCFastTransformHelperO2::instance()->create(0));
   mFastTransformRef = std::move(TPCFastTransformHelperO2::instance()->create(0));
+  mFastTransformMShape = std::move(TPCFastTransformHelperO2::instance()->create(0));
   mFastTransformHelper->setCorrMap(mFastTransform.get());
   mFastTransformHelper->setCorrMapRef(mFastTransformRef.get());
+  mFastTransformHelper->setCorrMapMShape(mFastTransformMShape.get());
   mConfig->configCalib.fastTransform = mFastTransformHelper->getCorrMap();
   mConfig->configCalib.fastTransformRef = mFastTransformHelper->getCorrMapRef();
+  mConfig->configCalib.fastTransformMShape = mFastTransformHelper->getCorrMapMShape();
   mConfig->configCalib.fastTransformHelper = mFastTransformHelper.get();
 
   mTrdGeo.reset(new o2::trd::GeometryFlat());

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -160,6 +160,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   cfg.runTPCTracking = true;
   cfg.lumiScaleType = sclOpt.lumiType;
   cfg.lumiScaleMode = sclOpt.lumiMode;
+  cfg.enableMShape = sclOpt.enableMShapeCorrection;
   cfg.decompressTPC = isEnabled(inputTypes, ioType::CompClustCTF);
   cfg.decompressTPCFromROOT = isEnabled(inputTypes, ioType::CompClustROOT);
   cfg.zsDecoder = isEnabled(inputTypes, ioType::ZSRaw);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -270,15 +270,18 @@ GPU_CONFIG_SELF="--severity $SEVERITY_TPC"
 
 parse_TPC_CORR_SCALING()
 {
+local IGNOREIDC=1
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --lumi-type=*) TPC_CORR_OPT+=" --lumi-type ${1#*=}"; [[ ${1#*=} == "2" ]] && NEED_TPC_SCALERS_WF=1; shift 1;;
-    --lumi-type) TPC_CORR_OPT+=" --lumi-type ${2}"; [[ ${2} == "2" ]] && NEED_TPC_SCALERS_WF=1; shift 2;;
+    --lumi-type=*) TPC_CORR_OPT+=" --lumi-type ${1#*=}"; [[ ${1#*=} == "2" ]] && { NEED_TPC_SCALERS_WF=1; IGNOREIDC=0; }; shift 1;;
+    --lumi-type) TPC_CORR_OPT+=" --lumi-type ${2}"; [[ ${2} == "2" ]] && { NEED_TPC_SCALERS_WF=1; IGNOREIDC=0; }; shift 2;;
+    --enable-M-shape-correction) TPC_CORR_OPT+=" --enable-M-shape-correction"; NEED_TPC_SCALERS_WF=1; TPC_SCALERS_CONF+=" --enable-M-shape-correction" ; shift 1;;
     --corrmap-lumi-mode=*) TPC_CORR_OPT+=" --corrmap-lumi-mode ${1#*=}"; shift 1;;
     --corrmap-lumi-mode) TPC_CORR_OPT+=" --corrmap-lumi-mode ${2}"; shift 2;;
     *) TPC_CORR_KEY+="$1;"; shift 1;;
   esac
 done
+[[ ${NEED_TPC_SCALERS_WF:-} == 1 ]] && [[ $IGNOREIDC == 1 ]] && TPC_SCALERS_CONF+=" --disable-IDC-scalers"
 }
 
 parse_TPC_CORR_SCALING $TPC_CORR_SCALING


### PR DESCRIPTION
The time dependent distortions that we observe in the DCAs on the A-side can be similarly corrected as the space-charge distortions. For this a new model is added which we can linearly scale up or down according to current V-shape observed in DCA.

Further changes:
- TPC IDC scaler adding helper function to split the scalers, when writing to file
- fixing timestamp in TPC time series