### PR TITLE
DPL: Improve warning message

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -122,7 +122,7 @@ void on_transition_requested_expired(uv_timer_t* handle)
   auto* state = (DeviceState*)handle->data;
   state->loopReason |= DeviceState::TIMER_EXPIRED;
   O2_SIGNPOST_ID_FROM_POINTER(cid, device, handle);
-  O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "callback", "Grace period for calibration expired. Exiting.");
+  O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "callback", "Exit transition timer expired. Exiting.");
   state->transitionHandling = TransitionHandlingState::Expired;
 }
 


### PR DESCRIPTION
This exit transition timeout is not only for calibration, but also to let the processing currently in flight finish (if possible).
Thus making it more general to avoid confusion.

We do not yet have the new EoS in? Once we have, we should have two different messages for the 2 timers expiring.