### PR TITLE
Fix double deletion in algorithm::deleteTCollections

### DIFF
--- a/Utilities/Mergers/src/MergerAlgorithm.cxx
+++ b/Utilities/Mergers/src/MergerAlgorithm.cxx
@@ -143,16 +143,27 @@ void merge(VectorOfTObjectPtrs& targets, const VectorOfTObjectPtrs& others)
   }
 }
 
+void deleteRecursive(TCollection* Coll)
+{
+  // I can iterate a collection
+  Coll->SetOwner(false);
+  auto ITelem = Coll->MakeIterator();
+  while (auto* element = ITelem->Next()) {
+    if (auto* Coll2 = dynamic_cast<TCollection*>(element)) {
+      Coll2->SetOwner(false);
+      deleteRecursive(Coll2);
+    }
+    Coll->Remove(element); // Remove from mother collection
+    delete element;        // Delete payload
+  }
+  delete ITelem;
+}
+
 void deleteTCollections(TObject* obj)
 {
-  if (auto c = dynamic_cast<TCollection*>(obj)) {
-    c->SetOwner(false);
-    auto iter = c->MakeIterator();
-    while (auto element = iter->Next()) {
-      deleteTCollections(element);
-    }
-    delete iter;
-    delete c;
+  if (auto* L = dynamic_cast<TCollection*>(obj)) {
+    deleteRecursive(L);
+    delete L;
   } else {
     delete obj;
   }


### PR DESCRIPTION
The related unit test randomly fails on Ubuntu 22.04  (~25% of the trials) with root v6.28 and v6.30.

This was first spotted in https://github.com/alisw/alidist/pull/5240 by pure chance, but it fails with c++17 as well and we think it can be a general issue.

A `TCollection*` cannot be deleted after its elements.
This is because of the dangling pointers inside it that are tested by the various `Clear()` re-implementations regardless of the ownership settings. See also https://github.com/root-project/root/issues/14504.

This reimplementation just recursively looks for all the lists and navigate them removing non-list elements and deleting them. Then it deletes the list as well. Please have a look as deletion mechanisms are difficult to validate. 

Valgrind shows no errors, whereas it was complaining earlier.

Find attached the log:
```
[O2/latest] ~/alice/latest/tests $> valgrind --leak-check=full --suppressions=$ROOTSYS/etc/valgrind-root.supp ./test2
==3418000== Memcheck, a memory error detector
==3418000== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3418000== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==3418000== Command: ./test2
==3418000==


 ====== Lists and elements in lists... ======
main = 0x6da05e0 is a: TObjArray with title: An array of objects
  main[0] = 0x6da0720 is a: TList with title: Doubly linked list
  main[1] = 0x6da1890 is a: TH1I with title: histo 1d

collectionInside = 0x6da0720 is a: TList with title: Doubly linked list
  collectionInside[0] = 0x6da0830 is a: TH1I with title: histo 1d
  collectionInside[1] = 0x6da0fd0 is a: TH1I with title: histo 1d


 ====== Deleting... ======
Deleting 0x6da0830 => histo 1d of type TH1I
Deleting 0x6da0fd0 =>  a histo 1d of type TH1I
Deleting 0x6da0720 => collectionInside of type TList
Deleting 0x6da1890 =>  b histo 1d of type TH1I
Deleting 0x6da05e0 => main of type TObjArray
==3418000==
==3418000== HEAP SUMMARY:
==3418000==     in use at exit: 10,397,929 bytes in 16,563 blocks
==3418000==   total heap usage: 165,505 allocs, 148,942 frees, 82,981,520 bytes allocated
==3418000==
==3418000== LEAK SUMMARY:
==3418000==    definitely lost: 0 bytes in 0 blocks
==3418000==    indirectly lost: 0 bytes in 0 blocks
==3418000==      possibly lost: 0 bytes in 0 blocks
==3418000==    still reachable: 10,361,917 bytes in 16,076 blocks
==3418000==         suppressed: 36,012 bytes in 487 blocks
==3418000== Reachable blocks (those to which a pointer was found) are not shown.
==3418000== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3418000==
==3418000== For lists of detected and suppressed errors, rerun with: -s
==3418000== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 388 from 31)
```

This can be reproduced and possibly further tested with:
```bash
c++ test2.C -o test2 -I $ROOTSYS/include/ -std=c++20 -L $ROOTSYS/lib -lRIO -lCore -lHist -g
valgrind --leak-check=full --suppressions=$ROOTSYS/etc/valgrind-root.supp ./test2
```
[test2.txt](https://github.com/AliceO2Group/AliceO2/files/14117065/test2.txt)

Cc: @ktf


