### PR TITLE
DPL GUI: fix keyboard support in remote GUI

### DIFF
--- a/Framework/Core/include/Framework/DebugGUI.h
+++ b/Framework/Core/include/Framework/DebugGUI.h
@@ -40,8 +40,7 @@ struct DebugGUI {
   virtual void updateMouseButton(bool isClicked) = 0;
   virtual void updateMouseWheel(int direction) = 0;
   virtual void updateWindowSize(int x, int y) = 0;
-  virtual void keyDown(char key) = 0;
-  virtual void keyUp(char key) = 0;
+  virtual void keyEvent(char key, bool down) = 0;
   virtual void charIn(char key) = 0;
 
   virtual void* initGUI(char const* windowTitle, ServiceRegistry& registry) = 0;

--- a/Framework/Core/src/DPLWebSocket.cxx
+++ b/Framework/Core/src/DPLWebSocket.cxx
@@ -152,12 +152,12 @@ struct GUIWebSocketHandler : public WebSocketHandler {
       }
       case GUIOpcodes::Keydown: {
         char key = *frame;
-        mContext.gui->plugin->keyDown(key);
+        mContext.gui->plugin->keyEvent(key, true);
         break;
       }
       case GUIOpcodes::Keyup: {
         char key = *frame;
-        mContext.gui->plugin->keyUp(key);
+        mContext.gui->plugin->keyEvent(key, false);
         break;
       }
       case GUIOpcodes::Charin: {

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -1216,22 +1216,22 @@ std::function<void(void)> getGUIDebugger(std::vector<DeviceInfo> const& infos,
 void updateMousePos(float x, float y)
 {
   ImGuiIO& io = ImGui::GetIO();
-  io.MousePos = ImVec2(x, y);
+  io.AddMousePosEvent(x, y);
 }
 
 void updateMouseButton(bool clicked)
 {
   ImGuiIO& io = ImGui::GetIO();
-  io.MouseDown[0] = clicked;
+  io.AddMouseButtonEvent(0, clicked);
 }
 
 void updateMouseWheel(int direction)
 {
   ImGuiIO& io = ImGui::GetIO();
   if (direction > 0) {
-    io.MouseWheel++;
+    io.AddMouseWheelEvent(0, 1.0);
   } else {
-    io.MouseWheel--;
+    io.AddMouseWheelEvent(0, -1.0);
   }
 }
 
@@ -1241,16 +1241,52 @@ void updateWindowSize(int x, int y)
   io.DisplaySize = ImVec2(x, y);
 }
 
-void keyDown(char key)
+void keyEvent(char key, bool down)
 {
   ImGuiIO& io = ImGui::GetIO();
-  io.KeysDown[io.KeyMap[(int)key]] = true;
-}
-
-void keyUp(char key)
-{
-  ImGuiIO& io = ImGui::GetIO();
-  io.KeysDown[io.KeyMap[(int)key]] = false;
+  switch (key) {
+    case 0:
+      io.AddKeyEvent(ImGuiKey_Tab, down);
+      break;
+    case 1:
+      io.AddKeyEvent(ImGuiKey_LeftArrow, down);
+      break;
+    case 2:
+      io.AddKeyEvent(ImGuiKey_RightArrow, down);
+      break;
+    case 3:
+      io.AddKeyEvent(ImGuiKey_UpArrow, down);
+      break;
+    case 4:
+      io.AddKeyEvent(ImGuiKey_DownArrow, down);
+      break;
+    case 5:
+      io.AddKeyEvent(ImGuiKey_PageUp, down);
+      break;
+    case 6:
+      io.AddKeyEvent(ImGuiKey_PageDown, down);
+      break;
+    case 7:
+      io.AddKeyEvent(ImGuiKey_Home, down);
+      break;
+    case 8:
+      io.AddKeyEvent(ImGuiKey_End, down);
+      break;
+    case 10:
+      io.AddKeyEvent(ImGuiKey_Delete, down);
+      break;
+    case 11:
+      io.AddKeyEvent(ImGuiKey_Backspace, down);
+      break;
+    case 13:
+      io.AddKeyEvent(ImGuiKey_Enter, down);
+      break;
+    case 14:
+      io.AddKeyEvent(ImGuiKey_Escape, down);
+      break;
+    default:
+      io.AddKeyEvent((ImGuiKey)key, down);
+  }
 }
 
 void charIn(char key)

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.h
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.h
@@ -43,8 +43,7 @@ void updateMousePos(float x, float y);
 void updateMouseButton(bool clicked);
 void updateMouseWheel(int direction);
 void updateWindowSize(int x, int y);
-void keyDown(char key);
-void keyUp(char key);
+void keyEvent(char key, bool pressed);
 void charIn(char key);
 
 } // namespace gui

--- a/Framework/GUISupport/src/Plugin.cxx
+++ b/Framework/GUISupport/src/Plugin.cxx
@@ -57,13 +57,9 @@ struct ImGUIDebugGUI : o2::framework::DebugGUI {
   {
     o2::framework::gui::updateWindowSize(x, y);
   }
-  void keyDown(char key) override
+  void keyEvent(char key, bool down) override
   {
-    o2::framework::gui::keyDown(key);
-  }
-  void keyUp(char key) override
-  {
-    o2::framework::gui::keyUp(key);
+    o2::framework::gui::keyEvent(key, down);
   }
   void charIn(char key) override
   {


### PR DESCRIPTION
DPL GUI: fix keyboard support in remote GUI

Move to use the new ImGUI API for keys / mouse events.
Map events from the web page to the correct enum value.
