### PR TITLE
DPL Analysis: rework the table iterator type hierachy

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1380,7 +1380,6 @@ class Table
     using bindings_pack_t = decltype(extractBindings(external_index_columns_t{}));
     using parent_t = Parent;
     using originals = originals_pack_t<T...>;
-
     using policy_t = IP;
 
     RowViewBase() = default;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2708,7 +2708,7 @@ struct Join : TableWrap<Ts...>::table_t {
   using const_iterator = iterator;
   using unfiltered_iterator = iterator;
   using unfiltered_const_iterator = const_iterator;
-  using filtered_iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowView<Filtered<Join<Ts...>>, Os...>{}; }(originals{}));
+  using filtered_iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<Filtered<Join<Ts...>>, Os...>{}; }(originals{}));
   using filtered_const_iterator = filtered_iterator;
 
   iterator begin()

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -3199,7 +3199,6 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
   using base_t = T;
   using table_t = typename FilteredBase<typename T::table_t>::table_t;
   using originals = originals_pack_t<T>;
-
   using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2704,11 +2704,11 @@ struct Join : TableWrap<Ts...>::table_t {
   using self_t = Join<Ts...>;
   using table_t = base;
   using persistent_columns_t = typename table_t::persistent_columns_t;
-  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<Join<Ts...>, Os...>{};}(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowView<Join<Ts...>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
   using unfiltered_iterator = iterator;
   using unfiltered_const_iterator = const_iterator;
-  using filtered_iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<Filtered<Join<Ts...>>, Os...>{};}(originals{}));
+  using filtered_iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowView<Filtered<Join<Ts...>>, Os...>{}; }(originals{}));
   using filtered_const_iterator = filtered_iterator;
 
   iterator begin()
@@ -2826,7 +2826,7 @@ class FilteredBase : public T
   using persistent_columns_t = typename T::persistent_columns_t;
   using external_index_columns_t = typename T::external_index_columns_t;
 
-  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowViewFiltered<FilteredBase<T>, Os...>{}; }(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<FilteredBase<T>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
@@ -3064,7 +3064,7 @@ class Filtered : public FilteredBase<T>
   using table_t = typename FilteredBase<T>::table_t;
   using originals = originals_pack_t<T>;
 
-  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowViewFiltered<Filtered<T>, Os...>{};}(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<Filtered<T>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   iterator begin()
@@ -3201,7 +3201,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
   using table_t = typename FilteredBase<typename T::table_t>::table_t;
   using originals = originals_pack_t<T>;
 
-  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowViewFiltered<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   iterator begin()

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2701,26 +2701,14 @@ struct Join : TableWrap<Ts...>::table_t {
   using base::bindExternalIndices;
   using base::bindInternalIndicesTo;
 
-  template <typename P, typename... Os>
-  constexpr static auto make_it(framework::pack<Os...>)
-  {
-    return typename table_t::template RowView<P, Os...>{};
-  }
-
-  template <typename P, typename... Os>
-  constexpr static auto make_fit(framework::pack<Os...>)
-  {
-    return typename table_t::template RowViewFiltered<P, Os...>{};
-  }
-
   using self_t = Join<Ts...>;
   using table_t = base;
   using persistent_columns_t = typename table_t::persistent_columns_t;
-  using iterator = decltype(make_it<Join<Ts...>>(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<Join<Ts...>, Os...>{};}(originals{}));
   using const_iterator = iterator;
   using unfiltered_iterator = iterator;
   using unfiltered_const_iterator = const_iterator;
-  using filtered_iterator = decltype(make_fit<Filtered<Join<Ts...>>>(originals{}));
+  using filtered_iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<Filtered<Join<Ts...>>, Os...>{};}(originals{}));
   using filtered_const_iterator = filtered_iterator;
 
   iterator begin()
@@ -2838,12 +2826,7 @@ class FilteredBase : public T
   using persistent_columns_t = typename T::persistent_columns_t;
   using external_index_columns_t = typename T::external_index_columns_t;
 
