### PR TITLE
DPL: do not run the check for the case data was not created nor dispatched

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -197,6 +197,11 @@ o2::framework::ServiceSpec CommonServices::streamContextSpec()
         LOGP(debug, "Data created out of band");
         return;
       }
+      if (didCreate == false && messageContext.didDispatch() == false) {
+        O2_SIGNPOST_ID_FROM_POINTER(cid, stream_context, service);
+        O2_SIGNPOST_EVENT_EMIT(stream_context, cid, "postProcessingCallbacks", "No data created");
+        return;
+      }
       for (size_t ri = 0; ri < routes.size(); ++ri) {
         if (stream->routeUserCreated[ri] == true) {
           continue;


### PR DESCRIPTION
DPL: do not run the check for the case data was not created nor dispatched
