### PR TITLE
Move some macros in `COMPILE_ONLY` mode in tests to workaround ROOT issues with C++20

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/test/CMakeLists.txt
@@ -18,7 +18,7 @@ o2_add_test_root_macro(CheckClusters.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase O2::DataFormatsITSMFT
                                              O2::ITSMFTSimulation O2::MathUtils
                                              O2::SimulationDataFormat
-                       LABELS its)
+                       LABELS its COMPILE_ONLY)
 
 o2_add_test_root_macro(CheckDigits.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -27,7 +27,7 @@ o2_add_test_root_macro(CheckDigits.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its)
+                       LABELS its COMPILE_ONLY)
 
 #o2_add_test_root_macro(CheckLUtime.C
 #                       PUBLIC_LINK_LIBRARIES O2::ITSMFTReconstruction
@@ -41,7 +41,7 @@ o2_add_test_root_macro(CreateDictionaries.C
                                              O2::ITSMFTSimulation
                                              O2::DataFormatsITSMFT
                                              O2::SimulationDataFormat
-                       LABELS its)
+                       LABELS its COMPILE_ONLY)
 
 #o2_add_test_root_macro(CheckCOG.C
 #                       PUBLIC_LINK_LIBRARIES O2::MathUtils
@@ -64,7 +64,7 @@ o2_add_test_root_macro(CheckTracksCA.C
                                              O2::ITSBase
                                              O2::DataFormatsITS
                                              O2::DataFormatsITSMFT
-                       LABELS its)
+                       LABELS its COMPILE_ONLY)
 
 o2_add_test_root_macro(CheckSquasher.C
                        PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat

--- a/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 /// \file CheckDigits.C
 /// \brief Simple macro to check ITSU digits
 

--- a/Detectors/ITSMFT/MFT/macros/test/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/macros/test/CMakeLists.txt
@@ -16,7 +16,7 @@ o2_add_test_root_macro(CreateDictionaries.C
                                              O2::ITSMFTSimulation
                                              O2::DataFormatsITSMFT
                                              O2::SimulationDataFormat
-                       LABELS mft)
+                       LABELS mft COMPILE_ONLY)
 
 o2_add_test_root_macro(MFTMisaligner.C
                        PUBLIC_LINK_LIBRARIES O2::MFTBase

--- a/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
@@ -18,7 +18,7 @@ o2_add_test_root_macro(CheckDigitsITS3.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
                        o2_add_test_root_macro(CheckClustersITS3.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -31,7 +31,7 @@ o2_add_test_root_macro(CheckDigitsITS3.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CheckTracksITS3.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -44,7 +44,7 @@ o2_add_test_root_macro(CheckTracksITS3.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CreateDictionariesITS3.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -81,7 +81,7 @@ o2_add_test_root_macro(buildMatBudLUT.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CheckHits.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -93,7 +93,7 @@ o2_add_test_root_macro(CheckHits.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CheckDigitsDensity.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -105,7 +105,7 @@ o2_add_test_root_macro(CheckDigitsDensity.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CheckClusterSize.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -117,7 +117,7 @@ o2_add_test_root_macro(CheckClusterSize.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CompareClusterSize.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
@@ -129,4 +129,4 @@ o2_add_test_root_macro(CompareClusterSize.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -217,7 +217,7 @@ o2_add_test_root_macro(runTPCRefit.C
                                              O2::ReconstructionDataFormats
                                              O2::SimulationDataFormat
                                              O2::TPCReconstruction
-                       LABELS tpc)
+                       LABELS tpc COMPILE_ONLY)
 
 # FIXME: move to subsystem dir
 o2_add_test_root_macro(run_CRUDataSkimming_its.C


### PR DESCRIPTION
From ITS(-3) perspective I think this is a no-brainer as we usually always compile our macros.
I am open to objections from other detectors, in case.