### PR TITLE
DPL: make sure we do not invoke user callback when Discarding

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -2297,8 +2297,8 @@ bool DataProcessingDevice::tryDispatchComputation(ServiceRegistryRef ref, std::v
       if (spec.forwards.empty() == false) {
         auto& timesliceIndex = ref.get<TimesliceIndex>();
         forwardInputs(ref, action.slot, currentSetOfInputs, timesliceIndex.getOldestPossibleOutput(), false);
-        continue;
       }
+      continue;
     }
     // If there is no optional inputs we canForwardEarly
     // the messages to that parallel processing can happen.


### PR DESCRIPTION
DPL: make sure we do not invoke user callback when Discarding

Not sure this is actually the correct thing to do.
