### PR TITLE
Hotfix for PID Hypothesis - switch to disable Canvas

### DIFF
--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -97,7 +97,7 @@ class PID
   float mCutMaxpTPC = 20.f;      // pTPC max value
   float mCutMinpTPCMIPs = 0.45f; // pTPC min value for MIPs
   float mCutMaxpTPCMIPs = 0.55f; // pTPC max value for MIPs
-  bool CreateCanvas=true;             // Decide whether to create the TCanvas Object as it cannot be merged
+  bool CreateCanvas = true;      // Decide whether to create the TCanvas Object as it cannot be merged
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHist;
   // Map for Canvases to be published
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -54,7 +54,7 @@ class PID
 
   /// bool extracts intormation from track and fills it to histograms
   /// @return true if information can be extracted and filled to histograms
-  bool processTrack(const o2::tpc::TrackTPC& track, size_t NTracks);
+  bool processTrack(const o2::tpc::TrackTPC& track, size_t nTracks);
 
   /// Initialize all histograms
   void initializeHistograms();
@@ -92,17 +92,7 @@ class PID
   float mCutMaxpTPC = 20.f;      // pTPC max value
   float mCutMinpTPCMIPs = 0.45f; // pTPC min value for MIPs
   float mCutMaxpTPCMIPs = 0.55f; // pTPC max value for MIPs
-  // ===| The following parameters are used to set up the getMostProbablePID() function. It needs some hardcoded cuts in the overlap region.
-  // ===| They are taken from O2/GPU/GPUTracking/Definitions/GPUSettingsList.h
-  float mCutKrangeMin = 0.47f; // minMomentum for Kaons in dEdx overlap region
-  float mCutKrangeMax = 0.57f; // maxMomentum for Kaons in dEdx overlap region
-  float mCutPrangeMin = 0.93f; // minMomentum for Protons in dEdx overlap region
-  float mCutPrangeMax = 1.03f; // maxMomentum for Protons in dEdx overlap region
-  float mCutDrangeMin = 1.88f; // minMomentum for Deuterons in dEdx overlap region
-  float mCutDrangeMax = 1.98f; // maxMomentum for Deuterons in dEdx overlap region
-  float mCutTrangeMin = 2.84f; // minMomentum for Tritons in dEdx overlap region
-  float mCutTrangeMax = 2.94f; // maxMomentum for Tritons in dEdx overlap region
-  float mPIDSigma = 0.06f;     // relative sigma for PID in combination with UseNSigma (hardcoded to 1)
+
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHist;
   // Map for Canvases to be published
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -107,7 +107,7 @@ class PID
   // Map for Canvases to be published
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;
   // Map for Histograms which will be put onto the canvases, and not published separately
-  std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHistCanvas; 
+  std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHistCanvas;
   ClassDefNV(PID, 1)
 };
 } // namespace qc

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -70,7 +70,8 @@ class PID
 
   // To set the elementary track cuts
   void setPIDCuts(int minnCls = 60, float absTgl = 1., float mindEdxTot = 10.0,
-                  float maxdEdxTot = 70., float minpTPC = 0.05, float maxpTPC = 20., float minpTPCMIPs = 0.45, float maxpTPCMIPs = 0.55)
+                  float maxdEdxTot = 70., float minpTPC = 0.05, float maxpTPC = 20., float minpTPCMIPs = 0.45,
+                  float maxpTPCMIPs = 0.55, int CreateCanvasI = 1)
   {
     mCutMinnCls = minnCls;
     mCutAbsTgl = absTgl;
@@ -80,6 +81,7 @@ class PID
     mCutMaxpTPC = maxpTPC;
     mCutMinpTPCMIPs = minpTPCMIPs;
     mCutMaxpTPCMIPs = maxpTPCMIPs;
+    CreateCanvas = CreateCanvasI;
   }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>>& getMapOfHisto() { return mMapHist; }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>>& getMapOfCanvas() { return mMapCanvas; }
@@ -95,7 +97,7 @@ class PID
   float mCutMaxpTPC = 20.f;      // pTPC max value
   float mCutMinpTPCMIPs = 0.45f; // pTPC min value for MIPs
   float mCutMaxpTPCMIPs = 0.55f; // pTPC max value for MIPs
