### PR TITLE
User-defined particle filtering in Pythia8 events

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -16,6 +16,7 @@
 
 #include "Generators/Generator.h"
 #include "Pythia8/Pythia.h"
+#include <functional>
 
 namespace o2
 {
@@ -160,6 +161,8 @@ class GeneratorPythia8 : public Generator
     getNfreeSpec(mPythia.info, nFreenProj, nFreepProj, nFreenTarg, nFreepTarg);
   };
 
+  typedef std::function<bool(const Pythia8::Particle&)> UserFilterFcn;
+
  protected:
   /** copy constructor **/
   GeneratorPythia8(const GeneratorPythia8&);
@@ -170,7 +173,7 @@ class GeneratorPythia8 : public Generator
    * @name Some function definitions
    */
   /** Select particles when pruning event */
-  typedef bool (*Select)(const Pythia8::Particle& particle);
+  typedef UserFilterFcn Select;
   /** Get relatives (mothers or daughters) of a particle */
   typedef std::vector<int> (*GetRelatives)(const Pythia8::Particle&);
   /** Set relatives (mothers or daughters) of a particle */
@@ -261,6 +264,11 @@ class GeneratorPythia8 : public Generator
    * Pythia8::UserHooks object */
   std::string mHooksFuncName;
   /** @} */
+
+  UserFilterFcn mUserFilterFcn = [](Pythia8::Particle const&) -> bool { return true; };
+  void initUserFilterCallback();
+
+  bool mApplyPruning = false;
 
   ClassDefOverride(GeneratorPythia8, 1);
 

--- a/Generators/include/Generators/GeneratorPythia8Param.h
+++ b/Generators/include/Generators/GeneratorPythia8Param.h
@@ -34,6 +34,7 @@ struct GeneratorPythia8Param : public o2::conf::ConfigurableParamHelper<Generato
   std::string hooksFileName = "";
   std::string hooksFuncName = "";
   bool includePartonEvent = false; // whether to keep the event before hadronization
+  std::string particleFilter = ""; // user particle filter
   O2ParamDef(GeneratorPythia8Param, "GeneratorPythia8");
 };
 

--- a/run/dpl_eventgen.cxx
+++ b/run/dpl_eventgen.cxx
@@ -19,6 +19,9 @@
 #include <CommonUtils/ConfigurableParam.h>
 #include <CommonUtils/RngHelper.h>
 #include <TStopwatch.h> // simple timer from ROOT
+#include <DetectorsCommonDataFormats/DetectorNameConf.h>
+#include <DetectorsBase/Detector.h>
+#include <TFile.h>
 #include <memory>
 
 using namespace o2::framework;
@@ -33,9 +36,12 @@ struct GeneratorTask {
   Configurable<int> aggregate{"aggregate-timeframe", 300, "Number of events to put in a timeframe"};
   Configurable<std::string> vtxModeArg{"vertexMode", "kDiamondParam", "Where the beam-spot vertex should come from. Must be one of kNoVertex, kDiamondParam, kCCDB"};
   Configurable<int64_t> ttl{"time-limit", -1, "Maximum run time limit in seconds (default no limit)"};
+  Configurable<std::string> outputPrefix{"output", "", "Optional prefix for kinematics files written on disc. If non-empty, files <prefix>_Kine.root + <prefix>_MCHeader.root will be created."};
   int nEvents = 0;
   int eventCounter = 0;
   int tfCounter = 0;
+  std::unique_ptr<TFile> outfile{};
+  std::unique_ptr<TTree> outtree{};
 
   // a pointer because object should only be constructed in the device (not during DPL workflow setup)
   std::unique_ptr<o2::eventgen::GeneratorService> genservice;
@@ -64,19 +70,36 @@ struct GeneratorTask {
       LOG(warn) << "Not yet supported. This needs definition of a timestamp and fetching of the MeanVertex CCDB object";
     }
     timer.Start();
+
+    if (outputPrefix->size() > 0 && !outfile.get()) {
+      auto kineoutfilename = o2::base::NameConf::getMCKinematicsFileName(outputPrefix->c_str());
+      outfile.reset(new TFile(kineoutfilename.c_str(), "RECREATE"));
+      outtree.reset(new TTree("o2sim", "o2sim"));
+    }
   }
 
   void run(o2::framework::ProcessingContext& pc)
   {
     std::vector<o2::MCTrack> mctracks;
     o2::dataformats::MCEventHeader mcheader;
+    auto mctrack_ptr = &mctracks;
+    if (outfile.get()) {
+      auto br = o2::base::getOrMakeBranch(*outtree, "MCTrack", &mctrack_ptr);
+      br->SetAddress(&mctrack_ptr);
+    }
+
     for (auto i = 0; i < std::min((int)aggregate, nEvents - eventCounter); ++i) {
       mctracks.clear();
       genservice->generateEvent_MCTracks(mctracks, mcheader);
       pc.outputs().snapshot(Output{"MC", "MCHEADER", 0}, mcheader);
       pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0}, mctracks);
       ++eventCounter;
+
+      if (outfile.get() && outtree.get()) {
+        outtree->Fill();
+      }
     }
+
     // report number of TFs injected for the rate limiter to work
     pc.services().get<o2::monitoring::Monitoring>().send(o2::monitoring::Metric{(uint64_t)tfCounter, "df-sent"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
     ++tfCounter;
@@ -92,6 +115,13 @@ struct GeneratorTask {
     if (eventCounter >= nEvents || time_expired) {
       pc.services().get<ControlService>().endOfStream();
       pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+
+      // write out data to disc if asked
+      if (outfile.get()) {
+        outtree->SetEntries(eventCounter);
+        outtree->Write();
+        outfile->Close();
+      }
     }
   }
 };


### PR DESCRIPTION
Provide the possibility to define a Pythia8 particle-filter function during runtime.
The filter function should be defined in a (macro) file (e.g., pythia8filter.macro).

The file should contain a function returning a C++ lambda with the filter function. A small example is:

```
o2::eventgen::GeneratorPythia8::UserFilterFcn filterPythia() {
  return [](Pythia8::Particle const &p) {
    // we keep only final state particles in some acceptance
    if (p.statusHepMC() == 1) {
      return std::abs(p.eta()) < 2.0;
    }
    // ... or internal particles
    return true;
  };
}
```

Application of this filter is done via setting the configurable parameter

```
GeneratorPythia8.particleFilter=pythia8filter.macro
```

Fixes https://its.cern.ch/jira/browse/O2-4577