### PR TITLE
DPL: wait as long as possible for Sporadic inputs

### DIFF
--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -76,6 +76,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::consumeWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -124,6 +125,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::consumeWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -184,6 +186,7 @@ TEST_CASE("DataRelayer")
 
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::consumeWhenAll();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -263,6 +266,7 @@ TEST_CASE("DataRelayer")
 
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::consumeWhenAll();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -346,6 +350,7 @@ TEST_CASE("DataRelayer")
     auto policy = CompletionPolicyHelpers::consumeWhenAll();
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
     DataRelayer relayer(policy, inputs, index, {registry});
     // Only two messages to fill the cache.
     relayer.setPipelineLength(2);
@@ -420,6 +425,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::processWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -490,6 +496,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::processWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -547,6 +554,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::processWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -605,6 +613,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::processWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -670,6 +679,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::consumeWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});
@@ -722,6 +732,7 @@ TEST_CASE("DataRelayer")
     std::vector<ForwardRoute> forwards;
     std::vector<InputChannelInfo> infos{1};
     TimesliceIndex index{1, infos};
+    ref.registerService(ServiceRegistryHelpers::handleForService<TimesliceIndex>(&index));
 
     auto policy = CompletionPolicyHelpers::consumeWhenAny();
     DataRelayer relayer(policy, inputs, index, {registry});

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -12,8 +12,13 @@
 o2_add_dpl_workflow(dummy-workflow
                   SOURCES src/o2DummyWorkflow.cxx
                   COMPONENT_NAME TestWorkflows)
+
 o2_add_dpl_workflow(detect-missing-timeframe
                   SOURCES test/test_DetectMissingTimeframe.cxx
+                  COMPONENT_NAME TestWorkflows)
+
+o2_add_dpl_workflow(wait-until-possible
+                  SOURCES test/test_WaitUntilPossible.cxx
                   COMPONENT_NAME TestWorkflows)
 
 o2_add_dpl_workflow(o2rootmessage-workflow

--- a/Framework/TestWorkflows/test/test_WaitUntilPossible.cxx
+++ b/Framework/TestWorkflows/test/test_WaitUntilPossible.cxx
@@ -1,0 +1,82 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/DataTakingContext.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/RawDeviceService.h"
+#include "Framework/ControlService.h"
+#include "Framework/Configurable.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/RateLimiter.h"
+#include <fairmq/Device.h>
+
+#include <iostream>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace o2::framework;
+
+#include "Framework/runDataProcessing.h"
+
+// This is how you can define your processing in a declarative way
+WorkflowSpec defineDataProcessing(ConfigContext const& specs)
+{
+  DataProcessorSpec a{
+    .name = "A",
+    .outputs = {OutputSpec{{"data"}, "TST", "A1", 0}},
+    .algorithm = AlgorithmSpec{adaptStateless(
+      [](DataAllocator& outputs, RawDeviceService& device, DataTakingContext& context, ProcessingContext& pcx) {
+        LOG(info) << "Data TST/A1/0 created";
+        outputs.make<int>(OutputRef{"data"}, 1);
+      })},
+  };
+  DataProcessorSpec b{
+    .name = "B",
+    .outputs = {OutputSpec{{"sporadic"}, "TST", "B1", 0, Lifetime::Sporadic}},
+    .algorithm = AlgorithmSpec{adaptStateless(
+      [](DataAllocator& outputs, RawDeviceService& device, DataTakingContext& context, ProcessingContext& pcx) {
+        // This will always be late, however since the oldest possible timeframe
+        // will be used to decide the scheduling, it will not be dropped.
+        sleep(1);
+        // We also create it only every second time, so that we can check that
+        // the sporadic output is not mandatory.
+        static int i = 0;
+        if (i++ % 2 == 0) {
+          LOG(info) << "Data TST/B1/0 created";
+          outputs.make<int>(OutputRef{"sporadic"}, 1);
+        }
+      })},
+  };
+  DataProcessorSpec d{
+    .name = "D",
+    .inputs = {InputSpec{"a1", "TST", "A1", 0, Lifetime::Timeframe},
+               InputSpec{"b1", "TST", "B1", 0, Lifetime::Sporadic}},
+    .algorithm = AlgorithmSpec{adaptStateless(
+      [](InputRecord& inputs) {
+        auto refA = inputs.get("a1");
+        auto headerA = o2::header::get<const DataProcessingHeader*>(refA.header);
+        LOG(info) << "Start time: " << headerA->startTime;
+        auto refB = inputs.get("b1");
+        if (!refB.header) {
+          LOG(info) << "No sporadic input for start time " << headerA->startTime;
+          return;
+        }
+        auto headerB = o2::header::get<const DataProcessingHeader*>(refB.header);
+        LOG(info) << "Start time: " << headerB->startTime;
+      })},
+  };
+
+  return workflow::concat(WorkflowSpec{a},
+                          WorkflowSpec{b},
+                          WorkflowSpec{d});
+}


### PR DESCRIPTION
DPL: wait as long as possible for Sporadic inputs

Right now if we have the standard consumeWhenAll policy and we have a sporadic
input, it will wait indefinitely until all the inputs arrive or it will drop
timeframes without that sporadic input.

This changes the behavior and waits only until the oldest possible timeframe
does not allow the Sporadic input to be there. At which point, it schedules the
processing in any case, under the assumption that a task declaring a sporadic
input knows what to do in case it's not there.
