### PR TITLE
Re-enable caching property in BasicCCDBManager for digitization

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -478,8 +478,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     // this will only be needed until digitizers take CCDB objects via DPL mechanism
     o2::ccdb::BasicCCDBManager::instance().setTimestamp(hbfu.startTime);
     // activate caching
-    o2::ccdb::BasicCCDBManager::instance().setCaching(false);
-    // without this, caching does not seem to work
+    o2::ccdb::BasicCCDBManager::instance().setCaching(true);
+    // this is asking the manager to check validity only locally - no further query to server done
     o2::ccdb::BasicCCDBManager::instance().setLocalObjectValidityChecking(true);
   }
   // update the digitization configuration with the right geometry file


### PR DESCRIPTION
This was off for some unknown reason - but it should be on. (So far it didn't matter since the assumption was that processes only fetch objects once per timeframe at most)

Fixes (indirectly) a memory leak in TPC digitization https://alice.its.cern.ch/jira/browse/O2-4494