### PR TITLE
DPL: attempt to have some dropping logic which does not break test

### DIFF
--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -54,17 +54,17 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
               // We count the number of consecutively dropped messages.
               // If we have more than 10, we switch to a completely
               // non-blocking approach.
-              int64_t timeout = 50;
+              int64_t timeout = 100;
               if (state.droppedMessages == 10 + 1) {
                 LOG(warning) << "Failed to send 10 messages with 10ms timeout in a row, switching to completely non-blocking mode.";
               }
               if (state.droppedMessages == 0) {
-                timeout = 50;
+                timeout = 100;
               }
               if (state.droppedMessages > 10) {
                 timeout = 0;
               }
-              int64_t result = info.channel.Send(parts, timeout);
+              int64_t result = info.channel.Send(parts, timeout * (state.droppedMessages + 1));
               if (result >= 0) {
                 state.droppedMessages = 0;
               } else if (state.droppedMessages < std::numeric_limits<decltype(state.droppedMessages)>::max()) {


### PR DESCRIPTION
DPL: attempt to have some dropping logic which does not break test

I suspect what is happening in the test is the consumers start
too late (and the lossy policy drops messages on the sender side
when that happens).

This should avoid the problem by increasing the delay up to 1 second,
before switching to lossy, giving enough time to the consumers to start.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12787).
* #12788
* __->__ #12787