### PR TITLE
GPU: Compile with -ffast-math

### DIFF
--- a/Common/Constants/include/CommonConstants/MathConstants.h
+++ b/Common/Constants/include/CommonConstants/MathConstants.h
@@ -22,8 +22,8 @@ namespace constants
 {
 namespace math
 {
-constexpr float Almost0 = 1.17549e-38;
-constexpr float Almost1 = 1.f - 1.0e-6;
+constexpr float Almost0 = 1.175494351e-38f;
+constexpr float Almost1 = 1.f - 1.0e-6f;
 constexpr float VeryBig = 1.f / Almost0;
 
 constexpr float PI = 3.14159274101257324e+00f;

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -163,7 +163,7 @@ TEST_CASE("TestGandivaTreeCreation")
   auto gandiva_tree2 = createExpressionTree(ptespecs, schema2);
 
   auto gandiva_expression2 = makeExpression(gandiva_tree2, resfield2);
-  REQUIRE(gandiva_expression2->ToString() == "if (bool less_than_or_equal_to(float absf((float) fSigned1Pt), (const float) 1.17549e-38 raw(7fffe1))) { (const float) 8.50709e+37 raw(7e80001f) } else { float absf(float divide((const float) 1 raw(3f800000), (float) fSigned1Pt)) }");
+  REQUIRE(gandiva_expression2->ToString() == "if (bool less_than_or_equal_to(float absf((float) fSigned1Pt), (const float) 1.17549e-38 raw(800000))) { (const float) 8.50706e+37 raw(7e800000) } else { float absf(float divide((const float) 1 raw(3f800000), (float) fSigned1Pt)) }");
 
   auto projector_b = createProjector(schema2, ptespecs, resfield2);
   auto fields = o2::soa::createFieldsFromColumns(o2::aod::Tracks::persistent_columns_t{});

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -13,6 +13,10 @@ set(MODULE GPUTracking)
 
 # set(CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE} "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}} -O0") # to uncomment if needed, tired of typing this...
 
+if(NOT ${GPUCA_NO_FAST_MATH} AND NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math")
+endif()
+
 include(cmake/helpers.cmake)
 
 if(ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")


### PR DESCRIPTION
We compile the GPU code with -ffast-math anyway, so no reason not to do the same for CPU by default in non-debug builds