### PR TITLE
Set innerparam to the rigidity

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2487,7 +2487,7 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
   if (contributorsGID[GIndex::Source::TPC].isIndexSet()) {
     const auto& tpcOrig = data.getTPCTrack(contributorsGID[GIndex::TPC]);
     const auto& tpcClData = mTPCCounters[contributorsGID[GIndex::TPC]];
-    extraInfoHolder.tpcInnerParam = tpcOrig.getP();
+    extraInfoHolder.tpcInnerParam = tpcOrig.getP() / tpcOrig.getAbsCharge();
     extraInfoHolder.tpcChi2NCl = tpcOrig.getNClusters() ? tpcOrig.getChi2() / tpcOrig.getNClusters() : 0;
     extraInfoHolder.tpcSignal = tpcOrig.getdEdx().dEdxTotTPC;
     extraInfoHolder.tpcNClsFindable = tpcOrig.getNClusters();


### PR DESCRIPTION
@shahor02 @fmazzasc @ddobrigk

I think that for the typical dE/dx plots (and for the PID itself!) we use this variable with the meaning of rigidity, and with the PID in tracking this has changed. I think we should make sure that the documentation also reflects the fact that this should be a rigidity.



