### PR TITLE
ITS NoiseCalib: Lifetime TimeFrame to Sporadic for 2 inputs

### DIFF
--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -272,8 +272,8 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useClusters, int pmode)
     }
   } else {
     useClusters = false;                                                                                         // not needed for normalization
-    inputs.emplace_back("mapspart", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPART"}, Lifetime::Sporadic);        // for normalization of multiple inputs only
-    inputs.emplace_back("mapspartInfo", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPARTINF"}, Lifetime::Sporadic); // for normalization of multiple inputs only
+    inputs.emplace_back("mapspart", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPART"}, Lifetime::Sporadic);         // for normalization of multiple inputs only
+    inputs.emplace_back("mapspartInfo", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPARTINF"}, Lifetime::Sporadic);  // for normalization of multiple inputs only
   }
   if (md == NoiseCalibratorSpec::ProcessingMode::Full || md == NoiseCalibratorSpec::ProcessingMode::Normalize) {
     inputs.emplace_back("confdbmap", "ITS", "CONFDBMAP", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/Confdbmap"));

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -272,8 +272,8 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useClusters, int pmode)
     }
   } else {
     useClusters = false;                                                                                         // not needed for normalization
-    inputs.emplace_back("mapspart", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPART"}, Lifetime::Timeframe);        // for normalization of multiple inputs only
-    inputs.emplace_back("mapspartInfo", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPARTINF"}, Lifetime::Timeframe); // for normalization of multiple inputs only
+    inputs.emplace_back("mapspart", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPART"}, Lifetime::Sporadic);        // for normalization of multiple inputs only
+    inputs.emplace_back("mapspartInfo", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPARTINF"}, Lifetime::Sporadic); // for normalization of multiple inputs only
   }
   if (md == NoiseCalibratorSpec::ProcessingMode::Full || md == NoiseCalibratorSpec::ProcessingMode::Normalize) {
     inputs.emplace_back("confdbmap", "ITS", "CONFDBMAP", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/Confdbmap"));


### PR DESCRIPTION
The two channels cannot have anymore 2 different lifetimes (timeframe and sporadic). Since also when used as inputs they are sporadic (only sent once the desired statistics is reached), I would propose to set them always as sporadic. 

Test locally worked. 

cc @shahor02 