### PR TITLE
Add new workflow enabling DPL level record file creation for muon alignment

### DIFF
--- a/Detectors/ForwardAlign/CMakeLists.txt
+++ b/Detectors/ForwardAlign/CMakeLists.txt
@@ -47,4 +47,4 @@ o2_add_executable(
         millerecord-writer-workflow
         SOURCES src/MilleRecordWriterSpec.cxx src/millerecord-writer-workflow.cxx
         COMPONENT_NAME fwdalign
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::ReconstructionDataFormats O2::SimulationDataFormat O2::ForwardAlign)        
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::ReconstructionDataFormats O2::SimulationDataFormat O2::ForwardAlign)

--- a/Detectors/ForwardAlign/CMakeLists.txt
+++ b/Detectors/ForwardAlign/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(ForwardAlign
                 src/SymBDMatrix.cxx
                 src/SymMatrix.cxx
                 src/VectorSparse.cxx
+                src/MilleRecordWriterSpec.cxx
         PUBLIC_LINK_LIBRARIES O2::CCDB
                 O2::Steer
                 ROOT::TreePlayer)
@@ -37,4 +38,13 @@ o2_target_root_dictionary(ForwardAlign
                 include/ForwardAlign/SymBDMatrix.h
                 include/ForwardAlign/SymMatrix.h
                 include/ForwardAlign/VectorSparse.h
+                include/ForwardAlign/MilleRecordWriterSpec.h
         LINKDEF src/ForwardAlignLinkDef.h)
+
+
+
+o2_add_executable(
+        millerecord-writer-workflow
+        SOURCES src/MilleRecordWriterSpec.cxx src/millerecord-writer-workflow.cxx
+        COMPONENT_NAME fwdalign
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::ReconstructionDataFormats O2::SimulationDataFormat O2::ForwardAlign)        

--- a/Detectors/ForwardAlign/include/ForwardAlign/MillePede2.h
+++ b/Detectors/ForwardAlign/include/ForwardAlign/MillePede2.h
@@ -156,6 +156,7 @@ class MillePede2
       fNGroupsSet = grID;
     }
   }
+  void ResetRecord() { fRecord->Reset(); }
   void SetNGloPar(const int n) { fNGloPar = n; }
   void SetNLocPar(const int n) { fNLocPar = n; }
   void SetNMaxIterations(const int n = 10) { fMaxIter = n; }
@@ -285,6 +286,9 @@ class MillePede2
     fIsLinear[id] = !v;
   }
 
+  /// \brief Disable record writer for DPL process
+  void DisableRecordWriter() { fDisableRecordWriter = true; }
+
  protected:
   /// \brief read data record (if any) at entry recID
   void ReadRecordData(const long recID, const bool doPrint = false);
@@ -360,6 +364,7 @@ class MillePede2
   long fCurrRecConstrID;      ///< ID of the current constraint record
   bool fLocFitAdd;            ///< Add contribution of carrent track (and not eliminate it)
   bool fUseRecordWeight;      ///< force or ignore the record weight
+  bool fDisableRecordWriter;  ///< disable record writer for DPL process
   int fMinRecordLength;       ///< ignore shorter records
   int fSelFirst;              ///< event selection start
   int fSelLast;               ///< event selection end

--- a/Detectors/ForwardAlign/include/ForwardAlign/MilleRecordWriterSpec.h
+++ b/Detectors/ForwardAlign/include/ForwardAlign/MilleRecordWriterSpec.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MilleRecordWriterSpec.h
+/// \brief Implementation of a data processor to write MillePede record in a root file
+///
+/// \author Chi Zhang, CEA-Saclay, chi.zhang@cern.ch
+
+#ifndef ALICEO2_FWDALIGN_MILLERECORDWRITERSPEC_H
+#define ALICEO2_FWDALIGN_MILLERECORDWRITERSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace fwdalign
+{
+
+framework::DataProcessorSpec getMilleRecordWriterSpec(bool useMC, const char* specName = "fwdalign-millerecord-writer",
+                                                      const char* fileName = "millerecords.root");
+
+} // namespace fwdalign
+} // namespace o2
+
+#endif // ALICEO2_FWDALIGN_MILLERECORDWRITERSPEC_H

--- a/Detectors/ForwardAlign/src/ForwardAlignLinkDef.h
+++ b/Detectors/ForwardAlign/src/ForwardAlignLinkDef.h
@@ -19,6 +19,7 @@
 #pragma link C++ class o2::fwdalign::MatrixSq + ;
 #pragma link C++ class o2::fwdalign::MillePede2 + ;
 #pragma link C++ class o2::fwdalign::MillePedeRecord + ;
+#pragma link C++ class std::vector < o2::fwdalign::MillePedeRecord> + ;
 #pragma link C++ class o2::fwdalign::MilleRecordReader + ;
 #pragma link C++ class o2::fwdalign::MilleRecordWriter + ;
 #pragma link C++ class o2::fwdalign::MinResSolve + ;

--- a/Detectors/ForwardAlign/src/MillePede2.cxx
+++ b/Detectors/ForwardAlign/src/MillePede2.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 /// @file MillePede2.cxx
-
+#include <iostream>
 #include "ForwardAlign/MillePede2.h"
 #include "Framework/Logger.h"
 #include <TStopwatch.h>
@@ -97,6 +97,7 @@ MillePede2::MillePede2()
     fConstraintsRecReader(nullptr)
 {
   fWghScl[0] = fWghScl[1] = -1;
+  fRecord = new o2::fwdalign::MillePedeRecord();
   LOGF(info, "MillePede2 instantiated");
 }
 
@@ -147,7 +148,8 @@ MillePede2::MillePede2(const MillePede2& src)
     fRecordWriter(nullptr),
     fConstraintsRecWriter(nullptr),
     fRecordReader(nullptr),
