### PR TITLE
Always load CTP Lumi and use it to scale TPC cov.matrix extra errors

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/TrackTuneParams.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/TrackTuneParams.h
@@ -16,6 +16,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
+#include <array>
 
 namespace o2
 {
@@ -32,13 +33,19 @@ struct TrackTuneParams : public o2::conf::ConfigurableParamHelper<TrackTuneParam
   };
   AddCovType tpcCovInnerType = AddCovType::Disable;
   AddCovType tpcCovOuterType = AddCovType::Disable;
-  bool sourceLevelTPC = true;   // if TPC corrections are allowed, apply them TPC source output level (tracking/reader), otherwise in the global tracking consumers BEFORE update by external detector
+  bool sourceLevelTPC = true;    // if TPC corrections are allowed, apply them TPC source output level (tracking), otherwise in the global tracking consumers BEFORE update by external detector
+  bool applyWhenReading = false; // if true, then apply at reading tracks from the file. This better NOT used as there is no way to apply lumi-dependent scaling in the reader
   bool useTPCInnerCorr = false; // request to correct TPC inner param
   bool useTPCOuterCorr = false; // request to correct TPC outer param
   float tpcParInner[5] = {};    // ad hoc correction to be added to TPC param at the inner XRef
   float tpcParOuter[5] = {};    // ad hoc correction to be added to TPC param at the outer XRef
-  float tpcCovInner[5] = {}; // ad hoc errors to be added to TPC cov.matrix at the inner XRef
-  float tpcCovOuter[5] = {}; // ad hoc errors to be added to TPC outer param at the outer XRef
+  float tpcCovInner[5] = {};    // ad hoc errors to be added to TPC cov.matrix at the inner XRef (not squared!)
+  float tpcCovOuter[5] = {};    // ad hoc errors to be added to TPC outer param cov.matrix at the outer XRef (not squared!)
+  float tpcCovInnerSlope[5] = {}; // slope of the error with respect to lumi, total correction = [tpcCovInner + lumi*tpcCovInnerSlope]^2
+  float tpcCovOuterSlope[5] = {}; // slope of the error with respect to lumi, total correction = [tpcCovOuter + lumi*tpcCovOuterSlope]^2
+
+  std::array<float, 5> getCovInnerTotal(float scale) const;
+  std::array<float, 5> getCovOuterTotal(float scale) const;
 
   O2ParamDef(TrackTuneParams, "trackTuneParams");
 };

--- a/DataFormats/Detectors/GlobalTracking/src/TrackTuneParams.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/TrackTuneParams.cxx
@@ -15,3 +15,25 @@
 
 #include "DataFormatsGlobalTracking/TrackTuneParams.h"
 O2ParamImpl(o2::globaltracking::TrackTuneParams);
+
+using namespace o2::globaltracking;
+
+std::array<float, 5> TrackTuneParams::getCovInnerTotal(float scale) const
+{
+  std::array<float, 5> cov{};
+  for (int i = 0; i < 5; i++) {
+    cov[i] = tpcCovInner[i] + scale * tpcCovInnerSlope[i];
+    cov[i] *= cov[i];
+  }
+  return cov;
+}
+
+std::array<float, 5> TrackTuneParams::getCovOuterTotal(float scale) const
+{
+  std::array<float, 5> cov{};
+  for (int i = 0; i < 5; i++) {
+    cov[i] = tpcCovOuter[i] + scale * tpcCovOuterSlope[i];
+    cov[i] *= cov[i];
+  }
+  return cov;
+}

--- a/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
+++ b/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
@@ -263,10 +263,10 @@ void BarrelAlignmentSpec::updateTimeDependentParams(ProcessingContext& pc)
     mTPCCorrMapsLoader.extractCCDBInputs(pc);
     bool updateMaps = false;
     if (mTPCCorrMapsLoader.isUpdated()) {
-      mController->setTPCCorrMaps(&mTPCCorrMapsLoader);
       mTPCCorrMapsLoader.acknowledgeUpdate();
       updateMaps = true;
     }
+    mController->setTPCCorrMaps(&mTPCCorrMapsLoader);
     if (mTPCVDriftHelper.isUpdated()) {
       LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",
            mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift,

--- a/Detectors/Align/Workflow/src/barrel-alignment-workflow.cxx
+++ b/Detectors/Align/Workflow/src/barrel-alignment-workflow.cxx
@@ -141,7 +141,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       }
       LOG(info) << "adding TOF request";
     }
-    if (sclOpt.lumiType == 1) {
+    if (sclOpt.requestCTPLumi) {
       src = src | GID::getSourcesMask("CTP");
     }
     // write the configuration used for the workflow

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -336,6 +336,9 @@ class MatchTOF
   UInt_t mDBGFlags = 0;
   std::string mDebugTreeFileName = "dbg_matchTOF.root"; ///< name for the debug tree file
 
+  std::array<float, 5> mCovDiagInner{}; ///< total cov.matrix extra diagonal error from TrackTuneParams
+  std::array<float, 5> mCovDiagOuter{}; ///< total cov.matrix extra diagonal error from TrackTuneParams
+
   ///----------- aux stuff --------------///
   static constexpr float MAXSNP = 0.85; // max snp of ITS or TPC track at xRef to be matched
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -611,6 +611,9 @@ class MatchTPCITS
   std::array<int16_t, o2::constants::lhc::LHCMaxBunches> mClosestBunchAbove; // closest filled bunch from above
   std::array<int16_t, o2::constants::lhc::LHCMaxBunches> mClosestBunchBelow; // closest filled bunch from below
 
+  std::array<float, 5> mCovDiagInner{}; ///< total cov.matrix extra diagonal error from TrackTuneParams
+  std::array<float, 5> mCovDiagOuter{}; ///< total cov.matrix extra diagonal error from TrackTuneParams
+
   const o2::itsmft::ChipMappingITS ITSChMap{};
 
   const o2::globaltracking::RecoContainer* mRecoCont = nullptr;

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -55,6 +55,7 @@ using MatrixDSym4 = ROOT::Math::SMatrix<double, 4, 4, ROOT::Math::MatRepSym<doub
 using MatrixD4 = ROOT::Math::SMatrix<double, 4, 4, ROOT::Math::MatRepStd<double, 4>>;
 using NAMES = o2::base::NameConf;
 using GTrackID = o2::dataformats::GlobalTrackID;
+using TrackTunePar = o2::globaltracking::TrackTuneParams;
 constexpr float MatchTPCITS::Tan70, MatchTPCITS::Cos70I2, MatchTPCITS::MaxSnp, MatchTPCITS::MaxTgp;
 
 LinksPoolMT* TPCABSeed::gLinksPool = nullptr;
@@ -265,6 +266,14 @@ void MatchTPCITS::updateTimeDependentParams()
   o2::math_utils::Point3D<float> p0(90., 1., 1), p1(90., 100., 100.);
   auto matbd = o2::base::Propagator::Instance()->getMatBudget(mParams->matCorr, p0, p1);
   mTPCmeanX0Inv = matbd.meanX2X0 / matbd.length;
+
+  const auto& trackTune = TrackTuneParams::Instance();
+  float scale = mTPCCorrMapsHelper->getInstLumiCTP();
+  if (scale < 0.f) {
+    scale = 0.f;
+  }
+  mCovDiagInner = trackTune.getCovInnerTotal(scale);
+  mCovDiagOuter = trackTune.getCovOuterTotal(scale);
 }
 
 //______________________________________________
