### PR TITLE
Add collinear DCAFitter and use it in SVertexer.

### DIFF
--- a/Common/DCAFitter/include/DCAFitter/DCAFitterN.h
+++ b/Common/DCAFitter/include/DCAFitter/DCAFitterN.h
@@ -188,6 +188,7 @@ class DCAFitterN
   void setMaxSnp(float s) { mMaxSnp = s; }
   void setMaxStep(float s) { mMaxStep = s; }
   void setMinXSeed(float x) { mMinXSeed = x; }
+  void setCollinear(bool isCollinear) { mIsCollinear = isCollinear; }
 
   int getNCandidates() const { return mCurHyp; }
   int getMaxIter() const { return mMaxIter; }
@@ -324,6 +325,7 @@ class DCAFitterN
   bool mPropagateToPCA = true;                                                                    // create tracks version propagated to PCA
   bool mUsePropagator = false;                                                                    // use propagator with 3D B-field, set automatically if material correction is requested
   bool mRefitWithMatCorr = false;                                                                 // when doing propagateTracksToVertex, propagate tracks to V0 with material corrections and rerun minimization again
+  bool mIsCollinear = false;                                                                      // use collinear fits when there 2 crossing points
   o2::base::Propagator::MatCorrType mMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE; // material corrections type
   int mMaxIter = 20;                                                                              // max number of iterations
   float mBz = 0;                                                                                  // bz field, to be set by user
@@ -339,7 +341,7 @@ class DCAFitterN
   float mMaxStep = 2.0;                                                                           // Max step for propagation with Propagator
   int mFitterID = 0;                                                                              // locat fitter ID (mostly for debugging)
   size_t mCallID = 0;
-  ClassDefNV(DCAFitterN, 1);
+  ClassDefNV(DCAFitterN, 2);
 };
 
 ///_________________________________________________________________________
@@ -355,8 +357,8 @@ int DCAFitterN<N, Args...>::process(const Tr&... args)
   for (int i = 0; i < N; i++) {
     mTrAux[i].set(*mOrigTrPtr[i], mBz);
   }
-  if (!mCrossings.set(mTrAux[0], *mOrigTrPtr[0], mTrAux[1], *mOrigTrPtr[1], mMaxDXYIni)) { // even for N>2 it should be enough to test just 1 loop
-    return 0;                                                                              // no crossing
+  if (!mCrossings.set(mTrAux[0], *mOrigTrPtr[0], mTrAux[1], *mOrigTrPtr[1], mMaxDXYIni, mIsCollinear)) { // even for N>2 it should be enough to test just 1 loop
+    return 0;                                                                                            // no crossing
   }
   for (int ih = 0; ih < MAXHYP; ih++) {
     mPropFailed[ih] = false;

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DecayNBodyIndex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DecayNBodyIndex.h
@@ -59,8 +59,10 @@ class V0Index : public DecayNBodyIndex<2>
   V0Index(int v, GIndex p, GIndex n) : DecayNBodyIndex<2>(v, {p, n}) {}
   bool isStandaloneV0() const { return testBit(0); }
   bool isPhotonOnly() const { return testBit(1); }
+  bool isCollinear() const { return testBit(2); }
   void setStandaloneV0() { setBit(0); }
   void setPhotonOnly() { setBit(1); }
+  void setCollinear() { setBit(2); }
   ClassDefNV(V0Index, 1);
 };
 

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -608,6 +608,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
     fitterV0.setMaxDZIni(mSVParams->mTPCTrackMaxDZIni);
     fitterV0.setMaxDXYIni(mSVParams->mTPCTrackMaxDXYIni);
     fitterV0.setMaxChi2(mSVParams->mTPCTrackMaxChi2);
+    fitterV0.setCollinear(true);
   }
 
   // feed DCAFitter
@@ -617,7 +618,9 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
     fitterV0.setMaxDZIni(mSVParams->maxDZIni);
     fitterV0.setMaxDXYIni(mSVParams->maxDXYIni);
     fitterV0.setMaxChi2(mSVParams->maxChi2);
+    fitterV0.setCollinear(false);
   }
+
   if (nCand == 0) { // discard this pair
     LOG(debug) << "RejDCAFitter";
     return false;
@@ -627,6 +630,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   // check closeness to the beam-line
   float dxv0 = v0XYZ[0] - mMeanVertex.getX(), dyv0 = v0XYZ[1] - mMeanVertex.getY(), r2v0 = dxv0 * dxv0 + dyv0 * dyv0;
   if (r2v0 < mMinR2ToMeanVertex) {
+    LOG(debug) << "RejMinR2ToMeanVertex";
     return false;
   }
   float rv0 = std::sqrt(r2v0), drv0P = rv0 - seedP.minR, drv0N = rv0 - seedN.minR;
@@ -860,6 +864,7 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
     }
     if (photonOnly) {
       mV0sIdxTmp[ithread].back().setPhotonOnly();
+      mV0sIdxTmp[ithread].back().setCollinear();
     }
 
     if (mSVParams->createFullV0s) {

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1313,8 +1313,10 @@ DECLARE_SOA_COLUMN(V0Type, v0Type, uint8_t);                            //! cust
 
 DECLARE_SOA_DYNAMIC_COLUMN(IsStandardV0, isStandardV0, //! is standard V0
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 0); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonV0, isPhotonV0, //! is standard V0
+DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonV0, isPhotonV0, //! is TPC-only V0 for which the photon-mass-hypothesis was good
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 1); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsCollinearV0, isCollinearV0, //! is V0 for which the photon-mass-hypothesis was good and was fitted collinearly
+                           [](uint8_t V0Type) -> bool { return V0Type & (1 << 2); });
 
 } // namespace v0
 
@@ -1329,7 +1331,8 @@ DECLARE_SOA_TABLE_VERSIONED(V0s_002, "AOD", "V0", 2, //! Run 3 V0 table (version
                             v0::PosTrackId, v0::NegTrackId,
                             v0::V0Type,
                             v0::IsStandardV0<v0::V0Type>,
-                            v0::IsPhotonV0<v0::V0Type>);
+                            v0::IsPhotonV0<v0::V0Type>,
+                            v0::IsCollinearV0<v0::V0Type>);
 
 using V0s = V0s_002; //! this defines the current default version
 using V0 = V0s::iterator;


### PR DESCRIPTION
- Adds a collinear option to the DCAFitter
- Adds this flag to TPConly tracks in the SVertexer
- Adds a getter for this bit in the DataModel (reason this is separate from the 'isPhotonV0', as this this _maybe_ used in the future separately, for now they are equivalent).