### PR TITLE
[EMCAL-565] Add check to mask entire SM/FEC if a certain fraction is masked

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -50,6 +50,8 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   float minCellEnergy_bc = 0.1;         ///< minimum cell energy considered for filling the histograms for bad channel calib. Should speedup the filling of the histogram to suppress noise
   float fractionEvents_bc = 1.;         ///< fraction of events used in bad channel calibration
   size_t nThreads_bc = 4;               ///< number of threads used for the bad channel calinration for filling the histograms
+  float fracMaskSMFully_bc = 0.5;       ///< fraction of bad+dead channel for a SM to be fully masked
+  float fracMaskFECFully_bc = 0.9;      ///< fraction of bad+dead channel for a FEC to be fully masked
 
   // parameters for time calibration
   unsigned int minNEvents_tc = 1e7;      ///< minimum number of events to trigger the calibration
@@ -70,16 +72,16 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   size_t nThreads_tc = 2;                ///< number of threads used for the time calinration for filling the histograms
 
   // common parameters
-  std::string calibType = "time";                                        ///< type of calibration to run
-  std::string localRootFilePath = "";                                    ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
-  bool enableFastCalib = false;                                          ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
-  bool enableTimeProfiling = false;                                      ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
-  bool setSavedSlotAllowed_EMC = true;                                   ///< if true, saving and loading of calibrations from last run and for next run is enabled
-  bool setSavedSlotAllowedSOR_EMC = true;                                ///< if true, stored calibrations from last run can be loaded in the next run (if false, storing of the calib histograms is still active in contrast to setSavedSlotAllowed_EMC)
-  long endTimeMargin = 2592000000;                                       ///< set end TS to 30 days after slot ends (1000 * 60 * 60 * 24 * 30)
-  std::string selectedClassMasks = "C0TVX-B-NOPF-EMC";                   ///< name of EMCal min. bias trigger that is used for calibration
-  int bcShiftCTP = 0;                                                    ///< bc shift of CTP digits to align them with EMC bc in case they are misaligned
-  std::string filePathSave = "./emc_calib";                              ///< path where calibration histograms are stored at EOR to save them for the next run
+  std::string calibType = "time";                      ///< type of calibration to run
+  std::string localRootFilePath = "";                  ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
+  bool enableFastCalib = false;                        ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
+  bool enableTimeProfiling = false;                    ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
+  bool setSavedSlotAllowed_EMC = true;                 ///< if true, saving and loading of calibrations from last run and for next run is enabled
+  bool setSavedSlotAllowedSOR_EMC = true;              ///< if true, stored calibrations from last run can be loaded in the next run (if false, storing of the calib histograms is still active in contrast to setSavedSlotAllowed_EMC)
+  long endTimeMargin = 2592000000;                     ///< set end TS to 30 days after slot ends (1000 * 60 * 60 * 24 * 30)
+  std::string selectedClassMasks = "C0TVX-B-NOPF-EMC"; ///< name of EMCal min. bias trigger that is used for calibration
+  int bcShiftCTP = 0;                                  ///< bc shift of CTP digits to align them with EMC bc in case they are misaligned
+  std::string filePathSave = "./emc_calib";            ///< path where calibration histograms are stored at EOR to save them for the next run
 
   // old parameters. Keep them for a bit (can be deleted after september 5th) as otherwise ccdb and o2 version might not be in synch
   unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration


### PR DESCRIPTION
- In a few runs in the 2022 and 2023 data taking, a low energetic noise was present in some SMs. This low-energetic noise was however not affecting all cells equally, leading to weird distributions in the number of bad channels within the SMs (more than 50+% of the SM were masked). For more details see: https://indico.cern.ch/event/1387104/contributions/5830894/subcontributions/468897/attachments/2806947/4898041/2024_02_23.pdf
- Now, a check is implemented to check the fraction of bad+dead cells within a SM. If this fraction exceeds a certain value (set to 50% by default but can be changed via the CalibParams), the whole SM is masked.
- Analogous, this was implemented per FEC. Here the default value was set to 90% in order to not overmask. This value still has to be properly tuned
- The effect on the runtime of the calibration was found to be negligible