### PR TITLE
DebugStreamer: remove suffix from tree name

### DIFF
--- a/Common/Utils/src/DebugStreamer.cxx
+++ b/Common/Utils/src/DebugStreamer.cxx
@@ -166,7 +166,7 @@ void o2::utils::DebugStreamer::mergeTrees(const char* inpFile, const char* outFi
   TFile fOut(outFile, "RECREATE");
   for (auto& list : lists) {
     auto tree = TTree::MergeTrees(&list.second, option);
-    fOut.WriteObject(tree, tree->GetName());
+    fOut.WriteObject(tree, list.first.data());
   }
 }
 


### PR DESCRIPTION
- The suffix is just a number like "_0" - where the number corresponds to n-th call to fill the tree