### PR TITLE
Warn about current and TPC scaler object runNumbers only once

### DIFF
--- a/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
@@ -85,10 +85,12 @@ class TPCScalerSpec : public Task
     const auto orbitResetTimeMS = o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS();
     const auto firstTFOrbit = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
     const double timestamp = orbitResetTimeMS + firstTFOrbit * o2::constants::lhc::LHCOrbitMUS * 0.001;
-
+    int currRun = pc.services().get<o2::framework::TimingInfo>().runNumber;
     if (mEnableMShape) {
-      if ((mMShapeTPCScaler.getRun() != -1) && pc.services().get<o2::framework::TimingInfo>().runNumber != mMShapeTPCScaler.getRun()) {
-        LOGP(error, "Run number {} of processed data and run number {} of loaded TPC M-shape scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mMShapeTPCScaler.getRun());
+      static int runWarningMS = -1;
+      if ((mMShapeTPCScaler.getRun() != -1) && currRun != mMShapeTPCScaler.getRun() && runWarningMS != currRun) {
+        LOGP(alarm, "Run number {} of processed data and run number {} of loaded TPC M-shape scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mMShapeTPCScaler.getRun());
+        runWarningMS = currRun;
       }
 
       const auto& boundaryPotential = mMShapeTPCScaler.getBoundaryPotential(timestamp);
@@ -139,8 +141,10 @@ class TPCScalerSpec : public Task
     }
 
     if (mEnableIDCs) {
-      if (pc.services().get<o2::framework::TimingInfo>().runNumber != mTPCScaler.getRun()) {
-        LOGP(error, "Run number {} of processed data and run number {} of loaded TPC scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mTPCScaler.getRun());
+      static int runWarningIDC = -1;
+      if (pc.services().get<o2::framework::TimingInfo>().runNumber != mTPCScaler.getRun() && runWarningIDC != currRun) {
+        LOGP(alarm, "Run number {} of processed data and run number {} of loaded TPC scaler doesnt match!", pc.services().get<o2::framework::TimingInfo>().runNumber, mTPCScaler.getRun());
+        runWarningIDC = currRun;
       }
       float scalerA = mTPCScaler.getMeanScaler(timestamp, o2::tpc::Side::A);
       float scalerC = mTPCScaler.getMeanScaler(timestamp, o2::tpc::Side::C);


### PR DESCRIPTION
@matthias-kleiner This can be one-time warning only since in any case what matters is the timestamp comparison which is done later. Changing since otherwise the online replay of runs which use maps with IDC scaling pollutes the IL with errors 
```
E	2	18:48:58.647		DPL	tpc-scaler	2mj3vBddjzt	549783	Run number 549783 of processed data and run number 544490 of loaded TPC scaler doesnt match!
E	2	18:48:58.652		DPL	tpc-scaler	2mj3vBddjzt	549783	Run number 549783 of processed data and run number 544490 of loaded TPC scaler doesnt match!
E	2	18:48:58.659		DPL	tpc-scaler	2mj3vBddjzt	549783	Run number 549783 of processed data and run number 544490 of loaded TPC scaler doesnt match!
```