### PR TITLE
Cleanup and perf optimization

### DIFF
--- a/Common/Utils/src/ConfigurableParam.cxx
+++ b/Common/Utils/src/ConfigurableParam.cxx
@@ -122,7 +122,6 @@ std::string EnumRegistry::toString() const
     out.append("\n");
   }
 
-  LOG(info) << out;
   return out;
 }
 

--- a/Detectors/Base/src/Stack.cxx
+++ b/Detectors/Base/src/Stack.cxx
@@ -83,7 +83,6 @@ Stack::Stack(Int_t size)
   }
 
   auto& param = o2::sim::StackParam::Instance();
-  LOG(info) << param;
   TransportFcn transportPrimary;
   if (param.transportPrimary.compare("none") == 0) {
     transportPrimary = [](const TParticle& p, const std::vector<TParticle>& particles) {


### PR DESCRIPTION
Fixing a problem where stack params were printed
even when just doing a `o2-sim-dpl-eventgen --help`.

Evidently a Stack object was uselessly created (and printing something).