### PR TITLE
ITS GPU: Remove hip_runtime.h include from headers, include cuda/hip runtime in source files

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Array.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Array.h
@@ -17,9 +17,6 @@
 #define ITSTRACKINGGPU_ARRAY_H_
 
 #include "GPUCommonDef.h"
-#ifdef __HIPCC__
-#include <hip/hip_runtime.h>
-#endif
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/ClusterLinesGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/ClusterLinesGPU.h
@@ -18,9 +18,6 @@
 #include "GPUCommonDef.h"
 #include <cstdint> /// Required to properly compile MathUtils
 #include "ITStracking/ClusterLines.h"
-#ifdef __HIPCC__
-#include <hip/hip_runtime.h>
-#endif
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Context.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Context.h
@@ -19,9 +19,6 @@
 #include <string>
 #include <vector>
 #include "ITStracking/Definitions.h"
-#ifdef __HIPCC__
-#include <hip/hip_runtime.h>
-#endif
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Stream.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Stream.h
@@ -18,10 +18,6 @@
 
 #include "ITStracking/Definitions.h"
 
-#ifdef __HIPCC__
-#include <hip/hip_runtime.h>
-#endif
-
 namespace o2
 {
 namespace its

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -13,10 +13,6 @@
 #ifndef TRACKINGITSGPU_INCLUDE_TIMEFRAMEGPU_H
 #define TRACKINGITSGPU_INCLUDE_TIMEFRAMEGPU_H
 
-#ifdef __HIPCC__
-#include <hip/hip_runtime.h>
-#endif
-
 #include "ITStracking/TimeFrame.h"
 #include "ITStracking/Configuration.h"
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/ClusterLinesGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/ClusterLinesGPU.cu
@@ -11,6 +11,7 @@
 ///
 /// \author matteo.concas@cern.ch
 
+#include <cuda_runtime.h>
 #include "ITStrackingGPU/ClusterLinesGPU.h"
 
 namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Context.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Context.cu
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <cuda_runtime.h>
 #include "ITStrackingGPU/Context.h"
 #include "ITStrackingGPU/Utils.h"
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 ///
 
+#include <cuda_runtime.h>
 #include "ITStrackingGPU/Stream.h"
 #include "ITStrackingGPU/Utils.h"
 #include "GPUCommonLogger.h"

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
+#include <cuda_runtime.h>
 #include <thrust/fill.h>
 #include <thrust/execution_policy.h>
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TracerGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TracerGPU.cu
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <cuda_runtime.h>
 #include "ITStrackingGPU/TracerGPU.h"
 
 #if !defined(__HIPCC__) && defined(__USE_GPU_TRACER__)

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 ///
 
+#include <cuda_runtime.h>
 #include <array>
 #include <sstream>
 #include <iostream>

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Utils.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Utils.cu
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <cuda_runtime.h>
 #include "ITStrackingGPU/Utils.h"
 #include "ITStrackingGPU/Context.h"
 #include "ITStracking/Constants.h"

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -11,6 +11,7 @@
 //
 /// \author matteo.concas@cern.ch
 
+#include <cuda_runtime.h>
 #include <iostream>
 #include <sstream>
 #include <fstream>

--- a/cmake/O2AddHipifiedExecutable.cmake
+++ b/cmake/O2AddHipifiedExecutable.cmake
@@ -37,7 +37,7 @@ function(o2_add_hipified_executable baseTargetName)
 
       add_custom_command(
         OUTPUT ${OUTPUT_HIP_FILE}
-        COMMAND ${hip_HIPIFY_PERL_EXECUTABLE} --quiet-warnings ${ABS_CUDA_SORUCE} | sed '1{/\#include \"hip\\/hip_runtime.h\"/d}' > ${OUTPUT_HIP_FILE}
+        COMMAND ${hip_HIPIFY_PERL_EXECUTABLE} --quiet-warnings ${ABS_CUDA_SORUCE} > ${OUTPUT_HIP_FILE}
         DEPENDS ${file}
         COMMENT "Hippifying ${HIP_SOURCE}"
       )

--- a/cmake/O2AddHipifiedLibrary.cmake
+++ b/cmake/O2AddHipifiedLibrary.cmake
@@ -37,7 +37,7 @@ function(o2_add_hipified_library baseTargetName)
 
       add_custom_command(
         OUTPUT ${OUTPUT_HIP_FILE}
-        COMMAND ${hip_HIPIFY_PERL_EXECUTABLE} --quiet-warnings ${ABS_CUDA_SORUCE} | sed '1{/\#include \"hip\\/hip_runtime.h\"/d}' > ${OUTPUT_HIP_FILE}
+        COMMAND ${hip_HIPIFY_PERL_EXECUTABLE} --quiet-warnings ${ABS_CUDA_SORUCE} > ${OUTPUT_HIP_FILE}
         DEPENDS ${file}
         COMMENT "Hippifying ${HIP_SOURCE}"
       )


### PR DESCRIPTION
@mconcas : Is this OK with you? For RTC, I have to get rid of all system includes from the header files of GPU code (or mask it) I think hip_runtime.h should be included in the main source files.

I have seen that you have stripped that from the hipify CMake macros. Was there a particular reason?

Anyhow, for me I added cuda_runtime to all source files and removed the stripping from the hipification and this works for me. So with this, RTC at least finishes the compilation, and normal O2 also compiles fine for me.