### PR TITLE
bug fix when creating diagnostic frequency (clear was missing)

### DIFF
--- a/DataFormats/Detectors/TOF/src/Diagnostic.cxx
+++ b/DataFormats/Detectors/TOF/src/Diagnostic.cxx
@@ -104,7 +104,7 @@ void Diagnostic::merge(const Diagnostic* prev)
 {
   LOG(debug) << "Merging diagnostic words";
   for (auto const& el : prev->mVector) {
-    fill(el.first, el.second + getFrequency(el.first));
+    fill(el.first, el.second);
   }
 }
 

--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -448,6 +448,7 @@ void WindowFiller::checkIfReuseFutureDigitsRO() // the same but using readout in
 void WindowFiller::fillDiagnosticFrequency()
 {
   bool isTOFempty = true;
+  mDiagnosticFrequency.clear();
   // fill diagnostic frequency
   for (int j = 0; j < mReadoutWindowData.size(); j++) {
     mDiagnosticFrequency.fillROW();


### PR DESCRIPTION
This is fix when sending TOF diagnostic frequencies, it adds:
1) clearing of the diagnostic frequency when moving to the next TF (this was a bug resulting in an over-weighting of TF at the start of run wrt to the end of run)
2) fixing fill call which applied update twice (no effect on average)

The fix was checked running the chain on the full LHC22q period
CTF -> TOF digit -> TOF calib info -> TOF calib workflow
Results are now consistent with the output of TOF QC and they will be used for MC anchoring.
The impact of the bug (mainly point 1) on previous sync calibration (for 2023 data) it is at the level of a second order effect if diagnostic frequencies change drammatically along the run-> to be fixed in case of evident discrepancy found with TOF QC  