-
+  bool CreateCanvas=true;             // Decide whether to create the TCanvas Object as it cannot be merged
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHist;
   // Map for Canvases to be published
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -56,6 +56,9 @@ class PID
   /// @return true if information can be extracted and filled to histograms
   bool processTrack(const o2::tpc::TrackTPC& track, size_t nTracks);
 
+  // dummy version to make it compatible with old QC version
+  bool processTrack(const o2::tpc::TrackTPC& track);
+
   /// Initialize all histograms
   void initializeHistograms();
 

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -24,6 +24,7 @@
 
 // root includes
 #include "TH1.h"
+#include "TCanvas.h"
 
 // o2 includes
 #include "DataFormatsTPC/Defs.h"
@@ -53,7 +54,7 @@ class PID
 
   /// bool extracts intormation from track and fills it to histograms
   /// @return true if information can be extracted and filled to histograms
-  bool processTrack(const o2::tpc::TrackTPC& track);
+  bool processTrack(const o2::tpc::TrackTPC& track, size_t NTracks);
 
   /// Initialize all histograms
   void initializeHistograms();
@@ -78,7 +79,9 @@ class PID
     mCutMaxpTPCMIPs = maxpTPCMIPs;
   }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>>& getMapOfHisto() { return mMapHist; }
+  std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>>& getMapOfCanvas() { return mMapCanvas; }
   const std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>>& getMapOfHisto() const { return mMapHist; }
+  const std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>>& getMapOfCanvas() const { return mMapCanvas; }
 
  private:
   int mCutMinnCls = 60;          // minimum N clusters
@@ -89,7 +92,22 @@ class PID
   float mCutMaxpTPC = 20.f;      // pTPC max value
   float mCutMinpTPCMIPs = 0.45f; // pTPC min value for MIPs
   float mCutMaxpTPCMIPs = 0.55f; // pTPC max value for MIPs
+  // ===| The following parameters are used to set up the getMostProbablePID() function. It needs some hardcoded cuts in the overlap region.
+  // ===| They are taken from O2/GPU/GPUTracking/Definitions/GPUSettingsList.h
+  float mCutKrangeMin = 0.47f; // minMomentum for Kaons in dEdx overlap region
+  float mCutKrangeMax = 0.57f; // maxMomentum for Kaons in dEdx overlap region
+  float mCutPrangeMin = 0.93f; // minMomentum for Protons in dEdx overlap region
+  float mCutPrangeMax = 1.03f; // maxMomentum for Protons in dEdx overlap region
+  float mCutDrangeMin = 1.88f; // minMomentum for Deuterons in dEdx overlap region
+  float mCutDrangeMax = 1.98f; // maxMomentum for Deuterons in dEdx overlap region
+  float mCutTrangeMin = 2.84f; // minMomentum for Tritons in dEdx overlap region
+  float mCutTrangeMax = 2.94f; // maxMomentum for Tritons in dEdx overlap region
+  float mPIDSigma = 0.06f;     // relative sigma for PID in combination with UseNSigma (hardcoded to 1)
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHist;
+  // Map for Canvases to be published
+  std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;
+  // Map for Histograms which will be put onto the canvases, and not published separately
+  std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHistCanvas; 
   ClassDefNV(PID, 1)
 };
 } // namespace qc

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -70,8 +70,7 @@ class PID
 
   // To set the elementary track cuts
   void setPIDCuts(int minnCls = 60, float absTgl = 1., float mindEdxTot = 10.0,
-                  float maxdEdxTot = 70., float minpTPC = 0.05, float maxpTPC = 20., float minpTPCMIPs = 0.45,
-                  float maxpTPCMIPs = 0.55, int CreateCanvasI = 1)
+                  float maxdEdxTot = 70., float minpTPC = 0.05, float maxpTPC = 20., float minpTPCMIPs = 0.45, float maxpTPCMIPs = 0.55)
   {
     mCutMinnCls = minnCls;
     mCutAbsTgl = absTgl;
@@ -81,7 +80,10 @@ class PID
     mCutMaxpTPC = maxpTPC;
     mCutMinpTPCMIPs = minpTPCMIPs;
     mCutMaxpTPCMIPs = maxpTPCMIPs;
-    CreateCanvas = CreateCanvasI;
+  }
+  void setCreateCanvas(int createCanvas = 1)
+  {
+    mCreateCanvas = createCanvas;
   }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>>& getMapOfHisto() { return mMapHist; }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>>& getMapOfCanvas() { return mMapCanvas; }
