### PR TITLE
Enable TF throttling with readers, use in dpl-workflow 

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -33,6 +33,7 @@ o2_add_library(GlobalTrackingWorkflow
                        src/GlobalFwdTrackWriterSpec.cxx
                        src/GlobalFwdMatchingAssessmentSpec.cxx
                        src/MatchedMFTMCHWriterSpec.cxx
+                       src/ReaderDriverSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::GlobalTracking
                                      O2::GlobalTrackingWorkflowReaders
                                      O2::GlobalTrackingWorkflowHelpers
@@ -48,6 +49,10 @@ o2_add_library(GlobalTrackingWorkflow
                                      O2::SimulationDataFormat
                                      O2::DetectorsVertexing
                                      O2::StrangenessTracking)
+o2_add_executable(driver-workflow
+                  COMPONENT_NAME reader
+                  SOURCES src/reader-driver-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::GlobalTrackingWorkflow )
 
 o2_add_executable(match-workflow
                   COMPONENT_NAME tpcits

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/ReaderDriverSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/ReaderDriverSpec.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ReaderDriverSpec.h
+
+#ifndef O2_READER_DRIVER_
+#define O2_READER_DRIVER_
+
+#include "Framework/DataProcessorSpec.h"
+#include <string>
+
+namespace o2
+{
+namespace globaltracking
+{
+
+/// create a processor spec
+/// pushes an empty output to provide timing to downstream devices
+framework::DataProcessorSpec getReaderDriverSpec(const std::string& metricChannel = "", size_t minSHM = 0);
+
+} // namespace globaltracking
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/src/ReaderDriverSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/ReaderDriverSpec.cxx
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ReaderDriverSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include <fairmq/Device.h>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "Framework/RateLimiter.h"
+#include "Framework/RawDeviceService.h"
+#include "GlobalTrackingWorkflow/ReaderDriverSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "CommonUtils/StringUtils.h"
+#include "TFile.h"
+#include "TTree.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace globaltracking
+{
+
+class ReadeDriverSpec : public o2::framework::Task
+{
+ public:
+  ReadeDriverSpec(size_t minSHM) : mMinSHM(minSHM) {}
+  ~ReadeDriverSpec() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  int mTFRateLimit = -999;
+  int mNTF = 0;
+  size_t mMinSHM = 0;
+};
+
+void ReadeDriverSpec::init(InitContext& ic)
+{
+  mNTF = ic.options().get<int>("max-tf");
+}
+
+void ReadeDriverSpec::run(ProcessingContext& pc)
+{
+  if (mTFRateLimit == -999) {
+    mTFRateLimit = std::stoi(pc.services().get<RawDeviceService>().device()->fConfig->GetValue<std::string>("timeframes-rate-limit"));
+  }
+  static RateLimiter limiter;
+  static int count = 0;
+  if (!count) {
+    if (o2::raw::HBFUtilsInitializer::NTFs < 0) {
+      LOGP(fatal, "Number of TFs to process was not initizalized in the HBFUtilsInitializer");
+    }
+    mNTF = (mNTF > 0 && mNTF < o2::raw::HBFUtilsInitializer::NTFs) ? mNTF : o2::raw::HBFUtilsInitializer::NTFs;
+  } else { // check only for count > 0
+    limiter.check(pc, mTFRateLimit, mMinSHM);
+  }
+  std::vector<char> v{};
+  pc.outputs().snapshot(Output{"GLO", "READER_DRIVER", 0}, v);
+  if (++count >= mNTF) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+DataProcessorSpec getReaderDriverSpec(const std::string& metricChannel, size_t minSHM)
+{
+  std::vector<OutputSpec> outputSpec;
+  std::vector<ConfigParamSpec> options;
+  options.emplace_back(ConfigParamSpec{"max-tf", o2::framework::VariantType::Int, -1, {"max TFs to process (<1 : no limits)"}});
+  if (!metricChannel.empty()) {
+    options.emplace_back(ConfigParamSpec{"channel-config", VariantType::String, metricChannel, {"Out-of-band channel config for TF throttling"}});
+  }
+  return DataProcessorSpec{
+    o2::raw::HBFUtilsInitializer::ReaderDriverDevice,
+    Inputs{},
+    Outputs{{"GLO", "READER_DRIVER", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<ReadeDriverSpec>(minSHM)},
+    options};
+}
+
+} // namespace globaltracking
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/reader-driver-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/reader-driver-workflow.cxx
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ChannelSpecHelpers.h"
+#include "GlobalTrackingWorkflow/ReaderDriverSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/CallbacksPolicy.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"timeframes-shm-limit", VariantType::String, "0", {"Minimum amount of SHM required in order to publish data"}},
+    {"metric-feedback-channel-format", VariantType::String, "name=metric-feedback,type=pull,method=connect,address=ipc://{}metric-feedback-{},transport=shmem,rateLogging=0", {"format for the metric-feedback channel for TF rate limiting"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options, "o2_tfidinfo.root,upstream");
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  int rateLimitingIPCID = std::stoi(configcontext.options().get<std::string>("timeframes-rate-limit-ipcid"));
+  std::string chanFmt = configcontext.options().get<std::string>("metric-feedback-channel-format");
+  std::string metricChannel{};
+  if (rateLimitingIPCID > -1 && !chanFmt.empty()) {
+    metricChannel = fmt::format(fmt::runtime(chanFmt), o2::framework::ChannelSpecHelpers::defaultIPCFolder(), rateLimitingIPCID);
+  }
+  size_t minSHM = std::stoul(configcontext.options().get<std::string>("timeframes-shm-limit"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::globaltracking::getReaderDriverSpec(metricChannel, minSHM));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
@@ -51,6 +51,10 @@ struct HBFUtilsInitializer {
   static constexpr char HBFConfOpt[] = "hbfutils-config";
   static constexpr char HBFTFInfoOpt[] = "tf-info-source";
   static constexpr char HBFUSrc[] = "hbfutils";
+  static constexpr char ReaderDriverDevice[] = "reader-driver";
+  static constexpr char UpstreamOpt[] = "upstream";
+
+  static int NTFs;
 
   HBFUtilsInitializer(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& wf);
   static HBFOpt getOptType(const std::string& optString);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -354,18 +354,26 @@ if [[ ! -z ${WORKFLOW_DETECTORS_USE_GLOBAL_READER_TRACKS} ]] || [[ ! -z ${WORKFL
   for i in ${WORKFLOW_DETECTORS_USE_GLOBAL_READER_CLUSTERS//,/ }; do
     export INPUT_DETECTOR_LIST=$(echo $INPUT_DETECTOR_LIST | sed -e "s/,$i,/,/g" -e "s/^$i,//" -e "s/,$i"'$'"//" -e "s/^$i"'$'"//")
   done
+
   GLOBAL_READER_OPTIONS=
   has_detector ITS && SYNCMODE==1 && GLOBAL_READER_OPTIONS+=" --ir-frames-its"
-  add_W o2-global-track-cluster-reader "--cluster-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER_CLUSTERS --track-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER_TRACKS $GLOBAL_READER_OPTIONS $DISABLE_MC --hbfutils-config o2_tfidinfo.root"
-  has_detector FV0 && has_detector_from_global_reader FV0 && add_W o2-fv0-digit-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --fv0-digit-infile o2_fv0digits.root"
-  has_detector MID && has_detector_from_global_reader MID && add_W o2-mid-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --mid-digit-infile mid-digits-decoded.root"
-  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --infile mchdigits.root"
-  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --infile mchfdigits.root --mch-output-digits-data-description F-DIGITS --mch-output-digitrofs-data-description TC-F-DIGITROFS"
-  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-errors-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
-  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-clusters-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
-  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-preclusters-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
-  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow "$DISABLE_MC --digit-subspec 0 --disable-trigrec --hbfutils-config o2_tfidinfo.root"
-  has_detector TOF && has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "$DISABLE_MC --input-type digits --output-type NONE --hbfutils-config o2_tfidinfo.root"
+
+  if [[ ! -z ${TIMEFRAME_RATE_LIMIT:-} ]] && [[ $TIMEFRAME_RATE_LIMIT != 0 ]]; then
+    HBFINI_OPTIONS=" --hbfutils-config o2_tfidinfo.root,upstream "
+    add_W o2-reader-driver-workflow "$HBFINI_OPTIONS"
+  else
+    HBFINI_OPTIONS=" --hbfutils-config o2_tfidinfo.root "
+  fi
+  add_W o2-global-track-cluster-reader "--cluster-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER_CLUSTERS --track-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER_TRACKS $GLOBAL_READER_OPTIONS $DISABLE_MC $HBFINI_OPTIONS"
+  has_detector FV0 && has_detector_from_global_reader FV0 && add_W o2-fv0-digit-reader-workflow "$DISABLE_MC $HBFINI_OPTIONS --fv0-digit-infile o2_fv0digits.root"
+  has_detector MID && has_detector_from_global_reader MID && add_W o2-mid-digits-reader-workflow "$DISABLE_MC $HBFINI_OPTIONS --mid-digit-infile mid-digits-decoded.root"
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "$DISABLE_MC $HBFINI_OPTIONS --infile mchdigits.root"
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "$DISABLE_MC $HBFINI_OPTIONS --infile mchfdigits.root --mch-output-digits-data-description F-DIGITS --mch-output-digitrofs-data-description TC-F-DIGITROFS"
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-errors-reader-workflow "$HBFINI_OPTIONS" "" 0
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-clusters-reader-workflow "$HBFINI_OPTIONS" "" 0
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-preclusters-reader-workflow "$HBFINI_OPTIONS" "" 0
+  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow "$DISABLE_MC --digit-subspec 0 --disable-trigrec $HBFINI_OPTIONS"
+  has_detector TOF && has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "$DISABLE_MC --input-type digits --output-type NONE $HBFINI_OPTIONS"
 fi
 
 if [[ ! -z $INPUT_DETECTOR_LIST ]]; then


### PR DESCRIPTION
The workflows driven by the input from the root files produced by detectors (e.g. by the `o2-global-track-cluster-reader`), 
can be preceded by the `o2-reader-driver-workflow` which will allow having TF throttling via the usual 
`--timeframes-rate-limit <NTF> --timeframes-rate-limit-ipcid <ID>` options.
The `o2-reader-driver-workflow` as well as all reader workflows must be provided with the `--hbfutils-config <tf_idinfo_file>,upstream` option, with <tf_idinfo_file> being the file produced by the
`o2-tfidinfo-writer-workflow` (usually o2_tfidinfo.root file). 
If this file is in the working directory then the `--hbfutils-config` option can be shortened to `upstream` only.

The `o2-reader-driver-workflow` is not supported for `o2simdigitizerworkflow_configuration.ini` version of the `--hbfutils-config`, since it is used only for MC,
where by construction there is only 1 TF, hence the throttling is meaningless.

Option `--max-tf <n>` of the `o2-reader-driver-workflow` allows to inject only 1st <n> TFs by the downstream readers.

A typical invocation of the throttled workflow is:

```
GLOSET=" --shm-segment-size 24000000000 --timeframes-rate-limit 2 --timeframes-rate-limit-ipcid 0"
HBFSET=" --hbfutils-config upstream,o2_tfidinfo.root "
o2-reader-driver-workflow $GLOSET $HBFSET --max-tf 3 | o2-global-track-cluster-reader $GLOSET $HBFSET --disable-mc --track-types <...> --cluster-types <...> | [<other readers> $GLOSET $HBFSET ] | <consumer workflows > $GLOSET --run
```

If the `dpl-workflow.sh` needs to inject the input data via readers and throttling is enabled (`$TIMEFRAME_RATE_LIMIT > 0`) then the `o2-reader-driver-workflow` will be added automatically.

Ping @chiarazampolli 