### PR TITLE
DPL Analysis: update slice index

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -665,9 +665,9 @@ struct FilteredIndexPolicy : IndexPolicyBase {
     return O2_BUILTIN_UNLIKELY(mSelectionRow == sentinel.index);
   }
 
-         /// Move iterator to one after the end. Since this is a view
-         /// we move the mSelectionRow to one past the view size and
-         /// the mRowIndex to one past the last entry in the selection
+  /// Move iterator to one after the end. Since this is a view
+  /// we move the mSelectionRow to one past the view size and
+  /// the mRowIndex to one past the last entry in the selection
   void moveToEnd()
   {
     this->mSelectionRow = this->mMaxSelection;
@@ -2862,7 +2862,7 @@ class FilteredBase : public T
   using external_index_columns_t = typename T::external_index_columns_t;
 
   using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<FilteredBase<T>, Os...>{}; }(originals{}));
-  using unfiltered_iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<FilteredBase<T>, Os...>{}; }(originals{}));
+  using unfiltered_iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowView<FilteredBase<T>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
@@ -3126,7 +3126,7 @@ class Filtered : public FilteredBase<T>
   using originals = originals_pack_t<T>;
 
   using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<Filtered<T>, Os...>{}; }(originals{}));
-  using unfiltered_iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<Filtered<T>, Os...>{}; }(originals{}));
+  using unfiltered_iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowView<Filtered<T>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   iterator begin()
@@ -3283,7 +3283,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
   using table_t = typename FilteredBase<typename T::table_t>::table_t;
   using originals = originals_pack_t<T>;
   using iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowViewFiltered<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
