### PR TITLE
Revert "DPL Analysis: make BindingNodes constexpr"

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -27,6 +27,7 @@
 #include <gandiva/selection_vector.h>
 #include <cassert>
 #include <fmt/format.h>
+#include <typeinfo>
 #include <gsl/span>
 #include <limits>
 
@@ -52,13 +53,13 @@ struct Binding {
   void bind(T const* table)
   {
     ptr = table;
-    hash = o2::framework::TypeIdHelpers::uniqueId<T>();
+    hash = typeHash<T>();
   }
 
   template <typename T>
   T const* get() const
   {
-    if (hash == o2::framework::TypeIdHelpers::uniqueId<T>()) {
+    if (hash == typeHash<T>()) {
       return static_cast<T const*>(ptr);
     }
     return nullptr;
@@ -1385,7 +1386,7 @@ class Table
 
   static constexpr auto hashes()
   {
-    return std::set{{o2::framework::TypeIdHelpers::uniqueId<C>()...}};
+    return std::set{{typeid(C).hash_code()...}};
   }
 
   template <typename IP, typename Parent, typename... T>
@@ -1885,8 +1886,8 @@ std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, 
       return _Getter_();                                                                                                                                                          \
     }                                                                                                                                                                             \
   };                                                                                                                                                                              \
-  [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_ { _Label_, o2::framework::TypeIdHelpers::uniqueId<_Name_>(),                                 \
-                                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_, typeid(_Name_).hash_code(),                                                                            \
+                                                                  o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_COLUMN(_Name_, _Getter_, _Type_) \
   DECLARE_SOA_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_)
@@ -1920,41 +1921,41 @@ std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, 
       return (*mColumnIterator & (static_cast<type>(1) << bit)) >> bit;                                                                                                           \
     }                                                                                                                                                                             \
   };                                                                                                                                                                              \
-  [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_ { _Label_, o2::framework::TypeIdHelpers::uniqueId<_Name_>(),                                 \
-                                                                                       o2::framework::expressions::selectArrowType<MAKEINT(_Size_)>() }
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_, typeid(_Name_).hash_code(),                                                                            \
+                                                                  o2::framework::expressions::selectArrowType<MAKEINT(_Size_)>() }
 
 #define DECLARE_SOA_BITMAP_COLUMN(_Name_, _Getter_, _Size_) \
   DECLARE_SOA_BITMAP_COLUMN_FULL(_Name_, _Getter_, _Size_, "f" #_Name_)
 
 /// An 'expression' column. i.e. a column that can be calculated from other
 /// columns with gandiva based on supplied C++ expression.
-#define DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_, _Expression_)                                                       \
-  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                                                                               \
-    static constexpr const char* mLabel = _Label_;                                                                                                \
-    using base = o2::soa::Column<_Type_, _Name_>;                                                                                                 \
-    using type = _Type_;                                                                                                                          \
-    using column_t = _Name_;                                                                                                                      \
-    using spawnable_t = std::true_type;                                                                                                           \
-    _Name_(arrow::ChunkedArray const* column)                                                                                                     \
-      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))                                                                    \
-    {                                                                                                                                             \
-    }                                                                                                                                             \
-                                                                                                                                                  \
-    _Name_() = default;                                                                                                                           \
-    _Name_(_Name_ const& other) = default;                                                                                                        \
-    _Name_& operator=(_Name_ const& other) = default;                                                                                             \
-                                                                                                                                                  \
-    decltype(auto) _Getter_() const                                                                                                               \
-    {                                                                                                                                             \
-      return *mColumnIterator;                                                                                                                    \
-    }                                                                                                                                             \
-    static o2::framework::expressions::Projector Projector()                                                                                      \
-    {                                                                                                                                             \
-      return _Expression_;                                                                                                                        \
-    }                                                                                                                                             \
-  };                                                                                                                                              \
-  [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_ { _Label_, o2::framework::TypeIdHelpers::uniqueId<_Name_>(), \
-                                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
+#define DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_, _Expression_)            \
+  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                                    \
+    static constexpr const char* mLabel = _Label_;                                                     \
+    using base = o2::soa::Column<_Type_, _Name_>;                                                      \
+    using type = _Type_;                                                                               \
+    using column_t = _Name_;                                                                           \
+    using spawnable_t = std::true_type;                                                                \
+    _Name_(arrow::ChunkedArray const* column)                                                          \
+      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))                         \
+    {                                                                                                  \
+    }                                                                                                  \
+                                                                                                       \
+    _Name_() = default;                                                                                \
+    _Name_(_Name_ const& other) = default;                                                             \
+    _Name_& operator=(_Name_ const& other) = default;                                                  \
+                                                                                                       \
+    decltype(auto) _Getter_() const                                                                    \
+    {                                                                                                  \
+      return *mColumnIterator;                                                                         \
+    }                                                                                                  \
+    static o2::framework::expressions::Projector Projector()                                           \
+    {                                                                                                  \
+      return _Expression_;                                                                             \
+    }                                                                                                  \
+  };                                                                                                   \
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_, typeid(_Name_).hash_code(), \
+                                                                  o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Expression_) \
   DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_, _Expression_);
