### PR TITLE
[EMCAL-565, EMCAL-566]: Differentiate between run type and max time d…

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -82,6 +82,9 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   std::string selectedClassMasks = "C0TVX-B-NOPF-EMC"; ///< name of EMCal min. bias trigger that is used for calibration
   int bcShiftCTP = 0;                                  ///< bc shift of CTP digits to align them with EMC bc in case they are misaligned
   std::string filePathSave = "./emc_calib";            ///< path where calibration histograms are stored at EOR to save them for the next run
+  bool requireSameFill = false;                        ///< if loading calib objects from previous run, require it to be in the same fill as the current one
+  bool requireSameRunType = true;                      ///< if loading calib objects from previous run, require it to be the same run type
+  int tsDiffMax = 48;                                  ///< if loading calib objects from previous run, limit time between the object being stored and loaded again (in hours)
 
   // old parameters. Keep them for a bit (can be deleted after september 5th) as otherwise ccdb and o2 version might not be in synch
   unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration
@@ -91,7 +94,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool enableTestMode = false;                ///< enable test mode for calibration
   float minCellEnergyForTimeCalib = 0.5;      ///< minimum cell energy to enter the time calibration (typical minimum seed energy for clusters), time resolution gets better with rising energy
   unsigned int slotLength = 0;                ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
-  bool UpdateAtEndOfRunOnly = false;          ///< switsch to enable trigger of calibration only at end of run
+  bool UpdateAtEndOfRunOnly = false;          ///< switch to enable trigger of calibration only at end of run
   int minTimeForFit = -300;                   ///< minimum cell time considered for the time calibration in ns
   int maxTimeForFit = 300;                    ///< maximum cell time considered for the time calibration in ns
   int restrictFitRangeToMax = 25;             ///< window around the largest entry within the minTimeForFit in which the fit is performed in ns

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -29,6 +29,7 @@
 #include "EMCALBase/Geometry.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "EMCALCalib/CalibDB.h"
+#include "DataFormatsParameters/GRPECSObject.h"
 
 #include "Framework/Logger.h"
 #include "CommonUtils/MemFileHelper.h"
@@ -100,12 +101,27 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<DataI
 
   bool setGainCalibrationFactors(o2::emcal::GainCalibrationFactors* gainCalibFactors);
 
+  /// \brief Set current fill number
+  /// \param fn fill number
+  void setFillNr(int fn) { mFillNr = fn; }
+
+  /// \brief Set current run type
+  /// \param rt tun type
+  void setRunType(o2::parameters::GRPECSObject::RunType rt) { mRunType = rt; }
+
+  /// \brief Set current timestamp obtained from data
+  /// \param ts timestamp in hours
+  void setCurrTSInHours(int ts) { mStartTSCalib = ts; }
+
  private:
-  int mNBins = 0;          ///< bins of the histogram for passing
-  float mRange = 0.;       ///< range of the histogram for passing
-  bool mTest = false;      ///< flag to be used when running in test mode: it simplify the processing (e.g. does not go through all channels)
-  bool mSaveAtEOR = false; ///< flag to pretend to have enough data in order to trigger the saving of the calib histograms for loading them at the next run
-  bool mLoadAtSOR = false; ///< flag weather to load the calibration histograms from the previous run at the SOR
+  int mNBins = 0;                                                                               ///< bins of the histogram for passing
+  float mRange = 0.;                                                                            ///< range of the histogram for passing
+  bool mTest = false;                                                                           ///< flag to be used when running in test mode: it simplify the processing (e.g. does not go through all channels)
+  bool mSaveAtEOR = false;                                                                      ///< flag to pretend to have enough data in order to trigger the saving of the calib histograms for loading them at the next run
+  bool mLoadAtSOR = false;                                                                      ///< flag weather to load the calibration histograms from the previous run at the SOR
+  o2::parameters::GRPECSObject::RunType mRunType = o2::parameters::GRPECSObject::RunType::NONE; ///< Run type needed if previous calibration is loaded.
+  int mFillNr = 0;                                                                              ///< fill nr. needed if previous calibration is loaded.
+  int mStartTSCalib = -1;                                                                       ///< First timestamp for calibration. Needed to check if calibration data from previous slot should be loaded
   std::shared_ptr<EMCALCalibExtractor> mCalibrator;
 
   // output
@@ -249,6 +265,9 @@ bool EMCALChannelCalibrator<DataInput, DataOutput>::saveLastSlotData(TFile& fl)
   auto& slot = cont.at(0);
   DataInput* c = slot.getContainer();
 
