### PR TITLE
Option to manage ROF length reporting

### DIFF
--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -82,6 +82,7 @@ class STFDecoder : public Task
   int mDumpOnError = 0;
   int mNThreads = 1;
   int mVerbosity = 0;
+  long mROFErrRepIntervalMS = 0;
   size_t mTFCounter = 0;
   size_t mEstNDig = 0;
   size_t mEstNClus = 0;

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -81,6 +81,8 @@ void STFDecoder<Mapping>::init(InitContext& ic)
   mApplyNoiseMap = !ic.options().get<bool>("ignore-noise-map");
   mUseClusterDictionary = !ic.options().get<bool>("ignore-cluster-dictionary");
   try {
+    float fr = ic.options().get<float>("rof-lenght-error-freq");
+    mROFErrRepIntervalMS = fr <= 0. ? -1 : long(fr * 1e3);
     mNThreads = std::max(1, ic.options().get<int>("nthreads"));
     mDecoder->setNThreads(mNThreads);
     mUnmutExtraLanes = ic.options().get<bool>("unmute-extra-lanes");
@@ -160,6 +162,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     mDecoder->setDecodeNextAuto(false);
     o2::InteractionRecord lastIR{}, firstIR{0, pc.services().get<o2::framework::TimingInfo>().firstTForbit};
     int nTriggersProcessed = mDecoder->getNROFsProcessed();
+    static long lastErrReportTS = 0;
     while (mDecoder->decodeNextTrigger() >= 0) {
       if ((!lastIR.isDummy() && lastIR >= mDecoder->getInteractionRecord()) || firstIR > mDecoder->getInteractionRecord()) {
         const int MaxErrLog = 2;
@@ -186,8 +189,12 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
 
     const auto& alpParams = o2::itsmft::DPLAlpideParam<Mapping::getDetID()>::Instance();
     int expectedTFSize = static_cast<int>(o2::constants::lhc::LHCMaxBunches * o2::base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() / alpParams.roFrameLengthInBC); // 3564*32 / ROF Length in BS = number of ROFs per TF
-    if ((expectedTFSize != nTriggersProcessed) && mTFCounter > 1 && nTriggersProcessed > 0) {
-      LOG(error) << "Inconsistent number of ROF per TF. From parameters: " << expectedTFSize << " from readout: " << nTriggersProcessed;
+    if ((expectedTFSize != nTriggersProcessed) && mROFErrRepIntervalMS > 0 && mTFCounter > 1 && nTriggersProcessed > 0) {
+      long currTS = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+      if (currTS - lastErrReportTS > mROFErrRepIntervalMS) {
+        LOGP(error, "Inconsistent number of ROF per TF. From parameters: {} from readout: {} (muting further reporting for {} ms)", expectedTFSize, nTriggersProcessed, mROFErrRepIntervalMS);
+        lastErrReportTS = currTS;
+      }
     }
     if (mDoClusters && mClusterer->getMaxROFDepthToSquash()) {
       // Digits squashing require to run on a batch of digits and uses a digit reader, cannot (?) run with decoder
@@ -413,6 +420,7 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
       {"allow-empty-rofs", VariantType::Bool, false, {"record ROFs w/o any hit"}},
       {"ignore-noise-map", VariantType::Bool, false, {"do not mask pixels flagged in the noise map"}},
       {"accept-rof-rampup-data", VariantType::Bool, false, {"do not discard data during ROF ramp up"}},
+      {"rof-lenght-error-freq", VariantType::Float, 60.f, {"do not report ROF lenght error more frequently than this value, disable if negative"}},
       {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}}}};
 }
 


### PR DESCRIPTION
Option `--rof-lenght-error-freq <float_time_in_seconds>` will set the interval between successive error reports (if any) about the wrong ROF length. No reporting is done if it is negative or 0 (to be used in calibration runs). The default interval is 60s.