### PR TITLE
Update ClusterLabel.h label energy fraction order

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ClusterLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ClusterLabel.h
@@ -38,12 +38,12 @@ class ClusterLabel
   struct labelWithE {
 
     /// \brief Constructor
-    labelWithE() : energyFraction(0.), label(0) {}
+    labelWithE() : label(0), energyFraction(0.) {}
 
     /// \brief Constructor
     /// \param e Energy fraction
     /// \param l MC label
-    labelWithE(float e, int l) : energyFraction(e), label(l) {}
+    labelWithE(int l, float e) : label(l), energyFraction(e) {}
 
     /// \brief Comparison lower operator comparing cells based on energy
     ///


### PR DESCRIPTION
- The order in which the labels and the energy fraction are given inside the `addValue` are label first, fraction second. However the constructer was expecting energy first and label second. This is now changed in the constructer.