-    fConstraintsRecReader(nullptr)
+    fConstraintsRecReader(nullptr),
+    fDisableRecordWriter(false)
 {
   fWghScl[0] = src.fWghScl[0];
   fWghScl[1] = src.fWghScl[1];
@@ -314,16 +316,17 @@ void MillePede2::EndChi2Storage()
 void MillePede2::SetLocalEquation(std::vector<double>& dergb, std::vector<double>& derlc,
                                   const double lMeas, const double lSigma)
 {
-  if (!fRecordWriter) {
-    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: null pointer to record writer";
-    return;
+  if (!fDisableRecordWriter) {
+    if (!fRecordWriter) {
+      LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: null pointer to record writer";
+      return;
+    }
+    if (!fRecordWriter->isInitOk()) {
+      LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: unintialised record writer";
+      return;
+    }
+    SetRecord(fRecordWriter->getRecord());
   }
-  if (!fRecordWriter->isInitOk()) {
-    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: unintialised record writer";
-    return;
-  }
-  SetRecord(fRecordWriter->getRecord());
-
   // write data of single measurement
   if (lSigma <= 0.0) { // If parameter is fixed, then no equation
     for (int i = fNLocPar; i--;) {
@@ -336,7 +339,6 @@ void MillePede2::SetLocalEquation(std::vector<double>& dergb, std::vector<double
   }
 
   fRecord->AddResidual(lMeas);
-
   // Retrieve local param interesting indices
   for (int i = 0; i < fNLocPar; i++) {
     if (!IsZero(derlc[i])) {
@@ -364,16 +366,17 @@ void MillePede2::SetLocalEquation(std::vector<int>& indgb, std::vector<double>& 
                                   std::vector<double>& derlc, const int nlc,
                                   const double lMeas, const double lSigma)
 {
-  if (!fRecordWriter) {
-    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: null pointer to record writer";
-    return;
+  if (!fDisableRecordWriter) {
+    if (!fRecordWriter) {
+      LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: null pointer to record writer";
+      return;
+    }
+    if (!fRecordWriter->isInitOk()) {
+      LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: unintialised record writer";
+      return;
+    }
+    SetRecord(fRecordWriter->getRecord());
   }
-  if (!fRecordWriter->isInitOk()) {
-    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: unintialised record writer";
-    return;
-  }
-  SetRecord(fRecordWriter->getRecord());
-
   if (lSigma <= 0.0) { // If parameter is fixed, then no equation
     for (int i = nlc; i--;) {
       derlc[i] = 0.0;

--- a/Detectors/ForwardAlign/src/MillePede2.cxx
+++ b/Detectors/ForwardAlign/src/MillePede2.cxx
@@ -97,7 +97,6 @@ MillePede2::MillePede2()
     fConstraintsRecReader(nullptr)
 {
   fWghScl[0] = fWghScl[1] = -1;
-  fRecord = new o2::fwdalign::MillePedeRecord();
   LOGF(info, "MillePede2 instantiated");
 }
 

--- a/Detectors/ForwardAlign/src/MilleRecordReader.cxx
+++ b/Detectors/ForwardAlign/src/MilleRecordReader.cxx
@@ -25,7 +25,7 @@ MilleRecordReader::MilleRecordReader()
     mIsSuccessfulInit(false),
     mIsConstraintsRec(false),
     mIsReadEntryOk(false),
-    mDataTreeName("milleRecords"),
+    mDataTreeName("o2sim"),
     mDataBranchName("data"),
     mRecord(nullptr),
     mCurrentDataID(-1),

--- a/Detectors/ForwardAlign/src/MilleRecordWriter.cxx
+++ b/Detectors/ForwardAlign/src/MilleRecordWriter.cxx
@@ -29,8 +29,8 @@ MilleRecordWriter::MilleRecordWriter()
     mIsSuccessfulInit(false),
     mIsConstraintsRec(false),
     mNEntriesAutoSave(10000),
-    mDataFileName("mft_mille_records.root"),
-    mDataTreeName("milleRecords"),
+    mDataFileName("millerecords.root"),
+    mDataTreeName("o2sim"),
     mDataBranchName("data"),
     mRecord(nullptr),
     mCurrentDataID(-1)
@@ -135,6 +135,7 @@ void MilleRecordWriter::terminate()
     mDataTree->Write();
     LOG(info) << "MilleRecordWriter::terminate() - wrote tree "
               << mDataTreeName.Data();
+    mDataFile->Close();
   }
 }
 

--- a/Detectors/ForwardAlign/src/MilleRecordWriterSpec.cxx
+++ b/Detectors/ForwardAlign/src/MilleRecordWriterSpec.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MilleRecordWriterSpec.cxx
+/// \brief Implementation of a data processor to write MillePede record in a root file
+///
+/// \author Chi Zhang, CEA-Saclay, chi.zhang@cern.ch
+
+#include "ForwardAlign/MilleRecordWriterSpec.h"
+
+#include <vector>
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "ForwardAlign/MillePedeRecord.h"
+
+namespace o2
+{
+namespace fwdalign
+{
+
+using namespace o2::framework;
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getMilleRecordWriterSpec(bool useMC, const char* specName, const char* fileName)
+{
+  return MakeRootTreeWriterSpec(specName,
+                                fileName,
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MillePede records for MCH-MID tracks"},
+                                BranchDefinition<fwdalign::MillePedeRecord>{InputSpec{"data", "MUON", "RECORD_MCHMID"}, "data"})();
+}
+
+} // namespace fwdalign
+} // namespace o2

--- a/Detectors/ForwardAlign/src/MilleRecordWriterSpec.cxx
+++ b/Detectors/ForwardAlign/src/MilleRecordWriterSpec.cxx
@@ -35,7 +35,7 @@ DataProcessorSpec getMilleRecordWriterSpec(bool useMC, const char* specName, con
   return MakeRootTreeWriterSpec(specName,
                                 fileName,
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MillePede records for MCH-MID tracks"},
-                                BranchDefinition<fwdalign::MillePedeRecord>{InputSpec{"data", "MUON", "RECORD_MCHMID"}, "data"})();
+                                BranchDefinition<fwdalign::MillePedeRecord>{InputSpec{"data", "MUON", "RECORD_MCHMID", Lifetime::Sporadic}, "data"})();
 }
 
 } // namespace fwdalign

--- a/Detectors/ForwardAlign/src/millerecord-writer-workflow.cxx
+++ b/Detectors/ForwardAlign/src/millerecord-writer-workflow.cxx
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file millerecord-writer-workflow.cxx
+/// \brief Implementation of a DPL device to run the MillePede record writer
+///
+/// \author Chi Zhang, CEA-Saclay, chi.zhang@cern.ch
+
+#include "ForwardAlign/MilleRecordWriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FWDALIGN|fwdalign).*[W,w]riter.*"));
+}
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  workflowOptions.emplace_back("disable-mc", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"disable MC propagation even if available"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+{
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  return WorkflowSpec{o2::fwdalign::getMilleRecordWriterSpec(useMC)};
+}

--- a/Detectors/MUON/MCH/Align/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Align/CMakeLists.txt
@@ -53,25 +53,7 @@ o2_add_executable(
         SOURCES src/align-record-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES
-          O2::MathUtils
-          O2::CCDB
-          O2::MCHAlign
-          O2::DataFormatsMCH
-          O2::ForwardAlign
-          O2::MCHTracking
-          O2::GlobalTracking
-          O2::GlobalTrackingWorkflow
-          O2::MCHGeometryTransformer
-          O2::CommonUtils
-          O2::DataFormatsParameters
-          O2::DetectorsBase
-          O2::DetectorsRaw
-          O2::Framework
-          O2::DetectorsRaw
-          O2::Headers
-          O2::ReconstructionDataFormats
-          O2::DetectorsCommonDataFormats
-          Boost::program_options)
+          O2::MCHAlign)
 
 
 

--- a/Detectors/MUON/MCH/Align/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Align/CMakeLists.txt
@@ -13,16 +13,20 @@ o2_add_library(MCHAlign
   SOURCES
     src/Aligner.cxx
     src/AlignmentSpec.cxx
+    src/AlignRecordSpec.cxx
   PUBLIC_LINK_LIBRARIES
     O2::MathUtils
     O2::CCDB
     O2::DataFormatsMCH
     O2::ForwardAlign
     O2::MCHTracking
+    O2::GlobalTracking
+    O2::GlobalTrackingWorkflow
     O2::MCHGeometryTransformer
     O2::CommonUtils
     O2::DataFormatsParameters
     O2::DetectorsBase
+    O2::DetectorsRaw
     O2::Framework
     O2::DetectorsRaw
     O2::Headers
@@ -32,7 +36,8 @@ o2_add_library(MCHAlign
 o2_target_root_dictionary(MCHAlign
   HEADERS
     include/MCHAlign/Aligner.h
-    include/MCHAlign/AlignmentSpec.h)
+    include/MCHAlign/AlignmentSpec.h
+    include/MCHAlign/AlignRecordSpec.h)
 
 o2_add_executable(
         alignment-workflow
@@ -41,6 +46,31 @@ o2_add_executable(
         PUBLIC_LINK_LIBRARIES
           O2::ForwardAlign
           O2::MCHAlign
+          Boost::program_options)
+
+o2_add_executable(
+        align-record-workflow
+        SOURCES src/align-record-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES
+          O2::MathUtils
+          O2::CCDB
+          O2::MCHAlign
+          O2::DataFormatsMCH
+          O2::ForwardAlign
+          O2::MCHTracking
+          O2::GlobalTracking
+          O2::GlobalTrackingWorkflow
+          O2::MCHGeometryTransformer
+          O2::CommonUtils
+          O2::DataFormatsParameters
+          O2::DetectorsBase
+          O2::DetectorsRaw
+          O2::Framework
+          O2::DetectorsRaw
+          O2::Headers
+          O2::ReconstructionDataFormats
+          O2::DetectorsCommonDataFormats
           Boost::program_options)
 
 

--- a/Detectors/MUON/MCH/Align/include/MCHAlign/AlignRecordSpec.h
+++ b/Detectors/MUON/MCH/Align/include/MCHAlign/AlignRecordSpec.h
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AlignRecordSpec.h
+/// \brief Definition of the process for creating alignment record during reconstruction
+///
+/// \author Chi ZHANG, CEA-Saclay, chi.zhang@cern.ch
+
+#ifndef O2_MCH_ALIGNRECORD_H_
+#define O2_MCH_ALIGNRECORD_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+
+using GID = o2::dataformats::GlobalTrackID;
+
+namespace o2
+{
+namespace mch
+{
+
+o2::framework::DataProcessorSpec getAlignRecordSpec(bool useMC, bool disableCCDB = false);
+
+} // end namespace mch
+} // end namespace o2
+
+#endif // O2_MCH_ALIGNRECORD_H_

--- a/Detectors/MUON/MCH/Align/include/MCHAlign/Aligner.h
+++ b/Detectors/MUON/MCH/Align/include/MCHAlign/Aligner.h
@@ -184,9 +184,7 @@ class Aligner : public TObject
     AllSides = SideTop | SideBottom | SideLeft | SideRight
   };
 
-  o2::fwdalign::MillePedeRecord ProcessTrack(Track& track, const o2::mch::geo::TransformationCreator& transformation, Bool_t doAlignment, Double_t weight = 1);
-
-  void ProcessTrack(o2::fwdalign::MillePedeRecord*);
+  void ProcessTrack(Track& track, const o2::mch::geo::TransformationCreator& transformation, Bool_t doAlignment, Double_t weight = 1);
 
   //@name modifiers
   //@{
@@ -301,6 +299,8 @@ class Aligner : public TObject
 
   /// get error on a given parameter
   double GetParError(int iPar) const;
+
+  o2::fwdalign::MillePedeRecord* GetRecord() const { return fTrackRecord; }
 
   void ReAlign(std::vector<o2::detectors::AlignParam>& params, std::vector<double>& misAlignments);
 
@@ -449,7 +449,7 @@ class Aligner : public TObject
   int fDetElemNumber;
 
   /// running Track record
-  o2::fwdalign::MillePedeRecord fTrackRecord;
+  o2::fwdalign::MillePedeRecord* fTrackRecord;
 
   /// Geometry transformation
   o2::mch::geo::TransformationCreator fTransformCreator;

--- a/Detectors/MUON/MCH/Align/include/MCHAlign/Aligner.h
+++ b/Detectors/MUON/MCH/Align/include/MCHAlign/Aligner.h
@@ -110,10 +110,10 @@ class Aligner : public TObject
   ~Aligner() = default;
 
   // initialize
-  void init(TString DataRecFName = "recDataFile.root", TString ConsRecFName = "recConsFile.root");
+  void init(TString DataRecFName = "millerecords.root", TString ConsRecFName = "milleconstraints.root");
 
   // terminate
-  void terminate(void);
+  void terminate();
 
   // array dimendions
   enum {
@@ -184,7 +184,7 @@ class Aligner : public TObject
     AllSides = SideTop | SideBottom | SideLeft | SideRight
   };
 
-  o2::fwdalign::MillePedeRecord* ProcessTrack(Track& track, const o2::mch::geo::TransformationCreator& transformation, Bool_t doAlignment, Double_t weight = 1);
+  o2::fwdalign::MillePedeRecord ProcessTrack(Track& track, const o2::mch::geo::TransformationCreator& transformation, Bool_t doAlignment, Double_t weight = 1);
 
   void ProcessTrack(o2::fwdalign::MillePedeRecord*);
 
@@ -314,6 +314,11 @@ class Aligner : public TObject
   void SetReadOnly()
   {
     mRead = true;
+  }
+
+  void DisableRecordWriter()
+  {
+    fDisableRecordWriter = true;
   }
 
  private:
@@ -451,6 +456,9 @@ class Aligner : public TObject
 
   /// preform evaluation
   bool fDoEvaluation;
+
+  /// disable record saving
+  bool fDisableRecordWriter;
 
   /// original local track params
   LocalTrackParam* fTrackParamOrig;

--- a/Detectors/MUON/MCH/Align/include/MCHAlign/Aligner.h
+++ b/Detectors/MUON/MCH/Align/include/MCHAlign/Aligner.h
@@ -107,7 +107,7 @@ class Aligner : public TObject
  public:
   Aligner();
 
-  ~Aligner() = default;
+  ~Aligner();
 
   // initialize
   void init(TString DataRecFName = "millerecords.root", TString ConsRecFName = "milleconstraints.root");
@@ -300,7 +300,7 @@ class Aligner : public TObject
   /// get error on a given parameter
   double GetParError(int iPar) const;
 
-  o2::fwdalign::MillePedeRecord* GetRecord() const { return fTrackRecord; }
+  o2::fwdalign::MillePedeRecord& GetRecord() { return fTrackRecord; }
 
   void ReAlign(std::vector<o2::detectors::AlignParam>& params, std::vector<double>& misAlignments);
 
@@ -401,9 +401,6 @@ class Aligner : public TObject
   /// Detector independent alignment class
   o2::fwdalign::MillePede2* fMillepede; // AliMillePede2 implementation
 
-  /// MCH cluster class
-  o2::mch::Cluster* fCluster;
-
   /// Number of standard deviations for chi2 cut
   int fNStdDev;
 
@@ -449,7 +446,7 @@ class Aligner : public TObject
   int fDetElemNumber;
 
   /// running Track record
-  o2::fwdalign::MillePedeRecord* fTrackRecord;
+  o2::fwdalign::MillePedeRecord fTrackRecord;
 
   /// Geometry transformation
   o2::mch::geo::TransformationCreator fTransformCreator;
@@ -459,10 +456,6 @@ class Aligner : public TObject
 
   /// disable record saving
   bool fDisableRecordWriter;
-
-  /// original local track params
-  LocalTrackParam* fTrackParamOrig;
-  LocalTrackParam* fTrackParamNew;
 
   LocalTrackClusterResidual* fTrkClRes;
 

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -114,8 +114,9 @@ class AlignRecordTask
     // Configuration for chamber fixing
     auto chambers = ic.options().get<string>("fix-chamber");
     for (int i = 0; i < chambers.length(); ++i) {
-      if (chambers[i] == ',')
+      if (chambers[i] == ',') {
         continue;
+      }
       int chamber = chambers[i] - '0';
       LOG(info) << Form("%s%d", "Fixing chamber: ", chamber);
       mAlign.FixChamber(chamber);
@@ -241,8 +242,9 @@ class AlignRecordTask
         }
       }
 
-      if (worstLocalChi2 < trackFitter.getMaxChi2())
+      if (worstLocalChi2 < trackFitter.getMaxChi2()) {
         break;
+      }
 
       if (!itWorstParam->isRemovable()) {
         removeTrack = true;

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -176,35 +176,27 @@ class AlignRecordTask
       const auto& mchTrack = mchTracks[mchTrackID];
       int first = mchTrack.getFirstClusterIdx();
       int last = mchTrack.getLastClusterIdx();
+      int Ncluster = last - first + 1;
+
+      if (Ncluster < 9) {
+        continue;
+      }
+
       int clIndex = -1;
       mch::Track convertedTrack;
 
       for (int i = first; i <= last; i++) {
         clIndex += 1;
         const auto& cluster = mchClusters[i];
-        mch::Cluster* mch_cluster = new mch::Cluster();
-        mch_cluster->x = cluster.x;
-        mch_cluster->y = cluster.y;
-        mch_cluster->z = cluster.z;
-
-        uint32_t ClUId = mch::Cluster::buildUniqueId(int(cluster.getDEId() / 100) - 1, cluster.getDEId(), clIndex);
-        mch_cluster->uid = ClUId;
-
-        mch_cluster->ex = cluster.ex;
-        mch_cluster->ey = cluster.ey;
-
-        convertedTrack.createParamAtCluster(*mch_cluster);
+        convertedTrack.createParamAtCluster(cluster);
       }
 
-      if (convertedTrack.getNClusters() > 9) {
-        // Erase removable track
-        if (!RemoveTrack(convertedTrack)) {
-          // mRecords.emplace_back(mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
-          pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
-        }
+      // Erase removable track
+      if (!RemoveTrack(convertedTrack)) {
+        mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord);
+        pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, *mAlign.GetRecord());
       }
     }
-    // pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mRecords);
   }
 
  private:

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -181,7 +181,7 @@ class AlignRecordTask
       if (Ncluster <= 9) {
         continue;
       }
-      
+
       mch::Track convertedTrack;
 
       for (int i = first; i <= last; i++) {

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -8,6 +8,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#include <filesystem>
 
 #include "MCHAlign/AlignRecordSpec.h"
 

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -178,7 +178,7 @@ class AlignRecordTask
       int last = mchTrack.getLastClusterIdx();
       int Ncluster = last - first + 1;
 
-      if (Ncluster < 9) {
+      if (Ncluster <= 9) {
         continue;
       }
 

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -181,12 +181,10 @@ class AlignRecordTask
       if (Ncluster <= 9) {
         continue;
       }
-
-      int clIndex = -1;
+      
       mch::Track convertedTrack;
 
       for (int i = first; i <= last; i++) {
-        clIndex += 1;
         const auto& cluster = mchClusters[i];
         convertedTrack.createParamAtCluster(cluster);
       }

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -1,0 +1,358 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHAlign/AlignRecordSpec.h"
+
+#include "DataFormatsMCH/TrackMCH.h"
+#include "DataFormatsMCH/Cluster.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "MathUtils/Utils.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "DetectorsBase/Propagator.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataTypes.h"
+#include "Framework/TableBuilder.h"
+#include "Framework/CCDBParamSpec.h"
+#include "Framework/CallbackService.h"
+#include "Framework/Task.h"
+#include "FT0Base/Geometry.h"
+#include "GlobalTracking/MatchTOF.h"
+#include "ReconstructionDataFormats/Cascade.h"
+#include "GlobalTracking/MatchGlobalFwd.h"
+#include "MCHTracking/TrackExtrap.h"
+#include "MCHTracking/TrackFitter.h"
+#include "MCHTracking/TrackParam.h"
+#include "MCHAlign/Aligner.h"
+#include "ForwardAlign/MillePedeRecord.h"
+#include "DetectorsCommonDataFormats/AlignParam.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsCommonDataFormats/DetectorNameConf.h"
+#include "MCHGeometryTransformer/Transformations.h"
+#include "ReconstructionDataFormats/GlobalFwdTrack.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "ReconstructionDataFormats/StrangeTrack.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/TrackMCHMID.h"
+
+#include <TTree.h>
+#include <TChain.h>
+
+const int fgNCh = 10;
+const int fgNDetElemCh[fgNCh] = {4, 4, 4, 4, 18, 18, 26, 26, 26, 26};
+const int fgSNDetElemCh[fgNCh + 1] = {0, 4, 8, 12, 16, 34, 52, 78, 104, 130, 156};
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+using namespace std;
+using std::cout;
+using std::endl;
+using DataRequest = o2::globaltracking::DataRequest;
+using GID = o2::dataformats::GlobalTrackID;
+
+class AlignRecordTask
+{
+ public:
+  //_________________________________________________________________________________________________
+  AlignRecordTask(std::shared_ptr<DataRequest> dataRequest, std::shared_ptr<base::GRPGeomRequest> ccdbRequest, bool useMC = true)
+    : mDataRequest(dataRequest), mCCDBRequest(ccdbRequest), mUseMC(useMC) {}
+
+  //_________________________________________________________________________________________________
+  void init(framework::InitContext& ic)
+  {
+
+    LOG(info) << "initializing align record maker";
+
+    if (mCCDBRequest) {
+      base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    } else {
+      auto grpFile = ic.options().get<std::string>("grp-file");
+      if (std::filesystem::exists(grpFile)) {
+        const auto grp = parameters::GRPObject::loadFrom(grpFile);
+        base::Propagator::initFieldFromGRP(grp);
+        TrackExtrap::setField();
+        TrackExtrap::useExtrapV2();
+        mAlign.SetBFieldOn(mch::TrackExtrap::isFieldON());
+        trackFitter.smoothTracks(true);
+      } else {
+        LOG(fatal) << "GRP file doesn't exist!";
+      }
+    }
+
+    // Configuration for alignment object
+    mAlign.SetDoEvaluation(false);
+    mAlign.DisableRecordWriter();
+    mAlign.SetAllowedVariation(0, 2.0);
+    mAlign.SetAllowedVariation(1, 0.3);
+    mAlign.SetAllowedVariation(2, 0.002);
+    mAlign.SetAllowedVariation(3, 2.0);
+    trackFitter.useChamberResolution();
+
+    // Configuration for chamber fixing
+    auto chambers = ic.options().get<string>("fix-chamber");
+    for (int i = 0; i < chambers.length(); ++i) {
+      if (chambers[i] == ',')
+        continue;
+      int chamber = chambers[i] - '0';
+      LOG(info) << Form("%s%d", "Fixing chamber: ", chamber);
+      mAlign.FixChamber(chamber);
+    }
+
+    // Init for output saving
+    auto OutputRecFileName = ic.options().get<string>("output-record-data");
+    auto OutputConsFileName = ic.options().get<string>("output-record-constraint");
+    mAlign.init(OutputRecFileName, OutputConsFileName);
+
+    ic.services().get<CallbackService>().set<CallbackService::Id::Stop>([this]() {
+      LOG(info) << "Saving records into ROOT file";
+      mAlign.terminate();
+    });
+  }
+
+  //_________________________________________________________________________________________________
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj)
+  {
+    /// finalize the track extrapolation setting
+    if (mCCDBRequest && base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+      if (matcher == framework::ConcreteDataMatcher("GLO", "GRPMAGFIELD", 0)) {
+        TrackExtrap::setField();
+        TrackExtrap::useExtrapV2();
+        mAlign.SetBFieldOn(mch::TrackExtrap::isFieldON());
+        trackFitter.smoothTracks(true);
+      }
+
+      if (matcher == framework::ConcreteDataMatcher("GLO", "GEOMALIGN", 0)) {
+        LOG(info) << "Loading reference geometry from CCDB";
+        transformation = geo::transformationFromTGeoManager(*gGeoManager);
+        for (int i = 0; i < 156; i++) {
+          int iDEN = GetDetElemId(i);
+          transform[iDEN] = transformation(iDEN);
+        }
+      }
+    }
+  }
+
+  //_________________________________________________________________________________________________
+  void run(framework::ProcessingContext& pc)
+  {
+    if (mCCDBRequest) {
+      base::GRPGeomHelper::instance().checkUpdates(pc);
+    }
+
+    o2::globaltracking::RecoContainer recoData;
+    recoData.collectData(pc, *mDataRequest.get());
+
+    const auto& mchTracks = recoData.getMCHTracks();
+    const auto& mchmidMatches = recoData.getMCHMIDMatches();
+    const auto& mchClusters = recoData.getMCHTrackClusters();
+
+    for (auto const& mchmidMatch : mchmidMatches) {
+
+      int mchTrackID = mchmidMatch.getMCHRef().getIndex();
+      const auto& mchTrack = mchTracks[mchTrackID];
+      int first = mchTrack.getFirstClusterIdx();
+      int last = mchTrack.getLastClusterIdx();
+      int clIndex = -1;
+      mch::Track convertedTrack;
+
+      for (int i = first; i <= last; i++) {
+        clIndex += 1;
+        const auto& cluster = mchClusters[i];
+        mch::Cluster* mch_cluster = new mch::Cluster();
+        mch_cluster->x = cluster.x;
+        mch_cluster->y = cluster.y;
+        mch_cluster->z = cluster.z;
+
+        uint32_t ClUId = mch::Cluster::buildUniqueId(int(cluster.getDEId() / 100) - 1, cluster.getDEId(), clIndex);
+        mch_cluster->uid = ClUId;
+
+        mch_cluster->ex = cluster.ex;
+        mch_cluster->ey = cluster.ey;
+
+        convertedTrack.createParamAtCluster(*mch_cluster);
+      }
+
+      if (convertedTrack.getNClusters() > 9) {
+        // Erase removable track
+        if (!RemoveTrack(convertedTrack)) {
+          //mRecords.emplace_back(mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
+          pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
+        }
+      }
+    }
+    //pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mRecords);
+  }
+
+ private:
+  //_________________________________________________________________________________________________
+  bool RemoveTrack(mch::Track& track)
+  {
+    bool removeTrack = false;
+
+    try {
+      trackFitter.fit(track, false);
+    } catch (exception const& e) {
+      removeTrack = true;
+      return removeTrack;
+    }
+
+    auto itStartingParam = std::prev(track.rend());
+
+    while (true) {
+      try {
+        trackFitter.fit(track, true, false, (itStartingParam == track.rbegin()) ? nullptr : &itStartingParam);
+      } catch (exception const&) {
+        removeTrack = true;
+        break;
+      }
+
+      double worstLocalChi2 = -1.0;
+
+      track.tagRemovableClusters(0x1F, false);
+      auto itWorstParam = track.end();
+
+      for (auto itParam = track.begin(); itParam != track.end(); ++itParam) {
+        if (itParam->getLocalChi2() > worstLocalChi2) {
+          worstLocalChi2 = itParam->getLocalChi2();
+          itWorstParam = itParam;
+        }
+      }
+
+      if (worstLocalChi2 < trackFitter.getMaxChi2())
+        break;
+
+      if (!itWorstParam->isRemovable()) {
+        removeTrack = true;
+        track.removable();
+        break;
+      }
+
+      auto itNextParam = track.removeParamAtCluster(itWorstParam);
+      auto itNextToNextParam = (itNextParam == track.end()) ? itNextParam : std::next(itNextParam);
+      itStartingParam = track.rbegin();
+
+      if (track.getNClusters() < 10) {
+        removeTrack = true;
+        break;
+      } else {
+        while (itNextToNextParam != track.end()) {
+          if (itNextToNextParam->getClusterPtr()->getChamberId() != itNextParam->getClusterPtr()->getChamberId()) {
+            itStartingParam = std::make_reverse_iterator(++itNextParam);
+            break;
+          }
+          ++itNextToNextParam;
+        }
+      }
+    }
+
+    if (!removeTrack) {
+      for (auto& param : track) {
+        param.setParameters(param.getSmoothParameters());
+        param.setCovariances(param.getSmoothCovariances());
+      }
+    }
+
+    return removeTrack;
+  }
+
+  //_________________________________________________________________________________________________
+  Int_t GetDetElemId(Int_t iDetElemNumber)
+  {
+    // make sure detector number is valid
+    if (!(iDetElemNumber >= fgSNDetElemCh[0] &&
+          iDetElemNumber < fgSNDetElemCh[fgNCh])) {
+      LOG(fatal) << "Invalid detector element number: " << iDetElemNumber;
+    }
+    /// get det element number from ID
+    // get chamber and element number in chamber
+    int iCh = 0;
+    int iDet = 0;
+    for (int i = 1; i <= fgNCh; i++) {
+      if (iDetElemNumber < fgSNDetElemCh[i]) {
+        iCh = i;
+        iDet = iDetElemNumber - fgSNDetElemCh[i - 1];
+        break;
+      }
+    }
+
+    // make sure detector index is valid
+    if (!(iCh > 0 && iCh <= fgNCh && iDet < fgNDetElemCh[iCh - 1])) {
+      LOG(fatal) << "Invalid detector element id: " << 100 * iCh + iDet;
+    }
+
+    // add number of detectors up to this chamber
+    return 100 * iCh + iDet;
+  }
+
+  std::shared_ptr<base::GRPGeomRequest> mCCDBRequest; ///< pointer to the CCDB requests
+  std::shared_ptr<DataRequest> mDataRequest;
+  GID::mask_t mInputSources;
+  bool mUseMC = true;
+  parameters::GRPMagField* grpmag;
+  TGeoManager* geo;
+
+  mch::TrackFitter trackFitter;
+  mch::Aligner mAlign{};
+  Double_t weightRecord{1.0};
+  std::vector<o2::fwdalign::MillePedeRecord> mRecords;
+
+  map<int, math_utils::Transform3D> transform;
+  mch::geo::TransformationCreator transformation;
+};
+
+//_________________________________________________________________________________________________
+o2::framework::DataProcessorSpec getAlignRecordSpec(bool useMC, bool disableCCDB)
+{
+  auto dataRequest = std::make_shared<DataRequest>();
+  o2::dataformats::GlobalTrackID::mask_t src = o2::dataformats::GlobalTrackID::getSourcesMask("MCH-MID");
+  dataRequest->requestMCHClusters(false);
+  dataRequest->requestTracks(src, useMC);
+
+  vector<OutputSpec> outputSpecs{};
+  auto ccdbRequest = disableCCDB ? nullptr : std::make_shared<base::GRPGeomRequest>(false,                         // orbitResetTime
+                                                                                    false,                         // GRPECS=true
+                                                                                    false,                         // GRPLHCIF
+                                                                                    true,                          // GRPMagField
+                                                                                    false,                         // askMatLUT
+                                                                                    base::GRPGeomRequest::Aligned, // geometry
+                                                                                    dataRequest->inputs,
+                                                                                    true); // query only once all objects except mag.field
+
+  outputSpecs.emplace_back("MUON", "RECORD_MCHMID", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "mch-align-record",
+    dataRequest->inputs,
+    outputSpecs,
+    AlgorithmSpec{adaptFromTask<AlignRecordTask>(dataRequest, ccdbRequest, useMC)},
+    Options{{"geo-file", VariantType::String, o2::base::NameConf::getAlignedGeomFileName(), {"Name of the reference geometry file"}},
+            {"grp-file", VariantType::String, o2::base::NameConf::getGRPFileName(), {"Name of the grp file"}},
+            {"fix-chamber", VariantType::String, "", {"Chamber fixing, ex 1,2,3"}},
+            {"output-record-data", VariantType::String, "recDataFile.root", {"Option for name of output record file for data"}},
+            {"output-record-constraint", VariantType::String, "recConsFile.root", {"Option for name of output record file for constraint"}}}};
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -197,12 +197,12 @@ class AlignRecordTask
       if (convertedTrack.getNClusters() > 9) {
         // Erase removable track
         if (!RemoveTrack(convertedTrack)) {
-          //mRecords.emplace_back(mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
+          // mRecords.emplace_back(mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
           pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mAlign.ProcessTrack(convertedTrack, transformation, false, weightRecord));
         }
       }
     }
-    //pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mRecords);
+    // pc.outputs().snapshot(Output{"MUON", "RECORD_MCHMID", 0}, mRecords);
   }
 
  private:

--- a/Detectors/MUON/MCH/Align/src/Aligner.cxx
+++ b/Detectors/MUON/MCH/Align/src/Aligner.cxx
@@ -132,14 +132,13 @@ Aligner::Aligner()
     fStartFac(65536),
     fResCutInitial(1000),
     fResCut(100),
-    fMillepede(nullptr), // to be modified
-    fCluster(nullptr),
+    fMillepede(nullptr),
     fNStdDev(3),
     fDetElemNumber(0),
     fGlobalParameterStatus(std::vector<int>(fNGlobal)),
     fGlobalDerivatives(std::vector<double>(fNGlobal)),
     fLocalDerivatives(std::vector<double>(fNLocal)),
-    fTrackRecord(nullptr),
+    fTrackRecord(),
     mNEntriesAutoSave(10000),
     mRecordWriter(new o2::fwdalign::MilleRecordWriter()),
     mWithConstraintsRecWriter(false),
@@ -148,12 +147,9 @@ Aligner::Aligner()
     mWithConstraintsRecReader(false),
     mConstraintsRecReader(nullptr),
     fTransformCreator(),
-    // fGeoCombiTransInverse(),
     fDoEvaluation(false),
     fDisableRecordWriter(false),
     mRead(false),
-    fTrackParamOrig(nullptr),
-    fTrackParamNew(nullptr),
     fTrkClRes(nullptr),
     fTFile(nullptr),
     fTTree(nullptr)
@@ -171,9 +167,6 @@ Aligner::Aligner()
   // initialize millepede
   fMillepede = new o2::fwdalign::MillePede2();
 
-  // initialize millepede record
-  fTrackRecord = new o2::fwdalign::MillePedeRecord();
-
   // initialize degrees of freedom
   // by default all parameters are free
   for (int iPar = 0; iPar < fNGlobal; ++iPar) {
@@ -188,6 +181,14 @@ Aligner::Aligner()
   for (int i = 0; i < fNGlobal; ++i) {
     fGlobalDerivatives[i] = 0.0;
   }
+}
+
+//________________________________________________________________________
+Aligner::~Aligner()
+{
+  delete mRecordWriter;
+  delete mRecordReader;
+  delete fMillepede;
 }
 
 //_____________________________________________________________________
@@ -216,7 +217,7 @@ void Aligner::init(TString DataRecFName, TString ConsRecFName)
         fMillepede->SetConstraintsRecWriter(mConstraintsRecWriter);
       }
     } else {
-      fMillepede->SetRecord(fTrackRecord);
+      fMillepede->SetRecord(&fTrackRecord);
     }
 
   } else {
@@ -327,12 +328,6 @@ void Aligner::init(TString DataRecFName, TString ConsRecFName)
     const int kSplitlevel = 98;
     const int kBufsize = 32000;
 
-    // fTrackParamOrig = new LocalTrackParam();
-    // fTTree->Branch("fTrackParamOrig", "LocalTrackParam", &fTrackParamOrig, kBufsize, kSplitlevel);
-
-    // fTrackParamNew = new LocalTrackParam();
-    // fTTree->Branch("fTrackParamNew", "LocalTrackParam", &fTrackParamNew, kBufsize, kSplitlevel);
-
     fTrkClRes = new o2::mch::LocalTrackClusterResidual();
     fTTree->Branch("fClDetElem", &(fTrkClRes->fClDetElem), "fClDetElem/I");
     fTTree->Branch("fClDetElemNumber", &(fTrkClRes->fClDetElemNumber), "fClDetElemNumber/I");
@@ -372,10 +367,6 @@ void Aligner::terminate()
       fTFile->Close();
     }
   }
