### PR TITLE
Workflow to update RCT with ts of 1st/last TFs seen

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -180,13 +180,11 @@ class CCDBManagerInstance
   void setFatalWhenNull(bool b) { mFatalWhenNull = b; }
 
   /// A convenience function for MC to fetch
-  /// valid start and end timestamps given an ALICE run number.
+  /// valid start and end timestamps for recorded TF data given an ALICE run number.
+  /// In absence of STF/ETF fields in the RCT with fall back to CTP SOX/EOX then to
+  /// ECS SOR/EOR.
   /// On error it fatals (if fatal == true) or else returns the pair -1, -1.
   std::pair<int64_t, int64_t> getRunDuration(int runnumber, bool fatal = true);
-
-  /// A convenience function for MC to fetch
-  /// valid start and end timestamps given an ALICE run number.
-  /// On error it fatals (if fatal == true) or else returns the pair -1, -1.
   static std::pair<int64_t, int64_t> getRunDuration(o2::ccdb::CcdbApi const& api, int runnumber, bool fatal = true);
 
   std::string getSummaryString() const;

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -530,6 +530,8 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   if (mCreateDict && mSaveDictAfter > 0 && (mNCTF % mSaveDictAfter) == 0) {
     storeDictionaries();
   }
+  int dummy = 0;
+  pc.outputs().snapshot({"ctfdone", 0}, dummy);
 }
 
 //___________________________________________________________________
