### PR TITLE
[EMCAL-795]: Add protection for TRUs when cheking HW address

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -178,8 +178,10 @@ bool AltroDecoder::checkChannelHWAddress(int hwaddress)
   if (fec > 9) {
     return false;
   }
-  if (!(altro == 0 || altro == 2 || altro == 3 || altro == 4)) {
-    return false;
+  if (fec > 0) { // fec == 0 corresponds to trigger, which only has a fake altro information. Hence it's not checked
+    if (!(altro == 0 || altro == 2 || altro == 3 || altro == 4)) {
+      return false;
+    }
   }
   return true;
 }


### PR DESCRIPTION
- Minor altro errors are observed with the error "CHANNEL_ORDER"
- The altro index for TRUs does not exist and therefore, the altro index is uninitialized
- Hence, no check for the altro index has to be done for TRUs
- TRUs correpond to fec==0 in each branch. The Altro Index check is therefore only performed for fec > 0