### PR TITLE
ITS efficiency maps protection for digitization out of range

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -73,8 +73,8 @@ class TimeDeadMap
     }
   }
 
-  void decodeMap(unsigned long orbit, o2::itsmft::NoiseMap& noisemap, bool includeStaticMap = true)
-  { // for time-dependent and (optionally) static part
+  void decodeMap(unsigned long orbit, o2::itsmft::NoiseMap& noisemap, bool includeStaticMap = true, long orbitGapAllowed = 33000)
+  { // for time-dependent and (optionally) static part. Use orbitGapAllowed = -1 to ignore check on orbit difference
 
     if (mMAP_VERSION != "3" && mMAP_VERSION != "4") {
       LOG(error) << "Trying to decode time-dependent deadmap version " << mMAP_VERSION << ". Not implemented, doing nothing.";
@@ -84,13 +84,15 @@ class TimeDeadMap
     if (mEvolvingDeadMap.empty()) {
       LOG(warning) << "Time-dependent dead map is empty. Doing nothing.";
       return;
-    } else if (orbit > mEvolvingDeadMap.rbegin()->first + 11000 * 300 || orbit < mEvolvingDeadMap.begin()->first - 11000 * 300) {
-      // the map should not leave several minutes uncovered.
-      LOG(warning) << "Time-dependent dead map: the requested orbit " << orbit << " seems to be out of the range stored in the map.";
     }
 
     std::vector<uint16_t> closestVec;
     long dT = getMapAtOrbit(orbit, closestVec);
+
+    if (orbitGapAllowed >= 0 && std::abs(dT) > orbitGapAllowed) {
+      LOG(warning) << "Requested orbit " << orbit << ", found " << orbit - dT << ". Orbit gap is too high, skipping time-dependent map.";
+      closestVec.clear();
+    }
 
     // add static part if requested. something may be masked twice
     if (includeStaticMap && mMAP_VERSION != "3") {
@@ -125,18 +127,19 @@ class TimeDeadMap
   void getStaticMap(std::vector<uint16_t>& mmap) { mmap = mStaticDeadMap; };
 
   long getMapAtOrbit(unsigned long orbit, std::vector<uint16_t>& mmap)
-  { // fills mmap and returns orbit - lower_bound
+  { // fills mmap and returns requested_orbit - found_orbit. Found orbit is the highest key lower or equal to the requested one
     if (mEvolvingDeadMap.empty()) {
       LOG(warning) << "Requested orbit " << orbit << "from an empty time-dependent map. Doing nothing";
       return (long)orbit;
     }
     auto closest = mEvolvingDeadMap.lower_bound(orbit);
-    if (closest != mEvolvingDeadMap.end()) {
+    if (closest != mEvolvingDeadMap.begin()) {
+      --closest;
       mmap = closest->second;
       return (long)orbit - closest->first;
     } else {
-      mmap = mEvolvingDeadMap.rbegin()->second;
-      return (long)(orbit)-mEvolvingDeadMap.rbegin()->first;
+      mmap = mEvolvingDeadMap.begin()->second;
+      return (long)(orbit)-mEvolvingDeadMap.begin()->first;
     }
   }
 

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+33// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -73,7 +73,7 @@ class TimeDeadMap
     }
   }
 
-  void decodeMap(unsigned long orbit, o2::itsmft::NoiseMap& noisemap, bool includeStaticMap = true, long orbitGapAllowed = 33000)
+  void decodeMap(unsigned long orbit, o2::itsmft::NoiseMap& noisemap, bool includeStaticMap = true, long orbitGapAllowed = 330000)
   { // for time-dependent and (optionally) static part. Use orbitGapAllowed = -1 to ignore check on orbit difference
 
     if (mMAP_VERSION != "3" && mMAP_VERSION != "4") {

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -1,4 +1,4 @@
-33// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -270,8 +270,8 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
   if (ec != nullptr) {
 
     LOG(important) << "Sending object " << info.getPath() << "/" << info.getFileName()
-              << "to ccdb-populator, of size " << image->size() << " bytes, valid for "
-              << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+                   << "to ccdb-populator, of size " << image->size() << " bytes, valid for "
+                   << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
     if (mRunMFT) {
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TimeDeadMap", 1}, *image.get());
@@ -285,8 +285,8 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
   else if (!ccdburl.empty()) { // send from this workflow
 
     LOG(important) << mSelfName << "sending object " << ccdburl << "/browse/" << info.getPath() << "/" << info.getFileName()
-              << " of size " << image->size() << " bytes, valid for "
-              << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+                   << " of size " << image->size() << " bytes, valid for "
+                   << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
     o2::ccdb::CcdbApi mApi;
     mApi.init(ccdburl);

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -278,7 +278,7 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 1}, info);
     } else {
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TimeDeadMap", 0}, *image.get());
-      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 0}, info);a
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 0}, info);
     }
   }
 

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -269,7 +269,7 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
 
   if (ec != nullptr) {
 
-    LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName()
+    LOG(important) << "Sending object " << info.getPath() << "/" << info.getFileName()
               << "to ccdb-populator, of size " << image->size() << " bytes, valid for "
               << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
@@ -284,7 +284,7 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
 
   else if (!ccdburl.empty()) { // send from this workflow
 
-    LOG(info) << mSelfName << "sending object " << ccdburl << "/browse/" << info.getPath() << "/" << info.getFileName()
+    LOG(important) << mSelfName << "sending object " << ccdburl << "/browse/" << info.getPath() << "/" << info.getFileName()
               << " of size " << image->size() << " bytes, valid for "
               << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
@@ -335,7 +335,7 @@ void ITSMFTDeadMapBuilder::stop()
       LOG(warning) << "endOfStream not processed. Sending output to ccdb from the " << detname << "deadmap builder workflow.";
       PrepareOutputCcdb(nullptr, mCCDBUrl);
     } else {
-      LOG(warning) << "endOfStream not processed. Nothing forwarded as output.";
+      LOG(alert) << "endOfStream not processed. Nothing forwarded as output.";
     }
     isEnded = true;
   }

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -284,7 +284,7 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
 
   else if (!ccdburl.empty()) { // send from this workflow
 
-    LOG(info) << mSelfName << "sending object " << ccdburl << "/browse/" << info.getFileName()
+    LOG(info) << mSelfName << "sending object " << ccdburl << "/browse/" << info.getPath() << "/" << info.getFileName()
               << " of size " << image->size() << " bytes, valid for "
               << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -278,7 +278,7 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 1}, info);
     } else {
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TimeDeadMap", 0}, *image.get());
-      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 0}, info);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TimeDeadMap", 0}, info);a
     }
   }
 
@@ -335,7 +335,7 @@ void ITSMFTDeadMapBuilder::stop()
       LOG(warning) << "endOfStream not processed. Sending output to ccdb from the " << detname << "deadmap builder workflow.";
       PrepareOutputCcdb(nullptr, mCCDBUrl);
     } else {
-      LOG(alert) << "endOfStream not processed. Nothing forwarded as output.";
+      LOG(alarm) << "endOfStream not processed. Nothing forwarded as output.";
     }
     isEnded = true;
   }


### PR DESCRIPTION
Changing function called by the digitizer. 
The time-evolving part of the map is not decoded if the difference between "requested orbit" and "found orbit" is larger than ~30 sec: only the chips contained in the static part are masked.

cc @iravasen @mcoquet642 


+async-label async-mc