### PR TITLE
DPL: add ability to disable inputs programmatically

### DIFF
--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -74,6 +74,9 @@ struct InputSpec {
 
   /// A set of configurables which can be used to customise the InputSpec.
   std::vector<ConfigParamSpec> metadata;
+  /// Wether or not the input is to be considered enabled.
+  /// Useful to programmatically disable inputs e.g. for the ProcessorOptions.
+  bool enabled = true;
 
   friend std::ostream& operator<<(std::ostream& stream, InputSpec const& arg);
   bool operator==(InputSpec const& that) const;

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -86,6 +86,10 @@ struct OutputSpec {
   /// A set of configurables which can be used to customise the InputSpec.
   std::vector<ConfigParamSpec> metadata;
 
+  /// Wether or not this output is enabled. This is useful to decide programmatically
+  /// wether or not to produce a given output.
+  bool enabled = true;
+
   friend std::ostream& operator<<(std::ostream& stream, OutputSpec const& arg);
 };
 

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -841,11 +841,13 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
     for (size_t wi = 0; wi < workflow.size(); ++wi) {
       auto& producer = workflow[wi];
 
-      for (size_t oi = 0; oi < producer.outputs.size(); ++oi) {
-        auto& out = producer.outputs[oi];
+      for (auto& output : producer.outputs) {
+        if (output.enabled == false) {
+          continue;
+        }
         auto uniqueOutputId = outputs.size();
         availableOutputsInfo.emplace_back(LogicalOutputInfo{wi, uniqueOutputId, false});
-        outputs.push_back(out);
+        outputs.push_back(output);
       }
     }
   };
@@ -879,6 +881,10 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
   std::vector<bool> matches(constOutputs.size());
   for (size_t consumer = 0; consumer < workflow.size(); ++consumer) {
     for (size_t input = 0; input < workflow[consumer].inputs.size(); ++input) {
+      // Skip disabled inputs.
+      if (workflow[consumer].inputs[input].enabled == false) {
+        continue;
+      }
       forwards.clear();
       for (size_t i = 0; i < constOutputs.size(); i++) {
         matches[i] = DataSpecUtils::match(workflow[consumer].inputs[input], constOutputs[i]);

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -169,14 +169,16 @@ TEST_CASE("TestDDS")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 },
                 {
                     &quot;binding&quot;: &quot;TST/A2/0&quot;,
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A2&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;options&quot;: [],
@@ -195,7 +197,8 @@ TEST_CASE("TestDDS")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;outputs&quot;: [
@@ -204,7 +207,8 @@ TEST_CASE("TestDDS")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;B1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;options&quot;: [],
@@ -223,7 +227,8 @@ TEST_CASE("TestDDS")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A2&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;outputs&quot;: [
@@ -232,7 +237,8 @@ TEST_CASE("TestDDS")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;C1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;options&quot;: [],
@@ -251,14 +257,16 @@ TEST_CASE("TestDDS")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;B1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 },
                 {
                     &quot;binding&quot;: &quot;y&quot;,
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;C1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;outputs&quot;: [],
@@ -433,14 +441,16 @@ TEST_CASE("TestDDSExpendable")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 },
                 {
                     &quot;binding&quot;: &quot;TST/A2/0&quot;,
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A2&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;options&quot;: [],
@@ -459,7 +469,8 @@ TEST_CASE("TestDDSExpendable")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;outputs&quot;: [
@@ -468,7 +479,8 @@ TEST_CASE("TestDDSExpendable")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;B1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;options&quot;: [],
@@ -487,7 +499,8 @@ TEST_CASE("TestDDSExpendable")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;A2&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;outputs&quot;: [
@@ -496,7 +509,8 @@ TEST_CASE("TestDDSExpendable")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;C1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;options&quot;: [],
@@ -515,14 +529,16 @@ TEST_CASE("TestDDSExpendable")
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;B1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 },
                 {
                     &quot;binding&quot;: &quot;y&quot;,
                     &quot;origin&quot;: &quot;TST&quot;,
                     &quot;description&quot;: &quot;C1&quot;,
                     &quot;subspec&quot;: 0,
-                    &quot;lifetime&quot;: 0
+                    &quot;lifetime&quot;: 0,
+                    &quot;enabled&quot;: 1
                 }
             ],
             &quot;outputs&quot;: [],


### PR DESCRIPTION
DPL: add ability to disable inputs programmatically

Disabled inputs will not result in an actual route for the data, however it
will be stored in the configuration, so that analysis workflows will not need
to have the configuration available at every step.