-  template <typename P, typename... Os>
-  constexpr static auto make_it(framework::pack<Os...>)
-  {
-    return typename table_t::template RowViewFiltered<P, Os...>{};
-  }
-  using iterator = decltype(make_it<FilteredBase<T>>(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowViewFiltered<FilteredBase<T>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
@@ -3081,7 +3064,7 @@ class Filtered : public FilteredBase<T>
   using table_t = typename FilteredBase<T>::table_t;
   using originals = originals_pack_t<T>;
 
-  using iterator = decltype(FilteredBase<T>::template make_it<Filtered<T>>(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowViewFiltered<Filtered<T>, Os...>{};}(originals{}));
   using const_iterator = iterator;
 
   iterator begin()
@@ -3218,7 +3201,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
   using table_t = typename FilteredBase<typename T::table_t>::table_t;
   using originals = originals_pack_t<T>;
 
-  using iterator = decltype(FilteredBase<T>::template make_it<Filtered<Filtered<T>>>(originals{}));
+  using iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowViewFiltered<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   iterator begin()

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -820,27 +820,12 @@ struct RowViewCore : public IP, C... {
     bindAllDynamicColumns(dynamic_columns_t{});
   }
 
-  RowViewCore(RowViewCore&& other) noexcept
-  {
-    IP::operator=(static_cast<IP&&>(other));
-    (void(static_cast<C&>(*this) = static_cast<C&&>(other)), ...);
-    bindIterators(persistent_columns_t{});
-    bindAllDynamicColumns(dynamic_columns_t{});
-  }
-
-  RowViewCore& operator=(RowViewCore const& other)
+  RowViewCore& operator=(RowViewCore other)
   {
     IP::operator=(static_cast<IP const&>(other));
-    (void(static_cast<C&>(*this) = static_cast<C const&>(other)), ...);
+    (void(static_cast<C&>(*this) = static_cast<C>(other)), ...);
     bindIterators(persistent_columns_t{});
     bindAllDynamicColumns(dynamic_columns_t{});
-    return *this;
-  }
-
-  RowViewCore& operator=(RowViewCore&& other) noexcept
-  {
-    IP::operator=(static_cast<IP&&>(other));
-    (void(static_cast<C&>(*this) = static_cast<C&&>(other)), ...);
     return *this;
   }
 
@@ -1396,29 +1381,68 @@ class Table
     using parent_t = Parent;
     using originals = originals_pack_t<T...>;
 
+    using policy_t = IP;
+
+    RowViewBase() = default;
+
     RowViewBase(arrow::ChunkedArray* columnData[sizeof...(C)], IP&& policy)
       : RowViewCore<IP, C...>(columnData, std::forward<decltype(policy)>(policy))
     {
     }
 
-    template <typename Tbl = table_t>
-    RowViewBase(RowViewBase<IP, Tbl, Tbl> const& other)
-      : RowViewCore<IP, C...>(other)
+    template <typename P, typename... O>
+    RowViewBase& operator=(RowViewBase<IP, P, O...> const& other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
     {
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...> const&>(other);
+      return *this;
     }
 
-    template <typename Tbl = table_t>
-    RowViewBase(RowViewBase<IP, Tbl, Tbl>&& other) noexcept
-      : RowViewCore<IP, C...>(other)
+    template <typename P, typename... O>
+    RowViewBase& operator=(RowViewBase<IP, P, T...>&& other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
     {
+      static_cast<RowViewCore<IP, C...>&>(*this) = std::forward<RowViewCore<IP, C...>>(other);
+      return *this;
     }
 
-    RowViewBase() = default;
-    RowViewBase(RowViewBase const&) = default;
-    RowViewBase(RowViewBase&&) = default;
+    template <typename P>
+    RowViewBase& operator=(RowViewBase<IP, P, T...> const& other)
+    {
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...> const&>(other);
+      return *this;
+    }
 
-    RowViewBase& operator=(RowViewBase const&) = default;
-    RowViewBase& operator=(RowViewBase&&) = default;
+    template <typename P>
+    RowViewBase& operator=(RowViewBase<IP, P, T...>&& other)
+    {
+      static_cast<RowViewCore<IP, C...>&>(*this) = std::forward<RowViewCore<IP, C...>>(other);
+      return *this;
+    }
+
+    template <typename P, typename... O>
+    RowViewBase(RowViewBase<IP, P, O...> const& other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
+    {
+      *this = other;
+    }
+
+    template <typename P, typename... O>
+    RowViewBase(RowViewBase<IP, P, O...>&& other) noexcept requires std::is_same_v<typename P::table_t, typename Parent::table_t>
+    {
+      *this = other;
+    }
+
+    template <typename P>
+    RowViewBase(RowViewBase<IP, P, T...> const& other)
+      // : RowViewCore<IP, C...>(static_cast<RowViewCore<IP, C...> const&>(other))
+    {
+      *this = other;
+    }
+
+    template <typename P>
+    RowViewBase(RowViewBase<IP, P, T...>&& other) noexcept
+      // : RowViewCore<IP, C...>(std::forward<RowViewCore<IP, C...>>(other))
+    {
+      *this = other;
+    }
 
     RowViewBase& operator=(RowViewSentinel const& other)
     {
@@ -1426,7 +1450,8 @@ class Table
       return *this;
     }
 
-    void matchTo(RowViewBase const& other)
+    template <typename P>
+    void matchTo(RowViewBase<IP, P, T...> const& other)
     {
       this->mRowIndex = other.mRowIndex;
     }
@@ -1763,9 +1788,6 @@ constexpr auto concat(T const&... t)
 {
   return typename o2::soa::TableIntersect<T...>::table_t(ArrowHelpers::concatTables({t.asArrowTable()...}));
 }
-
-template <typename... Ts>
-using JoinBase = decltype(join(std::declval<Ts>()...));
 
 template <typename T1, typename T2>
 using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
@@ -2677,26 +2699,38 @@ template <typename T>
 class FilteredBase;
 
 template <typename... Ts>
-struct Join : JoinBase<Ts...> {
-  Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0);
-
-  template <typename... ATs>
-  Join(uint64_t offset, std::shared_ptr<arrow::Table> t1, std::shared_ptr<arrow::Table> t2, ATs... ts);
-
-  using base = JoinBase<Ts...>;
+struct Join : TableWrap<Ts...>::table_t {
+  using base = typename TableWrap<Ts...>::table_t;
   using originals = originals_pack_t<Ts...>;
 
+  Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
+    : base{ArrowHelpers::joinTables(std::move(tables)), offset}
+  {
+    bindInternalIndicesTo(this);
+  }
   using base::bindExternalIndices;
   using base::bindInternalIndicesTo;
+
+  template <typename P, typename... Os>
+  constexpr static auto make_it(framework::pack<Os...>)
+  {
+    return typename table_t::template RowView<P, Os...>{};
+  }
+
+  template <typename P, typename... Os>
+  constexpr static auto make_fit(framework::pack<Os...>)
+  {
+    return typename table_t::template RowViewFiltered<P, Os...>{};
+  }
 
   using self_t = Join<Ts...>;
   using table_t = base;
   using persistent_columns_t = typename table_t::persistent_columns_t;
-  using iterator = typename table_t::template RowView<Join<Ts...>, Ts...>;
+  using iterator = decltype(make_it<Join<Ts...>>(originals{}));
   using const_iterator = iterator;
   using unfiltered_iterator = iterator;
   using unfiltered_const_iterator = const_iterator;
-  using filtered_iterator = typename table_t::template RowViewFiltered<FilteredBase<Join<Ts...>>, Ts...>;
+  using filtered_iterator = decltype(make_fit<Filtered<Join<Ts...>>>(originals{}));
   using filtered_const_iterator = filtered_iterator;
 
   iterator begin()
@@ -2763,21 +2797,6 @@ struct Join : JoinBase<Ts...> {
   }
 };
 
-template <typename... Ts>
-Join<Ts...>::Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset)
-  : JoinBase<Ts...>{ArrowHelpers::joinTables(std::move(tables)), offset}
-{
-  bindInternalIndicesTo(this);
-}
-
-template <typename... Ts>
-template <typename... ATs>
-Join<Ts...>::Join(uint64_t offset, std::shared_ptr<arrow::Table> t1, std::shared_ptr<arrow::Table> t2, ATs... ts)
-  : Join<Ts...>(std::vector<std::shared_ptr<arrow::Table>>{t1, t2, ts...}, offset)
-{
-  bindInternalIndicesTo(this);
-}
-
 template <typename T1, typename T2>
 struct Concat : ConcatBase<T1, T2> {
   Concat(std::shared_ptr<arrow::Table> t1, std::shared_ptr<arrow::Table> t2, uint64_t offset = 0)
@@ -2830,7 +2849,7 @@ class FilteredBase : public T
   using external_index_columns_t = typename T::external_index_columns_t;
 
   template <typename P, typename... Os>
-  constexpr static auto make_it(framework::pack<Os...> const&)
+  constexpr static auto make_it(framework::pack<Os...>)
   {
     return typename table_t::template RowViewFiltered<P, Os...>{};
   }
@@ -2877,11 +2896,6 @@ class FilteredBase : public T
     return iterator(mFilteredBegin);
   }
 
-  RowViewSentinel end()
-  {
-    return RowViewSentinel{*mFilteredEnd};
-  }
-
   const_iterator begin() const
   {
     return const_iterator(mFilteredBegin);
@@ -2890,6 +2904,16 @@ class FilteredBase : public T
   [[nodiscard]] RowViewSentinel end() const
   {
     return RowViewSentinel{*mFilteredEnd};
+  }
+
+  auto& cached_begin()
+  {
+    return mFilteredBegin;
+  }
+
+  auto const& cached_begin() const
+  {
+    return mFilteredBegin;
   }
 
   iterator iteratorAt(uint64_t i) const
@@ -3067,6 +3091,19 @@ class Filtered : public FilteredBase<T>
   using table_t = typename FilteredBase<T>::table_t;
   using originals = originals_pack_t<T>;
 
+  using iterator = decltype(FilteredBase<T>::template make_it<Filtered<T>>(originals{}));
+  using const_iterator = iterator;
+
+  iterator begin()
+  {
+    return iterator(this->cached_begin());
+  }
+
+  const_iterator begin() const
+  {
+    return const_iterator(this->cached_begin());
+  }
+
   Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
     : FilteredBase<T>(std::move(tables), selection, offset) {}
 
@@ -3190,6 +3227,19 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
   using base_t = T;
   using table_t = typename FilteredBase<typename T::table_t>::table_t;
   using originals = originals_pack_t<T>;
+
+  using iterator = decltype(FilteredBase<T>::template make_it<Filtered<Filtered<T>>>(originals{}));
+  using const_iterator = iterator;
+
+  iterator begin()
+  {
+    return iterator(this->cached_begin());
+  }
+
+  const_iterator begin() const
+  {
+    return const_iterator(this->cached_begin());
+  }
 
   Filtered(std::vector<Filtered<T>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
     : FilteredBase<typename T::table_t>(std::move(extractTablesFromFiltered(tables)), selection, offset)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1432,14 +1432,12 @@ class Table
 
     template <typename P>
     RowViewBase(RowViewBase<IP, P, T...> const& other)
-      // : RowViewCore<IP, C...>(static_cast<RowViewCore<IP, C...> const&>(other))
     {
       *this = other;
     }
 
     template <typename P>
     RowViewBase(RowViewBase<IP, P, T...>&& other) noexcept
-      // : RowViewCore<IP, C...>(std::forward<RowViewCore<IP, C...>>(other))
     {
       *this = other;
     }
@@ -1452,6 +1450,12 @@ class Table
 
     template <typename P>
     void matchTo(RowViewBase<IP, P, T...> const& other)
+    {
+      this->mRowIndex = other.mRowIndex;
+    }
+
+    template <typename P, typename... O>
+    void matchTo(RowViewBase<IP, P, O...> const& other) requires std::is_same_v<typename P::parent_t, typename Parent::table_t>
     {
       this->mRowIndex = other.mRowIndex;
     }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1391,30 +1391,16 @@ class Table
     }
 
     template <typename P, typename... O>
-    RowViewBase& operator=(RowViewBase<IP, P, O...> const& other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
+    RowViewBase& operator=(RowViewBase<IP, P, O...> other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
     {
-      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...> const&>(other);
-      return *this;
-    }
-
-    template <typename P, typename... O>
-    RowViewBase& operator=(RowViewBase<IP, P, T...>&& other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
-    {
-      static_cast<RowViewCore<IP, C...>&>(*this) = std::forward<RowViewCore<IP, C...>>(other);
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...>>(other);
       return *this;
     }
 
     template <typename P>
-    RowViewBase& operator=(RowViewBase<IP, P, T...> const& other)
+    RowViewBase& operator=(RowViewBase<IP, P, T...> other)
     {
-      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...> const&>(other);
-      return *this;
-    }
-
-    template <typename P>
-    RowViewBase& operator=(RowViewBase<IP, P, T...>&& other)
-    {
-      static_cast<RowViewCore<IP, C...>&>(*this) = std::forward<RowViewCore<IP, C...>>(other);
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...>>(other);
       return *this;
     }
 
@@ -1455,7 +1441,7 @@ class Table
     }
 
     template <typename P, typename... O>
-    void matchTo(RowViewBase<IP, P, O...> const& other) requires std::is_same_v<typename P::parent_t, typename Parent::table_t>
+    void matchTo(RowViewBase<IP, P, O...> const& other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
     {
       this->mRowIndex = other.mRowIndex;
     }

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -982,6 +982,7 @@ TEST_CASE("TestSelfIndexRecursion")
   auto pst = o2::aod::PointsSelfIndex{t3};
   pst.bindInternalIndicesTo(&pst);
 
+  // FIXME: only 4 levels of recursive self-index dereference are tested
   for (auto& p : pst) {
     auto ops = p.pointSeq_as<o2::aod::PointsSelfIndex>();
     for (auto& pp : ops) {
@@ -1035,6 +1036,7 @@ TEST_CASE("TestSelfIndexRecursion")
   FullPoints fp({t1, t2});
   fp.bindInternalIndicesTo(&fp);
 
+  // FIXME: only 4 levels of recursive self-index dereference are tested
   for (auto& p : fp) {
     auto bp = std::is_same_v<std::decay_t<decltype(p)>, FullPoints::iterator>;
     REQUIRE(bp);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1037,6 +1037,7 @@ TEST_CASE("TestSelfIndexRecursion")
   fp.bindInternalIndicesTo(&fp);
 
   // FIXME: only 4 levels of recursive self-index dereference are tested
+  // self-index binding should stay the same for recursive dereferences
   for (auto& p : fp) {
     auto bp = std::is_same_v<std::decay_t<decltype(p)>, FullPoints::iterator>;
     REQUIRE(bp);
@@ -1060,6 +1061,7 @@ TEST_CASE("TestSelfIndexRecursion")
 
   auto const& fpa = fp;
 
+  // iterators acquired through different means should have consistent types
   for (auto& it1 : fpa) {
     [[maybe_unused]] auto it2 = fpa.rawIteratorAt(0);
     [[maybe_unused]] auto it3 = fpa.iteratorAt(0);
@@ -1072,7 +1074,8 @@ TEST_CASE("TestSelfIndexRecursion")
   using FilteredPoints = o2::soa::Filtered<FullPoints>;
   FilteredPoints ffp({t1, t2}, {1, 2, 3}, 0);
   ffp.bindInternalIndicesTo(&ffp);
-
+  
+  // Filter should not interfere with self-index and the binding should stay the same
   for (auto& p : ffp) {
     using T1 = std::decay_t<decltype(p)>;
     auto bp = std::is_same_v<T1, FilteredPoints::iterator>;
@@ -1097,6 +1100,7 @@ TEST_CASE("TestSelfIndexRecursion")
 
   auto const& ffpa = ffp;
 
+  // rawIteratorAt() should create an unfiltered iterator, unline begin() and iteratorAt()
   for (auto& it1 : ffpa) {
     [[maybe_unused]] auto it2 = ffpa.rawIteratorAt(0);
     [[maybe_unused]] auto it3 = ffpa.iteratorAt(0);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1074,7 +1074,7 @@ TEST_CASE("TestSelfIndexRecursion")
   using FilteredPoints = o2::soa::Filtered<FullPoints>;
   FilteredPoints ffp({t1, t2}, {1, 2, 3}, 0);
   ffp.bindInternalIndicesTo(&ffp);
-  
+
   // Filter should not interfere with self-index and the binding should stay the same
   for (auto& p : ffp) {
     using T1 = std::decay_t<decltype(p)>;

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -154,7 +154,7 @@ TEST_CASE("TestTableIteration")
 
   for (auto& t : tests2) {
     REQUIRE(t.x() == value / 4);
-    REQUIRE(t.y() == value);
+    REQUIRE((size_t)t.y() == value);
     REQUIRE(value < 8);
     value++;
   }
@@ -275,7 +275,7 @@ TEST_CASE("TestJoinedTables")
   REQUIRE(Test::contains<TestY>());
   REQUIRE(!Test::contains<TestZ>());
 
-  Test tests{0, tableX, tableY};
+  Test tests{{tableX, tableY}, 0};
 
   REQUIRE(tests.contains<TestX>());
   REQUIRE(tests.contains<TestY>());
@@ -298,7 +298,7 @@ TEST_CASE("TestJoinedTables")
     REQUIRE(15 == test.x() + test.y() + test.z());
   }
   using TestMoreThanTwo = Join<TestX, TestY, TestZ>;
-  TestMoreThanTwo tests4{0, tableX, tableY, tableZ};
+  TestMoreThanTwo tests4{{tableX, tableY, tableZ}, 0};
   for (auto& test : tests4) {
     REQUIRE(15 == test.x() + test.y() + test.z());
   }
@@ -464,7 +464,7 @@ TEST_CASE("TestConcatTables")
   selectionJoin->SetIndex(1, 2);
   selectionJoin->SetIndex(2, 4);
   selectionJoin->SetNumSlots(3);
-  JoinedTest testJoin{0, tableA, tableC};
+  JoinedTest testJoin{{tableA, tableC}, 0};
   FilteredJoinTest filteredJoin{{testJoin.asArrowTable()}, selectionJoin};
 
   i = 0;
@@ -704,7 +704,7 @@ TEST_CASE("TestEmptyTables")
   o2::aod::Infos i{iempty};
 
   using PI = Join<o2::aod::Points, o2::aod::Infos>;
-  PI pi{0, pempty, iempty};
+  PI pi{{pempty, iempty}, 0};
   REQUIRE(pi.size() == 0);
   auto spawned = Extend<o2::aod::Points, o2::aod::test::ESum>(p);
   REQUIRE(spawned.size() == 0);
@@ -1062,9 +1062,55 @@ TEST_CASE("TestSelfIndexRecursion")
     [[maybe_unused]] auto it2 = fpa.rawIteratorAt(0);
     [[maybe_unused]] auto it3 = fpa.iteratorAt(0);
     auto bit1 = std::is_same_v<std::decay_t<decltype(it1)>, std::decay_t<decltype(it2)>>;
-    CHECK(bit1);
+    REQUIRE(bit1);
     auto bit2 = std::is_same_v<std::decay_t<decltype(it1)>, std::decay_t<decltype(it3)>>;
-    CHECK(bit2);
+    REQUIRE(bit2);
+  }
+
+  using FilteredPoints = o2::soa::Filtered<FullPoints>;
+  FilteredPoints ffp({t1, t2}, {1, 2, 3}, 0);
+  ffp.bindInternalIndicesTo(&ffp);
+
+  for (auto& p : ffp) {
+    using T1 = std::decay_t<decltype(p)>;
+    auto bp = std::is_same_v<T1, FilteredPoints::iterator>;
+    REQUIRE(bp);
+    auto ops = p.pointSeq_as<typename T1::parent_t>();
+    for (auto& pp : ops) {
+      auto bpp = std::is_same_v<std::decay_t<decltype(pp)>, FullPoints::iterator>;
+      REQUIRE(bpp);
+      auto opps = pp.pointSeq_as<FilteredPoints>();
+      for (auto& ppp : opps) {
+        auto bppp = std::is_same_v<std::decay_t<decltype(ppp)>, FullPoints::iterator>;
+        REQUIRE(bppp);
+        auto oppps = ppp.pointSeq_as<FilteredPoints>();
+        for (auto& pppp : oppps) {
+          auto bpppp = std::is_same_v<std::decay_t<decltype(pppp)>, FullPoints::iterator>;
+          REQUIRE(bpppp);
+          auto opppps = pppp.pointSeq_as<FilteredPoints>();
+        }
+      }
+    }
+  }
+
+  auto const& ffpa = ffp;
+
+  for (auto& it1 : ffpa) {
+    [[maybe_unused]] auto it2 = ffpa.rawIteratorAt(0);
+    [[maybe_unused]] auto it3 = ffpa.iteratorAt(0);
+    using T1 = std::decay_t<decltype(it1)>;
+    using T2 = std::decay_t<decltype(it2)>;
+    using T3 = std::decay_t<decltype(it3)>;
+    auto bit1 = !std::is_same_v<T1, T2>;
+    REQUIRE(bit1);
+    auto bit2 = !std::is_same_v<T1, T3>;
+    REQUIRE(bit2);
+    auto bit3 = std::is_same_v<typename T1::policy_t, typename T3::policy_t>;
+    REQUIRE(bit3);
+    auto bit4 = std::is_same_v<typename T1::policy_t, o2::soa::FilteredIndexPolicy>;
+    REQUIRE(bit4);
+    auto bit5 = std::is_same_v<typename T2::policy_t, o2::soa::DefaultIndexPolicy>;
+    REQUIRE(bit5);
   }
 }
 
@@ -1206,7 +1252,7 @@ TEST_CASE("TestIndexUnboundExceptions")
 
   for (auto& row : prt) {
     try {
-      auto sp = row.singlePoint();
+      [[maybe_unused]] auto sp = row.singlePoint();
     } catch (RuntimeErrorRef ref) {
       REQUIRE(std::string{error_from_ref(ref).what} == "Index pointing to Points3Ds is not bound! Did you subscribe to the table?");
     }
@@ -1255,7 +1301,7 @@ TEST_CASE("TestArrayColumns")
   o2::aod::BILists li{t};
   for (auto const& row : li) {
     auto iir = row.smallIntArray();
-    auto bbrr = row.boolArray_raw();
+    [[maybe_unused]] auto bbrr = row.boolArray_raw();
     REQUIRE(std::is_same_v<std::decay_t<decltype(iir)>, int8_t const*>);
     for (auto i = 0; i < 32; ++i) {
       REQUIRE(iir[i] == i);

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -12,9 +12,6 @@
 #include "Framework/ASoA.h"
 #include "Framework/TableBuilder.h"
 #include "Framework/AnalysisDataModel.h"
-#include "gandiva/tree_expr_builder.h"
-#include "arrow/status.h"
-#include "gandiva/filter.h"
 #include <catch_amalgamated.hpp>
 
 using namespace o2::framework;
@@ -50,7 +47,7 @@ TEST_CASE("TestJoinedTablesContains")
 
   using Test = o2::soa::Join<XY, ZD>;
 
-  Test tests{0, tXY, tZD};
+  Test tests{{tXY, tZD}, 0};
   REQUIRE(tests.asArrowTable()->num_columns() != 0);
   REQUIRE(tests.asArrowTable()->num_columns() ==
           tXY->num_columns() + tZD->num_columns());


### PR DESCRIPTION
* Ensure the compatibility of the iterators based on the same set of columns regardless of the parent table type
* Remove the move constructor and move assignment from `RowViewCore` as it was leaving the iterators in an undefined state
* Expand the recursive self-index dereference test for Filtered objects
* Remove some obsolete code 