### PR TITLE
DPL Analysis: explicit slicing methods for Partition

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -561,6 +561,28 @@ struct Partition {
     return mFiltered.get();
   }
 
+  template <typename T1>
+  [[nodiscard]] auto rawSliceBy(o2::framework::Preslice<T1> const& container, int value) const
+  {
+    return mFiltered->rawSliceBy(container, value);
+  }
+
+  [[nodiscard]] auto sliceByCached(framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache) const
+  {
+    return mFiltered->sliceByCached(node, value, cache);
+  }
+
+  [[nodiscard]] auto sliceByCachedUnsorted(framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache) const
+  {
+    return mFiltered->sliceByCachedUnsorted(node, value, cache);
+  }
+
+  template <typename T1, bool OPT, bool SORTED>
+  [[nodiscard]] auto sliceBy(o2::framework::PresliceBase<T1, OPT, SORTED> const& container, int value) const
+  {
+    return mFiltered->sliceBy(container, value);
+  }
+
   expressions::Filter filter;
   std::unique_ptr<o2::soa::Filtered<T>> mFiltered = nullptr;
   gandiva::NodePtr tree = nullptr;


### PR DESCRIPTION
Redirects slicing method from the underlying `Filtrered` to methods of `Partition` so that it can be used interchangeably with usual table-like entities in generic functions. 

@vkucera 