-  using unfiltered_iterator = decltype([]<typename... Os>(framework::pack<Os...>){ return typename table_t::template RowView<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
+  using unfiltered_iterator = decltype([]<typename... Os>(framework::pack<Os...>) { return typename table_t::template RowView<Filtered<Filtered<T>>, Os...>{}; }(originals{}));
   using const_iterator = iterator;
 
   iterator begin()

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2954,10 +2954,10 @@ class FilteredBase : public T
 
   auto rawSlice(uint64_t start, uint64_t end) const
   {
-    auto s = this->asArrowTable()->Slice(start, end - start + 1);
-    SelectionVector newSelection{static_cast<int64_t>(end - start + 1)};
-    std::iota(newSelection.begin(), newSelection.end(), 0);
-    return self_t{{s}, newSelection, start};
+    SelectionVector newSelection;
+    newSelection.resize(static_cast<int64_t>(end - start + 1));
+    std::iota(newSelection.begin(), newSelection.end(), start);
+    return self_t{{this->asArrowTable()}, std::move(newSelection), 0};
   }
 
   auto emptySlice() const
@@ -3227,12 +3227,14 @@ class Filtered : public FilteredBase<T>
     return it;
   }
 
+  using FilteredBase<T>::getSelectedRows;
+
   auto rawSlice(uint64_t start, uint64_t end) const
   {
-    auto s = this->asArrowTable()->Slice(start, end - start + 1);
-    SelectionVector newSelection{static_cast<int64_t>(end - start + 1)};
-    std::iota(newSelection.begin(), newSelection.end(), 0);
-    return self_t{{s}, newSelection, start};
+    SelectionVector newSelection;
+    newSelection.resize(static_cast<int64_t>(end - start + 1));
+    std::iota(newSelection.begin(), newSelection.end(), start);
+    return self_t{{this->asArrowTable()}, std::move(newSelection), 0};
   }
 
   auto emptySlice() const
@@ -3401,10 +3403,10 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
 
   auto rawSlice(uint64_t start, uint64_t end) const
   {
-    auto s = this->asArrowTable()->Slice(start, end - start + 1);
-    SelectionVector newSelection{static_cast<int64_t>(end - start + 1)};
-    std::iota(newSelection.begin(), newSelection.end(), 0);
-    return self_t{{s}, newSelection, start};
+    SelectionVector newSelection;
+    newSelection.resize(static_cast<int64_t>(end - start + 1));
+    std::iota(newSelection.begin(), newSelection.end(), start);
+    return self_t{{this->asArrowTable()}, std::move(newSelection), 0};
   }
 
   auto emptySlice() const

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1039,20 +1039,16 @@ TEST_CASE("TestSelfIndexRecursion")
   // FIXME: only 4 levels of recursive self-index dereference are tested
   // self-index binding should stay the same for recursive dereferences
   for (auto& p : fp) {
-    auto bp = std::is_same_v<std::decay_t<decltype(p)>, FullPoints::iterator>;
-    REQUIRE(bp);
+    REQUIRE(std::is_same_v<std::decay_t<decltype(p)>, FullPoints::iterator>);
     auto ops = p.pointSeq_as<FullPoints>();
     for (auto& pp : ops) {
-      auto bpp = std::is_same_v<std::decay_t<decltype(pp)>, FullPoints::iterator>;
-      REQUIRE(bpp);
+      REQUIRE(std::is_same_v<std::decay_t<decltype(pp)>, FullPoints::iterator>);
       auto opps = pp.pointSeq_as<FullPoints>();
       for (auto& ppp : opps) {
-        auto bppp = std::is_same_v<std::decay_t<decltype(ppp)>, FullPoints::iterator>;
-        REQUIRE(bppp);
+        REQUIRE(std::is_same_v<std::decay_t<decltype(ppp)>, FullPoints::iterator>);
         auto oppps = ppp.pointSeq_as<FullPoints>();
         for (auto& pppp : oppps) {
-          auto bpppp = std::is_same_v<std::decay_t<decltype(pppp)>, FullPoints::iterator>;
-          REQUIRE(bpppp);
+          REQUIRE(std::is_same_v<std::decay_t<decltype(pppp)>, FullPoints::iterator>);
           auto opppps = pppp.pointSeq_as<FullPoints>();
         }
       }
@@ -1077,21 +1073,16 @@ TEST_CASE("TestSelfIndexRecursion")
 
   // Filter should not interfere with self-index and the binding should stay the same
   for (auto& p : ffp) {
-    using T1 = std::decay_t<decltype(p)>;
-    auto bp = std::is_same_v<T1, FilteredPoints::iterator>;
-    REQUIRE(bp);
-    auto ops = p.pointSeq_as<typename T1::parent_t>();
+    REQUIRE(std::is_same_v<std::decay_t<decltype(p)>, FilteredPoints::iterator>);
+    auto ops = p.pointSeq_as<typename std::decay_t<decltype(p)>::parent_t>();
     for (auto& pp : ops) {
-      auto bpp = std::is_same_v<std::decay_t<decltype(pp)>, FullPoints::iterator>;
-      REQUIRE(bpp);
+      REQUIRE(std::is_same_v<std::decay_t<decltype(pp)>::parent_t, FilteredPoints>);
       auto opps = pp.pointSeq_as<FilteredPoints>();
       for (auto& ppp : opps) {
-        auto bppp = std::is_same_v<std::decay_t<decltype(ppp)>, FullPoints::iterator>;
-        REQUIRE(bppp);
+        REQUIRE(std::is_same_v<std::decay_t<decltype(ppp)>, FilteredPoints::iterator>);
         auto oppps = ppp.pointSeq_as<FilteredPoints>();
         for (auto& pppp : oppps) {
-          auto bpppp = std::is_same_v<std::decay_t<decltype(pppp)>, FullPoints::iterator>;
-          REQUIRE(bpppp);
+          REQUIRE(std::is_same_v<std::decay_t<decltype(pppp)>, FilteredPoints::iterator>);
           auto opppps = pppp.pointSeq_as<FilteredPoints>();
         }
       }
@@ -1100,7 +1091,7 @@ TEST_CASE("TestSelfIndexRecursion")
 
   auto const& ffpa = ffp;
 
-  // rawIteratorAt() should create an unfiltered iterator, unline begin() and iteratorAt()
+  // rawIteratorAt() should create an unfiltered iterator, unlike begin() and iteratorAt()
   for (auto& it1 : ffpa) {
     [[maybe_unused]] auto it2 = ffpa.rawIteratorAt(0);
     [[maybe_unused]] auto it3 = ffpa.iteratorAt(0);

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -479,17 +479,17 @@ namespace parts
 DECLARE_SOA_INDEX_COLUMN(Event, event);
 DECLARE_SOA_COLUMN(Property, property, int);
 DECLARE_SOA_SELF_SLICE_INDEX_COLUMN(Relatives, relatives);
-}
+} // namespace parts
 DECLARE_SOA_TABLE(Parts, "AOD", "PRTS", soa::Index<>, parts::EventId, parts::Property, parts::RelativesIdSlice);
 
 namespace things
 {
 DECLARE_SOA_INDEX_COLUMN(Event, event);
 DECLARE_SOA_INDEX_COLUMN(Part, part);
-}
+} // namespace things
 DECLARE_SOA_TABLE(Things, "AOD", "THNGS", soa::Index<>, things::EventId, things::PartId);
 
-}
+} // namespace o2::aod
 
 template <typename... As>
 static void overwriteInternalIndices(std::tuple<As...>& dest, std::tuple<As...> const& src)
@@ -520,7 +520,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
     if (filler[0] > filler[1]) {
       std::swap(filler[0], filler[1]);
     }
-    partsWriter(0,  std::floor(i/10.), i, filler);
+    partsWriter(0, std::floor(i / 10.), i, filler);
   }
   auto partsTable = builderP.finalize();
 