-  delete mRecordWriter;
-  delete mRecordReader;
-  delete fMillepede;
-  delete fTrackRecord;
 }
 
 //_____________________________________________________

--- a/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
@@ -212,6 +212,7 @@ class AlignmentTask
     mAlign.SetAllowedVariation(2, 0.002);
     mAlign.SetAllowedVariation(3, 2.0);
     trackFitter.smoothTracks(true);
+    trackFitter.useChamberResolution();
 
     // Fix chambers
     auto chambers = ic.options().get<string>("fix-chamber");

--- a/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
@@ -88,15 +88,6 @@ using namespace o2;
 class AlignmentTask
 {
  public:
-  double Reso_X{0.4};
-  double Reso_Y{0.4};
-  double ImproveCut{6.0};
-
-  int tracksGood = 0;
-  int tracksGoodwithoutFit = 0;
-  int tracksAll = 0;
-  int trackMCHMID = 0;
-
   const int fgNDetElemCh[10] = {4, 4, 4, 4, 18, 18, 26, 26, 26, 26};
   const int fgSNDetElemCh[11] = {0, 4, 8, 12, 16, 34, 52, 78, 104, 130, 156};
   const int fgNDetElemHalfCh[20] = {2, 2, 2, 2, 2, 2, 2, 2, 9,
@@ -170,22 +161,6 @@ class AlignmentTask
       LOG(info) << "Re-alignment mode";
     }
 
-    auto param_config = ic.options().get<string>("fitter-config");
-    if (param_config == "PbPb") {
-      Reso_X = 0.2;
-      Reso_Y = 0.2;
-      ImproveCut = 4.0;
-      LOG(info) << "Using PbPb parameter set for TrackFitter";
-    } else if (param_config == "pp") {
-      Reso_X = 0.4;
-      Reso_Y = 0.4;
-      ImproveCut = 6.0;
-      LOG(info) << "Using pp parameter set for TrackFitter";
-    } else {
-      LOG(fatal) << "Please enter a correct parameter configuration option";
-      exit(-1);
-    }
-
     if (mCCDBRequest) {
       LOG(info) << "Loading magnetic field and reference geometry from CCDB";
       base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
@@ -229,16 +204,14 @@ class AlignmentTask
       }
     }
 
