### PR TITLE
[EMCAL-688] ClusterLabel - Fix sorting and idexing

### DIFF
--- a/DataFormats/Detectors/EMCAL/src/ClusterLabel.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ClusterLabel.cxx
@@ -71,5 +71,5 @@ void ClusterLabel::orderLabels()
 {
   // Sort the pairs based on values in descending order
   std::sort(mClusterLabels.begin(), mClusterLabels.end(),
-            [](const labelWithE& a, const labelWithE& b) { return a.label >= b.label; });
+            [](const labelWithE& a, const labelWithE& b) { return a.energyFraction >= b.energyFraction; });
 }

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -89,16 +89,17 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
 
   std::vector<unsigned short> cellsIdices;
 
-  size_t iCell = 0;
   bool addClusterLabels = ((clusterLabel != nullptr) && (mCellLabelContainer.size() > 0));
   for (auto cellIndex : inputsIndices) {
     cellsIdices.push_back(cellIndex);
     if (addClusterLabels) {
-      for (size_t iLabel = 0; iLabel < mCellLabelContainer[iCell].GetLabelSize(); iLabel++) {
-        clusterLabel->addValue(mCellLabelContainer[iCell].GetLabel(iLabel),
-                               mCellLabelContainer[iCell].GetAmplitudeFraction(iLabel) * mInputsContainer[iCell].getEnergy());
+      for (size_t iLabel = 0; iLabel < mCellLabelContainer[cellIndex].GetLabelSize(); iLabel++) {
+        if (mCellLabelContainer[cellIndex].GetAmplitudeFraction(iLabel) <= 0.f) {
+          continue; // skip 0 entries
+        }
+        clusterLabel->addValue(mCellLabelContainer[cellIndex].GetLabel(iLabel),
+                               mCellLabelContainer[cellIndex].GetAmplitudeFraction(iLabel) * mInputsContainer[cellIndex].getEnergy());
       }
-      iCell++;
     }
   }
   if (addClusterLabels) {


### PR DESCRIPTION
This commit aims to fix the sorting of the cluster labels and wrong indexing inside the ClusterFactory
- in DataFormats/Detectors/EMCAL/src/ClusterLabel.cxx: 
    - `ClusterLabel::orderLabels()` now correctly orders by `energyFraction` and not by `label`
- in /Users/mhemmer/alice/O2/Detectors/EMCAL/base/src/ClusterFactory.cxx":
    - inside `o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster` the index used to access the CellLabels from the `mCellLabelContainer` is now `cellIndex` from `inputsIndices` instead of an extra variable `iCell` which resulted in using the wrong cells and thus wrong labels for the MC.