### PR TITLE
[EMCAL-1112] CCDB object for EMCAL pedestal calibration

### DIFF
--- a/Detectors/EMCAL/calib/CMakeLists.txt
+++ b/Detectors/EMCAL/calib/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(EMCALCalib
         src/TempCalibrationParams.cxx
         src/TempCalibParamSM.cxx
         src/GainCalibrationFactors.cxx
+        src/Pedestal.cxx
         src/TriggerTRUDCS.cxx
         src/TriggerSTUDCS.cxx
         src/TriggerSTUErrorCounter.cxx
@@ -37,6 +38,7 @@ o2_target_root_dictionary(EMCALCalib
         include/EMCALCalib/TempCalibrationParams.h
         include/EMCALCalib/TempCalibParamSM.h
         include/EMCALCalib/GainCalibrationFactors.h
+        include/EMCALCalib/Pedestal.h
         include/EMCALCalib/TriggerTRUDCS.h
         include/EMCALCalib/TriggerSTUDCS.h
         include/EMCALCalib/TriggerSTUErrorCounter.h
@@ -85,6 +87,13 @@ o2_add_test(TempCalibParamSM
 
 o2_add_test(GainCalibrationFactors
         SOURCES test/testGainCalibration.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+
+o2_add_test(Pedestal
+        SOURCES test/testPedestal.cxx
         PUBLIC_LINK_LIBRARIES O2::EMCALCalib
         COMPONENT_NAME emcal
         LABELS emcal

--- a/Detectors/EMCAL/calib/include/EMCALCalib/Pedestal.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/Pedestal.h
@@ -1,0 +1,94 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_PEDESTAL_H
+#define ALICEO2_EMCAL_PEDESTAL_H
+
+#include <iosfwd>
+#include <array>
+#include <Rtypes.h>
+
+class TH1;
+class TH2;
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class Pedestal
+/// \brief CCDB container for pedestal values
+/// \ingroup EMCALcalib
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since July 16th, 2019
+///
+/// Pedestal values can be added for each channel by
+/// ~~~.{cxx}
+/// o2::emcal::Pedestal ped;
+/// ped.addPedestalValue(23, 3, false);
+/// ~~~
+/// For the High Gain cells the last parameter should be set to false, for low
+/// gain it should be set to true.
+///
+/// One can read the pedestal values by calling
+/// ~~~.{cxx}
+/// auto param = ped.getPedestalValue(23, false);
+/// ~~~
+/// This will return the pedestal value for a certain HG cell.
+/// For low gain cells you have to set the last parameter false
+class Pedestal
+{
+ public:
+  /// \brief Constructor
+  Pedestal() = default;
+
+  /// \brief Destructor
+  ~Pedestal() = default;
+
+  /// \brief Comparison of two pedestal containers
+  /// \return true if the two list of pedestal values are the same, false otherwise
+  bool operator==(const Pedestal& other) const;
+
+  /// \brief Add pedestal to the container
+  /// \param cellID Absolute ID of cell
+  /// \param isLowGain Cell type is low gain cell
+  /// \param pedestal Pedestal value
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
+  void addPedestalValue(unsigned short cellID, short pedestal, bool isLowGain);
+
+  /// \brief Get the time calibration coefficient for a certain cell
+  /// \param cellID Absolute ID of cell
+  /// \param isLowGain Cell type is low gain cell
+  /// \return Pedestal value of the cell
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
+  short getPedestalValue(unsigned short cellID, bool isLowGain) const;
+
+  /// \brief Convert the pedestal container to a histogram
+  /// \param isLowGain Monitor low gain cells
+  /// \return Histogram representation of the pedestal container
+  TH1* getHistogramRepresentation(bool isLowGain) const;
+
+  /// \brief Convert the pedestal container to a 2D histogram
+  /// \param isLowGain Monitor low gain cells
+  /// \return 2D Histogram representation (heatmap with respect to column and row) of the pedestal container
+  TH2* getHistogramRepresentation2D(bool isLowGain) const;
+
+ private:
+  std::array<short, 17664> mPedestalValuesHG; ///< Container for the pedestal values (high gain)
+  std::array<short, 17664> mPedestalValuesLG; ///< Container for the pedestal values (low gain)
+
+  ClassDefNV(Pedestal, 1);
+};
+
+} // namespace emcal
+
+} // namespace o2
+#endif

--- a/Detectors/EMCAL/calib/src/EMCALCalibLinkDef.h
+++ b/Detectors/EMCAL/calib/src/EMCALCalibLinkDef.h
@@ -23,6 +23,7 @@
 #pragma link C++ class o2::emcal::TempCalibrationParams + ;
 #pragma link C++ class o2::emcal::TempCalibParamSM + ;
 #pragma link C++ class o2::emcal::GainCalibrationFactors + ;
+#pragma link C++ class o2::emcal::Pedestal + ;
 #pragma link C++ class o2::emcal::TriggerTRUDCS + ;
 #pragma link C++ class o2::emcal::TriggerSTUDCS + ;
 #pragma link C++ class o2::emcal::TriggerSTUErrorCounter + ;

--- a/Detectors/EMCAL/calib/src/Pedestal.cxx
+++ b/Detectors/EMCAL/calib/src/Pedestal.cxx
@@ -1,0 +1,106 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALBase/Geometry.h"
+#include "EMCALCalib/CalibContainerErrors.h"
+#include "EMCALCalib/Pedestal.h"
+
+#include <fairlogger/Logger.h>
+
+#include <TH1.h>
+#include <TH2.h>
+
+#include <iostream>
+
+#include <gsl/span>
+
+using namespace o2::emcal;
+
+void Pedestal::addPedestalValue(unsigned short cellID, short pedestal, bool isLowGain)
+{
+  if (cellID >= mPedestalValuesHG.size()) {
+    throw CalibContainerIndexException(cellID);
+  }
+  if (isLowGain) {
+    mPedestalValuesLG[cellID] = pedestal;
+  } else {
+    mPedestalValuesHG[cellID] = pedestal;
+  }
+}
+
+short Pedestal::getPedestalValue(unsigned short cellID, bool isLowGain) const
+{
+  if (cellID >= mPedestalValuesHG.size()) {
+    throw CalibContainerIndexException(cellID);
+  }
+  if (isLowGain) {
+    return mPedestalValuesLG[cellID];
+  } else {
+    return mPedestalValuesHG[cellID];
+  }
+}
+
+TH1* Pedestal::getHistogramRepresentation(bool isLowGain) const
+{
+  gsl::span<const short> data;
+  std::string histname, histtitle;
+  if (isLowGain) {
+    histname = "PedestalLG";
+    histtitle = "Pedestal values Params low Gain";
+    data = gsl::span<const short>(mPedestalValuesLG);
+  } else {
+    histname = "PedestalHG";
+    histtitle = "Pedestal values Params high Gain";
+    data = gsl::span<const short>(mPedestalValuesHG);
+  }
+
+  auto hist = new TH1S(histname.data(), histtitle.data(), data.size(), -0.5, data.size() - 0.5);
+  hist->SetDirectory(nullptr);
+  for (std::size_t icell{0}; icell < data.size(); ++icell) {
+    hist->SetBinContent(icell + 1, data[icell]);
+  }
+  return hist;
+}
+
+TH2* Pedestal::getHistogramRepresentation2D(bool isLowGain) const
+{
+  gsl::span<const short> data;
+  std::string histname, histtitle;
+  if (isLowGain) {
+    histname = "PedestalDistLG";
+    histtitle = "Pedestal values Params low Gain";
+    data = gsl::span<const short>(mPedestalValuesLG);
+  } else {
+    histname = "PedestalDistHG";
+    histtitle = "Pedestal values Params high Gain";
+    data = gsl::span<const short>(mPedestalValuesHG);
+  }
+
+  const int MAXROWS = 208,
+            MAXCOLS = 96;
+  auto hist = new TH2S(histname.data(), histtitle.data(), MAXCOLS, -0.5, double(MAXCOLS) - 0.5, MAXROWS, -0.5, double(MAXROWS) - 0.5);
+  hist->SetDirectory(nullptr);
+  try {
+    auto geo = Geometry::GetInstance();
+    for (size_t cellID = 0; cellID < data.size(); cellID++) {
+      auto position = geo->GlobalRowColFromIndex(cellID);
+      hist->Fill(std::get<1>(position), std::get<0>(position), data[cellID]);
+    }
+  } catch (o2::emcal::GeometryNotInitializedException& e) {
+    LOG(error) << "Geometry needs to be initialized";
+  }
+  return hist;
+}
+
+bool Pedestal::operator==(const Pedestal& other) const
+{
+  return mPedestalValuesHG == other.mPedestalValuesHG && mPedestalValuesLG == other.mPedestalValuesLG;
+}

--- a/Detectors/EMCAL/calib/test/testPedestal.cxx
+++ b/Detectors/EMCAL/calib/test/testPedestal.cxx
@@ -1,0 +1,112 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test_EMCAL_Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <random>
+#include "EMCALCalib/CalibContainerErrors.h"
+#include "EMCALCalib/Pedestal.h"
+
+/// \brief Standard tests for Pedestal container
+
+namespace o2
+{
+namespace emcal
+{
+
+using pedestalarray = std::array<short, 17664>;
+
+pedestalarray createRandomPedestals()
+{
+  std::random_device rd{};
+  std::mt19937 gen{rd()};
+  std::normal_distribution gaussrand{40., 5.};
+  pedestalarray pedestalcontainer;
+  for (std::size_t ichan{0}; ichan < pedestalcontainer.size(); ++ichan) {
+    pedestalcontainer[ichan] = std::round(gaussrand(gen));
+  }
+
+  return pedestalcontainer;
+}
+
+pedestalarray shiftPedestalValue(const pedestalarray& input, short shift = 1)
+{
+  pedestalarray shifted;
+  for (std::size_t ichan{0}; ichan < input.size(); ++ichan) {
+    shifted[ichan] = input[ichan] + shift;
+  }
+  return shifted;
+}
+
+BOOST_AUTO_TEST_CASE(testPedestal)
+{
+  auto pedestalsHG = createRandomPedestals(),
+       pedestalsLG = createRandomPedestals();
+
+  o2::emcal::Pedestal pedestalObject;
+  for (std::size_t ichan{0}; ichan < pedestalsHG.size(); ++ichan) {
+    pedestalObject.addPedestalValue(ichan, pedestalsHG[ichan], false);
+    pedestalObject.addPedestalValue(ichan, pedestalsLG[ichan], true);
+  }
+
+  // test adding entries beyond range
+  for (std::size_t ichan{17665}; ichan < 18000; ++ichan) {
+    BOOST_CHECK_EXCEPTION(pedestalObject.addPedestalValue(ichan, 2, false), o2::emcal::CalibContainerIndexException, [ichan](const o2::emcal::CalibContainerIndexException& e) { return e.getIndex() == ichan; });
+    BOOST_CHECK_EXCEPTION(pedestalObject.addPedestalValue(ichan, 3, true), o2::emcal::CalibContainerIndexException, [ichan](const o2::emcal::CalibContainerIndexException& e) { return e.getIndex() == ichan; });
+  }
+
+  // test reading values in range
+  for (std::size_t ichan{0}; ichan < pedestalsHG.size(); ++ichan) {
+    BOOST_CHECK_EQUAL(pedestalObject.getPedestalValue(ichan, false), pedestalsHG[ichan]);
+    BOOST_CHECK_EQUAL(pedestalObject.getPedestalValue(ichan, true), pedestalsLG[ichan]);
+  }
+
+  // test reading entries beyond range
+  for (std::size_t ichan{17665}; ichan < 18000; ++ichan) {
+    BOOST_CHECK_EXCEPTION(pedestalObject.getPedestalValue(ichan, false), o2::emcal::CalibContainerIndexException, [ichan](const o2::emcal::CalibContainerIndexException& e) { return e.getIndex() == ichan; });
+    BOOST_CHECK_EXCEPTION(pedestalObject.getPedestalValue(ichan, true), o2::emcal::CalibContainerIndexException, [ichan](const o2::emcal::CalibContainerIndexException& e) { return e.getIndex() == ichan; });
+  }
+
+  // tests for operator==
+  // shift pedestal by 1 for false test
+  // Test all cases:
+  // - same object
+  // - same HG, different LG
+  // - same LG, different HG
+  // - both HG and LG different
+  /*
+  auto shiftedPedestalsHG = shiftPedestalValue(pedestalsHG, 1),
+       shiftedPedestalsLG = shiftPedestalValue(pedestalsLG, 1);
+  o2::emcal::Pedestal same, differLow, differHigh, differBoth;
+  for (std::size_t ichan{0}; ichan < pedestalsHG.size(); ++ichan) {
+    same.addPedestalValue(ichan, pedestalsHG[ichan], false);
+    same.addPedestalValue(ichan, pedestalsLG[ichan], true);
+    differLow.addPedestalValue(ichan, pedestalsHG[ichan], false);
+    differLow.addPedestalValue(ichan, shiftedPedestalsLG[ichan], true);
+    differHigh.addPedestalValue(ichan, shiftedPedestalsHG[ichan], false);
+    differHigh.addPedestalValue(ichan, pedestalsLG[ichan], true);
+    differBoth.addPedestalValue(ichan, shiftedPedestalsHG[ichan], false);
+    differBoth.addPedestalValue(ichan, shiftedPedestalsLG[ichan], true);
+  }
+  BOOST_CHECK_EQUAL(pedestalObject, same);
+  BOOST_CHECK_NE(pedestalObject, differLow);
+  BOOST_CHECK_NE(pedestalObject, differHigh);
+  BOOST_CHECK_NE(pedestalObject, differBoth);
+  */
+}
+
+} // namespace emcal
+
+} // namespace o2


### PR DESCRIPTION
- separate pedestals for HG and LG
- pedestal as ADC counts (short)
- histogram representation both vs. cell ID and
  position in EMCAL for both channel types
- unit test coverage