### PR TITLE
Separation power for Pions and Electrons

### DIFF
--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -88,6 +88,7 @@ class PID
   }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>>& getMapOfHisto() { return mMapHist; }
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>>& getMapOfCanvas() { return mMapCanvas; }
+  TCanvas* getSeparationPowerCanvas() { return mSeparationPowerCanvas.get(); }
   const std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>>& getMapOfHisto() const { return mMapHist; }
   const std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>>& getMapOfCanvas() const { return mMapCanvas; }
 
@@ -107,6 +108,8 @@ class PID
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TCanvas>>> mMapCanvas;
   // Map for Histograms which will be put onto the canvases, and not published separately
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<TH1>>> mMapHistCanvas;
+  // Canvas for Trending Separation Power
+  std::unique_ptr<TCanvas> mSeparationPowerCanvas;
   ClassDefNV(PID, 1)
 };
 } // namespace qc

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -102,6 +102,7 @@ void PID::initializeHistograms()
     mMapCanvas["CdEdxPIDHypothesisVsp"].emplace_back(std::make_unique<TCanvas>("CdEdxPIDHypothesisVsp", "PID Hypothesis Ratio"));
     mMapCanvas["CdEdxPIDHypothesisVsp"].at(0)->Divide(5, 2);
   }
+  mSeparationPowerCanvas.reset(new TCanvas("CSeparationPower", "Separation Power"));
 }
 
 //______________________________________________________________________________
@@ -225,6 +226,7 @@ bool PID::processTrack(const o2::tpc::TrackTPC& track, size_t nTracks)
       }
     }
   }
+
   if (mCreateCanvas) {
     for (auto const& pairC : mMapCanvas) {
       for (auto& canv : pairC.second) {


### PR DESCRIPTION
This PR adds the separation power that can be trended for pions and electrons at the MIP point.