### PR TITLE
ALICE 3: Add ECal detector

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -74,14 +74,14 @@ void SimConfig::determineActiveModules(std::vector<std::string> const& inputargs
   if (activeModules[0] != "all") {
     if (isUpgrade) {
       for (int i = 0; i < activeModules.size(); ++i) {
-        if (activeModules[i] != "IT3" && activeModules[i] != "TRK" && activeModules[i] != "FT3" && activeModules[i] != "FCT" && activeModules[i] != "A3IP" && activeModules[i] != "TF3" && activeModules[i] != "RCH" && activeModules[i] != "MI3") {
+        if (activeModules[i] != "IT3" && activeModules[i] != "TRK" && activeModules[i] != "FT3" && activeModules[i] != "FCT" && activeModules[i] != "A3IP" && activeModules[i] != "TF3" && activeModules[i] != "RCH" && activeModules[i] != "MI3" && activeModules[i] != "ECL") {
           LOGP(fatal, "List of active modules contains {}, which is not a module from the upgrades.", activeModules[i]);
         }
       }
     }
     if (!isUpgrade) {
       for (int i = 0; i < activeModules.size(); ++i) {
-        if (activeModules[i] == "TRK" || activeModules[i] == "FT3" || activeModules[i] == "FCT" || activeModules[i] == "A3IP" && activeModules[i] == "TF3" && activeModules[i] == "RCH" && activeModules[i] == "MI3") {
+        if (activeModules[i] == "TRK" || activeModules[i] == "FT3" || activeModules[i] == "FCT" || activeModules[i] == "A3IP" && activeModules[i] == "TF3" && activeModules[i] == "RCH" && activeModules[i] == "MI3" && activeModules[i] == "ECL") {
           LOGP(fatal, "List of active modules contains {}, which is not a run 3 module", activeModules[i]);
         }
       }
@@ -93,7 +93,7 @@ void SimConfig::determineActiveModules(std::vector<std::string> const& inputargs
 #ifdef ENABLE_UPGRADES
     if (isUpgrade) {
       for (int d = DetID::First; d <= DetID::Last; ++d) {
-        if (d == DetID::TRK || d == DetID::FT3 || d == DetID::FCT || d == DetID::TF3 || d == DetID::RCH) {
+        if (d == DetID::TRK || d == DetID::FT3 || d == DetID::FCT || d == DetID::TF3 || d == DetID::RCH || d == DetID::ECL) {
           activeModules.emplace_back(DetID::getName(d));
         }
       }
@@ -112,7 +112,7 @@ void SimConfig::determineActiveModules(std::vector<std::string> const& inputargs
       activeModules.emplace_back("SHIL");
       for (int d = DetID::First; d <= DetID::Last; ++d) {
 #ifdef ENABLE_UPGRADES
-        if (d != DetID::IT3 && d != DetID::TRK && d != DetID::FT3 && d != DetID::FCT && d != DetID::TF3 && d != DetID::RCH && d != DetID::MI3) {
+        if (d != DetID::IT3 && d != DetID::TRK && d != DetID::FT3 && d != DetID::FCT && d != DetID::TF3 && d != DetID::RCH && d != DetID::ECL && d != DetID::MI3) {
           activeModules.emplace_back(DetID::getName(d));
         }
       }

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
@@ -86,7 +86,8 @@ class DetID
   static constexpr ID TF3 = 22;
   static constexpr ID RCH = 23;
   static constexpr ID MI3 = 24;
-  static constexpr ID Last = MI3;
+  static constexpr ID ECL = 25;
+  static constexpr ID Last = ECL;
 #else
   static constexpr ID Last = FOC; ///< if extra detectors added, update this !!!
 #endif
@@ -180,7 +181,7 @@ class DetID
   // detector names, will be defined in DataSources
   static constexpr const char* sDetNames[nDetectors + 1] = ///< defined detector names
 #ifdef ENABLE_UPGRADES
-    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", "IT3", "TRK", "FT3", "FCT", "TF3", "RCH", "MI3", nullptr};
+    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", "IT3", "TRK", "FT3", "FCT", "TF3", "RCH", "MI3", "ECL", nullptr};
 #else
     {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", nullptr};
 #endif
@@ -194,7 +195,7 @@ class DetID
 #ifdef ENABLE_UPGRADES
      ,
      o2h::gDataOriginIT3, o2h::gDataOriginTRK, o2h::gDataOriginFT3, o2h::gDataOriginFCT, o2h::gDataOriginTF3,
-     o2h::gDataOriginRCH, o2h::gDataOriginMI3
+     o2h::gDataOriginRCH, o2h::gDataOriginMI3, o2h::gDataOriginECL
 #endif
   };
 #endif // GPUCA_GPUCODE_DEVICE
@@ -213,7 +214,7 @@ GPUconstexpr() DetID::mask_t sMasks[DetID::nDetectors] = ///< detectot masks
 #ifdef ENABLE_UPGRADES
                                                                                                        ,
    DetID::mask_t(math_utils::bit2Mask(DetID::IT3)), DetID::mask_t(math_utils::bit2Mask(DetID::TRK)), DetID::mask_t(math_utils::bit2Mask(DetID::FT3)), DetID::mask_t(math_utils::bit2Mask(DetID::FCT)), DetID::mask_t(math_utils::bit2Mask(DetID::TF3)),
-   DetID::mask_t(math_utils::bit2Mask(DetID::RCH)), DetID::mask_t(math_utils::bit2Mask(DetID::MI3))
+   DetID::mask_t(math_utils::bit2Mask(DetID::RCH)), DetID::mask_t(math_utils::bit2Mask(DetID::MI3)), DetID::mask_t(math_utils::bit2Mask(DetID::ECL))
 #endif
 };
 } // namespace detid_internal

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -585,7 +585,8 @@ constexpr o2::header::DataOrigin gDataOriginFT3{"FT3"};
 constexpr o2::header::DataOrigin gDataOriginFCT{"FCT"};
 constexpr o2::header::DataOrigin gDataOriginTF3{"TF3"};
 constexpr o2::header::DataOrigin gDataOriginRCH{"RCH"};
-constexpr o2::header::DataOrigin gDataOriginMI3{"MI3"}; // upgrades
+constexpr o2::header::DataOrigin gDataOriginMI3{"MI3"};
+constexpr o2::header::DataOrigin gDataOriginECL{"ECL"}; // upgrades
 
 constexpr o2::header::DataOrigin gDataOriginGPU{"GPU"};
 

--- a/Detectors/Upgrades/ALICE3/ECal/CMakeLists.txt
+++ b/Detectors/Upgrades/ALICE3/ECal/CMakeLists.txt
@@ -9,12 +9,5 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Passive)
-add_subdirectory(TRK)
-add_subdirectory(ECal)
-add_subdirectory(FT3)
-add_subdirectory(FCT)
-add_subdirectory(AOD)
-add_subdirectory(IOTOF)
-add_subdirectory(RICH)
-add_subdirectory(macros)
+add_subdirectory(base)
+add_subdirectory(simulation)

--- a/Detectors/Upgrades/ALICE3/ECal/README.md
+++ b/Detectors/Upgrades/ALICE3/ECal/README.md
@@ -1,0 +1,10 @@
+<!-- doxy
+\page refDetectorsUpgradesALICE3TRK Tracker
+/doxy -->
+
+# ALICE 3 Electromagnetic Calorimenter
+
+This is top page for the ECL detector documentation.
+
+<!-- doxy
+/doxy -->

--- a/Detectors/Upgrades/ALICE3/ECal/base/CMakeLists.txt
+++ b/Detectors/Upgrades/ALICE3/ECal/base/CMakeLists.txt
@@ -9,12 +9,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Passive)
-add_subdirectory(TRK)
-add_subdirectory(ECal)
-add_subdirectory(FT3)
-add_subdirectory(FCT)
-add_subdirectory(AOD)
-add_subdirectory(IOTOF)
-add_subdirectory(RICH)
-add_subdirectory(macros)
+o2_add_library(ECalBase
+               SOURCES src/GeometryTGeo.cxx
+                       src/ECalBaseParam.cxx
+               PUBLIC_LINK_LIBRARIES O2::DetectorsBase)
+
+o2_target_root_dictionary(ECalBase
+               HEADERS include/ECalBase/GeometryTGeo.h
+                       include/ECalBase/ECalBaseParam.h)

--- a/Detectors/Upgrades/ALICE3/ECal/base/include/ECalBase/ECalBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/ECal/base/include/ECalBase/ECalBaseParam.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_ECAL_BASEPARAM_H
+#define O2_ECAL_BASEPARAM_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace ecal
+{
+struct ECalBaseParam : public o2::conf::ConfigurableParamHelper<ECalBaseParam> {
+  float rMin = 125.0;    // cm
+  float rMax = 155.0;    // cm
+  float zLength = 350.0; // cm
+
+  O2ParamDef(ECalBaseParam, "ECalBase");
+};
+
+} // namespace ecal
+} // end namespace o2
+
+#endif

--- a/Detectors/Upgrades/ALICE3/ECal/base/include/ECalBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/ECal/base/include/ECalBase/GeometryTGeo.h
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_ECAL_GEOMETRYTGEO_H
+#define ALICEO2_ECAL_GEOMETRYTGEO_H
+
+#include <DetectorsCommonDataFormats/DetMatrixCache.h>
+
+namespace o2
+{
+namespace ecal
+{
+class GeometryTGeo : public o2::detectors::DetMatrixCache
+{
+ public:
+  GeometryTGeo(bool build = false, int loadTrans = 0);
+  void Build(int loadTrans);
+  void fillMatrixCache(int mask);
+  static GeometryTGeo* Instance();
+
+  static const char* getECalVolPattern() { return sVolumeName.c_str(); }
+  static const char* getECalSensorPattern() { return sSensorName.c_str(); }
+
+  static const char* composeSymNameECal()
+  {
+    return Form("%s_%d", o2::detectors::DetID(o2::detectors::DetID::ECL).getName(), 0);
+  }
+  static const char* composeSymNameSensor(); // One single sensor for the moment
+
+ protected:
+  static std::string sVolumeName;
+  static std::string sSensorName;
+
+ private:
+  static std::unique_ptr<o2::ecal::GeometryTGeo> sInstance;
+};
+} // namespace ecal
+} // namespace o2
+#endif

--- a/Detectors/Upgrades/ALICE3/ECal/base/include/ECalBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/ECal/base/include/ECalBase/GeometryTGeo.h
@@ -33,7 +33,7 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   {
     return Form("%s_%d", o2::detectors::DetID(o2::detectors::DetID::ECL).getName(), 0);
   }
-  static const char* composeSymNameSensor(); // One single sensor for the moment
+  static const char* composeSymNameSensor(); // A single sensor for the moment
 
  protected:
   static std::string sVolumeName;

--- a/Detectors/Upgrades/ALICE3/ECal/base/src/ECalBaseLinkDef.h
+++ b/Detectors/Upgrades/ALICE3/ECal/base/src/ECalBaseLinkDef.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::ecal::GeometryTGeo +
+#pragma link C++ class o2::ecal::ECalBaseParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::ecal::ECalBaseParam> + ;
+
+#endif

--- a/Detectors/Upgrades/ALICE3/ECal/base/src/ECalBaseParam.cxx
+++ b/Detectors/Upgrades/ALICE3/ECal/base/src/ECalBaseParam.cxx
@@ -1,0 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ECalBase/ECalBaseParam.h"
+
+O2ParamImpl(o2::ecal::ECalBaseParam);

--- a/Detectors/Upgrades/ALICE3/ECal/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/ECal/base/src/GeometryTGeo.cxx
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <ECalBase/GeometryTGeo.h>
+#include <TGeoManager.h>
+
+namespace o2
+{
+namespace ecal
+{
+std::unique_ptr<o2::ecal::GeometryTGeo> GeometryTGeo::sInstance;
+
+std::string GeometryTGeo::sVolumeName = "ECALV";
+std::string GeometryTGeo::sSensorName = "ECALSensor";
+
+GeometryTGeo::GeometryTGeo(bool build, int loadTrans) : DetMatrixCache()
+{
+  if (sInstance) {
+    LOGP(fatal, "Invalid use of public constructor: o2::ecal::GeometryTGeo instance exists");
+  }
+  if (build) {
+    Build(loadTrans);
+  }
+}
+
+void GeometryTGeo::Build(int loadTrans)
+{
+  if (isBuilt()) {
+    LOGP(warning, "Already built");
+    return; // already initialized
+  }
+
+  if (!gGeoManager) {
+    LOGP(fatal, "Geometry is not loaded");
+  }
+
+  fillMatrixCache(loadTrans);
+}
+
+void GeometryTGeo::fillMatrixCache(int mask)
+{
+}
+
+GeometryTGeo* GeometryTGeo::Instance()
+{
+  if (!sInstance) {
+    sInstance = std::unique_ptr<GeometryTGeo>(new GeometryTGeo(true, 0));
+  }
+  return sInstance.get();
+}
+
+const char* GeometryTGeo::composeSymNameSensor()
+{
+  return Form("%s/%d", composeSymNameECal(), 0);
+}
+
+} // namespace ecal
+} // namespace o2

--- a/Detectors/Upgrades/ALICE3/ECal/simulation/CMakeLists.txt
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/CMakeLists.txt
@@ -9,12 +9,10 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Passive)
-add_subdirectory(TRK)
-add_subdirectory(ECal)
-add_subdirectory(FT3)
-add_subdirectory(FCT)
-add_subdirectory(AOD)
-add_subdirectory(IOTOF)
-add_subdirectory(RICH)
-add_subdirectory(macros)
+o2_add_library(ECalSimulation
+               SOURCES src/Detector.cxx
+               PUBLIC_LINK_LIBRARIES O2::ECalBase
+                                     O2::ITSMFTSimulation)
+
+o2_target_root_dictionary(ECalSimulation
+                          HEADERS include/ECalSimulation/Detector.h)

--- a/Detectors/Upgrades/ALICE3/ECal/simulation/include/ECalSimulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/include/ECalSimulation/Detector.h
@@ -1,0 +1,105 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Design and equations: Nicola Nicassio nicola.nicassio@cern.ch
+//
+
+#ifndef ALICEO2_ECAL_DETECTOR_H
+#define ALICEO2_ECAL_DETECTOR_H
+
+#include "DetectorsBase/Detector.h"
+#include "ITSMFTSimulation/Hit.h"
+
+#include "ECalBase/GeometryTGeo.h"
+
+#include <TLorentzVector.h>
+#include <TString.h>
+
+namespace o2
+{
+namespace ecal
+{
+
+class Detector : public o2::base::DetImpl<Detector>
+{
+ public:
+  Detector(bool active);
+  Detector();
+  ~Detector();
+
+  void ConstructGeometry() override;
+
+  o2::itsmft::Hit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos,
+                          const TVector3& startMom, double startE, double endTime, double eLoss,
+                          unsigned char startStatus, unsigned char endStatus);
+
+  // Mandatory overrides
+  void BeginPrimary() override { ; }
+  void FinishPrimary() override { ; }
+  void InitializeO2Detector() override;
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  bool ProcessHits(FairVolume* v = nullptr) override;
+  void EndOfEvent() override;
+  void Register() override;
+  void Reset() override;
+
+  // Custom memer functions
+  std::vector<o2::itsmft::Hit>* getHits(int iColl) const
+  {
+    if (!iColl) {
+      return mHits;
+    }
+    return nullptr;
+  }
+
+  void createMaterials();
+  void createGeometry();
+
+ private:
+  // Transient data about track passing the sensor
+  struct TrackData {
+    bool mHitStarted;              // hit creation started
+    unsigned char mTrkStatusStart; // track status flag
+    TLorentzVector mPositionStart; // position at entrance
+    TLorentzVector mMomentumStart; // momentum
+    double mEnergyLoss;            // energy loss
+  } mTrackData;                    //! transient data
+
+  GeometryTGeo* mGeometryTGeo;         //!
+  std::vector<o2::itsmft::Hit>* mHits; // ITSMFT ones for the moment
+
+  void defineSensitiveVolumes();
+  float mInnerRadius;
+  float mOuterRadius;
+  float mLength;
+
+ protected:
+  template <typename Det>
+  friend class o2::base::DetImpl;
+  ClassDefOverride(Detector, 1);
+};
+} // namespace ecal
+} // namespace o2
+
+#ifdef USESHM
+namespace o2
+{
+namespace base
+{
+template <>
+struct UseShm<o2::ecal::Detector> {
+  static constexpr bool value = true;
+};
+} // namespace base
+} // namespace o2
+#endif
+#endif

--- a/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
@@ -1,0 +1,234 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <FairVolume.h>
+
+#include <TVirtualMC.h>
+#include <TVirtualMCStack.h>
+#include <TGeoVolume.h>
+#include <TGeoTube.h>
+#include <TGeoManager.h>
+
+#include "DetectorsBase/Stack.h"
+#include "ITSMFTSimulation/Hit.h"
+#include "ECalSimulation/Detector.h"
+#include "ECalBase/ECalBaseParam.h"
+
+using o2::itsmft::Hit;
+
+namespace o2
+{
+namespace ecal
+{
+
+Detector::Detector()
+  : o2::base::DetImpl<Detector>("ECL", true),
+    mTrackData(),
+    mHits(o2::utils::createSimVector<o2::itsmft::Hit>())
+{
+}
+
+Detector::Detector(bool active)
+  : o2::base::DetImpl<Detector>("ECL", true),
+    mTrackData(),
+    mHits(o2::utils::createSimVector<o2::itsmft::Hit>())
+{
+  auto& ecalPars = ECalBaseParam::Instance();
+  mInnerRadius = ecalPars.rMin;
+  mOuterRadius = ecalPars.rMax;
+  mLength = ecalPars.zLength;
+}
+
+Detector::~Detector()
+{
+  if (mHits) {
+    o2::utils::freeSimVector(mHits);
+  }
+}
+
+void Detector::ConstructGeometry()
+{
+  createMaterials();
+  createGeometry();
+}
+
+void Detector::createMaterials()
+{
+  int ifield = 2;      // ?
+  float fieldm = 10.0; // ?
+  o2::base::Detector::initFieldTrackingParams(ifield, fieldm);
+
+  float tmaxfdLead = 0.1;        // .10000E+01; // Degree
+  float stemaxLead = .10000E+01; // cm
+  float deemaxLead = 0.1;        // 0.30000E-02; // Fraction of particle's energy 0<deemax<=1
+  float epsilLead = 1.0E-4;      // .10000E+01;
+  float stminLead = 0.0;         // cm "Default value used"
+
+  // First approximation is a detector full of lead
+  // Lead
+  Detector::Material(1, "LEAD", 207.19, 82., 11.35, .56, 18.5);
+  Detector::Medium(1, "LEAD", 1, 0, ifield, fieldm, tmaxfdLead, stemaxLead, deemaxLead, epsilLead, stminLead);
+}
+
+void Detector::InitializeO2Detector()
+{
+  LOG(info) << "Initialize ECal O2Detector";
+  mGeometryTGeo = GeometryTGeo::Instance();
+  // defineSensitiveVolumes();
+}
+
+void Detector::defineSensitiveVolumes()
+{
+  LOGP(info, "Adding ECal Sensitive Volumes");
+}
+
+void Detector::EndOfEvent() { Reset(); }
+
+void Detector::Register()
+{
+  // This will create a branch in the output tree called Hit, setting the last
+  // parameter to kFALSE means that this collection will not be written to the file,
+  // it will exist only during the simulation
+
+  if (FairRootManager::Instance()) {
+    FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, true);
+  }
+}
+
+void Detector::createGeometry()
+{
+  LOGP(info, "Creating ECal geometry");
+
+  TGeoManager* geoManager = gGeoManager;
+  TGeoVolume* vALIC = geoManager->GetVolume("barrel");
+  if (!vALIC) {
+    LOGP(fatal, "Could not find barrel volume while constructing ECal geometry");
+  }
+  new TGeoVolumeAssembly(GeometryTGeo::getECalVolPattern());
+  TGeoVolume* vECal = geoManager->GetVolume(GeometryTGeo::getECalVolPattern());
+  vALIC->AddNode(vECal, 2, new TGeoTranslation(0, 30., 0));
+
+  char vstrng[100] = "ECalVol";
+  vECal->SetTitle(vstrng);
+
+  // Build the ECal cylinder
+  auto& matmgr = o2::base::MaterialManager::Instance();
+  TGeoMedium* medPb = matmgr.getTGeoMedium("ECL_LEAD");
+  TGeoTube* ecalShape = new TGeoTube("ECLsh", mInnerRadius, mOuterRadius, mLength);
+  TGeoVolume* ecalVol = new TGeoVolume("ECL", ecalShape, medPb);
+  ecalVol->SetLineColor(kCyan + 1);
+  ecalVol->SetTransparency(50);
+  vECal->AddNode(ecalVol, 1, nullptr);
+}
+
+void Detector::Reset()
+{
+  if (!o2::utils::ShmManager::Instance().isOperational()) {
+    mHits->clear();
+  }
+}
+
+bool Detector::ProcessHits(FairVolume* vol)
+{
+  // This method is called from the MC stepping
+  if (!(fMC->TrackCharge())) {
+    return false;
+  }
+
+  int lay = vol->getVolumeId();
+  int volID = vol->getMCid();
+
+  // Is it needed to keep a track reference when the outer ITS volume is encountered?
+  auto stack = (o2::data::Stack*)fMC->GetStack();
+  if (fMC->IsTrackExiting() && (lay == 0)) {
+    o2::TrackReference tr(*fMC, GetDetId());
+    tr.setTrackID(stack->GetCurrentTrackNumber());
+    tr.setUserId(lay);
+    stack->addTrackReference(tr);
+  }
+  bool startHit = false, stopHit = false;
+  unsigned char status = 0;
+  if (fMC->IsTrackEntering()) {
+    status |= Hit::kTrackEntering;
+  }
+  if (fMC->IsTrackInside()) {
+    status |= Hit::kTrackInside;
+  }
+  if (fMC->IsTrackExiting()) {
+    status |= Hit::kTrackExiting;
+  }
+  if (fMC->IsTrackOut()) {
+    status |= Hit::kTrackOut;
+  }
+  if (fMC->IsTrackStop()) {
+    status |= Hit::kTrackStopped;
+  }
+  if (fMC->IsTrackAlive()) {
+    status |= Hit::kTrackAlive;
+  }
+
+  // track is entering or created in the volume
+  if ((status & Hit::kTrackEntering) || (status & Hit::kTrackInside && !mTrackData.mHitStarted)) {
+    startHit = true;
+  } else if ((status & (Hit::kTrackExiting | Hit::kTrackOut | Hit::kTrackStopped))) {
+    stopHit = true;
+  }
+
+  // increment energy loss at all steps except entrance
+  if (!startHit) {
+    mTrackData.mEnergyLoss += fMC->Edep();
+  }
+  if (!(startHit | stopHit)) {
+    return false; // do noting
+  }
+
+  if (startHit) {
+    mTrackData.mEnergyLoss = 0.;
+    fMC->TrackMomentum(mTrackData.mMomentumStart);
+    fMC->TrackPosition(mTrackData.mPositionStart);
+    mTrackData.mTrkStatusStart = status;
+    mTrackData.mHitStarted = true;
+  }
+  if (stopHit) {
+    TLorentzVector positionStop;
+    fMC->TrackPosition(positionStop);
+    // Retrieve the indices with the volume path
+    int stave(0), halfstave(0), chipinmodule(0), module;
+    fMC->CurrentVolOffID(1, chipinmodule);
+    fMC->CurrentVolOffID(2, module);
+    fMC->CurrentVolOffID(3, halfstave);
+    fMC->CurrentVolOffID(4, stave);
+
+    Hit* p = addHit(stack->GetCurrentTrackNumber(), lay, mTrackData.mPositionStart.Vect(), positionStop.Vect(),
+                    mTrackData.mMomentumStart.Vect(), mTrackData.mMomentumStart.E(), positionStop.T(),
+                    mTrackData.mEnergyLoss, mTrackData.mTrkStatusStart, status);
+    // p->SetTotalEnergy(vmc->Etot());
+
+    // RS: not sure this is needed
+    // Increment number of Detector det points in TParticle
+    stack->addHit(GetDetId());
+  }
+
+  return true;
+}
+
+o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos,
+                                  const TVector3& startMom, double startE, double endTime, double eLoss, unsigned char startStatus,
+                                  unsigned char endStatus)
+{
+  mHits->emplace_back(trackID, detID, startPos, endPos, startMom, startE, endTime, eLoss, startStatus, endStatus);
+  return &(mHits->back());
+}
+
+} // namespace ecal
+} // namespace o2
+
+ClassImp(o2::ecal::Detector);

--- a/Detectors/Upgrades/ALICE3/ECal/simulation/src/ECalSimulationLinkDef.h
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/src/ECalSimulationLinkDef.h
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::ecal::Detector + ;
+#pragma link C++ class o2::base::DetImpl < o2::ecal::Detector> + ;
+
+#endif

--- a/Detectors/Upgrades/ALICE3/Passive/include/Alice3DetectorsPassive/Magnet.h
+++ b/Detectors/Upgrades/ALICE3/Passive/include/Alice3DetectorsPassive/Magnet.h
@@ -35,11 +35,11 @@ class Alice3Magnet : public Alice3PassiveBase
   Alice3Magnet(const Alice3Magnet& orig);
   Alice3Magnet& operator=(const Alice3Magnet&);
 
-  float mInnerWrapInnerRadius{150.f}; // cm
+  float mInnerWrapInnerRadius{160.f}; // cm // Version including the Ecal according SD
   float mInnerWrapThickness{1.f};     // cm
-  float mCoilInnerRadius{170.f};      // cm
+  float mCoilInnerRadius{180.f};      // cm
   float mCoilThickness{0.3f};         // cm
-  float mRestMaterialRadius{170.3f};  // cm
+  float mRestMaterialRadius{180.3f};  // cm
   float mRestMaterialThickness{6.8f}; // cm
   float mOuterWrapInnerRadius{200.f}; // cm
   float mOuterWrapThickness{3.f};     // cm

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -111,7 +111,7 @@ o2_add_test_root_macro(analyzeOriginHits.C
                                              O2::DetectorsCommonDataFormats)
 
 if(ENABLE_UPGRADES)
-  set(upgradeTargets O2::Alice3DetectorsPassive O2::ITS3Simulation O2::TRKSimulation O2::FT3Simulation O2::FCTSimulation O2::IOTOFSimulation O2::RICHSimulation)
+  set(upgradeTargets O2::Alice3DetectorsPassive O2::ITS3Simulation O2::TRKSimulation O2::FT3Simulation O2::FCTSimulation O2::IOTOFSimulation O2::RICHSimulation O2::ECalSimulation)
 endif()
 
 o2_add_test_root_macro(build_geometry.C

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -55,6 +55,7 @@
 #include <FCTSimulation/Detector.h>
 #include <IOTOFSimulation/Detector.h>
 #include <RICHSimulation/Detector.h>
+#include <ECalSimulation/Detector.h>
 #include <Alice3DetectorsPassive/Pipe.h>
 #include <Alice3DetectorsPassive/Absorber.h>
 #include <Alice3DetectorsPassive/Magnet.h>
@@ -249,6 +250,11 @@ void build_geometry(FairRunSim* run = nullptr)
   if (isActivated("RCH")) {
     // ALICE 3 RICH
     addReadoutDetector(new o2::rich::Detector(isReadout("RCH")));
+  }
+
+  if (isActivated("ECL")) {
+    // ALICE 3 ECAL
+    addReadoutDetector(new o2::ecal::Detector(isReadout("ECL")));
   }
 #endif
 

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(allsim
                                 $<$<BOOL:${ENABLE_UPGRADES}>:O2::FCTSimulation>
                                 $<$<BOOL:${ENABLE_UPGRADES}>:O2::IOTOFSimulation>
                                 $<$<BOOL:${ENABLE_UPGRADES}>:O2::RICHSimulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::ECalSimulation>
                                 O2::Generators)
 
 add_library(internal::allsim ALIAS allsim)


### PR DESCRIPTION
Currently simplified as a lead cylinder.
![Screenshot from 2024-02-08 22-25-00](https://github.com/AliceO2Group/AliceO2/assets/4990252/5d1b85db-f43b-4930-940c-e5cb72a153e9)


This PR requires CCDB to add an additional dummy alignment object, opening the relevant JIRA ticket.
See: https://its.cern.ch/jira/browse/O2-4643