### PR TITLE
[EMCAL-1116] Minor improvemts to pedestal calibrator

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALPedestalHelper.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALPedestalHelper.h
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <bitset>
 
 namespace o2::emcal
 {
@@ -42,7 +43,7 @@ class EMCALPedestalHelper
   std::vector<char> createPedestalInstruction(const Pedestal& obj, const int runNum = -1);
 
   /// \brief print the vector produced by createInstructionString in a textfile
-  void dumpInstructions(const std::string_view filename, const std::vector<char> data, int mRun);
+  void dumpInstructions(const std::string_view filename, const gsl::span<char>& data);
 
  private:
   /// \brief initialize fMeanPed with zeros

--- a/Detectors/EMCAL/calibration/src/EMCALPedestalHelper.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALPedestalHelper.cxx
@@ -109,7 +109,7 @@ std::vector<char> EMCALPedestalHelper::createInstructionString(const int runNum)
       isect += 3; // skip non-installed sectors
     }
 
-    int activeDTC[kNDTC] = {0};
+    std::bitset<kNDTC> activeDTC;
     for (iDTC = 0; iDTC < kNDTC; iDTC++) {
       if (iDTC == 10 || iDTC == 20 || iDTC == 30) { // skip TRU
         activeDTC[iDTC] = 0;
@@ -180,17 +180,18 @@ std::vector<char> EMCALPedestalHelper::createInstructionString(const int runNum)
     } // iDTC
   }   // iSM
 
-  //   std::vector<char> output;
-  std::string instructionString(fout.str());
-  //   std::fill(instructionString.begin(), instructionString.end(), std::back_inserter(output));
+  if (runNum > 0) {
+    fout << 0xFFFFFFFF << std::endl;
+  }
+
+  const std::string instructionString(fout.str());
   std::vector<char> output(instructionString.begin(), instructionString.end());
   return output;
 }
 
-void EMCALPedestalHelper::dumpInstructions(const std::string_view filename, const std::vector<char> data, int mRun)
+void EMCALPedestalHelper::dumpInstructions(const std::string_view filename, const gsl::span<char>& data)
 {
   std::ofstream fout(filename.data());
-  fout << mRun << "\n";
   fout << data.data();
   fout.close();
 }

--- a/Detectors/EMCAL/calibration/src/PedestalCalibDevice.cxx
+++ b/Detectors/EMCAL/calibration/src/PedestalCalibDevice.cxx
@@ -73,7 +73,7 @@ void PedestalCalibDevice::sendData(o2::framework::EndOfStreamContext& ec, const 
   EMCALPedestalHelper helper;
   std::vector<char> vecPedData = helper.createPedestalInstruction(data, mAddRunNumber ? mRun : -1);
   if (mDumpToFile) {
-    helper.dumpInstructions("EMCAL-Pedestals.txt", vecPedData, mRun);
+    helper.dumpInstructions("EMCAL-Pedestals.txt", vecPedData);
   }
 
   auto clNameDCS = o2::utils::MemFileHelper::getClassName(vecPedData);


### PR DESCRIPTION
- In case the runnumber is added to the output, also add an end of file marker (0xFFFFFFFF)
- Use span instead of vector
- Use endl instead of \n