@@ -795,7 +797,7 @@ DataProcessorSpec getCTFWriterSpec(DetID::mask_t dets, const std::string& outTyp
   return DataProcessorSpec{
     "ctf-writer",
     inputs,
-    Outputs{},
+    Outputs{{OutputLabel{"ctfdone"}, "CTF", "DONE", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<CTFWriterSpec>(dets, outType, verbosity, reportInterval)}, // RS FIXME once global/local options clash is solved, --output-type will become device option
     Options{                                                                               //{"output-type", VariantType::String, "ctf", {"output types: ctf (per TF) or dict (create dictionaries) or both or none"}},
             {"save-ctf-after", VariantType::Int64, 0ll, {"autosave CTF tree with multiple CTFs after every N CTFs if >0 or every -N MBytes if < 0"}},

--- a/Detectors/GRP/workflows/CMakeLists.txt
+++ b/Detectors/GRP/workflows/CMakeLists.txt
@@ -31,6 +31,14 @@ o2_add_executable(grp-lhc-if-file-workflow
                                         O2::GRPCalibration
                                         O2::DetectorsCalibration)
 
+o2_add_executable(workflow
+                  COMPONENT_NAME rct-updater
+                  SOURCES src/rct-updater-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::CCDB
+                                        O2::DetectorsBase
+                                        O2::DataFormatsParameters)
+
 o2_add_executable(grp-create
                   COMPONENT_NAME ecs
                   SOURCES src/create-grp-ecs.cxx

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -134,6 +134,22 @@ int createGRPECSObject(const std::string& dataPeriod,
     } else {
       LOGP(alarm, "Upload to {}/{} with validity {}:{} for SOR:{}/EOR:{} FAILED, returned with code {}", ccdbServer, objPath, tstart, tendVal, tstart, tend, retValGLO);
     }
+    if (runType == GRPECSObject::RunType::PHYSICS || runType == GRPECSObject::RunType::COSMICS) { // also create the RCT/Info/RunInformation entry in case the run type is PHYSICS, to be finalized at EOR
+      char tempChar{};
+      std::map<std::string, std::string> mdRCT;
+      mdRCT["SOR"] = std::to_string(tstart);
+      mdRCT["EOR"] = std::to_string(tend);
+      mdRCT["SOX"] = std::to_string(tstartCTP);
+      mdRCT["EOX"] = std::to_string(tendCTP);
+      long startValRCT = (long)run;
+      long endValRCT = (long)(run + 1);
+      retValRCT = api.storeAsBinaryFile(&tempChar, sizeof(tempChar), "tmp.dat", "char", "RCT/Info/RunInformation", mdRCT, startValRCT, endValRCT);
+      if (retValRCT == 0) {
+        LOGP(info, "Uploaded initial RCT object to {}/{} with validity {}:{}", ccdbServer, "RCT/Info/RunInformation", startValRCT, endValRCT);
+      } else {
+        LOGP(alarm, "Upload of initial RCT object to {}/{} with validity {}:{} FAILED, returned with code {}", ccdbServer, "RCT/Info/RunInformation", startValRCT, endValRCT, retValRCT);
+      }
+    }
     if (tend > tstart) {
       // override SOR version to the same limits
       metadata.erase("EOR");
@@ -157,15 +173,14 @@ int createGRPECSObject(const std::string& dataPeriod,
         mdRCT["EOX"] = std::to_string(tendCTP);
         long startValRCT = (long)run;
         long endValRCT = (long)(run + 1);
-        retValRCT = api.storeAsBinaryFile(&tempChar, sizeof(tempChar), "tmp.dat", "char", "RCT/Info/RunInformation", mdRCT, startValRCT, endValRCT);
+        retValRCT = api.updateMetadata("RCT/Info/RunInformation", mdRCT, startValRCT);
         if (retValRCT == 0) {
-          LOGP(info, "Uploaded RCT object to {}/{} with validity {}:{}", ccdbServer, "RCT/Info/RunInformation", startValRCT, endValRCT);
+          LOGP(info, "Updated RCT object to SOR:{}/EOR:{} SOX:{}/EOX:{}", tstart, tend, tstartCTP, tendCTP);
         } else {
-          LOGP(alarm, "Uploaded RCT object to {}/{} with validity {}:{} FAILED, returned with code {}", ccdbServer, "RCT/Info/RunInformation", startValRCT, endValRCT, retValRCT);
+          LOGP(alarm, "Update of RCT object to SOR:{}/EOR:{} SOX:{}/EOX:{} FAILED, returned with code {}", tstart, tend, tstartCTP, tendCTP, retValRCT);
         }
       }
     }
-
   } else { // write a local file
     auto fname = o2::base::NameConf::getGRPECSFileName();
     TFile grpF(fname.c_str(), "recreate");

--- a/Detectors/GRP/workflows/src/rct-updater-workflow.cxx
+++ b/Detectors/GRP/workflows/src/rct-updater-workflow.cxx
@@ -1,0 +1,184 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/Logger.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/InputSpec.h"
+#include "Framework/Task.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  std::vector<o2::framework::ConfigParamSpec> options{{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  std::swap(workflowOptions, options);
+}
+
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "CCDB/CcdbApi.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+
+namespace o2::rct
+{
+class RCTUpdaterSpec : public o2::framework::Task
+{
+ public:
+  RCTUpdaterSpec(std::shared_ptr<o2::base::GRPGeomRequest> gr) : mGGCCDBRequest(gr) {}
+  ~RCTUpdaterSpec() final = default;
+
+  void init(InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+    mUpdateInterval = std::max(0.1f, ic.options().get<float>("update-interval"));
+    auto ccdb = ic.options().get<std::string>("ccdb-server");
+    if (!ccdb.empty() && ccdb != "none") {
+      mCCDBApi = std::make_unique<o2::ccdb::CcdbApi>();
+      mCCDBApi->init(ic.options().get<std::string>("ccdb-server"));
+    } else {
+      LOGP(warn, "No ccdb server provided, no RCT update will be done");
+    }
+  }
+
+  void run(ProcessingContext& pc) final
+  {
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+    auto tinfo = pc.services().get<o2::framework::TimingInfo>();
+    if (tinfo.globalRunNumberChanged) { // do we have RCT object?
+      const auto* grp = o2::base::GRPGeomHelper::instance().getGRPECS();
+      mNHBFPerTF = grp->getNHBFPerTF();
+      if (mNHBFPerTF < 1) {
+        mNHBFPerTF = 32;
+      }
+      mRunNumber = tinfo.runNumber;
+      mUpdateIntervalTF = uint32_t(mUpdateInterval / (mNHBFPerTF * o2::constants::lhc::LHCOrbitMUS * 1e-6)); // convert update interval in seconds to interval in TFs
+      LOGP(info, "Will update RCT after {} TFs of {} HBFs ({}s was requested)", mUpdateIntervalTF, mNHBFPerTF, mUpdateInterval);
+      mOrbitReset = o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS();
+      mMinOrbit = 0xffffffff;
+      mMaxOrbit = 0;
+      if (grp->getRunType() == o2::parameters::GRPECS::PHYSICS || grp->getRunType() == o2::parameters::GRPECS::COSMICS) {
+        mEnabled = true;
+      } else {
+        LOGP(warning, "Run {} type is {}, disabling RCT update", mRunNumber, o2::parameters::GRPECS::RunTypeNames[mRunNumber]);
+        mEnabled = false;
+      }
+      if (mEnabled) {
+        if (mCCDBApi) {
+          auto md = mCCDBApi->retrieveHeaders("RCT/Info/RunInformation", {}, grp->getRun());
+          if (md.empty()) {
+            mEnabled = false;
+            LOGP(alarm, "RCT object is missing for {} run {}, disabling RCT updater", o2::parameters::GRPECS::RunTypeNames[grp->getRunType()], grp->getRun());
+          }
+        }
+      }
+    }
+    if (mEnabled) {
+      if (tinfo.firstTForbit < mMinOrbit) {
+        mMinOrbit = tinfo.firstTForbit;
+      }
+      if (tinfo.firstTForbit > mMaxOrbit) {
+        mMaxOrbit = tinfo.firstTForbit;
+      }
+      if (tinfo.tfCounter > mLastTFUpdate + mUpdateIntervalTF) { // need to update
+        mLastTFUpdate = tinfo.tfCounter;
+        updateRCT();
+      }
+    }
+  }
+
+  void endOfStream(framework::EndOfStreamContext& ec) final
+  {
+    if (mEnabled) {
+      updateRCT();
+      mEnabled = false;
+    }
+  }
+
+  void stop() final
+  {
+    if (mEnabled) {
+      updateRCT();
+      mEnabled = false;
+    }
+  }
+
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final
+  {
+    if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+      return;
+    }
+  }
+
+  void updateRCT()
+  {
+    std::map<std::string, std::string> mdRCT;
+    if (mMinOrbit > mMaxOrbit) {
+      return;
+    }
+    mdRCT["STF"] = std::to_string(long(mMinOrbit * o2::constants::lhc::LHCOrbitMUS * 1e-3) + mOrbitReset);
+    mdRCT["ETF"] = std::to_string(long((mMaxOrbit + mNHBFPerTF - 1) * o2::constants::lhc::LHCOrbitMUS * 1e-3) + mOrbitReset);
+    long startValRCT = (long)mRunNumber;
+    long endValRCT = (long)(mRunNumber + 1);
+    if (mCCDBApi) {
+      int retValRCT = mCCDBApi->updateMetadata("RCT/Info/RunInformation", mdRCT, startValRCT);
+      if (retValRCT == 0) {
+        LOGP(info, "Updated RCT object for run {} with TF start:{} end:{}", mRunNumber, mdRCT["STF"], mdRCT["ETF"]);
+      } else {
+        LOGP(alarm, "Update of RCT object for run {} with TF start:{} end:{} FAILED, returned with code {}", mRunNumber, mdRCT["STF"], mdRCT["ETF"], retValRCT);
+      }
+    } else {
+      LOGP(info, "CCDB update disabled, TF timestamp range is {}:{}", mdRCT["STF"], mdRCT["ETF"]);
+    }
+  }
+
+ private:
+  bool mEnabled = true;
+  float mUpdateInterval = 1.;
+  int mUpdateIntervalTF = 1;
+  uint32_t mMinOrbit = 0xffffffff;
+  uint32_t mMaxOrbit = 0;
+  uint32_t mLastTFUpdate = 0;
+  long mOrbitReset = 0;
+  int mRunNumber = 0;
+  int mNHBFPerTF = 32;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+  std::unique_ptr<o2::ccdb::CcdbApi> mCCDBApi;
+};
+} // namespace o2::rct
+
+// ------------------------------------------------------------------
+#include "Framework/runDataProcessing.h"
+#include "Framework/DataProcessorSpec.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  std::vector<InputSpec> inputs{{"ctfdone", "CTF", "DONE", 0, Lifetime::Timeframe}};
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                              true,                           // GRPECS=true
+                                                              false,                          // GRPLHCIF
+                                                              false,                          // GRPMagField
+                                                              false,                          // askMatLUT
+                                                              o2::base::GRPGeomRequest::None, // geometry
+                                                              inputs,
+                                                              true); // query only once all objects except mag.field
+  specs.push_back(DataProcessorSpec{
+    "rct-updater",
+    inputs,
+    {},
+    AlgorithmSpec{adaptFromTask<o2::rct::RCTUpdaterSpec>(ggRequest)},
+    Options{
+      {"update-interval", VariantType::Float, 1.f, {"update every ... seconds"}},
+      {"ccdb-server", VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB to update"}}}});
+  return specs;
+}

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -76,6 +76,7 @@ if [[ "${GEN_TOPO_VERBOSE:-}" == "1" ]]; then
   echo "CALIB_FT0_TIMEOFFSET = $CALIB_FT0_TIMEOFFSET" 1>&2
   echo "CALIB_ITS_DEADMAP_TIME = $CALIB_ITS_DEADMAP_TIME" 1>&2
   echo "CALIB_MFT_DEADMAP_TIME = $CALIB_MFT_DEADMAP_TIME" 1>&2
+  echo "CALIB_RCT_UPDATER = ${CALIB_RCT_UPDATER:-}" 1>&2
 fi
 
 # beamtype dependent settings
@@ -191,6 +192,10 @@ fi
 
 # calibrations for AGGREGATOR_TASKS == BARREL_TF
 if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
+  # RCT updater
+  if [[ ${CALIB_RCT_UPDATER:-} == 1 ]]; then
+    add_W o2-rct-updater-workflow "--ccdb-server $CCDB_POPULATOR_UPLOAD_PATH"
+  fi
   # PrimaryVertex
   if [[ $CALIB_PRIMVTX_MEANVTX == 1 ]]; then
     : ${TFPERSLOTS_MEANVTX:=55000}

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -30,6 +30,8 @@ fi
 : ${CTF_FREE_DISK_WAIT:="10"}         # if disk on EPNs is close to full, wait X seconds before retrying to write
 : ${CTF_MAX_FREE_DISK_WAIT:="600"}    # if not enough disk space after this time throw error
 
+export CALIB_RCT_UPDATER=0
+
 # entropy encoding/decoding mode, '' is equivalent to '--ans-version compat' (compatible with < 09/2023 data),
 # use '--ans-version 1.0 --ctf-dict none' for the new per-TF dictionary mode
 : ${RANS_OPT:="--ans-version 1.0 --ctf-dict none"}
@@ -601,6 +603,7 @@ if has_processing_step ENTROPY_ENCODER && [[ ! -z "$WORKFLOW_DETECTORS_CTF" ]] &
   if [[ $CREATECTFDICT == 1 ]] && [[ $EXTINPUT == 1 ]]; then CONFIG_CTF+=" --save-dict-after $SAVE_CTFDICT_NTIMEFRAMES"; fi
   [[ $EPNSYNCMODE == 1 ]] && CONFIG_CTF+=" --require-free-disk 53687091200 --wait-for-free-disk $CTF_FREE_DISK_WAIT --max-wait-for-free-disk $CTF_MAX_FREE_DISK_WAIT"
   add_W o2-ctf-writer-workflow "$CONFIG_CTF"
+  [[ $SYNCMODE == 1 ]] && export CALIB_RCT_UPDATER=1
 fi
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
CTFwriter will send out a dummy message with spec `"CTF/DONE/0`, to which the `o2-rct-updater-workflow` on the calibration node will subscribe. In case of PHYSICS or COSMIC run types this workflow will update every `--update-interval <x>` second and also at EOS the RCT object with fields STF, ETF, corresponding to the timestamps of start / end of the first/last TF seen. 
Since this workflow updates the headers only, the RCT object must be already in CCDB from the beginning of the run. Therefore the `o2-ecs-grp-create` is modified to create RCT object already at SOR.