@@ -560,19 +560,19 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
     for (auto& thing : ts) {
       if (thing.has_part()) {
         auto part = thing.part_as<FilteredParts>();
-        REQUIRE(std::is_same_v<std::decay_t<decltype(part)>::parent_t,FilteredParts>);
+        REQUIRE(std::is_same_v<std::decay_t<decltype(part)>::parent_t, FilteredParts>);
         auto rs = part.relatives_as<std::decay_t<decltype(part)::parent_t>>();
         REQUIRE(std::is_same_v<std::decay_t<decltype(rs)>, FilteredParts>);
         for (auto& r : rs) {
-          REQUIRE(std::is_same_v<std::decay_t<decltype(r)>::parent_t,FilteredParts>);
+          REQUIRE(std::is_same_v<std::decay_t<decltype(r)>::parent_t, FilteredParts>);
           auto rss = r.relatives_as<std::decay_t<decltype(r)>::parent_t>();
           REQUIRE(std::is_same_v<std::decay_t<decltype(rss)>, FilteredParts>);
           for (auto& rr : rss) {
-            REQUIRE(std::is_same_v<std::decay_t<decltype(rr)>::parent_t,FilteredParts>);
+            REQUIRE(std::is_same_v<std::decay_t<decltype(rr)>::parent_t, FilteredParts>);
             auto rsss = rr.relatives_as<std::decay_t<decltype(rr)>::parent_t>();
             REQUIRE(std::is_same_v<std::decay_t<decltype(rsss)>, FilteredParts>);
             for (auto& rrr : rsss) {
-              REQUIRE(std::is_same_v<std::decay_t<decltype(rrr)>::parent_t,FilteredParts>);
+              REQUIRE(std::is_same_v<std::decay_t<decltype(rrr)>::parent_t, FilteredParts>);
               auto rssss = rrr.relatives_as<std::decay_t<decltype(rrr)>::parent_t>();
               REQUIRE(std::is_same_v<std::decay_t<decltype(rssss)>, FilteredParts>);
             }
@@ -581,7 +581,6 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
       }
     }
   }
-
 }
 
 TEST_CASE("EmptySliceables")

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -9,8 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+#include "Framework/TableBuilder.h"
+#include "Framework/GroupSlicer.h"
 #include "Framework/ArrowTableSlicingCache.h"
 #include <arrow/util/config.h>
 
