### PR TITLE
DPL: remove need for special engineering type

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -800,7 +800,7 @@ void processChildrenOutput(DriverInfo& driverInfo,
     }
 
     O2_SIGNPOST_ID_FROM_POINTER(sid, driver, &info);
-    O2_SIGNPOST_START(driver, sid, "bytes_processed", "bytes processed by " O2_ENG_TYPE(pid, "d"), info.pid);
+    O2_SIGNPOST_START(driver, sid, "bytes_processed", "bytes processed by %{xcode:pid}d", info.pid);
 
     std::string_view s = info.unprinted;
     size_t pos = 0;
@@ -848,7 +848,7 @@ void processChildrenOutput(DriverInfo& driverInfo,
     size_t oldSize = info.unprinted.size();
     info.unprinted = std::string(s);
     int64_t bytesProcessed = oldSize - info.unprinted.size();
-    O2_SIGNPOST_END(driver, sid, "bytes_processed", "bytes processed by " O2_ENG_TYPE(network - size - in - bytes, PRIi64), bytesProcessed);
+    O2_SIGNPOST_END(driver, sid, "bytes_processed", "bytes processed by %{xcode:network-size-in-bytes}" PRIi64, bytesProcessed);
   }
 }
 

--- a/Framework/Foundation/test/test_Signpost.cxx
+++ b/Framework/Foundation/test/test_Signpost.cxx
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
 
   // This has an engineering type, which we will not use on Linux / FairLogger
   O2_SIGNPOST_ID_FROM_POINTER(id4, test_Signpost, &id3);
-  O2_SIGNPOST_START(test_Signpost, id4, "Test category", "A signpost with an engineering type formatter " O2_ENG_TYPE(size - in - bytes, "d"), 1);
+  O2_SIGNPOST_START(test_Signpost, id4, "Test category", "A signpost with an engineering type formatter %{size-in-bytes}d", 1);
   O2_SIGNPOST_END(test_Signpost, id4, "Test category", "A signpost interval from a pointer");
 
   O2_SIGNPOST_START(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will not see, because they are off by default");

--- a/Framework/Foundation/test/test_SignpostLogger.cxx
+++ b/Framework/Foundation/test/test_SignpostLogger.cxx
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // This has an engineering type, which we will not use on Linux / FairLogger
   O2_SIGNPOST_ID_FROM_POINTER(id4, test_Signpost, &id3);
-  O2_SIGNPOST_START(test_Signpost, id4, "Test category", "A signpost with an engineering type formatter " O2_ENG_TYPE(size - in - bytes, "d"), 1);
+  O2_SIGNPOST_START(test_Signpost, id4, "Test category", "A signpost with an engineering type formatter %{size-in-bytes}d", 1);
   O2_SIGNPOST_END(test_Signpost, id4, "Test category", "A signpost interval from a pointer");
 
   O2_SIGNPOST_START(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will not see, because they are off by default");


### PR DESCRIPTION
DPL: remove need for special engineering type

We can simply use Instruments one and convert them to something sensible when
using the FairLogger implementation.
