### PR TITLE
ALICE 3: Add FWD and BWD RICH + Fixes to TOFs and cosmetics

### DIFF
--- a/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
@@ -125,7 +125,7 @@ void Detector::createGeometry()
   TGeoTube* ecalShape = new TGeoTube("ECLsh", mInnerRadius, mOuterRadius, mLength);
   TGeoVolume* ecalVol = new TGeoVolume("ECL", ecalShape, medPb);
   ecalVol->SetLineColor(kCyan + 1);
-  ecalVol->SetTransparency(50);
+  ecalVol->SetTransparency(0);
   vECal->AddNode(ecalVol, 1, nullptr);
 }
 

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Detector.cxx
@@ -65,10 +65,10 @@ void Detector::configLayers(bool itof, bool otof, bool ftof, bool btof)
     mOTOFLayer = OTOFLayer(std::string{GeometryTGeo::getOTOFLayerPattern()}, 85.f, 0.f, 680.f, 0.f, 0.02f, true); // oTOF
   }
   if (ftof) {
-    mFTOFLayer = FTOFLayer(std::string{GeometryTGeo::getFTOFLayerPattern()}, 15.f, 150.f, 0.f, 405.f, 0.02f, false); // fTOF
+    mFTOFLayer = FTOFLayer(std::string{GeometryTGeo::getFTOFLayerPattern()}, 15.f, 100.f, 0.f, 370.f, 0.02f, false); // fTOF
   }
   if (btof) {
-    mBTOFLayer = BTOFLayer(std::string{GeometryTGeo::getBTOFLayerPattern()}, 15.f, 150.f, 0.f, -405.f, 0.02f, false); // bTOF
+    mBTOFLayer = BTOFLayer(std::string{GeometryTGeo::getBTOFLayerPattern()}, 15.f, 100.f, 0.f, -370.f, 0.02f, false); // bTOF
   }
 }
 

