### PR TITLE
Handling of wrong Alpide chip_on_module ID

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -181,7 +181,17 @@ class AlpideCoder
       uint8_t dataCM = dataC & (~MaskChipID);
       //
       if ((expectInp & ExpectChipEmpty) && dataCM == CHIPEMPTY) { // empty chip was expected
-        chipData.setChipID(cidGetter(dataC & MaskChipID));        // here we set the global chip ID
+        uint16_t chipIDGlo = cidGetter(dataC & MaskChipID);
+        if (chipIDGlo == 0xffff) {
+          chipData.setChipID(chipIDGlo);
+#ifdef ALPIDE_DECODING_STAT
+          chipData.setErrorInfo(dataC & MaskChipID);
+          chipData.setError(ChipStat::WrongAlpideChipID);
+#endif
+          chipData.getData().clear();
+          return unexpectedEOF("CHIP_EMPTY:WrongChipID"); // abandon cable data
+        }
+        chipData.setChipID(chipIDGlo); // here we set the global chip ID
         if (!buffer.next(timestamp)) {
 #ifdef ALPIDE_DECODING_STAT
           chipData.setError(ChipStat::TruncatedChipEmpty);
@@ -194,7 +204,17 @@ class AlpideCoder
       }
 
       if ((expectInp & ExpectChipHeader) && dataCM == CHIPHEADER) { // chip header was expected
-        chipData.setChipID(cidGetter(dataC & MaskChipID));          // here we set the global chip ID
+        uint16_t chipIDGlo = cidGetter(dataC & MaskChipID);
+        if (chipIDGlo == 0xffff) {
+          chipData.setChipID(chipIDGlo);
+#ifdef ALPIDE_DECODING_STAT
+          chipData.setErrorInfo(dataC & MaskChipID);
+          chipData.setError(ChipStat::WrongAlpideChipID);
+#endif
+          chipData.getData().clear();
+          return unexpectedEOF("CHIP_EMPTY:WrongChipID"); // abandon cable data
+        }
+        chipData.setChipID(chipIDGlo); // here we set the global chip ID
         if (!buffer.next(timestamp)) {
 #ifdef ALPIDE_DECODING_STAT
           chipData.setError(ChipStat::TruncatedChipHeader);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
@@ -23,6 +23,7 @@
 #include "Headers/DataHeader.h"
 #include "ITSMFTReconstruction/RUInfo.h"
 #include "DetectorsCommonDataFormats/DetID.h"
+#include "Framework/Logger.h"
 
 namespace o2
 {
@@ -143,7 +144,12 @@ class ChipMappingITS
   ///< get chip global SW ID from chipID on module, cable SW ID and stave (RU) info
   uint16_t getGlobalChipID(uint16_t chOnModuleHW, int cableHW, const RUInfo& ruInfo) const
   {
-    return ruInfo.firstChipIDSW + mCableHWFirstChip[ruInfo.ruType][cableHW] + chipModuleIDHW2SW(ruInfo.ruType, chOnModuleHW);
+    if (chOnModuleHW < MaxHWChipIDPerModuleSB[ruInfo.ruType] && cableHW <= MaxHWCableID[ruInfo.ruType]) {
+      uint16_t chipOnRU = ruInfo.ruType == IB ? (cableHW == chOnModuleHW ? cableHW : 0xff) : (ruInfo.ruType == MB ? HWCableHWChip2ChipOnRU_MB[cableHW][chOnModuleHW] : HWCableHWChip2ChipOnRU_OB[cableHW][chOnModuleHW]);
+      // uint16_t chipOnRU = ruInfo.firstChipIDSW + mCableHWFirstChip[ruInfo.ruType][cableHW] + chipModuleIDHW2SW(ruInfo.ruType, chOnModuleHW);  // This is an old way, w/o error check
+      return chipOnRU < 0xff ? ruInfo.firstChipIDSW + chipOnRU : 0xffff;
+    }
+    return 0xffff;
   }
 
   ///< get chip global SW ID from Layer, abs Stave, module in Stave and chipID_on_module SW IDs
@@ -279,6 +285,9 @@ class ChipMappingITS
   ///< N chips per module of each sub-barrel
   static constexpr std::array<int, NSubB> NChipsPerModuleSB = {9, 14, 14};
 
+  ///< Max HW chip ID
+  static constexpr std::array<int, NSubB> MaxHWChipIDPerModuleSB = {9, 15, 15};
+
   ///< N cables per module of each sub-barrel
   static constexpr std::array<int, NSubB> NCablesPerModule = {9, 2, 2}; // NChipsPerModuleSB[]/NChipsPerCableSB[]
 
@@ -332,7 +341,7 @@ class ChipMappingITS
   static constexpr std::uint8_t ChipOBModSW2HW[14] = {0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14};
   // HW ID -> SW ID within the module
   static constexpr std::uint8_t ChipOBModHW2SW[15] = {0, 1, 2, 3, 4, 5, 6, 255, 7, 8, 9, 10, 11, 12, 13};
-
+  static constexpr std::array<int, NSubB> MaxHWCableID = {8, 27, 30};
   /// info per stave
   std::array<RUInfo, NStavesSB[IB] + NStavesSB[MB] + NStavesSB[OB]> mStavesInfo;
   std::vector<uint8_t> mFEEId2RUSW; // HW RU ID -> SW ID conversion
@@ -347,6 +356,8 @@ class ChipMappingITS
   std::vector<uint8_t> mCableHWFirstChip[NSubB]; ///< 1st chip of module (relative to the 1st chip of the stave) served by each cable
 
   std::array<int, NSubB> mCablesOnStaveSB = {0}; ///< pattern of cables per stave of sub-barrel
+  std::array<std::array<uint8_t, 15>, MaxHWCableID[MB] + 1> HWCableHWChip2ChipOnRU_MB; // mapping from HW cable ID / HW chip ID to Chip on RU, 255 means NA
+  std::array<std::array<uint8_t, 15>, MaxHWCableID[OB] + 1> HWCableHWChip2ChipOnRU_OB; // mapping from HW cable ID / HW chip ID to Chip on RU, 255 means NA
 
   ClassDefNV(ChipMappingITS, 1);
 };

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -67,6 +67,7 @@ struct ChipStat {
     TrailerAfterHeader,               // Trailer seen after header w/o FE of FD set
     FlushedIncomplete,                // ALPIDE MEB was flushed by the busy handling
     StrobeExtended,                   // ALPIDE received a second trigger while the strobe was still open
+    WrongAlpideChipID,                // Impossible for given cable ALPIDE ChipOnModule ID
     NErrorsDefined
   };
 
@@ -103,7 +104,8 @@ struct ChipStat {
     "TruncatedBuffer",                              // Truncated buffer, 0 padding
     "TrailerAfterHeader",                           // Trailer seen after header w/o FE of FD set
     "FlushedIncomplete",                            // ALPIDE MEB was flushed by the busy handling
-    "StrobeExtended"                                // ALPIDE received a second trigger while the strobe was still open
+    "StrobeExtended",                               // ALPIDE received a second trigger while the strobe was still open
+    "Wrong Alpide ChipID",                          // Impossible for given cable ALPIDE ChipOnModule ID
   };
 
   static constexpr std::array<uint32_t, NErrorsDefined> ErrActions = {
@@ -139,7 +141,8 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // Truncated buffer while something was expected
     ErrActPropagate | ErrActDump, // trailer seen after header w/o FE of FD set
     ErrActPropagate | ErrActDump, // ALPIDE MEB was flushed by the busy handling
-    ErrActPropagate | ErrActDump  // ALPIDE received a second trigger while the strobe was still open
+    ErrActPropagate | ErrActDump, // ALPIDE received a second trigger while the strobe was still open
+    ErrActPropagate | ErrActDump, // Impossible for given cable ALPIDE ChipOnModule ID
   };
   uint16_t feeID = -1;
   size_t nHits = 0;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
@@ -122,10 +122,11 @@ class ChipPixelData
   void setFirstUnmasked(uint32_t n) { mFirstUnmasked = n; }
   void setTrigger(uint32_t t) { mTrigger = t; }
 
-  void setError(ChipStat::DecErrors i) { mErrors |= 0x1 << i; }
+  void setError(ChipStat::DecErrors i) { mErrors |= 0x1UL << i; }
   void addErrorInfo(uint64_t b) { mErrorInfo |= b; }
-  void setErrorFlags(uint32_t f) { mErrors |= f; }
-  bool isErrorSet(ChipStat::DecErrors i) const { return mErrors & (0x1 << i); }
+  void setErrorInfo(uint64_t b) { mErrorInfo = b; }
+  void setErrorFlags(uint64_t f) { mErrors |= f; }
+  bool isErrorSet(ChipStat::DecErrors i) const { return mErrors & (0x1UL << i); }
   bool isErrorSet() const { return mErrors != 0; }
   auto getErrorFlags() const { return mErrors; }
   auto getErrorInfo() const { return mErrorInfo; }
@@ -254,7 +255,7 @@ class ChipPixelData
   uint32_t mFirstUnmasked = 0;                     // first unmasked entry in the mPixels
   uint32_t mStartID = 0;                           // entry of the 1st pixel data in the whole detector data, for MCtruth access
   uint32_t mTrigger = 0;                           // trigger pattern
-  uint32_t mErrors = 0;                            // errors set during decoding
+  uint64_t mErrors = 0;                            // errors set during decoding
   uint64_t mErrorInfo = 0;                         // optional extra info on the error
   std::array<uint8_t, MAXDATAERRBYTES> mRawBuff{}; // buffer for raw data showing an error
   o2::InteractionRecord mInteractionRecord = {};   // interaction record
@@ -262,7 +263,7 @@ class ChipPixelData
   std::vector<uint32_t> mPixIds;                   // vector of label indices in case of squashing+Monte Carlo
   std::vector<int> mPixelsOrder;                   // vector to get ordered access to pixel ids
 
-  ClassDefNV(ChipPixelData, 1);
+  ClassDefNV(ChipPixelData, 2);
 };
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -128,7 +128,6 @@ int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir)
     }
     cableData[icab].clear();
   }
