### PR TITLE
ITS - first version for time-dependent dead maps - wip

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -1,100 +1,91 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-# All rights not expressly granted are reserved.
+#Copyright 2019 - 2020 CERN and copyright holders of ALICE O2.
+#See https: // alice-o2.web.cern.ch/copyright for details of the copyright holders.
+#All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#This software is distributed under the terms of the GNU General Public
+#License v3(GPL Version 3), copied verbatim in the file "COPYING".
 #
-# In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
+#In applying this license CERN does not waive the privileges and immunities
+#granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
 o2_add_library(ITSWorkflow
-               TARGETVARNAME targetName
-               SOURCES src/RecoWorkflow.cxx
-                       src/ClusterWriterWorkflow.cxx
-                       src/ClustererSpec.cxx
-                       src/ClusterWriterSpec.cxx
-                       src/TrackerSpec.cxx
-                       src/CookedTrackerSpec.cxx
-                       src/TrackWriterSpec.cxx
-                       src/TrackReaderSpec.cxx
-                       src/VertexReaderSpec.cxx
-                       src/ThresholdCalibratorSpec.cxx
-                       src/ThresholdAggregatorWorkflow.cxx
-                       src/ThresholdAggregatorSpec.cxx
-		       src/DeadMapBuilderSpec.cxx
-                       src/DCSParserWorkflow.cxx
-                       src/DCSParserSpec.cxx
-                       src/DCSAdaposParserWorkflow.cxx
-                       src/DCSAdaposParserSpec.cxx
-                       src/DCSDataGeneratorWorkflow.cxx
-           src/DCSGeneratorSpec.cxx
-         PUBLIC_LINK_LIBRARIES O2::Framework
-                               O2::SimConfig
-                               O2::DetectorsDCS
-                               O2::DataFormatsITS
-                               O2::DataFormatsDCS
-                               O2::DataFormatsTRD
-                               O2::DataFormatsGlobalTracking
+                 TARGETVARNAME targetName
+                   SOURCES src /
+               RecoWorkflow.cxx
+                 src /
+               ClusterWriterWorkflow.cxx
+                 src /
+               ClustererSpec.cxx
+                 src /
+               ClusterWriterSpec.cxx
+                 src /
+               TrackerSpec.cxx
+                 src /
+               CookedTrackerSpec.cxx
+                 src /
+               TrackWriterSpec.cxx
+                 src /
+               TrackReaderSpec.cxx
+                 src /
+               VertexReaderSpec.cxx
+                 src /
+               ThresholdCalibratorSpec.cxx
+                 src /
+               ThresholdAggregatorWorkflow.cxx
+                 src /
+               ThresholdAggregatorSpec.cxx
+                 src /
+               DeadMapBuilderSpec.cxx
+                 src /
+               DCSParserWorkflow.cxx
+                 src /
+               DCSParserSpec.cxx
+                 src /
+               DCSAdaposParserWorkflow.cxx
+                 src /
+               DCSAdaposParserSpec.cxx
+                 src /
+               DCSDataGeneratorWorkflow.cxx
+                 src /
+               DCSGeneratorSpec.cxx
+                 PUBLIC_LINK_LIBRARIES O2::Framework
+                   O2::SimConfig
+                     O2::DetectorsDCS
+                       O2::DataFormatsITS
+                         O2::DataFormatsDCS
+                           O2::DataFormatsTRD
+                             O2::DataFormatsGlobalTracking
                                O2::SimulationDataFormat
-                               O2::ITStracking
-                               O2::ITSReconstruction
-                               O2::ITSMFTReconstruction
-                               O2::ITSMFTWorkflow
-                               O2::DetectorsCalibration
-                               O2::GlobalTrackingWorkflowWriters
-                               O2::CCDB
-                               O2::GPUTracking
-                               O2::GPUWorkflow)
+                                 O2::ITStracking
+                                   O2::ITSReconstruction
+                                     O2::ITSMFTReconstruction
+                                       O2::ITSMFTWorkflow
+                                         O2::DetectorsCalibration
+                                           O2::GlobalTrackingWorkflowWriters
+                                             O2::CCDB
+                                               O2::GPUTracking
+                                                 O2::GPUWorkflow)
 
-o2_add_executable(reco-workflow
-                  SOURCES src/its-reco-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow
-                                        O2::GlobalTrackingWorkflowReaders)
+  o2_add_executable(reco - workflow SOURCES src / its - reco - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow O2::GlobalTrackingWorkflowReaders)
 