@@ -419,15 +428,15 @@ void MatchTPCITS::addTPCSeed(const o2::track::TrackParCov& _tr, float t0, float 
                 MinusOne,
                 (extConstrained || tpcOrig.hasBothSidesClusters()) ? TrackLocTPC::Constrained : (tpcOrig.hasASideClustersOnly() ? TrackLocTPC::ASide : TrackLocTPC::CSide)});
   // propagate to matching Xref
-  const auto& trackTune = o2::globaltracking::TrackTuneParams::Instance();
+  const auto& trackTune = TrackTuneParams::Instance();
   // only TPC standalone need to be corrected on the input, provided they were not corrected at the source level,
   // other inputs are corrected in respective upstream matching processes
   if (srcGID.getSource() == GTrackID::TPC && !trackTune.sourceLevelTPC) {
     if (trackTune.useTPCInnerCorr) {
       trc.updateParams(trackTune.tpcParInner);
     }
-    if (trackTune.tpcCovInnerType != o2::globaltracking::TrackTuneParams::AddCovType::Disable) {
-      trc.updateCov(trackTune.tpcCovInner, trackTune.tpcCovInnerType == o2::globaltracking::TrackTuneParams::AddCovType::WithCorrelations);
+    if (trackTune.tpcCovInnerType != TrackTuneParams::AddCovType::Disable) {
+      trc.updateCov(mCovDiagInner, trackTune.tpcCovInnerType == TrackTuneParams::AddCovType::WithCorrelations);
     }
   }
   if (!propagateToRefX(trc)) {
@@ -1450,12 +1459,12 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS, pmr::vector<o2::dataform
     tofL.addX2X0(lInt * mTPCmeanX0Inv);
     propagator->PropagateToXBxByBz(tracOut, o2::constants::geom::XTPCOuterRef, MaxSnp, 10., mUseMatCorrFlag, &tofL);
 
-    const auto& trackTune = o2::globaltracking::TrackTuneParams::Instance();
+    const auto& trackTune = TrackTuneParams::Instance();
     if (trackTune.useTPCOuterCorr) {
       tracOut.updateParams(trackTune.tpcParOuter);
     }
-    if (trackTune.tpcCovOuterType != o2::globaltracking::TrackTuneParams::AddCovType::Disable) {
-      tracOut.updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType == o2::globaltracking::TrackTuneParams::AddCovType::WithCorrelations);
+    if (trackTune.tpcCovOuterType != TrackTuneParams::AddCovType::Disable) {
+      tracOut.updateCov(mCovDiagOuter, trackTune.tpcCovOuterType == TrackTuneParams::AddCovType::WithCorrelations);
     }
   }
   trfit.setChi2Match(tpcMatchRec.chi2);
@@ -1584,12 +1593,12 @@ bool MatchTPCITS::refitABTrack(int iITSAB, const TPCABSeed& seed, pmr::vector<o2
     tofL.addStep(lInt, tracOut.getP2Inv());
     tofL.addX2X0(lInt * mTPCmeanX0Inv);
     propagator->PropagateToXBxByBz(tracOut, o2::constants::geom::XTPCOuterRef, MaxSnp, 10., mUseMatCorrFlag, &tofL);
-    const auto& trackTune = o2::globaltracking::TrackTuneParams::Instance();
+    const auto& trackTune = TrackTuneParams::Instance();
     if (trackTune.useTPCOuterCorr) {
       tracOut.updateParams(trackTune.tpcParOuter);
     }
-    if (trackTune.tpcCovOuterType != o2::globaltracking::TrackTuneParams::AddCovType::Disable) {
-      tracOut.updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType == o2::globaltracking::TrackTuneParams::AddCovType::WithCorrelations);
+    if (trackTune.tpcCovOuterType != TrackTuneParams::AddCovType::Disable) {
+      tracOut.updateCov(mCovDiagOuter, trackTune.tpcCovOuterType == TrackTuneParams::AddCovType::WithCorrelations);
     }
   }
 

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -133,10 +133,10 @@ void CosmicsMatchingSpec::updateTimeDependentParams(ProcessingContext& pc)
   }
   bool updateMaps = false;
   if (mTPCCorrMapsLoader.isUpdated()) {
-    mMatching.setTPCCorrMaps(&mTPCCorrMapsLoader);
     mTPCCorrMapsLoader.acknowledgeUpdate();
     updateMaps = true;
   }
