### PR TITLE
IS_SIMULATED_DATA is obsolete

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -315,7 +315,7 @@ fi
 ( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && has_detector EMC && RAW_EMC_SUBSPEC=" --subspecification 1 "
 has_detector_reco MID && has_detector_matching MCHMID && MFTMCHConf="FwdMatching.useMIDMatch=true;" || MFTMCHConf="FwdMatching.useMIDMatch=false;"
 
-[[ $IS_SIMULATED_DATA == "1" ]] && EMCRAW2C_CONFIG+=" --no-checkactivelinks"
+[[ $RUNTYPE == "SYNTHETIC" ]] && EMCRAW2C_CONFIG+=" --no-checkactivelinks"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Temporary extra options

--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -51,7 +51,7 @@ fi
 export EXTINPUT=1
 export SYNCMODE=1
 export SHMTHROW=0
-export IS_SIMULATED_DATA=1
+export RUNTYPE=SYNTHETIC
 export DATADIST_NEW_DPL_CHAN=1
 
 [[ -z $GEN_TOPO_MYDIR ]] && GEN_TOPO_MYDIR="$(dirname $(realpath $0))"


### PR DESCRIPTION
@davidrohr I saw that `IS_SIMULATED_DATA` was actually only used in this single place in O2. So we can remove it here and then also everywhere in O2DPG