### PR TITLE
Fine-grained verbosity control for Primary generator + Pythia8

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8Param.h
+++ b/Generators/include/Generators/GeneratorPythia8Param.h
@@ -26,7 +26,7 @@ namespace eventgen
 /**
  ** a parameter class/struct to keep the settings of
  ** the Pythia8 event generator and
- ** allow the user to modify them 
+ ** allow the user to modify them
  **/
 
 struct GeneratorPythia8Param : public o2::conf::ConfigurableParamHelper<GeneratorPythia8Param> {
@@ -35,6 +35,7 @@ struct GeneratorPythia8Param : public o2::conf::ConfigurableParamHelper<Generato
   std::string hooksFuncName = "";
   bool includePartonEvent = false; // whether to keep the event before hadronization
   std::string particleFilter = ""; // user particle filter
+  int verbose = 0;                 // verbose control (if > 0 may show more info messages about what is going on)
   O2ParamDef(GeneratorPythia8Param, "GeneratorPythia8");
 };
 

--- a/Generators/include/Generators/PrimaryGeneratorParam.h
+++ b/Generators/include/Generators/PrimaryGeneratorParam.h
@@ -28,6 +28,7 @@ namespace eventgen
 struct PrimaryGeneratorParam : public o2::conf::ConfigurableParamHelper<PrimaryGeneratorParam> {
   int id = -1;
   std::string description = "";
+  int verbose = 0; // if > 1 the primary generator may emit more info messages about what's going on
   O2ParamDef(PrimaryGeneratorParam, "PrimaryGenerator");
 };
 

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -505,8 +505,10 @@ void GeneratorPythia8::pruneEvent(Pythia8::Event& event, Select select)
       }
     }
   }
-  LOG(info) << "Pythia event was pruned from " << event.size()
-            << " to " << pruned.size() << " particles";
+  if (GeneratorPythia8Param::Instance().verbose) {
+    LOG(info) << "Pythia event was pruned from " << event.size()
+              << " to " << pruned.size() << " particles";
+  }
   // Assign our pruned event to the event passed in
   event = pruned;
 }

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -315,7 +315,9 @@ void PrimaryGenerator::fixInteractionVertex()
   }
   auto sampledvertex = mMeanVertex->sample();
 
-  LOG(info) << "Sampled interacting vertex " << sampledvertex;
+  if (PrimaryGeneratorParam::Instance().verbose) {
+    LOG(info) << "Sampled interacting vertex " << sampledvertex;
+  }
   SetBeam(sampledvertex.X(), sampledvertex.Y(), 0., 0.);
   SetTarget(sampledvertex.Z(), 0.);
 }


### PR DESCRIPTION
Introduce configurable options to allow control
of log output of the primary generator and Pythia8 event generation.

By default, switch off a couple of messages that are repetetive and lead to large log files when we simulate many events.

This is meant for the use case of running the generators on-the-fly in hyperloop.

Allowing fine-grained control of output seems better than globally demoting from info to debug.

relates to https://its.cern.ch/jira/browse/O2-4681