### PR TITLE
Switch on reading of BadChannel CCDB information in StatusMap Creator with protection added

### DIFF
--- a/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
+++ b/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
@@ -29,7 +29,7 @@ struct DigitFilterParam : public o2::conf::ConfigurableParamHelper<DigitFilterPa
   bool rejectBackground = true; ///< attempts to reject background (loose background selection, don't kill signal)
   bool selectSignal = false;    ///< attempts to select only signal (strict background selection, might loose signal)
   int timeOffset = 120;         ///< digit time calibration offset
-  uint32_t statusMask = 0;      ///< mask to reject digits based on the statusmap (0=no rejection,1=badchannels from ped calib only,2=badchannels from rejectlist,3=1+2)
+  uint32_t statusMask = 3;      ///< mask to reject digits based on the statusmap (0=no rejection,1=badchannels from ped calib only,2=badchannels from rejectlist,3=1+2)
 
   O2ParamDef(DigitFilterParam, "MCHDigitFilter");
 };

--- a/Detectors/MUON/MCH/Status/include/MCHStatus/StatusMapCreatorParam.h
+++ b/Detectors/MUON/MCH/Status/include/MCHStatus/StatusMapCreatorParam.h
@@ -24,7 +24,7 @@ namespace o2::mch
  */
 struct StatusMapCreatorParam : public o2::conf::ConfigurableParamHelper<StatusMapCreatorParam> {
 
-  bool useBadChannels = false; ///< reject bad channels (obtained during pedestal calibration runs)
+  bool useBadChannels = true; ///< reject bad channels (obtained during pedestal calibration runs)
   bool useRejectList = true;  ///< use extra (relative to bad channels above) rejection list
 
   bool isActive() const { return useBadChannels || useRejectList; }

--- a/Detectors/MUON/MCH/Status/src/StatusMap.cxx
+++ b/Detectors/MUON/MCH/Status/src/StatusMap.cxx
@@ -30,17 +30,18 @@ void assertValidMask(uint32_t mask)
 
 void StatusMap::add(gsl::span<const DsChannelId> badchannels, uint32_t mask)
 {
-    assertValidMask(mask);
-    for (auto id : badchannels) {
-        try {
-            ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
-            mStatus[cc] |= mask;
-        } catch (const std::exception& e) {
-            // Catch exceptions thrown by the ChannelCode constructor
-            LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.",
-                 id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
-        }
+  assertValidMask(mask);
+  for (auto id : badchannels) {
+    try {
+      ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
+      mStatus[cc] |= mask;
     }
+    catch (const std::exception& e) {
+      // Catch exceptions thrown by the ChannelCode constructor
+      LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.",
+                 id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
+    }
+  }
 }
 
 void StatusMap::add(gsl::span<const ChannelCode> badchannels, uint32_t mask)

--- a/Detectors/MUON/MCH/Status/src/StatusMap.cxx
+++ b/Detectors/MUON/MCH/Status/src/StatusMap.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "MCHStatus/StatusMap.h"
+#include "Framework/Logger.h"
 
 #include <fmt/format.h>
 
@@ -31,8 +32,15 @@ void StatusMap::add(gsl::span<const DsChannelId> badchannels, uint32_t mask)
 {
   assertValidMask(mask);
   for (auto id : badchannels) {
-    ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
-    mStatus[cc] |= mask;
+      try{
+          ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
+          mStatus[cc] |= mask;
+      }
+      catch (const std::exception& e) {
+          // Catch exceptions thrown by the ChannelCode constructor
+          LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.",
+                       id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
+      }
   }
 }
 

--- a/Detectors/MUON/MCH/Status/src/StatusMap.cxx
+++ b/Detectors/MUON/MCH/Status/src/StatusMap.cxx
@@ -35,11 +35,9 @@ void StatusMap::add(gsl::span<const DsChannelId> badchannels, uint32_t mask)
     try {
       ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
       mStatus[cc] |= mask;
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
       // Catch exceptions thrown by the ChannelCode constructor
-      LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.",
-                 id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
+      LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.", id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
     }
   }
 }

--- a/Detectors/MUON/MCH/Status/src/StatusMap.cxx
+++ b/Detectors/MUON/MCH/Status/src/StatusMap.cxx
@@ -30,18 +30,17 @@ void assertValidMask(uint32_t mask)
 
 void StatusMap::add(gsl::span<const DsChannelId> badchannels, uint32_t mask)
 {
-  assertValidMask(mask);
-  for (auto id : badchannels) {
-      try{
-          ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
-          mStatus[cc] |= mask;
-      }
-      catch (const std::exception& e) {
-          // Catch exceptions thrown by the ChannelCode constructor
-          LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.",
-                       id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
-      }
-  }
+    assertValidMask(mask);
+    for (auto id : badchannels) {
+        try {
+            ChannelCode cc(id.getSolarId(), id.getElinkId(), id.getChannel());
+            mStatus[cc] |= mask;
+        } catch (const std::exception& e) {
+            // Catch exceptions thrown by the ChannelCode constructor
+            LOGP(warning, "Error processing channel - SolarId: {} ElinkId: {} Channel: {}. Error: {}. This channel is skipped.",
+                 id.getSolarId(), id.getElinkId(), id.getChannel(), e.what());
+        }
+    }
 }
 
 void StatusMap::add(gsl::span<const ChannelCode> badchannels, uint32_t mask)


### PR DESCRIPTION
Switch on reading of BadChannel CCDB information in StatusMap Creator.
A protection has been added to remove from the list of BadChannels unphysical (SolarId, Elink Id, Channel Id) as well as Invalid Pad Id