### PR TITLE
MCTrack: Calculate energy in double

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -298,8 +298,10 @@ template <typename T>
 inline Double_t MCTrackT<T>::GetEnergy() const
 {
   const auto mass = GetMass();
-  return std::sqrt(mass * mass + mStartVertexMomentumX * mStartVertexMomentumX +
-                   mStartVertexMomentumY * mStartVertexMomentumY + mStartVertexMomentumZ * mStartVertexMomentumZ);
+  Double_t px = mStartVertexMomentumX;
+  Double_t py = mStartVertexMomentumY;
+  Double_t pz = mStartVertexMomentumZ;
+  return std::sqrt(mass * mass + px * px + py * py + pz * pz);
 }
 
 template <typename T>


### PR DESCRIPTION
in previous version, intermediate steps happened in float with a precision loss on the global result.

Fixes another instance of the problem discussed here:

https://its.cern.ch/jira/browse/ALIROOT-8233