### PR TITLE
TPC dEdx calib request geometry

### DIFF
--- a/Detectors/TPC/workflow/src/CalibdEdxSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalibdEdxSpec.cxx
@@ -65,6 +65,11 @@ class CalibdEdxDevice : public Task
     mCalib->set2DFitThreshold(minEntries2D);
     mCalib->setElectronCut(fitThreshold, fitPasses, fitThresholdLowFactor);
     mCalib->setMaterialType(mMatType);
+
+    o2::base::Propagator::Instance()->setTGeoFallBackAllowed(false);
+    if (mMatType == o2::base::Propagator::MatCorrType::USEMatCorrTGeo) {
+      LOG(error) << "Must not configure TGeo for material correction as that is not available for processing";
+    }
   }
 
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final


### PR DESCRIPTION
It seems the TPC dEdx calibration requires the geometry to be there. At least in the synthetic run 546312 it crashed with the stack trace below. In the FST the crash was not reproducible, not clear if the track propagation loop was not entered there.

```
#0  0x00001465c77455c9 in TGeoManager::GetCurrentNavigator (this=0x0) at /local/workspace/DailyBuilds/DailyO2epn/daily-tags.CgzX6UHAhM/SOURCES/ROOT/v6-30-01-alice2/v6-30-01-alice2/geom/geom/src/TGeoManager.cxx:816
#1  0x00001465c7748041 in TGeoManager::InitTrack (this=<optimized out>, point=point@entry=0x7fff15a64690, dir=dir@entry=0x7fff15a646b0) at /local/workspace/DailyBuilds/DailyO2epn/daily-tags.CgzX6UHAhM/SOURCES/ROOT/v6-30-01-alice2/v6-30-01-alice2/geom/geom/src/TGeoManager.cxx:2856
#2  0x00001465cc438761 in o2::base::GeometryManager::meanMaterialBudget (x0=<optimized out>, y0=<optimized out>, z0=<optimized out>, x1=<optimized out>, y1=<optimized out>, z1=<optimized out>) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/Base/src/GeometryManager.cxx:429
#3  0x00001465cc450267 in o2::base::GeometryManager::meanMaterialBudget (end=..., start=...) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/slc8_x86-64/ROOT/v6-30-01-alice2-6/include/Math/GenVector/Cartesian3D.h:109
#4  0x00001465cc454c6f in o2::base::PropagatorImpl<float>::PropagateToXBxByBz(o2::track::TrackParametrization<float>&, float, float, float, o2::base::PropagatorImpl<float>::MatCorrType, o2::track::TrackLTIntegral*, int) const::{lambda()#1}::operator()() const (__closure=<synthetic pointer>)
    at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/Base/src/Propagator.cxx:256
#5  o2::base::PropagatorImpl<float>::PropagateToXBxByBz (this=0x1465d1f22f60 <o2::base::PropagatorImpl<float>::Instance(bool)::instance>, this@entry=0x1465d087be40 <o2::base::PropagatorImpl<float>::Instance(bool)::instance>, track=..., xToGo=108.474998, maxSnp=maxSnp@entry=0.899999976, maxStep=maxStep@entry=2, matCorr=o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT, tofInfo=tofInfo@entry=0x0, signCorr=-1, signCorr@entry=0)
    at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/Base/src/Propagator.cxx:280
#6  0x00001465d06bbc8f in o2::tpc::CalibdEdx::fill (track=..., this=0x6b06d90) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/TPC/calibration/src/CalibdEdx.cxx:84
#7  o2::tpc::CalibdEdx::fill (this=0x6b06d90, track=...) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/TPC/calibration/src/CalibdEdx.cxx:58
#8  0x00001465d06bbfc9 in o2::tpc::CalibdEdx::fill (this=0x6b06d90, tracks=...) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/TPC/calibration/src/CalibdEdx.cxx:112
```