### PR TITLE
Do not store failed laser calib, ignore in VDriftHelper

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/LtrCalibData.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/LtrCalibData.h
@@ -43,6 +43,11 @@ struct LtrCalibData {
   std::vector<uint16_t> nTrackTF;      ///< number of laser tracks per TF
   std::vector<float> dEdx;             ///< dE/dx of each track
 
+  bool isValid() const
+  {
+    return (std::abs(dvCorrectionA - 1.f) < 0.2) || (std::abs(dvCorrectionC - 1.f) < 0.2);
+  }
+
   float getDriftVCorrection() const
   {
     float correction = 0;

--- a/Detectors/TPC/calibration/src/VDriftHelper.cxx
+++ b/Detectors/TPC/calibration/src/VDriftHelper.cxx
@@ -57,6 +57,10 @@ void VDriftHelper::accountLaserCalibration(const LtrCalibData* calib, long fallB
   if (!calib || mForceParamDrift) { // laser may set only DriftParam (the offset is 0)
     return;
   }
+  if (!calib->isValid()) {
+    LOGP(warn, "Ignoring invalid laser calibration (corrections: A-side={}, C-side={}, NTracks: A-side={} C-side={})", calib->dvCorrectionA, calib->dvCorrectionC, calib->nTracksA, calib->nTracksC);
+    return;
+  }
   // old entries of laser calib have no update time assigned
   long updateTS = calib->creationTime > 0 ? calib->creationTime : fallBackTimeStamp;
   LOG(info) << "accountLaserCalibration " << calib->refVDrift << " / " << calib->getDriftVCorrection() << " t " << updateTS << " vs " << mVDLaser.creationTime;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibLaserTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibLaserTracksSpec.h
@@ -121,14 +121,14 @@ class CalibLaserTracksDevice : public o2::framework::Task
 
     using clbUtils = o2::calibration::Utils;
     auto ltrCalib = mCalib.getCalibData();
+    if (!ltrCalib.isValid()) {
+      LOGP(error, "Invalid Laser calibration (corrections: A-side={}, C-side={}, NTracks: A-side={} C-side={}), will NOT upload to CCDB", ltrCalib.dvCorrectionA, ltrCalib.dvCorrectionC, ltrCalib.nTracksA, ltrCalib.nTracksC);
+      return;
+    }
 
     if (mNormalize) {
       ltrCalib.normalize(0.);
       LOGP(info, "After normalization: correction factors: {} / {} for A- / C-Side, reference: {}, vdrift correction: {}", ltrCalib.dvCorrectionA, ltrCalib.dvCorrectionC, ltrCalib.refVDrift, ltrCalib.getDriftVCorrection());
-    }
-    if (ltrCalib.getDriftVCorrection() == 0) {
-      LOG(error) << "Extracted drift correction is 0, something is wrong, will not upload the object";
-      return;
     }
 
     o2::ccdb::CcdbObjectInfo w;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/LaserTracksCalibratorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/LaserTracksCalibratorSpec.h
@@ -88,6 +88,10 @@ class LaserTracksCalibratorDevice : public o2::framework::Task
     const long timeEnd = o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP;
     for (uint32_t iCalib = 0; iCalib < calibrations.size(); ++iCalib) {
       const auto& object = calibrations[iCalib];
+      if (!object.isValid()) {
+        LOGP(error, "Invalid Laser calibration (corrections: A-side={}, C-side={}, NTracks: A-side={} C-side={}), will NOT upload to CCDB", object.dvCorrectionA, object.dvCorrectionC, object.nTracksA, object.nTracksC);
+        continue;
+      }
       o2::ccdb::CcdbObjectInfo w;
       auto image = o2::ccdb::CcdbApi::createObjectImage(&object, &w);
 


### PR DESCRIPTION
see https://ali-bookkeeping.cern.ch/?page=log-detail&id=86312