### PR TITLE
More flexibel use of event setup from collisioncontext

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -180,7 +180,7 @@ class SimConfig
   SimConfigData mConfigData; //!
 
   // adjust/overwrite some option settings when collision context is used
-  void adjustFromCollContext();
+  void adjustFromCollContext(std::string const& collcontextfile, std::string const& prefix);
 
   ClassDefNV(SimConfig, 1);
 };

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -256,7 +256,17 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
     mConfigData.mFilterNoHitEvents = true;
   }
   mConfigData.mFromCollisionContext = vm["fromCollContext"].as<std::string>();
-  adjustFromCollContext();
+  // we decompose the argument to fetch
+  // (a) collision contextfilename
+  // (b) sim prefix to use from the context
+  auto pos = mConfigData.mFromCollisionContext.find(':');
+  std::string collcontextfile{mConfigData.mFromCollisionContext};
+  std::string simprefix{mConfigData.mOutputPrefix};
+  if (pos != std::string::npos) {
+    collcontextfile = mConfigData.mFromCollisionContext.substr(0, pos);
+    simprefix = mConfigData.mFromCollisionContext.substr(pos + 1);
+  }
+  adjustFromCollContext(collcontextfile, simprefix);
 
   // analyse vertex options
   if (!parseVertexModeString(vm["vertexMode"].as<std::string>(), mConfigData.mVertexMode)) {
@@ -323,28 +333,28 @@ bool SimConfig::parseFieldString(std::string const& fieldstring, int& fieldvalue
   return true;
 }
 
-void SimConfig::adjustFromCollContext()
+void SimConfig::adjustFromCollContext(std::string const& collcontextfile, std::string const& prefix)
 {
   // When we use pregenerated collision contexts, some options
   // need to be auto-adjusted. Do so and inform about this in the logs.
-  if (mConfigData.mFromCollisionContext == "") {
+  if (collcontextfile == "") {
     return;
   }
 
-  auto context = o2::steer::DigitizationContext::loadFromFile(mConfigData.mFromCollisionContext);
+  auto context = o2::steer::DigitizationContext::loadFromFile(collcontextfile);
   if (context) {
     //  find the events belonging to a source that corresponds to a sim prefix
-    LOG(info) << "Looking up simprefixes " << mConfigData.mOutputPrefix;
-    int sourceid = context->findSimPrefix(mConfigData.mOutputPrefix);
+    LOG(info) << "Looking up simprefixes " << prefix;
+    int sourceid = context->findSimPrefix(prefix);
     if (sourceid == -1) {
-      LOG(error) << "Could not find collisions with sim prefix " << mConfigData.mOutputPrefix << " in the collision context. The collision contet specifies the following prefixes:";
-      for (auto& prefix : context->getSimPrefixes()) {
-        LOG(info) << prefix;
+      LOG(error) << "Could not find collisions with sim prefix " << prefix << " in the collision context. The collision context specifies the following prefixes:";
+      for (auto& sp : context->getSimPrefixes()) {
+        LOG(info) << sp;
       }
       LOG(fatal) << "Aborting due to prefix error";
     } else {
       auto collisionmap = context->getCollisionIndicesForSource(sourceid);
-      LOG(info) << "Found " << collisionmap.size() << " events in the collisioncontext for prefix " << mConfigData.mOutputPrefix;
+      LOG(info) << "Found " << collisionmap.size() << " events in the collisioncontext for prefix " << prefix;
 
       // check if collisionmap is dense (otherwise it will get screwed up with order/indexing in ROOT output)
       bool good = true;
@@ -368,7 +378,7 @@ void SimConfig::adjustFromCollContext()
       LOG(info) << "Setting number of events to simulate to " << mConfigData.mNEvents;
     }
   } else {
-    LOG(fatal) << "Could not open collision context file " << mConfigData.mFromCollisionContext;
+    LOG(fatal) << "Could not open collision context file " << collcontextfile;
   }
 }
 


### PR DESCRIPTION
can now give --fromCollContext file[:prefix]
on the command line to specify prefix to use (previously less flexible).