+  // timestamp in hours
+  int timeNow = static_cast<int>(o2::ccdb::getCurrentTimestamp() / o2::ccdb::CcdbObjectInfo::HOUR);
+
   if constexpr (std::is_same<DataInput, o2::emcal::EMCALChannelData>::value) {
     auto hist = c->getHisto();
     auto histTime = c->getHistoTime();
@@ -257,20 +276,36 @@ bool EMCALChannelCalibrator<DataInput, DataOutput>::saveLastSlotData(TFile& fl)
     TH2F hTime = o2::utils::TH2FFromBoost(histTime, "histTime");
     TH1D hNEvents("hNEvents", "hNEvents", 1, 0, 1);
     hNEvents.SetBinContent(1, c->getNEvents());
+    TH1I hGlobalProperties("hGlobalProperties", "hGlobalProperties", 3, -0.5, 2.5);
+    hGlobalProperties.GetXaxis()->SetBinLabel(1, "Fill nr.");
+    hGlobalProperties.GetXaxis()->SetBinLabel(2, "run type");
+    hGlobalProperties.GetXaxis()->SetBinLabel(2, "ts in hours");
+    hGlobalProperties.SetBinContent(1, mFillNr);
+    hGlobalProperties.SetBinContent(2, mRunType);
+    hGlobalProperties.SetBinContent(3, timeNow);
 
     fl.cd();
     hEnergy.Write("EnergyVsCellID");
     hTime.Write("TimeVsCellID");
     hNEvents.Write("NEvents");
+    hGlobalProperties.Write("GlobalProperties");
   } else if constexpr (std::is_same<DataInput, o2::emcal::EMCALTimeCalibData>::value) {
     auto histTime = c->getHisto();
     TH2F hTime = o2::utils::TH2FFromBoost(histTime);
     TH1D hNEvents("hNEvents", "hNEvents", 1, 0, 1);
     hNEvents.SetBinContent(1, c->getNEvents());
+    TH1I hGlobalProperties("hGlobalProperties", "hGlobalProperties", 3, -0.5, 2.5);
+    hGlobalProperties.GetXaxis()->SetBinLabel(1, "Fill nr.");
+    hGlobalProperties.GetXaxis()->SetBinLabel(2, "run type");
+    hGlobalProperties.GetXaxis()->SetBinLabel(2, "ts in hours");
+    hGlobalProperties.SetBinContent(1, mFillNr);
+    hGlobalProperties.SetBinContent(2, mRunType);
+    hGlobalProperties.SetBinContent(3, timeNow);
 
     fl.cd();
     hTime.Write("TimeVsCellID");
     hNEvents.Write("NEvents");
+    hGlobalProperties.Write("GlobalProperties");
   }
 
   return true;
@@ -295,6 +330,31 @@ bool EMCALChannelCalibrator<DataInput, DataOutput>::adoptSavedData(const o2::cal
   }
   auto& slot = cont.at(0);
   DataInput* c = slot.getContainer();
+
+  // check run type and fill
+  TH1I* hGlobalProperties = (TH1I*)fl.Get("GlobalProperties");
+  if (!hGlobalProperties) {
+    LOG(error) << "GlobalProperties histogram not found. Will not load previous calibration histograms";
+  } else {
+    int fillNr = hGlobalProperties->GetBinContent(1);
+    int runType = hGlobalProperties->GetBinContent(2);
+    int tsOld = hGlobalProperties->GetBinContent(3);
+    int tsDiff = (mStartTSCalib > 0 ? mStartTSCalib : static_cast<int>(o2::ccdb::getCurrentTimestamp() / o2::ccdb::CcdbObjectInfo::HOUR)) - tsOld; // get current timestamp if mStartTSCalib is not set
+    LOG(debug) << "tsOld " << tsOld << "   tsNow " << (mStartTSCalib > 0 ? mStartTSCalib : static_cast<int>(o2::ccdb::getCurrentTimestamp() / o2::ccdb::CcdbObjectInfo::HOUR)) << "   tsDiff " << tsDiff;
+
+    if (EMCALCalibParams::Instance().requireSameRunType && runType != static_cast<int>(mRunType)) {
+      LOG(info) << "adoptSavedData: Same run type required but run types differ: " << runType << " != " << static_cast<int>(mRunType);
+      return false;
+    }
+    if (EMCALCalibParams::Instance().requireSameFill && fillNr != mFillNr) {
+      LOG(info) << "adoptSavedData: Same fill nr. required but fills differ: " << fillNr << " != " << mFillNr;
+      return false;
+    }
+    if (EMCALCalibParams::Instance().tsDiffMax > 0 && (EMCALCalibParams::Instance().tsDiffMax < tsDiff || tsDiff < 0)) {
+      LOG(info) << "adoptSavedData: Maximum difference in ts is: " << EMCALCalibParams::Instance().tsDiffMax << " but " << tsDiff << " is given";
+      return false;
+    }
+  }
 
   if constexpr (std::is_same<DataInput, o2::emcal::EMCALChannelData>::value) {
     TH2D* hEnergy = (TH2D*)fl.Get("EnergyVsCellID");


### PR DESCRIPTION
…ifference for loading of calib hists

- Online calibration relies on saving and loading the calibration histograms at the EOR (SOR)
- However, the old objects should not be loaded if the run type (calib, physics etc.) differes, or if the time difference between the old object and the current data taking is too long
- Now, the root file storing the objects is named differently, depending on the run type
- The old timestamp (in hours) is stored in the file itself and then loaded at SOR and compared to the current ts
- The fill Nr is stored in the file and an option is implemented to only load calibration objects if the fill is the same as for the old object
- All parameters are configurable in the Calib Params