### PR TITLE
EMCAL increase check interval for bad channel and time calibrations

### DIFF
--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -426,6 +426,10 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     if (mTimeCalibrator) {
       LOG(info) << "Configuring time calibrator";
       mTimeCalibrator->setSlotLength(EMCALCalibParams::Instance().slotLength_tc);
+      if (EMCALCalibParams::Instance().slotLength_tc == 0) {
+        // for infinite slot length do not check if there is enough statistics after every TF
+        mTimeCalibrator->setCheckIntervalInfiniteSlot(1e5);
+      }
       if (EMCALCalibParams::Instance().UpdateAtEndOfRunOnly_tc) {
         mTimeCalibrator->setUpdateAtTheEndOfRunOnly();
       }
@@ -437,6 +441,10 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     if (mBadChannelCalibrator) {
       LOG(info) << "Configuring bad channel calibrator";
       mBadChannelCalibrator->setSlotLength(EMCALCalibParams::Instance().slotLength_bc);
+      if (EMCALCalibParams::Instance().slotLength_bc == 0) {
+        // for infinite slot length do not check if there is enough statistics after every TF
+        mBadChannelCalibrator->setCheckIntervalInfiniteSlot(1e5);
+      }
       if (EMCALCalibParams::Instance().UpdateAtEndOfRunOnly_bc) {
         mBadChannelCalibrator->setUpdateAtTheEndOfRunOnly();
       }


### PR DESCRIPTION
Hi @mfasDa going through some logs on the aggregator node I saw that the EMC calibrations are checking very frequently if there is enough statistics to calibrate (120k times for run 550191 where only 4 objects were uploaded in the end). As described in https://github.com/AliceO2Group/AliceO2/tree/dev/Detectors/Calibration#configuration-of-the-timeslot one can use the `setCheckIntervalInfiniteSlot` to reduce the check frequency.