### PR TITLE
DPL: replace LOG with Signposts

### DIFF
--- a/Framework/Core/include/Framework/AsyncQueue.h
+++ b/Framework/Core/include/Framework/AsyncQueue.h
@@ -32,8 +32,9 @@ struct AsyncTaskId {
 
 /// An actuatual task to be executed
 struct AsyncTask {
-  // The task to be executed
-  std::function<void()> task;
+  // The task to be executed. Id can be used as unique
+  // id for the signpost in the async_queue stream.
+  std::function<void(size_t id)> task;
   // The associated task spec
   AsyncTaskId id = {-1};
   TimesliceId timeslice = {TimesliceId::INVALID};
@@ -49,10 +50,11 @@ struct AsyncQueue {
 };
 
 struct AsyncQueueHelpers {
+  using AsyncCallback = std::function<void(size_t)>;
   static AsyncTaskId create(AsyncQueue& queue, AsyncTaskSpec spec);
   // Schedule a task with @a taskId to be executed whenever the timeslice
   // is past timeslice. If debounce is provided, only execute the task
-  static void post(AsyncQueue& queue, AsyncTaskId taskId, std::function<void()> task, TimesliceId timeslice, int64_t debounce = 0);
+  static void post(AsyncQueue& queue, AsyncTaskId taskId, AsyncCallback task, TimesliceId timeslice, int64_t debounce = 0);
   /// Run all the tasks which are older than the oldestPossible timeslice
   /// executing them by:
   /// 1. sorting the tasks by timeslice

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -82,6 +82,7 @@ using Value = o2::monitoring::tags::Value;
 
 O2_DECLARE_DYNAMIC_LOG(data_processor_context);
 O2_DECLARE_DYNAMIC_LOG(stream_context);
+O2_DECLARE_DYNAMIC_LOG(async_queue);
 
 namespace o2::framework
 {
@@ -580,11 +581,14 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
                              (uint64_t)oldestPossibleOutput.timeslice.value,
                              oldestPossibleOutput.slot.index == -1 ? "channel" : "slot",
                              (uint64_t)(oldestPossibleOutput.slot.index == -1 ? oldestPossibleOutput.channel.value : oldestPossibleOutput.slot.index));
+      O2_SIGNPOST_EVENT_EMIT_ERROR(data_processor_context, cid, "oldest_possible_timeslice", "Ordered active %d", decongestion->orderedCompletionPolicyActive);
       if (decongestion->orderedCompletionPolicyActive) {
         auto oldNextTimeslice = decongestion->nextTimeslice;
         decongestion->nextTimeslice = std::max(decongestion->nextTimeslice, (int64_t)oldestPossibleOutput.timeslice.value);
+        timesliceIndex.updateOldestPossibleOutput();
+        O2_SIGNPOST_EVENT_EMIT_ERROR(data_processor_context, cid, "oldest_possible_timeslice", "Next timeslice %" PRIi64, decongestion->nextTimeslice);
         if (oldNextTimeslice != decongestion->nextTimeslice) {
-          LOGP(error, "Some Lifetime::Timeframe data got dropped starting at {}", oldNextTimeslice);
+          O2_SIGNPOST_EVENT_EMIT_ERROR(data_processor_context, cid, "oldest_possible_timeslice", "Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
           timesliceIndex.rescan();
         }
       }
@@ -630,7 +634,7 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       auto oldestPossibleOutput = relayer.getOldestPossibleOutput();
 
       if (oldestPossibleOutput.timeslice.value == decongestion.lastTimeslice) {
-        O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Not sending already sent value: %" PRIu64, (uint64_t)oldestPossibleOutput.timeslice.value);
+        O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Synchronous: Not sending already sent value: %" PRIu64, (uint64_t)oldestPossibleOutput.timeslice.value);
         return;
       }
       if (oldestPossibleOutput.timeslice.value < decongestion.lastTimeslice) {
@@ -646,14 +650,15 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Queueing oldest possible timeslice %" PRIu64 " propagation for execution.",
                              (uint64_t)oldestPossibleOutput.timeslice.value);
       AsyncQueueHelpers::post(
-        queue, decongestion.oldestPossibleTimesliceTask, [ref = services, oldestPossibleOutput, &decongestion, &proxy, &spec, device, &timesliceIndex]() {
-          O2_SIGNPOST_ID_FROM_POINTER(cid, data_processor_context, &decongestion);
+        queue, decongestion.oldestPossibleTimesliceTask, [ref = services, oldestPossibleOutput, &decongestion, &proxy, &spec, device, &timesliceIndex](size_t id) {
+          O2_SIGNPOST_ID_GENERATE(cid, async_queue);
+          cid.value = id;
           if (decongestion.lastTimeslice >= oldestPossibleOutput.timeslice.value) {
-            O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Not sending already sent value: %" PRIu64 "> %" PRIu64,
+            O2_SIGNPOST_EVENT_EMIT(async_queue, cid, "oldest_possible_timeslice", "Not sending already sent value: %" PRIu64 "> %" PRIu64,
                 decongestion.lastTimeslice, (uint64_t)oldestPossibleOutput.timeslice.value);
             return;
           }
-          O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Running oldest possible timeslice %" PRIu64 " propagation.",
+          O2_SIGNPOST_EVENT_EMIT(async_queue, cid, "oldest_possible_timeslice", "Running oldest possible timeslice %" PRIu64 " propagation.",
                                  (uint64_t)oldestPossibleOutput.timeslice.value);
           DataProcessingHelpers::broadcastOldestPossibleTimeslice(ref, oldestPossibleOutput.timeslice.value);
 
@@ -662,21 +667,22 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
             auto& state = proxy.getForwardChannelState(ChannelIndex{fi});
             // TODO: this we could cache in the proxy at the bind moment.
             if (info.channelType != ChannelAccountingType::DPL) {
-              O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Skipping channel %{public}s", info.name.c_str());
+              O2_SIGNPOST_EVENT_EMIT(async_queue, cid, "oldest_possible_timeslice", "Skipping channel %{public}s", info.name.c_str());
               continue;
             }
             if (DataProcessingHelpers::sendOldestPossibleTimeframe(ref, info, state, oldestPossibleOutput.timeslice.value)) {
-              O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice",
+              O2_SIGNPOST_EVENT_EMIT(async_queue, cid, "oldest_possible_timeslice",
                                      "Forwarding to channel %{public}s oldest possible timeslice %" PRIu64 ", priority %d",
                                      info.name.c_str(), (uint64_t)oldestPossibleOutput.timeslice.value, 20);
             }
           }
           decongestion.lastTimeslice = oldestPossibleOutput.timeslice.value;
           if (decongestion.orderedCompletionPolicyActive) {
+
             int64_t oldNextTimeslice = decongestion.nextTimeslice;
             decongestion.nextTimeslice = std::max(decongestion.nextTimeslice, (int64_t)oldestPossibleOutput.timeslice.value);
             if (oldNextTimeslice != decongestion.nextTimeslice) {
-              LOGP(error, "Some Lifetime::Timeframe data got dropped starting at {}", oldNextTimeslice);
+              O2_SIGNPOST_EVENT_EMIT_ERROR(async_queue, cid, "oldest_possible_timeslice", "Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
               timesliceIndex.rescan();
             }
           }

--- a/Framework/Core/src/TimesliceIndex.cxx
+++ b/Framework/Core/src/TimesliceIndex.cxx
@@ -9,7 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/TimesliceIndex.h"
-#include "Framework/Logger.h"
+#include "Framework/Signpost.h"
+
+O2_DECLARE_DYNAMIC_LOG(timeslice_index);
 
 namespace o2::framework
 {
@@ -33,6 +35,8 @@ void TimesliceIndex::associate(TimesliceId timestamp, TimesliceSlot slot)
   mVariables[slot.index].put({0, static_cast<uint64_t>(timestamp.value)});
   mVariables[slot.index].commit();
   mDirty[slot.index] = true;
+  O2_SIGNPOST_ID_GENERATE(tid, timeslice_index);
+  O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "associate", "Associating timestamp %zu to slot %zu", timestamp.value, slot.index);
 }
 
 TimesliceSlot TimesliceIndex::findOldestSlot(TimesliceId timestamp) const
@@ -63,13 +67,18 @@ TimesliceSlot TimesliceIndex::findOldestSlot(TimesliceId timestamp) const
 std::tuple<TimesliceIndex::ActionTaken, TimesliceSlot> TimesliceIndex::replaceLRUWith(data_matcher::VariableContext& newContext, TimesliceId timestamp)
 {
   auto oldestSlot = findOldestSlot(timestamp);
+  O2_SIGNPOST_ID_GENERATE(tid, timeslice_index);
   if (TimesliceIndex::isValid(oldestSlot) == false) {
     mVariables[oldestSlot.index] = newContext;
+    auto debugTimestamp = std::get_if<uint64_t>(&mVariables[oldestSlot.index].get(0));
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "replaceLRUWith", "slot %zu timeslice %zu (%" PRIu64 ")", oldestSlot.index, timestamp.value, *debugTimestamp);
     return std::make_tuple(ActionTaken::ReplaceUnused, oldestSlot);
   }
   auto oldTimestamp = std::get_if<uint64_t>(&mVariables[oldestSlot.index].get(0));
   if (oldTimestamp == nullptr) {
     mVariables[oldestSlot.index] = newContext;
+    auto debugTimestamp = std::get_if<uint64_t>(&mVariables[oldestSlot.index].get(0));
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "replaceLRUWith", "slot %zu timeslice %zu (%" PRIu64 ")", oldestSlot.index, timestamp.value, *debugTimestamp);
     return std::make_tuple(ActionTaken::ReplaceUnused, oldestSlot);
   }
 
@@ -80,9 +89,12 @@ std::tuple<TimesliceIndex::ActionTaken, TimesliceSlot> TimesliceIndex::replaceLR
 
   if (*newTimestamp > *oldTimestamp) {
     switch (mBackpressurePolicy) {
-      case BackpressureOp::DropAncient:
+      case BackpressureOp::DropAncient: {
         mVariables[oldestSlot.index] = newContext;
+        auto debugTimestamp = std::get_if<uint64_t>(&mVariables[oldestSlot.index].get(0));
+        O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "replaceLRUWith", "slot %zu timeslice %zu (%" PRIu64 ")", oldestSlot.index, timestamp.value, *debugTimestamp);
         return std::make_tuple(ActionTaken::ReplaceObsolete, oldestSlot);
+      }
       case BackpressureOp::DropRecent:
         return std::make_tuple(ActionTaken::DropObsolete, TimesliceSlot{TimesliceSlot::INVALID});
       case BackpressureOp::Wait:
@@ -90,9 +102,12 @@ std::tuple<TimesliceIndex::ActionTaken, TimesliceSlot> TimesliceIndex::replaceLR
     }
   } else {
     switch (mBackpressurePolicy) {
-      case BackpressureOp::DropRecent:
+      case BackpressureOp::DropRecent: {
         mVariables[oldestSlot.index] = newContext;
+        auto debugTimestamp = std::get_if<uint64_t>(&mVariables[oldestSlot.index].get(0));
+        O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "replaceLRUWith", "slot %zu timeslice %zu (%" PRIu64 ")", oldestSlot.index, timestamp.value, *debugTimestamp);
         return std::make_tuple(ActionTaken::ReplaceObsolete, oldestSlot);
+      }
       case BackpressureOp::DropAncient:
         return std::make_tuple(ActionTaken::DropObsolete, TimesliceSlot{TimesliceSlot::INVALID});
       case BackpressureOp::Wait:
@@ -124,9 +139,12 @@ bool TimesliceIndex::didReceiveData() const
 
 TimesliceIndex::OldestInputInfo TimesliceIndex::setOldestPossibleInput(TimesliceId timestamp, ChannelIndex channel)
 {
+  O2_SIGNPOST_ID_GENERATE(tid, timeslice_index);
   // Each channel oldest possible input must be monotoically increasing.
   if (timestamp.value < mChannels[channel.value].oldestForChannel.value) {
-    LOG(error) << "Received bogus oldest possible timeslice " << timestamp.value << " for channel " << channel.value << ". Expected >= " << mChannels[channel.value].oldestForChannel.value;
+    O2_SIGNPOST_EVENT_EMIT_ERROR(timeslice_index, tid, "setOldestPossibleInput",
+                                 "Received bogus oldest possible timeslice %zu for channel %d. Expected >= %zu.",
+                                 timestamp.value, channel.value, mChannels[channel.value].oldestForChannel.value);
   }
   mChannels[channel.value].oldestForChannel = timestamp;
   OldestInputInfo result{timestamp, channel};
@@ -144,11 +162,13 @@ TimesliceIndex::OldestInputInfo TimesliceIndex::setOldestPossibleInput(Timeslice
     }
   }
   if (changed && mOldestPossibleInput.timeslice.value != result.timeslice.value) {
-    LOG(debug) << "Success: Oldest possible input is " << result.timeslice.value << " due to channel " << result.channel.value;
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "setOldestPossibleInput", "Success: Oldest possible input is %zu due to channel %d",
+                           result.timeslice.value, result.channel.value);
   } else if (mOldestPossibleInput.timeslice.value != result.timeslice.value) {
-    LOG(debug) << "Oldest possible input updated from timestamp: " << mOldestPossibleInput.timeslice.value << " --> " << result.timeslice.value;
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "setOldestPossibleInput", "Oldest possible input updated from timestamp: %zu --> %zu",
+                           mOldestPossibleInput.timeslice.value, result.timeslice.value);
   } else {
-    LOG(debug) << "No change in oldest possible input";
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "setOldestPossibleInput", "No change in oldest possible input");
   }
   mOldestPossibleInput = result;
   return mOldestPossibleInput;
@@ -187,13 +207,15 @@ TimesliceIndex::OldestOutputInfo TimesliceIndex::updateOldestPossibleOutput()
       result.channel = {(int)-1};
     }
   }
