### PR TITLE
GLOQC: Add Cluster/Chi2 Efficiency Plots and DCAr_TPC vs P_T

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
@@ -59,7 +59,7 @@ class MatchITSTPCQC
   bool init();
   void initDataRequest();
   void run(o2::framework::ProcessingContext& ctx);
-  void setDataRequest(std::shared_ptr<o2::globaltracking::DataRequest> dr) { mDataRequest = dr; }
+  void setDataRequest(const std::shared_ptr<o2::globaltracking::DataRequest>& dr) { mDataRequest = dr; }
   void finalize();
   void reset();
 
@@ -87,6 +87,14 @@ class MatchITSTPCQC
   TH2F* getHistoEtaVsPtDen(matchType m) const { return mEtaVsPtDen[m]; }
   TEfficiency* getFractionITSTPCmatchEtaVsPt(matchType m) const { return mFractionITSTPCmatchEtaVsPt[m]; }
 
+  TH2F* getHistoClsVsPtNum(matchType m) const { return mClsVsPtNum[m]; }
+  TH2F* getHistoClsVsPtDen(matchType m) const { return mClsVsPtDen[m]; }
+  TEfficiency* getFractionITSTPCmatchClsVsPt(matchType m) const { return mFractionITSTPCmatchClsVsPt[m]; }
+
+  TH2F* getHistoChi2VsPtNum(matchType m) const { return mChi2VsPtNum[m]; }
+  TH2F* getHistoChi2VsPtDen(matchType m) const { return mChi2VsPtDen[m]; }
+  TEfficiency* getFractionITSTPCmatchChi2VsPt(matchType m) const { return mFractionITSTPCmatchChi2VsPt[m]; }
+
   TH1F* getHistoPtPhysPrimNum(matchType m) const { return mPtPhysPrimNum[m]; }
   TH1F* getHistoPtPhysPrimDen(matchType m) const { return mPtPhysPrimDen[m]; }
   TEfficiency* getFractionITSTPCmatchPhysPrim(matchType m) const { return mFractionITSTPCmatchPhysPrim[m]; }
@@ -107,6 +115,9 @@ class MatchITSTPCQC
   TH1F* getHistoChi2Refit() const { return mChi2Refit; }
   TH2F* getHistoTimeResVsPt() const { return mTimeResVsPt; }
   TH1F* getHistoDCAr() const { return mDCAr; }
+  TH2F* getHistoDCArVsPtNum() const { return mDCArVsPtNum; }
+  TH2F* getHistoDCArVsPtDen() const { return mDCArVsPtDen; }
+  TEfficiency* getFractionITSTPCmatchDCArVsPt() const { return mFractionITSTPCmatchDCArVsPt; }
 
   TH1D* getHisto1OverPtNum(matchType m) const { return m1OverPtNum[m]; }
   TH1D* getHisto1OverPtDen(matchType m) const { return m1OverPtDen[m]; }
@@ -122,7 +133,7 @@ class MatchITSTPCQC
   /// \tparam T type of the publisher
   /// \param publisher the publisher e.g. getObjectsManager()
   template <typename T>
