### PR TITLE
ITS DCS Parser workflow: fixing defult url for rct object

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -665,7 +665,7 @@ DataProcessorSpec getITSDCSParserSpec()
     Options{
       {"verbose", VariantType::Bool, false, {"Use verbose output mode"}},
       {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}},
-      {"ccdb-url-rct", VariantType::String, "", {"CCDB url from where to get RCT object for headers, default is o2-ccdb.internal. Use http://alice-ccdb.cern.ch for local tests"}}}};
+      {"ccdb-url-rct", VariantType::String, "http://o2-ccdb.internal", {"CCDB url from where to get RCT object for headers, default is o2-ccdb.internal. Use http://alice-ccdb.cern.ch for local tests"}}}};
 }
 } // namespace its
 } // namespace o2


### PR DESCRIPTION
- Fixing bug that was affecting the ITS Parser Workflow since November
- Crash due to an empty default string passed to the workflow 
@shahor02, @iravasen 