@@ -97,7 +99,7 @@ class PID
   float mCutMaxpTPC = 20.f;      // pTPC max value
   float mCutMinpTPCMIPs = 0.45f; // pTPC min value for MIPs
   float mCutMaxpTPCMIPs = 0.55f; // pTPC max value for MIPs
-  bool CreateCanvas = true;      // Decide whether to create the TCanvas Object as it cannot be merged
+  bool mCreateCanvas = true;     // Decide whether to create the TCanvas Object as it cannot be merged
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHist;
   // Map for Canvases to be published
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;

--- a/Detectors/TPC/qc/macro/runPID.C
+++ b/Detectors/TPC/qc/macro/runPID.C
@@ -98,7 +98,7 @@ void runPID(std::string outputFileName = "PID", std::string_view inputFileName =
     // ---| track loop |---
     for (int k = 0; k < nTracks; k++) {
       auto track = (*tpcTracks)[k];
-      pid.processTrack(track);
+      pid.processTrack(track, nTracks);
     }
   }
 

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -177,7 +177,7 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t NTracks)
       for (size_t iSpecies = 0; iSpecies < o2::track::PID::NIDs; ++iSpecies) {
         dEdxRatio = dEdxTot[idEdxType] / mPID.getExpectedSignal(track, static_cast<o2::track::PID::ID>(iSpecies));
       }
-      const auto PIDHypothesis = mPID.getMostProbablePID(track, mCutKrangeMin, mCutKrangeMax, mCutPrangeMin, mCutPrangeMax, mCutDrangeMin, mCutDrangeMax, mCutTrangeMin, mCutTrangeMax);
+      const auto PIDHypothesis = mPID.getMostProbablePID(track, mCutKrangeMin, mCutKrangeMax, mCutPrangeMin, mCutPrangeMax, mCutDrangeMin, mCutDrangeMax, mCutTrangeMin, mCutTrangeMax,1,mPIDSigma);
       int Hypothesis = static_cast<int>(PIDHypothesis) + 1;
       if (static_cast<int>(PIDHypothesis) <= o2::track::PID::NIDs) {
         if (track.getCharge() > 0) {

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -172,15 +172,8 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
       mMapHist["hdEdxMaxVsp"][idEdxType]->Fill(pTPC, dEdxMax[idEdxType]);
       const auto pidHypothesis = track.getPID().getID();
       if (pidHypothesis <= o2::track::PID::NIDs) {
-        //TH1* pidHist = mMapHistCanvas["hdEdxVspHypoPos"][idEdxType];
         auto pidHist = mMapHistCanvas[(track.getCharge() > 0) ? "hdEdxVspHypoPos" : "hdEdxVspHypoNeg"][idEdxType].get();
         pidHist->SetBinContent(pidHist->GetXaxis()->FindBin(pTPC), pidHist->GetYaxis()->FindBin(dEdxTot[idEdxType]), pidHypothesis + 1);
-
-        //if (track.getCharge() > 0) {
-        //  mMapHistCanvas["hdEdxVspHypoPos"][idEdxType]->SetBinContent(mMapHistCanvas["hdEdxVspHypoPos"][idEdxType]->GetXaxis()->FindBin(pTPC), mMapHistCanvas["hdEdxVspHypoPos"][idEdxType]->GetYaxis()->FindBin(dEdxTot[idEdxType]), pidHypothesis + 1);
-        //} else {
-        //  mMapHistCanvas["hdEdxVspHypoNeg"][idEdxType]->SetBinContent(mMapHistCanvas["hdEdxVspHypoNeg"][idEdxType]->GetXaxis()->FindBin(pTPC), mMapHistCanvas["hdEdxVspHypoNeg"][idEdxType]->GetYaxis()->FindBin(dEdxTot[idEdxType]), pidHypothesis + 1);
-        //}
       }
     }
 

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -89,12 +89,12 @@ void PID::initializeHistograms()
     mMapHist["hdEdxMaxMIPVsSec"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxMaxMIPVsSec_{}", name).data(), (fmt::format("MIP Q_{{Max}} {}", name) + ";sector;d#it{E}/d#it{x}_{Max} (arb. unit)").data(), binsSec.bins, binsSec.min, binsSec.max, binsdEdxMIPMax.bins, binsdEdxMIPMax.min, binsdEdxMIPMax.max));
     mMapHist["hMIPNclVsTgl"].emplace_back(std::make_unique<TH2F>(fmt::format("hMIPNclVsTgl_{}", name).data(), (fmt::format("rec. clusters {}", name) + ";#tan(#lambda);d#it{E}/d#it{x}_{Max} (arb. unit)").data(), 50, -2, 2, nclMax[idEdxType], 0, nclMax[idEdxType]));
     mMapHist["hMIPNclVsTglSub"].emplace_back(std::make_unique<TH2F>(fmt::format("hMIPNclVsTglSub_{}", name).data(), (fmt::format("rec. + sub-thrs. clusters {}", name) + ";#tan(#lambda);d#it{E}/d#it{x}_{Max} (arb. unit)").data(), 50, -2, 2, nclMax[idEdxType], 0, nclMax[idEdxType]));
-    if (CreateCanvas) {
+    if (mCreateCanvas) {
       mMapHistCanvas["hdEdxVspHypoPos"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxVspHypoPos_{}", name).data(), (fmt::format("Q_{{Tot}} Pos {}", name) + ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{Tot} (arb. unit)").data(), 200, bins.data(), binsdEdxTot.bins, binsdEdxTot.min, binsdEdxTot.max));
       mMapHistCanvas["hdEdxVspHypoNeg"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxVspHypoNeg_{}", name).data(), (fmt::format("Q_{{Tot}} Neg {}", name) + ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{Tot} (arb. unit)").data(), 200, bins.data(), binsdEdxTot.bins, binsdEdxTot.min, binsdEdxTot.max));
     }
   }
