### PR TITLE
DPL: make stacktrace level not atomic

### DIFF
--- a/Framework/Foundation/include/Framework/Signpost.h
+++ b/Framework/Foundation/include/Framework/Signpost.h
@@ -179,7 +179,7 @@ struct _o2_log_t {
   // 0 means the log is disabled.
   // 1 means only the current signpost is printed.
   // >1 means the current signpost and n levels of the stacktrace are printed.
-  std::atomic<int> stacktrace = 0;
+  int stacktrace = 0;
 
   // Default stacktrace level for the log, when enabled.
   int defaultStacktrace = 1;


### PR DESCRIPTION
DPL: make stacktrace level not atomic

Not needed and simplifies overriding it from the outside via ptrace /
vm_write.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12594).
* #12597
* #12596
* #12595
* __->__ #12594