### PR TITLE
DPL: escape arguments with '&' character in CommandInfo

### DIFF
--- a/Framework/Core/src/CommandInfo.cxx
+++ b/Framework/Core/src/CommandInfo.cxx
@@ -27,7 +27,7 @@ CommandInfo::CommandInfo(int argc, char* const* argv)
 
   for (size_t ai = 1; ai < argc; ++ai) {
     const char* arg = argv[ai];
-    if (strpbrk(arg, "\" ;@") != nullptr || arg[0] == 0) {
+    if (strpbrk(arg, "\" ;@&") != nullptr || arg[0] == 0) {
       commandStream << " '" << arg << "'";
     } else if (strpbrk(arg, "'") != nullptr) {
       commandStream << " \"" << arg << "\"";


### PR DESCRIPTION
The specific use are query parameters for apricot URIs in QC, which are delimited by &, such as:
```
o2-qc -b --config 'apricot://apricot-endpoint.cern.ch/components/qc/ANY/any/qc-config?process=true&aaa=333'
```