--- a/Detectors/Upgrades/ALICE3/MID/simulation/src/MIDLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/MID/simulation/src/MIDLayer.cxx
@@ -137,11 +137,7 @@ MIDLayer::Stave::Module::Sensor::Sensor(std::string sensorName,
 void MIDLayer::createLayer(TGeoVolume* motherVolume)
 {
   LOGP(debug, "Creating MIDLayer: {}", mName);
-  TGeoTube* layer = new TGeoTube(mName.c_str(), mRadius, mRadius + 10, mLength);
-  auto* airMed = gGeoManager->GetMedium("MI3_AIR");
-  TGeoVolume* layerVolume = new TGeoVolume(mName.c_str(), layer, airMed);
-  layerVolume->SetVisibility(true);
-  layerVolume->SetTransparency(0);
+  TGeoVolumeAssembly* layerVolume = new TGeoVolumeAssembly(mName.c_str());
   motherVolume->AddNode(layerVolume, 0);
   for (auto& stave : mStaves) {
     stave.createStave(layerVolume);
@@ -151,11 +147,7 @@ void MIDLayer::createLayer(TGeoVolume* motherVolume)
 void MIDLayer::Stave::createStave(TGeoVolume* motherVolume)
 {
   LOGP(debug, "\tCreating MIDStave: {} layer: {}", mName, mLayer);
-  TGeoBBox* stave = new TGeoBBox(mName.c_str(), mWidth, mThickness, mLength);
-  auto* airMed = gGeoManager->GetMedium("MI3_AIR");
-  TGeoVolume* staveVolume = new TGeoVolume(mName.c_str(), stave, airMed);
-  staveVolume->SetVisibility(true);
-  staveVolume->SetTransparency(0);
+  TGeoVolumeAssembly* staveVolume = new TGeoVolumeAssembly(mName.c_str());
   // Create the modules
   for (auto& module : mModules) {
     module.createModule(staveVolume);
@@ -173,16 +165,8 @@ void MIDLayer::Stave::Module::createModule(TGeoVolume* motherVolume)
   // Module is an air box with floating bars inside for the moment
   auto sumWidth = ((mBarWidth * 2 + mBarSpacing) * mNBars) / 2;
   LOGP(debug, "\t\t\tCreating MIDModule: {} with ", mName);
-  TGeoBBox* module = nullptr;
-  if (!mLayer) {
-    module = new TGeoBBox(mName.c_str(), sumWidth, mBarThickness, mBarLength);
-  } else {
-    module = new TGeoBBox(mName.c_str(), mBarLength, mBarThickness, sumWidth);
-  }
-  auto* airMed = gGeoManager->GetMedium("MI3_AIR");
-  TGeoVolume* moduleVolume = new TGeoVolume(mName.c_str(), module, airMed);
-  moduleVolume->SetVisibility(true);
-  moduleVolume->SetTransparency(0);
+  TGeoVolumeAssembly* moduleVolume = new TGeoVolumeAssembly(mName.c_str() /*, module, airMed*/);
+
   // Create the bars
   for (auto& sensor : mSensors) {
     sensor.createSensor(moduleVolume);
@@ -213,9 +197,11 @@ void MIDLayer::Stave::Module::Sensor::createSensor(TGeoVolume* motherVolume)
   if (!mLayer) {
     sensorTrans = new TGeoTranslation(mModuleOffset + 2 * totWidth * mNumber + totWidth, 0, 0);
     sensorVolume->SetLineColor(kBlue);
+    sensorVolume->SetTransparency(50);
   } else {
     sensorTrans = new TGeoTranslation(0, 0, mModuleOffset + 2 * totWidth * mNumber + totWidth);
     sensorVolume->SetLineColor(kPink);
+    sensorVolume->SetTransparency(50);
   }
   motherVolume->AddNode(sensorVolume, 0, sensorTrans);
 }

--- a/Detectors/Upgrades/ALICE3/Passive/src/Absorber.cxx
+++ b/Detectors/Upgrades/ALICE3/Passive/src/Absorber.cxx
@@ -156,7 +156,7 @@ void Alice3Absorber::ConstructGeometry()
   TGeoVolume* abso = new TGeoVolume("Absorber", absorings, kMedIron);
 
   abso->SetVisibility(1);
-  abso->SetLineColor(kGray);
+  abso->SetLineColor(kBlack);
 
   //
   //    Adding volumes to mother volume

--- a/Detectors/Upgrades/ALICE3/Passive/src/Magnet.cxx
+++ b/Detectors/Upgrades/ALICE3/Passive/src/Magnet.cxx
@@ -122,12 +122,10 @@ void Alice3Magnet::ConstructGeometry()
   TGeoVolume* outerWrapVol = new TGeoVolume("outerWrap", outerLayer, kMedAl);
 
   innerWrapVol->SetLineColor(kRed);
-  innerVacuumVol->SetLineColor(kGray);
-  innerVacuumVol->SetVisibility(1);
-  coilsVol->SetLineColor(kOrange);
+  innerVacuumVol->SetLineColor(kRed);
+  coilsVol->SetLineColor(kRed);
   restMaterialVol->SetLineColor(kRed);
-  outerVacuumVol->SetLineColor(kGray);
-  outerVacuumVol->SetVisibility(1);
+  outerVacuumVol->SetLineColor(kRed);
   outerWrapVol->SetLineColor(kRed);
 
   new TGeoVolumeAssembly("magnet");

--- a/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/GeometryTGeo.h
@@ -30,6 +30,8 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   static const char* getRICHRingPattern() { return sRingName.c_str(); }
   static const char* getRICHChipPattern() { return sChipName.c_str(); }
   static const char* getRICHSensorPattern() { return sSensorName.c_str(); }
+  static const char* getRICHSensorFWDPattern() { return sSensorFWDName.c_str(); }
+  static const char* getRICHSensorBWDPattern() { return sSensorBWDName.c_str(); }
 
   static const char* composeSymNameRICH(int d)
   {
@@ -44,6 +46,8 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   static std::string sRingName;
   static std::string sChipName;
   static std::string sSensorName;
+  static std::string sSensorFWDName;
+  static std::string sSensorBWDName;
 
  private:
   static std::unique_ptr<o2::rich::GeometryTGeo> sInstance;

--- a/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/GeometryTGeo.h
@@ -40,6 +40,8 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   static const char* composeSymNameRing(int d, int ring);
   static const char* composeSymNameChip(int d, int ring);
   static const char* composeSymNameSensor(int d, int ring);
+  static const char* composeSymNameSensorFWD(int d);
+  static const char* composeSymNameSensorBWD(int d);
 
  protected:
   static std::string sVolumeName;

--- a/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/RICHBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/RICHBaseParam.h
@@ -26,8 +26,9 @@ struct RICHBaseParam : public o2::conf::ConfigurableParamHelper<RICHBaseParam> {
   float radiatorThickness = 2.0; // cm
   float detectorThickness = 0.2; // cm
   float zRichLength = 700.0;     // cm
-  int nRings = 21;
+  int nRings = 23;
   int nTiles = 36;
+  bool oddGeom = true;
   std::string configFile = "";
 
   O2ParamDef(RICHBaseParam, "RICHBase");

--- a/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/RICHBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/RICHBaseParam.h
@@ -29,7 +29,26 @@ struct RICHBaseParam : public o2::conf::ConfigurableParamHelper<RICHBaseParam> {
   int nRings = 23;
   int nTiles = 36;
   bool oddGeom = true;
-  std::string configFile = "";
+
+  // FWD and BWD RICH
+  bool enableFWDRich = true;
+  bool enableBWDRich = true;
+
+  // Aerogel:
+  float zAerogelMin = 375.f;
+  float zAerogelMax = 377.f;
+  float rAerogelMin = 13.7413f;
+  float rAerogelMax = 103.947f;
+  // Argon:
+  float zArgonMin = 377.f;
+  float zArgonMax = 407.f;
+  float rArgonMin = 13.7413f;
+  float rArgonMax = 103.947f;
+  // Detector:
+  float zDetectorMin = 407.f;
+  float zDetectorMax = 407.2f;
+  float rDetectorMin = 13.7413f;
+  float rDetectorMax = 103.947f;
 
   O2ParamDef(RICHBaseParam, "RICHBase");
 };

--- a/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/RICHBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/RICH/base/include/RICHBase/RICHBaseParam.h
@@ -26,29 +26,28 @@ struct RICHBaseParam : public o2::conf::ConfigurableParamHelper<RICHBaseParam> {
   float radiatorThickness = 2.0; // cm
   float detectorThickness = 0.2; // cm
   float zRichLength = 700.0;     // cm
-  int nRings = 23;
+  int nRings = 25;
   int nTiles = 36;
-  bool oddGeom = true;
+  bool oddGeom = false;
 
   // FWD and BWD RICH
   bool enableFWDRich = true;
   bool enableBWDRich = true;
 
+  float rFWDMin = 13.7413f;
+  float rFWDMax = 103.947f;
+
   // Aerogel:
   float zAerogelMin = 375.f;
   float zAerogelMax = 377.f;
-  float rAerogelMin = 13.7413f;
-  float rAerogelMax = 103.947f;
+
   // Argon:
   float zArgonMin = 377.f;
   float zArgonMax = 407.f;
-  float rArgonMin = 13.7413f;
-  float rArgonMax = 103.947f;
+
   // Detector:
-  float zDetectorMin = 407.f;
-  float zDetectorMax = 407.2f;
-  float rDetectorMin = 13.7413f;
-  float rDetectorMax = 103.947f;
+  float zSiliconMin = 407.f;
+  float zSiliconMax = 407.2f;
 
   O2ParamDef(RICHBaseParam, "RICHBase");
 };

--- a/Detectors/Upgrades/ALICE3/RICH/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/base/src/GeometryTGeo.cxx
@@ -78,12 +78,12 @@ const char* GeometryTGeo::composeSymNameSensor(int d, int rg)
 
 const char* GeometryTGeo::composeSymNameSensorFWD(int d)
 {
-  return Form("%s/%s%d", composeSymNameRICH(d), getRICHSensorFWDPattern());
+  return Form("%s/%s", composeSymNameRICH(d), getRICHSensorFWDPattern());
 }
 
 const char* GeometryTGeo::composeSymNameSensorBWD(int d)
 {
-  return Form("%s/%s%d", composeSymNameRICH(d), getRICHSensorBWDPattern());
+  return Form("%s/%s", composeSymNameRICH(d), getRICHSensorBWDPattern());
 }
 
 } // namespace rich

--- a/Detectors/Upgrades/ALICE3/RICH/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/base/src/GeometryTGeo.cxx
@@ -22,6 +22,8 @@ std::string GeometryTGeo::sVolumeName = "RICHV";
 std::string GeometryTGeo::sRingName = "RICHRing";
 std::string GeometryTGeo::sChipName = "RICHChip";
 std::string GeometryTGeo::sSensorName = "RICHSensor";
+std::string GeometryTGeo::sSensorFWDName = "FWDRICHSensor"; // only one big sensor for now
+std::string GeometryTGeo::sSensorBWDName = "BWDRICHSensor"; // only one big sensor for now
 
 GeometryTGeo::GeometryTGeo(bool build, int loadTrans) : DetMatrixCache()
 {
@@ -72,6 +74,16 @@ const char* GeometryTGeo::composeSymNameChip(int d, int rg)
 const char* GeometryTGeo::composeSymNameSensor(int d, int rg)
 {
   return Form("%s/%s%d", composeSymNameChip(d, rg), getRICHSensorPattern(), rg);
+}
+
+const char* GeometryTGeo::composeSymNameSensorFWD(int d)
+{
+  return Form("%s/%s%d", composeSymNameRICH(d), getRICHSensorFWDPattern());
+}
+
+const char* GeometryTGeo::composeSymNameSensorBWD(int d)
+{
+  return Form("%s/%s%d", composeSymNameRICH(d), getRICHSensorBWDPattern());
 }
 
 } // namespace rich

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/Detector.h
@@ -62,10 +62,6 @@ class Detector : public o2::base::DetImpl<Detector>
     return nullptr;
   }
 
-  void configDefault();
-  void configFromFile(std::string fileName = "alice3_RICH_layout.txt");
-  void configToFile(std::string fileName = "alice3_RICH_layout.txt");
-
   void createMaterials();
   void createGeometry();
   void prepareLayout();
@@ -109,6 +105,11 @@ class Detector : public o2::base::DetImpl<Detector>
   std::vector<double> mR0PhotoDet;
   template <typename Det>
   friend class o2::base::DetImpl;
+
+  // FWD and BWD RICH
+  FWDRich mFWDRich;
+  BWDRich mBWDRich;
+
   ClassDefOverride(Detector, 1);
 };
 } // namespace rich

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/Detector.h
@@ -68,8 +68,7 @@ class Detector : public o2::base::DetImpl<Detector>
 
   void createMaterials();
   void createGeometry();
-  void prepareEvenLayout();
-  void prepareOddLayout();
+  void prepareLayout();
   void createRings(TGeoVolume*);
 
  private:

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/RICHRing.h
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/RICHRing.h
@@ -72,52 +72,32 @@ class FWDRich
  public:
   FWDRich() = default;
   FWDRich(std::string name,
+          float rMin,
+          float rMax,
           float zAerogelMin,
-          float aerogelDZ,
-          float aerogelRmin,
-          float aerogelRmax,
+          float dZAerogel,
           float zArgonMin,
-          float argonDZ,
-          float argonRmin,
-          float argonRmax,
+          float dZArgon,
           float zSiliconMin,
-          float siliconDZ,
-          float siliconRmin,
-          float siliconRmax)
-    : mName{name},
-      mZAerogelMin{zAerogelMin},
-      mAerogelDZ{aerogelDZ},
-      mAerogelRmin{aerogelRmin},
-      mAerogelRmax{aerogelRmax},
-      mZArgonMin{zArgonMin},
-      mArgonDZ{argonDZ},
-      mArgonRmin{argonRmin},
-      mArgonRmax{argonRmax},
-      mZSiliconMin{zSiliconMin},
-      mSiliconDZ{siliconDZ},
-      mSiliconRmin{siliconRmin},
-      mSiliconRmax{siliconRmax}
-  {
-  }
+          float dZSilicon);
   void createFWDRich(TGeoVolume* motherVolume);
 
  protected:
   std::string mName;
+  float mRmin;
+  float mRmax;
+
   // Aerogel:
   float mZAerogelMin;
-  float mAerogelDZ;
-  float mAerogelRmin;
-  float mAerogelRmax;
+  float mDZAerogel;
+
   // Argon:
   float mZArgonMin;
-  float mArgonDZ;
-  float mArgonRmin;
-  float mArgonRmax;
+  float mDZArgon;
+
   // Silicon:
   float mZSiliconMin;
-  float mSiliconDZ;
-  float mSiliconRmin;
-  float mSiliconRmax;
+  float mDZSilicon;
 };
 
 class BWDRich
@@ -125,52 +105,32 @@ class BWDRich
  public:
   BWDRich() = default;
   BWDRich(std::string name,
+          float rMin,
+          float rMax,
           float zAerogelMin,
-          float aerogelDZ,
-          float aerogelRmin,
-          float aerogelRmax,
+          float dZAerogel,
           float zArgonMin,
-          float argonDZ,
-          float argonRmin,
-          float argonRmax,
+          float dZArgon,
           float zSiliconMin,
-          float siliconDZ,
-          float siliconRmin,
-          float siliconRmax)
-    : mName{name},
-      mZAerogelMin{zAerogelMin},
-      mAerogelDZ{aerogelDZ},
-      mAerogelRmin{aerogelRmin},
-      mAerogelRmax{aerogelRmax},
-      mZArgonMin{zArgonMin},
-      mArgonDZ{argonDZ},
-      mArgonRmin{argonRmin},
-      mArgonRmax{argonRmax},
-      mZSiliconMin{zSiliconMin},
-      mSiliconDZ{siliconDZ},
-      mSiliconRmin{siliconRmin},
-      mSiliconRmax{siliconRmax}
-  {
-  }
+          float dZSilicon);
   void createBWDRich(TGeoVolume* motherVolume);
 
  protected:
   std::string mName;
