### PR TITLE
FoCal: Add two new detIDs for FoCal

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
@@ -78,17 +78,19 @@ class DetID
   static constexpr ID TST = 15;
   static constexpr ID CTP = 16;
   static constexpr ID FOC = 17;
+  static constexpr ID FOP = 18;
+  static constexpr ID FOH = 19;
 #ifdef ENABLE_UPGRADES
-  static constexpr ID IT3 = 18;
-  static constexpr ID TRK = 19;
-  static constexpr ID FT3 = 20;
-  static constexpr ID FCT = 21;
-  static constexpr ID TF3 = 22;
-  static constexpr ID RCH = 23;
-  static constexpr ID MI3 = 24;
+  static constexpr ID IT3 = 20;
+  static constexpr ID TRK = 21;
+  static constexpr ID FT3 = 22;
+  static constexpr ID FCT = 23;
+  static constexpr ID TF3 = 24;
+  static constexpr ID RCH = 25;
+  static constexpr ID MI3 = 26;
   static constexpr ID Last = MI3;
 #else
-  static constexpr ID Last = FOC; ///< if extra detectors added, update this !!!
+  static constexpr ID Last = FOH; ///< if extra detectors added, update this !!!
 #endif
   static constexpr ID First = ITS;
 
@@ -180,9 +182,9 @@ class DetID
   // detector names, will be defined in DataSources
   static constexpr const char* sDetNames[nDetectors + 1] = ///< defined detector names
 #ifdef ENABLE_UPGRADES
-    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", "IT3", "TRK", "FT3", "FCT", "TF3", "RCH", "MI3", nullptr};
+    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", "FOP", "FOH", "IT3", "TRK", "FT3", "FCT", "TF3", "RCH", "MI3", nullptr};
 #else
-    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", nullptr};
+    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FT0", "FV0", "FDD", "TST", "CTP", "FOC", "FOP", "FOH", nullptr};
 #endif
 
   static constexpr std::array<o2h::DataOrigin, nDetectors>
@@ -190,7 +192,7 @@ class DetID
     {o2h::gDataOriginITS, o2h::gDataOriginTPC, o2h::gDataOriginTRD, o2h::gDataOriginTOF, o2h::gDataOriginPHS,
      o2h::gDataOriginCPV, o2h::gDataOriginEMC, o2h::gDataOriginHMP, o2h::gDataOriginMFT, o2h::gDataOriginMCH,
      o2h::gDataOriginMID, o2h::gDataOriginZDC, o2h::gDataOriginFT0, o2h::gDataOriginFV0, o2h::gDataOriginFDD,
-     o2h::gDataOriginTST, o2h::gDataOriginCTP, o2h::gDataOriginFOC
+     o2h::gDataOriginTST, o2h::gDataOriginCTP, o2h::gDataOriginFOC, o2h::gDataOriginFOP, o2h::gDataOriginFOH
 #ifdef ENABLE_UPGRADES
      ,
      o2h::gDataOriginIT3, o2h::gDataOriginTRK, o2h::gDataOriginFT3, o2h::gDataOriginFCT, o2h::gDataOriginTF3,
@@ -209,9 +211,9 @@ GPUconstexpr() DetID::mask_t sMasks[DetID::nDetectors] = ///< detectot masks
   {DetID::mask_t(math_utils::bit2Mask(DetID::ITS)), DetID::mask_t(math_utils::bit2Mask(DetID::TPC)), DetID::mask_t(math_utils::bit2Mask(DetID::TRD)), DetID::mask_t(math_utils::bit2Mask(DetID::TOF)), DetID::mask_t(math_utils::bit2Mask(DetID::PHS)),
    DetID::mask_t(math_utils::bit2Mask(DetID::CPV)), DetID::mask_t(math_utils::bit2Mask(DetID::EMC)), DetID::mask_t(math_utils::bit2Mask(DetID::HMP)), DetID::mask_t(math_utils::bit2Mask(DetID::MFT)), DetID::mask_t(math_utils::bit2Mask(DetID::MCH)),
    DetID::mask_t(math_utils::bit2Mask(DetID::MID)), DetID::mask_t(math_utils::bit2Mask(DetID::ZDC)), DetID::mask_t(math_utils::bit2Mask(DetID::FT0)), DetID::mask_t(math_utils::bit2Mask(DetID::FV0)), DetID::mask_t(math_utils::bit2Mask(DetID::FDD)),
-   DetID::mask_t(math_utils::bit2Mask(DetID::TST)), DetID::mask_t(math_utils::bit2Mask(DetID::CTP)), DetID::mask_t(math_utils::bit2Mask(DetID::FOC))
+   DetID::mask_t(math_utils::bit2Mask(DetID::TST)), DetID::mask_t(math_utils::bit2Mask(DetID::CTP)), DetID::mask_t(math_utils::bit2Mask(DetID::FOC)), DetID::mask_t(math_utils::bit2Mask(DetID::FOP)), DetID::mask_t(math_utils::bit2Mask(DetID::FOH))
 #ifdef ENABLE_UPGRADES
-                                                                                                       ,
+                                                                                                                                                                                                         ,
    DetID::mask_t(math_utils::bit2Mask(DetID::IT3)), DetID::mask_t(math_utils::bit2Mask(DetID::TRK)), DetID::mask_t(math_utils::bit2Mask(DetID::FT3)), DetID::mask_t(math_utils::bit2Mask(DetID::FCT)), DetID::mask_t(math_utils::bit2Mask(DetID::TF3)),
    DetID::mask_t(math_utils::bit2Mask(DetID::RCH)), DetID::mask_t(math_utils::bit2Mask(DetID::MI3))
 #endif


### PR DESCRIPTION
Example of change in case of adding two new DetIDs for FoCal.
Names are placeholders.