### PR TITLE
[EMCAL-752] Fix number of LEDMON channel in Pedestal object

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/Pedestal.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/Pedestal.h
@@ -82,10 +82,10 @@ class Pedestal
   TH2* getHistogramRepresentation2D(bool isLowGain, bool isLEDMON) const;
 
  private:
-  std::array<short, 17664> mPedestalValuesHG;       ///< Container for the pedestal values (high gain)
-  std::array<short, 17664> mPedestalValuesLG;       ///< Container for the pedestal values (low gain)
-  std::array<short, 17664> mPedestalValuesLEDMONHG; ///< Container for the LEDMON pedestal values (high gain)
-  std::array<short, 17664> mPedestalValuesLEDMONLG; ///< Container for the LEDMON pedestal values (low gain)
+  std::array<short, 17664> mPedestalValuesHG;     ///< Container for the pedestal values (high gain)
+  std::array<short, 17664> mPedestalValuesLG;     ///< Container for the pedestal values (low gain)
+  std::array<short, 480> mPedestalValuesLEDMONHG; ///< Container for the LEDMON pedestal values (high gain)
+  std::array<short, 480> mPedestalValuesLEDMONLG; ///< Container for the LEDMON pedestal values (low gain)
 
   ClassDefNV(Pedestal, 1);
 };

--- a/Detectors/EMCAL/calib/src/Pedestal.cxx
+++ b/Detectors/EMCAL/calib/src/Pedestal.cxx
@@ -124,15 +124,22 @@ TH2* Pedestal::getHistogramRepresentation2D(bool isLowGain, bool isLEDMON) const
     }
   }
 
-  const int MAXROWS = 208,
-            MAXCOLS = 96;
+  const int MAXROWS = isLEDMON ? 10 : 208,
+            MAXCOLS = isLEDMON ? 48 : 96;
+
   auto hist = new TH2S(histname.data(), histtitle.data(), MAXCOLS, -0.5, double(MAXCOLS) - 0.5, MAXROWS, -0.5, double(MAXROWS) - 0.5);
   hist->SetDirectory(nullptr);
   try {
     auto geo = Geometry::GetInstance();
-    for (size_t cellID = 0; cellID < data.size(); cellID++) {
-      auto position = geo->GlobalRowColFromIndex(cellID);
-      hist->Fill(std::get<1>(position), std::get<0>(position), data[cellID]);
+    for (size_t ichan = 0; ichan < data.size(); ichan++) {
+      if (isLEDMON) {
+        int col = ichan % 48,
+            row = ichan / 48;
+        hist->Fill(col, row, data[ichan]);
+      } else {
+        auto position = geo->GlobalRowColFromIndex(ichan);
+        hist->Fill(std::get<1>(position), std::get<0>(position), data[ichan]);
+      }
     }
   } catch (o2::emcal::GeometryNotInitializedException& e) {
     LOG(error) << "Geometry needs to be initialized";

--- a/Detectors/EMCAL/calib/test/testPedestal.cxx
+++ b/Detectors/EMCAL/calib/test/testPedestal.cxx
@@ -26,14 +26,14 @@ namespace o2
 namespace emcal
 {
 
-using pedestalarray = std::array<short, 17664>;
+using pedestalarray = std::vector<short>;
 
-pedestalarray createRandomPedestals()
+pedestalarray createRandomPedestals(bool isLEDMON)
 {
   std::random_device rd{};
   std::mt19937 gen{rd()};
   std::normal_distribution gaussrand{40., 5.};
-  pedestalarray pedestalcontainer;
+  pedestalarray pedestalcontainer(isLEDMON ? 480 : 17664);
   for (std::size_t ichan{0}; ichan < pedestalcontainer.size(); ++ichan) {
     pedestalcontainer[ichan] = std::round(gaussrand(gen));
   }
@@ -52,15 +52,17 @@ pedestalarray shiftPedestalValue(const pedestalarray& input, short shift = 1)
 
 BOOST_AUTO_TEST_CASE(testPedestal)
 {
-  auto pedestalsHG = createRandomPedestals(),
-       pedestalsLG = createRandomPedestals(),
-       pedestalsLEDMONHG = createRandomPedestals(),
-       pedestalsLEDMONLG = createRandomPedestals();
+  auto pedestalsHG = createRandomPedestals(false),
+       pedestalsLG = createRandomPedestals(false),
+       pedestalsLEDMONHG = createRandomPedestals(true),
+       pedestalsLEDMONLG = createRandomPedestals(true);
 
   o2::emcal::Pedestal pedestalObject;
   for (std::size_t ichan{0}; ichan < pedestalsHG.size(); ++ichan) {
     pedestalObject.addPedestalValue(ichan, pedestalsHG[ichan], false, false);
     pedestalObject.addPedestalValue(ichan, pedestalsLG[ichan], true, false);
+  }
+  for (std::size_t ichan{0}; ichan < pedestalsLEDMONHG.size(); ++ichan) {
     pedestalObject.addPedestalValue(ichan, pedestalsLEDMONHG[ichan], false, true);
     pedestalObject.addPedestalValue(ichan, pedestalsLEDMONLG[ichan], true, true);
   }
@@ -75,6 +77,8 @@ BOOST_AUTO_TEST_CASE(testPedestal)
   for (std::size_t ichan{0}; ichan < pedestalsHG.size(); ++ichan) {
     BOOST_CHECK_EQUAL(pedestalObject.getPedestalValue(ichan, false, false), pedestalsHG[ichan]);
     BOOST_CHECK_EQUAL(pedestalObject.getPedestalValue(ichan, true, false), pedestalsLG[ichan]);
+  }
+  for (std::size_t ichan{0}; ichan < pedestalsLEDMONHG.size(); ++ichan) {
     BOOST_CHECK_EQUAL(pedestalObject.getPedestalValue(ichan, false, true), pedestalsLEDMONHG[ichan]);
     BOOST_CHECK_EQUAL(pedestalObject.getPedestalValue(ichan, true, true), pedestalsLEDMONLG[ichan]);
   }


### PR DESCRIPTION
- In total, only 480 LEDMON channels are in the EMCal (was 17664 in the code)
- Subsequently also modified the plotting of the 2D map of the object