### PR TITLE
o2-sim: Change way to create standalone MCHeader file

### DIFF
--- a/DataFormats/simulation/src/MCEventHeader.cxx
+++ b/DataFormats/simulation/src/MCEventHeader.cxx
@@ -61,6 +61,54 @@ void MCEventHeader::extractFileFromKinematics(std::string_view kinefilename, std
   }
 }
 
+/** alternative implementations below
+
+void MCEventHeader::extractFileFromKinematics(std::string_view kinefilename, std::string_view targetfilename) {
+  TFile kinefile(kinefilename.data(), "OPEN");
+  auto kinetree = static_cast<TTree*>(kinefile.Get("o2sim")); // belongs to "kinefile"
+  kinetree->SetBranchStatus("*", 0);
+  // activate header branch
+  kinetree->SetBranchStatus("MCEventHeader*", 1);
+  std::unique_ptr<TFile> headeronlyfile{TFile::Open(targetfilename.data(), "RECREATE")};
+  auto headeronlytree = kinetree->CloneTree(0);
+
+  // copy the branches
+  headeronlytree->CopyEntries(kinetree, kinetree->GetEntries());
+  headeronlytree->SetEntries(kinetree->GetEntries());
+  // flush to disc
+  headeronlytree->Write();
+}
+
+void MCEventHeader::extractFileFromKinematics(std::string_view kinefilename, std::string_view targetfilename)
+{
+  TFile kinefile(kinefilename.data(), "OPEN");
+  auto kinetree = static_cast<TTree*>(kinefile.Get("o2sim")); // owned by "kinefile"
+  auto headerbranchorig = kinetree->GetBranch("MCEventHeader.");
+  if (!headerbranchorig) {
+    return;
+  }
+
+  std::unique_ptr<TFile> headeronlyfile{TFile::Open(targetfilename.data(), "RECREATE")};
+  auto headeronlytree = new TTree("o2sim", "o2sim"); // owned by headeronlyfile
+  MCEventHeader* header = nullptr;
+  auto targetBranch = headeronlytree->Branch("MCEventHeader.", &header);
+  headerbranchorig->SetAddress(&header);
+
+  for (auto entry = 0; entry < kinetree->GetEntries(); ++entry) {
+    headerbranchorig->GetEntry(entry);
+    targetBranch->Fill();
+    if (header) {
+      delete header;
+      header = nullptr;
+    }
+  }
+  headeronlytree->SetEntries(kinetree->GetEntries());
+  // flush to disc
+  headeronlytree->Write();
+}
+
+*/
+
 /*****************************************************************/
 /*****************************************************************/
 

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -346,7 +346,7 @@ void launchShutdownThread()
 
     struct timespec initial, remaining;
     initial.tv_sec = 5;
-    // for for specified time ... (and account for possible signal interruptions)
+    // wait for specified time ... (and account for possible signal interruptions)
     while (nanosleep(&initial, &remaining) == -1 && remaining.tv_sec > 0) {
       initial = remaining;
     }
@@ -772,22 +772,8 @@ int main(int argc, char* argv[])
   // (mainly useful for continuous integration / automated testing suite)
   auto returncode = errored ? 1 : checkresult();
   if (returncode == 0) {
-    // Extract a single file for MCEventHeaders
-    // This file will be small and can quickly unblock start of signal transport (in embedding).
-    // This is useful when we cache background events on the GRID. The headers file can be copied quickly
-    // and the rest of kinematics + Hits may follow asyncronously since they are only needed at much
-    // later stages (digitization).
-
-    auto& conf = o2::conf::SimConfig::Instance();
-    if (conf.writeToDisc()) {
-      // easy check: see if we have number of entries in output tree == number of events asked
-      std::string kinefilename = o2::base::NameConf::getMCKinematicsFileName(conf.getOutPrefix().c_str());
-      std::string headerfilename = o2::base::NameConf::getMCHeadersFileName(conf.getOutPrefix().c_str());
-      o2::dataformats::MCEventHeader::extractFileFromKinematics(kinefilename, headerfilename);
-    }
     LOG(info) << "SIMULATION RETURNED SUCCESFULLY";
   }
-
   cleanup();
   return returncode;
 }


### PR DESCRIPTION
This is changing the way we create o2sim_MCHeader.root, which is now created directly in the merger device.

The reason for this change is an (unexplainable) segmentation fault in the routine MCEventHeader::extractFileFromKinematics on some ARM servers (CNAF). This routine was until now used to copy MC header information from o2sim_Kine.root to o2sim_MCHeader.root

The present change avoids this segfault.