### PR TITLE
GLOQC: Fix QC-1091

### DIFF
--- a/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
+++ b/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
@@ -680,7 +680,9 @@ void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
           std::array<float, 2> dca;
           if (trkRef.propagateParamToDCA(v, mBz, &dca)) {
             mDCAr->Fill(dca[0]);
-            mDCArVsPtNum->Fill(trkRef.getPt(), dca[0]);
+            if (!mUseMC) {
+              mDCArVsPtNum->Fill(trkRef.getPt(), dca[0]);
+            }
           }
           LOG(debug) << "*** chi2Matching = " << trk.getChi2Match() << ", chi2refit = " << trk.getChi2Refit() << ", timeResolution = " << trk.getTimeMUS().getTimeStampError();
         }


### PR DESCRIPTION
This is to fix crash observed here: https://its.cern.ch/jira/browse/QC-1091
I did not manage to reproduce the issue and hope to test it in the nightlies, it should be trivial.
The hypothesis is that in MC (where the crash was observed), the numerator gets filled twice thus when creating the efficiency the numerator is higher then denumerator which by definition cannot be for TEfficiency.
This is to fix a bug introduced in #12566.

@shahor02 It was suggested to quickly test this in the MC nightlies so if you agree to merge this quickly this would be super :) 