-    trackFitter.smoothTracks(true);
-    trackFitter.setChamberResolution(Reso_X, Reso_Y);
-    trackFitter.useChamberResolution();
-
-    mAlign.SetDoEvaluation(true);
+    auto doEvaluation = ic.options().get<bool>("do-evaluation");
+    mAlign.SetDoEvaluation(doEvaluation);
     // Variation range for parameters
     mAlign.SetAllowedVariation(0, 2.0);
     mAlign.SetAllowedVariation(1, 0.3);
     mAlign.SetAllowedVariation(2, 0.002);
     mAlign.SetAllowedVariation(3, 2.0);
+    trackFitter.smoothTracks(true);
 
     // Fix chambers
     auto chambers = ic.options().get<string>("fix-chamber");
@@ -298,12 +271,10 @@ class AlignmentTask
 
       for (int iMCHTrack = mchROF.getFirstIdx();
            iMCHTrack <= mchROF.getLastIdx(); ++iMCHTrack) {
-        tracksAll += 1;
         // MCH-MID matching
         if (!FindMuon(iMCHTrack, muonTracks)) {
           continue;
         }
-        trackMCHMID += 1;
 
         auto mchTrack = mchTracks.at(iMCHTrack);
         int id_track = iMCHTrack;
@@ -313,21 +284,17 @@ class AlignmentTask
         if (nb_clusters <= 9) {
           continue;
         }
-        tracksGoodwithoutFit += 1;
 
         // Format conversion from TrackMCH to Track(MCH internal use)
         mch::Track convertedTrack = MCHFormatConvert(mchTrack, mchClusters, doReAlign);
 
         // Erase removable track
-        if (RemoveTrack(convertedTrack, ImproveCut)) {
+        if (RemoveTrack(convertedTrack)) {
           continue;
-        } else {
-          tracksGood += 1;
         }
 
         //  Track processing, saving residuals
-        o2::fwdalign::MillePedeRecord* mchRecord = mAlign.ProcessTrack(convertedTrack, transformation,
-                                                                       doAlign, weightRecord);
+        mAlign.ProcessTrack(convertedTrack, transformation, doAlign, weightRecord);
       }
     }
   }
