### PR TITLE
Fixes in CTP digitizer for anchored MC

### DIFF
--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Configuration.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Configuration.h
@@ -23,7 +23,7 @@
 #include <bitset>
 #include <map>
 #include <set>
-#include <iostream>
+#include <iosfwd>
 namespace o2
 {
 namespace ctp
@@ -175,7 +175,7 @@ class CTPConfiguration
   std::vector<std::string> getDetectorList() const;
   o2::detectors::DetID::mask_t getDetectorMask() const;
   uint64_t getClassMaskForInputMask(uint64_t inputMask) const;
-  void printConfigString() { std::cout << mConfigString << std::endl; };
+  void printConfigString();
   std::string getConfigString() { return mConfigString; };
   CTPDescriptor* getDescriptor(int index) { return &mDescriptors[index]; };
   int assignDescriptors();
@@ -197,6 +197,9 @@ class CTPConfiguration
   int processConfigurationLineRun3v2(std::string& line, int& level, std::map<int, std::vector<int>>& descInputsIndex);
   ClassDefNV(CTPConfiguration, 6);
 };
+
+std::ostream& operator<<(std::ostream& in, const CTPConfiguration& conf);
+
 } // namespace ctp
 } // namespace o2
 #endif //_CTP_CONFIGURATION_H_

--- a/DataFormats/Detectors/CTP/src/Configuration.cxx
+++ b/DataFormats/Detectors/CTP/src/Configuration.cxx
@@ -19,6 +19,7 @@
 #include <regex>
 #include "CommonUtils/StringUtils.h"
 #include <fairlogger/Logger.h>
+#include <iostream>
 
 using namespace o2::ctp;
 //
@@ -996,6 +997,10 @@ int CTPConfiguration::checkConfigConsistency() const
   std::cout << "CTP Config consistency checked. WARNINGS:" << iw << " ERRORS:" << ret << std::endl;
   return ret;
 }
+void CTPConfiguration::printConfigString()
+{
+  std::cout << mConfigString << std::endl;
+};
 //
 int CTPInputsConfiguration::createInputsConfigFromFile(std::string& filename)
 {
@@ -1117,4 +1122,10 @@ int CTPInputsConfiguration::getInputIndexFromName(std::string& name)
   }
   LOG(warn) << "Input with name:" << name << " not in default input config";
   return 0xff;
+}
+
+std::ostream& o2::ctp::operator<<(std::ostream& in, const o2::ctp::CTPConfiguration& conf)
+{
+  conf.printStream(in);
+  return in;
 }

--- a/Detectors/CTP/simulation/include/CTPSimulation/Digitizer.h
+++ b/Detectors/CTP/simulation/include/CTPSimulation/Digitizer.h
@@ -34,7 +34,10 @@ class Digitizer
   void setCCDBServer(const std::string& server) { mCCDBServer = server; }
   std::vector<CTPDigit> process(const gsl::span<o2::ctp::CTPInputDigit> detinputs);
   void calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, std::bitset<CTP_NCLASSES>& classmask);
+  void setCTPConfiguration(o2::ctp::CTPConfiguration* config);
+  o2::ctp::CTPConfiguration* getDefaultCTPConfiguration();
   void init();
+
  private:
   // CTP configuration
   std::string mCCDBServer = o2::base::NameConf::getCCDBServer();
@@ -43,4 +46,4 @@ class Digitizer
 };
 } // namespace ctp
 } // namespace o2
-#endif //ALICEO2_CTP_DIGITIZER_H
+#endif // ALICEO2_CTP_DIGITIZER_H


### PR DESCRIPTION
- Use DPL CCDB backend to provide CTP
  Configuration in workflow setup
- Move default CCDB config to dedicated funtion,
  only call if not set from outside (lazy evaluation)
- Make check for trigger cluster case-insensitive
- Add operator<< for CTPConfiguration