-o2_add_executable(cluster-writer-workflow
-                  SOURCES src/its-cluster-writer-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+    o2_add_executable(cluster - writer - workflow SOURCES src / its - cluster - writer - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-o2_add_executable(cluster-reader-workflow
-                  SOURCES src/its-cluster-reader-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+      o2_add_executable(cluster - reader - workflow SOURCES src / its - cluster - reader - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-o2_add_executable(threshold-calib-workflow
-                  SOURCES src/its-threshold-calib-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+        o2_add_executable(threshold - calib - workflow SOURCES src / its - threshold - calib - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-o2_add_executable(threshold-aggregator-workflow
-                  SOURCES src/its-threshold-aggregator-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+          o2_add_executable(threshold - aggregator - workflow SOURCES src / its - threshold - aggregator - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-o2_add_executable(deadmap-builder-workflow
-		  SOURCES src/its-deadmap-builder-workflow.cxx
-		  COMPONENT_NAME its
-		  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
-		
-o2_add_executable(dcs-parser-workflow
-                  SOURCES src/its-dcs-parser-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+            o2_add_executable(deadmap - builder - workflow SOURCES src / its - deadmap - builder - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-o2_add_executable(dcs-generator-workflow
-                  SOURCES src/its-dcs-generator-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+              o2_add_executable(dcs - parser - workflow SOURCES src / its - dcs - parser - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-o2_add_executable(dcs-adapos-parser-workflow
-                  SOURCES src/its-dcs-adapos-parser-workflow.cxx
-                  COMPONENT_NAME its
-                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+                o2_add_executable(dcs - generator - workflow SOURCES src / its - dcs - generator - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-if (OpenMP_CXX_FOUND)
-    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
-    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
-endif()
+                  o2_add_executable(dcs - adapos - parser - workflow SOURCES src / its - dcs - adapos - parser - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+
+                    if (OpenMP_CXX_FOUND)
+                      target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+                        target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+                          endif()

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -1,91 +1,100 @@
-#Copyright 2019 - 2020 CERN and copyright holders of ALICE O2.
-#See https: // alice-o2.web.cern.ch/copyright for details of the copyright holders.
-#All rights not expressly granted are reserved.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-#This software is distributed under the terms of the GNU General Public
-#License v3(GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
-#In applying this license CERN does not waive the privileges and immunities
-#granted to it by virtue of its status as an Intergovernmental Organization
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
 o2_add_library(ITSWorkflow
-                 TARGETVARNAME targetName
-                   SOURCES src /
-               RecoWorkflow.cxx
-                 src /
-               ClusterWriterWorkflow.cxx
-                 src /
-               ClustererSpec.cxx
-                 src /
-               ClusterWriterSpec.cxx
-                 src /
-               TrackerSpec.cxx
-                 src /
-               CookedTrackerSpec.cxx
-                 src /
-               TrackWriterSpec.cxx
-                 src /
-               TrackReaderSpec.cxx
-                 src /
-               VertexReaderSpec.cxx
-                 src /
-               ThresholdCalibratorSpec.cxx
-                 src /
-               ThresholdAggregatorWorkflow.cxx
-                 src /
-               ThresholdAggregatorSpec.cxx
-                 src /
-               DeadMapBuilderSpec.cxx
-                 src /
-               DCSParserWorkflow.cxx
-                 src /
-               DCSParserSpec.cxx
-                 src /
-               DCSAdaposParserWorkflow.cxx
-                 src /
-               DCSAdaposParserSpec.cxx
-                 src /
-               DCSDataGeneratorWorkflow.cxx
-                 src /
-               DCSGeneratorSpec.cxx
-                 PUBLIC_LINK_LIBRARIES O2::Framework
-                   O2::SimConfig
-                     O2::DetectorsDCS
-                       O2::DataFormatsITS
-                         O2::DataFormatsDCS
-                           O2::DataFormatsTRD
-                             O2::DataFormatsGlobalTracking
+               TARGETVARNAME targetName
+               SOURCES src/RecoWorkflow.cxx
+                       src/ClusterWriterWorkflow.cxx
+                       src/ClustererSpec.cxx
+                       src/ClusterWriterSpec.cxx
+                       src/TrackerSpec.cxx
+                       src/CookedTrackerSpec.cxx
+                       src/TrackWriterSpec.cxx
+                       src/TrackReaderSpec.cxx
+                       src/VertexReaderSpec.cxx
+                       src/ThresholdCalibratorSpec.cxx
+                       src/ThresholdAggregatorWorkflow.cxx
+                       src/ThresholdAggregatorSpec.cxx
+                       src/DeadMapBuilderSpec.cxx
+                       src/DCSParserWorkflow.cxx
+                       src/DCSParserSpec.cxx
+                       src/DCSAdaposParserWorkflow.cxx
+                       src/DCSAdaposParserSpec.cxx
+                       src/DCSDataGeneratorWorkflow.cxx
+           src/DCSGeneratorSpec.cxx
+         PUBLIC_LINK_LIBRARIES O2::Framework
+                               O2::SimConfig
+                               O2::DetectorsDCS
+                               O2::DataFormatsITS
+                               O2::DataFormatsDCS
+                               O2::DataFormatsTRD
+                               O2::DataFormatsGlobalTracking
                                O2::SimulationDataFormat
-                                 O2::ITStracking
-                                   O2::ITSReconstruction
-                                     O2::ITSMFTReconstruction
-                                       O2::ITSMFTWorkflow
-                                         O2::DetectorsCalibration
-                                           O2::GlobalTrackingWorkflowWriters
-                                             O2::CCDB
-                                               O2::GPUTracking
-                                                 O2::GPUWorkflow)
+                               O2::ITStracking
+                               O2::ITSReconstruction
+                               O2::ITSMFTReconstruction
+                               O2::ITSMFTWorkflow
+                               O2::DetectorsCalibration
+                               O2::GlobalTrackingWorkflowWriters
+                               O2::CCDB
+                               O2::GPUTracking
+                               O2::GPUWorkflow)
 
-  o2_add_executable(reco - workflow SOURCES src / its - reco - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow O2::GlobalTrackingWorkflowReaders)
+o2_add_executable(reco-workflow
+                  SOURCES src/its-reco-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow
+                                        O2::GlobalTrackingWorkflowReaders)
 
-    o2_add_executable(cluster - writer - workflow SOURCES src / its - cluster - writer - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(cluster-writer-workflow
+                  SOURCES src/its-cluster-writer-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-      o2_add_executable(cluster - reader - workflow SOURCES src / its - cluster - reader - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(cluster-reader-workflow
+                  SOURCES src/its-cluster-reader-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-        o2_add_executable(threshold - calib - workflow SOURCES src / its - threshold - calib - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(threshold-calib-workflow
+                  SOURCES src/its-threshold-calib-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-          o2_add_executable(threshold - aggregator - workflow SOURCES src / its - threshold - aggregator - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(threshold-aggregator-workflow
+                  SOURCES src/its-threshold-aggregator-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-            o2_add_executable(deadmap - builder - workflow SOURCES src / its - deadmap - builder - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(deadmap-builder-workflow
+                  SOURCES src/its-deadmap-builder-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+		
+o2_add_executable(dcs-parser-workflow
+                  SOURCES src/its-dcs-parser-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-              o2_add_executable(dcs - parser - workflow SOURCES src / its - dcs - parser - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(dcs-generator-workflow
+                  SOURCES src/its-dcs-generator-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-                o2_add_executable(dcs - generator - workflow SOURCES src / its - dcs - generator - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+o2_add_executable(dcs-adapos-parser-workflow
+                  SOURCES src/its-dcs-adapos-parser-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
-                  o2_add_executable(dcs - adapos - parser - workflow SOURCES src / its - dcs - adapos - parser - workflow.cxx COMPONENT_NAME its PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
-
-                    if (OpenMP_CXX_FOUND)
-                      target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
-                        target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
-                          endif()
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(ITSWorkflow
                        src/ThresholdCalibratorSpec.cxx
                        src/ThresholdAggregatorWorkflow.cxx
                        src/ThresholdAggregatorSpec.cxx
+		       src/DeadMapBuilderSpec.cxx
                        src/DCSParserWorkflow.cxx
                        src/DCSParserSpec.cxx
                        src/DCSAdaposParserWorkflow.cxx
@@ -73,6 +74,11 @@ o2_add_executable(threshold-aggregator-workflow
                   COMPONENT_NAME its
                   PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
+o2_add_executable(deadmap-builder-workflow
+		  SOURCES src/its-deadmap-builder-workflow.cxx
+		  COMPONENT_NAME its
+		  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+		
 o2_add_executable(dcs-parser-workflow
                   SOURCES src/its-dcs-parser-workflow.cxx
                   COMPONENT_NAME its

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -78,7 +78,7 @@ o2_add_executable(deadmap-builder-workflow
                   SOURCES src/its-deadmap-builder-workflow.cxx
                   COMPONENT_NAME its
                   PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
-		
+
 o2_add_executable(dcs-parser-workflow
                   SOURCES src/its-dcs-parser-workflow.cxx
                   COMPONENT_NAME its

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
@@ -1,0 +1,162 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DeadMapBuilderSpec.h
+
+#ifndef O2_ITS_DEADMAP_BUILDER_
+#define O2_ITS_DEADMAP_BUILDER_
+
+
+#include <sys/stat.h>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <array>
+#include <set>
+#include <deque>
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+// Boost library for easy access of host name
+#include <boost/asio/ip/host_name.hpp>
+
+#include "Framework/CCDBParamSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/RawDeviceService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/DataTakingContext.h"
+#include "Framework/TimingInfo.h"
+#include <fairmq/Device.h>
+
+#include <ITSMFTReconstruction/RawPixelDecoder.h> //o2::itsmft::RawPixelDecoder
+#include "DetectorsCalibration/Utils.h"
+#include "DetectorsCommonDataFormats/FileMetaData.h"
+#include "DetectorsBase/GRPGeomHelper.h" //nicolo
+#include "CCDB/CcdbApi.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "DataFormatsDCS/DCSConfigObject.h"
+
+// ROOT includes
+#include "TTree.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TF1.h"
+#include "TFile.h"
+
+using namespace o2::framework;
+using namespace o2::itsmft;
+
+
+namespace o2
+{
+namespace its
+{
+
+  struct ITSDMInpConf {
+    int chipModSel = 0;
+    int chipModBase = 1;
+  };
+
+
+class ITSDeadMapBuilder : public Task
+{
+ public:
+  ITSDeadMapBuilder(const ITSDMInpConf& inpConf, std::string datasource);
+  ~ITSDeadMapBuilder() override;
+
+  using ChipPixelData = o2::itsmft::ChipPixelData;
+  o2::itsmft::ChipMappingITS mp;
+
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(EndOfStreamContext& ec) final;
+
+  void finalize();
+  void stop() final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
+
+  //////////////////////////////////////////////////////////////////
+ private:
+
+
+  std::string mSelfName;
+  
+  bool DebugMode = false;
+  short int N_CHIPS = o2::itsmft::ChipMappingITS::getNChips();
+  short int N_CHIPS_IB = o2::itsmft::ChipMappingITS::getNChips(0);
+  int mTFLength = o2::base::GRPGeomHelper::getNHBFPerTF();  // TODO. returns 128 see https://github.com/AliceO2Group/AliceO2/blob/051b56f9f136e7977e83f5d26d922db9bd6ecef5/Detectors/Base/src/GRPGeomHelper.cxx#L233 and correct also default option is getSpec
+  std::set<short int> mChipsAlive;
+  std::set<short int> mLanesAlive;
+  uint mStepCounter=0;
+  uint mTFCounter=0;
+
+  std::string mLocalOutputDir;
+  
+  ULong64_t mapelement_t0 = 0x0; // 7x<9b>              0: used for IB: chips = lanes
+  ULong64_t mapelement_t1 = 0x1; // 5x<12b>          0001: used for OB lanes
+  ULong64_t mapelement_t2 = 0x3; // 000.. <12b><12b> 0011: used for lane intervals
+  ULong64_t mapelement_t3 = 0x5; // 4x<15b>          0101: used for single chips
+  std::vector<ULong64_t>* mDeadMapTF = new std::vector<ULong64_t>{};
+
+  Long64_t mFirstOrbitTF = 0x0;
+
+  std::string mDataSource = "chipsstatus";
+
+  int mTFSampling = 1000;
+
+
+  /// TEMPORARY FOR LOCAL DEVELOPMENT
+  TTree* mTreeObject = new TTree("map","map");
+  TH2F *Htime = new TH2F("time","time",1000,0,5000,10000,0,10000);
+ 
+  
+  void updateTimeDependentParams(ProcessingContext& pc);
+  
+
+  void finalizeOutput();
+  void PrepareOutputCcdb(DataAllocator& output);
+
+
+  // Utils
+
+  short int getLaneIDFromChip(short int);
+  std::vector<short int> decodeITSMapWord(ULong64_t);
+  
+
+  o2::framework::DataTakingContext mDataTakingContext{};
+  o2::framework::TimingInfo mTimingInfo{};
+
+
+  // Flag to avoid that endOfStream and stop are both done
+  bool isEnded = false;
+
+  
+  // flag to set url for ccdb mgr
+  std::string mCcdbMgrUrl = "";
+  
+  // Run stop requested flag for EoS operations
+  bool mRunStopRequested = false;
+
+};
+
+// Create a processor spec
+  o2::framework::DataProcessorSpec getITSDeadMapBuilderSpec(const ITSDMInpConf& inpConf, std::string datasource);
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
@@ -14,7 +14,6 @@
 #ifndef O2_ITS_DEADMAP_BUILDER_
 #define O2_ITS_DEADMAP_BUILDER_
 
-
 #include <sys/stat.h>
 #include <filesystem>
 #include <string>
@@ -60,17 +59,15 @@
 using namespace o2::framework;
 using namespace o2::itsmft;
 
-
 namespace o2
 {
 namespace its
 {
 
-  struct ITSDMInpConf {
-    int chipModSel = 0;
-    int chipModBase = 1;
-  };
-
+struct ITSDMInpConf {
+  int chipModSel = 0;
+  int chipModBase = 1;
+};
 
 class ITSDeadMapBuilder : public Task
 {
@@ -85,29 +82,26 @@ class ITSDeadMapBuilder : public Task
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
 
- 
   void stop() final;
-  
+
   //////////////////////////////////////////////////////////////////
  private:
-
-
   std::string mSelfName;
-  
+
   bool DebugMode = false;
   bool mDoLocalOutput = false;
   short int N_CHIPS = o2::itsmft::ChipMappingITS::getNChips();
   short int N_CHIPS_IB = o2::itsmft::ChipMappingITS::getNChips(0);
-  int mTFLength = o2::base::GRPGeomHelper::getNHBFPerTF();  // TODO. returns 128 see https://github.com/AliceO2Group/AliceO2/blob/051b56f9f136e7977e83f5d26d922db9bd6ecef5/Detectors/Base/src/GRPGeomHelper.cxx#L233 and correct also default option is getSpec
+  int mTFLength = 32; // TODO find utility for proper value -- o2::base::GRPGeomHelper::getNHBFPerTF() returns 128 see https://github.com/AliceO2Group/AliceO2/blob/051b56f9f136e7977e83f5d26d922db9bd6ecef5/Detectors/Base/src/GRPGeomHelper.cxx#L233 and correct also default option is getSpec
   std::set<short int> mLanesAlive;
-  uint mStepCounter=0;
-  uint mTFCounter=0;
+  uint mStepCounter = 0;
+  uint mTFCounter = 0;
 
   std::string mObjectName = "its_time_deadmap.root";
   std::string mLocalOutputDir;
 
   std::string MAP_VERSION = "1"; // to change in case the encoding or the format change
-  
+
   ULong64_t t0_identifier = 0x0; // 7x<9b>             0: used for IB: chips = lanes
   ULong64_t t1_identifier = 0x1; // 5x<12b>         0001: used for OB lanes
   ULong64_t t2_identifier = 0x3; // 2x<15b> 2x<15b> 0011: used for lane intervals
@@ -120,45 +114,34 @@ class ITSDeadMapBuilder : public Task
 
   int mTFSampling = 1000;
 
+  TTree* mTreeObject = new TTree("map", "map");
 
-  /// TEMPORARY FOR LOCAL DEVELOPMENT
-  TTree* mTreeObject = new TTree("map","map");
-  TH2F *Htime = new TH2F("time","time",1000,0,5000,10000,0,10000);
- 
-  
-  void updateTimeDependentParams(ProcessingContext& pc);
-  
+  /// Only for debug mode
+  TH2F* Htime = new TH2F("time", "time", 1000, 0, 5000, 10000, 0, 10000);
+
   // main method
-  std::pair<int, int> FillMapElement();  // returns dead lanes and number of words
+  std::pair<int, int> FillMapElementITS(); // returns number of dead lanes and number of words
 
   void finalizeOutput();
   void PrepareOutputCcdb(DataAllocator& output);
-
 
   // Utils
 
   short int getLaneIDFromChip(short int);
   std::vector<short int> decodeITSMapWord(ULong64_t);
-  
 
   o2::framework::DataTakingContext mDataTakingContext{};
   o2::framework::TimingInfo mTimingInfo{};
 
-
   // Flag to avoid that endOfStream and stop are both done
   bool isEnded = false;
 
-  
-  // flag to set url for ccdb mgr
-  std::string mCcdbMgrUrl = "";
-  
   // Run stop requested flag for EoS operations
   bool mRunStopRequested = false;
-
 };
 
 // Create a processor spec
-  o2::framework::DataProcessorSpec getITSDeadMapBuilderSpec(const ITSDMInpConf& inpConf, std::string datasource);
+o2::framework::DataProcessorSpec getITSDeadMapBuilderSpec(const ITSDMInpConf& inpConf, std::string datasource);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
@@ -106,7 +106,7 @@ class ITSDeadMapBuilder : public Task
   ULong64_t t1_identifier = 0x1; // 5x<12b>         0001: used for OB lanes
   ULong64_t t2_identifier = 0x3; // 2x<15b> 2x<15b> 0011: used for lane intervals
   ULong64_t t3_identifier = 0x5; // 4x<15b>         0101: used for single chips
-  std::vector<ULong64_t>* mDeadMapTF = new std::vector<ULong64_t>{};
+  std::vector<ULong64_t>* mDeadMapTF = nullptr;
 
   Long64_t mFirstOrbitTF = 0x0;
 
@@ -114,10 +114,7 @@ class ITSDeadMapBuilder : public Task
 
   int mTFSampling = 1000;
 
-  TTree* mTreeObject = new TTree("map", "map");
-
-  /// Only for debug mode
-  TH2F* Htime = new TH2F("time", "time", 1000, 0, 5000, 10000, 0, 10000);
+  TTree* mTreeObject = nullptr;
 
   // main method
   std::pair<int, int> FillMapElementITS(); // returns number of dead lanes and number of words

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DeadMapBuilderSpec.h
@@ -85,10 +85,9 @@ class ITSDeadMapBuilder : public Task
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
 
-  void finalize();
+ 
   void stop() final;
-  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
-
+  
   //////////////////////////////////////////////////////////////////
  private:
 
@@ -96,20 +95,23 @@ class ITSDeadMapBuilder : public Task
   std::string mSelfName;
   
   bool DebugMode = false;
+  bool mDoLocalOutput = false;
   short int N_CHIPS = o2::itsmft::ChipMappingITS::getNChips();
   short int N_CHIPS_IB = o2::itsmft::ChipMappingITS::getNChips(0);
   int mTFLength = o2::base::GRPGeomHelper::getNHBFPerTF();  // TODO. returns 128 see https://github.com/AliceO2Group/AliceO2/blob/051b56f9f136e7977e83f5d26d922db9bd6ecef5/Detectors/Base/src/GRPGeomHelper.cxx#L233 and correct also default option is getSpec
-  std::set<short int> mChipsAlive;
   std::set<short int> mLanesAlive;
   uint mStepCounter=0;
   uint mTFCounter=0;
 
+  std::string mObjectName = "its_time_deadmap.root";
   std::string mLocalOutputDir;
+
+  std::string MAP_VERSION = "1"; // to change in case the encoding or the format change
   
-  ULong64_t mapelement_t0 = 0x0; // 7x<9b>              0: used for IB: chips = lanes
-  ULong64_t mapelement_t1 = 0x1; // 5x<12b>          0001: used for OB lanes
-  ULong64_t mapelement_t2 = 0x3; // 000.. <12b><12b> 0011: used for lane intervals
-  ULong64_t mapelement_t3 = 0x5; // 4x<15b>          0101: used for single chips
+  ULong64_t t0_identifier = 0x0; // 7x<9b>             0: used for IB: chips = lanes
+  ULong64_t t1_identifier = 0x1; // 5x<12b>         0001: used for OB lanes
+  ULong64_t t2_identifier = 0x3; // 2x<15b> 2x<15b> 0011: used for lane intervals
+  ULong64_t t3_identifier = 0x5; // 4x<15b>         0101: used for single chips
   std::vector<ULong64_t>* mDeadMapTF = new std::vector<ULong64_t>{};
 
   Long64_t mFirstOrbitTF = 0x0;
@@ -126,6 +128,8 @@ class ITSDeadMapBuilder : public Task
   
   void updateTimeDependentParams(ProcessingContext& pc);
   
+  // main method
+  std::pair<int, int> FillMapElement();  // returns dead lanes and number of words
 
   void finalizeOutput();
   void PrepareOutputCcdb(DataAllocator& output);

--- a/Detectors/ITSMFT/ITS/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DeadMapBuilderSpec.cxx
@@ -232,8 +232,8 @@ std::pair<int, int> ITSDeadMapBuilder::FillMapElementITS()
 
       if (laneUp - laneLow - 1 > 6) { // more than 6 lanes (or full stave) --> better to save in a single word
         bool isfilled = (mapelement_t2 != t2_identifier);
-        mapelement_t2 = mapelement_t2 | ((ULong64_t)((laneLow + 2) & 0xFFF) << 4 + 30 * isfilled);
-        mapelement_t2 = mapelement_t2 | ((ULong64_t)((laneUp - 1 + 1) & 0xFFF) << 19 + 30 * isfilled);
+        mapelement_t2 = mapelement_t2 | ((ULong64_t)((laneLow + 2) & 0xFFF) << (4 + 30 * isfilled));
+        mapelement_t2 = mapelement_t2 | ((ULong64_t)((laneUp - 1 + 1) & 0xFFF) << (19 + 30 * isfilled));
         dcount_t2 += (laneUp - laneLow - 1);
         if (isfilled) {
           mDeadMapTF->push_back(mapelement_t2);

--- a/Detectors/ITSMFT/ITS/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DeadMapBuilderSpec.cxx
@@ -1,0 +1,394 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DeadMapBuilderSpec.cxx
+
+#include "ITSWorkflow/DeadMapBuilderSpec.h"
+#include "CommonUtils/FileSystemUtils.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsITSMFT/Digit.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
+
+namespace o2
+{
+namespace its
+{
+
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+// Default constructor
+  ITSDeadMapBuilder::ITSDeadMapBuilder(const ITSDMInpConf& inpConf, std::string datasource)
+  : mDataSource(datasource)
+{
+  mSelfName = o2::utils::Str::concat_string(ChipMappingITS::getName(), "ITSDeadMapBuilder");
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Default deconstructor
+ITSDeadMapBuilder::~ITSDeadMapBuilder()
+{
+  // Clear dynamic memory
+
+    
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void ITSDeadMapBuilder::init(InitContext& ic)
+{
+  LOGF(info, "ITSDeadMapBuilder init...", mSelfName);
+
+  mTreeObject->Branch("orbit",&mFirstOrbitTF);
+  mTreeObject->Branch("deadmap",&mDeadMapTF);
+
+  mTFSampling = ic.options().get<int>("tf-sampling");
+  DebugMode = ic.options().get<bool>("debug");
+  mTFLength = ic.options().get<int>("tf-length");
+  mLocalOutputDir = ic.options().get<std::string>("output-dir");
+
+  LOG(info) << "Sampling one TF every "<<mTFSampling;
+
+
+  return;
+}
+
+
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+// Grouping chips in lanes
+short int ITSDeadMapBuilder::getLaneIDFromChip(short int chip)
+{
+  if (chip < N_CHIPS_IB) return chip;
+  else return N_CHIPS_IB + (short int)((chip-N_CHIPS_IB)/7);
+}
+
+
+  ///////////////////////////////////////////////
+  // to be imported by any code using the deadmap to traslate tree entries in lane lists
+  // TODO: cross check once the encoding rule is finalized
+std::vector<short int> ITSDeadMapBuilder::decodeITSMapWord(ULong64_t word){
+  
+std::vector<short int> lanelist{};
+
+  if ((word & 0x1) == 0x0) { // _t0
+    for (int l=0; l<7; l++){
+      short int lanepp = (short int)(( word >> (9*l+1)) & 0x1FF);
+      if (lanepp == 0) break;
+      lanelist.push_back(lanepp-1);
+    }
+  }
+  else if ((word & 0xF) == 0x1){ // _t1
+    for (int l=0; l<5; l++){
+      short int lanepp = (short int)(( word >> (12*l+4)) & 0xFFF);
+      if (lanepp == 0) break;
+      lanelist.push_back(lanepp-1);
+    }
+  }
+  else if ((word & 0xF) == 0x3){ // _ t2
+    short int lanelowpp = (short int)((word >> 4) & 0xFFF);
+    short int laneuppp =  (short int)((word >> 16) & 0xFFF);
+    for (short int lane = lanelowpp; lane <= laneuppp; lane++) lanelist.push_back(lane-1);
+  }
+  else{ // word not recognized
+    lanelist.push_back(-1);
+  }
+  return lanelist;
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+
+void ITSDeadMapBuilder::finalizeOutput()
+{
+  std::string localoutfilename = mLocalOutputDir+"/object.root";
+  TFile outfile(localoutfilename.c_str(),"RECREATE");
+  outfile.cd();
+  mTreeObject->Write();
+  outfile.Close();
+
+  if (DebugMode){
+    std::string localoutfilename2 = mLocalOutputDir+"/time.root";
+    TFile outfile2(localoutfilename2.c_str(),"RECREATE");
+    outfile2.cd();
+    
+    Htime->Write();
+    outfile2.Close();
+  }
+  return;
+
+} // finalizeOutput
+
+
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+// Main running function
+// Get info from previous stf decoder workflow, then loop over readout frames
+//     (ROFs) to count hits and extract thresholds
+void ITSDeadMapBuilder::run(ProcessingContext& pc)
+{
+  if (mRunStopRequested) { // give up when run stop request arrived
+    return;
+  }
+
+  std::chrono::time_point<std::chrono::high_resolution_clock> start;
+  std::chrono::time_point<std::chrono::high_resolution_clock> end;
+  int difference;
+  start = std::chrono::high_resolution_clock::now();
+
+  mTFCounter++;
+
+  
+  mFirstOrbitTF = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
+
+  if ( (Long64_t)(mFirstOrbitTF / mTFLength) % mTFSampling != 0) return;
+
+  mStepCounter++;
+  LOG(info) << "Processing step #"<<mStepCounter<<" out of "<<mTFCounter<<" TF received. First orbit "<<mFirstOrbitTF;
+  
+
+  mChipsAlive.clear();
+  mLanesAlive.clear();
+  mDeadMapTF->clear();
+  
+
+
+  bool newchip = false;
+  
+  if (mDataSource == "digits"){
+    const auto elements = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("elements");
+    const  auto ROFs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROFs");
+    for (const auto& rof : ROFs) {
+      auto elementsInTF = rof.getROFData(elements);
+      for (const auto& el : elementsInTF){
+	short int chipID = (short int)el.getChipIndex();
+	newchip = mChipsAlive.insert(chipID).second;
+	mLanesAlive.insert(getLaneIDFromChip(chipID));
+      }
+    }
+  }
+  else if (mDataSource == "clusters"){
+    const  auto elements = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("elements");
+    const  auto ROFs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROFs");
+    for (const auto& rof : ROFs) {
+      auto elementsInTF = rof.getROFData(elements);
+      for (const auto& el : elementsInTF){
+	short int chipID = (short int)el.getSensorID();
+	newchip = mChipsAlive.insert(chipID).second;
+	mLanesAlive.insert(getLaneIDFromChip(chipID));
+      }
+    }
+  }
+  else if (mDataSource == "chipsstatus"){
+    const auto elements = pc.inputs().get<std::vector<char>>("elements");
+    for (short int chipID=0; chipID < elements.size(); chipID++){
+      if (elements.at(chipID)) {
+	newchip = mChipsAlive.insert(chipID).second;
+	mLanesAlive.insert(getLaneIDFromChip(chipID));
+      }
+    }
+  }
+
+ 
+  mChipsAlive.insert(N_CHIPS);
+  mLanesAlive.insert(getLaneIDFromChip(N_CHIPS));
+
+
+  
+
+  std::set<short int>::iterator laneIt = mLanesAlive.begin();
+
+  short int laneLow = -1, laneUp = -1;
+
+  int dcount_t0 = 0, dcount_t1 = 0, dcount_t2 = 0;
+  mapelement_t0 = 0x0;
+  mapelement_t1 = 0x1;
+  mapelement_t2 = 0x3;
+  
+  for (int ilane = 0; ilane < mLanesAlive.size(); ilane++){
+
+    laneLow = laneUp; 
+    laneUp = *laneIt;
+    laneIt++;
+
+    if (laneUp -laneLow -1 > 6){  // more than 6 lanes (or full stave) --> better to save in a single word
+      mapelement_t2 = mapelement_t2 | ( (ULong64_t)((laneLow+2) & 0xFFF) << 4);
+      mapelement_t2 = mapelement_t2 | ( (ULong64_t)((laneUp-1+1) & 0xFFF) << 16);
+      dcount_t2 += (laneUp -laneLow -1);
+      mDeadMapTF->push_back(mapelement_t2);
+      mapelement_t2 = 0x3;
+    }
+
+    else{
+       for (short int idead = laneLow+1; idead < laneUp; idead++ ){
+        
+         if (idead < N_CHIPS_IB){ // IB;
+       	if (DebugMode) LOG(info)<<"-DEBUG- low/up:"<<laneLow<<"/"<<laneUp<<" - Dead lane:"<<idead;
+       	mapelement_t0 = mapelement_t0 | ( (ULong64_t)((idead+1) & 0x1FF) << ( 1 + 9*(dcount_t0 % 7)));
+       	if (DebugMode) LOG(info)<<"-DEBUG- New map element type 0 "<<mapelement_t0;
+       	dcount_t0++;
+       	if (dcount_t0 % 7 == 0){
+       	  mDeadMapTF->push_back(mapelement_t0);
+       	  if (DebugMode) LOG(info)<<"-DEBUG- Pushing up map element type 0 "<<mapelement_t0;
+       	  mapelement_t0 = 0x0;
+       	}
+         }
+         else{ // OB
+       	mapelement_t1 = mapelement_t1 | ( (ULong64_t)((idead+1) & 0xFFF) << ( 4 + 12*(dcount_t1 % 5)));
+       	dcount_t1++;
+       	if (dcount_t1 % 5 == 0){
+       	  mDeadMapTF->push_back(mapelement_t1);
+       	  mapelement_t1 = 0x1;
+       	}
+         }
+         
+       } // end loop over dead lanes
+    }
+
+    
+  } // end loop over alive lanes set
+      
+  if (mapelement_t0 != 0x0) mDeadMapTF->push_back(mapelement_t0);
+  if (mapelement_t1 != 0x1) mDeadMapTF->push_back(mapelement_t1);
+
+  int dcountTot = dcount_t0 + dcount_t1 + dcount_t2;
+
+  LOG(info) << "Dead lanes: "<<dcountTot<<", t0|t1|t2: "<<dcount_t0<<"|"<<dcount_t1<<"|"<<dcount_t2<<", saved in "<<mDeadMapTF->size()<<" words.";
+
+  mTreeObject->Fill();
+
+  end = std::chrono::high_resolution_clock::now();
+  difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
+  LOG(info) << "Elapsed time: "<<difference/1000.<<" ms";
+  if (DebugMode) Htime->Fill(difference/1000., 1.*(dcountTot));
+   
+  return;
+}
+
+
+ 
+void ITSDeadMapBuilder::finalize()
+{
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void ITSDeadMapBuilder::PrepareOutputCcdb(DataAllocator& output)
+{
+  if (DebugMode) LOG(info)<<"-DEBUG- Entering PrepareOutputCcdb.";
+
+  long tstart = o2::ccdb::getCurrentTimestamp();
+  long secinyear = 365L* 24  * 3600 * 1000;
+  long tend = o2::ccdb::getFutureTimestamp(secinyear);
+
+  std::map<std::string, std::string> md = {
+    {"test", "content"}};
+
+  std::string path("ITS/Calib/");
+  std::string name_str = "time_dead_map";
+
+  o2::ccdb::CcdbObjectInfo info((path+name_str),"time_dead_map","timedeadmap.root",md,tstart,tend);
+  
+  std::vector<int> dummyobj ={1};
+  auto image = o2::ccdb::CcdbApi::createObjectImage(mTreeObject, &info);
+  
+  info.setFileName("time_deadmap.root");
+
+  LOG(info) << "Sending object "<< info.getPath() << "/" << info.getFileName()
+	    << " of size "<< image->size() << "bytes, valid for" 
+	    << info.getStartValidityTimestamp()<<" : "<<info.getEndValidityTimestamp();
+
+  output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_TimeDeadMap", 0}, *image);
+  output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_TimeDeadMap", 0}, info);
+
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// O2 functionality allowing to do post-processing when the upstream device
+// tells that there will be no more input data
+void ITSDeadMapBuilder::endOfStream(EndOfStreamContext& ec)
+{
+  if (!isEnded && !mRunStopRequested) {
+    LOGF(info, "endOfStream report:", mSelfName);
+    if (1 /*isFinalizeEos*/) {
+      finalize();
+    }
+    finalizeOutput();
+    PrepareOutputCcdb(ec.outputs());
+    isEnded = true;
+  }
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// DDS stop method: simply close the latest tree
+void ITSDeadMapBuilder::stop()
+{
+  if (!isEnded) {
+    LOGF(info, "stop() report:", mSelfName);
+    if (1 /*isFinalizeEos*/) {
+      finalize();
+    }
+    this->finalizeOutput();
+    isEnded = true;
+  }
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+DataProcessorSpec getITSDeadMapBuilderSpec(const ITSDMInpConf& inpConf, std::string datasource)
+{
+  o2::header::DataOrigin detOrig = o2::header::gDataOriginITS;
+  std::vector<InputSpec> inputs;
+
+  if (datasource == "digits"){
+    inputs.emplace_back("elements", detOrig, "DIGITS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("ROFs", detOrig, "DIGITSROF", 0, Lifetime::Timeframe);
+  }
+  else if (datasource == "clusters"){
+    inputs.emplace_back("elements",detOrig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("ROFs",detOrig,"CLUSTERSROF",0 ,Lifetime::Timeframe);
+  }
+  else if (datasource == "chipsstatus"){
+    inputs.emplace_back("elements",detOrig,"CHIPSSTATUS",0 ,Lifetime::Timeframe);
+  }
+  else{
+    return DataProcessorSpec{0x0}; // TODO: ADD PROTECTION
+  }
+
+  
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_TimeDeadMap"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_TimeDeadMap"});
+
+  return DataProcessorSpec{
+    "its-deadmap-builder_" + std::to_string(inpConf.chipModSel),
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<ITSDeadMapBuilder>(inpConf, datasource)},
+    Options{{"debug", VariantType::Bool, false, {"Temporary debug mode"}},
+            {"tf-sampling", VariantType::Int, 997, {"Process every Nth TF. Selection according to first TF Orbit."}},
+	    {"tf-length", VariantType::Int, 32, {"Orbits per TFs."}}, 
+            {"output-dir", VariantType::String, "./", {"ROOT trees output directory."}}}};
+}
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DeadMapBuilderSpec.cxx
@@ -17,22 +17,15 @@
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 
-#ifdef WITH_OPENMP
-#include <omp.h>
-#endif
-
 namespace o2
 {
 namespace its
 {
 
-
-
-
 //////////////////////////////////////////////////////////////////////////////
 // Default constructor
-  ITSDeadMapBuilder::ITSDeadMapBuilder(const ITSDMInpConf& inpConf, std::string datasource)
-    : mDataSource(datasource)
+ITSDeadMapBuilder::ITSDeadMapBuilder(const ITSDMInpConf& inpConf, std::string datasource)
+  : mDataSource(datasource)
 {
   mSelfName = o2::utils::Str::concat_string(ChipMappingITS::getName(), "ITSDeadMapBuilder");
 }
@@ -42,100 +35,95 @@ namespace its
 ITSDeadMapBuilder::~ITSDeadMapBuilder()
 {
   // Clear dynamic memory
-
-    
 }
 
 //////////////////////////////////////////////////////////////////////////////
 void ITSDeadMapBuilder::init(InitContext& ic)
 {
-  // LOGF(info, "ITSDeadMapBuilder init...", mSelfName);
-  // TODO: LOGF doesn't work. It prints only the first argument --> replace all
+
   LOG(info) << "ITSDeadMapBuilder init... " << mSelfName;
 
-  mTreeObject->Branch("orbit",&mFirstOrbitTF);
-  mTreeObject->Branch("deadmap",&mDeadMapTF);
+  mTreeObject->Branch("orbit", &mFirstOrbitTF);
+  mTreeObject->Branch("deadmap", &mDeadMapTF);
 
   mTFSampling = ic.options().get<int>("tf-sampling");
   DebugMode = ic.options().get<bool>("debug");
   mTFLength = ic.options().get<int>("tf-length");
   mDoLocalOutput = ic.options().get<bool>("local-output");
+  mObjectName = ic.options().get<std::string>("output-filename");
   mLocalOutputDir = ic.options().get<std::string>("output-dir");
 
-  LOG(info) << "Sampling one TF every "<<mTFSampling;
-
+  LOG(info) << "Sampling one TF every " << mTFSampling;
 
   return;
 }
-
-
-
-
 
 //////////////////////////////////////////////////////////////////////////////
 // Grouping chips in lanes
 short int ITSDeadMapBuilder::getLaneIDFromChip(short int chip)
 {
-  if (chip < N_CHIPS_IB) return chip;
-  else return N_CHIPS_IB + (short int)((chip-N_CHIPS_IB)/7);
+  // TODO: does o2::itsmft::ChipMappingITS already contain this?
+  if (chip < N_CHIPS_IB)
+    return chip;
+  else
+    return N_CHIPS_IB + (short int)((chip - N_CHIPS_IB) / 7);
 }
 
+///////////////////////////////////////////////
+// Not used here: to be imported by any code using the deadmap to traslate tree entries in lane lists
+std::vector<short int> ITSDeadMapBuilder::decodeITSMapWord(ULong64_t word)
+{
 
-  ///////////////////////////////////////////////
-  // to be imported by any code using the deadmap to traslate tree entries in lane lists
-  // TODO: cross check once the encoding rule is finalized
-std::vector<short int> ITSDeadMapBuilder::decodeITSMapWord(ULong64_t word){
-  
-std::vector<short int> lanelist{};
+  std::vector<short int> lanelist{};
 
-  if ((word & 0x1) == 0x0) { // _t0
-    for (int l=0; l<7; l++){
-      short int lanepp = (short int)(( word >> (9*l+1)) & 0x1FF);
-      if (lanepp == 0) break;
-      lanelist.push_back(lanepp-1);
+  if ((word & 0x1) == 0x0) { // _t0 aka IB
+    for (int l = 0; l < 7; l++) {
+      short int lanepp = (short int)((word >> (9 * l + 1)) & 0x1FF);
+      if (lanepp == 0)
+        break;
+      lanelist.push_back(lanepp - 1);
     }
-  }
-  else if ((word & 0xF) == 0x1){ // _t1
-    for (int l=0; l<5; l++){
-      short int lanepp = (short int)(( word >> (12*l+4)) & 0xFFF);
-      if (lanepp == 0) break;
-      lanelist.push_back(lanepp-1);
+  } else if ((word & 0xF) == 0x1) { // _t1 aka OB
+    for (int l = 0; l < 5; l++) {
+      short int lanepp = (short int)((word >> (12 * l + 4)) & 0xFFF);
+      if (lanepp == 0)
+        break;
+      lanelist.push_back(lanepp - 1);
     }
-  }
-  else if ((word & 0xF) == 0x3){ // _ t2
-    short int lanelowpp = (short int)((word >> 4) & 0x7FFF);
-    short int laneuppp =  (short int)((word >> 19) & 0x7FFF);
-    for (short int lane = lanelowpp; lane <= laneuppp; lane++) lanelist.push_back(lane-1);
-    lanelowpp = (uint)((word >> 34) & 0x7FFF);
-    if (lanelowpp){
-      laneuppp = (uint)((word >> 49) & 0x7FFF);
-      for (uint lane = lanelowpp; lane <= laneuppp; lane++) lanelist.push_back(lane-1);
+  } else if ((word & 0xF) == 0x3) { // _ t2 aka interval
+    short int lanelowpp = (uint)((word >> 4) & 0x7FFF);
+    short int laneuppp = (uint)((word >> 19) & 0x7FFF);
+    for (short int lane = lanelowpp; lane <= laneuppp; lane++)
+      lanelist.push_back(lane - 1);
+    lanelowpp = (short int)((word >> 34) & 0x7FFF);
+    if (lanelowpp) {
+      laneuppp = (short int)((word >> 49) & 0x7FFF);
+      for (short int lane = lanelowpp; lane <= laneuppp; lane++)
+        lanelist.push_back(lane - 1);
     }
-  }
-  else{ // word not recognized
+  } else { // word not recognized // for the use: add protection
     lanelist.push_back(-1);
   }
+  LOG(info) << "Word " << word << " encodes " << lanelist.size() << " lanes";
   return lanelist;
 }
-
 
 //////////////////////////////////////////////////////////////////////////////
 
 void ITSDeadMapBuilder::finalizeOutput()
 {
 
-  if (mDoLocalOutput){
-    std::string localoutfilename = mLocalOutputDir+"/"+mObjectName;
-    TFile outfile(localoutfilename.c_str(),"RECREATE");
+  if (mDoLocalOutput) {
+    std::string localoutfilename = mLocalOutputDir + "/" + mObjectName;
+    TFile outfile(localoutfilename.c_str(), "RECREATE");
     outfile.cd();
     mTreeObject->Write();
     outfile.Close();
   }
-  if (DebugMode){
-    std::string localoutfilename2 = mLocalOutputDir+"/time.root";
-    TFile outfile2(localoutfilename2.c_str(),"RECREATE");
+  if (DebugMode) {
+    std::string localoutfilename2 = mLocalOutputDir + "/time.root";
+    TFile outfile2(localoutfilename2.c_str(), "RECREATE");
     outfile2.cd();
-    
     Htime->Write();
     outfile2.Close();
   }
@@ -143,14 +131,8 @@ void ITSDeadMapBuilder::finalizeOutput()
 
 } // finalizeOutput
 
-
-
-
-
 //////////////////////////////////////////////////////////////////////////////
 // Main running function
-// Get info from previous stf decoder workflow, then loop over readout frames
-//     (ROFs) to count hits and extract thresholds
 void ITSDeadMapBuilder::run(ProcessingContext& pc)
 {
   if (mRunStopRequested) { // give up when run stop request arrived
@@ -159,51 +141,49 @@ void ITSDeadMapBuilder::run(ProcessingContext& pc)
 
   std::chrono::time_point<std::chrono::high_resolution_clock> start;
   std::chrono::time_point<std::chrono::high_resolution_clock> end;
-  int difference;
+
   start = std::chrono::high_resolution_clock::now();
 
   mTFCounter++;
 
   mFirstOrbitTF = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
 
-  if ( (Long64_t)(mFirstOrbitTF / mTFLength) % mTFSampling != 0) return;
+  if ((Long64_t)(mFirstOrbitTF / mTFLength) % mTFSampling != 0)
+    return;
 
   mStepCounter++;
-  LOG(info) << "Processing step #"<<mStepCounter<<" out of "<<mTFCounter<<" TF received. First orbit "<<mFirstOrbitTF;
-  
+  LOG(info) << "Processing step #" << mStepCounter << " out of " << mTFCounter << " TF received. First orbit " << mFirstOrbitTF;
 
   mLanesAlive.clear();
   mDeadMapTF->clear();
-  
+
   bool newlane = false;
-  
-  if (mDataSource == "digits"){
+
+  if (mDataSource == "digits") {
     const auto elements = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("elements");
-    const  auto ROFs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROFs");
+    const auto ROFs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROFs");
     for (const auto& rof : ROFs) {
       auto elementsInTF = rof.getROFData(elements);
-      for (const auto& el : elementsInTF){
-	short int chipID = (short int)el.getChipIndex();
-	newlane = mLanesAlive.insert(getLaneIDFromChip(chipID)).second;
+      for (const auto& el : elementsInTF) {
+        short int chipID = (short int)el.getChipIndex();
+        newlane = mLanesAlive.insert(getLaneIDFromChip(chipID)).second;
       }
     }
-  }
-  else if (mDataSource == "clusters"){
-    const  auto elements = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("elements");
-    const  auto ROFs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROFs");
+  } else if (mDataSource == "clusters") {
+    const auto elements = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("elements");
+    const auto ROFs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROFs");
     for (const auto& rof : ROFs) {
       auto elementsInTF = rof.getROFData(elements);
-      for (const auto& el : elementsInTF){
-	short int chipID = (short int)el.getSensorID();
-	newlane = mLanesAlive.insert(getLaneIDFromChip(chipID)).second;
+      for (const auto& el : elementsInTF) {
+        short int chipID = (short int)el.getSensorID();
+        newlane = mLanesAlive.insert(getLaneIDFromChip(chipID)).second;
       }
     }
-  }
-  else if (mDataSource == "chipsstatus"){
+  } else if (mDataSource == "chipsstatus") {
     const auto elements = pc.inputs().get<std::vector<char>>("elements");
-    for (short int chipID=0; chipID < elements.size(); chipID++){
+    for (short int chipID = 0; chipID < elements.size(); chipID++) {
       if (elements.at(chipID)) {
-	newlane = mLanesAlive.insert(getLaneIDFromChip(chipID)).second;
+        newlane = mLanesAlive.insert(getLaneIDFromChip(chipID)).second;
       }
     }
   }
@@ -211,104 +191,105 @@ void ITSDeadMapBuilder::run(ProcessingContext& pc)
   mLanesAlive.insert(getLaneIDFromChip(N_CHIPS));
 
   // filling the vector
-  std::pair<int,int> fillresult = FillMapElement(); // first = n dead lanes, second = n words
+  std::pair<int, int> fillresult = FillMapElementITS(); // first = n dead lanes, second = n words
 
   // filling the tree
   mTreeObject->Fill();
 
   end = std::chrono::high_resolution_clock::now();
-  difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+  int difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
 
-  LOG(info) << "Elapsed time: "<<difference/1000.<<" ms";
-  if (DebugMode) Htime->Fill(difference/1000., 1.*(fillresult.first));
-   
+  LOG(info) << "Elapsed time in TF processing: " << difference / 1000. << " ms";
+  if (DebugMode)
+    Htime->Fill(difference / 1000., 1. * (fillresult.first));
+
   return;
-
 }
 
-std::pair<int,int> ITSDeadMapBuilder::FillMapElement(){
+std::pair<int, int> ITSDeadMapBuilder::FillMapElementITS()
+{
 
-  if (MAP_VERSION == "1"){  // Force developer to change metadata in case encoding is changed
-  
+  if (MAP_VERSION == "1") { // Force developer to change metadata in case encoding is changed
+
     std::set<short int>::iterator laneIt = mLanesAlive.begin();
 
     short int laneLow = -1, laneUp = -1;
 
     int dcount_t0 = 0, dcount_t1 = 0, dcount_t2 = 0;
-    
+
     ULong64_t mapelement_t0 = t0_identifier;
     ULong64_t mapelement_t1 = t1_identifier;
     ULong64_t mapelement_t2 = t2_identifier;
- 
-    for (int ilane = 0; ilane < mLanesAlive.size(); ilane++){
 
-      laneLow = laneUp; 
+    for (int ilane = 0; ilane < mLanesAlive.size(); ilane++) {
+
+      laneLow = laneUp;
       laneUp = *laneIt;
       laneIt++;
 
-      if (laneUp -laneLow -1 > 6){  // more than 6 lanes (or full stave) --> better to save in a single word
-	bool isfilled = (mapelement_t2 != t2_identifier); 
-	mapelement_t2 = mapelement_t2 | ( (ULong64_t)((laneLow+2) & 0xFFF) << 4+30*isfilled);
-	mapelement_t2 = mapelement_t2 | ( (ULong64_t)((laneUp-1+1) & 0xFFF) << 19+30*isfilled);
-	dcount_t2 += (laneUp -laneLow -1);
-	if (isfilled){
-	  mDeadMapTF->push_back(mapelement_t2);
-	  mapelement_t2 = t2_identifier;
-	}
+      if (laneUp - laneLow - 1 > 6) { // more than 6 lanes (or full stave) --> better to save in a single word
+        bool isfilled = (mapelement_t2 != t2_identifier);
+        mapelement_t2 = mapelement_t2 | ((ULong64_t)((laneLow + 2) & 0xFFF) << 4 + 30 * isfilled);
+        mapelement_t2 = mapelement_t2 | ((ULong64_t)((laneUp - 1 + 1) & 0xFFF) << 19 + 30 * isfilled);
+        dcount_t2 += (laneUp - laneLow - 1);
+        if (isfilled) {
+          mDeadMapTF->push_back(mapelement_t2);
+          mapelement_t2 = t2_identifier;
+        }
       }
 
-      else{
-	for (short int idead = laneLow+1; idead < laneUp; idead++ ){
-        
-	  if (idead < N_CHIPS_IB){ // IB;
-	    if (DebugMode) LOG(info)<<"-DEBUG- low/up:"<<laneLow<<"/"<<laneUp<<" - Dead lane:"<<idead;
-	    mapelement_t0 = mapelement_t0 | ( (ULong64_t)((idead+1) & 0x1FF) << ( 1 + 9*(dcount_t0 % 7)));
-	    if (DebugMode) LOG(info)<<"-DEBUG- New map element type 0 "<<mapelement_t0;
-	    dcount_t0++;
-	    if (dcount_t0 % 7 == 0){
-	      mDeadMapTF->push_back(mapelement_t0);
-	      if (DebugMode) LOG(info)<<"-DEBUG- Pushing up map element type 0 "<<mapelement_t0;
-	      mapelement_t0 = t0_identifier;
-	    }
-	  }
-	  else{ // OB
-	    mapelement_t1 = mapelement_t1 | ( (ULong64_t)((idead+1) & 0xFFF) << ( 4 + 12*(dcount_t1 % 5)));
-	    dcount_t1++;
-	    if (dcount_t1 % 5 == 0){
-	      mDeadMapTF->push_back(mapelement_t1);
-	      mapelement_t1 = t1_identifier;
-	    }
-	  }    
-	} // end loop over dead lanes
-      }    
+      else {
+        for (short int idead = laneLow + 1; idead < laneUp; idead++) {
+
+          if (idead < N_CHIPS_IB) { // IB;
+
+            mapelement_t0 = mapelement_t0 | ((ULong64_t)((idead + 1) & 0x1FF) << (1 + 9 * (dcount_t0 % 7)));
+            dcount_t0++;
+
+            if (dcount_t0 % 7 == 0) {
+              mDeadMapTF->push_back(mapelement_t0);
+              mapelement_t0 = t0_identifier;
+            }
+          }
+
+          else { // OB
+            mapelement_t1 = mapelement_t1 | ((ULong64_t)((idead + 1) & 0xFFF) << (4 + 12 * (dcount_t1 % 5)));
+            dcount_t1++;
+            if (dcount_t1 % 5 == 0) {
+              mDeadMapTF->push_back(mapelement_t1);
+              mapelement_t1 = t1_identifier;
+            }
+          }
+        } // end loop over dead lanes
+      }
     } // end loop over alive lanes set
-      
-    // fill with last info in the buffer (not fully filled elements)
-    if (mapelement_t0 != t0_identifier) mDeadMapTF->push_back(mapelement_t0);
-    if (mapelement_t1 != t1_identifier) mDeadMapTF->push_back(mapelement_t1);
-    if (mapelement_t2 != t2_identifier) mDeadMapTF->push_back(mapelement_t2);
+
+    // fill with last info in the buffer (partially empty words)
+    if (mapelement_t0 != t0_identifier)
+      mDeadMapTF->push_back(mapelement_t0);
+    if (mapelement_t1 != t1_identifier)
+      mDeadMapTF->push_back(mapelement_t1);
+    if (mapelement_t2 != t2_identifier)
+      mDeadMapTF->push_back(mapelement_t2);
 
     int dcountTot = dcount_t0 + dcount_t1 + dcount_t2;
 
-    LOG(info) << "Dead lanes: "<<dcountTot<<", type0|1|2: "<<dcount_t0<<"|"<<dcount_t1<<"|"<<dcount_t2<<", saved in "<<mDeadMapTF->size()<<" words.";
+    LOG(info) << "Dead lanes: " << dcountTot << ", type0|1|2: " << dcount_t0 << "|" << dcount_t1 << "|" << dcount_t2 << ", saved in " << mDeadMapTF->size() << " words.";
 
-    return std::pair<int,int>{dcountTot, mDeadMapTF->size()};
+    return std::pair<int, int>{dcountTot, mDeadMapTF->size()};
 
   } // end of map version condition
 
-  return std::pair<int,int>{-1,-1};
+  LOG(error) << "Invalid MAP version requested. Filling dummy vector";
+  return std::pair<int, int>{-1, -1};
 }
 
- 
-
- 
 //////////////////////////////////////////////////////////////////////////////
 void ITSDeadMapBuilder::PrepareOutputCcdb(DataAllocator& output)
 {
-  if (DebugMode) LOG(info)<<"-DEBUG- Entering PrepareOutputCcdb.";
 
   long tstart = o2::ccdb::getCurrentTimestamp();
-  long secinyear = 365L* 24  * 3600 * 1000;
+  long secinyear = 365L * 24 * 3600;
   long tend = o2::ccdb::getFutureTimestamp(secinyear);
 
   std::map<std::string, std::string> md = {
@@ -317,19 +298,18 @@ void ITSDeadMapBuilder::PrepareOutputCcdb(DataAllocator& output)
   std::string path("ITS/Calib/");
   std::string name_str = "time_dead_map";
 
-  o2::ccdb::CcdbObjectInfo info((path+name_str),"time_dead_map",mObjectName,md,tstart,tend);
-  
+  o2::ccdb::CcdbObjectInfo info((path + name_str), "time_dead_map", mObjectName, md, tstart, tend);
+
   auto image = o2::ccdb::CcdbApi::createObjectImage(mTreeObject, &info);
-  
+
   info.setAdjustableEOV();
 
-  LOG(info) << "Sending object "<< info.getPath() << "/" << info.getFileName()
-	    << " of size "<< image->size() << "bytes, valid for" 
-	    << info.getStartValidityTimestamp()<<" : "<<info.getEndValidityTimestamp();
+  LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName()
+            << " of size " << image->size() << "bytes, valid for"
+            << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
   output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_TimeDeadMap", 0}, *image);
   output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_TimeDeadMap", 0}, info);
-
 
   return;
 }
@@ -355,7 +335,11 @@ void ITSDeadMapBuilder::stop()
   if (!isEnded) {
     LOGF(info, "stop() report:", mSelfName);
     finalizeOutput();
-    LOG(error) << "stop() not sending object as output. ccdb will not be populated.";
+    if (mDoLocalOutput) {
+      LOG(info) << "stop() not sending object as output. ccdb will not be populated.";
+    } else {
+      LOG(error) << "stop() not sending object as output. ccdb will not be populated.";
+    }
     isEnded = true;
   }
   return;
@@ -367,36 +351,33 @@ DataProcessorSpec getITSDeadMapBuilderSpec(const ITSDMInpConf& inpConf, std::str
   o2::header::DataOrigin detOrig = o2::header::gDataOriginITS;
   std::vector<InputSpec> inputs;
 
-  if (datasource == "digits"){
+  if (datasource == "digits") {
     inputs.emplace_back("elements", detOrig, "DIGITS", 0, Lifetime::Timeframe);
     inputs.emplace_back("ROFs", detOrig, "DIGITSROF", 0, Lifetime::Timeframe);
-  }
-  else if (datasource == "clusters"){
-    inputs.emplace_back("elements",detOrig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
-    inputs.emplace_back("ROFs",detOrig,"CLUSTERSROF",0 ,Lifetime::Timeframe);
-  }
-  else if (datasource == "chipsstatus"){
-    inputs.emplace_back("elements",detOrig,"CHIPSSTATUS",0 ,Lifetime::Timeframe);
-  }
-  else{
+  } else if (datasource == "clusters") {
+    inputs.emplace_back("elements", detOrig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("ROFs", detOrig, "CLUSTERSROF", 0, Lifetime::Timeframe);
+  } else if (datasource == "chipsstatus") {
+    inputs.emplace_back("elements", detOrig, "CHIPSSTATUS", 0, Lifetime::Timeframe);
+  } else {
     return DataProcessorSpec{0x0}; // TODO: ADD PROTECTION
   }
 
-  
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_TimeDeadMap"});
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_TimeDeadMap"});
 
   return DataProcessorSpec{
-    "its-deadmap-builder_" + std::to_string(inpConf.chipModSel),
+    "its-deadmap-builder",
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<ITSDeadMapBuilder>(inpConf, datasource)},
-    Options{{"debug", VariantType::Bool, false, {"Temporary debug mode"}},
-            {"tf-sampling", VariantType::Int, 997, {"Process every Nth TF. Selection according to first TF Orbit."}},
-	    {"tf-length", VariantType::Int, 32, {"Orbits per TFs."}},
-	    {"local-output", VariantType::Bool, false, {"Save ROOT tree file locally."}}, 
-            {"output-dir", VariantType::String, "./", {"ROOT tree output directory."}}}};
+    Options{{"debug", VariantType::Bool, false, {"Developer debug mode. It saves extra objects to disk."}},
+            {"tf-sampling", VariantType::Int, 1000, {"Process every Nth TF. Selection according to first TF Orbit."}},
+            {"tf-length", VariantType::Int, 32, {"Orbits per TFs."}},
+            {"output-filename", VariantType::String, "its_time_deadmap.root", {"ROOT object file name."}},
+            {"local-output", VariantType::Bool, false, {"Save ROOT tree file locally."}},
+            {"output-dir", VariantType::String, "./", {"ROOT tree local output directory."}}}};
 }
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/its-deadmap-builder-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-deadmap-builder-workflow.cxx
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSWorkflow/DeadMapBuilderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "ITStracking/TrackingConfigParam.h"
+#include "ITStracking/Configuration.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{
+    ConfigParamSpec{"chip-mod-selector", VariantType::Int, 0, {"Integer to be used with chip-mod-base for parallel chip access: if(chipID %% chipModSel != chipModBase), chip id skipped"}},
+    ConfigParamSpec{"chip-mod-base", VariantType::Int, 1, {"Integer to be used with chip-mod-selector chip access: if(chipID %% chipModSel != chipModBase), chip id skipped"}},
+    ConfigParamSpec{"source",VariantType::String, "chipsstatus", {"Loop over: digits, clusters or chipsstatus"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  LOG(info) << "Initializing O2 ITS Dead Map Builder";
+
+  WorkflowSpec wf;
+  o2::its::ITSDMInpConf inpConf;
+  inpConf.chipModSel = configcontext.options().get<int>("chip-mod-selector");
+  inpConf.chipModBase = configcontext.options().get<int>("chip-mod-base");
+
+  std::string datasource = configcontext.options().get<std::string>("source");
+
+  LOG(info) << "Building deadmaps from collection of:  "<< datasource;
+
+  wf.emplace_back(o2::its::getITSDeadMapBuilderSpec(inpConf,datasource));
+
+  return wf;
+}

--- a/Detectors/ITSMFT/ITS/workflow/src/its-deadmap-builder-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-deadmap-builder-workflow.cxx
@@ -23,7 +23,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     ConfigParamSpec{"chip-mod-selector", VariantType::Int, 0, {"Integer to be used with chip-mod-base for parallel chip access: if(chipID %% chipModSel != chipModBase), chip id skipped"}},
     ConfigParamSpec{"chip-mod-base", VariantType::Int, 1, {"Integer to be used with chip-mod-selector chip access: if(chipID %% chipModSel != chipModBase), chip id skipped"}},
-    ConfigParamSpec{"source",VariantType::String, "chipsstatus", {"Loop over: digits, clusters or chipsstatus"}}};
+    ConfigParamSpec{"source", VariantType::String, "chipsstatus", {"Loop over: digits, clusters or chipsstatus"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -42,9 +42,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   std::string datasource = configcontext.options().get<std::string>("source");
 
-  LOG(info) << "Building deadmaps from collection of:  "<< datasource;
+  LOG(info) << "Building deadmaps from collection of:  " << datasource;
 
-  wf.emplace_back(o2::its::getITSDeadMapBuilderSpec(inpConf,datasource));
+  wf.emplace_back(o2::its::getITSDeadMapBuilderSpec(inpConf, datasource));
 
   return wf;
 }


### PR DESCRIPTION
This is a first working version. It can produce local output or be attached to ccdb populator. It can take input from ctf reader or run over decoded raw data. 

E.g. workflow for local output reading CTFs:

```
o2-ctf-reader-workflow -b --ctf-input list.dat --remote-regex "^alien:///alice/data/.+" --copy-cmd no-copy --onlyDet ITS | o2-its-deadmap-builder-workflow --local-output --output-dir ./ --source clusters -b
```

To run on all the TFs: --tf-sampling 1








