### PR TITLE
O2sim: DPL: restore mctracks-to-aod task name as topology adaptation relies on it

### DIFF
--- a/run/o2sim_mctracks_to_aod.cxx
+++ b/run/o2sim_mctracks_to_aod.cxx
@@ -18,7 +18,7 @@
 template <typename T>
 using Configurable = o2::framework::Configurable<T>;
 
-struct Task {
+struct MctracksToAod {
   /** @{
       @name Types used */
   using Collisions = o2::aod::McCollisions;
@@ -142,7 +142,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   using o2::framework::adaptAnalysisTask;
 
-  auto spec = adaptAnalysisTask<Task>(cfgc);
+  auto spec = adaptAnalysisTask<MctracksToAod>(cfgc);
   spec.inputs.emplace_back("mctracks", "MC", "MCTRACKS", 0.,
                            Lifetime::Timeframe);
   spec.inputs.emplace_back("mcheader", "MC", "MCHEADER", 0.,


### PR DESCRIPTION
The name of the `mctracks-to-aod` converter is reserved and used by the topology calculation to prevent adding `aod-reader`. 