### PR TITLE
GPU: Bump GPU compilation to C++ 20

### DIFF
--- a/dependencies/FindO2GPU.cmake
+++ b/dependencies/FindO2GPU.cmake
@@ -66,7 +66,7 @@ endfunction()
 STRING(REGEX REPLACE "\-std=[^ ]*" "" O2_GPU_CMAKE_CXX_FLAGS_NOSTD "${CMAKE_CXX_FLAGS}") # Need to strip c++17 imposed by alidist defaults
 
 if(ENABLE_CUDA)
-  set(CMAKE_CUDA_STANDARD 17)
+  set(CMAKE_CUDA_STANDARD 20)
   set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
   include(CheckLanguage)
   check_language(CUDA)
@@ -206,7 +206,7 @@ endif()
 # Detect and enable HIP
 if(ENABLE_HIP)
   if("$ENV{CMAKE_PREFIX_PATH}" MATCHES "rocm")
-    set(CMAKE_HIP_STANDARD 17)
+    set(CMAKE_HIP_STANDARD 20)
     set(CMAKE_HIP_STANDARD_REQUIRED TRUE)
     if(HIP_AMDGPUTARGET)
       set(AMDGPU_TARGETS "${HIP_AMDGPUTARGET}" CACHE STRING "AMD GPU targets to compile for" FORCE)


### PR DESCRIPTION
This works for me locally, but the build container still uses the old ROCm, and we cannot bump ROCm yet, since it miscompiles for the EPNs due to compiler bugs. Let's see if this goes through. If not, we mark it draft until AMD fixes their stuff...