### PR TITLE
DPL: make sure homogeneous_apply_ref complains when we are missing an explicit constructor

### DIFF
--- a/Framework/Foundation/include/Framework/StructToTuple.h
+++ b/Framework/Foundation/include/Framework/StructToTuple.h
@@ -135,10 +135,12 @@ struct UniversalType {
 template <typename T>
 consteval auto brace_constructible_size(auto... Members)
 {
-  if constexpr (requires { T{Members...}; } == false)
+  if constexpr (requires { T{Members...}; } == false) {
+    static_assert(sizeof...(Members) != 0, "You need to make sure that you have implicit constructors or that you call the explicit constructor correctly.");
     return sizeof...(Members) - 1;
-  else
+  } else {
     return brace_constructible_size<T>(Members..., UniversalType{});
+  }
 }
 #else
 template <typename T>


### PR DESCRIPTION
DPL: make sure homogeneous_apply_ref complains when we are missing an explicit constructor

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12701).
* #12704
* __->__ #12701