@@ -111,7 +112,7 @@ TEST_CASE("GroupSlicerOneAssociated")
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
-  unsigned int count = 0;
+  auto count = 0;
   for (auto& slice : g) {
     auto as = slice.associatedTables();
     auto gg = slice.groupingElement();
@@ -189,7 +190,7 @@ TEST_CASE("GroupSlicerSeveralAssociated")
   s = slices.updateCacheEntry(2, {trkTableZ});
   o2::framework::GroupSlicer g(e, tt, slices);
 
-  unsigned int count = 0;
+  auto count = 0;
   for (auto& slice : g) {
     auto as = slice.associatedTables();
     auto gg = slice.groupingElement();
@@ -250,7 +251,7 @@ TEST_CASE("GroupSlicerMismatchedGroups")
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
-  unsigned int count = 0;
+  auto count = 0;
   for (auto& slice : g) {
     auto as = slice.associatedTables();
     auto gg = slice.groupingElement();
@@ -308,7 +309,7 @@ TEST_CASE("GroupSlicerMismatchedUnassignedGroups")
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
-  unsigned int count = 0;
+  auto count = 0;
   for (auto& slice : g) {
     auto as = slice.associatedTables();
     auto gg = slice.groupingElement();
@@ -358,7 +359,7 @@ TEST_CASE("GroupSlicerMismatchedFilteredGroups")
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
-  unsigned int count = 0;
+  auto count = 0;
 
   for (auto& slice : g) {
     auto as = slice.associatedTables();
@@ -469,6 +470,118 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
     }
     ++count;
   }
+}
+
+namespace o2::aod
+{
+namespace parts
+{
+DECLARE_SOA_INDEX_COLUMN(Event, event);
+DECLARE_SOA_COLUMN(Property, property, int);
+DECLARE_SOA_SELF_SLICE_INDEX_COLUMN(Relatives, relatives);
+}
+DECLARE_SOA_TABLE(Parts, "AOD", "PRTS", soa::Index<>, parts::EventId, parts::Property, parts::RelativesIdSlice);
+
+namespace things
+{
+DECLARE_SOA_INDEX_COLUMN(Event, event);
+DECLARE_SOA_INDEX_COLUMN(Part, part);
+}
+DECLARE_SOA_TABLE(Things, "AOD", "THNGS", soa::Index<>, things::EventId, things::PartId);
+
+}
+
+template <typename... As>
+static void overwriteInternalIndices(std::tuple<As...>& dest, std::tuple<As...> const& src)
+{
+  (std::get<As>(dest).bindInternalIndicesTo(&std::get<As>(src)), ...);
+}
+
+TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
+{
+  TableBuilder builderE;
+  auto evtsWriter = builderE.cursor<aod::Events>();
+  for (auto i = 0; i < 20; ++i) {
+    evtsWriter(0, i, 0.5f * i, 2.f * i, 3.f * i);
+  }
+  auto evtTable = builderE.finalize();
+
+  TableBuilder builderP;
+  auto partsWriter = builderP.cursor<aod::Parts>();
+  int filler[2];
+  std::random_device rd;  // a seed source for the random number engine
+  std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
+  std::uniform_int_distribution<> distrib(0, 99);
+
+  for (auto i = 0; i < 100; ++i) {
+
+    filler[0] = distrib(gen);
+    filler[1] = distrib(gen);
+    if (filler[0] > filler[1]) {
+      std::swap(filler[0], filler[1]);
+    }
+    partsWriter(0,  std::floor(i/10.), i, filler);
+  }
+  auto partsTable = builderP.finalize();
+
+  TableBuilder builderT;
+  auto thingsWriter = builderT.cursor<aod::Things>();
+  for (auto i = 0; i < 10; ++i) {
+    thingsWriter(0, i, distrib(gen));
+  }
+  auto thingsTable = builderT.finalize();
+
+  aod::Events e{evtTable};
+  // aod::Parts p{partsTable};
+  aod::Things t{thingsTable};
+  using FilteredParts = soa::Filtered<aod::Parts>;
+  auto size = distrib(gen);
+  soa::SelectionVector rows;
+  for (auto i = 0; i < size; ++i) {
+    rows.push_back(distrib(gen));
+  }
+  FilteredParts fp{{partsTable}, rows};
+  auto associatedTuple = std::make_tuple(fp, t);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::Parts>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())},
+                                 {soa::getLabelFromType<aod::Things>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s0 = slices.updateCacheEntry(0, partsTable);
+  auto s1 = slices.updateCacheEntry(1, thingsTable);
+  o2::framework::GroupSlicer g(e, associatedTuple, slices);
+
+  overwriteInternalIndices(associatedTuple, associatedTuple);
+
+  // For a grouped case, the recursive access of a slice-self index of a filtered table should have consistent types
+  for (auto& slice : g) {
+    auto as = slice.associatedTables();
+    auto gg = slice.groupingElement();
+    overwriteInternalIndices(as, associatedTuple);
+    auto& ts = std::get<1>(as);
+    ts.bindExternalIndices(&e, &std::get<0>(associatedTuple));
+    for (auto& thing : ts) {
+      if (thing.has_part()) {
+        auto part = thing.part_as<FilteredParts>();
+        REQUIRE(std::is_same_v<std::decay_t<decltype(part)>::parent_t,FilteredParts>);
+        auto rs = part.relatives_as<std::decay_t<decltype(part)::parent_t>>();
+        REQUIRE(std::is_same_v<std::decay_t<decltype(rs)>, FilteredParts>);
+        for (auto& r : rs) {
+          REQUIRE(std::is_same_v<std::decay_t<decltype(r)>::parent_t,FilteredParts>);
+          auto rss = r.relatives_as<std::decay_t<decltype(r)>::parent_t>();
+          REQUIRE(std::is_same_v<std::decay_t<decltype(rss)>, FilteredParts>);
+          for (auto& rr : rss) {
+            REQUIRE(std::is_same_v<std::decay_t<decltype(rr)>::parent_t,FilteredParts>);
+            auto rsss = rr.relatives_as<std::decay_t<decltype(rr)>::parent_t>();
+            REQUIRE(std::is_same_v<std::decay_t<decltype(rsss)>, FilteredParts>);
+            for (auto& rrr : rsss) {
+              REQUIRE(std::is_same_v<std::decay_t<decltype(rrr)>::parent_t,FilteredParts>);
+              auto rssss = rrr.relatives_as<std::decay_t<decltype(rrr)>::parent_t>();
+              REQUIRE(std::is_same_v<std::decay_t<decltype(rssss)>, FilteredParts>);
+            }
+          }
+        }
+      }
+    }
+  }
+
 }
 
 TEST_CASE("EmptySliceables")
@@ -595,7 +708,7 @@ TEST_CASE("ArrowDirectSlicing")
       REQUIRE(arr[2] == 0.3f * (float)rid);
 
       auto d = row.lst();
-      REQUIRE(d.size() == sizes[i]);
+      REQUIRE(d.size() == (size_t)sizes[i]);
       for (auto z = 0u; z < d.size(); ++z) {
         REQUIRE(d[z] == 0.5 * (double)z);
       }


### PR DESCRIPTION
* If the source object is Filtered, the returned slice is also Filtered for recursive following
* The raw iterator preserves correct paren_t if returned from a Filtered object
** DefaultIndexPolicy can be now constructed from FilteredIndexPolicy
** FilteredIndexPolicy holds the total number of unfiltered rows
* Recursive grouped self-index test added