### PR TITLE
fix for TOF calib

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1353,7 +1353,7 @@ int MatchTOF::findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FI
   }
 
   int index = -1;
-  int distMax = 0;
+  int distMax = 10;
   bool bestQuality = false; // prioritize FT0 BC with good quality (FT0-AC + vertex) to remove umbiguity in Pb-Pb (not a strict cut because inefficient in pp)
   const int distThr = 8;
 
@@ -1369,8 +1369,8 @@ int MatchTOF::findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FI
     int bct0 = (ir.orbit - firstOrbit) * o2::constants::lhc::LHCMaxBunches + ir.bc;
     int dist = bc - bct0;
 
-    bool worseDistance = dist < 0 || dist > distThr || dist < distMax;
-    if (worseDistance && (!quality || bestQuality)) { // discard if BC is later than the one selected, but is has a better quality
+    bool worseDistance = dist < 0 || dist > distThr || dist > distMax;
+    if (worseDistance) { // discard if BC is not in the proper range or it is worse than the one already found
       continue;
     }
 


### PR DESCRIPTION
Hi @chiarazampolli , @shahor02,
after checking the TOF calib output of the last cycle of relval I found that there is a problem when selecting FT0 BC when there are multiple-candidate: not always the correct one is taken because of a wrong condition (bug) in the code.
I didn't spot this problem in the previous LHC23zzh cpass* I checked, probably because the IR was lower.
Today I prepared a fix, tested on the debug production which gives the right results.
I apologize for not spotting the problem before (my fault).
Francesco

