### PR TITLE
[MCH] add functionality and protections in mapping

### DIFF
--- a/Detectors/MUON/MCH/GlobalMapping/CMakeLists.txt
+++ b/Detectors/MUON/MCH/GlobalMapping/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(MCHGlobalMapping
         PUBLIC_LINK_LIBRARIES O2::MCHRawElecMap
                               O2::MCHMappingInterface
                               O2::MCHConditions
+                              O2::Framework
         PRIVATE_LINK_LIBRARIES O2::MCHConstants)
 
 o2_target_root_dictionary(MCHGlobalMapping

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.cxx
@@ -126,11 +126,11 @@ CathodeSegmentation::CathodeSegmentation(
 {
   fillRtree();
   for (auto dualSampaId : mDualSampaIds) {
-    mDualSampaId2CatPadIndices.emplace(dualSampaId, getCatPadIndices(dualSampaId));
+    mDualSampaId2CatPadIndices.emplace(dualSampaId, catPadIndices(dualSampaId));
   }
 }
 
-std::vector<int> CathodeSegmentation::getCatPadIndices(int dualSampaId) const
+std::vector<int> CathodeSegmentation::catPadIndices(int dualSampaId) const
 {
   std::vector<int> pi;
 
@@ -145,6 +145,15 @@ std::vector<int> CathodeSegmentation::getCatPadIndices(int dualSampaId) const
     }
   }
   return pi;
+}
+
+std::vector<int> CathodeSegmentation::getCatPadIndices(int dualSampaId) const
+{
+  auto it = mDualSampaId2CatPadIndices.find(dualSampaId);
+  if (it == mDualSampaId2CatPadIndices.end()) {
+    return {};
+  }
+  return it->second;
 }
 
 std::vector<int> CathodeSegmentation::getCatPadIndices(double xmin, double ymin,

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.h
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.h
@@ -48,7 +48,7 @@ class CathodeSegmentation
                       std::vector<std::pair<float, float>> padSizes);
 
   /// Return the list of catPadIndices for the pads of the given dual sampa.
-  std::vector<int> getCatPadIndices(int dualSampaIds) const;
+  std::vector<int> getCatPadIndices(int dualSampaId) const;
 
   /// Return the list of catPadIndices for the pads contained in the box
   /// {xmin,ymin,xmax,ymax}.
@@ -104,6 +104,8 @@ class CathodeSegmentation
   const PadGroupType& padGroupType(int catPadIndex) const;
 
   double squaredDistance(int catPadIndex, double x, double y) const;
+
+  std::vector<int> catPadIndices(int dualSampaId) const;
 
  private:
   int mSegType;

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
@@ -78,7 +78,7 @@ class Segmentation
    * Validity of the returned value can be tested using isValid()
    */
   ///@{
-  /** Find the pads at position (x,y) (in cm). 
+  /** Find the pads at position (x,y) (in cm).
     Returns true is the bpad and nbpad has been filled with a valid dePadIndex,
     false otherwise (if position is outside the segmentation area).
     @param bpad the dePadIndex of the bending pad at position (x,y)
@@ -117,15 +117,18 @@ class Segmentation
   void forEachPad(CALLABLE&& func) const;
 
   template <typename CALLABLE>
+  void forEachPadInDualSampa(int dualSampaId, CALLABLE&& func) const;
+
+  template <typename CALLABLE>
   void forEachNeighbouringPad(int dePadIndex, CALLABLE&& func) const;
 
   template <typename CALLABLE>
   void forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const;
   ///@}
 
-  /** @name Access to individual cathode segmentations. 
-    * Not needed in most cases.
-    */
+  /** @name Access to individual cathode segmentations.
+   * Not needed in most cases.
+   */
   ///@{
   const CathodeSegmentation& bending() const;
   const CathodeSegmentation& nonBending() const;

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
@@ -122,6 +122,20 @@ void Segmentation::forEachPad(CALLABLE&& func) const
 }
 
 template <typename CALLABLE>
+void Segmentation::forEachPadInDualSampa(int dualSampaId, CALLABLE&& func) const
+{
+  bool isBending = dualSampaId < 1024;
+  if (isBending) {
+    mBending.forEachPadInDualSampa(dualSampaId, func);
+  } else {
+    int offset{mPadIndexOffset};
+    mNonBending.forEachPadInDualSampa(dualSampaId, [&offset, &func](int catPadIndex) {
+      func(catPadIndex + offset);
+    });
+  }
+}
+
+template <typename CALLABLE>
 void Segmentation::forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const
 {
   mBending.forEachPadInArea(xmin, ymin, xmax, ymax, func);


### PR DESCRIPTION
- add a function to loop over DE pad indices connected to a dual sampa.
- speedup the retrieval of cathode pad indices connected to a dual sampa.
- add protections in the conversions DsDetId <--> DsIndex