-
   return ntot;
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingITS.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingITS.cxx
@@ -155,6 +155,28 @@ ChipMappingITS::ChipMappingITS()
       chipCount += NChipsPerStaveSB[sInfo.ruType];
     }
   }
+
+  // MB lookup
+  for (int ichw = 0; ichw <= MaxHWCableID[MB]; ichw++) { // loop over HW cables
+    for (int ihw = 0; ihw < 15; ihw++) {                 // init with invalid IDs
+      HWCableHWChip2ChipOnRU_MB[ichw][ihw] = 0xff;
+    }
+  }
+  for (int ichip = 0; ichip < NChipsPerStaveSB[MB]; ichip++) {
+    const auto& chInfo = mChipsInfo[NChipsPerStaveSB[IB] + ichip];
+    HWCableHWChip2ChipOnRU_MB[chInfo.cableHW][chInfo.chipOnModuleHW] = uint8_t(ichip);
+  }
+
+  // OB lookup
+  for (int ichw = 0; ichw <= MaxHWCableID[OB]; ichw++) { // loop over HW cables
+    for (int ihw = 0; ihw < 15; ihw++) {                 // init with invalid IDs
+      HWCableHWChip2ChipOnRU_OB[ichw][ihw] = 0xff;
+    }
+  }
+  for (int ichip = 0; ichip < NChipsPerStaveSB[OB]; ichip++) {
+    const auto& chInfo = mChipsInfo[NChipsPerStaveSB[IB] + NChipsPerStaveSB[MB] + ichip];
+    HWCableHWChip2ChipOnRU_OB[chInfo.cableHW][chInfo.chipOnModuleHW] = uint8_t(ichip);
+  }
   assert(ctrStv == getNRUs());
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -57,7 +57,7 @@ uint32_t ChipStat::addErrors(const ChipPixelData& d, int verbosity)
   uint32_t res = 0;
   if (d.getErrorFlags()) {
     for (int i = NErrorsDefined; i--;) {
-      if (d.getErrorFlags() & (0x1 << i)) {
+      if (d.getErrorFlags() & (0x1UL << i)) {
         res |= ErrActions[i] & ErrActPropagate;
         if (verbosity > -1 && (!errorCounts[i] || verbosity > 1)) {
           LOGP(info, "New error registered at bc/orbit {}/{} on the FEEID:{:#04x} chip#{}: {}{}",

--- a/Detectors/ITSMFT/common/reconstruction/src/PixelData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/PixelData.cxx
@@ -30,6 +30,7 @@ void PixelData::sanityCheck() const
 void ChipPixelData::print() const
 {
   // print chip data
+  static_assert(ChipStat::DecErrors::NErrorsDefined > sizeof(mErrors), "too many DecErrors defined");
   std::bitset<4> flg(mROFlags);
   printf("Chip %d in Orbit %6d BC:%4d (ROFrame %d) ROFlags: 4b'%4s | %4lu hits\n", mChipID,
          mInteractionRecord.orbit, mInteractionRecord.bc, mROFrame, flg.to_string().c_str(), mPixels.size());
@@ -51,6 +52,10 @@ std::string ChipPixelData::getErrorDetails(int pos) const
       rbuf += fmt::format(fmt::runtime(i ? " {:02x}" : "{:02x}"), (int)getRawErrBuff()[i]);
     }
     rbuf += '>';
+    return rbuf;
+  }
+  if (pos == int(ChipStat::WrongAlpideChipID)) {
+    std::string rbuf = fmt::format(" {} for this link", mErrorInfo & 0xffff);
     return rbuf;
   }
   return {};


### PR DESCRIPTION
Ignore cable data if decoded alpide chipID does not fit to expectations for the cable being decoded.
A new error [Wrong Alpide ChipID] is registered in this case. Note that the number of defined errors is now 34 therefore the per-chip mask for registered errors is set to uint64.