### PR TITLE
EPN Stderr monitor: Prepend messages from syslog with [GLOBAL SYSLOG]

### DIFF
--- a/Utilities/EPNMonitoring/src/EPNstderrMonitor.cxx
+++ b/Utilities/EPNMonitoring/src/EPNstderrMonitor.cxx
@@ -126,7 +126,7 @@ void EPNMonitor::sendLog(const std::string& file, const std::string& message)
     mLoggerContext->setField(InfoLogger::InfoLoggerContext::FieldName::Facility, ("stderr/" + file).substr(0, 31));
     mLoggerContext->setField(InfoLogger::InfoLoggerContext::FieldName::Run, mRunNumber != 0 ? std::to_string(mRunNumber) : "unspecified");
     static const InfoLogger::InfoLogger::InfoLoggerMessageOption opt = {InfoLogger::InfoLogger::Severity::Error, 3, InfoLogger::InfoLogger::undefinedMessageOption.errorCode, InfoLogger::InfoLogger::undefinedMessageOption.sourceFile, InfoLogger::InfoLogger::undefinedMessageOption.sourceLine};
-    mLogger->log(opt, *mLoggerContext, "stderr: %s", message.c_str());
+    mLogger->log(opt, *mLoggerContext, "stderr: %s", file == "SYSLOG" ? (std::string("[GLOBAL SYSLOG]: ") + message).c_str() : message.c_str());
   } else {
     printf("stderr: %s: %s\n", file.c_str(), message.c_str());
   }


### PR DESCRIPTION
@martenole @chiarazampolli : This add the `[GLOBAL SYSLOG]` prefix that Ole proposed so seterr/SYSLOG messages.