### PR TITLE
Avoid ambiguity in format_to

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeaderHelpers.h
+++ b/DataFormats/Headers/include/Headers/DataHeaderHelpers.h
@@ -40,7 +40,7 @@ struct fmt::formatter<T, std::enable_if_t<o2::header::is_descriptor<T>::value, c
   template <typename FormatContext>
   auto format(const T& p, FormatContext& ctx)
   {
-    return format_to(ctx.out(), "{}", p.template as<std::string>());
+    return fmt::format_to(ctx.out(), "{}", p.template as<std::string>());
   }
 };
 
@@ -79,7 +79,7 @@ struct fmt::formatter<o2::header::DataHeader> {
                fmt::format("  firstTForbit : {}\n", h.firstTForbit) +
                fmt::format("  tfCounter    : {}\n", h.tfCounter) +
                fmt::format("  runNumber    : {}\n", h.runNumber);
-    return format_to(ctx.out(), "{}", res);
+    return fmt::format_to(ctx.out(), "{}", res);
   }
 };
 


### PR DESCRIPTION
Otherwise I am getting the following error with gcc 13.2
```
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/DataFormats/Headers/include/Headers/DataHeaderHelpers.h:82:21: error: call of overloaded 'format_to(fmt::v10::basic_format_context<fmt::v10::appender, char>::iterator, const char [3], std::__cxx11::basic_string<char>&)' is ambiguous
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:    82 |     return format_to(ctx.out(), "{}", res);
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:       |            ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: In file included from /home/oschmidt/alice/sw/fedora39_x86-64/FairLogger/v1.11.1-local3/include/fairlogger/Logger.h:27,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Logger/include/Framework/Logger.h:14,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/ServiceRegistryRef.h:15,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/ExpirationHandler.h:19,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/InputRoute.h:14,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/FairMQDeviceProxy.h:20,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/src/FairMQDeviceProxy.cxx:12:
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:2814:17: note: candidate: 'OutputIt fmt::v10::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt = appender; T = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format_string<char, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>]'
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:  2814 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:       |                 ^~~~~~~~~
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: In file included from /usr/include/c++/13/bits/chrono_io.h:39,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /usr/include/c++/13/chrono:3330,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/DataProcessingHeader.h:19,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/DataDescriptorMatcher.h:15,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:                  from /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/include/Framework/ExpirationHandler.h:17:
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /usr/include/c++/13/format:3828:5: note: candidate: '_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v10::appender; _Args = {__cxx11::basic_string<char, char_traits<char>, allocator<char> >&}; format_string<_Args ...> = basic_format_string<char, __cxx11::basic_string<char, char_traits<char>, allocator<char> >&>]'
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:  3828 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:       |     ^~~~~~~~~
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = const o2::header::DataHeader; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:1808:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {const o2::header::DataHeader, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {o2::header::DataHeader, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]'
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:1826:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<_Args>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {const o2::header::DataHeader, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]'
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:2788:44:   required from 'std::string fmt::v10::format(format_string<T ...>, T&& ...) [with T = {const o2::header::DataHeader&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, const o2::header::DataHeader&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]'
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/SOURCES/O2/trdchamberstat/0/Framework/Core/src/FairMQDeviceProxy.cxx:134:5:   required from here
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:1576:63: error: 'fmt::v10::detail::type_is_unformattable_for<const o2::header::DataHeader, char> _' has incomplete type
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:  1576 |     type_is_unformattable_for<T, typename Context::char_type> _;
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:       |                                                               ^
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:1580:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:  1580 |       formattable,
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0:       |       ^~~~~~~~~~~
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/fedora39_x86-64/fmt/10.1.1-local4/include/fmt/core.h:1580:7: note: 'formattable' evaluates to false
2024-02-05@15:08:40:DEBUG:O2PDPSuite:O2:0: cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
```