### PR TITLE
ITS-TPC matching uses minTPCRow per sector + params from CCDB

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -45,7 +45,9 @@ struct MatchTPCITSParams : public o2::conf::ConfigurableParamHelper<MatchTPCITSP
   float minTPCTrackR = 50.; ///< cut on minimal TPC tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   float minITSTrackR = 50.; ///< cut on minimal ITS tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   int minTPCClusters = 25; ///< minimum number of clusters to consider
-  int askMinTPCRow = 15;   ///< disregard tracks starting above this row
+  int askMinTPCRow[36] = { ///< disregard tracks starting above this row
+                          15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                          15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15};
 
   float cutMatchingChi2 = 30.f; ///< cut on matching chi2
 
@@ -90,6 +92,16 @@ struct MatchTPCITSParams : public o2::conf::ConfigurableParamHelper<MatchTPCITSP
 };
 
 } // namespace globaltracking
+
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::globaltracking::MatchTPCITSParams> : std::true_type {
+};
+} // namespace framework
+
 } // end namespace o2
 
 #endif

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -400,7 +400,7 @@ void MatchTPCITS::addTPCSeed(const o2::track::TrackParCov& _tr, float t0, float 
   uint8_t clSect = 0, clRow = 0;
   uint32_t clIdx = 0;
   tpcOrig.getClusterReference(mTPCTrackClusIdx, tpcOrig.getNClusterReferences() - 1, clSect, clRow, clIdx);
-  if (clRow > mParams->askMinTPCRow) {
+  if (clRow > mParams->askMinTPCRow[clSect]) {
     return;
   }
   // create working copy of track param


### PR DESCRIPTION
phi of ITS/TPC matched tracks for run LHC23zzm/544692 with missing A11 sector, processed with default settings (blue), 
minTPCRow in A11 set to 78 (`tpcitsMatch.askMinTPCRow[11]=78`, red) and minTPCRow in A10,A11,A12 set to 78 (`tpcitsMatch.askMinTPCRow[10]=78;tpcitsMatch.askMinTPCRow[11]=78;tpcitsMatch.askMinTPCRow[12]=78;`, blue)

![minrowdiff](https://github.com/AliceO2Group/AliceO2/assets/7382029/f65a0832-921d-4345-8039-0694512492a5)

The excess in the latter case is likely due to the fake matches.