### PR TITLE
DPL Analysis: make sure additional AOD origins are not skipped

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -41,6 +41,7 @@
 #include "Framework/RateLimiter.h"
 #include "Framework/Plugins.h"
 #include "Framework/DeviceSpec.h"
+#include "WorkflowHelpers.h"
 #include <Monitoring/Monitoring.h>
 
 #include "TFile.h"
@@ -370,8 +371,7 @@ DataProcessorSpec
         }
 
         // skip non-AOD refs
-        if (!DataSpecUtils::partialMatch(*ref.spec, header::DataOrigin("AOD")) &&
-            !DataSpecUtils::partialMatch(*ref.spec, header::DataOrigin("DYN"))) {
+        if (!DataSpecUtils::partialMatch(*ref.spec, writableAODOrigins)) {
           continue;
         }
         startTime = DataRefUtils::getHeader<DataProcessingHeader*>(ref)->startTime;


### PR DESCRIPTION
@ktf not sure if I missed it in the original PR or it got reverted somehow, but currently it is impossible to write tables with AOD1 or AOD2. This PR fixes it. Could you please fast-track it?