-  void publishHistograms(std::shared_ptr<T> publisher)
+  void publishHistograms(const std::shared_ptr<T>& publisher)
   {
     for (int i = 0; i < matchType::SIZE; ++i) {
       publisher->startPublishing(mPtNum[i]);
@@ -178,6 +189,14 @@ class MatchITSTPCQC
       publisher->startPublishing(mEtaVsPtDen[i]);
       publisher->startPublishing(mFractionITSTPCmatchEtaVsPt[i]);
 
+      publisher->startPublishing(mClsVsPtNum[i]);
+      publisher->startPublishing(mClsVsPtDen[i]);
+      publisher->startPublishing(mFractionITSTPCmatchClsVsPt[i]);
+
+      publisher->startPublishing(mChi2VsPtNum[i]);
+      publisher->startPublishing(mChi2VsPtDen[i]);
+      publisher->startPublishing(mFractionITSTPCmatchChi2VsPt[i]);
+
       publisher->startPublishing(m1OverPtNum[i]);
       publisher->startPublishing(m1OverPtDen[i]);
       publisher->startPublishing(mFractionITSTPCmatch1OverPt[i]);
@@ -193,6 +212,9 @@ class MatchITSTPCQC
     publisher->startPublishing(mResidualPhi);
     publisher->startPublishing(mResidualEta);
     publisher->startPublishing(mDCAr);
+    publisher->startPublishing(mDCArVsPtNum);
+    publisher->startPublishing(mDCArVsPtDen);
+    publisher->startPublishing(mFractionITSTPCmatchDCArVsPt);
   }
 
   void setSources(GID::mask_t src) { mSrc = src; }
@@ -288,6 +310,14 @@ class MatchITSTPCQC
   TH2F* mEtaVsPtNum[matchType::SIZE] = {};
   TH2F* mEtaVsPtDen[matchType::SIZE] = {};
   TEfficiency* mFractionITSTPCmatchEtaVsPt[matchType::SIZE] = {};
+  // Clusters
+  TH2F* mClsVsPtNum[matchType::SIZE] = {};
+  TH2F* mClsVsPtDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchClsVsPt[matchType::SIZE] = {};
+  // Chi2
+  TH2F* mChi2VsPtNum[matchType::SIZE] = {};
+  TH2F* mChi2VsPtDen[matchType::SIZE] = {};
+  TEfficiency* mFractionITSTPCmatchChi2VsPt[matchType::SIZE] = {};
   // Eta split per PID hypothesis in tracking
   TH1D* mEtaNumVsTrkPID[matchType::SIZE][track::PID::NIDs] = {};
   TH1D* mEtaDenVsTrkPID[matchType::SIZE][track::PID::NIDs] = {};
@@ -301,6 +331,9 @@ class MatchITSTPCQC
   TH1F* mChi2Refit = nullptr;
   TH2F* mTimeResVsPt = nullptr;
   TH1F* mDCAr = nullptr;
+  TH2F* mDCArVsPtNum = nullptr;
+  TH2F* mDCArVsPtDen = nullptr;
+  TEfficiency* mFractionITSTPCmatchDCArVsPt = nullptr;
   // 1/Pt
   TH1D* m1OverPtNum[matchType::SIZE] = {};
   TH1D* m1OverPtDen[matchType::SIZE] = {};

--- a/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
+++ b/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
@@ -70,6 +70,16 @@ void MatchITSTPCQC::deleteHistograms()
     delete mEtaVsPtDen[i];
     delete mFractionITSTPCmatchEtaVsPt[i];
 
+    // Clusters
+    delete mClsVsPtNum[i];
+    delete mClsVsPtDen[i];
+    delete mFractionITSTPCmatchClsVsPt[i];
+
+    // Chi2
+    delete mChi2VsPtNum[i];
+    delete mChi2VsPtDen[i];
+    delete mFractionITSTPCmatchChi2VsPt[i];
+
     if (mUseTrkPID) { // Vs Tracking PID hypothesis
       for (int j = 0; j < o2::track::PID::NIDs; ++j) {
         // Pt
@@ -105,6 +115,9 @@ void MatchITSTPCQC::deleteHistograms()
   delete mChi2Refit;
   delete mTimeResVsPt;
   delete mDCAr;
+  delete mDCArVsPtNum;
+  delete mDCArVsPtDen;
+  delete mFractionITSTPCmatchDCArVsPt;
 }
 
 //__________________________________________________________
@@ -136,6 +149,14 @@ void MatchITSTPCQC::reset()
     mEtaVsPtNum[i]->Reset();
     mEtaVsPtDen[i]->Reset();
 
+    // Clusters
+    mClsVsPtNum[i]->Reset();
+    mClsVsPtDen[i]->Reset();
+
+    // Chi2
+    mChi2VsPtNum[i]->Reset();
+    mChi2VsPtDen[i]->Reset();
+
     if (mUseTrkPID) { // Vs Tracking PID hypothesis
       for (int j = 0; j < o2::track::PID::NIDs; ++j) {
         // Pt
@@ -164,6 +185,8 @@ void MatchITSTPCQC::reset()
   mChi2Refit->Reset();
   mTimeResVsPt->Reset();
   mDCAr->Reset();
+  mDCArVsPtNum->Reset();
+  mDCArVsPtDen->Reset();
 }
 
 //__________________________________________________________
@@ -172,6 +195,7 @@ bool MatchITSTPCQC::init()
 
   std::array<std::string, 2> title{"TPC", "ITS"};
   std::array<std::string, 2> etaSel{"", ", |eta| < 0.9"};
+  std::array<int, 2> maxNCls{156, 7};
   for (int i = 0; i < matchType::SIZE; ++i) {
     // Pt
     mPtNum[i] = new TH1D(Form("mPtNum_%s", title[i].c_str()), Form("Pt distribution of ITSTPC matched tracks, wrt %s tracks %s; Pt [GeV/c]; dNdPt", title[i].c_str(), etaSel[i].c_str()), 100, 0.f, 20.f);
@@ -191,9 +215,17 @@ bool MatchITSTPCQC::init()
     mEtaNum[i] = new TH1F(Form("mEtaNum_%s", title[i].c_str()), Form("Eta distribution of ITSTPC matched tracks, wrt %s tracks; Eta; dNdEta", title[i].c_str()), 100, -2.f, 2.f);
     mEtaDen[i] = new TH1F(Form("mEtaDen_%s", title[i].c_str()), Form("Eta distribution of %s tracks; Eta; dNdEta", title[i].c_str()), 100, -2.f, 2.f);
     mFractionITSTPCmatchEta[i] = new TEfficiency(Form("mFractionITSTPCmatchEta_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks , wrt %s tracks, vs Eta; Eta; Eff", title[i].c_str()), 100, -2.f, 2.f);
-    mEtaVsPtNum[i] = new TH2F(Form("mEtaVsPtNum_%s", title[i].c_str()), Form("Eta vs Pt distribution of ITSTPC matched tracks, wrt %s tracks; #it{p}_{T} [GeV#it{c}]; #it{p}_{T} [GeV#it{c}]; Eta", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
-    mEtaVsPtDen[i] = new TH2F(Form("mEtaVsPtDen_%s", title[i].c_str()), Form("Eta vs Pt distribution of %s tracks; #it{p}_{T} [GeV#it{c}]; #it{p}_{T} [GeV#it{c}]; Eta", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
+    mEtaVsPtNum[i] = new TH2F(Form("mEtaVsPtNum_%s", title[i].c_str()), Form("Eta vs Pt distribution of ITSTPC matched tracks, wrt %s tracks; #it{p}_{T} [GeV#it{c}]; Eta", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
+    mEtaVsPtDen[i] = new TH2F(Form("mEtaVsPtDen_%s", title[i].c_str()), Form("Eta vs Pt distribution of %s tracks; #it{p}_{T} [GeV#it{c}]; Eta", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
     mFractionITSTPCmatchEtaVsPt[i] = new TEfficiency(Form("mFractionITSTPCmatchEtaVsPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks, wrt %s tracks, Eta vs Pt; #it{p}_{T} [GeV#it{c}]; Eta; Eff", title[i].c_str()), 100, 0.f, 20.f, 100, -2.f, 2.f);
+    // Clusters
+    mClsVsPtNum[i] = new TH2F(Form("mClsVsPtNum_%s", title[i].c_str()), Form("#Clusters vs Pt distribution of ITSTPC matched tracks, wrt %s tracks; #it{p}_{T} [GeV#it{c}]; #Clusters", title[i].c_str()), 100, 0.f, 20.f, maxNCls[i], 0, maxNCls[i]);
+    mClsVsPtDen[i] = new TH2F(Form("mClsVsPtDen_%s", title[i].c_str()), Form("#Clusters vs Pt distribution of %s tracks; #it{p}_{T} [GeV#it{c}]; #Clusters", title[i].c_str()), 100, 0.f, 20.f, maxNCls[i], 0, maxNCls[i]);
+    mFractionITSTPCmatchClsVsPt[i] = new TEfficiency(Form("mFractionITSTPCmatchClsVsPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks, wrt %s tracks, #Clusters vs Pt; #it{p}_{T} [GeV#it{c}]; #Clusters; Eff", title[i].c_str()), 100, 0.f, 20.f, maxNCls[i], 0, maxNCls[i]);
+    // Chi2
+    mChi2VsPtNum[i] = new TH2F(Form("mChi2VsPtNum_%s", title[i].c_str()), Form("Chi2 vs Pt distribution of ITSTPC matched tracks, wrt %s tracks; #it{p}_{T} [GeV#it{c}]; Chi2", title[i].c_str()), 100, 0.f, 20.f, 200, 0, 300);
+    mChi2VsPtDen[i] = new TH2F(Form("mChi2VsPtDen_%s", title[i].c_str()), Form("Chi2 vs Pt distribution of %s tracks; #it{p}_{T} [GeV#it{c}]; Chi2", title[i].c_str()), 100, 0.f, 20.f, 200, 0, 300);
+    mFractionITSTPCmatchChi2VsPt[i] = new TEfficiency(Form("mFractionITSTPCmatchChi2VsPt_%s", title[i].c_str()), Form("Fraction of ITSTPC matched tracks, wrt %s tracks, Chi2 vs Pt; #it{p}_{T} [GeV#it{c}]; Chi2; Eff", title[i].c_str()), 100, 0.f, 20.f, 200, 0, 300);
     if (mUseTrkPID) { // Vs Tracking PID hypothesis
       for (int j = 0; j < o2::track::PID::NIDs; ++j) {
         // Pt
@@ -231,6 +263,9 @@ bool MatchITSTPCQC::init()
   mChi2Matching = new TH1F("mChi2Matching", "Chi2 of matching; chi2", 200, 0, 300);
   mChi2Refit = new TH1F("mChi2Refit", "Chi2 of refit; chi2", 200, 0, 300);
   mDCAr = new TH1F("mDCAr", "DCA of TPC tracks; DCAr", 200, -100, 100);
+  mDCArVsPtNum = new TH2F("mDCArVsPtNum", "DCA of TPC tracks Vs Pt Num; #it{p}_{T} [GeV/c]; DCAr", 100, 0, 20., 200, -30, 30);
+  mDCArVsPtDen = new TH2F("mDCArVsPtDen", "DCA of TPC tracks Vs Pt Den; #it{p}_{T} [GeV/c]; DCAr", 100, 0, 20., 200, -30, 30);
+  mFractionITSTPCmatchDCArVsPt = new TEfficiency("mFractionITSTPCmatchDCArVsPt", "Fraction of ITSTPC matched tracks wrt TPC vs DCAr; #it{p}_{T} [GeV#it{c}]; DCAr; Eff", 100, 0, 20., 200, -30, 30);
 
   // log binning for pT
   const Int_t nbinsPt = 100;
@@ -279,6 +314,14 @@ bool MatchITSTPCQC::init()
     mEtaVsPtNum[i]->Sumw2();
     mEtaVsPtDen[i]->Sumw2();
 
+    // Clusters
+    mClsVsPtNum[i]->Sumw2();
+    mClsVsPtDen[i]->Sumw2();
+
+    // Chi2
+    mChi2VsPtNum[i]->Sumw2();
+    mChi2VsPtDen[i]->Sumw2();
+
     if (mUseTrkPID) { // Vs Tracking PID hypothesis
       for (int j = 0; j < o2::track::PID::NIDs; ++j) {
         // Pt
@@ -318,6 +361,9 @@ bool MatchITSTPCQC::init()
   mChi2Matching->GetYaxis()->SetTitleOffset(1.4);
   mChi2Refit->GetYaxis()->SetTitleOffset(1.4);
   mTimeResVsPt->GetYaxis()->SetTitleOffset(1.4);
+
+  mDCArVsPtNum->Sumw2();
+  mDCArVsPtDen->Sumw2();
 
   if (mUseMC) {
     mcReader.initFromDigitContext("collisioncontext.root");
@@ -507,6 +553,25 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
         // we fill also the denominator
         mEtaDen[i]->Fill(trkDen.getEta());
         mEtaVsPtDen[i]->Fill(trkDen.getPt(), trkDen.getEta());
+        if (i == matchType::TPC) {
+          auto tpcTrk = mTPCTracks[trk.getRefTPC()];
+          mClsVsPtNum[i]->Fill(tpcTrk.getPt(), tpcTrk.getNClusters());
+          mChi2VsPtNum[i]->Fill(tpcTrk.getPt(), tpcTrk.getChi2());
+          mClsVsPtDen[i]->Fill(tpcTrk.getPt(), tpcTrk.getNClusters());
+          mChi2VsPtDen[i]->Fill(tpcTrk.getPt(), tpcTrk.getChi2());
+          math_utils::Point3D<float> v{};
+          std::array<float, 2> dca{};
+          if (tpcTrk.propagateParamToDCA(v, mBz, &dca)) {
+            mDCArVsPtNum->Fill(tpcTrk.getPt(), dca[0]);
+            mDCArVsPtDen->Fill(tpcTrk.getPt(), dca[0]);
+          }
+        } else {
+          const auto& itsTrk = mITSTracks[trk.getRefITS()];
+          mClsVsPtNum[i]->Fill(itsTrk.getPt(), itsTrk.getNClusters());
+          mChi2VsPtNum[i]->Fill(itsTrk.getPt(), itsTrk.getChi2());
+          mClsVsPtDen[i]->Fill(itsTrk.getPt(), itsTrk.getNClusters());
+          mChi2VsPtDen[i]->Fill(itsTrk.getPt(), itsTrk.getChi2());
+        }
         if (mUseTrkPID) { // Vs Tracking PID hypothesis
           mEtaNumVsTrkPID[i][trkDen.getPID()]->Fill(trkDen.getEta());
           // we fill also the denominator
@@ -594,6 +659,15 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
             mEtaNumVsTrkPID[i][trkRef.getPID()]->Fill(trkRef.getEta());
           }
           mEtaVsPtNum[i]->Fill(trkRef.getPt(), trkRef.getEta());
+          if (i == matchType::TPC) {
+            const auto& tpcTrk = mTPCTracks[trk.getRefTPC()];
+            mClsVsPtNum[i]->Fill(tpcTrk.getPt(), tpcTrk.getNClusters());
+            mChi2VsPtNum[i]->Fill(tpcTrk.getPt(), tpcTrk.getChi2());
+          } else {
+            const auto& itsTrk = mITSTracks[trk.getRefITS()];
+            mClsVsPtNum[i]->Fill(itsTrk.getPt(), itsTrk.getNClusters());
+            mChi2VsPtNum[i]->Fill(itsTrk.getPt(), itsTrk.getChi2());
+          }
         }
         if (i == matchType::TPC) {
           mResidualPt->Fill(trk.getPt(), trk.getPt() - trkRef.getPt());
@@ -606,6 +680,7 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
           std::array<float, 2> dca;
           if (trkRef.propagateParamToDCA(v, mBz, &dca)) {
             mDCAr->Fill(dca[0]);
+            mDCArVsPtNum->Fill(trkRef.getPt(), dca[0]);
           }
           LOG(debug) << "*** chi2Matching = " << trk.getChi2Match() << ", chi2refit = " << trk.getChi2Refit() << ", timeResolution = " << trk.getTimeMUS().getTimeStampError();
         }
@@ -699,6 +774,13 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
       mEtaDen[matchType::TPC]->Fill(trk.getEta());
       mEtaVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getEta());
       m1OverPtDen[matchType::TPC]->Fill(trk.getSign() * trk.getPtInv());
+      mClsVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getNClusters());
+      mChi2VsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getChi2());
+      math_utils::Point3D<float> v{};
+      std::array<float, 2> dca{};
+      if (auto trc = trk; trc.propagateParamToDCA(v, mBz, &dca)) {
+        mDCArVsPtDen->Fill(trc.getPt(), dca[0]);
+      }
       if (el.second.mIsPhysicalPrimary) {
         mPtPhysPrimDen[matchType::TPC]->Fill(trk.getPt());
         mPhiPhysPrimDen[matchType::TPC]->Fill(trk.getPhi());
@@ -720,6 +802,8 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
       }
       mEtaDen[matchType::ITS]->Fill(trk.getEta());
       mEtaVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getEta());
+      mClsVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getNClusters());
+      mChi2VsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getChi2());
       if (el.second.mIsPhysicalPrimary) {
         if (std::abs(trk.getEta()) < 0.9) {
           mPtPhysPrimDen[matchType::ITS]->Fill(trk.getPt());
@@ -747,6 +831,13 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
         mEtaDen[matchType::TPC]->Fill(trk.getEta());
         mEtaVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getEta());
         m1OverPtDen[matchType::TPC]->Fill(trk.getSign() * trk.getPtInv());
+        mClsVsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getNClusters());
+        mChi2VsPtDen[matchType::TPC]->Fill(trk.getPt(), trk.getChi2());
+        math_utils::Point3D<float> v{};
+        std::array<float, 2> dca{};
+        if (auto trc = trk; trc.propagateParamToDCA(v, mBz, &dca)) {
+          mDCArVsPtDen->Fill(trc.getPt(), dca[0]);
+        }
         ++mNTPCSelectedTracks;
       }
     }
@@ -768,6 +859,8 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
         }
         mEtaDen[matchType::ITS]->Fill(trk.getEta());
         mEtaVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getEta());
+        mClsVsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getNClusters());
+        mChi2VsPtDen[matchType::ITS]->Fill(trk.getPt(), trk.getChi2());
         ++mNITSSelectedTracks;
       } else {
         LOG(debug) << "Not filling for this track (ITS) " << itrk << " with pt = " << trk.getPt();
@@ -793,7 +886,7 @@ bool MatchITSTPCQC::selectTrack(o2::tpc::TrackTPC const& track)
   }
 
   math_utils::Point3D<float> v{};
-  std::array<float, 2> dca;
+  std::array<float, 2> dca{};
   if (!(const_cast<o2::tpc::TrackTPC&>(track).propagateParamToDCA(v, mBz, &dca, mDCATPCCut)) || std::abs(dca[0]) > mDCATPCCutY) {
     return false;
   }
@@ -841,6 +934,8 @@ void MatchITSTPCQC::finalize()
     setEfficiency(mFractionITSTPCmatchPhiVsPt[ti], mPhiVsPtNum[ti], mPhiVsPtDen[ti], true);
     setEfficiency(mFractionITSTPCmatchEtaVsPt[ti], mEtaVsPtNum[ti], mEtaVsPtDen[ti], true);
     setEfficiency(mFractionITSTPCmatch1OverPt[ti], m1OverPtNum[ti], m1OverPtDen[ti]);
+    setEfficiency(mFractionITSTPCmatchClsVsPt[ti], mClsVsPtNum[ti], mClsVsPtDen[ti], true);
+    setEfficiency(mFractionITSTPCmatchChi2VsPt[ti], mChi2VsPtNum[ti], mChi2VsPtDen[ti], true);
     if (mUseTrkPID) { // Vs Tracking PID hypothesis
       for (int j = 0; j < o2::track::PID::NIDs; ++j) {
         setEfficiency(mFractionITSTPCmatchPtVsTrkPID[ti][j], mPtNumVsTrkPID[ti][j], mPtDenVsTrkPID[ti][j]);
@@ -855,6 +950,7 @@ void MatchITSTPCQC::finalize()
       setEfficiency(mFractionITSTPCmatchPhysPrim1OverPt[ti], m1OverPtPhysPrimNum[ti], m1OverPtPhysPrimDen[ti]);
     }
   }
+  setEfficiency(mFractionITSTPCmatchDCArVsPt, mDCArVsPtNum, mDCArVsPtDen, true);
   /*
   mPtTPC->Scale(scaleFactTPC);
   mPt->Scale(scaleFactITSTPC);
@@ -877,25 +973,49 @@ void MatchITSTPCQC::finalize()
 
 void MatchITSTPCQC::setEfficiency(TEfficiency* eff, TH1* hnum, TH1* hden, bool is2D)
 {
-  if (!eff) {
+  if (eff == nullptr) {
     LOG(fatal) << "Cannot get TEfficiency object ";
   }
-  if (!hnum) {
+  if (hnum == nullptr) {
     LOG(fatal) << "Cannot get numerator histogram for TEfficiency object " << eff->GetName();
   }
-  if (!hden) {
+  if (hden == nullptr) {
     LOG(fatal) << "Cannot get denominator histogram for TEfficiency object " << eff->GetName();
   }
-  LOG(info) << "Setting efficiency " << eff->GetName() << " from " << hnum->GetName() << " and " << hden->GetName();
 
   // we need to force to replace the total histogram, otherwise it will compare it to the previous passed one, and it might get an error of inconsistency in the bin contents
-  if constexpr (0) { // checking
-    LOG(info) << "Num " << hnum->GetName() << " " << hnum->GetNbinsX() << " " << hnum->GetNbinsY();
-    LOG(info) << "Den " << hden->GetName() << " " << hden->GetNbinsX() << " " << hden->GetNbinsY();
-    for (int i = 1; i <= hden->GetNbinsX(); i++) {
-      if (hden->GetBinContent(i) < hnum->GetBinContent(i)) {
-        LOG(warning) << "bin " << i << " den: " << hden->GetBinContent(i) << " < num: " << hnum->GetBinContent(i) << " should be the opposite";
+  if constexpr (false) { // checking
+    bool bad{false};
+    LOG(info) << "Setting efficiency " << eff->GetName() << " from " << hnum->GetName() << " and " << hden->GetName();
+    LOG(info) << "Num " << hnum->GetName() << " " << hnum->GetNbinsX() << " " << hnum->GetNbinsY() << " with " << hnum->GetEntries() << " entries";
+    LOG(info) << "Den " << hden->GetName() << " " << hden->GetNbinsX() << " " << hden->GetNbinsY() << " with " << hden->GetEntries() << " entries";
+    if (hnum->GetDimension() != hden->GetDimension()) {
+      LOGP(warning, "Histograms have different dimensions (num={} to den={})", hnum->GetDimension(), hden->GetDimension());
+      bad = true;
+    }
+    if (!TEfficiency::CheckBinning(*hnum, *hden)) {
+      LOGP(warning, "Histograms do not have a compatible binning");
+      bad = true;
+    }
+    if (!is2D) {
+      for (int i = 1; i <= hden->GetNbinsX(); i++) {
+        if (hden->GetBinContent(i) < hnum->GetBinContent(i)) {
+          LOG(warning) << "bin " << i << " den: " << hden->GetBinContent(i) << " < num: " << hnum->GetBinContent(i) << " should be the opposite";
+          bad = true;
+        }
       }
+    } else {
+      for (int i = 1; i <= hden->GetNbinsX(); i++) {
+        for (int j = 1; j <= hden->GetNbinsY(); j++) {
+          if (hden->GetBinContent(i, j) < hnum->GetBinContent(i, j)) {
+            LOGP(warning, "bin {}/{} -> den: {} < num: {}", i, j, hden->GetBinContent(i, j), hnum->GetBinContent(i, j));
+            bad = true;
+          }
+        }
+      }
+    }
+    if (bad) {
+      return;
     }
   }
   // we need to force to replace the total histogram, otherwise it will compare it to the previous passed one, and it might get an error of inconsistency in the bin contents
@@ -971,6 +1091,14 @@ void MatchITSTPCQC::getHistos(TObjArray& objar)
     objar.Add(mEtaVsPtDen[i]);
     objar.Add(mFractionITSTPCmatchEtaVsPt[i]);
 
+    objar.Add(mClsVsPtNum[i]);
+    objar.Add(mClsVsPtDen[i]);
+    objar.Add(mFractionITSTPCmatchClsVsPt[i]);
+
+    objar.Add(mChi2VsPtNum[i]);
+    objar.Add(mChi2VsPtDen[i]);
+    objar.Add(mFractionITSTPCmatchChi2VsPt[i]);
+
     objar.Add(m1OverPtNum[i]);
     objar.Add(m1OverPtDen[i]);
     objar.Add(mFractionITSTPCmatch1OverPt[i]);
@@ -986,4 +1114,7 @@ void MatchITSTPCQC::getHistos(TObjArray& objar)
   objar.Add(mResidualPhi);
   objar.Add(mResidualEta);
   objar.Add(mDCAr);
+  objar.Add(mDCArVsPtNum);
+  objar.Add(mDCArVsPtDen);
+  objar.Add(mFractionITSTPCmatchDCArVsPt);
 }

--- a/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
@@ -29,18 +29,18 @@ namespace o2
 namespace globaltracking
 {
 
-void ITSTPCMatchingQCDevice::init(InitContext& ic)
+void ITSTPCMatchingQCDevice::init(InitContext& /*ic*/)
 {
-  const o2::globaltracking::ITSTPCMatchingQCParams* params = &o2::globaltracking::ITSTPCMatchingQCParams::Instance();
+  const o2::globaltracking::ITSTPCMatchingQCParams& params = o2::globaltracking::ITSTPCMatchingQCParams::Instance();
 
   mMatchITSTPCQC = std::make_unique<o2::globaltracking::MatchITSTPCQC>();
   mMatchITSTPCQC->init();
   mMatchITSTPCQC->setDataRequest(mDataRequest);
-  mMatchITSTPCQC->setPtCut(params->minPtCut);
-  mMatchITSTPCQC->setEtaCut(params->etaCut);
-  mMatchITSTPCQC->setMinNTPCClustersCut(params->minNTPCClustersCut);
-  mMatchITSTPCQC->setMinDCAtoBeamPipeDistanceCut(params->minDCACut);
-  mMatchITSTPCQC->setMinDCAtoBeamPipeYCut(params->minDCACutY);
+  mMatchITSTPCQC->setPtCut(params.minPtCut);
+  mMatchITSTPCQC->setEtaCut(params.etaCut);
+  mMatchITSTPCQC->setMinNTPCClustersCut(params.minNTPCClustersCut);
+  mMatchITSTPCQC->setMinDCAtoBeamPipeDistanceCut(params.minDCACut);
+  mMatchITSTPCQC->setMinDCAtoBeamPipeYCut(params.minDCACutY);
   o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
   if (mUseMC) {
     mMatchITSTPCQC->setUseMC(mUseMC);
@@ -74,6 +74,10 @@ void ITSTPCMatchingQCDevice::sendOutput(DataAllocator& output)
   output.snapshot(Output{"GLO", "ITSTPCMATCHQC", 0}, objar);
 
   TFile* f = new TFile(Form("outITSTPCmatchingQC.root"), "RECREATE");
+  if (f == nullptr) {
+    LOGP(error, "Cannot write QC to file 'outITSTPCmatchingQC.root'");
+    return;
+  }
   objar.Write("ObjArray", TObject::kSingleKey);
   f->Close();
 }


### PR DESCRIPTION
Pinging @mfaggin.
This adds these plots (data is pbpb_apass1_relval_debug/0720):
![c1](https://github.com/AliceO2Group/AliceO2/assets/42321018/9d90d4f7-53b3-4388-842c-48a6d3aea849)
Plot 1,2(left-right): Efficiency Vs Cluster Vs Pt for $\frac{NClusters_{ITSTPC}(p_{T,DET})}{NClusters_{DET}(p_{T,DET})}$ DET=ITS,TPC
Plot 3,4 Same but for Chi2
Plot 5 DCAr Vs Pt for TPC tracks