### PR TITLE
Fix merging of FT0 time offset container

### DIFF
--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0TimeOffsetSlotContainer.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0TimeOffsetSlotContainer.h
@@ -32,7 +32,7 @@ class FT0TimeOffsetSlotContainer final
   FT0TimeOffsetSlotContainer(std::size_t minEntries); // constructor is needed due to current version of FITCalibration library, should be removed
   FT0TimeOffsetSlotContainer(FT0TimeOffsetSlotContainer const&) = default;
   FT0TimeOffsetSlotContainer(FT0TimeOffsetSlotContainer&&) = default;
-  FT0TimeOffsetSlotContainer& operator=(FT0TimeOffsetSlotContainer const&) = default;
+  FT0TimeOffsetSlotContainer& operator=(FT0TimeOffsetSlotContainer&) = default;
   FT0TimeOffsetSlotContainer& operator=(FT0TimeOffsetSlotContainer&&) = default;
   bool hasEnoughEntries() const;
   void fill(const gsl::span<const float>& data);
@@ -42,6 +42,8 @@ class FT0TimeOffsetSlotContainer final
   TimeSpectraInfoObject generateCalibrationObject(long tsStartMS, long tsEndMS, const std::string& pathToHists) const;
   typedef float FlatHistoValue_t;
   typedef o2::dataformats::FlatHisto2D<FlatHistoValue_t> FlatHisto2D_t;
+  auto getHistogram() const { return mHistogram; }
+  auto isFirstTF() const { return mIsFirstTF; }
 
  private:
   // Slot number

--- a/Detectors/FIT/FT0/calibration/src/FT0TimeOffsetSlotContainer.cxx
+++ b/Detectors/FIT/FT0/calibration/src/FT0TimeOffsetSlotContainer.cxx
@@ -96,6 +96,14 @@ void FT0TimeOffsetSlotContainer::fill(const gsl::span<const float>& data)
 void FT0TimeOffsetSlotContainer::merge(FT0TimeOffsetSlotContainer* prev)
 {
   LOG(info) << "MERGING";
+  if (mIsFirstTF && prev->isFirstTF()) {
+    // nothing to be done
+    return;
+  } else if (mIsFirstTF && !prev->isFirstTF()) {
+    // need to make mHistogram operational first
+    mHistogram.init(prev->getHistogram().getNBinsX(), prev->getHistogram().getXMin(), prev->getHistogram().getXMax(), prev->getHistogram().getNBinsY(), prev->getHistogram().getYMin(), prev->getHistogram().getYMax());
+    mIsFirstTF = false;
+  }
   *this = *prev;
   if (mCurrentSlot == 0) {
     // This part should at the stage `hasEnoughData()` but it is const method


### PR DESCRIPTION
To fix observed crash e.g. on staging run 305 env ID 2m7jPR6Ei3N. Upon merging two slots the calibration crashes in case the histograms have not been initialized before with the error
stderr: what(): trying to copy read-only histogram