### PR TITLE
ITS MFT Time-evolving dead maps

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -58,7 +58,7 @@ class TimeDeadMap
 
   void decodeMap(o2::itsmft::NoiseMap& noisemap)
   { // for static part only
-    if (mMAP_VERSION != "3") {
+    if (mMAP_VERSION == "3") {
       LOG(error) << "Trying to decode static part of deadmap version " << mMAP_VERSION << ". Not implemented, doing nothing.";
       return;
     }

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -89,6 +89,9 @@ class ITSMFTDeadMapBuilder : public Task
 
   uint mStepCounter = 0;
   uint mTFCounter = 0;
+  int mRunNumber = -1;
+
+  long mTimeStart = -1; // TODO: better to use RCT info?
 
   std::string mObjectName;
   std::string mLocalOutputDir;

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -89,7 +89,6 @@ class ITSMFTDeadMapBuilder : public Task
 
   uint mStepCounter = 0;
   uint mTFCounter = 0;
-  int mRunNumber = -1;
 
   long mTimeStart = -1; // TODO: better to use RCT info?
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -82,6 +82,7 @@ class ITSMFTDeadMapBuilder : public Task
 
   bool mRunMFT = false;
   bool mDoLocalOutput = false;
+  bool mSkipStaticMap = false;
   uint16_t N_CHIPS;
   uint16_t N_CHIPS_ITSIB = o2::itsmft::ChipMappingITS::getNChips(0);
   int mTFLength = 32; // TODO find utility for proper value -- o2::base::GRPGeomHelper::getNHBFPerTF() returns 128 see https://github.com/AliceO2Group/AliceO2/blob/051b56f9f136e7977e83f5d26d922db9bd6ecef5/Detectors/Base/src/GRPGeomHelper.cxx#L233 and correct also default option is getSpec
@@ -92,7 +93,9 @@ class ITSMFTDeadMapBuilder : public Task
   std::string mObjectName;
   std::string mLocalOutputDir;
 
-  std::string MAP_VERSION = "3"; // to change in case the encoding or the format change
+  std::string MAP_VERSION = "4"; // to change in case the encoding or the format change
+
+  std::vector<bool> mStaticChipStatus{};
 
   std::vector<uint16_t> mDeadMapTF{};
 

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -65,7 +65,6 @@ void ITSMFTDeadMapBuilder::init(InitContext& ic)
   mStaticChipStatus.clear();
   mMapObject.clear();
   mMapObject.setMapVersion(MAP_VERSION);
-  mRunNumber = -1;
 
   if (!mSkipStaticMap) {
     mStaticChipStatus.resize(N_CHIPS, false);
@@ -134,12 +133,6 @@ void ITSMFTDeadMapBuilder::run(ProcessingContext& pc)
 {
   if (mRunStopRequested) { // give up when run stop request arrived
     return;
-  }
-
-  if (mRunNumber < 0) {
-    auto tInfo = pc.services().get<o2::framework::TimingInfo>();
-    mRunNumber = tInfo.runNumber;
-    LOG(info) << "Run number is " << mRunNumber;
   }
 
   std::chrono::time_point<std::chrono::high_resolution_clock> start;

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -255,6 +255,8 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(DataAllocator& output)
     output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 0}, info);
   }
 
+  LOG(info) << "AAA snapshots created";
+
   return;
 }
 
@@ -266,7 +268,11 @@ void ITSMFTDeadMapBuilder::endOfStream(EndOfStreamContext& ec)
   if (!isEnded && !mRunStopRequested) {
     LOG(info) << "endOfStream report:" << mSelfName;
     finalizeOutput();
-    PrepareOutputCcdb(ec.outputs());
+    if (mMapObject.getEvolvingMapSize() > 0) {
+      PrepareOutputCcdb(ec.outputs());
+    } else {
+      LOG(warning) << "Time-dependent dead map is empty and will not be forwarded as output";
+    }
     isEnded = true;
   }
   return;


### PR DESCRIPTION
- Implemented static part of the map. At the moment that's relevant only for ITS. If not needed, one can save a bit of space by disabling it with `--skip-static-map`.
- Added protection against forwarding empty objects as output.
- Timestamps used as ccdb validity set according to the task's start/end run time.

cc @MauriceCoke 