### PR TITLE
DPL Analysis: fix internal indices not properly bound when grouping is used

### DIFF
--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -384,7 +384,7 @@ struct AnalysisDataProcessorBuilder {
         return true;
       },
                              task);
-
+      overwriteInternalIndices(associatedTables, associatedTables);
       if constexpr (soa::is_soa_iterator_v<std::decay_t<G>>) {
         auto slicer = GroupSlicer(groupingTable, associatedTables, slices);
         for (auto& slice : slicer) {
@@ -406,7 +406,6 @@ struct AnalysisDataProcessorBuilder {
           invokeProcessWithArgsGeneric(task, processingFunction, slice.groupingElement(), associatedSlices);
         }
       } else {
-        overwriteInternalIndices(associatedTables, associatedTables);
         // bind partitions and grouping table
         homogeneous_apply_refs([&groupingTable](auto& x) {
           PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -194,10 +194,9 @@ struct GroupSlicer {
             return typedTable;
 
           } else {
-            auto groupedElementsTable = originalTable.asArrowTable()->Slice(offset, count);
-            std::decay_t<A1> typedTable{{groupedElementsTable}, offset};
-            typedTable.bindInternalIndicesTo(&originalTable);
-            return typedTable;
+            auto groupedElementsTable = originalTable.rawSlice(offset, offset + count - 1);
+            groupedElementsTable.bindInternalIndicesTo(&originalTable);
+            return groupedElementsTable;
           }
         } else {
           // generic split


### PR DESCRIPTION
* `overwriteInternalIndices()` should be called unconditionally.
* Use table object method when slicing, instead of constructing a new instance