### PR TITLE
ITSMFT: check on strobe length for STFDecoder

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -120,6 +120,7 @@ class RawPixelDecoder final : public PixelReader
 
   void setSkipRampUpData(bool v = true) { mSkipRampUpData = v; }
   bool getSkipRampUpData() const { return mSkipRampUpData; }
+  auto getNROFsProcessed() const { return mROFCounter; }
 
   struct LinkEntry {
     int entry = -1;

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -95,6 +95,8 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
       collectROFCableData(iru);
     }
 
+    mROFCounter++;
+
     if (!doIRMajorityPoll()) {
       continue; // no links with data
     }
@@ -114,7 +116,6 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
 
     if (mNChipsFiredROF || (mAlloEmptyROFs && mNLinksDone < mNLinksInTF)) { // fill some statistics
       mTrigger = mLinkForTriggers ? mLinkForTriggers->trigger : 0;
-      mROFCounter++;
       mNChipsFired += mNChipsFiredROF;
       mNPixelsFired += mNPixelsFiredROF;
       mCurRUDecodeID = 0; // getNextChipData will start from here

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -188,9 +188,9 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
 
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     int expectedTFSize = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC); // 3564*32 / ROF Length in BS = number of ROFs per TF
-    if ((expectedTFSize != nTriggersProcessed) && (mTFCounter > 1) && (nTriggersProcessed > 0))
+    if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1 && nTriggersProcessed > 0) {
       LOG(error) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
-
+    }
     if (mDoClusters && mClusterer->getMaxROFDepthToSquash()) {
       // Digits squashing require to run on a batch of digits and uses a digit reader, cannot (?) run with decoder
       //  - Setup decoder for running on a batch of digits

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -159,8 +159,8 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
 
     mDecoder->setDecodeNextAuto(false);
     o2::InteractionRecord lastIR{}, firstIR{0, pc.services().get<o2::framework::TimingInfo>().firstTForbit};
-   int nTriggersProcessed =0;
-   while (mDecoder->decodeNextTrigger() >= 0) {
+    int nTriggersProcessed = 0;
+    while (mDecoder->decodeNextTrigger() >= 0) {
       if ((!lastIR.isDummy() && lastIR >= mDecoder->getInteractionRecord()) || firstIR > mDecoder->getInteractionRecord()) {
         const int MaxErrLog = 2;
         static int errLocCount = 0;
@@ -170,7 +170,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
         continue;
       }
       lastIR = mDecoder->getInteractionRecord();
-      if (mDoDigits || mClusterer->getMaxROFDepthToSquash()) { // call before clusterization, since the latter will hide the digits
+      if (mDoDigits || mClusterer->getMaxROFDepthToSquash()) {      // call before clusterization, since the latter will hide the digits
         mDecoder->fillDecodedDigits(digVec, digROFVec, chipStatus); // lot of copying involved
 
         if (mDoCalibData) {
@@ -186,9 +186,9 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     }
 
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-    std::cout<<"mTFCounter= "<< mTFCounter << " from params: "<< 3564*32/alpParams.roFrameLengthInBC << " from redout: "<< nTriggersProcessed<< " number from geometry: "<< o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF()<<std::endl;
-    int expectedValue = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC);
-    if ( (expectedValue != nTriggersProcessed) && mTFCounter > 1) LOG(fatal)<< "Inconsistant size of ROF and Strobbing rate, from parameters: "<< 3564*32/alpParams.roFrameLengthInBC << " from readout: "<<  nTriggersProcessed;
+    int expectedTFSize = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC); // 3564*32 / ROF Length in BS = number of ROFs per TF
+    if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1)
+      LOG(fatal) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
 
     if (mDoClusters && mClusterer->getMaxROFDepthToSquash()) {
       // Digits squashing require to run on a batch of digits and uses a digit reader, cannot (?) run with decoder

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -188,7 +188,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
 
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     int expectedTFSize = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC); // 3564*32 / ROF Length in BS = number of ROFs per TF
-    if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1)
+    if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1 && nTriggersProcessed > 0)
       LOG(error) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
 
     if (mDoClusters && mClusterer->getMaxROFDepthToSquash()) {

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -188,7 +188,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
 
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     int expectedTFSize = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC); // 3564*32 / ROF Length in BS = number of ROFs per TF
-    if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1 && nTriggersProcessed > 0)
+    if ((expectedTFSize != nTriggersProcessed) && (mTFCounter > 1) && (nTriggersProcessed > 0))
       LOG(error) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
 
     if (mDoClusters && mClusterer->getMaxROFDepthToSquash()) {

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -188,7 +188,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     int expectedTFSize = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC); // 3564*32 / ROF Length in BS = number of ROFs per TF
     if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1)
-      LOG(fatal) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
+      LOG(error) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
 
     if (mDoClusters && mClusterer->getMaxROFDepthToSquash()) {
       // Digits squashing require to run on a batch of digits and uses a digit reader, cannot (?) run with decoder


### PR DESCRIPTION
Added check on the number of ROF per TF for ITS and MFT decoders. 

Here the strobe length from parameters (ECS env or CCDB) is compared with number of triggers from Decoder. 

