### PR TITLE
DPL: install o2-log in the proper place

### DIFF
--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -59,6 +59,8 @@ set_property(TARGET o2-test-framework-foundation PROPERTY RUNTIME_OUTPUT_DIRECTO
 set_property(TARGET o2-test-framework-Signpost PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
 set_property(TARGET o2-test-framework-SignpostLogger PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
 set_property(TARGET o2-test-framework-ThreadSanitizer PROPERTY RUNTIME_OUTPUT_DIRECTORY ${outdir})
+get_filename_component(bindir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../bin ABSOLUTE)
+set_property(TARGET o2-log PROPERTY RUNTIME_OUTPUT_DIRECTORY ${bindir})
 
 add_test(NAME framework:foundation COMMAND o2-test-framework-foundation)
 


### PR DESCRIPTION
DPL: install o2-log in the proper place

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12599).
* #12600
* __->__ #12599