### PR TITLE
TPC M-Shape correction: Suppress error message if default object is used

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCMShapeCorrection.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCMShapeCorrection.h
@@ -78,6 +78,11 @@ class TPCMShapeCorrection
   /// \param name name of the output object
   void dumpToFile(const char* file, const char* name);
 
+  /// dump this object to several files each containing the correction for n minutes
+  /// \param file output file
+  /// \param nSlices number of slices
+  void dumpToFileSlices(const char* file, const char* name, int nSlices);
+
   /// load from input file (which were written using the dumpToFile method)
   /// \param inpf input file
   /// \param name name of the object in the file

--- a/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
@@ -87,7 +87,7 @@ class TPCScalerSpec : public Task
     const double timestamp = orbitResetTimeMS + firstTFOrbit * o2::constants::lhc::LHCOrbitMUS * 0.001;
 
     if (mEnableMShape) {
-      if (pc.services().get<o2::framework::TimingInfo>().runNumber != mMShapeTPCScaler.getRun()) {
+      if ((mMShapeTPCScaler.getRun() != -1) && pc.services().get<o2::framework::TimingInfo>().runNumber != mMShapeTPCScaler.getRun()) {
         LOGP(error, "Run number {} of processed data and run number {} of loaded TPC M-shape scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mMShapeTPCScaler.getRun());
       }
 
@@ -190,6 +190,9 @@ class TPCScalerSpec : public Task
     if (matcher == ConcreteDataMatcher(o2::header::gDataOriginTPC, "MSHAPEPOTCCDB", 0)) {
       LOGP(info, "Updating M-shape TPC scaler");
       mMShapeTPCScaler.setFromTree(*((TTree*)obj));
+      if (mMShapeTPCScaler.getRun() == -1) {
+        LOGP(info, "Loaded default M-Shape correction object from CCDB");
+      }
     }
   }
 


### PR DESCRIPTION
- add option to dump M-Shape correction to several files to reduce data volume