### PR TITLE
Set bits in the AO2D track mc mask according to documentation

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1158,11 +1158,14 @@ void AODProducerWorkflowDPL::fillMCTrackLabelsTable(MCTrackLabelCursorType& mcTr
               }
             }
           }
-          if (mcTruth.isFake() || (isSetTOF && isTOFFake)) {
-            labelHolder.labelMask |= (0x1 << 15);
+          if (isSetTOF && isTOFFake) {
+            labelHolder.labelMask |= (0x1 << 11);
           }
           if (mcTruth.isNoise()) {
             labelHolder.labelMask |= (0x1 << 14);
+          }
+          if (mcTruth.isFake()) {
+            labelHolder.labelMask |= (0x1 << 15);
           }
           mcTrackLabelCursor(labelHolder.labelID,
                              labelHolder.labelMask);


### PR DESCRIPTION
- **Set bits in the track mc mask according to documentation**
According to the [documentation](https://github.com/AliceO2Group/AliceO2/blob/25fed0222034939656422b6c0d727dd9cad1983b/Framework/Core/include/Framework/AnalysisDataModel.h#L1661), bit 11 of the AO2D mc mask for the tracks should be reserved for TOF fake matches, and bit 15 should be used for the fake. This was brought up by @wang-yuanzhe and @fmazzasc while checking for TOF fake matches. @noferini @shahor02, does this make sense to you? @ddobrigk might also be interested as it changes the meaning of a bit in the AO2D.