### PR TITLE
ITSMFT time-evolving dead maps, builder and simulation

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -28,6 +28,7 @@ o2_target_root_dictionary(DataFormatsITSMFT
                                  include/DataFormatsITSMFT/Digit.h
                                  include/DataFormatsITSMFT/GBTCalibData.h
                                  include/DataFormatsITSMFT/NoiseMap.h
+                                 include/DataFormatsITSMFT/TimeDeadMap.h
                                   include/DataFormatsITSMFT/Cluster.h
                                   include/DataFormatsITSMFT/CompCluster.h
                                   include/DataFormatsITSMFT/ClusterPattern.h

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -105,7 +105,7 @@ class NoiseMap
   void applyProbThreshold(float t, long int n, float relErr = 0.2f, int minChipID = 0, int maxChipID = 24119)
   {
     // Remove from the maps all pixels with the firing probability below the threshold
-    // Apply the cut only for chips between minChipID and maxChipID (included).
+    // Apply the cut only for chips between minChipID and maxChipID (included)
     if (n < 1) {
       LOGP(alarm, "Cannot apply threshold with {} ROFs scanned", n);
       return;

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -105,7 +105,7 @@ class NoiseMap
   void applyProbThreshold(float t, long int n, float relErr = 0.2f, int minChipID = 0, int maxChipID = 24119)
   {
     // Remove from the maps all pixels with the firing probability below the threshold
-    // Apply the cut only for chips between minChipID and maxChipID (included)
+    // Apply the cut only for chips between minChipID and maxChipID (included).
     if (n < 1) {
       LOGP(alarm, "Cannot apply threshold with {} ROFs scanned", n);
       return;

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -169,31 +169,7 @@ class NoiseMap
   // Methods required by the calibration framework
   void print();
   void fill(const gsl::span<const CompClusterExt> data);
-  void merge(const NoiseMap* prev, bool sumstrobes = false)
-  {
-    if (prev == nullptr) {
-      return;
-    }
-    if (mNoisyPixels.size() != prev->size()) {
-      LOGP(error, "Trying to merge NoiseMap with different sizes: {} vs {}. Doing nothing.", mNoisyPixels.size(), prev->size());
-      return;
-    }
-    if (sumstrobes) {
-      mNumOfStrobes += prev->getNumberOfStrobes();
-    }
-
-    for (size_t chipID = 0; chipID < mNoisyPixels.size(); chipID++) {
-
-      const auto* prevChipMap = prev->getChipMap(chipID);
-
-      if (prevChipMap) {
-        // Iterate over previous map and add its entries
-        for (const auto& p : *prevChipMap) {
-          mNoisyPixels[chipID][p.first] = std::max(mNoisyPixels[chipID][p.first], p.second);
-        }
-      }
-    }
-  }
+  void merge(const NoiseMap* prev) {}
 
   const std::map<int, int>* getChipMap(int chip) const { return chip < (int)mNoisyPixels.size() ? &mNoisyPixels[chip] : nullptr; }
 

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -1,3 +1,16 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimeDeadMap.h
+/// \brief Definition of the ITSMFT time-dependend dead map
 #ifndef ALICEO2_ITSMFT_TIMEDEADMAP_H
 #define ALICEO2_ITSMFT_TIMEDEADMAP_H
 

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -1,0 +1,143 @@
+#ifndef ALICEO2_ITSMFT_TIMEDEADMAP_H
+#define ALICEO2_ITSMFT_TIMEDEADMAP_H
+
+#include "Rtypes.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include <iostream>
+#include <vector>
+#include <map>
+
+namespace o2
+{
+
+namespace itsmft
+{
+
+class TimeDeadMap
+{
+ public:
+  // Constructor
+  TimeDeadMap(std::map<unsigned long, std::vector<uint16_t>>& deadmap)
+  {
+    mEvolvingDeadMap.swap(deadmap);
+  }
+
+  /// Constructor
+  TimeDeadMap() = default;
+  /// Destructor
+  ~TimeDeadMap() = default;
+
+  void fillMap(unsigned long firstOrbit, std::vector<uint16_t> deadVect)
+  {
+    mEvolvingDeadMap[firstOrbit] = deadVect;
+  };
+
+  void fillMap(std::vector<uint16_t> deadVect)
+  {
+    mStaticDeadMap = deadVect;
+  }
+
+  void clear()
+  {
+    mEvolvingDeadMap.clear();
+    mStaticDeadMap.clear();
+  }
+
+  void decodeMap(o2::itsmft::NoiseMap* noisemap)
+  { // for static part only
+    if (mMAP_VERSION != "3") {
+      LOG(error) << "Trying to decode static part of deadmap version " << mMAP_VERSION << ". Not implemented, doing nothing.";
+      return;
+    }
+    for (int iel = 0; iel < mStaticDeadMap.size(); iel++) {
+      uint16_t w = mStaticDeadMap.at(iel);
+      noisemap->maskFullChip(w & 0x7FFF);
+      if (w & 0x8000) {
+        for (int w2 = (w & 0x7FFF) + 1; w2 < mStaticDeadMap.at(iel + 1); w2++) {
+          noisemap->maskFullChip(w2);
+        }
+      }
+    }
+  }
+
+  void decodeMap(unsigned long orbit, o2::itsmft::NoiseMap* noisemap, bool includeStaticMap = true) // for time-dependent and (optionally) static part
+  {
+
+    if (mMAP_VERSION != "3" && mMAP_VERSION != "4") {
+      LOG(error) << "Trying to decode time-dependent deadmap version " << mMAP_VERSION << ". Not implemented, doing nothing.";
+      return;
+    }
+
+    if (mEvolvingDeadMap.empty()) {
+      LOG(warning) << "Time-dependent dead map is empty. Doing nothing.";
+      return;
+    } else if (orbit > mEvolvingDeadMap.rbegin()->first + 11000 * 300 || orbit < mEvolvingDeadMap.begin()->first - 11000 * 300) {
+      // the map should not leave several minutes uncovered.
+      LOG(warning) << "Time-dependent dead map: the requested orbit " << orbit << " seems to be out of the range stored in the map.";
+    }
+
+    std::vector<uint16_t> closestVec;
+    long dT = getMapAtOrbit(orbit, closestVec);
+
+    // add static part if requested. something may be masked twice
+    if (includeStaticMap && mMAP_VERSION != "3") {
+      closestVec.insert(closestVec.end(), mStaticDeadMap.begin(), mStaticDeadMap.end());
+    }
+
+    // vector encoding: if 1<<15 = 0x8000 is set, the word encodes the first element of a range, with mask (1<<15)-1 = 0x7FFF. The last element of the range is the next in the vector.
+
+    for (int iel = 0; iel < closestVec.size(); iel++) {
+      uint16_t w = closestVec.at(iel);
+      noisemap->maskFullChip(w & 0x7FFF);
+      if (w & 0x8000) {
+        for (int w2 = (w & 0x7FFF) + 1; w2 < closestVec.at(iel + 1); w2++) {
+          noisemap->maskFullChip(w2);
+        }
+      }
+    }
+  };
+
+  std::string getMapVersion() { return mMAP_VERSION; };
+
+  unsigned long getEvolvingMapSize() { return mEvolvingDeadMap.size(); };
+
+  std::vector<unsigned long> getEvolvingMapKeys()
+  {
+    std::vector<unsigned long> keys;
+    std::transform(mEvolvingDeadMap.begin(), mEvolvingDeadMap.end(), std::back_inserter(keys),
+                   [](const auto& O) { return O.first; });
+    return keys;
+  }
+
+  void getStaticMap(std::vector<uint16_t>& mmap) { mmap = mStaticDeadMap; };
+
+  long getMapAtOrbit(unsigned long orbit, std::vector<uint16_t>& mmap)
+  { // fills mmap and returns orbit - upper_bound
+    auto closest = mEvolvingDeadMap.lower_bound(orbit);
+    if (closest != mEvolvingDeadMap.end()) {
+      mmap = closest->second;
+      return (long)orbit - closest->first;
+    } else {
+      mmap = mEvolvingDeadMap.rbegin()->second;
+      return (long)(orbit)-mEvolvingDeadMap.rbegin()->first;
+    }
+  }
+
+  void setMapVersion(std::string version) { mMAP_VERSION = version; };
+
+  bool isDefault() { return mIsDefaultObject; };
+  void setAsDefault(bool isdef = true) { mIsDefaultObject = isdef; };
+
+ private:
+  bool mIsDefaultObject = false;
+  std::string mMAP_VERSION = "3";
+  std::map<unsigned long, std::vector<uint16_t>> mEvolvingDeadMap; ///< Internal dead chip map representation. key = orbit
+  std::vector<uint16_t> mStaticDeadMap;                            ///< To store map valid for every orbit. Filled starting from version = 4.
+
+  ClassDefNV(TimeDeadMap, 2);
+};
+
+} // namespace itsmft
+} // namespace o2
+
+#endif /* ALICEO2_ITSMFT_TIMEDEADMAP_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -125,9 +125,9 @@ class TimeDeadMap
   void getStaticMap(std::vector<uint16_t>& mmap) { mmap = mStaticDeadMap; };
 
   long getMapAtOrbit(unsigned long orbit, std::vector<uint16_t>& mmap)
-  { // fills mmap and returns orbit - upper_bound
+  { // fills mmap and returns orbit - lower_bound
     if (mEvolvingDeadMap.empty()) {
-      LOG(warning) << "Requested orbit " << orbit << "from an empty time-dependent map. Returning empty vector.";
+      LOG(warning) << "Requested orbit " << orbit << "from an empty time-dependent map. Doing nothing";
       return (long)orbit;
     }
     auto closest = mEvolvingDeadMap.lower_bound(orbit);

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -17,6 +17,7 @@
 
 #pragma link C++ class o2::itsmft::Digit + ;
 #pragma link C++ class o2::itsmft::NoiseMap + ;
+#pragma link C++ class o2::itsmft::TimeDeadMap + ;
 #pragma link C++ class std::vector < o2::itsmft::Digit> + ;
 
 #pragma link C++ class o2::itsmft::GBTCalibData + ;

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -18,7 +18,7 @@
 #include <deque>
 #include <memory>
 
-#include "Rtypes.h"  // for Digitizer::Class
+#include "Rtypes.h" // for Digitizer::Class
 #include "TObject.h" // for TObject
 
 #include "ITSMFTSimulation/ChipDigitsContainer.h"

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -18,7 +18,7 @@
 #include <deque>
 #include <memory>
 
-#include "Rtypes.h" // for Digitizer::Class
+#include "Rtypes.h"  // for Digitizer::Class
 #include "TObject.h" // for TObject
 
 #include "ITSMFTSimulation/ChipDigitsContainer.h"
@@ -59,7 +59,7 @@ class Digitizer : public TObject
   o2::itsmft::DigiParams& getParams() { return (o2::itsmft::DigiParams&)mParams; }
   const o2::itsmft::DigiParams& getParams() const { return mParams; }
   void setNoiseMap(const o2::itsmft::NoiseMap* mp) { mNoiseMap = mp; }
-  void setDeadChannelsMap(const o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
+  void setDeadChannelsMap(o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
 
   void init();
 
@@ -111,8 +111,8 @@ class Digitizer : public TObject
 
   static constexpr float sec2ns = 1e9;
 
-  o2::itsmft::DigiParams mParams; ///< digitization parameters
-  o2::InteractionTimeRecord mEventTime; ///< global event time and interaction record
+  o2::itsmft::DigiParams mParams;          ///< digitization parameters
+  o2::InteractionTimeRecord mEventTime;    ///< global event time and interaction record
   o2::InteractionRecord mIRFirstSampledTF; ///< IR of the 1st sampled IR, noise-only ROFs will be inserted till this IR only
   double mCollisionTimeWrtROF;
   uint32_t mROFrameMin = 0; ///< lowest RO frame of current digits
@@ -137,7 +137,7 @@ class Digitizer : public TObject
   std::vector<o2::itsmft::ROFRecord>* mROFRecords = nullptr;               //! output ROF records
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mMCLabels = nullptr; //! output labels
   const o2::itsmft::NoiseMap* mNoiseMap = nullptr;
-  const o2::itsmft::NoiseMap* mDeadChanMap = nullptr;
+  o2::itsmft::NoiseMap* mDeadChanMap = nullptr;
 
   ClassDefOverride(Digitizer, 2);
 };

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -59,7 +59,7 @@ class Digitizer : public TObject
   o2::itsmft::DigiParams& getParams() { return (o2::itsmft::DigiParams&)mParams; }
   const o2::itsmft::DigiParams& getParams() const { return mParams; }
   void setNoiseMap(const o2::itsmft::NoiseMap* mp) { mNoiseMap = mp; }
-  void setDeadChannelsMap(o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
+  void setDeadChannelsMap(const o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
 
   void init();
 
@@ -137,7 +137,7 @@ class Digitizer : public TObject
   std::vector<o2::itsmft::ROFRecord>* mROFRecords = nullptr;               //! output ROF records
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mMCLabels = nullptr; //! output labels
   const o2::itsmft::NoiseMap* mNoiseMap = nullptr;
-  o2::itsmft::NoiseMap* mDeadChanMap = nullptr;
+  const o2::itsmft::NoiseMap* mDeadChanMap = nullptr;
 
   ClassDefOverride(Digitizer, 2);
 };

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -42,6 +42,7 @@
 #include <fairmq/Device.h>
 
 #include <ITSMFTReconstruction/RawPixelDecoder.h> //o2::itsmft::RawPixelDecoder
+#include "DataFormatsITSMFT/TimeDeadMap.h"
 #include "DetectorsCalibration/Utils.h"
 #include "DetectorsCommonDataFormats/FileMetaData.h"
 #include "DetectorsBase/GRPGeomHelper.h"
@@ -91,7 +92,7 @@ class ITSMFTDeadMapBuilder : public Task
   std::string mObjectName;
   std::string mLocalOutputDir;
 
-  std::string MAP_VERSION = "2"; // to change in case the encoding or the format change
+  std::string MAP_VERSION = "3"; // to change in case the encoding or the format change
 
   std::vector<uint16_t> mDeadMapTF{};
 
@@ -101,14 +102,14 @@ class ITSMFTDeadMapBuilder : public Task
 
   int mTFSampling = 1000;
 
-  std::map<unsigned long, std::vector<uint16_t>> mMapObject{};
+  o2::itsmft::TimeDeadMap mMapObject;
 
   void finalizeOutput();
   void PrepareOutputCcdb(DataAllocator& output);
 
   // Utils
 
-  uint16_t getElementIDFromChip(uint16_t);
+  std::vector<uint16_t> getChipIDsOnSameCable(uint16_t);
 
   o2::framework::DataTakingContext mDataTakingContext{};
   o2::framework::TimingInfo mTimingInfo{};

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -20,6 +20,7 @@
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/NoiseMap.h"
+#include "DataFormatsITSMFT/TimeDeadMap.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "DetectorsBase/BaseDPLDigitizer.h"
 #include "DetectorsCommonDataFormats/DetID.h"
@@ -61,6 +62,7 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     }
     mID == o2::detectors::DetID::ITS ? updateTimeDependentParams<o2::detectors::DetID::ITS>(pc) : updateTimeDependentParams<o2::detectors::DetID::MFT>(pc);
     std::string detStr = mID.getName();
+    mFirstOrbitTF = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
     // read collision context from input
     auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
     context->initSimChains(mID, mSimChains);
@@ -189,8 +191,21 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
       return;
     }
     if (matcher == ConcreteDataMatcher(mOrigin, "DEADMAP", 0)) {
-      LOG(info) << mID.getName() << " dead map updated";
-      mDigitizer.setDeadChannelsMap((const o2::itsmft::NoiseMap*)obj);
+      LOG(info) << mID.getName() << " static dead map updated";
+      mDeadMap = (o2::itsmft::NoiseMap*)obj;
+      mDigitizer.setDeadChannelsMap(mDeadMap);
+      return;
+    }
+    if (matcher == ConcreteDataMatcher(mOrigin, "TimeDeadMap", 0)) {
+      o2::itsmft::TimeDeadMap* timedeadmap = (o2::itsmft::TimeDeadMap*)obj;
+      if (!timedeadmap->isDefault()) {
+        timedeadmap->decodeMap(mFirstOrbitTF, mDeadMap, true);
+        mDigitizer.setDeadChannelsMap(mDeadMap);
+        LOG(info) << mID.getName() << " time-dependent dead map updated";
+      } else {
+        LOG(info) << mID.getName() << " time-dependent dead map is default/empty";
+      }
+
       return;
     }
     if (matcher == ConcreteDataMatcher(mOrigin, "ALPIDEPARAM", 0)) {
@@ -215,6 +230,8 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     std::string detstr(o2::detectors::DetID::getName(DETID));
     pc.inputs().get<o2::itsmft::NoiseMap*>(detstr + "_noise");
     pc.inputs().get<o2::itsmft::NoiseMap*>(detstr + "_dead");
+    // TODO: the code should run even if this object does not exist. Or: create default object
+    pc.inputs().get<o2::itsmft::TimeDeadMap*>(detstr + "_time_dead");
     pc.inputs().get<o2::itsmft::DPLAlpideParam<DETID>*>(detstr + "_alppar");
 
     auto& dopt = o2::itsmft::DPLDigitizerParam<DETID>::Instance();
@@ -263,6 +280,7 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
   bool mWithMCTruth = true;
   bool mFinished = false;
   bool mDisableQED = false;
+  unsigned long mFirstOrbitTF = 0x0;
   o2::detectors::DetID mID;
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
   o2::itsmft::Digitizer mDigitizer;
@@ -275,6 +293,7 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabelsAccum;
   std::vector<o2::itsmft::MC2ROFRecord> mMC2ROFRecordsAccum;
   std::vector<TChain*> mSimChains;
+  o2::itsmft::NoiseMap* mDeadMap = nullptr;
 
   int mFixMC2ROF = 0;                                                             // 1st entry in mc2rofRecordsAccum to be fixed for ROFRecordID
   o2::parameters::GRPObject::ROMode mROMode = o2::parameters::GRPObject::PRESENT; // readout mode
@@ -340,6 +359,7 @@ DataProcessorSpec getITSDigitizerSpec(int channel, bool mctruth)
   inputs.emplace_back("collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   inputs.emplace_back("ITS_noise", "ITS", "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/NoiseMap"));
   inputs.emplace_back("ITS_dead", "ITS", "DEADMAP", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/DeadMap"));
+  inputs.emplace_back("ITS_time_dead", "ITS", "TimeDeadMap", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/TimeDeadMap"));
   inputs.emplace_back("ITS_alppar", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam"));
 
   return DataProcessorSpec{(detStr + "Digitizer").c_str(),
@@ -358,6 +378,7 @@ DataProcessorSpec getMFTDigitizerSpec(int channel, bool mctruth)
   inputs.emplace_back("collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   inputs.emplace_back("MFT_noise", "MFT", "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/NoiseMap"));
   inputs.emplace_back("MFT_dead", "MFT", "DEADMAP", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/DeadMap"));
+  inputs.emplace_back("MFT_time_dead", "MFT", "TimeDeadMap", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/TimeDeadMap"));
   inputs.emplace_back("MFT_alppar", "MFT", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("MFT/Config/AlpideParam"));
   parHelper << "Params as " << o2::itsmft::DPLDigitizerParam<ITSDPLDigitizerTask::DETID>::getParamName().data() << ".<param>=value;... with"
             << o2::itsmft::DPLDigitizerParam<ITSDPLDigitizerTask::DETID>::Instance()

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -199,7 +199,12 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     if (matcher == ConcreteDataMatcher(mOrigin, "TimeDeadMap", 0)) {
       o2::itsmft::TimeDeadMap* timedeadmap = (o2::itsmft::TimeDeadMap*)obj;
       if (!timedeadmap->isDefault()) {
-        timedeadmap->decodeMap(mFirstOrbitTF, mDeadMap, true);
+        timedeadmap->decodeMap(mFirstOrbitTF, *mDeadMap, true);
+        static bool UpdateDone = false;
+        if (UpdateDone) {
+          LOGP(fatal, "Attempt to add time-dependent map to already modified static map");
+        }
+        UpdateDone = true;
         mDigitizer.setDeadChannelsMap(mDeadMap);
         LOG(info) << mID.getName() << " time-dependent dead map updated";
       } else {

--- a/Steer/src/SteerLinkDef.h
+++ b/Steer/src/SteerLinkDef.h
@@ -20,6 +20,6 @@
 #pragma link C++ class o2::steer::O2MCApplicationEvalMat + ;
 #pragma link C++ class o2::steer::O2MCApplication + ;
 #pragma link C++ class o2::steer::MCKinematicsReader + ;
-#pragma link C++ class o2::steer::MaterialBudgetMap +
+#pragma link C++ class o2::steer::MaterialBudgetMap + ;
 
 #endif


### PR DESCRIPTION
Co-authored by @mcoquet642 .

This imports the new time-dependent efficiency maps of ITS and MFT into digitizer, and improves the map format.

- New class TimeDeadMap defined, to facilitate handling of InputRecords
- The class hosts a static map (same vector format, not attached to any orbit number). This can accommodate list of ITS fully dead elements (cc @iravasen ).
-  Now using same encoding for ITS and MFT: storing list of chip IDs
- TimeDeadMap is fetched by digitizer and it's content added to the existing map. A default empty object will be needed.

cc @shahor02 @mconcas @mcoquet642 @iravasen @IsakovAD
