### PR TITLE
[EMCAL-1116] Add maximum value for pedestal calib

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -431,6 +431,9 @@ class EMCALCalibExtractor
       for (const auto& isLG : {false, true}) {
         for (unsigned short iCell = 0; iCell < maxChannels; ++iCell) {
           auto [mean, rms] = obj.getValue(iCell, isLG, isLEDMON); // get mean and rms for pedestals
+          if (rms > EMCALCalibParams::Instance().maxPedestalRMS) {
+            mean = mMaxPedestalVal;
+          }
           pedestalData.addPedestalValue(iCell, mean, isLG, isLEDMON);
         }
       }
@@ -455,6 +458,10 @@ class EMCALCalibExtractor
         continue;
       for (unsigned short iCell = 0; iCell < maxChannels; ++iCell) {
         short mean = static_cast<short>(obj->GetBinContent(iCell + 1));
+        short rms = static_cast<short>(obj->GetBinError(iCell + 1) / obj->GetBinEntries(iCell + 1));
+        if (rms > EMCALCalibParams::Instance().maxPedestalRMS) {
+          mean = mMaxPedestalVal;
+        }
         pedestalData.addPedestalValue(iCell, mean, isLG, isLEDMON);
       }
     }
@@ -481,9 +488,10 @@ class EMCALCalibExtractor
   std::array<float, 20> mBadCellFracSM;                  ///< Fraction of bad+dead channels per SM
   std::array<std::array<float, 36>, 20> mBadCellFracFEC; ///< Fraction of bad+dead channels per FEC
 
-  o2::emcal::Geometry* mGeometry = nullptr; ///< pointer to the emcal geometry class
-  static constexpr int mNcells = 17664;     ///< Number of total cells of EMCal + DCal
-  static constexpr int mLEDMONs = 480;      ///< Number of total LEDMONS of EMCal + DCal
+  o2::emcal::Geometry* mGeometry = nullptr;      ///< pointer to the emcal geometry class
+  static constexpr int mNcells = 17664;          ///< Number of total cells of EMCal + DCal
+  static constexpr int mLEDMONs = 480;           ///< Number of total LEDMONS of EMCal + DCal
+  static constexpr short mMaxPedestalVal = 1023; ///< Maximum value for pedestals
 
   ClassDefNV(EMCALCalibExtractor, 1);
 };

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -86,6 +86,9 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool requireSameRunType = true;                      ///< if loading calib objects from previous run, require it to be the same run type
   int tsDiffMax = 48;                                  ///< if loading calib objects from previous run, limit time between the object being stored and loaded again (in hours)
 
+  // Parameters for pedestal calibration
+  short maxPedestalRMS = 10; ///< Maximum value for RMS for pedestals (has to be tuned)
+
   // old parameters. Keep them for a bit (can be deleted after september 5th) as otherwise ccdb and o2 version might not be in synch
   unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration
   unsigned int minNEntries = 1e6;             ///< minimum number of entries to trigger the calibration


### PR DESCRIPTION
- In order to not set unreasonable values for the pedestal calibration, a maximum value is introduced
- The value is configurable in the CalibrationParams