### PR TITLE
DPL: do not validate lifetime when consumer uses consumeWhenAny

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1074,8 +1074,6 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
 
   WorkflowHelpers::constructGraph(workflow, logicalEdges, outputs, availableForwardsInfo);
 
-  WorkflowHelpers::validateEdges(workflow, logicalEdges, outputs);
-
   // We need to instanciate one device per (me, timeIndex) in the
   // DeviceConnectionEdge. For each device we need one new binding
   // server per (me, other) -> port Moreover for each (me, other,
@@ -1122,10 +1120,13 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
                        inActions, workflow, availableForwardsInfo, channelPolicies, channelPrefix, defaultOffer, overrideServices);
   // We apply the completion policies here since this is where we have all the
   // devices resolved.
-  for (auto& device : devices) {
+  std::map<std::string, DataProcessorPoliciesInfo> policies;
+  for (DeviceSpec& device : devices) {
     bool hasPolicy = false;
+    policies[device.name].completionPolicyName = "unknown";
     for (auto& policy : completionPolicies) {
       if (policy.matcher(device) == true) {
+        policies[policy.name].completionPolicyName = policy.name;
         device.completionPolicy = policy;
         hasPolicy = true;
         break;
@@ -1158,6 +1159,15 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
       throw runtime_error_f("Unable to find a resource policy for %s", device.id.c_str());
     }
   }
+  // Iterate of the workflow and create a consistent vector of DataProcessorPoliciesInfo
+  std::vector<DataProcessorPoliciesInfo> policiesVector;
+  for (size_t wi = 0; wi < workflow.size(); ++wi) {
+    auto& processor = workflow[wi];
+    auto& info = policies[processor.name];
+    policiesVector.push_back(info);
+  }
+
+  WorkflowHelpers::validateEdges(workflow, policiesVector, logicalEdges, outputs);
 
   for (auto& device : devices) {
     device.resourceMonitoringInterval = resourcesMonitoringInterval;

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -141,6 +141,11 @@ struct TopoIndexInfo {
   friend std::ostream& operator<<(std::ostream& out, TopoIndexInfo const& info);
 };
 
+// Information about the policies which were derived for a given data processor.
+struct DataProcessorPoliciesInfo {
+  std::string completionPolicyName;
+};
+
 struct OutputObj {
   InputSpec spec;
   bool isdangling;
@@ -234,6 +239,7 @@ struct WorkflowHelpers {
   /// For example we should make sure that Lifetime::Timeframe inputs of
   /// one node is not connected to an Output of Lifetime::Sporadic of another node.
   static void validateEdges(WorkflowSpec const& workflow,
+                            std::vector<DataProcessorPoliciesInfo> const& policiesInfos,
                             std::vector<DeviceConnectionEdge> const& edges,
                             std::vector<OutputSpec> const& outputs);
 };


### PR DESCRIPTION
DPL: do not validate lifetime when consumer uses consumeWhenAny