+  float mRmin;
+  float mRmax;
+
   // Aerogel:
   float mZAerogelMin;
-  float mAerogelDZ;
-  float mAerogelRmin;
-  float mAerogelRmax;
+  float mDZAerogel;
+
   // Argon:
   float mZArgonMin;
-  float mArgonDZ;
-  float mArgonRmin;
-  float mArgonRmax;
+  float mDZArgon;
+
   // Silicon:
   float mZSiliconMin;
-  float mSiliconDZ;
-  float mSiliconRmin;
-  float mSiliconRmax;
+  float mDZSilicon;
 };
 
 } // namespace rich

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/RICHRing.h
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/include/RICHSimulation/RICHRing.h
@@ -66,6 +66,113 @@ class Ring
   ClassDef(Ring, 0);
 };
 
+// Definitions for fwd and bwd RICH are put here
+class FWDRich
+{
+ public:
+  FWDRich() = default;
+  FWDRich(std::string name,
+          float zAerogelMin,
+          float aerogelDZ,
+          float aerogelRmin,
+          float aerogelRmax,
+          float zArgonMin,
+          float argonDZ,
+          float argonRmin,
+          float argonRmax,
+          float zSiliconMin,
+          float siliconDZ,
+          float siliconRmin,
+          float siliconRmax)
+    : mName{name},
+      mZAerogelMin{zAerogelMin},
+      mAerogelDZ{aerogelDZ},
+      mAerogelRmin{aerogelRmin},
+      mAerogelRmax{aerogelRmax},
+      mZArgonMin{zArgonMin},
+      mArgonDZ{argonDZ},
+      mArgonRmin{argonRmin},
+      mArgonRmax{argonRmax},
+      mZSiliconMin{zSiliconMin},
+      mSiliconDZ{siliconDZ},
+      mSiliconRmin{siliconRmin},
+      mSiliconRmax{siliconRmax}
+  {
+  }
+  void createFWDRich(TGeoVolume* motherVolume);
+
+ protected:
+  std::string mName;
+  // Aerogel:
+  float mZAerogelMin;
+  float mAerogelDZ;
+  float mAerogelRmin;
+  float mAerogelRmax;
+  // Argon:
+  float mZArgonMin;
+  float mArgonDZ;
+  float mArgonRmin;
+  float mArgonRmax;
+  // Silicon:
+  float mZSiliconMin;
+  float mSiliconDZ;
+  float mSiliconRmin;
+  float mSiliconRmax;
+};
+
+class BWDRich
+{
+ public:
+  BWDRich() = default;
+  BWDRich(std::string name,
+          float zAerogelMin,
+          float aerogelDZ,
+          float aerogelRmin,
+          float aerogelRmax,
+          float zArgonMin,
+          float argonDZ,
+          float argonRmin,
+          float argonRmax,
+          float zSiliconMin,
+          float siliconDZ,
+          float siliconRmin,
+          float siliconRmax)
+    : mName{name},
+      mZAerogelMin{zAerogelMin},
+      mAerogelDZ{aerogelDZ},
+      mAerogelRmin{aerogelRmin},
+      mAerogelRmax{aerogelRmax},
+      mZArgonMin{zArgonMin},
+      mArgonDZ{argonDZ},
+      mArgonRmin{argonRmin},
+      mArgonRmax{argonRmax},
+      mZSiliconMin{zSiliconMin},
+      mSiliconDZ{siliconDZ},
+      mSiliconRmin{siliconRmin},
+      mSiliconRmax{siliconRmax}
+  {
+  }
+  void createBWDRich(TGeoVolume* motherVolume);
+
+ protected:
+  std::string mName;
+  // Aerogel:
+  float mZAerogelMin;
+  float mAerogelDZ;
+  float mAerogelRmin;
+  float mAerogelRmax;
+  // Argon:
+  float mZArgonMin;
+  float mArgonDZ;
+  float mArgonRmin;
+  float mArgonRmax;
+  // Silicon:
+  float mZSiliconMin;
+  float mSiliconDZ;
+  float mSiliconRmin;
+  float mSiliconRmax;
+};
+
 } // namespace rich
 } // namespace o2
 #endif // ALICEO2_RICH_RING_H

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
@@ -402,11 +402,27 @@ void Detector::prepareLayout()
   // FWD and BWD RICH
   if (richPars.enableFWDRich) {
     LOGP(info, "Setting up FWD RICH layout");
-    mFWDRich = FWDRich();
+    mFWDRich = FWDRich(GeometryTGeo::getRICHSensorFWDPattern(),
+                       richPars.rFWDMin,
+                       richPars.rFWDMax,
+                       richPars.zAerogelMin,
+                       richPars.zAerogelMax - richPars.zArgonMin,
+                       richPars.zArgonMin,
+                       richPars.zArgonMax - richPars.zArgonMin,
+                       richPars.zSiliconMin,
+                       richPars.zSiliconMax - richPars.zSiliconMin);
   }
   if (richPars.enableBWDRich) {
     LOGP(info, "Setting up BWD RICH layout");
-    mBWDRich = BWDRich();
+    mBWDRich = BWDRich(GeometryTGeo::getRICHSensorBWDPattern(),
+                       richPars.rFWDMin,
+                       richPars.rFWDMax,
+                       richPars.zAerogelMin,
+                       richPars.zAerogelMax - richPars.zAerogelMin,
+                       richPars.zArgonMin,
+                       richPars.zArgonMax - richPars.zArgonMin,
+                       richPars.zSiliconMin,
+                       richPars.zSiliconMax - richPars.zSiliconMin);
   }
 }
 } // namespace rich

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
@@ -169,6 +169,13 @@ void Detector::createGeometry()
                          (float)mThetaBi[iRing],
                          GeometryTGeo::getRICHVolPattern()};
   }
