### PR TITLE
TPC: Add scaledMultiplicity and avgCharge(not yet used) to reject debug streamers

### DIFF
--- a/GPU/GPUTracking/Merger/GPUTPCGMPropagator.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPropagator.cxx
@@ -663,7 +663,7 @@ GPUd() int GPUTPCGMPropagator::Update(float posY, float posZ, int iRow, const GP
     } else {
       int retVal = InterpolateReject(param, posY, posZ, clusterState, rejectChi2, inter, err2Y, err2Z);
       GPUCA_DEBUG_STREAMER_CHECK(if (o2::utils::DebugStreamer::checkStream(o2::utils::StreamFlags::streamRejectCluster, iTrk)) {
-        o2::utils::DebugStreamer::instance()->getStreamer("debug_InterpolateReject", "UPDATE") << o2::utils::DebugStreamer::instance()->getUniqueTreeName("tree_InterpolateReject").data() << "mAlpha=" << mAlpha << "iRow=" << iRow << "posY=" << posY << "posZ=" << posZ << "clusterState=" << clusterState << "rejectChi2=" << rejectChi2 << "interpolationhit=" << *inter << "refit=" << refit << "retVal=" << retVal << "err2Y=" << err2Y << "err2Z=" << err2Z << "track=" << mT << "\n";
+        o2::utils::DebugStreamer::instance()->getStreamer("debug_InterpolateReject", "UPDATE") << o2::utils::DebugStreamer::instance()->getUniqueTreeName("tree_InterpolateReject").data() << "mAlpha=" << mAlpha << "iRow=" << iRow << "posY=" << posY << "posZ=" << posZ << "clusterState=" << clusterState << "rejectChi2=" << rejectChi2 << "interpolationhit=" << *inter << "refit=" << refit << "retVal=" << retVal << "err2Y=" << err2Y << "err2Z=" << err2Z << "track=" << mT << "scaledMultiplicity" << (time >= 0.f ? param.GetScaledMult(sector, iRow, time) / param.tpcGeometry.Row2X(iRow) : 0.f) << "avgCharge" << avgCharge << "\n";
       })
       if (retVal) {
         return retVal;


### PR DESCRIPTION
Adds debug streamers for scaledMultiplicity and avgCharge.
Scaled multiplicity is the full scaled multiplicity as it goes into the cluster error formula, ie divided by the rowX and scaled by the factor configured via configKeyValues.

We will have the same for avgCharge once that is fully available, but currently that is still constant 0, just adding it here already to do it in one change.