@@ -345,27 +312,22 @@ class AlignmentTask
         auto mchTrack = mchTracks.at(iMCHTrack);
         int id_track = iMCHTrack;
         int nb_clusters = mchTrack.getNClusters();
-        tracksAll += 1;
 
         // Track selection, saving only tracks having exactly 10 clusters
         if (nb_clusters <= 9) {
           continue;
         }
-        tracksGoodwithoutFit += 1;
 
         // Format conversion from TrackMCH to Track(MCH internal use)
         Track convertedTrack = MCHFormatConvert(mchTrack, mchClusters, doReAlign);
 
         // Erase removable track
-        if (RemoveTrack(convertedTrack, ImproveCut)) {
+        if (RemoveTrack(convertedTrack)) {
           continue;
-        } else {
-          tracksGood += 1;
         }
 
         //  Track processing, saving residuals
-        o2::fwdalign::MillePedeRecord* mchRecord = mAlign.ProcessTrack(convertedTrack, transformation,
-                                                                       doAlign, weightRecord);
+        mAlign.ProcessTrack(convertedTrack, transformation, doAlign, weightRecord);
       }
     }
   }
@@ -445,14 +407,6 @@ class AlignmentTask
     }
     auto tEnd = std::chrono::high_resolution_clock::now();
     mElapsedTime = tEnd - tStart;
