### PR TITLE
[EMCAL-1055] Require FIT trigger in digitization

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -67,7 +67,7 @@ class Digitizer : public TObject
   /// Steer conversion of hits to digits
   void process(const std::vector<LabeledDigit>& labeledDigit);
 
-  void setEventTime(o2::InteractionTimeRecord record);
+  void setEventTime(o2::InteractionTimeRecord record, bool trigger);
   double getTriggerTime() const { return mDigits.getTriggerTime(); }
   double getEventTime() const { return mDigits.getEventTime(); }
   bool isLive(double t) const { return mDigits.isLive(t); }

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -81,7 +81,7 @@ class DigitsWriteoutBuffer
   unsigned int getBufferSize() const { return mBufferSize; }
 
   /// forward the marker for every 100 ns
-  void forwardMarker(o2::InteractionTimeRecord record);
+  void forwardMarker(o2::InteractionTimeRecord record, bool trigger);
 
   /// Setters for the live time, busy time, pre-trigger time
   void setLiveTime(unsigned int liveTime) { mLiveTime = liveTime; }

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -233,10 +233,10 @@ double Digitizer::smearTime(double time, double energy)
 }
 
 //_______________________________________________________________________
-void Digitizer::setEventTime(o2::InteractionTimeRecord record)
+void Digitizer::setEventTime(o2::InteractionTimeRecord record, bool trigger)
 {
 
-  mDigits.forwardMarker(record);
+  mDigits.forwardMarker(record, trigger);
 
   mPhase = mSimParam->doSimulateL1Phase() ? mDigits.getPhase() : 0;
 

--- a/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
@@ -125,7 +125,7 @@ void DigitsVectorStream::fill(std::deque<o2::emcal::DigitTimebin>& digitlist, o2
   mTriggerRecords.emplace_back(record, o2::trigger::PhT, mStartIndex, numberOfNewDigits);
   mStartIndex = mDigits.size();
 
-  LOG(info) << "Have " << mStartIndex << " digits ";
+  LOG(info) << "Trigger Orbit " << record.orbit << ", BC " << record.bc << ": have " << numberOfNewDigits << " digits (" << mStartIndex << " total)";
 }
 
 //_______________________________________________________________________

--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -25,8 +25,20 @@ o2_add_library(EMCALWorkflow
         src/CellRecalibratorSpec.cxx
         src/EntropyDecoderSpec.cxx
         src/StandaloneAODProducerSpec.cxx
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsCTP O2::DataFormatsEMCAL O2::EMCALSimulation O2::Steer
-        O2::DPLUtils O2::EMCALBase O2::EMCALCalib O2::EMCALCalibration O2::EMCALReconstruction O2::Algorithm O2::MathUtils)
+        PUBLIC_LINK_LIBRARIES O2::Framework
+        O2::DataFormatsCTP
+        O2::DataFormatsEMCAL
+        O2::DataFormatsFT0
+        O2::DataFormatsFV0
+        O2::EMCALSimulation
+        O2::Steer
+        O2::DPLUtils
+        O2::EMCALBase
+        O2::EMCALCalib
+        O2::EMCALCalibration
+        O2::EMCALReconstruction
+        O2::Algorithm
+        O2::MathUtils)
 
 o2_add_executable(reco-workflow
         COMPONENT_NAME emcal

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
@@ -28,6 +28,12 @@ class TChain;
 
 namespace o2
 {
+
+namespace ctp
+{
+class CTPConfiguration;
+}
+
 namespace emcal
 {
 class CalibLoader;
@@ -45,7 +51,7 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer, public o2::framew
  public:
   using o2::base::BaseDPLDigitizer::init;
   /// \brief Constructor
-  DigitizerSpec(std::shared_ptr<CalibLoader> calibloader) : o2::base::BaseDPLDigitizer(o2::base::InitServices::GEOM), o2::framework::Task(), mCalibHandler(calibloader) {}
+  DigitizerSpec(std::shared_ptr<CalibLoader> calibloader, bool requireCTPInput) : o2::base::BaseDPLDigitizer(o2::base::InitServices::GEOM), o2::framework::Task(), mRequireCTPInput(requireCTPInput), mCalibHandler(calibloader) {}
 
   /// \brief Destructor
   ~DigitizerSpec() final = default;
@@ -71,16 +77,18 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer, public o2::framew
   Bool_t mFinished = false;                   ///< Flag for digitization finished
   bool mIsConfigured = false;                 ///< Initialization status of the digitizer
   bool mRunSDitizer = false;                  ///< Run SDigitization
+  bool mRequireCTPInput = false;              ///< Require CTP min. bias input
   Digitizer mDigitizer;                       ///< Digitizer object
   o2::emcal::SDigitizer mSumDigitizer;        ///< Summed digitizer
   std::shared_ptr<CalibLoader> mCalibHandler; ///< Handler of calibration objects
   std::vector<Hit> mHits;                     ///< Vector with input hits
   std::vector<TChain*> mSimChains;
+  o2::ctp::CTPConfiguration* mCTPConfig; ///< CTP configuration
 };
 
 /// \brief Create new digitizer spec
 /// \return Digitizer spec
-o2::framework::DataProcessorSpec getEMCALDigitizerSpec(int channel, bool mctruth = true, bool useccdb = true);
+o2::framework::DataProcessorSpec getEMCALDigitizerSpec(int channel, bool requireCTPInput, bool mctruth = true, bool useccdb = true);
 
 } // namespace emcal
 } // end namespace o2

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -198,6 +198,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option to use/not use CCDB for EMCAL
   workflowOptions.push_back(ConfigParamSpec{"no-use-ccdb-emc", o2::framework::VariantType::Bool, false, {"Disable access to ccdb EMCAL simulation objects"}});
 
+  // option to require/not require CTP MB inputs in EMCAL
+  workflowOptions.push_back(ConfigParamSpec{"no-require-ctpinputs-emc", o2::framework::VariantType::Bool, false, {"Disable requirement of CTP min. bias inputs in EMCAL simulation"}});
+
   // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
   workflowOptions.push_back(ConfigParamSpec{"disable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
   workflowOptions.push_back(ConfigParamSpec{"trd-digit-downscaling", VariantType::Int, 1, {"only keep TRD digits for every n-th trigger"}});
@@ -653,9 +656,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // the EMCal part
   if (isEnabled(o2::detectors::DetID::EMC)) {
     auto useCCDB = !configcontext.options().get<bool>("no-use-ccdb-emc");
+    bool requireCTPInputs = !configcontext.options().get<bool>("no-require-ctpinputs-emc");
     detList.emplace_back(o2::detectors::DetID::EMC);
     // connect the EMCal digitization
-    digitizerSpecs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++, mctruth, useCCDB));
+    digitizerSpecs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++, requireCTPInputs, mctruth, useCCDB));
     // connect the EMCal digit writer
     writerSpecs.emplace_back(o2::emcal::getEMCALDigitWriterSpec(mctruth));
   }


### PR DESCRIPTION
Triggering of collisons in the DigitsWriteoutBuffer is
based of FT0/FV0 detector trigger inputs. All FIT
triggers are accepted. The self-triggered mode stays as option for EMCAL-only simulations.