@@ -2214,139 +2215,139 @@ std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, 
 #define DECLARE_SOA_ARRAY_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_ARRAY_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Name_##s, "")
 
 /// NORMAL
-#define DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Table_, _Suffix_)                                                                                           \
-  struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                                                                                                  \
-    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                                                                                                \
-    static_assert((*_Suffix_ == '\0') || (*_Suffix_ == '_'), "Suffix has to begin with _");                                                                                  \
-    static constexpr const char* mLabel = "fIndex" #_Table_ _Suffix_;                                                                                                        \
-    using base = o2::soa::Column<_Type_, _Name_##Id>;                                                                                                                        \
-    using type = _Type_;                                                                                                                                                     \
-    using column_t = _Name_##Id;                                                                                                                                             \
-    using binding_t = _Table_;                                                                                                                                               \
-    _Name_##Id(arrow::ChunkedArray const* column)                                                                                                                            \
-      : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                                                                                           \
-    {                                                                                                                                                                        \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    _Name_##Id() = default;                                                                                                                                                  \
-    _Name_##Id(_Name_##Id const& other) = default;                                                                                                                           \
-    _Name_##Id& operator=(_Name_##Id const& other) = default;                                                                                                                \
-    type inline getId() const                                                                                                                                                \
-    {                                                                                                                                                                        \
-      return _Getter_##Id();                                                                                                                                                 \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    type _Getter_##Id() const                                                                                                                                                \
-    {                                                                                                                                                                        \
-      return *mColumnIterator;                                                                                                                                               \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    bool has_##_Getter_() const                                                                                                                                              \
-    {                                                                                                                                                                        \
-      return *mColumnIterator >= 0;                                                                                                                                          \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    template <typename T>                                                                                                                                                    \
-    auto _Getter_##_as() const                                                                                                                                               \
-    {                                                                                                                                                                        \
-      if (O2_BUILTIN_UNLIKELY(mBinding.ptr == nullptr)) {                                                                                                                    \
-        o2::soa::notBoundTable(#_Table_);                                                                                                                                    \
-      }                                                                                                                                                                      \
-      if (O2_BUILTIN_UNLIKELY(!has_##_Getter_())) {                                                                                                                          \
-        o2::soa::accessingInvalidIndexFor(#_Getter_);                                                                                                                        \
-      }                                                                                                                                                                      \
-      auto t = mBinding.get<T>();                                                                                                                                            \
-      if (O2_BUILTIN_UNLIKELY(t == nullptr)) {                                                                                                                               \
-        o2::soa::dereferenceWithWrongType();                                                                                                                                 \
-      }                                                                                                                                                                      \
-      return t->rawIteratorAt(*mColumnIterator);                                                                                                                             \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    auto _Getter_() const                                                                                                                                                    \
-    {                                                                                                                                                                        \
-      return _Getter_##_as<binding_t>();                                                                                                                                     \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    template <typename T>                                                                                                                                                    \
-    bool setCurrent(T* current)                                                                                                                                              \
-    {                                                                                                                                                                        \
-      if constexpr (o2::soa::is_binding_compatible_v<T, binding_t>()) {                                                                                                      \
-        assert(current != nullptr);                                                                                                                                          \
-        this->mBinding.bind(current);                                                                                                                                        \
-        return true;                                                                                                                                                         \
-      }                                                                                                                                                                      \
-      return false;                                                                                                                                                          \
-    }                                                                                                                                                                        \
-                                                                                                                                                                             \
-    bool setCurrentRaw(o2::soa::Binding current)                                                                                                                             \
-    {                                                                                                                                                                        \
-      this->mBinding = current;                                                                                                                                              \
-      return true;                                                                                                                                                           \
-    }                                                                                                                                                                        \
-    binding_t const* getCurrent() const { return mBinding.get<binding_t>(); }                                                                                                \
-    o2::soa::Binding getCurrentRaw() const { return mBinding; }                                                                                                              \
-    o2::soa::Binding mBinding;                                                                                                                                               \
-  };                                                                                                                                                                         \
-  [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" #_Table_ _Suffix_, o2::framework::TypeIdHelpers::uniqueId<_Name_##Id>(), \
-                                                                                           o2::framework::expressions::selectArrowType<_Type_>() }
+#define DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Table_, _Suffix_)                                                \
+  struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                                                       \
+    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                                                     \
+    static_assert((*_Suffix_ == '\0') || (*_Suffix_ == '_'), "Suffix has to begin with _");                                       \
+    static constexpr const char* mLabel = "fIndex" #_Table_ _Suffix_;                                                             \
+    using base = o2::soa::Column<_Type_, _Name_##Id>;                                                                             \
+    using type = _Type_;                                                                                                          \
+    using column_t = _Name_##Id;                                                                                                  \
+    using binding_t = _Table_;                                                                                                    \
+    _Name_##Id(arrow::ChunkedArray const* column)                                                                                 \
+      : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                                                \
+    {                                                                                                                             \
+    }                                                                                                                             \
+                                                                                                                                  \
+    _Name_##Id() = default;                                                                                                       \
+    _Name_##Id(_Name_##Id const& other) = default;                                                                                \
+    _Name_##Id& operator=(_Name_##Id const& other) = default;                                                                     \
+    type inline getId() const                                                                                                     \
+    {                                                                                                                             \
+      return _Getter_##Id();                                                                                                      \
+    }                                                                                                                             \
+                                                                                                                                  \
+    type _Getter_##Id() const                                                                                                     \
+    {                                                                                                                             \
+      return *mColumnIterator;                                                                                                    \
+    }                                                                                                                             \
+                                                                                                                                  \
+    bool has_##_Getter_() const                                                                                                   \
+    {                                                                                                                             \
+      return *mColumnIterator >= 0;                                                                                               \
+    }                                                                                                                             \
+                                                                                                                                  \
+    template <typename T>                                                                                                         \
+    auto _Getter_##_as() const                                                                                                    \
+    {                                                                                                                             \
+      if (O2_BUILTIN_UNLIKELY(mBinding.ptr == nullptr)) {                                                                         \
+        o2::soa::notBoundTable(#_Table_);                                                                                         \
+      }                                                                                                                           \
+      if (O2_BUILTIN_UNLIKELY(!has_##_Getter_())) {                                                                               \
+        o2::soa::accessingInvalidIndexFor(#_Getter_);                                                                             \
+      }                                                                                                                           \
+      auto t = mBinding.get<T>();                                                                                                 \
+      if (O2_BUILTIN_UNLIKELY(t == nullptr)) {                                                                                    \
+        o2::soa::dereferenceWithWrongType();                                                                                      \
+      }                                                                                                                           \
+      return t->rawIteratorAt(*mColumnIterator);                                                                                  \
+    }                                                                                                                             \
+                                                                                                                                  \
+    auto _Getter_() const                                                                                                         \
+    {                                                                                                                             \
+      return _Getter_##_as<binding_t>();                                                                                          \
+    }                                                                                                                             \
+                                                                                                                                  \
+    template <typename T>                                                                                                         \
+    bool setCurrent(T* current)                                                                                                   \
+    {                                                                                                                             \
+      if constexpr (o2::soa::is_binding_compatible_v<T, binding_t>()) {                                                           \
+        assert(current != nullptr);                                                                                               \
+        this->mBinding.bind(current);                                                                                             \
+        return true;                                                                                                              \
+      }                                                                                                                           \
+      return false;                                                                                                               \
+    }                                                                                                                             \
+                                                                                                                                  \
+    bool setCurrentRaw(o2::soa::Binding current)                                                                                  \
+    {                                                                                                                             \
+      this->mBinding = current;                                                                                                   \
+      return true;                                                                                                                \
+    }                                                                                                                             \
+    binding_t const* getCurrent() const { return mBinding.get<binding_t>(); }                                                     \
+    o2::soa::Binding getCurrentRaw() const { return mBinding; }                                                                   \
+    o2::soa::Binding mBinding;                                                                                                    \
+  };                                                                                                                              \
+  static const o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" #_Table_ _Suffix_, typeid(_Name_##Id).hash_code(), \
+                                                                      o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Name_##s, "")
 
 /// SELF
-#define DECLARE_SOA_SELF_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_)                                                                                      \
-  struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                                                                                        \
-    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                                                                                      \
-    static constexpr const char* mLabel = "fIndex" _Label_;                                                                                                        \
-    using base = o2::soa::Column<_Type_, _Name_##Id>;                                                                                                              \
-    using type = _Type_;                                                                                                                                           \
-    using column_t = _Name_##Id;                                                                                                                                   \
-    using self_index_t = std::true_type;                                                                                                                           \
-    _Name_##Id(arrow::ChunkedArray const* column)                                                                                                                  \
-      : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                                                                                 \
-    {                                                                                                                                                              \
-    }                                                                                                                                                              \
-                                                                                                                                                                   \
-    _Name_##Id() = default;                                                                                                                                        \
-    _Name_##Id(_Name_##Id const& other) = default;                                                                                                                 \
-    _Name_##Id& operator=(_Name_##Id const& other) = default;                                                                                                      \
-    type inline getId() const                                                                                                                                      \
-    {                                                                                                                                                              \
-      return _Getter_##Id();                                                                                                                                       \
-    }                                                                                                                                                              \
-                                                                                                                                                                   \
-    type _Getter_##Id() const                                                                                                                                      \
-    {                                                                                                                                                              \
-      return *mColumnIterator;                                                                                                                                     \
-    }                                                                                                                                                              \
-                                                                                                                                                                   \
-    bool has_##_Getter_() const                                                                                                                                    \
-    {                                                                                                                                                              \
-      return *mColumnIterator >= 0;                                                                                                                                \
-    }                                                                                                                                                              \
-                                                                                                                                                                   \
-    template <typename T>                                                                                                                                          \
-    auto _Getter_##_as() const                                                                                                                                     \
-    {                                                                                                                                                              \
-      if (O2_BUILTIN_UNLIKELY(!has_##_Getter_())) {                                                                                                                \
-        o2::soa::accessingInvalidIndexFor(#_Getter_);                                                                                                              \
-      }                                                                                                                                                            \
-      auto t = mBinding.get<T>();                                                                                                                                  \
-      if (O2_BUILTIN_UNLIKELY(t == nullptr)) {                                                                                                                     \
-        o2::soa::dereferenceWithWrongType();                                                                                                                       \
-      }                                                                                                                                                            \
-      return t->rawIteratorAt(*mColumnIterator);                                                                                                                   \
-    }                                                                                                                                                              \
-                                                                                                                                                                   \
-    bool setCurrentRaw(o2::soa::Binding current)                                                                                                                   \
-    {                                                                                                                                                              \
-      this->mBinding = current;                                                                                                                                    \
-      return true;                                                                                                                                                 \
-    }                                                                                                                                                              \
-    o2::soa::Binding getCurrentRaw() const { return mBinding; }                                                                                                    \
-    o2::soa::Binding mBinding;                                                                                                                                     \
-  };                                                                                                                                                               \
-  [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" _Label_, o2::framework::TypeIdHelpers::uniqueId<_Name_##Id>(), \
-                                                                                           o2::framework::expressions::selectArrowType<_Type_>() }
+#define DECLARE_SOA_SELF_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_)                                           \
+  struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                                             \
+    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                                           \
+    static constexpr const char* mLabel = "fIndex" _Label_;                                                             \
+    using base = o2::soa::Column<_Type_, _Name_##Id>;                                                                   \
+    using type = _Type_;                                                                                                \
+    using column_t = _Name_##Id;                                                                                        \
+    using self_index_t = std::true_type;                                                                                \
+    _Name_##Id(arrow::ChunkedArray const* column)                                                                       \
+      : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                                      \
+    {                                                                                                                   \
+    }                                                                                                                   \
+                                                                                                                        \
+    _Name_##Id() = default;                                                                                             \
+    _Name_##Id(_Name_##Id const& other) = default;                                                                      \
+    _Name_##Id& operator=(_Name_##Id const& other) = default;                                                           \
+    type inline getId() const                                                                                           \
+    {                                                                                                                   \
+      return _Getter_##Id();                                                                                            \
+    }                                                                                                                   \
+                                                                                                                        \
+    type _Getter_##Id() const                                                                                           \
+    {                                                                                                                   \
+      return *mColumnIterator;                                                                                          \
+    }                                                                                                                   \
+                                                                                                                        \
+    bool has_##_Getter_() const                                                                                         \
+    {                                                                                                                   \
+      return *mColumnIterator >= 0;                                                                                     \
+    }                                                                                                                   \
+                                                                                                                        \
+    template <typename T>                                                                                               \
+    auto _Getter_##_as() const                                                                                          \
+    {                                                                                                                   \
+      if (O2_BUILTIN_UNLIKELY(!has_##_Getter_())) {                                                                     \
+        o2::soa::accessingInvalidIndexFor(#_Getter_);                                                                   \
+      }                                                                                                                 \
+      auto t = mBinding.get<T>();                                                                                       \
+      if (O2_BUILTIN_UNLIKELY(t == nullptr)) {                                                                          \
+        o2::soa::dereferenceWithWrongType();                                                                            \
+      }                                                                                                                 \
+      return t->rawIteratorAt(*mColumnIterator);                                                                        \
+    }                                                                                                                   \
+                                                                                                                        \
+    bool setCurrentRaw(o2::soa::Binding current)                                                                        \
+    {                                                                                                                   \
+      this->mBinding = current;                                                                                         \
+      return true;                                                                                                      \
+    }                                                                                                                   \
+    o2::soa::Binding getCurrentRaw() const { return mBinding; }                                                         \
+    o2::soa::Binding mBinding;                                                                                          \
+  };                                                                                                                    \
+  static const o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" _Label_, typeid(_Name_##Id).hash_code(), \
+                                                                      o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_SELF_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_SELF_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, #_Name_)
 /// SELF SLICE

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -126,7 +126,7 @@ struct AnalysisDataProcessorBuilder {
     DataSpecUtils::updateInputList(inputs, std::move(newInput));
   }
 
-  static void doAppendEnumeration(const char*, int64_t, int64_t, int64_t, std::vector<InputSpec>& inputs)
+  static void doAppendEnumeration(const char* name, int64_t begin, int64_t end, int64_t step, std::vector<InputSpec>& inputs)
   {
     std::vector<ConfigParamSpec> inputMetadata;
     // FIXME: for the moment we do not support begin, end and step.
@@ -148,11 +148,11 @@ struct AnalysisDataProcessorBuilder {
     if constexpr (is_enumeration_v<dT> == false) {
       if constexpr (soa::is_soa_filtered_v<dT>) {
         auto fields = createFieldsFromColumns(typename dT::table_t::persistent_columns_t{});
-        eInfos.emplace_back(ai, hash, dT::hashes(), std::make_shared<arrow::Schema>(fields));
+        eInfos.push_back({ai, hash, dT::hashes(), std::make_shared<arrow::Schema>(fields), nullptr});
       } else if constexpr (soa::is_soa_iterator_v<dT>) {
         auto fields = createFieldsFromColumns(typename dT::parent_t::persistent_columns_t{});
         if constexpr (std::is_same_v<typename dT::policy_t, soa::FilteredIndexPolicy>) {
-          eInfos.emplace_back(ai, hash, dT::parent_t::hashes(), std::make_shared<arrow::Schema>(fields));
+          eInfos.push_back({ai, hash, dT::parent_t::hashes(), std::make_shared<arrow::Schema>(fields), nullptr});
         }
       }
       doAppendInputWithMetadata(soa::make_originals_from_type<dT>(), name, value, inputs);
@@ -189,7 +189,7 @@ struct AnalysisDataProcessorBuilder {
   static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<StringPair>& bk, std::vector<StringPair>& bku)
   {
     int ai = 0;
-    auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(Args...)>();
+    auto hash = typeHash<R (C::*)(Args...)>();
     if constexpr (soa::is_soa_iterator_v<std::decay_t<framework::pack_element_t<0, framework::pack<Args...>>>>) {
       appendGroupingCandidates(bk, bku, framework::pack<Args...>{});
     }
@@ -205,7 +205,7 @@ struct AnalysisDataProcessorBuilder {
   template <typename R, typename C, typename Grouping, typename... Args>
   static auto bindGroupingTable(InputRecord& record, R (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
   {
-    auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(Grouping, Args...)>();
+    auto hash = typeHash<R (C::*)(Grouping, Args...)>();
     return extractSomethingFromRecord<Grouping, 0>(record, infos, hash);
   }
 
@@ -291,7 +291,7 @@ struct AnalysisDataProcessorBuilder {
   static auto bindAssociatedTables(InputRecord& record, R (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
   {
     constexpr auto p = pack<Args...>{};
-    auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(Grouping, Args...)>();
+    auto hash = typeHash<R (C::*)(Grouping, Args...)>();
     return std::make_tuple(extractSomethingFromRecord<Args, has_type_at_v<Args>(p) + 1>(record, infos, hash)...);
   }
 

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -50,20 +50,13 @@ using FilterPtr = std::shared_ptr<gandiva::Filter>;
 
 using atype = arrow::Type;
 struct ExpressionInfo {
-  ExpressionInfo(int ai, size_t hash, std::set<uint32_t>&& hs, gandiva::SchemaPtr sc)
-    : argumentIndex(ai),
-      processHash(hash),
-      hashes(hs),
-      schema(sc)
-  {
-  }
   int argumentIndex;
   size_t processHash;
-  std::set<uint32_t> hashes;
+  std::set<size_t> hashes;
   gandiva::SchemaPtr schema;
-  gandiva::NodePtr tree = nullptr;
-  gandiva::FilterPtr filter = nullptr;
-  gandiva::Selection selection = nullptr;
+  gandiva::NodePtr tree;
+  gandiva::FilterPtr filter;
+  gandiva::Selection selection;
   bool resetSelection = false;
 };
 
@@ -129,9 +122,9 @@ struct LiteralNode {
 struct BindingNode {
   BindingNode(BindingNode const&) = default;
   BindingNode(BindingNode&&) = delete;
-  constexpr BindingNode(const char* name_, uint32_t hash_, atype::type type_) : name{name_}, hash{hash_}, type{type_} {}
-  const char* name;
-  uint32_t hash;
+  BindingNode(std::string const& name_, std::size_t hash_, atype::type type_) : name{name_}, hash{hash_}, type{type_} {}
+  std::string name;
+  std::size_t hash;
   atype::type type;
 };
 

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -44,7 +44,8 @@ expressions::BindingNode getMatchingIndexNode()
   using selected_indices_t = selected_pack_multicondition<is_index_to_g_t, pack<G>, external_index_columns_pack>;
   static_assert(pack_size(selected_indices_t{}) == 1, "No matching index column from associated to grouping");
   using index_column_t = pack_head_t<selected_indices_t>;
-  return expressions::BindingNode{index_column_t::mLabel, o2::framework::TypeIdHelpers::uniqueId<typename index_column_t::column_t>(), expressions::selectArrowType<typename index_column_t::type>()};
+  auto label = std::string(index_column_t::mLabel);
+  return expressions::BindingNode{label, typeid(typename index_column_t::column_t).hash_code(), expressions::selectArrowType<typename index_column_t::type>()};
 }
 
 template <typename T1, typename GroupingPolicy, typename BP, typename G, typename... As>

--- a/Framework/Core/include/Framework/StringHelpers.h
+++ b/Framework/Core/include/Framework/StringHelpers.h
@@ -163,4 +163,10 @@ constexpr auto get_size(const std::string_view& str)
     return const_str_details::as_chars<literal_to_chars>(); \
   }()
 
+template <typename T>
+constexpr auto typeHash()
+{
+  return compile_time_hash(typeid(T).name());
+}
+
 #endif // O2_FRAMEWORK_STRINGHELPERS_H

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -700,9 +700,9 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
   return tree;
 }
 
-bool isTableCompatible(std::set<uint32_t> const& hashes, Operations const& specs)
+bool isTableCompatible(std::set<size_t> const& hashes, Operations const& specs)
 {
-  std::set<uint32_t> opHashes;
+  std::set<size_t> opHashes;
   for (auto const& spec : specs) {
     if (spec.left.datum.index() == 3) {
       opHashes.insert(spec.left.hash);

--- a/Framework/Foundation/include/Framework/TypeIdHelpers.h
+++ b/Framework/Foundation/include/Framework/TypeIdHelpers.h
@@ -14,12 +14,11 @@
 
 #include <string_view>
 #include <sstream>
-#include <source_location>
 #include "Framework/StringHelpers.h"
 
 namespace o2::framework
 {
-#ifdef __CLING__
+
 template <typename T>
 struct unique_type_id {
   static constexpr auto get() noexcept
@@ -33,52 +32,34 @@ struct unique_type_id {
 
 template <typename T>
 inline constexpr auto unique_type_id_v = unique_type_id<T>::value;
-#endif
 
-#ifndef __CLING__
-/// Workaround GCC optimizing out unused template parameter
-template <typename T>
-consteval static std::string_view type_name_impl(T*)
-{
-  return std::source_location::current().function_name();
-}
-#endif
+struct TypeIdHelpers {
+  /// Return a unique id for a given type
+  /// This works just fine with GCC and CLANG,
+  /// C++20 will allow us to use:
+  ///    std::source_location::current().function_name();
+  template <typename T>
+  constexpr static uint32_t uniqueId()
+  {
+    constexpr uint32_t r = crc32(unique_type_id_v<T>.data(), unique_type_id_v<T>.size());
+    return r;
+  }
+};
 
 /// Return pure type name with no namespaces etc.
-/// Works with GCC and CLANG
+/// Works fine with GCC and CLANG
 template <typename T>
 constexpr static std::string_view type_name()
 {
-#ifdef __CLING__
   constexpr std::string_view wrapped_name{unique_type_id_v<T>};
-#else
-  constexpr std::string_view wrapped_name = type_name_impl<T>(nullptr);
-#endif
   const std::string_view left_marker{"T = "};
-#ifdef __clang__
   const std::string_view right_marker{"]"};
-#else
-  const std::string_view right_marker{";"};
-#endif
   const auto left_marker_index = wrapped_name.find(left_marker);
   const auto start_index = left_marker_index + left_marker.size();
   const auto end_index = wrapped_name.find(right_marker, left_marker_index);
   const auto length = end_index - start_index;
   return wrapped_name.substr(start_index, length);
 }
-
-struct TypeIdHelpers {
-  template <typename T>
-  constexpr static uint32_t uniqueId()
-  {
-#ifdef __CLING__
-    constexpr uint32_t r = crc32(unique_type_id_v<T>.data(), unique_type_id_v<T>.size());
-    return r;
-#else
-    return compile_time_hash(type_name<T>().data());
-#endif
-  }
-};
 
 /// Convert a CamelCase task struct name to snake-case task name
 inline static std::string type_to_task_name(std::string_view& camelCase)


### PR DESCRIPTION
Reverts AliceO2Group/AliceO2#12661

Hi @ktf and @aalkin would you be OK to revert this? It is requires c++20 features which we don't yet have employed at P2 and therefore our daily builds are failing, e.g. https://alijenkins.cern.ch/job/DailyBuilds/job/DailyO2epn/1252/console
Next week's FLP suite should contain the bump of the O2 defaults and then this could be merged