-    // Evaluation for track removing and selection
-    LOG(info) << Form("%s%d", "Number of good tracks used in alignment process: ", tracksGood);
-    LOG(info) << Form("%s%d", "Number of good tracks without fit processing: ", tracksGoodwithoutFit);
-    LOG(info) << Form("%s%d", "Number of MCH-MID tracks: ", trackMCHMID);
-    LOG(info) << Form("%s%d", "Total number of tracks loaded: ", tracksAll);
-    LOG(info) << Form("%s%f", "Ratio of MCH-MID track: ", double(trackMCHMID) / tracksAll);
-    LOG(info) << Form("%s%f", "Ratio before fit: ", double(tracksGoodwithoutFit) / tracksAll);
-    LOG(info) << Form("%s%f", "Ratio after fit: ", double(tracksGood) / tracksAll);
 
     // Generate new geometry w.r.t alignment results
     if (doAlign) {
@@ -573,10 +527,9 @@ class AlignmentTask
   }
 
   //_________________________________________________________________________________________________
-  bool RemoveTrack(Track& track, double ImproveCut)
+  bool RemoveTrack(Track& track)
   {
 
-    double maxChi2Cluster = 2 * ImproveCut * ImproveCut;
     bool removeTrack = false;
 
     try {
@@ -610,7 +563,7 @@ class AlignmentTask
         }
       }
 
