### PR TITLE
Switch on reading of BadChannel CCDB information in StatusMap Creator with protection added

### DIFF
--- a/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
+++ b/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
@@ -29,7 +29,7 @@ struct DigitFilterParam : public o2::conf::ConfigurableParamHelper<DigitFilterPa
   bool rejectBackground = true; ///< attempts to reject background (loose background selection, don't kill signal)
   bool selectSignal = false;    ///< attempts to select only signal (strict background selection, might loose signal)
   int timeOffset = 120;         ///< digit time calibration offset
-  uint32_t statusMask = 0;      ///< mask to reject digits based on the statusmap (0=no rejection,1=badchannels from ped calib only,2=badchannels from rejectlist,3=1+2)
+  uint32_t statusMask = 3;      ///< mask to reject digits based on the statusmap (0=no rejection,1=badchannels from ped calib only,2=badchannels from rejectlist,3=1+2)
 
   O2ParamDef(DigitFilterParam, "MCHDigitFilter");
 };

--- a/Detectors/MUON/MCH/Status/include/MCHStatus/StatusMapCreatorParam.h
+++ b/Detectors/MUON/MCH/Status/include/MCHStatus/StatusMapCreatorParam.h
@@ -24,7 +24,7 @@ namespace o2::mch
  */
 struct StatusMapCreatorParam : public o2::conf::ConfigurableParamHelper<StatusMapCreatorParam> {
 
-  bool useBadChannels = false; ///< reject bad channels (obtained during pedestal calibration runs)
+  bool useBadChannels = true; ///< reject bad channels (obtained during pedestal calibration runs)
   bool useRejectList = true;  ///< use extra (relative to bad channels above) rejection list
 
   bool isActive() const { return useBadChannels || useRejectList; }

--- a/Detectors/MUON/MCH/Status/src/StatusMapCreatorSpec.cxx
+++ b/Detectors/MUON/MCH/Status/src/StatusMapCreatorSpec.cxx
@@ -53,11 +53,10 @@ class StatusMapCreatorTask
 
     void updateStatusMap()
     {
-      mStatusMap.clear();
-     
-      //create filtered vectors to reject unphysical Solar Id, Elink Id, Channel Id stored in the Bad Channel CCDB
-      std::vector<o2::mch::DsChannelId> filteredBadChannels;
-      std::vector<o2::mch::DsChannelId> filteredRejectList;
+        mStatusMap.clear();
+        //create filtered vectors to reject unphysical Solar Id, Elink Id, Channel Id stored in the Bad Channel CCDB
+        std::vector<o2::mch::DsChannelId> filteredBadChannels;
+        std::vector<o2::mch::DsChannelId> filteredRejectList;
         
         for (const auto& channel : mBadChannels) {
             // Check if the channel has a (SolarId, LinkId, channelId)  that corresponds to a valid Detection Element and valid Pad
@@ -68,29 +67,29 @@ class StatusMapCreatorTask
             std::optional<o2::mch::raw::DsDetId> dsDetId = mElec2DetMapper(dsElecId);
             if(!dsDetId){
                 LOGP(info, "No detection element associated to this channel from Bad Channels CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             channel.getSolarId(), channel.getElinkId(), channel.getChannel());
+                     channel.getSolarId(), channel.getElinkId(), channel.getChannel());
                 continue;}
             auto deId = dsDetId->deId();
             if(!deId){
                 LOGP(info, "No detection element id associated to this channel from Bad Channels CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             channel.getSolarId(), channel.getElinkId(), channel.getChannel());
+                     channel.getSolarId(), channel.getElinkId(), channel.getChannel());
                 continue;}
             const auto& seg = o2::mch::mapping::segmentation(deId);
             auto dsId = dsDetId->dsId();
             if(!dsId){
                 LOGP(info, "No ds element associated to this channel from Bad Channels CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             channel.getSolarId(), channel.getElinkId(), channel.getChannel());
+                     channel.getSolarId(), channel.getElinkId(), channel.getChannel());
                 continue;}
             int dePadIndex = seg.findPadByFEE(dsId, channel.getChannel());
             if (!seg.isValid(dePadIndex)){
                 LOGP(info, "No Valid Pad index associated to this channel from Bad Channels CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             channel.getSolarId(), channel.getElinkId(), channel.getChannel());
+                     channel.getSolarId(), channel.getElinkId(), channel.getChannel());
                 continue;
             }
             
-           
+            
             LOGP(info, "List of Valid Channels from Bad Channels CCDB - SolarId: {} ElinkId: {} Channel: {}. This channel is kept",
-                         channel.getSolarId(), channel.getElinkId(), channel.getChannel());
+                 channel.getSolarId(), channel.getElinkId(), channel.getChannel());
             filteredBadChannels.push_back(channel);
         }
         
@@ -104,39 +103,39 @@ class StatusMapCreatorTask
             std::optional<o2::mch::raw::DsDetId> rldsDetId = rlmElec2DetMapper(rldsElecId);
             if(!rldsDetId){
                 LOGP(info, "No detection element associated to this channel from Reject List CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
+                     rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
                 continue;}
             auto rldeId = rldsDetId->deId();
             if(!rldeId){
                 LOGP(info, "No detection element id associated to this channel from Reject List CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
+                     rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
                 continue;}
             const auto& rlseg = o2::mch::mapping::segmentation(rldeId);
             auto rldsId = rldsDetId->dsId();
             if(!rldsId){
                 LOGP(info, "No ds element associated to this channel from Reject List CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
+                     rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
                 continue;}
             int rldePadIndex = rlseg.findPadByFEE(rldsId, rlchannel.getChannel());
             if (!rlseg.isValid(rldePadIndex)){
                 LOGP(info, "No Valid Pad index associated to this channel from Reject List CCDB - SolarId: {} ElinkId: {} Channel: {}. Skip this channel",
-                             rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
+                     rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
                 continue;
             }
             
-           
+            
             LOGP(info, "List of Valid Channels from Reject List CCDB - SolarId: {} ElinkId: {} Channel: {}. This channel is kept",
-                         rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
+                 rlchannel.getSolarId(), rlchannel.getElinkId(), rlchannel.getChannel());
             filteredRejectList.push_back(rlchannel);
-      }
-
-
-      // Update the StatusMap with the filtered vector
-      mStatusMap.add(filteredBadChannels, StatusMap::kBadPedestal);
-      mStatusMap.add(filteredRejectList, StatusMap::kRejectList);
+        }
         
-      mStatusMapUpdated = true;
-  }
+        
+        // Update the StatusMap with the filtered vector
+        mStatusMap.add(filteredBadChannels, StatusMap::kBadPedestal);
+        mStatusMap.add(filteredRejectList, StatusMap::kRejectList);
+        
+        mStatusMapUpdated = true;
+    }
 
   void
     init(InitContext& ic)


### PR DESCRIPTION
Switch on reading of BadChannel CCDB information in StatusMap Creator. 
A protection has been added to remove from the list of BadChannels unphysical (SolarId, Elink Id, Channel Id) as well as Invalid Pad Id