### PR TITLE
DPL: get rid of simplified CompletionPolicy

### DIFF
--- a/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TPCSectorCompletionPolicy.h
+++ b/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TPCSectorCompletionPolicy.h
@@ -91,7 +91,7 @@ class TPCSectorCompletionPolicy
       return std::regex_match(device.name.begin(), device.name.end(), std::regex(expression.c_str()));
     };
 
-    auto callback = [bRequireAll = mRequireAll, inputMatchers = mInputMatchers, externalInputMatchers = mExternalInputMatchers, pTpcSectorMask = mTpcSectorMask, orderCheck = mOrderCheck](framework::InputSpan const& inputs) -> framework::CompletionPolicy::CompletionOp {
+    auto callback = [bRequireAll = mRequireAll, inputMatchers = mInputMatchers, externalInputMatchers = mExternalInputMatchers, pTpcSectorMask = mTpcSectorMask, orderCheck = mOrderCheck](framework::InputSpan const& inputs, auto const&, auto&) -> framework::CompletionPolicy::CompletionOp {
       unsigned long tpcSectorMask = pTpcSectorMask ? *pTpcSectorMask : 0xFFFFFFFFF;
       std::bitset<NSectors> validSectors = 0;
       bool haveMatchedInput = false;

--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -64,26 +64,21 @@ struct CompletionPolicy {
 
   using Matcher = std::function<bool(DeviceSpec const& device)>;
   using InputSetElement = DataRef;
-  using Callback = std::function<CompletionOp(InputSpan const&)>;
   using CallbackFull = std::function<CompletionOp(InputSpan const&, std::vector<InputSpec> const&, ServiceRegistryRef&)>;
   using CallbackConfigureRelayer = std::function<void(DataRelayer&)>;
 
   /// Constructor
   CompletionPolicy()
-    : name{}, matcher{}, callback{} {}
+    : name{}, matcher{}, callbackFull{} {}
   /// Constructor for emplace_back
-  CompletionPolicy(std::string _name, Matcher _matcher, Callback _callback, bool _balanceChannels = true)
-    : name(std::move(_name)), matcher(std::move(_matcher)), callback(std::move(_callback)), callbackFull{nullptr}, balanceChannels{_balanceChannels} {}
   CompletionPolicy(std::string _name, Matcher _matcher, CallbackFull _callback, bool _balanceChannels = true)
-    : name(std::move(_name)), matcher(std::move(_matcher)), callback(nullptr), callbackFull{std::move(_callback)}, balanceChannels{_balanceChannels} {}
+    : name(std::move(_name)), matcher(std::move(_matcher)), callbackFull{std::move(_callback)}, balanceChannels{_balanceChannels} {}
 
   /// Name of the policy itself.
   std::string name = "";
   /// Callback to be used to understand if the policy should apply
   /// to the given device.
   Matcher matcher = nullptr;
-  /// Actual policy which decides what to do with a partial InputRecord.
-  Callback callback = nullptr;
   /// Actual policy which decides what to do with a partial InputRecord, extended version
   CallbackFull callbackFull = nullptr;
   /// A callback which allows you to configure the behavior of the data relayer associated

--- a/Framework/Core/test/test_CompletionPolicy.cxx
+++ b/Framework/Core/test/test_CompletionPolicy.cxx
@@ -12,6 +12,7 @@
 #include <catch_amalgamated.hpp>
 #include "Framework/CompletionPolicy.h"
 #include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/ServiceRegistry.h"
 #include "Headers/DataHeader.h"
 #include "Headers/NameHeader.h"
 #include "Framework/CompletionPolicy.h"
@@ -39,7 +40,9 @@ TEST_CASE("TestCompletionPolicy_callback")
     return true;
   };
 
-  auto callback = [&stack](InputSpan const& inputRefs) {
+  ServiceRegistry services;
+
+  auto callback = [&stack](InputSpan const& inputRefs, std::vector<InputSpec> const&, ServiceRegistryRef&) {
     for (auto const& ref : inputRefs) {
       auto const* header = CompletionPolicyHelpers::getHeader<o2::header::DataHeader>(ref);
       REQUIRE(header == reinterpret_cast<o2::header::DataHeader*>(stack.data()));
@@ -53,7 +56,9 @@ TEST_CASE("TestCompletionPolicy_callback")
     {"test", matcher, callback}};
   CompletionPolicy::InputSetElement ref{nullptr, reinterpret_cast<const char*>(stack.data()), nullptr};
   InputSpan const& inputs{[&ref](size_t) { return ref; }, 1};
+  std::vector<InputSpec> specs;
+  ServiceRegistryRef servicesRef{services};
   for (auto& policy : policies) {
-    policy.callback(inputs);
+    policy.callbackFull(inputs, specs, servicesRef);
   }
 }

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -53,7 +53,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
                         // search for spec names starting with "processor"
                         return spec.name.find("processor") == 0;
                       },
-                      [](auto const&) { return o2::framework::CompletionPolicy::CompletionOp::Consume; }});
+                      [](auto const&, auto const&, auto &) { return o2::framework::CompletionPolicy::CompletionOp::Consume; }});
 }
 
 #include "Framework/runDataProcessing.h"


### PR DESCRIPTION
DPL: get rid of simplified CompletionPolicy

The full blown version has been there for a while now, and in any case
it's required if one wants to access the oldest possible timeframe.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12450).
* #12451
* __->__ #12450