### PR TITLE
Only override LD_LIBRARY_PATH for rootcling, not for CMake

### DIFF
--- a/cmake/rootcling_wrapper.sh.in
+++ b/cmake/rootcling_wrapper.sh.in
@@ -26,7 +26,7 @@ while [[ $# -gt 0 ]]; do
     shift 2
     ;;
   --ld_library_path)
-    LD_LIBRARY_PATH="$2"
+    libpath="$2"
     shift 2
     ;;
   --dictionary_file)
@@ -82,7 +82,7 @@ esac
 
 LOGFILE=${DICTIONARY_FILE}.log
 
-@CMAKE_COMMAND@ -E env LD_LIBRARY_PATH=${LD_LIBRARY_PATH} @ROOT_rootcling_CMD@ \
+@CMAKE_COMMAND@ -E env "LD_LIBRARY_PATH=$libpath" @ROOT_rootcling_CMD@ \
   -f $DICTIONARY_FILE \
   -inlineInputHeader \
   -noGlobalUsingStd \


### PR DESCRIPTION
CMake depends on more things that are in the customised LD_LIBRARY_PATH, such as OpenSSL. Therefore, the new LD_LIBRARY_PATH must only apply to the rootcling command, not to CMake.

Assigning to an exported variable in bash changes the exported definition, so assigning to LD_LIBRARY_PATH directly (even without explicitly exporting) means the variable already takes effect for the wrapping cmake command. This does not seem to be intended, so use a temporary variable instead.