### PR TITLE
Preserve svfinder efficiency if the TPC is not loaded

### DIFF
--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -536,7 +536,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
         continue;
       }
 
-      if (!hasTPC && nITSclu < mSVParams->mITSSAminNclu && (!shortOBITSOnlyTrack || mSVParams->mRejectITSonlyOBtrack)) {
+      if (!tpcGID.isSourceSet() && nITSclu < mSVParams->mITSSAminNclu && (!shortOBITSOnlyTrack || mSVParams->mRejectITSonlyOBtrack)) {
         continue; // reject short ITS-only
       }
 


### PR DESCRIPTION
The `hasTPC` flag is always false is the TPC is not loaded. This means that the previous version of the code was discarding all the tracks including TPC if TPC is not loaded, e.g. ITS-TPC tracks, thus killing the efficiency. @shahor02 @ddobrigk @f3sch 