-      if (worstLocalChi2 < maxChi2Cluster) {
+      if (worstLocalChi2 < trackFitter.getMaxChi2()) {
         break;
       }
 
@@ -933,8 +886,8 @@ o2::framework::DataProcessorSpec getAlignmentSpec(bool disableCCDB)
     Options{{"geo-file-ref", VariantType::String, o2::base::NameConf::getAlignedGeomFileName(), {"Name of the reference geometry file"}},
             {"geo-file-ideal", VariantType::String, o2::base::NameConf::getGeomFileName(), {"Name of the ideal geometry file"}},
             {"grp-file", VariantType::String, o2::base::NameConf::getGRPFileName(), {"Name of the grp file"}},
-            {"fitter-config", VariantType::String, "", {"Option of parameter set for TrackFitter, pp or PbPb"}},
             {"do-align", VariantType::Bool, false, {"Switch for alignment, otherwise only residuals will be stored"}},
+            {"do-evaluation", VariantType::Bool, false, {"Option for saving residuals for evaluation"}},
             {"do-realign", VariantType::Bool, false, {"Switch for re-alignment using another geometry"}},
             {"matched", VariantType::Bool, false, {"Switch for using MCH-MID matched tracks"}},
             {"fix-chamber", VariantType::String, "", {"Chamber fixing, ex 1,2,3"}},

--- a/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
@@ -74,6 +74,7 @@
 #include "MCHTracking/TrackExtrap.h"
 #include "MCHTracking/TrackParam.h"
 #include "MCHTracking/TrackFitter.h"
+#include "MCHBase/TrackerParam.h"
 #include "ReconstructionDataFormats/TrackMCHMID.h"
 
 namespace o2
@@ -211,8 +212,14 @@ class AlignmentTask
     mAlign.SetAllowedVariation(1, 0.3);
     mAlign.SetAllowedVariation(2, 0.002);
     mAlign.SetAllowedVariation(3, 2.0);
+
+    // Configuration for track fitter
+    const auto& trackerParam = TrackerParam::Instance();
+    trackFitter.setBendingVertexDispersion(trackerParam.bendingVertexDispersion);
+    trackFitter.setChamberResolution(trackerParam.chamberResolutionX, trackerParam.chamberResolutionY);
     trackFitter.smoothTracks(true);
     trackFitter.useChamberResolution();
+    mImproveCutChi2 = trackerParam.sigmaCutForImprovement;
 
     // Fix chambers
     auto chambers = ic.options().get<string>("fix-chamber");
@@ -564,7 +571,7 @@ class AlignmentTask
         }
       }
 
