### PR TITLE
CTP configuration fix input name level

### DIFF
--- a/DataFormats/Detectors/CTP/src/Configuration.cxx
+++ b/DataFormats/Detectors/CTP/src/Configuration.cxx
@@ -1111,7 +1111,7 @@ int CTPInputsConfiguration::getInputIndexFromName(std::string& name)
 {
   std::string namecorr = name;
   if ((name[0] == '0') || (name[0] == 'M') || (name[0] == '1')) {
-    namecorr.substr(1, namecorr.size() - 1);
+    namecorr = namecorr.substr(1, namecorr.size() - 1);
   } else {
     LOG(warn) << "Input name without level:" << name;
   }


### PR DESCRIPTION
Hi @lietava I got the compiler warning below and think this is how it was intended. Not sure if this is something relevant, please check.

2024-03-22@09:13:47:DEBUG:O2PDPSuite:O2:0: /home/oschmidt/alice/sw/SOURCES/O2/tpccalib/0/DataFormats/Detectors/CTP/src/Configuration.cxx:1114:44: warning: ignoring return value of 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::substr(size_type, size_type) const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; size_type = long unsigned int]', declared with attribute 'nodiscard' [-Wunused-result]