### PR TITLE
DPL: allow a given buffer to be deserialised multiple times

### DIFF
--- a/Framework/Core/include/Framework/TMessageSerializer.h
+++ b/Framework/Core/include/Framework/TMessageSerializer.h
@@ -115,6 +115,7 @@ inline std::unique_ptr<T> TMessageSerializer::deserialize(FairInputTBuffer& buff
   // FIXME: we need to add consistency check for buffer data to be serialized
   // at the moment, TMessage might simply crash if an invalid or inconsistent
   // buffer is provided
+  buffer.SetBufferOffset(0);
   buffer.InitMap();
   TClass* serializedClass = buffer.ReadClass();
   buffer.SetBufferOffset(0);


### PR DESCRIPTION
DPL: allow a given buffer to be deserialised multiple times

This is only exercised in one of the tests, AFAICT, but it should not
harm.
