### PR TITLE
[FEAT] DPL: use Signposts everywhere in DataProcessingDevice

### DIFF
--- a/Framework/CHANGELOG.md
+++ b/Framework/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2024-03-14: Move DataProcessingDevice to use Signposts
+
+All the messages from DataProcessingDevice have been migrated to use Signpost.
+This will hopefully simplify debugging.
+
 # 2024-02-22: Drop Tracy support
 
 Tracy support never took off, so I am dropping it. This was mostly because people do not know about it and having a per process profile GUI was way unpractical. Moreover, needing an extra compile time flag meant one most likely did not have the support compiled in when needed.

--- a/Framework/Core/COOKBOOK.md
+++ b/Framework/Core/COOKBOOK.md
@@ -524,8 +524,7 @@ Sometimes (e.g. when running a child inside valgrind) it might be useful to disa
 some-workflow --monitoring-backend=no-op://
 ```
 
-notice that the 
-will not function properly if you do so.
+notice that the will not function properly if you do so.
 
 ## Profiling
 

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1584,9 +1584,13 @@ void DataProcessingDevice::doPrepare(ServiceRegistryRef ref)
 void DataProcessingDevice::doRun(ServiceRegistryRef ref)
 {
   auto& context = ref.get<DataProcessorContext>();
+  O2_SIGNPOST_ID_FROM_POINTER(dpid, device, &context);
   auto switchState = [ref](StreamingState newState) {
     auto& state = ref.get<DeviceState>();
-    LOG(detail) << "New state " << (int)newState << " old state " << (int)state.streaming;
+    auto& context = ref.get<DataProcessorContext>();
+    O2_SIGNPOST_ID_FROM_POINTER(dpid, device, &context);
+    O2_SIGNPOST_END(device, dpid, "state", "End of processing state %d", (int)state.streaming);
+    O2_SIGNPOST_START(device, dpid, "state", "Starting processing state %d", (int)newState);
     state.streaming = newState;
     ref.get<ControlService>().notifyStreamingState(state.streaming);
   };
@@ -1625,7 +1629,7 @@ void DataProcessingDevice::doRun(ServiceRegistryRef ref)
   }
 
   if (state.streaming == StreamingState::EndOfStreaming) {
-    LOGP(detail, "We are in EndOfStreaming. Flushing queues.");
+    O2_SIGNPOST_EVENT_EMIT(device, dpid, "state", "We are in EndOfStreaming. Flushing queues.");
     // We keep processing data until we are Idle.
     // FIXME: not sure this is the correct way to drain the queues, but
     // I guess we will see.
@@ -1646,7 +1650,7 @@ void DataProcessingDevice::doRun(ServiceRegistryRef ref)
     context.postEOSCallbacks(eosContext);
 
     for (auto& channel : spec.outputChannels) {
-      LOGP(detail, "Sending end of stream to {}", channel.name);
+      O2_SIGNPOST_EVENT_EMIT(device, dpid, "state", "Sending end of stream to %{public}s.", channel.name.c_str());
       DataProcessingHelpers::sendEndOfStream(ref, channel);
     }
     // This is needed because the transport is deleted before the device.
@@ -1658,7 +1662,7 @@ void DataProcessingDevice::doRun(ServiceRegistryRef ref)
       *context.wasActive = true;
     }
     // On end of stream we shut down all output pollers.
-    LOGP(detail, "Shutting down output pollers");
+    O2_SIGNPOST_EVENT_EMIT(device, dpid, "state", "Shutting down output pollers.");
     for (auto& poller : state.activeOutputPollers) {
       uv_poll_stop(poller);
     }
@@ -1667,7 +1671,7 @@ void DataProcessingDevice::doRun(ServiceRegistryRef ref)
 
   if (state.streaming == StreamingState::Idle) {
     // On end of stream we shut down all output pollers.
-    LOGP(detail, "We are in Idle. Shutting down output pollers.");
+    O2_SIGNPOST_EVENT_EMIT(device, dpid, "state", "Shutting down output pollers.");
     for (auto& poller : state.activeOutputPollers) {
       uv_poll_stop(poller);
     }


### PR DESCRIPTION
[FEAT] DPL: use Signposts everywhere in DataProcessingDevice

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/12868).
* #12723 (3 commits)
* __->__ #12868 (5 commits)