-  if (CreateCanvas) {
+  if (mCreateCanvas) {
     mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
     mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
   }
@@ -177,7 +177,7 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
     if (std::abs(tgl) < mCutAbsTgl) {
       mMapHist["hdEdxTotVsp"][idEdxType]->Fill(pTPC, dEdxTot[idEdxType]);
       mMapHist["hdEdxMaxVsp"][idEdxType]->Fill(pTPC, dEdxMax[idEdxType]);
-      if (CreateCanvas) {
+      if (mCreateCanvas) {
         const auto pidHypothesis = track.getPID().getID();
         if (pidHypothesis <= o2::track::PID::NIDs) {
           auto pidHist = mMapHistCanvas[(track.getCharge() > 0) ? "hdEdxVspHypoPos" : "hdEdxVspHypoNeg"][idEdxType].get();
@@ -217,7 +217,7 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
       }
     }
   }
-  if (CreateCanvas) {
+  if (mCreateCanvas) {
     for (auto const& pairC : mMapCanvas) {
       for (auto& canv : pairC.second) {
         int h = 1;

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -222,7 +222,6 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t NTracks)
 
   for (auto const& pairC : mMapCanvas) {
     for (auto& canv : pairC.second) {
-      //LOGP(error, pairC.first);
       int h = 1;
       for (auto const& pairH : mMapHistCanvas) {
         for (auto& hist : pairH.second) {

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -99,8 +99,6 @@ void PID::initializeHistograms()
     mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
     mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
   }
-  mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
-  mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -40,9 +40,6 @@ struct binning {
 
 constexpr std::array<float, 5> xks{90.f, 108.475f, 151.7f, 188.8f, 227.65f};
 const std::vector<std::string_view> rocNames{"TPC", "IROC", "OROC1", "OROC2", "OROC3"};
-//const std::vector<std::string_view> SpeciesNames{"Proton", "Pion", "Kaon", "Deuteron", "Triton"};
-//const std::vector<std::string_view> SpeciesNames{"Pion", "Kaon", "Proton", "Deuteron"};
-//const std::vector<std::string_view> chargeName{"Minus", "Plus"};
 const std::vector<int> nclCuts{60, 25, 14, 12, 10};
 const std::vector<int> nclMax{152, 63, 34, 30, 25};
 const binning binsdEdxTot{2000, 0., 6000.};

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -89,12 +89,16 @@ void PID::initializeHistograms()
     mMapHist["hdEdxMaxMIPVsSec"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxMaxMIPVsSec_{}", name).data(), (fmt::format("MIP Q_{{Max}} {}", name) + ";sector;d#it{E}/d#it{x}_{Max} (arb. unit)").data(), binsSec.bins, binsSec.min, binsSec.max, binsdEdxMIPMax.bins, binsdEdxMIPMax.min, binsdEdxMIPMax.max));
     mMapHist["hMIPNclVsTgl"].emplace_back(std::make_unique<TH2F>(fmt::format("hMIPNclVsTgl_{}", name).data(), (fmt::format("rec. clusters {}", name) + ";#tan(#lambda);d#it{E}/d#it{x}_{Max} (arb. unit)").data(), 50, -2, 2, nclMax[idEdxType], 0, nclMax[idEdxType]));
     mMapHist["hMIPNclVsTglSub"].emplace_back(std::make_unique<TH2F>(fmt::format("hMIPNclVsTglSub_{}", name).data(), (fmt::format("rec. + sub-thrs. clusters {}", name) + ";#tan(#lambda);d#it{E}/d#it{x}_{Max} (arb. unit)").data(), 50, -2, 2, nclMax[idEdxType], 0, nclMax[idEdxType]));
-
-    mMapHistCanvas["hdEdxVspHypoPos"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxVspHypoPos_{}", name).data(), (fmt::format("Q_{{Tot}} Pos {}", name) + ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{Tot} (arb. unit)").data(), 200, bins.data(), binsdEdxTot.bins, binsdEdxTot.min, binsdEdxTot.max));
-    mMapHistCanvas["hdEdxVspHypoNeg"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxVspHypoNeg_{}", name).data(), (fmt::format("Q_{{Tot}} Neg {}", name) + ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{Tot} (arb. unit)").data(), 200, bins.data(), binsdEdxTot.bins, binsdEdxTot.min, binsdEdxTot.max));
+    if (CreateCanvas) {
+      mMapHistCanvas["hdEdxVspHypoPos"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxVspHypoPos_{}", name).data(), (fmt::format("Q_{{Tot}} Pos {}", name) + ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{Tot} (arb. unit)").data(), 200, bins.data(), binsdEdxTot.bins, binsdEdxTot.min, binsdEdxTot.max));
+      mMapHistCanvas["hdEdxVspHypoNeg"].emplace_back(std::make_unique<TH2F>(fmt::format("hdEdxVspHypoNeg_{}", name).data(), (fmt::format("Q_{{Tot}} Neg {}", name) + ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{Tot} (arb. unit)").data(), 200, bins.data(), binsdEdxTot.bins, binsdEdxTot.min, binsdEdxTot.max));
+    }
   }
-  mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
-  mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
+  if (CreateCanvas) {
+
+    mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
+    mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
+  }
 }
 
 //______________________________________________________________________________
@@ -174,10 +178,12 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
     if (std::abs(tgl) < mCutAbsTgl) {
       mMapHist["hdEdxTotVsp"][idEdxType]->Fill(pTPC, dEdxTot[idEdxType]);
       mMapHist["hdEdxMaxVsp"][idEdxType]->Fill(pTPC, dEdxMax[idEdxType]);
-      const auto pidHypothesis = track.getPID().getID();
-      if (pidHypothesis <= o2::track::PID::NIDs) {
-        auto pidHist = mMapHistCanvas[(track.getCharge() > 0) ? "hdEdxVspHypoPos" : "hdEdxVspHypoNeg"][idEdxType].get();
-        pidHist->SetBinContent(pidHist->GetXaxis()->FindBin(pTPC), pidHist->GetYaxis()->FindBin(dEdxTot[idEdxType]), pidHypothesis + 1);
+      if (CreateCanvas) {
+        const auto pidHypothesis = track.getPID().getID();
+        if (pidHypothesis <= o2::track::PID::NIDs) {
+          auto pidHist = mMapHistCanvas[(track.getCharge() > 0) ? "hdEdxVspHypoPos" : "hdEdxVspHypoNeg"][idEdxType].get();
+          pidHist->SetBinContent(pidHist->GetXaxis()->FindBin(pTPC), pidHist->GetYaxis()->FindBin(dEdxTot[idEdxType]), pidHypothesis + 1);
+        }
       }
     }
 
@@ -212,15 +218,16 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
       }
     }
   }
-
-  for (auto const& pairC : mMapCanvas) {
-    for (auto& canv : pairC.second) {
-      int h = 1;
-      for (auto const& pairH : mMapHistCanvas) {
-        for (auto& hist : pairH.second) {
-          canv->cd(h);
-          hist->Draw();
-          h++;
+  if (CreateCanvas) {
+    for (auto const& pairC : mMapCanvas) {
+      for (auto& canv : pairC.second) {
+        int h = 1;
+        for (auto const& pairH : mMapHistCanvas) {
+          for (auto& hist : pairH.second) {
+            canv->cd(h);
+            hist->Draw();
+            h++;
+          }
         }
       }
     }

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -113,6 +113,12 @@ void PID::resetHistograms()
 }
 
 //______________________________________________________________________________
+
+// dummy version to make it compatible with old QC version.
+bool PID::processTrack(const o2::tpc::TrackTPC& track)
+{
+  return true;
+}
 bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
 {
   // ===| variables required for cutting and filling |===

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -177,7 +177,7 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t NTracks)
       for (size_t iSpecies = 0; iSpecies < o2::track::PID::NIDs; ++iSpecies) {
         dEdxRatio = dEdxTot[idEdxType] / mPID.getExpectedSignal(track, static_cast<o2::track::PID::ID>(iSpecies));
       }
-      const auto PIDHypothesis = mPID.getMostProbablePID(track, mCutKrangeMin, mCutKrangeMax, mCutPrangeMin, mCutPrangeMax, mCutDrangeMin, mCutDrangeMax, mCutTrangeMin, mCutTrangeMax,1,mPIDSigma);
+      const auto PIDHypothesis = mPID.getMostProbablePID(track, mCutKrangeMin, mCutKrangeMax, mCutPrangeMin, mCutPrangeMax, mCutDrangeMin, mCutDrangeMax, mCutTrangeMin, mCutTrangeMax, 1, mPIDSigma);
       int Hypothesis = static_cast<int>(PIDHypothesis) + 1;
       if (static_cast<int>(PIDHypothesis) <= o2::track::PID::NIDs) {
         if (track.getCharge() > 0) {

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -95,7 +95,6 @@ void PID::initializeHistograms()
     }
   }
   if (CreateCanvas) {
-
     mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
     mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
   }

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -25,7 +25,6 @@
 // o2 includes
 #include "DataFormatsTPC/dEdxInfo.h"
 #include "DataFormatsTPC/TrackTPC.h"
-#include "DataFormatsTPC/PIDResponse.h"
 #include "TPCQC/PID.h"
 #include "TPCQC/Helpers.h"
 
@@ -50,7 +49,6 @@ const binning binsdEdxMIPTot{100, mipTot / 3., mipTot * 3.};
 const binning binsdEdxMIPMax{100, mipMax / 3., mipMax * 3.};
 const binning binsSec{36, 0., 36.};
 const auto bins = o2::tpc::qc::helpers::makeLogBinning(200, 0.05, 20);
-o2::tpc::PIDResponse mPID;
 
 //______________________________________________________________________________
 void PID::initializeHistograms()


### PR DESCRIPTION
There was an issue with the last PR #12630  where TCanvas could not be merged. This PR allows to disable the TCanvas generation through the JSON file. This is paired with another PR in QC (https://github.com/AliceO2Group/QualityControl/pull/2151).