### PR TITLE
Fix sign in AltroDecoder

### DIFF
--- a/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
@@ -284,7 +284,7 @@ void AltroDecoder::readTRUDigits(short absId, int payloadSize)
     currentsample += bunchlength + 2;
   }
   truDigitPack dp = {0};
-  dp.mHeader = 1;
+  dp.mHeader = -1;
   dp.mAmp = maxAmp;
   dp.mTime = timeBin;
   int chId = (absId - Mapping::NCHANNELS - 1) % 224;


### PR DESCRIPTION
Fix sign in AltroDecoder

A 1 bit signed bitfield is -1, not 1.
