### PR TITLE
DPL: avoid invoking matchDataHeader twice when sending data

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -399,7 +399,7 @@ class DataAllocator
                     "\n - std::vector of messageable structures or pointers to those"
                     "\n - types with ROOT dictionary and implementing ROOT ClassDef interface");
     }
-    addPartToContext(std::move(payloadMessage), spec, serializationType);
+    addPartToContext(routeIndex, std::move(payloadMessage), spec, serializationType);
   }
 
   /// Take a snapshot of a raw data array which can be either POD or may contain a serialized
@@ -527,7 +527,7 @@ class DataAllocator
                                                size_t payloadSize);                                 //
 
   Output getOutputByBind(OutputRef&& ref);
-  void addPartToContext(fair::mq::MessagePtr&& payload,
+  void addPartToContext(RouteIndex routeIndex, fair::mq::MessagePtr&& payload,
                         const Output& spec,
                         o2::header::SerializationMethod serializationMethod);
 };

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -119,11 +119,9 @@ fair::mq::MessagePtr DataAllocator::headerMessageFromOutput(Output const& spec, 
   return o2::pmr::getMessage(o2::header::Stack{channelAlloc, dh, dph, spec.metaHeader});
 }
 
-void DataAllocator::addPartToContext(fair::mq::MessagePtr&& payloadMessage, const Output& spec,
+void DataAllocator::addPartToContext(RouteIndex routeIndex, fair::mq::MessagePtr&& payloadMessage, const Output& spec,
                                      o2::header::SerializationMethod serializationMethod)
 {
-  auto& timingInfo = mRegistry.get<TimingInfo>();
-  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
   auto headerMessage = headerMessageFromOutput(spec, routeIndex, serializationMethod, 0);
 
   // FIXME: this is kind of ugly, we know that we can change the content of the
@@ -284,7 +282,7 @@ void DataAllocator::snapshot(const Output& spec, const char* payload, size_t pay
   fair::mq::MessagePtr payloadMessage(proxy.createOutputMessage(routeIndex, payloadSize));
   memcpy(payloadMessage->GetData(), payload, payloadSize);
 
-  addPartToContext(std::move(payloadMessage), spec, serializationMethod);
+  addPartToContext(routeIndex, std::move(payloadMessage), spec, serializationMethod);
 }
 
 Output DataAllocator::getOutputByBind(OutputRef&& ref)
@@ -348,7 +346,7 @@ void DataAllocator::cookDeadBeef(const Output& spec)
   auto deadBeefOutput = Output{spec.origin, spec.description, 0xdeadbeef};
   auto headerMessage = headerMessageFromOutput(deadBeefOutput, routeIndex, header::gSerializationMethodNone, 0);
 
-  addPartToContext(proxy.createOutputMessage(routeIndex, 0), deadBeefOutput, header::gSerializationMethodNone);
+  addPartToContext(routeIndex, proxy.createOutputMessage(routeIndex, 0), deadBeefOutput, header::gSerializationMethodNone);
 }
 
 } // namespace o2::framework


### PR DESCRIPTION
DPL: avoid invoking matchDataHeader twice when sending data

Percolate precomputed value instead, given that payload and
header all go to the same route.
