### PR TITLE
[EMCAL-710] Fix namespace in stream operator

### DIFF
--- a/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
@@ -111,7 +111,7 @@ const char* ErrorTypeFEE::getErrorTypeTitle(unsigned int errorTypeID)
   };
 }
 
-std::ostream& operator<<(std::ostream& stream, const ErrorTypeFEE& error)
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const ErrorTypeFEE& error)
 {
   error.PrintStream(stream);
   return stream;


### PR DESCRIPTION
Stream operator for ErrorTypeFEE must be put explicitly into namespace o2::emcal, otherwise it is part of the global namespace.