+  mMatching.setTPCCorrMaps(&mTPCCorrMapsLoader);
   if (mTPCVDriftHelper.isUpdated()) {
     LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",
          mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift,

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
@@ -189,10 +189,10 @@ void SecondaryVertexingSpec::updateTimeDependentParams(ProcessingContext& pc)
   if (mSrc[GTrackID::TPC]) {
     bool updateMaps = false;
     if (mTPCCorrMapsLoader.isUpdated()) {
-      mVertexer.setTPCCorrMaps(&mTPCCorrMapsLoader);
       mTPCCorrMapsLoader.acknowledgeUpdate();
       updateMaps = true;
     }
+    mVertexer.setTPCCorrMaps(&mTPCCorrMapsLoader);
     if (mTPCVDriftHelper.isUpdated()) {
       LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",
            mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift,

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
@@ -117,10 +117,10 @@ void TOFMatcherSpec::updateTimeDependentParams(ProcessingContext& pc)
   // we may have other params which need to be queried regularly
   bool updateMaps = false;
   if (mTPCCorrMapsLoader.isUpdated()) {
-    mMatcher.setTPCCorrMaps(&mTPCCorrMapsLoader);
     mTPCCorrMapsLoader.acknowledgeUpdate();
     updateMaps = true;
   }
+  mMatcher.setTPCCorrMaps(&mTPCCorrMapsLoader);
   if (mTPCVDriftHelper.isUpdated()) {
     LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",
          mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift,

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -190,10 +190,11 @@ void TPCITSMatchingDPL::updateTimeDependentParams(ProcessingContext& pc)
   // we may have other params which need to be queried regularly
   bool updateMaps = false;
   if (mTPCCorrMapsLoader.isUpdated()) {
-    mMatching.setTPCCorrMaps(&mTPCCorrMapsLoader);
     mTPCCorrMapsLoader.acknowledgeUpdate();
     updateMaps = true;
   }
+  mMatching.setTPCCorrMaps(&mTPCCorrMapsLoader);
+
   if (mTPCVDriftHelper.isUpdated()) {
     LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",
          mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift,

--- a/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
@@ -97,7 +97,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (GID::includesDet(DetID::TOF, src)) {
     src |= GID::getSourceMask(GID::TOF);
   }
-  if (sclOpt.lumiType == 1) {
+  if (sclOpt.requestCTPLumi) {
     src = src | GID::getSourcesMask("CTP");
   }
   GID::mask_t srcCl = src;

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -93,7 +93,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (src[GID::TPC]) {
     srcClus |= GID::getSourceMask(GID::TPC);
   }
-  if (sclOpt.lumiType == 1) {
+  if (sclOpt.requestCTPLumi) {
     src = src | GID::getSourcesMask("CTP");
   }
   WorkflowSpec specs;

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -148,7 +148,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (src[GID::TPC] && refitTPCTOF) { // load clusters
     clustermask |= GID::getSourceMask(GID::TPC);
   }
-  if (sclOpt.lumiType == 1) {
+  if (sclOpt.requestCTPLumi) {
     src = src | GID::getSourcesMask("CTP");
   }
   if (useMC) {

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -83,7 +83,7 @@ WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcont
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto calib = configcontext.options().get<bool>("produce-calibration-data");
   auto srcL = src | GID::getSourcesMask("ITS,TPC"); // ITS is neadded always, TPC must be loaded even if bare TPC tracks are not used in matching
-  if (sclOpt.lumiType == 1) {
+  if (sclOpt.requestCTPLumi) {
     srcL = srcL | GID::getSourcesMask("CTP");
   }
 

--- a/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
@@ -65,7 +65,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto sclOpt = o2::tpc::CorrectionMapsLoader::parseGlobalOptions(configcontext.options());
   GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
   GID::mask_t srcCls = allowedSourcesClus & GID::getSourcesMask(configcontext.options().get<std::string>("cluster-sources"));
-  if (sclOpt.lumiType == 1) {
+  if (sclOpt.requestCTPLumi) {
     srcTrc = srcTrc | GID::getSourcesMask("CTP");
     srcCls = srcCls | GID::getSourcesMask("CTP");
   }

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrMapParam.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrMapParam.h
@@ -25,7 +25,7 @@ namespace tpc
 {
 
 struct CorrMapParam : public o2::conf::ConfigurableParamHelper<CorrMapParam> {
-  float lumiInst = 0.;       // override instantaneous lumi (if > 0) for TPC corr.map scaling, disable corrections if < 0"
+  float lumiInst = 0.;       // override CTP instantaneous lumi (if > 0)
   float lumiMean = 0.;       // override TPC corr.map mean lumi (if > 0), disable corrections if < 0
   float lumiMeanRef = 0.;    // override TPC corr.mapRef mean lumi (if > 0)"
   float lumiInstFactor = 1.; // scaling to apply to instantaneous lumi from CTP (but not to IDC scaler)

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrMapParam.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrMapParam.h
@@ -28,7 +28,7 @@ struct CorrMapParam : public o2::conf::ConfigurableParamHelper<CorrMapParam> {
   float lumiInst = 0.;       // override instantaneous lumi (if > 0) for TPC corr.map scaling, disable corrections if < 0"
   float lumiMean = 0.;       // override TPC corr.map mean lumi (if > 0), disable corrections if < 0
   float lumiMeanRef = 0.;    // override TPC corr.mapRef mean lumi (if > 0)"
-  float lumiInstFactor = 1.; // scaling to apply to instantaneous lumi from CTP (but not corrmap-lumi-inst)
+  float lumiInstFactor = 1.; // scaling to apply to instantaneous lumi from CTP (but not to IDC scaler)
   int ctpLumiSource = 0;     // CTP lumi source: 0 = LumiInfo.getLumi(), 1 = LumiInfo.getLumiAlt()
 
   O2ParamDef(CorrMapParam, "TPCCorrMap");

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -38,9 +38,10 @@ namespace tpc
 {
 
 struct CorrectionMapsLoaderGloOpts {
-  int lumiType = 0; ///< 0: no scaling, 1: CTP, 2: IDC
-  int lumiMode = 0; ///< 0: classical scaling, 1: Using of the derivative map, 2: Using of the derivative map for MC
+  int lumiType = 0; ///< what estimator to used for corrections scaling: 0: no scaling, 1: CTP, 2: IDC
+  int lumiMode = 0; ///< what corrections method to use: 0: classical scaling, 1: Using of the derivative map, 2: Using of the derivative map for MC
   bool enableMShapeCorrection = false;
+  bool requestCTPLumi = true; //< request CTP Lumi regardless of what is used for corrections scaling
 
   bool needTPCScalersWorkflow() const
   {
@@ -72,8 +73,8 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
   static void addOption(std::vector<o2::framework::ConfigParamSpec>& options, o2::framework::ConfigParamSpec&& osp);
   static void addInput(std::vector<o2::framework::InputSpec>& inputs, o2::framework::InputSpec&& isp);
 
-  float mInstLumiFactor = 1.0; // multiplicative factor for inst. lumi
-  int mCTPLumiSource = 0;      // 0: main, 1: alternative CTP lumi source
+  float mInstLumiCTPFactor = 1.0; // multiplicative factor for inst. lumi
+  int mLumiCTPSource = 0;         // 0: main, 1: alternative CTP lumi source
   std::unique_ptr<GPUCA_NAMESPACE::gpu::TPCFastTransform> mCorrMapMShape{nullptr};
 #endif
 };

--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -52,7 +52,8 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
   int dumRep = 0;
   o2::ctp::LumiInfo lumiObj;
   static o2::ctp::LumiInfo lumiPrev;
-  if (getLumiScaleType() == 1 && mInstLumiOverride <= 0.) {
+
+  if (getLumiCTPAvailable() && mInstCTPLumiOverride <= 0.) {
     if (pc.inputs().get<gsl::span<char>>("CTPLumi").size() == sizeof(o2::ctp::LumiInfo)) {
       lumiPrev = lumiObj = pc.inputs().get<o2::ctp::LumiInfo>("CTPLumi");
     } else {
@@ -61,10 +62,14 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
       }
       lumiObj = lumiPrev;
     }
-    setInstLumi(mInstLumiFactor * (mCTPLumiSource == 0 ? lumiObj.getLumi() : lumiObj.getLumiAlt()));
-  } else if (getLumiScaleType() == 2 && mInstLumiOverride <= 0.) {
+    setInstLumiCTP(mInstLumiCTPFactor * (mLumiCTPSource == 0 ? lumiObj.getLumi() : lumiObj.getLumiAlt()));
+    if (getLumiScaleType() == 1) {
+      setInstLumi(getInstLumiCTP());
+    }
+  }
+  if (getLumiScaleType() == 2) {
     float tpcScaler = pc.inputs().get<float>("tpcscaler");
-    setInstLumi(mInstLumiFactor * tpcScaler);
+    setInstLumi(tpcScaler);
   }
   if (getUseMShapeCorrection()) {
     LOGP(info, "Setting M-Shape map");
@@ -80,6 +85,7 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
   if (!mScaleInverse) {
     updateInverse();
   }
+  reportScaling();
 }
 
 //________________________________________________________
@@ -99,9 +105,11 @@ void CorrectionMapsLoader::requestCCDBInputs(std::vector<InputSpec>& inputs, std
     LOG(fatal) << "Correction mode unknown! Choose either 0 (default) or 1 (derivative map) for flag corrmap-lumi-mode.";
   }
 
-  if (gloOpts.lumiType == 1) {
+  if (gloOpts.requestCTPLumi) {
     addInput(inputs, {"CTPLumi", "CTP", "LUMI", 0, Lifetime::Timeframe});
-  } else if (gloOpts.lumiType == 2) {
+  }
+
+  if (gloOpts.lumiType == 2) {
     addInput(inputs, {"tpcscaler", o2::header::gDataOriginTPC, "TPCSCALER", 0, Lifetime::Timeframe});
   }
 
@@ -126,9 +134,10 @@ void CorrectionMapsLoader::addOptions(std::vector<ConfigParamSpec>& options)
 void CorrectionMapsLoader::addGlobalOptions(std::vector<ConfigParamSpec>& options)
 {
   // these are options which should be added at the workflow level, since they modify the inputs of the devices
-  addOption(options, ConfigParamSpec{"lumi-type", o2::framework::VariantType::Int, 0, {"1 = require CTP lumi for TPC correction scaling, 2 = require TPC scalers for TPC correction scaling"}});
+  addOption(options, ConfigParamSpec{"lumi-type", o2::framework::VariantType::Int, 0, {"1 = use CTP lumi for TPC correction scaling, 2 = use TPC scalers for TPC correction scaling"}});
   addOption(options, ConfigParamSpec{"corrmap-lumi-mode", o2::framework::VariantType::Int, 0, {"scaling mode: (default) 0 = static + scale * full; 1 = full + scale * derivative; 2 = full + scale * derivative (for MC)"}});
   addOption(options, ConfigParamSpec{"enable-M-shape-correction", o2::framework::VariantType::Bool, false, {"Enable M-shape distortion correction"}});
+  addOption(options, ConfigParamSpec{"disable-ctp-lumi-request", o2::framework::VariantType::Bool, false, {"do not request CTP lumi (regardless what is used for corrections)"}});
 }
 
 //________________________________________________________
@@ -138,6 +147,10 @@ CorrectionMapsLoaderGloOpts CorrectionMapsLoader::parseGlobalOptions(const o2::f
   tpcopt.lumiType = opts.get<int>("lumi-type");
   tpcopt.lumiMode = opts.get<int>("corrmap-lumi-mode");
   tpcopt.enableMShapeCorrection = opts.get<bool>("enable-M-shape-correction");
+  tpcopt.requestCTPLumi = !opts.get<bool>("disable-ctp-lumi-request");
+  if (!tpcopt.requestCTPLumi && tpcopt.lumiType == 1) {
+    LOGP(fatal, "Scaling with CTP Lumi is requested but this input is disabled");
+  }
   return tpcopt;
 }
 
@@ -164,7 +177,7 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
     setCorrMap((o2::gpu::TPCFastTransform*)obj);
     mCorrMap->rectifyAfterReadingFromFile();
     if (getMeanLumiOverride() == 0 && mCorrMap->getLumi() > 0.) {
-      setMeanLumi(mCorrMap->getLumi());
+      setMeanLumi(mCorrMap->getLumi(), false);
     }
     LOGP(debug, "MeanLumiOverride={} MeanLumiMap={} -> meanLumi = {}", getMeanLumiOverride(), mCorrMap->getLumi(), getMeanLumi());
     setUpdatedMap();
@@ -182,11 +195,11 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
   }
   if (matcher == ConcreteDataMatcher("TPC", "CorrMapParam", 0)) {
     const auto& par = o2::tpc::CorrMapParam::Instance();
-    mMeanLumiOverride = par.lumiMean;
+    mMeanLumiOverride = par.lumiMean; // negative value switches off corrections !!!
     mMeanLumiRefOverride = par.lumiMeanRef;
-    mInstLumiOverride = par.lumiInst;
-    mInstLumiFactor = par.lumiInstFactor;
-    mCTPLumiSource = par.ctpLumiSource;
+    mInstCTPLumiOverride = par.lumiInst;
+    mInstLumiCTPFactor = par.lumiInstFactor;
+    mLumiCTPSource = par.ctpLumiSource;
 
     if (mMeanLumiOverride != 0.) {
       setMeanLumi(mMeanLumiOverride, false);
@@ -194,8 +207,11 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
     if (mMeanLumiRefOverride != 0.) {
       setMeanLumiRef(mMeanLumiRefOverride);
     }
-    if (mInstLumiOverride != 0.) {
-      setInstLumi(mInstLumiOverride, false);
+    if (mInstCTPLumiOverride != 0.) {
+      setInstLumiCTP(mInstCTPLumiOverride * mInstLumiCTPFactor);
+      if (getLumiScaleType() == 1) {
+        setInstLumi(getInstLumiCTP(), false);
+      }
     }
     setUpdatedLumi();
     int scaleType = getLumiScaleType();
@@ -203,8 +219,10 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
     if (scaleType >= lumiS.size()) {
       LOGP(fatal, "Wrong lumi-scale-type provided!");
     }
-    LOGP(info, "TPC correction map params updated (corr.map scaling type={}): override values: lumiMean={} lumiRefMean={} lumiInst={} lumiScaleMode={}, LumiInst scale={}, CTP Lumi source={}",
-         lumiS[scaleType], mMeanLumiOverride, mMeanLumiRefOverride, mInstLumiOverride, mLumiScaleMode, mInstLumiFactor, mCTPLumiSource);
+
+    LOGP(info, "TPC correction map params updated: SP corrections: {} (corr.map scaling type={}, override values: lumiMean={} lumiRefMean={} lumiScaleMode={}), CTP Lumi: source={} lumiInstOverride={} , LumiInst scale={} ",
+         canUseCorrections() ? "ON" : "OFF",
+         lumiS[scaleType], mMeanLumiOverride, mMeanLumiRefOverride, mLumiScaleMode, mLumiCTPSource, mInstCTPLumiOverride, mInstLumiCTPFactor);
   }
   return false;
 }
@@ -216,20 +234,22 @@ void CorrectionMapsLoader::init(o2::framework::InitContext& ic)
     LOGP(fatal, "TPC correction lumi scaling mode is not set");
   }
   const auto& inputRouts = ic.services().get<const o2::framework::DeviceSpec>().inputs;
+  bool foundCTP = false, foundTPCScl = false, foundMShape = false;
   for (const auto& route : inputRouts) {
     if (route.matcher == InputSpec{"CTPLumi", "CTP", "LUMI", 0, Lifetime::Timeframe}) {
-      if (getLumiScaleType() != 1) {
-        LOGP(fatal, "Lumi scaling source CTP is not compatible with TPC correction lumi scaler type {}", getLumiScaleType());
-      }
+      foundCTP = true;
     } else if (route.matcher == InputSpec{"tpcscaler", o2::header::gDataOriginTPC, "TPCSCALER", 0, Lifetime::Timeframe}) {
-      if (getLumiScaleType() != 2) {
-        LOGP(fatal, "Lumi scaling source TPCScaler is not compatible with TPC correction lumi scaler type {}", getLumiScaleType());
-      }
-      setLumiScaleType(2);
+      foundTPCScl = true;
     } else if (route.matcher == InputSpec{"mshape", o2::header::gDataOriginTPC, "TPCMSHAPE", 0, Lifetime::Timeframe}) {
-      enableMShapeCorrection(true);
+      foundMShape = true;
     }
   }
+  setLumiCTPAvailable(foundCTP);
+  enableMShapeCorrection(foundMShape);
+  if ((getLumiScaleType() == 1 && !foundCTP) || (getLumiScaleType() == 2 && !foundTPCScl)) {
+    LOGP(fatal, "Lumi scaling source {}({}) is not available for TPC correction", getLumiScaleType(), getLumiScaleType() == 1 ? "CTP" : "TPCScaler");
+  }
+
   if ((getLumiScaleMode() == 1) || (getLumiScaleMode() == 2)) {
     mScaleInverse = ic.options().get<bool>("do-not-recalculate-inverse-correction");
   } else {
@@ -243,16 +263,18 @@ void CorrectionMapsLoader::init(o2::framework::InitContext& ic)
 void CorrectionMapsLoader::copySettings(const CorrectionMapsLoader& src)
 {
   setInstLumi(src.getInstLumi(), false);
+  setInstLumiCTP(src.getInstLumiCTP());
   setMeanLumi(src.getMeanLumi(), false);
+  setLumiCTPAvailable(src.getLumiCTPAvailable());
   setMeanLumiRef(src.getMeanLumiRef());
   setLumiScaleType(src.getLumiScaleType());
   setMeanLumiOverride(src.getMeanLumiOverride());
   setMeanLumiRefOverride(src.getMeanLumiRefOverride());
-  setInstLumiOverride(src.getInstLumiOverride());
+  setInstCTPLumiOverride(src.getInstCTPLumiOverride());
   setLumiScaleMode(src.getLumiScaleMode());
   enableMShapeCorrection(src.getUseMShapeCorrection());
-  mInstLumiFactor = src.mInstLumiFactor;
-  mCTPLumiSource = src.mCTPLumiSource;
+  mInstLumiCTPFactor = src.mInstLumiCTPFactor;
+  mLumiCTPSource = src.mLumiCTPSource;
   mLumiScaleMode = src.mLumiScaleMode;
   mScaleInverse = src.getScaleInverse();
 }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -188,10 +188,10 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     mTPCCorrMapsLoader.extractCCDBInputs(pc);
     bool updateMaps = false;
     if (mTPCCorrMapsLoader.isUpdated()) {
-      mPadGainTracks.setTPCCorrMaps(&mTPCCorrMapsLoader);
       mTPCCorrMapsLoader.acknowledgeUpdate();
       updateMaps = true;
     }
+    mPadGainTracks.setTPCCorrMaps(&mTPCCorrMapsLoader);
     if (mTPCVDriftHelper.isUpdated()) {
       LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} and DriftTimeOffset correction {} wrt {} from source {}",
            mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift,

--- a/Detectors/TPC/workflow/readers/src/TrackReaderSpec.cxx
+++ b/Detectors/TPC/workflow/readers/src/TrackReaderSpec.cxx
@@ -46,7 +46,9 @@ void TrackReader::run(ProcessingContext& pc)
   mTree->GetEntry(ent);
   using TrackTunePar = o2::globaltracking::TrackTuneParams;
   const auto& trackTune = TrackTunePar::Instance();
-  if (trackTune.sourceLevelTPC &&
+  // Normally we should not apply tuning here as with sourceLevelTPC==true it is already applied in the tracking.
+  // Note that there is no way to apply lumi scaling here!!!
+  if ((trackTune.sourceLevelTPC && trackTune.applyWhenReading) &&
       (trackTune.useTPCInnerCorr || trackTune.useTPCOuterCorr ||
        trackTune.tpcCovInnerType != TrackTunePar::AddCovType::Disable || trackTune.tpcCovOuterType != TrackTunePar::AddCovType::Disable)) {
     for (auto& trc : mTracksOut) {

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -173,11 +173,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     }
     return false;
   }};
-
   if (!disableRootInput || inputType == InputType::PassThrough) {
-    if (sclOpts.lumiType == 1) { // need CTP digits (lumi) reader
-      specs.emplace_back(o2::ctp::getDigitsReaderSpec(false));
-    }
     // The OutputSpec of the PublisherSpec is configured depending on the input
     // type. Note that the configuration of the dispatch trigger in the main file
     // needs to be done in accordance. This means, if a new input option is added
@@ -200,6 +196,9 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
       if (sclOpts.needTPCScalersWorkflow()) { // for standalone tpc-reco workflow
         specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpts.lumiType == 2, sclOpts.enableMShapeCorrection));
       }
+      if (sclOpts.requestCTPLumi) { // need CTP digits (lumi) reader
+        specs.emplace_back(o2::ctp::getDigitsReaderSpec(false));
+      }
     } else if (inputType == InputType::ClustersHardware) {
       specs.emplace_back(o2::tpc::getPublisherSpec(PublisherConf{
                                                      "tpc-clusterhardware-reader",
@@ -220,6 +219,9 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
       }
       if (sclOpts.needTPCScalersWorkflow()) { // for standalone tpc-reco workflow
         specs.emplace_back(o2::tpc::getTPCScalerSpec(sclOpts.lumiType == 2, sclOpts.enableMShapeCorrection));
+      }
+      if (sclOpts.requestCTPLumi) { // need CTP digits (lumi) reader
+        specs.emplace_back(o2::ctp::getDigitsReaderSpec(false));
       }
     } else if (inputType == InputType::CompClusters) {
       // TODO: need to check if we want to store the MC labels alongside with compressed clusters
@@ -454,6 +456,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     cfg.lumiScaleType = sclOpts.lumiType;
     cfg.lumiScaleMode = sclOpts.lumiMode;
     cfg.enableMShape = sclOpts.enableMShapeCorrection;
+    cfg.enableCTPLumi = sclOpts.requestCTPLumi;
     cfg.decompressTPC = decompressTPC;
     cfg.decompressTPCFromROOT = decompressTPC && inputType == InputType::CompClusters;
     cfg.caClusterer = caClusterer;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -99,7 +99,8 @@ class TRDGlobalTracking : public o2::framework::Task
   gsl::span<const int> mITSABTrackClusIdx;                            ///< input ITSAB track cluster indices span
   std::vector<o2::BaseCluster<float>> mITSClustersArray;              ///< ITS clusters created in run() method from compact clusters
   const o2::itsmft::TopologyDictionary* mITSDict = nullptr;           ///< cluster patterns dictionary
-
+  std::array<float, 5> mCovDiagInner{};                               ///< total cov.matrix extra diagonal error from TrackTuneParams
+  std::array<float, 5> mCovDiagOuter{};                               ///< total cov.matrix extra diagonal error from TrackTuneParams
   // PID
   PIDPolicy mPolicy{PIDPolicy::DEFAULT}; ///< Model to load an evaluate
   std::unique_ptr<PIDBase> mBase;        ///< PID engine

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -96,7 +96,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (!configcontext.options().get<bool>("disable-ft0-pileup-tagging")) {
     srcTRD |= GTrackID::getSourcesMask("FT0");
   }
-  if (sclOpt.lumiType == 1) {
+  if (sclOpt.requestCTPLumi) {
     srcTRD = srcTRD | GTrackID::getSourcesMask("CTP");
   }
   // Parse PID policy string

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -34,6 +34,7 @@ class CorrectionMapsHelper
   CorrectionMapsHelper() = default;
   ~CorrectionMapsHelper() { clear(); }
   CorrectionMapsHelper(const CorrectionMapsHelper&) = delete;
+  void updateLumiScale(bool report = false);
   void clear();
 
   GPUd() void Transform(int slice, int row, float pad, float time, float& x, float& y, float& z, float vertexTime = 0) const
@@ -66,7 +67,14 @@ class CorrectionMapsHelper
   void setCorrMapRef(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
   void setCorrMapMShape(GPUCA_NAMESPACE::gpu::TPCFastTransform* m);
   void reportScaling();
-  void setInstLumi(float v, bool report = true)
+  void setInstLumiCTP(float v)
+  {
+    if (v != mInstLumiCTP) {
+      mInstLumiCTP = v;
+    }
+  }
+
+  void setInstLumi(float v, bool report = false)
   {
     if (v != mInstLumi) {
       mInstLumi = v;
@@ -74,7 +82,7 @@ class CorrectionMapsHelper
     }
   }
 
-  void setMeanLumi(float v, bool report = true)
+  void setMeanLumi(float v, bool report = false)
   {
     if (v != mMeanLumi) {
       mMeanLumi = v;
@@ -93,26 +101,11 @@ class CorrectionMapsHelper
   {
     if (v != mLumiScaleMode) {
       mLumiScaleMode = v;
-      updateLumiScale();
+      updateLumiScale(false);
     }
   }
 
-  void updateLumiScale(bool report = true)
-  {
-    if (mMeanLumi < 0.f || mInstLumi < 0.f) {
-      mLumiScale = -1.f;
-    } else if ((mLumiScaleMode == 1) || (mLumiScaleMode == 2)) {
-      mLumiScale = mMeanLumiRef ? (mInstLumi - mMeanLumi) / mMeanLumiRef : 0.f;
-      LOGP(debug, "mInstLumi: {}  mMeanLumi: {} mMeanLumiRef: {}", mInstLumi, mMeanLumi, mMeanLumiRef);
-    } else {
-      mLumiScale = mMeanLumi ? mInstLumi / mMeanLumi : 0.f;
-    }
-    setUpdatedLumi();
-    if (report) {
-      reportScaling();
-    }
-  }
-
+  GPUd() float getInstLumiCTP() const { return mInstLumiCTP; }
   GPUd() float getInstLumi() const { return mInstLumi; }
   GPUd() float getMeanLumi() const { return mMeanLumi; }
   GPUd() float getMeanLumiRef() const { return mMeanLumiRef; }
@@ -137,19 +130,20 @@ class CorrectionMapsHelper
 #endif
   void setOwner(bool v);
   void acknowledgeUpdate() { mUpdatedFlags = 0; }
-
+  void setLumiCTPAvailable(bool v) { mLumiCTPAvailable = v; }
+  bool getLumiCTPAvailable() const { return mLumiCTPAvailable; }
   void setLumiScaleType(int v) { mLumiScaleType = v; }
   int getLumiScaleType() const { return mLumiScaleType; }
   void enableMShapeCorrection(bool v) { mEnableMShape = v; }
   bool getUseMShapeCorrection() const { return mEnableMShape; }
-
+  bool canUseCorrections() const { return mMeanLumi >= 0.; }
   void setMeanLumiOverride(float f) { mMeanLumiOverride = f; }
   void setMeanLumiRefOverride(float f) { mMeanLumiRefOverride = f; }
   float getMeanLumiOverride() const { return mMeanLumiOverride; }
   float getMeanLumiRefOverride() const { return mMeanLumiRefOverride; }
 
-  void setInstLumiOverride(float f) { mInstLumiOverride = f; }
-  float getInstLumiOverride() const { return mInstLumiOverride; }
+  void setInstCTPLumiOverride(float f) { mInstCTPLumiOverride = f; }
+  float getInstCTPLumiOverride() const { return mInstCTPLumiOverride; }
 
   int getUpdateFlags() const { return mUpdatedFlags; }
 
@@ -171,24 +165,26 @@ class CorrectionMapsHelper
                      LumiBit = 0x4,
                      MapMShapeBit = 0x10 };
   bool mOwner = false; // is content of pointers owned by the helper
+  bool mLumiCTPAvailable = false; // is CTP Lumi available
   // these 2 are global options, must be set by the workflow global options
-  int mLumiScaleType = -1; // require CTP Lumi for mInstLumi
+  int mLumiScaleType = -1; // use CTP Lumi (1) or TPCScaler (2) for the correction scaling, 0 - no scaling
   int mLumiScaleMode = -1; // scaling-mode of the correciton maps
   int mUpdatedFlags = 0;
-  float mInstLumi = 0.;                                            // instanteneous luminosity (a.u)
-  float mMeanLumi = 0.;                                            // mean luminosity of the map (a.u)
-  float mMeanLumiRef = 0.;                                         // mean luminosity of the ref map (a.u)
+  float mInstLumiCTP = 0.;                                         // instanteneous luminosity from CTP (a.u)
+  float mInstLumi = 0.;                                            // instanteneous luminosity (a.u) used for TPC corrections scaling
+  float mMeanLumi = 0.;                                            // mean luminosity of the map (a.u) used for TPC corrections scaling
+  float mMeanLumiRef = 0.;                                         // mean luminosity of the ref map (a.u) used for TPC corrections scaling reference
   float mLumiScale = 0.;                                           // precalculated mInstLumi/mMeanLumi
   float mMeanLumiOverride = -1.f;                                  // optional value to override mean lumi
   float mMeanLumiRefOverride = -1.f;                               // optional value to override ref mean lumi
-  float mInstLumiOverride = -1.f;                                  // optional value to override inst lumi
+  float mInstCTPLumiOverride = -1.f;                               // optional value to override inst lumi from CTP
   bool mEnableMShape = false;                                      ///< use v shape correction
   bool mScaleInverse{false};                                       // if set to false the inverse correction is already scaled and will not scaled again
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMap{nullptr};       // current transform
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapRef{nullptr};    // reference transform
   GPUCA_NAMESPACE::gpu::TPCFastTransform* mCorrMapMShape{nullptr}; // correction map for v-shape distortions on A-side
 #ifndef GPUCA_ALIROOT_LIB
-  ClassDefNV(CorrectionMapsHelper, 5);
+  ClassDefNV(CorrectionMapsHelper, 6);
 #endif
 };
 

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -105,6 +105,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
     int itsTriggerType = 0;
     int lumiScaleMode = 0;
     bool enableMShape = false;
+    bool enableCTPLumi = false;
     int enableDoublePipeline = 0;
     int tpcDeadMapSources = -1;
     bool decompressTPC = false;

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -1089,7 +1089,7 @@ Inputs GPURecoWorkflowSpec::inputs()
     inputs.emplace_back("tpcthreshold", gDataOriginTPC, "PADTHRESHOLD", 0, Lifetime::Condition, ccdbParamSpec("TPC/Config/FEEPad"));
     o2::tpc::VDriftHelper::requestCCDBInputs(inputs);
     Options optsDummy;
-    o2::tpc::CorrectionMapsLoaderGloOpts gloOpts{mSpecConfig.lumiScaleType, mSpecConfig.lumiScaleMode, mSpecConfig.enableMShape};
+    o2::tpc::CorrectionMapsLoaderGloOpts gloOpts{mSpecConfig.lumiScaleType, mSpecConfig.lumiScaleMode, mSpecConfig.enableMShape, mSpecConfig.enableCTPLumi};
     mCalibObjects.mFastTransformHelper->requestCCDBInputs(inputs, optsDummy, gloOpts); // option filled here is lost
   }
   if (mSpecConfig.decompressTPC) {

--- a/GPU/Workflow/src/GPUWorkflowTPC.cxx
+++ b/GPU/Workflow/src/GPUWorkflowTPC.cxx
@@ -413,19 +413,26 @@ void GPURecoWorkflowSpec::doTrackTuneTPC(GPUTrackingInOutPointers& ptrs, char* b
       throw std::runtime_error("Buffer does not match span");
     }
     o2::tpc::TrackTPC* tpcTracks = reinterpret_cast<o2::tpc::TrackTPC*>(buffout);
+    float scale = mCalibObjects.mFastTransformHelper->getInstLumiCTP();
+    if (scale < 0.f) {
+      scale = 0.f;
+    }
+    auto diagInner = trackTune.getCovInnerTotal(scale);
+    auto diagOuter = trackTune.getCovOuterTotal(scale);
+
     for (unsigned int itr = 0; itr < ptrs.nOutputTracksTPCO2; itr++) {
       auto& trc = tpcTracks[itr];
       if (trackTune.useTPCInnerCorr) {
         trc.updateParams(trackTune.tpcParInner);
       }
       if (trackTune.tpcCovInnerType != TrackTunePar::AddCovType::Disable) {
-        trc.updateCov(trackTune.tpcCovInner, trackTune.tpcCovInnerType == TrackTunePar::AddCovType::WithCorrelations);
+        trc.updateCov(diagInner, trackTune.tpcCovInnerType == TrackTunePar::AddCovType::WithCorrelations);
       }
       if (trackTune.useTPCOuterCorr) {
         trc.getParamOut().updateParams(trackTune.tpcParOuter);
       }
       if (trackTune.tpcCovOuterType != TrackTunePar::AddCovType::Disable) {
-        trc.getParamOut().updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType == TrackTunePar::AddCovType::WithCorrelations);
+        trc.getParamOut().updateCov(diagOuter, trackTune.tpcCovOuterType == TrackTunePar::AddCovType::WithCorrelations);
       }
     }
   }

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -161,6 +161,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   cfg.lumiScaleType = sclOpt.lumiType;
   cfg.lumiScaleMode = sclOpt.lumiMode;
   cfg.enableMShape = sclOpt.enableMShapeCorrection;
+  cfg.enableCTPLumi = sclOpt.requestCTPLumi;
   cfg.decompressTPC = isEnabled(inputTypes, ioType::CompClustCTF);
   cfg.decompressTPCFromROOT = isEnabled(inputTypes, ioType::CompClustROOT);
   cfg.zsDecoder = isEnabled(inputTypes, ioType::ZSRaw);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -130,7 +130,7 @@ if [[ $SYNCMODE == 1 ]]; then
     fi
     ITSTPC_CONFIG_KEY+="tpcitsMatch.safeMarginTimeCorrErr=5.;tpcitsMatch.cutMatchingChi2=60;"
     if [[ -z $TRACKTUNETPCINNER ]]; then # account for extra TPC errors
-      TRACKTUNETPCINNER="trackTuneParams.sourceLevelTPC=true;trackTuneParams.tpcCovInnerType=1;trackTuneParams.useTPCInnerCorr=false;trackTuneParams.tpcCovInner[0]=0.25;trackTuneParams.tpcCovInner[2]=2.25e-4;trackTuneParams.tpcCovInner[3]=2.25e-4;trackTuneParams.tpcCovInner[4]=0.0256;"
+      TRACKTUNETPCINNER="trackTuneParams.sourceLevelTPC=true;trackTuneParams.tpcCovInnerType=1;trackTuneParams.useTPCInnerCorr=false;trackTuneParams.tpcCovInner[0]=0.5;trackTuneParams.tpcCovInner[2]=0.01;trackTuneParams.tpcCovInner[3]=0.01;trackTuneParams.tpcCovInner[4]=0.1;"
     fi
   fi
   GPU_CONFIG_KEY+="GPU_global.synchronousProcessing=1;GPU_proc.clearO2OutputFromGPU=1;"
@@ -278,6 +278,7 @@ while [[ $# -gt 0 ]]; do
     --enable-M-shape-correction) TPC_CORR_OPT+=" --enable-M-shape-correction"; NEED_TPC_SCALERS_WF=1; TPC_SCALERS_CONF+=" --enable-M-shape-correction" ; shift 1;;
     --corrmap-lumi-mode=*) TPC_CORR_OPT+=" --corrmap-lumi-mode ${1#*=}"; shift 1;;
     --corrmap-lumi-mode) TPC_CORR_OPT+=" --corrmap-lumi-mode ${2}"; shift 2;;
+    --disable-ctp-lumi-request) TPC_CORR_OPT+=" --disable-ctp-lumi-request"; shift 1;;
     *) TPC_CORR_KEY+="$1;"; shift 1;;
   esac
 done


### PR DESCRIPTION
@miranov25 note that in the pp the CTP int.rate is the visible one (~0.75 of the total one) while in the pbpb we get ZDC EM int.rate which is factor 28 larger than the hadronic one. In the async reco we are rescaling it to the equivalent pp visible rate  (mult. factor 90 is assumed) by multiplying it by 2.414. Therefore, when preparing the parameters for 
`diagError^2 = [a + int_rate*b]^2` one should assume `int_rate = 3379600 Hz`

with a and b being `trackTuneParams.tpcCovInner` and `trackTuneParams.tpcErrInnerSlope` (same for the Outer).
Note that the meaning of the tpcCovInner and tpcCovOuter was changed from err^2 to err.

----------------------

* Load CTP lumi by default, even if it is not used for corrections scaling

CTP Lumi is loaded (unless `--disable-ctp-lumi-request` is explicitly passed) even if TPC IDC scaler is used for distortions rescaling. Can be extracted as `CorrectionMapsHelper::getInstLumiCTP()`, while the `getInstLumi()` will return whatever instantaneous rate is used for the corrections scaling (e.g. the same CTPLumi or IDC scaler for ` mLumiScaleType == 1` and `2` respectively).
    
The TPCCorrMap.lumiInst now overrides only the CTP Lumi (if !=0) but does not affect IDC scaler. Therefore it cannot be used anymore to disable the corrections via negative value. Instead, TPCCorrMap.meanLumi < 0 will disable all corrections.
Similarly, the TPCCorrMap.lumiInstFactor is now applied only to CTP Lumi but not to IDC scaler. Note that the TPCCorrMap.lumiInstFactor will be used as a multiplier also in the case of the overridden inst. CTP lumi, i.e.     TPCCorrMap.lumiInst*TPCCorrMap.lumiInstFactor will be used as overridden CTP lumi.

* Make extra cov.error for TPC linear in CTP Lumi

Now the `trackTuneParams.tpcCovInnerSlope[0..4]` and `trackTuneParams.tpcCovOuterSlope[0..4]`
configurable can be used to scale the TPC extra cov.matrix errors linearly with scaling parameters.
All devices (re)fitting TPC tracks will apply the `errors^2` (if allowed by other options of trackTuneParams)
`(tpcCorInner + lumi*tpcCovInnerSlope)^2` and `(tpcCovOuter + lumi*tpcCovOuterSlope)^2`, with lumi being
`CorrectionMapsHelper.getInstLumiCTP()`