### PR TITLE
Uniform A-side X coordinate sign with the reconstructed one

### DIFF
--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -271,7 +271,7 @@ void Detector::getDetIDandSecID(TString const& volname, math_utils::Vector3D<flo
 
     if (x.Z() > 0) {
       detector = ZNA;
-      xDet = x - math_utils::Vector3D<float>(Geometry::ZNAPOSITION[0], Geometry::ZNAPOSITION[1], Geometry::ZNAPOSITION[2]);
+      xDet = -(x - math_utils::Vector3D<float>(Geometry::ZNAPOSITION[0], Geometry::ZNAPOSITION[1], Geometry::ZNAPOSITION[2]));
 
     } else if (x.Z() < 0) {
       detector = ZNC;
@@ -297,7 +297,7 @@ void Detector::getDetIDandSecID(TString const& volname, math_utils::Vector3D<flo
     // proton calorimeter
     if (x.Z() > 0) {
       detector = ZPA; // (NB -> DIFFERENT FROM AliRoot!!!)
-      xDet = x - math_utils::Vector3D<float>(Geometry::ZPAPOSITION[0], Geometry::ZPAPOSITION[1], Geometry::ZPAPOSITION[2]);
+      xDet = -(x - math_utils::Vector3D<float>(Geometry::ZPAPOSITION[0], Geometry::ZPAPOSITION[1], Geometry::ZPAPOSITION[2]));
     } else if (x.Z() < 0) {
       detector = ZPC; // (NB -> DIFFERENT FROM AliRoot!!!)
       xDet = x - math_utils::Vector3D<float>(Geometry::ZPCPOSITION[0], Geometry::ZPCPOSITION[1], Geometry::ZPCPOSITION[2]);


### PR DESCRIPTION
We realized that there is a mismatch in the sign of the x coordinates on A-side ZDCs between simulated and reconstructed data. The proposed change aims at fixing this bug. 