### PR TITLE
Debug DataAllocator::matchDataHeader crash

### DIFF
--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -53,7 +53,7 @@ RouteIndex DataAllocator::matchDataHeader(const Output& spec, size_t timeslice)
   for (auto ri = 0; ri < allowedOutputRoutes.size(); ++ri) {
     auto& route = allowedOutputRoutes[ri];
     if (DataSpecUtils::match(route.matcher, spec.origin, spec.description, spec.subSpec) && ((timeslice % route.maxTimeslices) == route.timeslice)) {
-      stream.routeUserCreated[ri] = true;
+      stream.routeUserCreated.at(ri) = true;
       return RouteIndex{ri};
     }
   }


### PR DESCRIPTION
Hi @ktf I am trying to understand a crash that was observed running at P2, but not in my local FST. See stacktrace below. gdb tells me `ri=4`, but I cannot check the stream.routeUserCreated size. But seems to be out of bounds access which happens at end of stream:
```
#0  std::_Bit_reference::operator= (__x=true, this=<optimized out>) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/slc8_x86-64/GCC-Toolchain/v12.2.0-alice1-6/include/c++/12.2.0/bits/stl_bvector.h:103
#1  o2::framework::DataAllocator::matchDataHeader (this=this@entry=0x58e9290, spec=..., timeslice=22760714681488) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Framework/Core/src/DataAllocator.cxx:56
#2  0x000000000043c409 in o2::framework::DataAllocator::snapshot<std::vector<float, std::allocator<float> > > (this=0x58e9290, spec=..., object=...) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Framework/Core/include/Framework/DataAllocator.h:299
#3  0x0000000000459b71 in o2::tpc::TPCFactorizeIDCSpec::sendOutput (this=this@entry=0x58eba80, output=...) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h:213
#4  0x00000000004612e3 in o2::tpc::TPCFactorizeIDCSpec::endOfStream (ec=..., this=0x58eba80) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.7N6dAiguBh/SOURCES/O2/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/a2fb7d98a0c7334cd0ea5425a8694cd6bec6a8ea/Framework/Core/include/Framework/EndOfStreamContext.h:31
```