+
+  if (richPars.enableFWDRich) {
+    mFWDRich.createFWDRich(vRICH);
+  }
+  if (richPars.enableBWDRich) {
+    mBWDRich.createBWDRich(vRICH);
+  }
 }
 
 void Detector::InitializeO2Detector()
@@ -311,8 +318,8 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 
 void Detector::prepareLayout()
 { // Mere translation of Nicola's code
-  LOGP(info, "Setting up ODD layout for bRICH");
   auto& richPars = RICHBaseParam::Instance();
+  LOGP(info, "Setting up {} layout for bRICH", richPars.oddGeom ? "odd" : "even");
 
   bool isOdd = richPars.oddGeom;
   mThetaBi.resize(richPars.nRings);
@@ -390,6 +397,16 @@ void Detector::prepareLayout()
   for (size_t iRing{0}; iRing < richPars.nRings; ++iRing) {
     mR0Radiator[iRing] = mR0Tilt[iRing] - (mTRplusG[iRing] - richPars.radiatorThickness / 2) * TMath::Cos(mThetaBi[iRing]);
     mR0PhotoDet[iRing] = mR0Tilt[iRing] - (richPars.detectorThickness / 2) * TMath::Cos(mThetaBi[iRing]);
+  }
+
+  // FWD and BWD RICH
+  if (richPars.enableFWDRich) {
+    LOGP(info, "Setting up FWD RICH layout");
+    mFWDRich = FWDRich();
+  }
+  if (richPars.enableBWDRich) {
+    LOGP(info, "Setting up BWD RICH layout");
+    mBWDRich = BWDRich();
   }
 }
 } // namespace rich

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
@@ -154,5 +154,125 @@ Ring::Ring(int rPosId,
   }
 }
 
