### PR TITLE
Some fixes for onnxruntime in TRD, but disabling it since still broken and untested

### DIFF
--- a/Detectors/TRD/pid/CMakeLists.txt
+++ b/Detectors/TRD/pid/CMakeLists.txt
@@ -22,8 +22,9 @@ o2_add_library(TRDPID
                                       fmt::fmt
               TARGETVARNAME libname)
 
-if(onnxruntime_FOUND)
-  target_compile_definitions(${libname} PRIVATE TRDPID_WITH_ONNX)
+# if(onnxruntime_FOUND) # ONNXRuntime code in TRD currently disabled since it is not tested
+if(0)
+  target_compile_definitions(${libname} PUBLIC TRDPID_WITH_ONNX)
   target_link_libraries(${libname} PRIVATE onnxruntime::onnxruntime)
   target_sources(${libname} PRIVATE src/ML.cxx)
   o2_target_root_dictionary(TRDPID

--- a/Detectors/TRD/pid/CMakeLists.txt
+++ b/Detectors/TRD/pid/CMakeLists.txt
@@ -22,10 +22,10 @@ o2_add_library(TRDPID
                                       fmt::fmt
               TARGETVARNAME libname)
 
-if(ONNXRuntime_FOUND)
+if(onnxruntime_FOUND)
   target_compile_definitions(${libname} PRIVATE TRDPID_WITH_ONNX)
-  target_link_libraries(${libname} ONNXRuntime::ONNXRuntime)
-  target_sources(${libname} src/ML.cxx)
+  target_link_libraries(${libname} PRIVATE onnxruntime::onnxruntime)
+  target_sources(${libname} PRIVATE src/ML.cxx)
   o2_target_root_dictionary(TRDPID
                             HEADERS include/TRDPID/PIDBase.h
                                     include/TRDPID/PIDParameters.h


### PR DESCRIPTION
TRD tries to use onnxruntime it seems, but this code is buggy since it checks for `ONNXRuntime_FOUND` which is never said, so this code was never used. Also the CMake code was wrong lacking the `PRIVATE` keyword, which was not seen, since it was never used.
This fixes it (requires https://github.com/AliceO2Group/AliceO2/pull/12963) and enables the TRD ML.cxx compilation if onnruntime is present.

@martenole : Could you check if this code is actually sane, since it was never used before? The alternative would be to just drop it, but I would not compile something conditionally based on a broken condition.