### PR TITLE
DPL Analysis: add ability to have ConfigurableGroup produce prefixed options

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -532,6 +532,14 @@ struct OptionManager {
   {
     /// Recurse, in case we are brace constructible
     if constexpr (std::is_base_of_v<ConfigurableGroup, ANY>) {
+      if constexpr (requires {x.prefix;}) {
+        homogeneous_apply_refs<true>([prefix = x.prefix]<typename C>(C& y) { //apend group prefix if set
+          if constexpr (requires {y.name;}) {
+            y.name = prefix + "." + y.name;
+          }
+          return true;
+        }, x);
+      }
       homogeneous_apply_refs<true>([&options](auto& y) { return OptionManager<std::decay_t<decltype(y)>>::appendOption(options, y); }, x);
       return true;
     } else {

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -532,13 +532,14 @@ struct OptionManager {
   {
     /// Recurse, in case we are brace constructible
     if constexpr (std::is_base_of_v<ConfigurableGroup, ANY>) {
-      if constexpr (requires {x.prefix;}) {
-        homogeneous_apply_refs<true>([prefix = x.prefix]<typename C>(C& y) { //apend group prefix if set
-          if constexpr (requires {y.name;}) {
+      if constexpr (requires { x.prefix; }) {
+        homogeneous_apply_refs<true>([prefix = x.prefix]<typename C>(C& y) { // apend group prefix if set
+          if constexpr (requires { y.name; }) {
             y.name = prefix + "." + y.name;
           }
           return true;
-        }, x);
+        },
+                                     x);
       }
       homogeneous_apply_refs<true>([&options](auto& y) { return OptionManager<std::decay_t<decltype(y)>>::appendOption(options, y); }, x);
       return true;

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -132,9 +132,11 @@ struct TestCCDBObject {
 
 struct KTask {
   struct : public ConfigurableGroup {
+    std::string prefix = "foo";
     Configurable<int> anInt{"someConfigurable", {}, "Some Configurable Object"};
     Configurable<int> anotherInt{"someOtherConfigurable", {}, "Some Configurable Object"};
   } foo;
+
   Configurable<int> anThirdInt{"someThirdConfigurable", {}, "Some Configurable Object"};
   struct : public ConditionGroup {
     Condition<TestCCDBObject> test{"path"};


### PR DESCRIPTION
Defining `std::string prefix = "foo";` inside `ConfigurableGroup` will add it as a prefix to all configurables inside the group. This will make them appear structured in Hyperloop interface.

@jgrosseo @ddobrigk 