+FWDRich::FWDRich(std::string name,
+                 float rMin,
+                 float rMax,
+                 float zAerogelMin,
+                 float dZAerogel,
+                 float zArgonMin,
+                 float dZArgon,
+                 float zSiliconMin,
+                 float dZSilicon) : mName{name},
+                                    mRmin{rMin},
+                                    mRmax{rMax},
+                                    mZAerogelMin{zAerogelMin},
+                                    mDZAerogel{dZAerogel},
+                                    mZArgonMin{zArgonMin},
+                                    mDZArgon{dZArgon},
+                                    mZSiliconMin{zSiliconMin},
+                                    mDZSilicon{dZSilicon}
+{
+}
+
+BWDRich::BWDRich(std::string name,
+                 float rMin,
+                 float rMax,
+                 float zAerogelMin,
+                 float dZAerogel,
+                 float zArgonMin,
+                 float dZArgon,
+                 float zSiliconMin,
+                 float dZSilicon) : mName{name},
+                                    mRmin{rMin},
+                                    mRmax{rMax},
+                                    mZAerogelMin{zAerogelMin},
+                                    mDZAerogel{dZAerogel},
+                                    mZArgonMin{zArgonMin},
+                                    mDZArgon{dZArgon},
+                                    mZSiliconMin{zSiliconMin},
+                                    mDZSilicon{dZSilicon}
+{
+}
+
+void FWDRich::createFWDRich(TGeoVolume* motherVolume)
+{
+  TGeoMedium* medAerogel = gGeoManager->GetMedium("RCH_AEROGEL$");
+  if (!medAerogel) {
+    LOGP(fatal, "RICH: Aerogel medium not found");
+  }
+  TGeoMedium* medSi = gGeoManager->GetMedium("RCH_SILICON$");
+  if (!medSi) {
+    LOGP(fatal, "RICH: Silicon medium not found");
+  }
+  TGeoMedium* medAr = gGeoManager->GetMedium("RCH_ARGON$");
+  if (!medAr) {
+    LOGP(fatal, "RICH: Argon medium not found");
+  }
+
+  // Create the aerogel volume
+  TGeoTube* aerogel = new TGeoTube(mRmin, mRmax, mDZAerogel / 2);
+  TGeoVolume* aerogelVol = new TGeoVolume(mName.c_str(), aerogel, medAerogel);
+  aerogelVol->SetLineColor(kBlue - 9);
+
+  TGeoTranslation* transAerogel = new TGeoTranslation(0, 0, mZAerogelMin + mDZAerogel / 2);
+  motherVolume->AddNode(aerogelVol, 1, transAerogel);
+
+  // Create the argon volume
+  TGeoTube* argon = new TGeoTube(mRmin, mRmax, mDZArgon / 2);
+  TGeoVolume* argonVol = new TGeoVolume(mName.c_str(), argon, medAr);
+  argonVol->SetLineColor(kGray);
+
+  TGeoTranslation* transArgon = new TGeoTranslation(0, 0, mZArgonMin + mDZArgon / 2);
+  motherVolume->AddNode(argonVol, 1, transArgon);
+
+  // Create the silicon volume
+  TGeoTube* silicon = new TGeoTube(mRmin, mRmax, mDZSilicon / 2);
+  TGeoVolume* siliconVol = new TGeoVolume(mName.c_str(), silicon, medSi);
+  siliconVol->SetLineColor(kOrange);
+
+  TGeoTranslation* transSilicon = new TGeoTranslation(0, 0, mZSiliconMin + mDZSilicon / 2);
+  motherVolume->AddNode(siliconVol, 1, transSilicon);
+}
+
+void BWDRich::createBWDRich(TGeoVolume* motherVolume)
+{
+  TGeoMedium* medAerogel = gGeoManager->GetMedium("RCH_AEROGEL$");
+  if (!medAerogel) {
+    LOGP(fatal, "RICH: Aerogel medium not found");
+  }
+  TGeoMedium* medSi = gGeoManager->GetMedium("RCH_SILICON$");
+  if (!medSi) {
+    LOGP(fatal, "RICH: Silicon medium not found");
+  }
+  TGeoMedium* medAr = gGeoManager->GetMedium("RCH_ARGON$");
+  if (!medAr) {
+    LOGP(fatal, "RICH: Argon medium not found");
+  }
+
+  // Create the aerogel volume
+  TGeoTube* aerogel = new TGeoTube(mRmin, mRmax, mDZAerogel / 2);
+  TGeoVolume* aerogelVol = new TGeoVolume(mName.c_str(), aerogel, medAerogel);
+  aerogelVol->SetLineColor(kBlue - 9);
+
+  TGeoTranslation* transAerogel = new TGeoTranslation(0, 0, -mZAerogelMin - mDZAerogel / 2);
+  motherVolume->AddNode(aerogelVol, 1, transAerogel);
+
+  // Create the argon volume
+  TGeoTube* argon = new TGeoTube(mRmin, mRmax, mDZArgon / 2);
+  TGeoVolume* argonVol = new TGeoVolume(mName.c_str(), argon, medAr);
+  argonVol->SetLineColor(kGray);
+
+  TGeoTranslation* transArgon = new TGeoTranslation(0, 0, -mZArgonMin - mDZArgon / 2);
+  motherVolume->AddNode(argonVol, 1, transArgon);
+
+  // Create the silicon volume
+  TGeoTube* silicon = new TGeoTube(mRmin, mRmax, mDZSilicon / 2);
+  TGeoVolume* siliconVol = new TGeoVolume(mName.c_str(), silicon, medSi);
+  siliconVol->SetLineColor(kOrange);
+
+  TGeoTranslation* transSilicon = new TGeoTranslation(0, 0, -mZSiliconMin - mDZSilicon / 2);
+  motherVolume->AddNode(siliconVol, 1, transSilicon);
+}
+
 } // namespace rich
 } // namespace o2


### PR DESCRIPTION
This PR finalises the first implementation of all the detectors in ALICE 3 geometry according to the SD specifications as of today.
Notable last changes includes

1. fwd and bwd RICH
2. Even layout for barrel RICH
3. Fixup to fTOF and bTOF z position

<img width="2531" alt="ALICE3_20022024" src="https://github.com/AliceO2Group/AliceO2/assets/4990252/ca507a0b-c492-4e36-b1c1-d7b3c61c2815">