### PR TITLE
Update bench_ransTPC.cxx

### DIFF
--- a/Utilities/rANS/benchmarks/bench_ransTPC.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransTPC.cxx
@@ -378,7 +378,7 @@ int main(int argc, char* argv[])
     LOG(info) << "######################################################";
   });
   writer.EndObject();
-  writer.Flush();
+  stream.Flush();
   of.close();
 
   // writerFrequencies.EndObject();


### PR DESCRIPTION
The valid use of `rapidjson::Writer::Flush` cannot be detected. 

`rapidjson::Writer::Flush` was introduced 15th of March, 2017, _without_ updating the version number (last version update is from 25th of August, 2016 from 1.0.2 to 1.1.0).  The authors of `rapidjson` should really get their act together and bump the version when they change the API.

Note that `rapidjson::Writer::Flush` simply calls
`rapidjson::OStreamWrapper::Flush`.

Thus, to ensure maximum compatibility with the last versioned `rapidjson` (present on Ubuntu, f.ex.) this changes the call according.