### PR TITLE
Fixes in GRP DCS processor

### DIFF
--- a/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
@@ -65,18 +65,18 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   std::string url = config.options().get<std::string>("ccdb-url");
 
-  std::unordered_map<DPID, o2h::DataDescription> dpid2DataDesc;
+  std::unordered_map<DPID, std::vector<o2h::DataDescription>> dpid2DataDesc;
 
   if (testMode) {
     DPID dpidtmp;
     DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000100", DeliveryType::DPVAL_STRING);
-    dpid2DataDesc[dpidtmp] = "COMMON"; // i.e. this will go to {DCS/COMMON/0} OutputSpec
+    dpid2DataDesc[dpidtmp] = {"COMMON"}; // i.e. this will go to {DCS/COMMON/0} OutputSpec
     DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000110", DeliveryType::DPVAL_STRING);
-    dpid2DataDesc[dpidtmp] = "COMMON";
+    dpid2DataDesc[dpidtmp] = {"COMMON"};
     DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000200", DeliveryType::DPVAL_STRING);
-    dpid2DataDesc[dpidtmp] = "COMMON1";
+    dpid2DataDesc[dpidtmp] = {"COMMON1"};
     DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000240", DeliveryType::DPVAL_INT);
-    dpid2DataDesc[dpidtmp] = "COMMON1";
+    dpid2DataDesc[dpidtmp] = {"COMMON1"};
   }
 
   else {
@@ -95,7 +95,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
         for (auto& el : *dpid2Det) {
           o2::header::DataDescription tmpd;
           tmpd.runtimeInit(el.second.c_str(), el.second.size());
-          dpid2DataDesc[el.first] = tmpd;
+          dpid2DataDesc[el.first].push_back(tmpd);
         }
       }
     }
@@ -107,7 +107,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   // now collect all required outputs to define OutputSpecs for specifyExternalFairMQDeviceProxy
   std::unordered_map<o2h::DataDescription, int, std::hash<o2h::DataDescription>> outMap;
   for (auto itdp : dpid2DataDesc) {
-    outMap[itdp.second]++;
+    for (const auto& ds : itdp.second) {
+      outMap[ds]++;
+    }
   }
 
   Outputs dcsOutputs;

--- a/Detectors/GRP/calibration/include/GRPCalibration/GRPDCSDPsProcessor.h
+++ b/Detectors/GRP/calibration/include/GRPCalibration/GRPDCSDPsProcessor.h
@@ -42,7 +42,14 @@ inline unsigned long llu2lu(std::uint64_t v) { return (unsigned long)v; }
 struct GRPEnvVariables {
 
   std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>> mEnvVars;
-
+  size_t totalEntries() const
+  {
+    size_t s = 0;
+    for (const auto& el : mEnvVars) {
+      s += el.second.size();
+    }
+    return s;
+  }
   void print()
   {
     for (const auto& el : mEnvVars) {
@@ -116,10 +123,16 @@ struct MagFieldHelper {
 struct GRPCollimators {
 
   std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>> mCollimators;
-
+  size_t totalEntries() const
+  {
+    size_t s = 0;
+    for (const auto& el : mCollimators) {
+      s += el.second.size();
+    }
+    return s;
+  }
   void print()
   {
-
     for (const auto& el : mCollimators) {
       std::printf("%-60s\n", el.first.c_str());
       for (const auto& it : el.second) {
@@ -291,7 +304,9 @@ class GRPDCSDPsProcessor
   {
     // keep only the latest measurement
     for (auto& el : mapToReset) {
-      el.second.erase(el.second.begin(), el.second.end() - 1);
+      if (el.second.begin() != el.second.end()) {
+        el.second.erase(el.second.begin(), el.second.end() - 1);
+      }
     }
   }
 

--- a/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
+++ b/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
@@ -175,7 +175,6 @@ bool GRPDCSDPsProcessor::processCollimators(const DPCOM& dpcom)
 
 bool GRPDCSDPsProcessor::processEnvVar(const DPCOM& dpcom)
 {
-
   // function to process Data Points that are related to env variables
   bool match = processPairD(dpcom, "CavernTemperature", mEnvVars.mEnvVars) ||
                processPairD(dpcom, "CavernAtmosPressure", mEnvVars.mEnvVars) ||
@@ -396,14 +395,14 @@ void GRPDCSDPsProcessor::updateEnvVarsCCDB()
 void GRPDCSDPsProcessor::updateCollimatorsCCDB()
 {
 
-  // we need to update a CCDB for the Env Variables DPs --> let's prepare the CCDBInfo
+  // we need to update a CCDB for the Collimators Variables DPs --> let's prepare the CCDBInfo
 
   if (mVerbose) {
     LOG(info) << "Entry related to Collimators needs to be updated with startTime " << mStartValidityColli;
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mEnvVars, mccdbCollimatorsInfo, "GLO/Config/Collimators", md, mStartValidityColli, mStartValidityColli + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
+  o2::calibration::Utils::prepareCCDBobjectInfo(mCollimators, mccdbCollimatorsInfo, "GLO/Config/Collimators", md, mStartValidityColli, mStartValidityColli + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
   return;
 }
 

--- a/Detectors/GRP/workflows/include/GRPWorkflows/GRPDCSDPsSpec.h
+++ b/Detectors/GRP/workflows/include/GRPWorkflows/GRPDCSDPsSpec.h
@@ -45,6 +45,9 @@ class GRPDCSDPsDataProcessor : public Task
   int64_t mDPsUpdateInterval;
   bool mReportTiming = false;
   bool mLHCIFupdated = false;
+  size_t mEmptyCyclesEnvVars = 0;
+  size_t mEmptyCyclesCollimators = 0;
+  size_t mWarnEmptyCycles = 1;
 };
 } // namespace grp
 


### PR DESCRIPTION
Warn about empty collimator or env.vars object.
Protection in resetAndKeepLast agains empty vectors