### PR TITLE
TRD shift tracklet position by one pad

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -138,20 +138,14 @@ class Tracklet64
   GPUd() float getPadWidth() const { return 0.635f + 0.03f * (getDetector() % constants::NLAYER); }
 
   // pad column number inside pad row as float
-  GPUd() float getPadColFloat() const { return getPositionFloat() + getMCMCol() * constants::NCOLMCM + constants::NADCMCM / 2.f; }
+  // FIXME: understand why the offset seems to be 8 pads and not nChannels / 2 = 10.5
+  GPUd() float getPadColFloat() const { return getPositionFloat() + getMCMCol() * constants::NCOLMCM + 8; }
 
   // pad column number inside pad row as int can be off by +-1 pad (same function name as for TRD digit)
-  // FIXME: understand why the offset seems to be 8 pads and not nChannels / 2 = 10.5
-  GPUd() int getPadCol() const { return GPUCA_NAMESPACE::gpu::CAMath::Float2IntRn(getPadColFloat() - 2); }
+  GPUd() int getPadCol() const { return GPUCA_NAMESPACE::gpu::CAMath::Float2IntRn(getPadColFloat()); }
 
   // translate local position into global y (in cm) not taking into account calibrations (ExB, vDrift, t0)
-  GPUd() float getUncalibratedY() const
-  {
-    // one pad column has 144 pads, the offset of -63 is the center of the first MCM in that column
-    // which is connected to the pads -63 - 9 = -72 to -63 + 9 = -54
-    int offsetInNumberOfPads = -63 + constants::NCOLMCM * getMCMCol();
-    return (offsetInNumberOfPads + getPositionFloat()) * getPadWidth();
-  }
+  GPUd() float getUncalibratedY() const { return (getPadColFloat() - (constants::NCOLUMN / 2.f)) * getPadWidth(); }
 
   // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
   GPUd() float getUncalibratedDy(float nTbDrift = 19.4f) const { return getSlopeFloat() * getPadWidth() * nTbDrift; }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -139,13 +139,15 @@ class Tracklet64
 
   // pad column number inside pad row as float
   // FIXME: understand why the offset seems to be 8 pads and not nChannels / 2 = 10.5
-  GPUd() float getPadColFloat() const { return getPositionFloat() + getMCMCol() * constants::NCOLMCM + 8; }
+  // Due to wrong pad shift included in alignment we need to optionally shift the tracklets by one pad
+  // in case we are not using the ideal alignment
+  GPUd() float getPadColFloat(bool applyShift) const { return getPositionFloat() + getMCMCol() * constants::NCOLMCM + 8.f + (applyShift ? 1.f : 0.f); }
 
   // pad column number inside pad row as int can be off by +-1 pad (same function name as for TRD digit)
-  GPUd() int getPadCol() const { return GPUCA_NAMESPACE::gpu::CAMath::Float2IntRn(getPadColFloat()); }
+  GPUd() int getPadCol(bool applyShift = false) const { return GPUCA_NAMESPACE::gpu::CAMath::Float2IntRn(getPadColFloat(applyShift)); }
 
   // translate local position into global y (in cm) not taking into account calibrations (ExB, vDrift, t0)
-  GPUd() float getUncalibratedY() const { return (getPadColFloat() - (constants::NCOLUMN / 2.f)) * getPadWidth(); }
+  GPUd() float getUncalibratedY(bool applyShift = false) const { return (getPadColFloat(applyShift) - (constants::NCOLUMN / 2.f)) * getPadWidth(); }
 
   // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
   GPUd() float getUncalibratedDy(float nTbDrift = 19.4f) const { return getSlopeFloat() * getPadWidth() * nTbDrift; }

--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -33,8 +33,6 @@ class TrackletTransformer
   void setCalVdriftExB(const CalVdriftExB* cal) { mCalVdriftExB = cal; };
   void setApplyXOR() { mApplyXOR = true; }
 
-  float calculateY(int hcid, int column, int position, const PadPlane* padPlane) const;
-
   float calculateZ(int padrow, const PadPlane* padPlane) const;
 
   float calculateDy(int hcid, int slope, const PadPlane* padPlane) const;

