### PR TITLE
Disable the reading of the BadChannel CCDB information 

### DIFF
--- a/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
+++ b/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
@@ -29,7 +29,7 @@ struct DigitFilterParam : public o2::conf::ConfigurableParamHelper<DigitFilterPa
   bool rejectBackground = true; ///< attempts to reject background (loose background selection, don't kill signal)
   bool selectSignal = false;    ///< attempts to select only signal (strict background selection, might loose signal)
   int timeOffset = 120;         ///< digit time calibration offset
-  uint32_t statusMask = 3;      ///< mask to reject digits based on the statusmap (0=no rejection,1=badchannels from ped calib only,2=badchannels from rejectlist,3=1+2)
+  uint32_t statusMask = 0;      ///< mask to reject digits based on the statusmap (0=no rejection,1=badchannels from ped calib only,2=badchannels from rejectlist,3=1+2)
 
   O2ParamDef(DigitFilterParam, "MCHDigitFilter");
 };

--- a/Detectors/MUON/MCH/Status/include/MCHStatus/StatusMapCreatorParam.h
+++ b/Detectors/MUON/MCH/Status/include/MCHStatus/StatusMapCreatorParam.h
@@ -24,7 +24,7 @@ namespace o2::mch
  */
 struct StatusMapCreatorParam : public o2::conf::ConfigurableParamHelper<StatusMapCreatorParam> {
 
-  bool useBadChannels = true; ///< reject bad channels (obtained during pedestal calibration runs)
+  bool useBadChannels = false; ///< reject bad channels (obtained during pedestal calibration runs)
   bool useRejectList = true;  ///< use extra (relative to bad channels above) rejection list
 
   bool isActive() const { return useBadChannels || useRejectList; }


### PR DESCRIPTION
Disable the reading of the BadChannel CCDB information in the StatusMapCreator. A protection needs to be added to the task in future to cope with invalid solar Id in the BadChannel CCDB