+  O2_SIGNPOST_ID_GENERATE(tid, timeslice_index);
   if (changed && mOldestPossibleOutput.timeslice.value != result.timeslice.value) {
-    LOGP(debug, "Oldest possible output {} due to {} {}",
-         result.timeslice.value,
-         result.channel.value == -1 ? "slot" : "channel",
-         result.channel.value == -1 ? mOldestPossibleOutput.slot.index : mOldestPossibleOutput.channel.value);
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "updateOldestPossibleOutput", "Oldest possible output %zu due to %{public}s %zu",
+                           result.timeslice.value,
+                           result.channel.value == -1 ? "slot" : "channel",
+                           result.channel.value == -1 ? mOldestPossibleOutput.slot.index : mOldestPossibleOutput.channel.value);
   } else if (mOldestPossibleOutput.timeslice.value != result.timeslice.value) {
-    LOG(debug) << "Oldest possible output updated from oldest Input : " << mOldestPossibleOutput.timeslice.value << " --> " << result.timeslice.value;
+    O2_SIGNPOST_EVENT_EMIT(timeslice_index, tid, "updateOldestPossibleOutput", "Oldest possible output updated from oldest Input : %zu --> %zu",
+                           mOldestPossibleOutput.timeslice.value, result.timeslice.value);
   }
   mOldestPossibleOutput = result;
 

