### PR TITLE
Clean- and speed-up of AODToHepMC utility

### DIFF
--- a/Generators/include/Generators/AODToHepMC.h
+++ b/Generators/include/Generators/AODToHepMC.h
@@ -24,7 +24,7 @@
 #include <HepMC3/GenCrossSection.h>
 #include <HepMC3/WriterAscii.h>
 #include <fstream>
-#define AODTOHEPMC_WITH_HEAVYION
+#include <list>
 
 namespace o2
 {
@@ -286,7 +286,7 @@ struct AODToHepMC {
   /** Alias of MC collisions table row */
   using Header = o2::aod::McCollision;
   /** Alias MC particles (tracks) table */
-  using Tracks = o2::aod::StoredMcParticles_001;
+  using Tracks = o2::aod::McParticles;
   /** Alias MC particles (tracks) table row */
   using Track = typename Tracks::iterator;
   /** Alias auxiliary MC table of cross-sections */
@@ -324,11 +324,15 @@ struct AODToHepMC {
    * object */
   using PdfInfoPtr = HepMC3::GenPdfInfoPtr;
   /** Type used to map tracks to HepMC particles */
-  using ParticleMap = std::map<long, ParticlePtr>;
+  using ParticleMap = std::unordered_map<long, ParticlePtr>;
   /** A container of pointers to particles */
   using ParticleVector = std::vector<ParticlePtr>;
+  /** A container of pointers to particles */
+  using ParticleList = std::list<ParticlePtr>;
   /** A container of pointers to vertexes */
   using VertexVector = std::vector<VertexPtr>;
+  /** A container of pointers to vertexes */
+  using VertexList = std::list<VertexPtr>;
   /** Alias of HepMC writer class */
   using WriterAscii = HepMC3::WriterAscii;
   /** The of pointer to HepMC writer class */
@@ -354,11 +358,11 @@ struct AODToHepMC {
   /** Maps tracks to particles */
   ParticleMap mParticles; //! Cache of particles
   /** List of vertexes made */
-  VertexVector mVertices; //! Cache of vertices
+  VertexList mVertices; //! Cache of vertices
   /** List of beam particles */
   ParticleVector mBeams; //! Cache of beam particles
   /** Particles without a mother */
-  ParticleVector mOrphans; //! Cache of particles w/o mothers
+  ParticleList mOrphans; //! Cache of particles w/o mothers
   /** @} */
   /**
    * @{
@@ -413,12 +417,8 @@ struct AODToHepMC {
    */
   virtual void process(Header const& collision,
                        XSections const& xsections,
-                       PdfInfos const& pdfs
-#ifdef AODTOHEPMC_WITH_HEAVYION
-                       ,
-                       HeavyIons const& heavyions
-#endif
-  );
+                       PdfInfos const& pdfs,
+                       HeavyIons const& heavyions);
   /**
    * Call after process an.  Thisf finalises the event and optionally
    * outputs to dump.
@@ -452,8 +452,7 @@ struct AODToHepMC {
    * Set the various fields in the header of the HepMC3::GenEvent
    * object
    *
-   * @param header Header object
-   */
+   * @param header Header object   */
   virtual void makeHeader(Header const& header);
   /**
    * Make cross-section information.  If no entry in the table,

--- a/run/o2aod_mc_to_hepmc.cxx
+++ b/run/o2aod_mc_to_hepmc.cxx
@@ -45,7 +45,7 @@
  * Processed do not process events piece-meal, but rather in whole.
  *
  */
-struct Task {
+struct AodToHepmc {
   /** Alias the converter type */
   using Converter = o2::eventgen::AODToHepMC;
 
@@ -129,14 +129,14 @@ struct Task {
    *
    * Instead of using the provided preprocessor macro, we instantise
    * the template directly here.  This is so that we can specify the
-   * command line argument (@c --hepmc-aux) rather than to rely on an
-   * auto-generated name (would be @ --processAux).
+   * command line argument (@c --hepmc-no-aux) rather than to rely on an
+   * auto-generated name (would be @c --processPlain).
    */
-  decltype(o2::framework::ProcessConfigurable{&Task::processPlain,
+  decltype(o2::framework::ProcessConfigurable{&AodToHepmc::processPlain,
                                               "hepmc-no-aux", false,
                                               "Do not process auxiliary "
                                               "information"})
-    doPlain = o2::framework::ProcessConfigurable{&Task::processPlain,
+    doPlain = o2::framework::ProcessConfigurable{&AodToHepmc::processPlain,
                                                  "hepmc-no-aux", false,
                                                  "Do not process auxiliary "
                                                  "information"};
@@ -149,7 +149,6 @@ struct Task {
 
 //--------------------------------------------------------------------
 using WorkflowSpec = o2::framework::WorkflowSpec;
-using TaskName = o2::framework::TaskName;
 using DataProcessorSpec = o2::framework::DataProcessorSpec;
 using ConfigContext = o2::framework::ConfigContext;
 
@@ -159,8 +158,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
   using o2::framework::adaptAnalysisTask;
 
   // Task: Two entry: header, tracks, and header, tracks, auxiliary
-  return WorkflowSpec{
-    adaptAnalysisTask<Task>(cfg, TaskName{"o2-aod-mc-to-hepmc"})};
+  return WorkflowSpec{adaptAnalysisTask<AodToHepmc>(cfg)};
 }
 //
 // EOF

--- a/run/o2aod_mc_to_hepmc.cxx
+++ b/run/o2aod_mc_to_hepmc.cxx
@@ -14,32 +14,6 @@
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
 #include <Generators/AODToHepMC.h>
-// #define HEPMC_PROCESS_AUX
-
-#ifndef HEPMC_PROCESS_AUX
-//--------------------------------------------------------------------
-using o2::framework::ConfigParamKind;
-using o2::framework::ConfigParamSpec;
-
-// -------------------------------------------------------------------
-void customize(std::vector<ConfigParamSpec>& workflowOptions)
-{
-  using o2::framework::VariantType;
-
-  workflowOptions.emplace_back(ConfigParamSpec{"hepmc-aux",               //
-                                               VariantType::Bool,         //
-                                               false,                     //
-                                               {"Also process auxiliary " //
-                                                "HepMC tables"},
-                                               ConfigParamKind::kProcessFlag});
-}
-#endif
-
-//--------------------------------------------------------------------
-// This _must_ be included after our "customize" function above, or
-// that function will not be taken into account.
-#include <Framework/runDataProcessing.h>
-
 //--------------------------------------------------------------------
 /** Task to convert AOD MC tables into HepMC event structure
  *
@@ -53,188 +27,25 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
  *
  *  The application @c o2-sim-mcevent-to-aod publishes these tables.
  *
- *  Ideally, processing auxiliary information should be optional, as
- *  in @c Task2 below.  However, that causes problems.  See @c Task2.
- */
-struct Task1 {
-  /** Alias the converter */
-  using Converter = o2::eventgen::AODToHepMC;
-
-  /** Our converter */
-  Converter mConverter;
-
-  /** @{
-   * @name Container types */
-  /** Alias converter header table type */
-  using Headers = Converter::Headers;
-  /** Alias converter header type */
-  using Header = Converter::Header;
-  /** Alias converter track table type */
-  using Tracks = Converter::Tracks;
-  /** Alias converter cross-section table type */
-  using XSections = Converter::XSections;
-  /** Alias converter cross-section type */
-  using XSection = Converter::XSection;
-  /** Alias converter parton distribution function table type */
-  using PdfInfos = Converter::PdfInfos;
-  /** Alias converter parton distribution function type */
-  using PdfInfo = Converter::PdfInfo;
-  /** Alias converter heavy-ions table type */
-  using HeavyIons = Converter::HeavyIons;
-  /** Alias converter heavy-ions type */
-  using HeavyIon = Converter::HeavyIon;
-  /** @} */
-
-  /** Initialize the job */
-  void init(o2::framework::InitContext& ic)
-  {
-    mConverter.init();
-  }
-  /** Default processing of an event
-   *
-   *  @param collision  Event header
-   *  @param tracks     Tracks of the event
-   */
-  void process(Header const& collision,
-               XSections const& xsections,
-               PdfInfos const& pdfs,
-#ifdef AODTOHEPMC_WITH_HEAVYION
-               HeavyIons const& heavyions,
-#endif
-               Tracks const& tracks)
-  {
-    LOG(debug) << "=== Processing everything ===";
-    mConverter.startEvent();
-    mConverter.process(collision,
-                       xsections,
-                       pdfs
-#ifdef AODTOHEPMC_WITH_HEAVYION
-                       ,
-                       heavyions
-#endif
-    );
-    mConverter.process(collision, tracks);
-    mConverter.endEvent();
-  }
-};
-
-//--------------------------------------------------------------------
-/**
- * Same as Task1 above, except only header and tracks are processed.
- *
- *  - @c o2::aod::McCollisions
- *  - @c o2::aod::McParticles
- *
- */
-struct Task2 {
-  /** Alias the converter type */
-  using Converter = o2::eventgen::AODToHepMC;
-
-  /** Our converter */
-  Converter mConverter;
-
-  /** @{
-   * @name Container types */
-  /** Alias converter header table type */
-  using Headers = Converter::Headers;
-  /** Alias converter header type */
-  using Header = Converter::Header;
-  /** Alias converter track table type */
-  using Tracks = Converter::Tracks;
-  /** Alias converter cross-section table type */
-  using XSections = Converter::XSections;
-  /** Alias converter cross-section type */
-  using XSection = Converter::XSection;
-  /** Alias converter parton distribution function table type */
-  using PdfInfos = Converter::PdfInfos;
-  /** Alias converter parton distribution function type */
-  using PdfInfo = Converter::PdfInfo;
-  /** Alias converter heavy-ions table type */
-  using HeavyIons = Converter::HeavyIons;
-  /** Alias converter heavy-ions type */
-  using HeavyIon = Converter::HeavyIon;
-  /** @} */
-
-  /** Initialize the job */
-  void init(o2::framework::InitContext& ic)
-  {
-    mConverter.init();
-  }
-  /** Default processing of an event
-   *
-   *  @param collision  Event header
-   *  @param tracks     Tracks of the event
-   */
-  void process(Header const& collision,
-               Tracks const& tracks)
-  {
-    LOG(debug) << "=== Processing only tracks ===";
-    mConverter.startEvent();
-    mConverter.process(collision, tracks);
-    mConverter.endEvent();
-  }
-};
-
-#ifdef HEPMC_PROCESS_AUX
-//--------------------------------------------------------------------
-/**
  *  Ideally, this application should work with the case where only
  *
  *  - @c o2::aod::McCollisions
  *  - @c o2::aod::McParticles
  *
- *  is available, through the use of @c
- *  o2::framework::ProcessConfigurable, but that seems to fail
- *  consistently.  The issue seems that the application @c
- *  o2-sim-mcevent-to-aod @c SIGSEGV since it stops publishing the
- *  tables when the main process of the client (this application) does
- *  not require those tables.
+ * This is selected by the option `--hepmc-no-aux`
  *
- *  I tried various combinations of options for @c
- *  o2-sim-mcevent-to-aod but nothing seems to work.
+ * The thing to remember here, is that each task process is expected
+ * to do a _complete_ job.  That is, a process _cannot_ assume that
+ * another process has been called before-hand or will be called
+ * later, for the same event in the same order.
  *
- *  The error is
+ * That is, each process will get _all_ events of a time-frame and
+ * then the next process will get _all_ events of the time-frame.
  *
- *  @verbatim
- *  Exception caught: Unable to find OutputSpec with label HepMCXSections. Available Routes:
- *  - McCollisions: AOD/MCCOLLISION/0
- *  - McParticles: AOD/MCPARTICLE/1
- *  - : TFF/TFFilename/0
- *  - : TFN/TFNumber/0
- *  @endverbatim
+ * Processed do not process events piece-meal, but rather in whole.
  *
- * Or
- *
- * @verbatim
- * InputRecord::get: no input with binding HepMCHeavyIons found. Available inputs: McCollisions, McParticles
- * @endverbatim
- *
- *  Interstingly, the application @c o2-sim-mcevent-to-aod works fine
- *  on its own, e.g., like
- *
- *  @verbatim
- *  ./o2-sim-kine-publisher \
- *    --aggregate-timeframe 1 \
- *    --kineFileName pythia8pp |
- *  ./o2-sim-mcevent-to-aod \
- *    --aod-writer-keep dangling
- *  @endverbatim
- *
- *  works fine.
- *
- * Actually, it is not likely that this will ever work.  The various
- * process are done out of sync.  That is, first all input events of
- * the timeframe are passed to the regular `process` method - i.e.,
- * tracks and collision headers are processed.  Then all input events
- * of the timeframe are passed to the optional `processAux` method -
- * i.e., auxiliary tables and collision headers.
- *
- * That means that we cannot correlate the tracks and aux tables into
- * one event, which is what we need to format a proper HepMC
- * event. The reason why it could work in the above example is because
- * we only process one timeframe at a time.
  */
-struct Task3 {
+struct Task {
   /** Alias the converter type */
   using Converter = o2::eventgen::AODToHepMC;
 
@@ -268,44 +79,50 @@ struct Task3 {
   {
     mConverter.init();
   }
-  /** Process tracks of an event
-   *
-   *  @param collision  Event header
-   *  @param tracks     Tracks of the event
-   */
-  void processTracks(Header const& collision,
-                     Tracks const& tracks)
-  {
-    LOG(debug) << "=== Processing event tracks ===";
-    mConverter.process(collision, tracks);
-  }
-  /** Optional processing of event to extract extra HepMC information
+  /** Processing of event to extract extra HepMC information
    *
    *  @param collision Event header
+   *  @param tracks    Tracks of the event
    *  @param xsections Cross-section information
+   *  @param pdf       Cross-section information
    *  @param heavyions Heavy ion (geometry) information
    */
-  void processAux(Header const& collision,
-                  XSections const& xsections,
-                  PdfInfos const& pdfs,
-                  HeavyIons const& heavyions)
+  void process(Header const& collision,
+               Tracks const& tracks,
+               XSections const& xsections,
+               PdfInfos const& pdfs,
+               HeavyIons const& heavyions)
   {
-    LOG(debug) << "=== Processing event auxiliaries ===";
+    // Do not run this if --hepmc-no-aux was passed
+    if (doPlain) {
+      return;
+    }
+    LOG(debug) << "=== Processing everything ===";
+    mConverter.startEvent();
     mConverter.process(collision,
                        xsections,
                        pdfs,
                        heavyions);
+    mConverter.process(collision, tracks);
+    mConverter.endEvent();
   }
-  /** Default processing of an event
+  /** Processing of an event for particles only
    *
    *  @param collision  Event header
    *  @param tracks     Tracks of the event
    */
-  void process(Header const& collision,
-               Tracks const& tracks)
+  void processPlain(Header const& collision,
+                    Tracks const& tracks)
   {
+    // Do not run this if --hepmc-no-aux was not passed
+    if (not doPlain) {
+      return;
+    }
+
     LOG(debug) << "=== Processing only tracks ===";
-    processTracks(collision, tracks);
+    mConverter.startEvent();
+    mConverter.process(collision, tracks);
+    mConverter.endEvent();
   }
   /**
    * Make a process option.
@@ -315,16 +132,20 @@ struct Task3 {
    * command line argument (@c --hepmc-aux) rather than to rely on an
    * auto-generated name (would be @ --processAux).
    */
-  decltype(o2::framework::ProcessConfigurable{&Task3::processAux,
-                                              "hepmc-aux", false,
-                                              "Process auxilirary "
+  decltype(o2::framework::ProcessConfigurable{&Task::processPlain,
+                                              "hepmc-no-aux", false,
+                                              "Do not process auxiliary "
                                               "information"})
-    doAux = o2::framework::ProcessConfigurable{&Task3::processAux,
-                                               "hepmc-aux", false,
-                                               "Process auxilirary "
-                                               "information"};
+    doPlain = o2::framework::ProcessConfigurable{&Task::processPlain,
+                                                 "hepmc-no-aux", false,
+                                                 "Do not process auxiliary "
+                                                 "information"};
 };
-#endif
+
+//--------------------------------------------------------------------
+// This _must_ be included after our "customize" function above, or
+// that function will not be taken into account.
+#include <Framework/runDataProcessing.h>
 
 //--------------------------------------------------------------------
 using WorkflowSpec = o2::framework::WorkflowSpec;
@@ -337,22 +158,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
 {
   using o2::framework::adaptAnalysisTask;
 
-  // Task1: One entry: header, tracks, auxiliary
-  // Task2: One entry: header, tracks
-  // Task3: Two entry: header, tracks, and auxiliary
-#ifndef HEPMC_PROCESS_AUX
-  if (cfg.options().get<bool>("hepmc-aux")) {
-    LOG(info) << "Creating full o2-aod-to-hepmc processor";
-    return WorkflowSpec{
-      adaptAnalysisTask<Task1>(cfg, TaskName{"o2-aod-to-hepmc"})};
-  }
-  LOG(info) << "Creating minimal o2-aod-to-hepmc processor";
+  // Task: Two entry: header, tracks, and header, tracks, auxiliary
   return WorkflowSpec{
-    adaptAnalysisTask<Task2>(cfg, TaskName{"o2-aod-to-hepmc"})};
-#else
-  return WorkflowSpec{
-    adaptAnalysisTask<Task3>(cfg, TaskName{"o2-aod-mc-to-hepmc"})};
-#endif
+    adaptAnalysisTask<Task>(cfg, TaskName{"o2-aod-mc-to-hepmc"})};
 }
 //
 // EOF


### PR DESCRIPTION
- Speed-up of internal containers
  - Switch from `std::map` to `std::unordered_map`
  - Switch from `std::vector` to `std::list`
- Speed up of processing mothers and daughters
  - Check if there are any daughters or mothers (with `has_daughters` and `has_mothers`) before iterating over them (`daughters_as` and `mothers_as`).  Constructing an empty slice is non-triviai.  Note that member functions `daughters_as` and `mothers_as` are rather expensive operations.
- Clean-up
  - Removed unused code
  - Removed redundant debug statements
  - in `o2-aod-to-hepmc` remove unused and not-working tasks.