### PR TITLE
ITS GPU: INVALID_TRIGGER_ERROR_NO_HOST_CODE should not be defined away but GPUg() should only be used in GPUCode

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TrackingKernels.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TrackingKernels.h
@@ -22,6 +22,7 @@ namespace its
 {
 namespace gpu
 {
+#ifdef GPUCA_GPUCODE // GPUg() global kernels must only when compiled by GPU compiler
 GPUd() bool fitTrack(TrackITSExt& track,
                      int start,
                      int end,
@@ -46,6 +47,7 @@ GPUg() void fitTrackSeedsKernel(
   float maxChi2ClusterAttachment,
   float maxChi2NDF,
   const o2::base::Propagator* propagator);
+#endif
 
 } // namespace gpu
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
@@ -16,7 +16,6 @@
 #include <unistd.h>
 #include <thread>
 
-#define INVALID_TRIGGER_ERROR_NO_HOST_CODE // workaround to fix undefined type in GPUg() protection on host
 #include "DataFormatsITS/TrackITS.h"
 
 #include "ITStrackingGPU/TrackerTraitsGPU.h"


### PR DESCRIPTION
@mconcas : `GPUg()` is a gpu keyword, not to be used in host code. Defining it away actually creates ambigious symbols: The host code will assume it is a normal CPU function, while it is in fact compiled as a GPU kernel.

I agree that there might be a use case to have the same function available as GPU-kernel and per thread on the CPU. But I think in that case, it is better to just wrap it in a kernel. Overall, I think we should not define `INVALID_TRIGGER_ERROR_NO_HOST_CODE` away, but it is a genuine error, and we should hide the kernel definitions in host code which does not understand it.