--- a/Framework/Core/test/test_AsyncQueue.cxx
+++ b/Framework/Core/test/test_AsyncQueue.cxx
@@ -22,9 +22,9 @@ TEST_CASE("TestDebouncing")
   // Push two tasks on the queue with the same id
   auto count = 0;
   AsyncQueueHelpers::post(
-    queue, taskId, [&count]() { count += 1; }, TimesliceId{0}, 10);
+    queue, taskId, [&count](size_t) { count += 1; }, TimesliceId{0}, 10);
   AsyncQueueHelpers::post(
-    queue, taskId, [&count]() { count += 2; }, TimesliceId{1}, 20);
+    queue, taskId, [&count](size_t) { count += 2; }, TimesliceId{1}, 20);
   AsyncQueueHelpers::run(queue, TimesliceId{2});
   REQUIRE(count == 2);
 }
@@ -39,9 +39,9 @@ TEST_CASE("TestPriority")
   // Push two tasks on the queue with the same id
   auto count = 0;
   AsyncQueueHelpers::post(
-    queue, taskId1, [&count]() { count += 10; }, TimesliceId{0});
+    queue, taskId1, [&count](size_t) { count += 10; }, TimesliceId{0});
   AsyncQueueHelpers::post(
-    queue, taskId2, [&count]() { count /= 10; }, TimesliceId{0});
+    queue, taskId2, [&count](size_t) { count /= 10; }, TimesliceId{0});
   AsyncQueueHelpers::run(queue, TimesliceId{2});
   REQUIRE(count == 10);
 }