-      if (worstLocalChi2 < trackFitter.getMaxChi2()) {
+      if (worstLocalChi2 < mImproveCutChi2) {
         break;
       }
 
@@ -859,6 +866,7 @@ class AlignmentTask
 
   geo::TransformationCreator transformation{};
   TrackFitter trackFitter{};
+  double mImproveCutChi2{};
 
   std::chrono::duration<double> mElapsedTime{};
 };

--- a/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
@@ -219,7 +219,7 @@ class AlignmentTask
     trackFitter.setChamberResolution(trackerParam.chamberResolutionX, trackerParam.chamberResolutionY);
     trackFitter.smoothTracks(true);
     trackFitter.useChamberResolution();
-    mImproveCutChi2 = trackerParam.sigmaCutForImprovement;
+    mImproveCutChi2 = 2. * trackerParam.sigmaCutForImprovement * trackerParam.sigmaCutForImprovement;
 
     // Fix chambers
     auto chambers = ic.options().get<string>("fix-chamber");

--- a/Detectors/MUON/MCH/Align/src/align-record-workflow.cxx
+++ b/Detectors/MUON/MCH/Align/src/align-record-workflow.cxx
@@ -1,0 +1,76 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file align-record-workflow.cxx
+/// \brief Implementation of a DPL device to create MillePede record for muon alignment
+///
+/// \author Chi ZHANG, CEA-Saclay, chi.zhang@cern.ch
+
+#include "MCHAlign/AlignRecordSpec.h"
+
+#include "Framework/CompletionPolicy.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/CallbacksPolicy.h"
+#include "ForwardAlign/MilleRecordWriterSpec.h"
+
+using namespace o2::framework;
+using namespace std;
+
+using GID = o2::dataformats::GlobalTrackID;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
+    {"disable-ccdb", VariantType::Bool, false, {"disable input files from CCDB"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  o2::conf::ConfigurableParam::writeINI("o2mchalignrecord-workflow_configuration.ini");
+
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  bool disableCCDB = configcontext.options().get<bool>("disable-ccdb");
+  bool disableRootOutput = configcontext.options().get<bool>("disable-root-output");
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::mch::getAlignRecordSpec(useMC, disableCCDB));
+  auto srcTracks = GID::getSourcesMask("MCH");
+  auto srcClusters = GID::getSourcesMask("MCH");
+  auto matchMask = GID::getSourcesMask("MCH-MID");
+
+  if (!disableRootOutput) {
+    specs.emplace_back(o2::fwdalign::getMilleRecordWriterSpec(useMC));
+  }
+
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcClusters, matchMask, srcTracks, useMC, srcClusters, srcTracks);
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}


### PR DESCRIPTION
This is a proposal of having a DPL-level task for creating `MillePede2` record file to be used by muon alignment. Some adaptations have been made as well in `Detectors/ForwardAlign/` especially to disable the internal record writer of aligner class. Ideally this workflow should be placed right after matching of `MCH-MID`, tests have been done locally with minimum modifications in `async_pass.sh` fetched from O2DPG.