### PR TITLE
Added public member function to set MID track efficiency word

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
@@ -188,6 +188,9 @@ class Track
   /// Overload ostream operator for MID track
   friend std::ostream& operator<<(std::ostream& stream, const Track& track);
 
+  /// set efficiency word (public function)
+  void setEfficiencyWord(uint32_t efficiencyWord) { mEfficiencyWord = efficiencyWord; }
+
  private:
   /// Set portions of the efficiency word
   /// \param pos Position in the word


### PR DESCRIPTION
I added a new public member function to the MID Track.h file in order to publicly access this feature in other codes
@dstocco 