@@ -56,9 +56,9 @@ TEST_CASE("TestOldestTimeslice")
   // Push two tasks on the queue with the same id
   auto count = 0;
   AsyncQueueHelpers::post(
-    queue, taskId1, [&count]() { count += 10; }, TimesliceId{1});
+    queue, taskId1, [&count](size_t) { count += 10; }, TimesliceId{1});
   AsyncQueueHelpers::post(
-    queue, taskId2, [&count]() { count += 20; }, TimesliceId{0});
+    queue, taskId2, [&count](size_t) { count += 20; }, TimesliceId{0});
   AsyncQueueHelpers::run(queue, TimesliceId{0});
   REQUIRE(count == 20);
   AsyncQueueHelpers::run(queue, TimesliceId{0});
@@ -77,11 +77,11 @@ TEST_CASE("TestOldestTimesliceWithBounce")
   // Push two tasks on the queue with the same id
   auto count = 0;
   AsyncQueueHelpers::post(
-    queue, taskId1, [&count]() { count += 10; }, TimesliceId{2});
+    queue, taskId1, [&count](size_t) { count += 10; }, TimesliceId{2});
   AsyncQueueHelpers::post(
-    queue, taskId2, [&count]() { count += 20; }, TimesliceId{1}, 10);
+    queue, taskId2, [&count](size_t) { count += 20; }, TimesliceId{1}, 10);
   AsyncQueueHelpers::post(
-    queue, taskId2, [&count]() { count += 30; }, TimesliceId{1}, 20);
+    queue, taskId2, [&count](size_t) { count += 30; }, TimesliceId{1}, 20);
   AsyncQueueHelpers::run(queue, TimesliceId{0});
   REQUIRE(count == 0);
   REQUIRE(queue.tasks.size() == 3);
