### PR TITLE
Impose def. TOffset 7.3TB on laser calib, use actual value for VDriftTgl

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/ParameterDetector.h
+++ b/Detectors/TPC/base/include/TPCBase/ParameterDetector.h
@@ -32,7 +32,7 @@ struct ParameterDetector : public o2::conf::ConfigurableParamHelper<ParameterDet
   float TPCRecoWindowSim = 1.5f; ///< length of the reconstruction window in units of drift time of the TPC in simulation (Neutron capture process can extend up to 30-40 TPC drift time)
   float PadCapacitance = 0.1f; ///< Capacitance of a single pad [pF]
   TimeBin TmaxTriggered = 550; ///< Maximum time bin in case of triggered readout mode
-  float DriftTimeOffset = 0.;  ///< drift time offset in time bins
+  float DriftTimeOffset = 7.3; ///< drift time offset in time bins (we observe ~2.4\mus before October 2023 and ~1.45 \mus after)
 
   O2ParamDef(ParameterDetector, "TPCDetParam");
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibLaserTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibLaserTracks.h
@@ -161,6 +161,7 @@ class CalibLaserTracks
   int mTriggerPos{0};                                          ///< trigger position, if < 0 it treats it as the CE position
   float mBz{0.5};                                              ///< Bz field in Tesla
   float mDriftV{0};                                            ///< drift velocity used during reconstruction
+  float mTOffsetMUS{0};                                        ///< time offset in \mus to impose
   float mZbinWidth{0};                                         ///< width of a bin in us
   uint64_t mTFstart{0};                                        ///< start time of processed time frames
   uint64_t mTFend{0};                                          ///< end time of processed time frames

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
@@ -30,6 +30,7 @@ struct TPCVDTglContainer {
   size_t entries = 0;
   size_t nTFProc = 0;
   double driftVFullMean = 0.;
+  static float tOffsetRef;
   static float driftVRef;
 
   TPCVDTglContainer(int ntgl, float tglMax, int ndtgl, float dtglMax)
@@ -64,6 +65,9 @@ struct TPCVDTglContainer {
       LOGP(warn, "data with VDriftRef={} were received while initially was set to {}, keep old one", vref, driftVRef);
     }
     driftVFullMean = (driftVFullMean * nTFProc + vfull) / (nTFProc + 1);
+    if (tOffsetRef == 0.f) {
+      tOffsetRef = data[0].first; // assign 1st full toffset as a reference
+    }
     nTFProc++;
   }
 

--- a/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
@@ -16,6 +16,7 @@
 #include "MathUtils/Utils.h"
 #include "TPCBase/ParameterGas.h"
 #include "TPCBase/ParameterElectronics.h"
+#include "TPCBase/ParameterDetector.h"
 #include "TPCCalibration/CalibLaserTracks.h"
 #include "TLinearFitter.h"
 #include <chrono>
@@ -239,8 +240,10 @@ void CalibLaserTracks::updateParameters()
 {
   const auto& gasParam = ParameterGas::Instance();
   const auto& electronicsParam = ParameterElectronics::Instance();
+  const auto& detpar = o2::tpc::ParameterDetector::Instance();
   mDriftV = gasParam.DriftV;
   mZbinWidth = electronicsParam.ZbinWidth;
+  mTOffsetMUS = detpar.DriftTimeOffset * mZbinWidth;
 }
 
 //______________________________________________________________________________
@@ -335,6 +338,8 @@ void CalibLaserTracks::fillCalibData(LtrCalibData& calibData, const std::vector<
   calibData.dvOffsetC = dvC.x1;
   calibData.dvCorrectionC = dvC.x2;
   calibData.nTracksC = uint16_t(pairsC.size());
+
+  calibData.refTimeOffset = mTOffsetMUS;
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/calibration/src/TPCVDriftTglCalibration.cxx
+++ b/Detectors/TPC/calibration/src/TPCVDriftTglCalibration.cxx
@@ -28,6 +28,7 @@ using Slot = o2::calibration::TimeSlot<TPCVDTglContainer>;
 using clbUtils = o2::calibration::Utils;
 
 float TPCVDTglContainer::driftVRef = 0.f;
+float TPCVDTglContainer::tOffsetRef = 0.f;
 
 //_____________________________________________
 void TPCVDriftTglCalibration::initOutput()
@@ -89,7 +90,8 @@ void TPCVDriftTglCalibration::finalizeSlot(Slot& slot)
                                                                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(),
                                                                corrFact,
                                                                corrFactErr,
-                                                               float(cont->driftVFullMean)});
+                                                               float(cont->driftVFullMean),
+                                                               cont->tOffsetRef, 0.f});
     // at this stage the correction object is defined wrt average corrected drift used for the slot processing, we want to redefine it to run-constant reference vdrift
     vd.normalize(cont->driftVRef);
 

--- a/Detectors/TPC/calibration/src/VDriftHelper.cxx
+++ b/Detectors/TPC/calibration/src/VDriftHelper.cxx
@@ -32,7 +32,7 @@ VDriftHelper::VDriftHelper()
   const auto& elpar = o2::tpc::ParameterElectronics::Instance();
   mVD.corrFact = 1.0;
   mVD.refVDrift = gaspar.DriftV;
-  mVD.refTimeOffset = detpar.DriftTimeOffset / elpar.ZbinWidth;
+  mVD.refTimeOffset = detpar.DriftTimeOffset * elpar.ZbinWidth; // convert time bins to \mus
   // was it imposed from the command line?
   mVD.creationTime = 1;                                                                                                         // just to be above 0
   if (o2::conf::ConfigurableParam::getProvenance("TPCGasParam.DriftV") == o2::conf::ConfigurableParam::EParamProvenance::kRT) { // we stick to this value


### PR DESCRIPTION
tpc::ParameterDetector.DriftTimeOffset default is set to 7.3TB (~1.45mus). It will be imposed on the vdrift object created by the laser calibration. The VDrift calibration via TPC/ITS tgLambda difference will simply impose to its output object the offset used at the beginning of the reconstruction (i.e. taken either from TPC/Calib/LaserTracks or from TPC/Calib/VDriftTgl, unless this parameter was overridden from the command line).