--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -32,6 +32,7 @@ class TrackletTransformer
 
   void setCalVdriftExB(const CalVdriftExB* cal) { mCalVdriftExB = cal; };
   void setApplyXOR() { mApplyXOR = true; }
+  void setApplyShift(bool f) { mApplyShift = f; }
 
   float calculateZ(int padrow, const PadPlane* padPlane) const;
 
@@ -48,6 +49,7 @@ class TrackletTransformer
  private:
   Geometry* mGeo{nullptr};
   bool mApplyXOR{false};
+  bool mApplyShift{true};
 
   float mXAnode;
 

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -27,18 +27,6 @@ void TrackletTransformer::init()
   mXAnode = mGeo->cdrHght() + mGeo->camHght() / 2;
 }
 
-float TrackletTransformer::calculateY(int hcid, int column, int position, const PadPlane* padPlane) const
-{
-  double padWidth = padPlane->getWidthIPad();
-  int side = hcid % 2;
-  position += 1 << (NBITSTRKLPOS - 1); // shift such that position = 1 << (NBITSTRKLPOS - 1) corresponds to the MCM center
-  // slightly modified TDP eq 16.1 (appended -1 to the end to account for MCM shared pads)
-  double pad = float(position - (1 << (NBITSTRKLPOS - 1))) * GRANULARITYTRKLPOS + NCOLMCM * (4 * side + column) + 10. - 1.;
-  float y = padWidth * (pad - 72);
-
-  return y;
-}
-
 float TrackletTransformer::calculateZ(int padrow, const PadPlane* padPlane) const
 {
   double rowPos = padPlane->getRowPos(padrow);
@@ -114,7 +102,7 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet, b
 
   // 5mm below cathode plane to reduce error propogation from tracklet fit and driftV
   float x = mGeo->cdrHght() - 0.5;
-  float y = calculateY(hcid, column, position, padPlane);
+  float y = tracklet.getUncalibratedY();
   float z = calculateZ(padrow, padPlane);
 
   float dy = calculateDy(detector, slope, padPlane);

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -102,7 +102,7 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet, b
 
   // 5mm below cathode plane to reduce error propogation from tracklet fit and driftV
   float x = mGeo->cdrHght() - 0.5;
-  float y = tracklet.getUncalibratedY();
+  float y = tracklet.getUncalibratedY(mApplyShift);
   float z = calculateZ(padrow, padPlane);
 
   float dy = calculateDy(detector, slope, padPlane);

--- a/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
@@ -51,6 +51,8 @@ class PulseHeight
   /// Reset the output
   void reset();
 
+  void setApplyShift(bool f) { mApplyShift = f; }
+
   /// Main processing function
   void process();
 
@@ -82,6 +84,7 @@ class PulseHeight
   // settings
   const TRDCalibParams& mParams{TRDCalibParams::Instance()}; ///< reference to calibration parameters
   bool mWriteOutput{false};                                  ///< will be set to true in case createOutputFile() is called
+  bool mApplyShift{true};
 
   ClassDefNV(PulseHeight, 1);
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/TrackBasedCalib.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/TrackBasedCalib.h
@@ -62,6 +62,8 @@ class TrackBasedCalib
   // Set the local gain factors with values from the ccdb
   void setLocalGainFactors(const LocalGainFactor* localGain) { mLocalGain = localGain; }
 
+  void setApplyShift(bool f) { mApplyShift = f; }
+
   /// Reset the output
   void reset();
 
@@ -92,6 +94,7 @@ class TrackBasedCalib
   AngularResidHistos mAngResHistos;                  ///< aggregated data for the track based calibration
   std::vector<int> mGainCalibHistos;                 ///< aggregated input data for gain calibration
   float bz;                                          ///< magnetic field
+  bool mApplyShift{true};
 
   // input arrays which should not be modified since they are provided externally
   gsl::span<const TrackTRD> mTracksInITSTPCTRD;        ///< TRD tracks reconstructed from TPC or ITS-TPC seeds

--- a/Detectors/TRD/calibration/src/PulseHeight.cxx
+++ b/Detectors/TRD/calibration/src/PulseHeight.cxx
@@ -135,7 +135,7 @@ void PulseHeight::findDigitsForTracklet(const Tracklet64& trklt, const TriggerRe
     if (digit.isSharedDigit()) {
       continue; // avoid double-counting of the same digit
     }
-    if (digit.getDetector() != trkltDet || digit.getPadRow() != trklt.getPadRow() || digit.getPadCol() != trklt.getPadCol()) {
+    if (digit.getDetector() != trkltDet || digit.getPadRow() != trklt.getPadRow() || digit.getPadCol() != trklt.getPadCol(mApplyShift)) {
       // for now we loose charge information from padrow-crossing tracklets (~15% of all tracklets)
       continue;
     }

--- a/Detectors/TRD/calibration/src/TrackBasedCalib.cxx
+++ b/Detectors/TRD/calibration/src/TrackBasedCalib.cxx
@@ -159,10 +159,10 @@ int TrackBasedCalib::filldEdx(gsl::span<const TrackTRD>& tracks, bool isTPCTRD)
 
       float localGainCorr = 1.;
       if (mLocalGain) {
-        localGainCorr = mLocalGain->getValue(trkltDet, tracklet.getPadCol(), tracklet.getPadRow());
+        localGainCorr = mLocalGain->getValue(trkltDet, tracklet.getPadCol(mApplyShift), tracklet.getPadRow());
       }
       if (TMath::Abs(localGainCorr) < 0.0001f) {
-        LOGP(warn, "Invalid localGainCorr {} for det {}, pad col {}, pad row {}", localGainCorr, trkltDet, tracklet.getPadCol(), tracklet.getPadRow());
+        LOGP(warn, "Invalid localGainCorr {} for det {}, pad col {}, pad row {}", localGainCorr, trkltDet, tracklet.getPadCol(mApplyShift), tracklet.getPadRow());
         continue;
       }
 

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -80,6 +80,8 @@ class Tracking
   /// Initialize the input arrays
   void setInput(const o2::globaltracking::RecoContainer& input);
 
+  void setApplyShift(bool f) { mApplyShift = f; }
+
   /// Main processing function
   void run();
 
@@ -107,6 +109,7 @@ class Tracking
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
   RecoParam mRecoParam;                              ///< parameters required for TRD reconstruction
   bool mPID{true};                                   ///< if TPC only tracks are not available we don't fill PID info
+  bool mApplyShift{true};
 
   // QA results
   std::vector<TrackQC> mTrackQC;

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -108,7 +108,7 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
     // \sqrt{ (dx/dx)^2 + (dy/dx)^2 + (dz/dx)^2}
     auto tphi = trk.getSnp() / std::sqrt((1.f - trk.getSnp()) * (1.f + trk.getSnp()));
     auto trackletLength = std::sqrt(1.f + tphi * tphi + trk.getTgl() * trk.getTgl());
-    auto cor = mLocalGain.getValue(tracklet.getHCID() / 2, tracklet.getPadCol(), tracklet.getPadRow()) * trackletLength;
+    auto cor = mLocalGain.getValue(tracklet.getHCID() / 2, tracklet.getPadCol(mApplyShift), tracklet.getPadRow()) * trackletLength;
     float q0{tracklet.getQ0() / cor}, q1{tracklet.getQ1() / cor}, q2{tracklet.getQ2() / cor};
 
     // z-row merging
@@ -117,9 +117,9 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
         if (tracklet.getTrackletWord() == trklt.getTrackletWord()) { // skip original tracklet
           continue;
         }
-        if (std::abs(tracklet.getPadCol() - trklt.getPadCol()) <= 1 && std::abs(tracklet.getPadRow() - trklt.getPadRow()) == 1) {
+        if (std::abs(tracklet.getPadCol(mApplyShift) - trklt.getPadCol(mApplyShift)) <= 1 && std::abs(tracklet.getPadRow() - trklt.getPadRow()) == 1) {
           // Add charge information
-          auto cor = mLocalGain.getValue(trklt.getHCID() / 2, trklt.getPadCol(), trklt.getPadRow()) * trackletLength;
+          auto cor = mLocalGain.getValue(trklt.getHCID() / 2, trklt.getPadCol(mApplyShift), trklt.getPadRow()) * trackletLength;
           q0 += trklt.getQ0() / cor;
           q1 += trklt.getQ1() / cor;
           q2 += trklt.getQ2() / cor;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
@@ -31,6 +31,7 @@
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "TRDQC/Tracking.h"
+#include <cstring>
 
 #include "DetectorsBase/GRPGeomHelper.h"
 
@@ -53,6 +54,10 @@ class TRDGlobalTrackingQC : public Task
     o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
     if (!mTPCavailable) {
       mQC.disablePID();
+    }
+    if (getenv("ALIEN_JDL_LPMPRODUCTIONTYPE") && std::strcmp(getenv("ALIEN_JDL_LPMPRODUCTIONTYPE"), "MC") == 0) {
+      // apply artificial pad shift in case non-ideal alignment is used to compensate for shift in current alignment from real data
+      mQC.setApplyShift(false);
     }
   }
   void run(ProcessingContext& pc) final

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
@@ -23,6 +23,7 @@
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "TRDCalibration/PulseHeight.h"
 #include "DataFormatsTRD/PHData.h"
+#include <cstring>
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -41,6 +42,10 @@ class PuseHeightDevice : public o2::framework::Task
     mPulseHeight = std::make_unique<PulseHeight>();
     if (ic.options().get<bool>("enable-root-output")) {
       mPulseHeight->createOutputFile();
+    }
+    if (getenv("ALIEN_JDL_LPMPRODUCTIONTYPE") && std::strcmp(getenv("ALIEN_JDL_LPMPRODUCTIONTYPE"), "MC") == 0) {
+      // apply artificial pad shift in case non-ideal alignment is used to compensate for shift in current alignment from real data
+      mPulseHeight->setApplyShift(false);
     }
   }
 

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include <gsl/span>
+#include <cstring>
 
 #include "TRDWorkflow/TRDTrackletTransformerSpec.h"
 
@@ -33,6 +34,10 @@ void TRDTrackletTransformerSpec::init(o2::framework::InitContext& ic)
   o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
   if (ic.options().get<bool>("apply-xor")) {
     mTransformer.setApplyXOR();
+  }
+  if (getenv("ALIEN_JDL_LPMPRODUCTIONTYPE") && std::strcmp(getenv("ALIEN_JDL_LPMPRODUCTIONTYPE"), "MC") == 0) {
+    // apply artificial pad shift in case non-ideal alignment is used to compensate for shift in current alignment from real data
+    mTransformer.setApplyShift(false);
   }
 }
 

--- a/Detectors/TRD/workflow/src/TrackBasedCalibSpec.cxx
+++ b/Detectors/TRD/workflow/src/TrackBasedCalibSpec.cxx
@@ -26,6 +26,7 @@
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "TStopwatch.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include <cstring>
 
 using namespace o2::framework;
 using namespace o2::globaltracking;
@@ -61,6 +62,10 @@ class TRDTrackBasedCalibDevice : public Task
 void TRDTrackBasedCalibDevice::init(InitContext& ic)
 {
   o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+  if (getenv("ALIEN_JDL_LPMPRODUCTIONTYPE") && std::strcmp(getenv("ALIEN_JDL_LPMPRODUCTIONTYPE"), "MC") == 0) {
+    // apply artificial pad shift in case non-ideal alignment is used to compensate for shift in current alignment from real data
+    mCalibrator.setApplyShift(false);
+  }
   mTimer.Stop();
   mTimer.Reset();
 }


### PR DESCRIPTION
In https://alice.its.cern.ch/jira/browse/O2-4440 a splitting of high pT tracks matched to TRD was observed. This seems to be due to a wrong conversion from tracklet coordinates to tracking coordinates. We are one pad off.
Further studies are still needed, not to be merged yet.
Pinging to @shahor02 