@@ -103,11 +103,11 @@ TEST_CASE("TestOldestTimesliceWithNegativeBounce")
   // Push two tasks on the queue with the same id
   auto count = 0;
   AsyncQueueHelpers::post(
-    queue, taskId1, [&count]() { count += 10; }, TimesliceId{2});
+    queue, taskId1, [&count](size_t) { count += 10; }, TimesliceId{2});
   AsyncQueueHelpers::post(
-    queue, taskId2, [&count]() { count += 20; }, TimesliceId{1}, -10);
+    queue, taskId2, [&count](size_t) { count += 20; }, TimesliceId{1}, -10);
   AsyncQueueHelpers::post(
-    queue, taskId2, [&count]() { count += 30; }, TimesliceId{1}, -20);
+    queue, taskId2, [&count](size_t) { count += 30; }, TimesliceId{1}, -20);
   AsyncQueueHelpers::run(queue, TimesliceId{0});
   REQUIRE(count == 0);
   REQUIRE(queue.tasks.size() == 3);
@@ -128,13 +128,13 @@ TEST_CASE("TestOldestTimeslicePerTimeslice")
   // Push two tasks on the queue with the same id
   auto count = 0;
   AsyncQueueHelpers::post(
-    queue, taskId1, [&count]() { count += 10; }, TimesliceId{1});
+    queue, taskId1, [&count](size_t) { count += 10; }, TimesliceId{1});
   REQUIRE(queue.tasks.size() == 1);
   AsyncQueueHelpers::run(queue, TimesliceId{0});
   REQUIRE(queue.tasks.size() == 1);
   REQUIRE(count == 0);
   AsyncQueueHelpers::post(
-    queue, taskId1, [&count]() { count += 20; }, TimesliceId{2});
+    queue, taskId1, [&count](size_t) { count += 20; }, TimesliceId{2});
   REQUIRE(queue.tasks.size() == 2);
   AsyncQueueHelpers::run(queue, TimesliceId{1});
   REQUIRE(queue.tasks.size() == 1);


### PR DESCRIPTION
DPL: replace LOG with Signposts

Move a bunch of log messages to use signposts for:

* AsyncQueue
* TimesliceIndex
* CommonServices
* DataRelayer

Also modified the async queue to get the oldest possible timeslice as index, so
that we can use that to track executions.
