### PR TITLE
[EMCAL-916, EMCAL-537, EMCAL-550, EMCAL-911] Integrate TRU decoding into sync reco

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_library(DataFormatsEMCAL
         src/ErrorTypeFEE.cxx
         src/CellLabel.cxx
         src/ClusterLabel.cxx
+        src/CompressedTriggerData.cxx
         PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
         O2::Headers
         O2::MathUtils

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CompressedTriggerData.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CompressedTriggerData.h
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_COMPRESSEDTRIGGERDATA_H
+#define ALICEO2_EMCAL_COMPRESSEDTRIGGERDATA_H
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace o2::emcal
+{
+
+/// \struct CompressedTRU
+/// \brief Compressed reconstructed TRU information
+/// \ingroup EMCALDataFormat
+struct CompressedTRU {
+  uint8_t mTRUIndex;        ///< TRU index
+  uint8_t mTriggerTime;     ///< Trigger time of the TRU
+  bool mFired;              ///< Fired status of the TRU
+  uint8_t mNumberOfPatches; ///< Number of patches found for the TRU
+};
+
+/// \struct CompressedTriggerPatch
+/// \brief Compressed reconstructed L0 trigger patch information
+/// \ingroup EMCALDataFormat
+struct CompressedTriggerPatch {
+  uint8_t mTRUIndex;        ///< Index of the TRU where the trigger patch has been found
+  uint8_t mPatchIndexInTRU; ///< Index of the trigger patch in the TRU
+  uint8_t mTime;            ///< Reconstructed time of the trigger patch
+  uint16_t mADC;            ///< ADC sum of the trigger patch
+};
+
+/// \struct CompressedL0TimeSum
+/// \brief Compressed L0 timesum information
+/// \ingroup EMCALDataFormat
+struct CompressedL0TimeSum {
+  uint16_t mIndex;   ///< Absolute ID of the FastOR
+  uint16_t mTimesum; ///< ADC value of the time-sum (4-integral)
+};
+
+/// \brief Output stream operator of the CompressedTRU
+/// \param stream Stream to write to
+/// \param tru TRU data to be streamed
+/// \return Stream after writing
+std::ostream& operator<<(std::ostream& stream, const CompressedTRU& tru);
+
+/// \brief Output stream operator of the CompressedTriggerPatch
+/// \param stream Stream to write to
+/// \param patch Trigger patch to be streamed
+/// \return Stream after writing
+std::ostream& operator<<(std::ostream& stream, const CompressedTriggerPatch& patch);
+
+/// \brief Output stream operator of the CompressedL0TimeSum
+/// \param stream Stream to write to
+/// \param timesum FastOR L0 timesum to be streamed
+/// \return Stream after writing
+std::ostream& operator<<(std::ostream& stream, const CompressedL0TimeSum& timesum);
+
+} // namespace o2::emcal
+
+#endif // ALICEO2_EMCAL_COMPRESSEDTRIGGERDATA_H

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
@@ -191,7 +191,7 @@ class ErrorTypeFEE
 
   /// \brief Get the number of error types
   /// \return Number of error types (including undefined)
-  static constexpr int getNumberOfErrorTypes() { return 7; }
+  static constexpr int getNumberOfErrorTypes() { return 9; }
 
   /// \brief Get the name of the error type
   /// \param errorTypeID ID of the error type

--- a/DataFormats/Detectors/EMCAL/src/CompressedTriggerData.cxx
+++ b/DataFormats/Detectors/EMCAL/src/CompressedTriggerData.cxx
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "DataFormatsEMCAL/CompressedTriggerData.h"
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::CompressedTRU& tru)
+{
+  stream << "TRU " << tru.mTRUIndex << ": Fired " << (tru.mFired ? "yes" : "no") << ", time " << (tru.mFired ? std::to_string(static_cast<int>(tru.mTriggerTime)) : "Undefined") << ", number of patches " << tru.mNumberOfPatches;
+  return stream;
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::CompressedTriggerPatch& patch)
+{
+  stream << "Patch " << patch.mPatchIndexInTRU << " in TRU " << patch.mTRUIndex << ": Time " << patch.mTime << ", ADC " << patch.mADC;
+  return stream;
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::CompressedL0TimeSum& timesum)
+{
+  stream << "FastOR " << timesum.mIndex << ": " << timesum.mTimesum << " ADC counts";
+  return stream;
+}

--- a/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingV2.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingV2.h
@@ -49,6 +49,7 @@ class TriggerMappingV2
   static constexpr unsigned int FASTORSPHI = (5 * FASTORSPHISM) + (1 * FASTORSPHISM / 3)              /*EMCAL*/
                                              + (3 * FASTORSPHISM) + (1 * FASTORSPHISM / 3) /*DCAL */; ///< Number of FastOR/EMCALs in Phi
   static constexpr unsigned int ALLFASTORS = FASTORSETA * FASTORSPHI;                                 ///< Number of FastOR/EMCALs
+  static constexpr unsigned int PATCHESINTRU = 77;
 
   //********************************************
   // Index types

--- a/Detectors/EMCAL/base/src/TriggerMappingV2.cxx
+++ b/Detectors/EMCAL/base/src/TriggerMappingV2.cxx
@@ -390,7 +390,7 @@ TriggerMappingV2::IndexTRU TriggerMappingV2::getTRUIndexFromOnlineHardareAddree(
 
   unsigned short branch = (hardwareAddress >> 11) & 0x1; // 0/1
 
-  IndexTRU truIndex = ((ddlID << 1) | branch) - 1; // 0..2
+  IndexTRU truIndex = (((ddlID % 2) << 1) | branch) - 1; // 0..2
 
   truIndex = (supermoduleID % 2) ? 2 - truIndex : truIndex;
 

--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(EMCALReconstruction
         src/AltroDecoder.cxx
         src/Bunch.cxx
         src/Channel.cxx
+        src/FastORTimeSeries.cxx
         src/RecoParam.cxx
         src/RawDecodingError.cxx
         src/STUDecoderError.cxx
@@ -32,6 +33,7 @@ o2_add_library(EMCALReconstruction
         src/CTFCoder.cxx
         src/CTFHelper.cxx
         src/StuDecoder.cxx
+        src/TRUDataHandler.cxx
         PUBLIC_LINK_LIBRARIES O2::Headers
         AliceO2::InfoLogger
         O2::DataFormatsEMCAL
@@ -49,6 +51,7 @@ o2_target_root_dictionary(
         include/EMCALReconstruction/RawPayload.h
         include/EMCALReconstruction/Bunch.h
         include/EMCALReconstruction/Channel.h
+        include/EMCALReconstruction/FastORTimeSeries.h
         include/EMCALReconstruction/CaloFitResults.h
         include/EMCALReconstruction/CaloRawFitter.h
         include/EMCALReconstruction/CaloRawFitterStandard.h
@@ -59,6 +62,7 @@ o2_target_root_dictionary(
         include/EMCALReconstruction/DigitReader.h
         include/EMCALReconstruction/RecoParam.h
         include/EMCALReconstruction/StuDecoder.h
+        include/EMCALReconstruction/TRUDataHandler.h
 )
 
 o2_add_executable(rawreader-file

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/FastORTimeSeries.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/FastORTimeSeries.h
@@ -1,0 +1,83 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_FASTORTIMESERIES_H
+#define ALICEO2_EMCAL_FASTORTIMESERIES_H
+
+#include <vector>
+#include <gsl/span>
+#include "Rtypes.h"
+
+namespace o2::emcal
+{
+
+/// \class FastORTimeSeries
+/// \brief Container for FastOR time series
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \ingroup EMCALReconstruction
+/// \since April 19, 2024
+///
+/// Time series are encoded in bunches in the raw data, which are usually time-reversed.
+/// The FastORTimeSeries handles the time series of all bunches in the readout window,
+/// in proper future-direction time order, correcting the time-reversal from the Fake-ALTRO.
+/// Consequently the ADC samples are expected in time-reversed format. The function
+/// calculateL1TimeSum calculates the timesum of the timeseries as 4-integral with respect to
+/// a given L0 time, which is expected at the end of the time integration range.
+class FastORTimeSeries
+{
+ public:
+  /// @brief Dummy constructor
+  FastORTimeSeries() = default;
+
+  /// \brief Construcor
+  /// \param maxsamples Maximum number of time samples
+  /// \param timesamples Time-reversed raw ADC samples
+  /// \param starttime Start time
+  FastORTimeSeries(int maxsamples, const gsl::span<const uint16_t> timesamples, uint8_t starttime)
+  {
+    setSize(maxsamples);
+    fillReversed(timesamples, starttime);
+  }
+
+  /// \brief Destructor
+  ~FastORTimeSeries() = default;
+
+  void setTimeSamples(const gsl::span<const uint16_t> timesamples, uint8_t starttime) { fillReversed(timesamples, starttime); }
+
+  /// \brief Calculate L0 timesum (4-integral of the ADC series) with respect to a given L0 time
+  /// \param l0time L0 time (end of the time series)
+  /// \return Timesum of the time series
+  uint16_t calculateL1TimeSum(uint8_t l0time) const;
+
+  /// \brief Access raw ADC values (in forward time order)
+  /// \return ADC values of the time series in forward time order
+  const gsl::span<const uint16_t> getADCs() const { return mTimeSamples; }
+
+  /// \brief Clear ADC samples in the time series
+  void clear();
+
+ private:
+  /// \brief Set the container size for the ADC samples
+  /// \param maxsamples Max. amount of samples to be handled
+  void setSize(int maxsamples);
+
+  /// \brief Fill the internal time samples in proper time order
+  /// \param timesamples Time-reversed time samples
+  /// \param starttime Start time
+  void fillReversed(const gsl::span<const uint16_t> timesamples, uint8_t starttime);
+
+  std::vector<uint16_t> mTimeSamples; ///< Raw ADC time samples (in forward time order)
+
+  ClassDef(FastORTimeSeries, 1);
+};
+
+} // namespace o2::emcal
+
+#endif

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoContainer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoContainer.h
@@ -14,8 +14,10 @@
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since May 30, 2023
 
+#include <array>
 #include <cstdint>
 #include <exception>
+#include <iosfwd>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -24,6 +26,9 @@
 #include <Rtypes.h>
 #include <CommonDataFormat/InteractionRecord.h>
 #include <DataFormatsEMCAL/Cell.h>
+#include <EMCALBase/TriggerMappingV2.h>
+#include <EMCALReconstruction/FastORTimeSeries.h>
+#include <EMCALReconstruction/TRUDataHandler.h>
 
 namespace o2::emcal
 {
@@ -53,6 +58,36 @@ struct RecCellInfo {
 class EventContainer
 {
  public:
+  /// \class TRUIndexException
+  /// \brief Handler for access of TRU data with invalid TRU index
+  /// \ingroup EMCALReconstruction
+  class TRUIndexException final : public std::exception
+  {
+   public:
+    /// \brief Constructor
+    /// \param index TRU index raising the exception
+    TRUIndexException(std::size_t index);
+
+    /// \brief Destructor
+    ~TRUIndexException() noexcept final = default;
+
+    /// \brief Get the error message of the exception
+    /// \return Error message
+    const char* what() const noexcept final { return mMessage.data(); }
+
+    /// \brief Get the TRU index raising the exception
+    /// \return TRU index
+    std::size_t getIndex() const { return mIndex; }
+
+    /// \brief Print error message on stream
+    /// \param stream Stream to print on
+    void printStream(std::ostream& stream) const;
+
+   private:
+    std::size_t mIndex;   ///< TRU index raising the exception
+    std::string mMessage; ///< Buffer for error message
+  };
+
   /// \brief Constructor
   EventContainer() = default;
 
@@ -95,6 +130,22 @@ class EventContainer
   /// \return Number of LEDMONs
   int getNumberOfLEDMONs() const { return mLEDMons.size(); }
 
+  /// \brief Read and write access TRU data of a given TRU
+  /// \param truIndex Index of the TRU
+  /// \return TRU data handler for the TRU
+  /// \throw TRUIndexException in case the TRU index is invalid (>= 52)
+  TRUDataHandler& getTRUData(std::size_t truIndex);
+
+  /// \brief Read-only access TRU data of a given TRU
+  /// \param truIndex Index of the TRU
+  /// \return TRU data handler for the TRU
+  /// \throw TRUIndexException in case the TRU index is invalid (>= 52)
+  const TRUDataHandler& readTRUData(std::size_t truIndex) const;
+
+  /// \brief Access to container with FastOR time series
+  /// \return Container with time series
+  const std::unordered_map<uint16_t, FastORTimeSeries>& getTimeSeriesContainer() const { return mL0FastORs; }
+
   /// \brief Add cell information to the event container
   /// \param tower Tower ID
   /// \param energy Cell energy
@@ -129,6 +180,16 @@ class EventContainer
     setCellCommon(tower, energy, time, celltype, true, hwaddress, ddlID, doMergeHGLG);
   }
 
+  /// \brief Add bunch of time series to the container
+  /// \param fastORAbsID Absolute ID of the FastOR
+  /// \param starttime Start time of the bunch
+  /// \param timesamples Time samples of the bunch in time-reversed format
+  ///
+  /// In case a TimeSeries is already present for the given FastOR abs. ID in the container
+  /// the bunch is added to this, otherwise a new TimeSeries is added with the ADCs of the
+  /// bunch.
+  void setFastOR(uint16_t fastORAbsID, uint8_t starttime, const gsl::span<const uint16_t> timesamples);
+
   /// \brief Sort Cells / LEDMONs in container according to tower / module ID
   /// \param isLEDmon Switch between Cell and LEDMON
   void sortCells(bool isLEDmon);
@@ -148,21 +209,26 @@ class EventContainer
   /// \return True if the energy is in the saturation region, false otherwise
   bool isCellSaturated(double energy) const;
 
-  o2::InteractionRecord mInteractionRecord;
-  uint64_t mTriggerBits = 0;         ///< Trigger bits of the event
-  std::vector<RecCellInfo> mCells;   ///< Container of cells in event
-  std::vector<RecCellInfo> mLEDMons; ///< Container of LEDMONs in event
+  /// \brief Initialize the TRU handlers
+  void initTRUs();
+
+  o2::InteractionRecord mInteractionRecord;                       ///< Interaction record of the event
+  uint64_t mTriggerBits = 0;                                      ///< Trigger bits of the event
+  std::vector<RecCellInfo> mCells;                                ///< Container of cells in event
+  std::vector<RecCellInfo> mLEDMons;                              ///< Container of LEDMONs in event
+  std::array<TRUDataHandler, TriggerMappingV2::ALLTRUS> mTRUData; ///< TRU status
+  std::unordered_map<uint16_t, FastORTimeSeries> mL0FastORs;      ///< L0 FastOR time series
 };
 
 /// \class RecoContainer
-/// \brief Handler for cells in
+/// \brief Handler for cells/LEDMONS/Trigger data in timeframes
 /// \ingroup EMCALReconstruction
 class RecoContainer
 {
  public:
   /// \class InteractionNotFoundException
   /// \brief Handling of access to trigger interaction record not present in container
-  class InteractionNotFoundException : public std::exception
+  class InteractionNotFoundException final : public std::exception
   {
    public:
     /// \brief Constructor

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/TRUDataHandler.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/TRUDataHandler.h
@@ -1,0 +1,185 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_TRUDataHandler_H
+#define ALICEO2_EMCAL_TRUDataHandler_H
+
+#include <array>
+#include <bitset>
+#include <cstdint>
+#include <exception>
+#include <iosfwd>
+#include <string>
+
+#include "Rtypes.h"
+
+#include "EMCALBase/TriggerMappingV2.h"
+
+namespace o2::emcal
+{
+
+/// \class TRUDataHandler
+/// \brief Helper class to handle decoded TRU data during the reconstruction
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \ingroup EMCALReconstruction
+/// \since April 19, 2024
+///
+/// The decoded TRU data contains the following information
+/// - Index of the TRU
+/// - Trigger time of the TRU
+/// - Fired or not
+/// - Index of fired patches with time the patch has fired
+/// The information is decoded in columns 96 to 105 of the FakeALTRO data. The
+/// class does not handle FastOR timesums (colums 0-96), they are handled by a
+/// separate class FastORTimeSeries.
+class TRUDataHandler
+{
+ public:
+  /// \class PatchIndexException
+  /// \brief Handler of errors related to invalid trigger patch IDs
+  /// \ingroup EMCALReconstruction
+  class PatchIndexException final : public std::exception
+  {
+   public:
+    /// \brief Constructor
+    /// \param index Patch index raising the exception
+    PatchIndexException(int8_t index);
+
+    /// \brief  Destructor
+    ~PatchIndexException() noexcept final = default;
+
+    /// \brief Get patch index raising the exception
+    /// \return Patch index
+    int8_t getIndex() const { return mIndex; }
+
+    /// \brief Access Error message
+    /// \return Error message
+    const char* what() const noexcept final
+    {
+      return mMessage.data();
+    }
+
+    /// \brief Print error on output stream
+    /// \param stream Stream to be printed to
+    void printStream(std::ostream& stream) const;
+
+   private:
+    int8_t mIndex = -1;   ///< Patch index rainsing the exception
+    std::string mMessage; ///< Buffer for error message
+  };
+
+  /// \brief Constructor
+  TRUDataHandler();
+
+  /// \brief Destructor
+  ~TRUDataHandler() = default;
+
+  /// \brief Reset handler
+  void reset();
+
+  /// \brief Set reconstructed trigger patch
+  /// \param index Index of the trigger patch in the TRU
+  /// \param time Decoded time of the patch
+  /// \throw PatchIndexException in case the patch index is invalid (>= 77)
+  void setPatch(unsigned int index, unsigned int time)
+  {
+    checkPatchIndex(index);
+    mPatchTimes[index] = time;
+  }
+
+  /// \brief Mark TRU as fired (containing at least one patch above threshold)
+  /// \param fired
+  void setFired(bool fired) { mL0Fired = fired; }
+
+  /// \brief Set the L0 time of the TRU
+  /// \param l0time L0 time of the TRU
+  void setL0time(int l0time) { mL0Time = l0time; }
+
+  /// \brief Set the index of the TRU (in global STU indexing scheme)
+  /// \param index Index of the TRU
+  void setTRUIndex(int index) { mTRUIndex = index; }
+
+  /// \brief Check whether the TRU was fired (at least one patch above threshold)
+  /// \return True if the TRU was fired, false otherwise
+  bool isFired() const { return mL0Fired; }
+
+  int8_t getL0time() const { return mL0Time; }
+
+  /// \brief Check whehther the patch at the given index has fired
+  /// \param index Index of the patch
+  /// \return True if the patch has fired, false otherwise
+  /// \throw PatchIndexException in case the patch index is invalid (>= 77)
+  bool hasPatch(unsigned int index) const
+  {
+    checkPatchIndex(index);
+    return mPatchTimes[index] < UCHAR_MAX;
+  }
+
+  /// \brief Get the trigger time of the trigger patch at a given index
+  /// \param index Index of the trigger patch
+  /// \return Reconstructed patch time (UCHAR_MAX in case the patch has not fired)
+  /// \throw PatchIndexException in case the patch index is invalid (>= 77)
+  uint8_t getPatchTime(unsigned int index) const
+  {
+    checkPatchIndex(index);
+    return mPatchTimes[index];
+  }
+
+  /// \brief Check whether the TRU has any patch fired
+  /// \return True if at least one fired patch was found, false otherwise
+  bool hasAnyPatch() const
+  {
+    for (int ipatch = 0; ipatch < mPatchTimes.size(); ipatch++) {
+      if (hasPatch(ipatch)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// \brief Get the index of the TRU in global (STU) index schemes
+  /// \return Index of the TRU
+  int getTRUIndex() const { return mTRUIndex; }
+
+  /// \brief Print TRU information to an output stream
+  /// \param stream Stream to print on
+  void printStream(std::ostream& stream) const;
+
+ private:
+  /// \brief Check whether the patch index is valid
+  /// \throw PatchIndexException in case the patch index is invalid (>= 77)
+  void checkPatchIndex(unsigned int index) const
+  {
+    if (index >= mPatchTimes.size()) {
+      throw PatchIndexException(index);
+    }
+  }
+
+  std::array<uint8_t, o2::emcal::TriggerMappingV2::PATCHESINTRU> mPatchTimes; ///< Patch times: In case the patch time is smaller than UCHAR_MAX then the patch has fired
+  bool mL0Fired = false;                                                      ///< TRU has fired
+  int8_t mL0Time = -1;                                                        ///< L0 time of the TRU
+  int8_t mTRUIndex = -1;                                                      ///< Index of the TRU
+  ClassDefNV(TRUDataHandler, 1);
+};
+
+/// \brief Output stream operator for the TRU data handler
+/// \param stream Stream to print on
+/// \param data TRU data to be streamed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const TRUDataHandler& data);
+
+/// \brief Output stream operator of the PatchIndexException
+/// \param stream Stream to print on
+/// \param error Error to be streamed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const TRUDataHandler::PatchIndexException& error);
+
+} // namespace o2::emcal
+#endif

--- a/Detectors/EMCAL/reconstruction/src/EMCALReconstructionLinkDef.h
+++ b/Detectors/EMCAL/reconstruction/src/EMCALReconstructionLinkDef.h
@@ -25,6 +25,8 @@
 #pragma link C++ class o2::emcal::CaloRawFitterStandard + ;
 #pragma link C++ class o2::emcal::CaloRawFitterGamma2 + ;
 #pragma link C++ class o2::emcal::StuDecoder + ;
+#pragma link C++ class o2::emcal::FastORTimeSeries + ;
+#pragma link C++ class o2::emcal::TRUDataHandler + ;
 
 #pragma link C++ class o2::emcal::RecoParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::RecoParam> + ;

--- a/Detectors/EMCAL/reconstruction/src/FastORTimeSeries.cxx
+++ b/Detectors/EMCAL/reconstruction/src/FastORTimeSeries.cxx
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <algorithm>
+#include <iostream>
+#include "EMCALReconstruction/FastORTimeSeries.h"
+
+using namespace o2::emcal;
+
+void FastORTimeSeries::fillReversed(const gsl::span<const uint16_t> samples, uint8_t starttime)
+{
+
+  for (std::size_t isample = 0; isample < samples.size(); isample++) {
+    mTimeSamples[starttime - isample] = samples[isample];
+  }
+}
+
+uint16_t FastORTimeSeries::calculateL1TimeSum(uint8_t l0time) const
+{
+  uint16_t timesum = 0;
+  int firstbin = l0time - 4; // Include sample before the L0 time
+  for (int isample = firstbin; isample < firstbin + 4; isample++) {
+    timesum += mTimeSamples[isample];
+  }
+  return timesum;
+}
+
+void FastORTimeSeries::setSize(int maxsamples)
+{
+  mTimeSamples.resize(maxsamples);
+}
+
+void FastORTimeSeries::clear()
+{
+  std::fill(mTimeSamples.begin(), mTimeSamples.end(), 0);
+}

--- a/Detectors/EMCAL/reconstruction/src/TRUDataHandler.cxx
+++ b/Detectors/EMCAL/reconstruction/src/TRUDataHandler.cxx
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "EMCALReconstruction/TRUDataHandler.h"
+
+using namespace o2::emcal;
+
+TRUDataHandler::TRUDataHandler()
+{
+  reset();
+}
+
+void TRUDataHandler::reset()
+{
+  mTRUIndex = -1;
+  mL0Fired = false;
+  mL0Time = -1;
+  std::fill(mPatchTimes.begin(), mPatchTimes.end(), UCHAR_MAX);
+}
+
+void TRUDataHandler::printStream(std::ostream& stream) const
+{
+  std::string patchstring;
+  for (auto index = 0; index < mPatchTimes.size(); index++) {
+    if (hasPatch(index)) {
+      if (patchstring.length()) {
+        patchstring += ", ";
+      }
+      patchstring += std::to_string(index);
+    }
+  }
+  if (!patchstring.length()) {
+    patchstring = "-";
+  }
+  stream << "TRU: " << static_cast<int>(mTRUIndex) << ", time " << static_cast<int>(mL0Time) << ", fired: " << (mL0Fired ? "yes" : "no") << ", patches: " << patchstring;
+}
+
+TRUDataHandler::PatchIndexException::PatchIndexException(int8_t index) : mIndex(index), mMessage()
+{
+  mMessage = "Invalid patch index " + std::to_string(index);
+}
+
+void TRUDataHandler::PatchIndexException::printStream(std::ostream& stream) const
+{
+  stream << what();
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const TRUDataHandler& data)
+{
+  data.printStream(stream);
+  return stream;
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const TRUDataHandler::PatchIndexException& error)
+{
+  error.printStream(stream);
+  return stream;
+}

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -55,6 +55,7 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \param disableRootInput Disable reading from ROOT file (raw mode)
 /// \param disableRootOutput Disable writing ROOT files (sync reco)
 /// \param disableDecodingErrors Diable streaming raw decoding errors (async reco)
+/// \param disableTriggerReconstruction Disable trigger reconstrction
 /// \return EMCAL reconstruction workflow for the configuration provided
 /// \ingroup EMCALwokflow
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
@@ -66,7 +67,8 @@ framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,
                                     bool disableRootOutput = false,
-                                    bool disableDecodingErrors = false);
+                                    bool disableDecodingErrors = false,
+                                    bool disableTriggerReconstruction = false);
 } // namespace reco_workflow
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <iostream>
 #include <bitset>
+#include <set>
 
 #include <InfoLogger/InfoLogger.hxx>
 
@@ -75,6 +76,10 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
     LOG(error) << "Failed to initialize mapper";
   }
 
+  if (!mTriggerMapping) {
+    mTriggerMapping = std::make_unique<TriggerMappingV2>(mGeometry);
+  }
+
   auto fitmethod = ctx.options().get<std::string>("fitmethod");
   if (fitmethod == "standard") {
     LOG(info) << "Using standard raw fitter";
@@ -131,9 +136,15 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   mOutputCells.clear();
   mOutputTriggerRecords.clear();
   mOutputDecoderErrors.clear();
+  mOutputTRUs.clear();
+  mOutputTRUTriggerRecords.clear();
+  mOutputPatches.clear();
+  mOutputPatchTriggerRecords.clear();
+  mOutputTimesums.clear();
+  mOutputTimesumTriggerRecords.clear();
 
   if (isLostTimeframe(ctx)) {
-    sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors);
+    sendData(ctx);
     return;
   }
 
@@ -216,6 +227,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       if (!currentEvent.getTriggerBits()) {
         currentEvent.setTriggerBits(triggerbits);
       }
+      CellTimeCorrection timeCorrector{timeshift, bcmod4};
 
       if (feeID >= 40) {
         continue; // skip STU ddl
@@ -268,67 +280,32 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         // Loop over all the channels
         int nBunchesNotOK = 0;
         for (auto& chan : decoder.getChannels()) {
-          int iRow, iCol;
-          ChannelType_t chantype;
           try {
-            iRow = map.getRow(chan.getHardwareAddress());
-            iCol = map.getColumn(chan.getHardwareAddress());
-            chantype = map.getChannelType(chan.getHardwareAddress());
+            auto iRow = map.getRow(chan.getHardwareAddress());
+            auto iCol = map.getColumn(chan.getHardwareAddress());
+            auto chantype = map.getChannelType(chan.getHardwareAddress());
+            LocalPosition channelPosition{iSM, feeID, iCol, iRow};
+            switch (chantype) {
+              case o2::emcal::ChannelType_t::HIGH_GAIN:
+              case o2::emcal::ChannelType_t::LOW_GAIN:
+                addFEEChannelToEvent(currentEvent, chan, timeCorrector, channelPosition, chantype);
+                break;
+              case o2::emcal::ChannelType_t::LEDMON:
+                // Drop LEDMON reconstruction in case of physics triggers
+                if (triggerbits & o2::trigger::Cal) {
+                  addFEEChannelToEvent(currentEvent, chan, timeCorrector, channelPosition, chantype);
+                }
+                break;
+              case o2::emcal::ChannelType_t::TRU:
+                addTRUChannelToEvent(currentEvent, chan, channelPosition);
+                break;
+              default:
+                LOG(error) << "Unknown channel type for HW address " << chan.getHardwareAddress();
+                break;
+            }
           } catch (Mapper::AddressNotFoundException& ex) {
             handleAddressError(ex, feeID, chan.getHardwareAddress());
             continue;
-          }
-
-          if (!(chantype == o2::emcal::ChannelType_t::HIGH_GAIN || chantype == o2::emcal::ChannelType_t::LOW_GAIN || chantype == o2::emcal::ChannelType_t::LEDMON)) {
-            continue;
-          }
-
-          // Drop LEDMON reconstruction in case of physics triggers
-          if (chantype == o2::emcal::ChannelType_t::LEDMON && !(triggerbits & o2::trigger::Cal)) {
-            continue;
-          }
-
-          int CellID = -1;
-          bool isLowGain = false;
-          try {
-            if (chantype == o2::emcal::ChannelType_t::HIGH_GAIN || chantype == o2::emcal::ChannelType_t::LOW_GAIN) {
-              // high- / low-gain cell
-              CellID = getCellAbsID(iSM, iCol, iRow);
-              isLowGain = chantype == o2::emcal::ChannelType_t::LOW_GAIN;
-            } else {
-              CellID = geLEDMONAbsID(iSM, iCol); // Module index encoded in colum for LEDMONs
-              isLowGain = iRow == 0;             // For LEDMONs gain type is encoded in the row (0 - low gain, 1 - high gain)
-            }
-          } catch (ModuleIndexException& e) {
-            handleGeometryError(e, iSM, CellID, chan.getHardwareAddress(), chantype);
-            continue;
-          }
-
-          // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
-          CaloFitResults fitResults;
-          try {
-            fitResults = mRawFitter->evaluate(chan.getBunches());
-            // Prevent negative entries - we should no longer get here as the raw fit usually will end in an error state
-            if (fitResults.getAmp() < 0) {
-              fitResults.setAmp(0.);
-            }
-            if (fitResults.getTime() < 0) {
-              fitResults.setTime(0.);
-            }
-            // apply correction for bc mod 4
-            double celltime = fitResults.getTime() - timeshift - 25 * bcmod4;
-            double amp = fitResults.getAmp() * o2::emcal::constants::EMCAL_ADCENERGY;
-            if (isLowGain) {
-              amp *= o2::emcal::constants::EMCAL_HGLGFACTOR;
-            }
-            if (chantype == o2::emcal::ChannelType_t::LEDMON) {
-              // Mark LEDMONs as HIGH_GAIN/LOW_GAIN for gain type merging - will be flagged as LEDMON later when pushing to the output container
-              currentEvent.setLEDMONCell(CellID, amp, celltime, isLowGain ? o2::emcal::ChannelType_t::LOW_GAIN : o2::emcal::ChannelType_t::HIGH_GAIN, chan.getHardwareAddress(), feeID, mMergeLGHG);
-            } else {
-              currentEvent.setCell(CellID, amp, celltime, chantype, chan.getHardwareAddress(), feeID, mMergeLGHG);
-            }
-          } catch (CaloRawFitter::RawFitterError_t& fiterror) {
-            handleFitError(fiterror, feeID, CellID, chan.getHardwareAddress());
           }
         }
       } catch (o2::emcal::MappingHandler::DDLInvalid& ddlerror) {
@@ -400,10 +377,31 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
     }
     LOG(debug) << "Next event [Orbit " << interaction.orbit << ", BC (" << interaction.bc << "]: Accepted " << ncellsEvent << " cells and " << nLEDMONsEvent << " LEDMONS";
     mOutputTriggerRecords.emplace_back(interaction, currentevent.getTriggerBits(), eventstart, ncellsEvent + nLEDMONsEvent);
+
+    // Add trigger data
+    if (mDoTriggerReconstruction) {
+      auto [trus, patches] = buildL0Patches(currentevent);
+      LOG(debug) << "Found " << patches.size() << " L0 patches from " << trus.size() << " TRUs";
+      auto trusstart = mOutputTRUs.size();
+      std::copy(trus.begin(), trus.end(), std::back_inserter(mOutputTRUs));
+      mOutputTRUTriggerRecords.emplace_back(interaction, currentevent.getTriggerBits(), trusstart, trus.size());
+      auto patchesstart = mOutputPatches.size();
+      std::copy(patches.begin(), patches.end(), std::back_inserter(mOutputPatches));
+      mOutputPatchTriggerRecords.emplace_back(interaction, currentevent.getTriggerBits(), patchesstart, patches.size());
+      // For L0 timesums use fixed time, across TRUs and triggers, determined from the patch time QC
+      // average found to be - will be made configurable
+      auto timesumsstart = mOutputTimesums.size();
+      auto timesums = buildL0Timesums(currentevent, 8);
+      std::copy(timesums.begin(), timesums.end(), std::back_inserter(mOutputTimesums));
+      mOutputTimesumTriggerRecords.emplace_back(interaction, currentevent.getTriggerBits(), timesumsstart, timesums.size());
+    }
   }
 
   LOG(info) << "[EMCALRawToCellConverter - run] Writing " << mOutputCells.size() << " cells from " << mOutputTriggerRecords.size() << " events ...";
-  sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors);
+  if (mDoTriggerReconstruction) {
+    LOG(info) << "[EMCALRawToCellConverter - run] Writing " << mOutputTRUs.size() << " TRU infos and " << mOutputPatches.size() << " trigger patches and " << mOutputTimesums.size() << " timesums from " << mOutputTRUTriggerRecords.size() << " events ...";
+  }
+  sendData(ctx);
 }
 
 void RawToCellConverterSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -447,6 +445,197 @@ bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) 
   }
   contDeadBeef = 0; // if good data, reset the counter
   return false;
+}
+
+void RawToCellConverterSpec::addFEEChannelToEvent(o2::emcal::EventContainer& currentEvent, const o2::emcal::Channel& currentchannel, const CellTimeCorrection& timeCorrector, const LocalPosition& position, ChannelType_t chantype)
+{
+  int CellID = -1;
+  bool isLowGain = false;
+  try {
+    if (chantype == o2::emcal::ChannelType_t::HIGH_GAIN || chantype == o2::emcal::ChannelType_t::LOW_GAIN) {
+      // high- / low-gain cell
+      CellID = getCellAbsID(position.mSupermoduleID, position.mColumn, position.mRow);
+      isLowGain = chantype == o2::emcal::ChannelType_t::LOW_GAIN;
+    } else {
+      CellID = geLEDMONAbsID(position.mSupermoduleID, position.mColumn); // Module index encoded in colum for LEDMONs
+      isLowGain = position.mRow == 0;                                    // For LEDMONs gain type is encoded in the row (0 - low gain, 1 - high gain)
+    }
+  } catch (ModuleIndexException& e) {
+    handleGeometryError(e, position.mSupermoduleID, CellID, currentchannel.getHardwareAddress(), chantype);
+    return;
+  }
+
+  // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
+  CaloFitResults fitResults;
+  try {
+    fitResults = mRawFitter->evaluate(currentchannel.getBunches());
+    // Prevent negative entries - we should no longer get here as the raw fit usually will end in an error state
+    if (fitResults.getAmp() < 0) {
+      fitResults.setAmp(0.);
+    }
+    if (fitResults.getTime() < 0) {
+      fitResults.setTime(0.);
+    }
+    // apply correction for bc mod 4
+    double celltime = timeCorrector.getCorrectedTime(fitResults.getTime());
+    double amp = fitResults.getAmp() * o2::emcal::constants::EMCAL_ADCENERGY;
+    if (isLowGain) {
+      amp *= o2::emcal::constants::EMCAL_HGLGFACTOR;
+    }
+    if (chantype == o2::emcal::ChannelType_t::LEDMON) {
+      // Mark LEDMONs as HIGH_GAIN/LOW_GAIN for gain type merging - will be flagged as LEDMON later when pushing to the output container
+      currentEvent.setLEDMONCell(CellID, amp, celltime, isLowGain ? o2::emcal::ChannelType_t::LOW_GAIN : o2::emcal::ChannelType_t::HIGH_GAIN, currentchannel.getHardwareAddress(), position.mFeeID, mMergeLGHG);
+    } else {
+      currentEvent.setCell(CellID, amp, celltime, chantype, currentchannel.getHardwareAddress(), position.mFeeID, mMergeLGHG);
+    }
+  } catch (CaloRawFitter::RawFitterError_t& fiterror) {
+    handleFitError(fiterror, position.mFeeID, CellID, currentchannel.getHardwareAddress());
+  }
+}
+
+void RawToCellConverterSpec::addTRUChannelToEvent(o2::emcal::EventContainer& currentEvent, const o2::emcal::Channel& currentchannel, const LocalPosition& position)
+{
+  auto tru = mTriggerMapping->getTRUIndexFromOnlineHardareAddree(currentchannel.getHardwareAddress(), position.mFeeID, position.mSupermoduleID);
+  if (position.mColumn >= 96 && position.mColumn <= 105) {
+    auto& trudata = currentEvent.getTRUData(tru);
+    // Trigger patch information encoded columns 95-105
+    for (auto& bunch : currentchannel.getBunches()) {
+      LOG(debug) << "Found bunch of length " << static_cast<int>(bunch.getBunchLength()) << " with start time " << static_cast<int>(bunch.getStartTime()) << " (column " << static_cast<int>(position.mColumn) << ")";
+      auto l0time = bunch.getStartTime();
+      int isample = 0;
+      for (auto& adc : bunch.getADC()) {
+        // patch word might be in any of the samples, need to check all of them
+        // in case of colum 105 the first 6 bits are the patch word, the remaining 4 bits are the header word
+        if (adc == 0) {
+          isample++;
+          continue;
+        }
+        if (position.mColumn == 105) {
+          std::bitset<6> patchBits(adc & 0x3F);
+          std::bitset<4> headerbits((adc >> 6) & 0xF);
+          for (auto localindex = 0; localindex < patchBits.size(); localindex++) {
+            if (patchBits.test(localindex)) {
+              auto globalindex = (position.mColumn - 96) * 10 + localindex;
+              LOG(debug) << "Found patch with index " << globalindex << " in sample " << isample;
+              // std::cout << "Found patch with index " << globalindex << " in sample " << isample << " (" << (bunch.getStartTime() - isample) << ")" << std::endl;
+              trudata.setPatch(globalindex, bunch.getStartTime() - isample);
+            }
+          }
+          if (headerbits.test(2)) {
+            LOG(debug) << "TRU " << tru << ": Found TRU fired (" << tru << ") in sample " << isample;
+            // std::cout << "TRU " << tru << ": Found TRU fired (" << tru << ") in sample " << isample << " (" << (bunch.getStartTime() - isample) << ")" << std::endl;
+            trudata.setFired(true);
+            trudata.setL0time(bunch.getStartTime() - isample);
+          }
+        } else {
+          std::bitset<10> patchBits(adc & 0x3FF);
+          for (auto localindex = 0; localindex < patchBits.size(); localindex++) {
+            if (patchBits.test(localindex)) {
+              auto globalindex = (position.mColumn - 96) * 10 + localindex;
+              LOG(debug) << "TRU " << tru << ": Found patch with index " << globalindex << " in sample " << isample;
+              // std::cout << "TRU " << tru << ": Found patch with index " << globalindex << " in sample " << isample << " (" << (bunch.getStartTime() - isample) << ")" << std::endl;
+              trudata.setPatch(globalindex, bunch.getStartTime() - isample);
+            }
+          }
+        }
+        isample++;
+      }
+    }
+  } else {
+    auto absFastOR = mTriggerMapping->getAbsFastORIndexFromIndexInTRU(tru, position.mColumn);
+    for (auto& bunch : currentchannel.getBunches()) {
+      // FastOR data reversed internally (positive in time direction)
+      // -> Start time marks the first timebin, consequently it must be also reversed.
+      // std::cout << "Adding non-reversed FastOR time series for FastOR " << absFastOR << " (TRU " << tru << ", index " << static_cast<int>(position.mColumn) << ") with start time " << static_cast<int>(bunch.getStartTime()) << " (reversed " << bunch.getStartTime() + 1 - bunch.getADC().size() << "): ";
+      // for (auto adc : bunch.getADC()) {
+      //  std::cout << adc << ", ";
+      //}
+      // std::cout << std::endl;
+      currentEvent.setFastOR(absFastOR, bunch.getStartTime(), bunch.getADC());
+    }
+  }
+}
+
+std::tuple<RawToCellConverterSpec::TRUContainer, RawToCellConverterSpec::PatchContainer> RawToCellConverterSpec::buildL0Patches(const EventContainer& currentevent) const
+{
+  LOG(debug) << "Reconstructing patches for Orbit " << currentevent.getInteractionRecord().orbit << ", BC " << currentevent.getInteractionRecord().bc;
+  TRUContainer eventTRUs;
+  PatchContainer eventPatches;
+  auto& fastOrs = currentevent.getTimeSeriesContainer();
+  std::set<uint16_t> foundFastOrs;
+  for (auto fastor : fastOrs) {
+    foundFastOrs.insert(fastor.first);
+  }
+  for (std::size_t itru = 0; itru < TriggerMappingV2::ALLTRUS; itru++) {
+    auto& currenttru = currentevent.readTRUData(itru);
+    if (!currenttru.hasAnyPatch()) {
+      continue;
+    }
+    auto l0time = currenttru.getL0time();
+    LOG(debug) << "Found patches in TRU " << itru << ", fired:  " << (currenttru.isFired() ? "yes" : "no") << ", L0 time " << static_cast<int>(l0time);
+    uint8_t npatches = 0;
+    for (auto ipatch = 0; ipatch < o2::emcal::TriggerMappingV2::PATCHESINTRU; ipatch++) {
+      if (currenttru.hasPatch(ipatch)) {
+        auto patchtime = currenttru.getPatchTime(ipatch);
+        LOG(debug) << "Found patch " << ipatch << " in TRU " << itru << " with time " << static_cast<int>(patchtime);
+        auto fastorStart = mTriggerMapping->getAbsFastORIndexFromIndexInTRU(itru, ipatch);
+        auto fastORs = mTriggerMapping->getFastORIndexFromL0Index(itru, ipatch, 4);
+        std::array<const FastORTimeSeries*, 4> fastors;
+        std::fill(fastors.begin(), fastors.end(), nullptr);
+        int indexFastorInTRU = 0;
+        for (auto fastor : fastORs) {
+          auto [truID, fastorTRU] = mTriggerMapping->getTRUFromAbsFastORIndex(fastor);
+          // std::cout << "Patch has abs FastOR " << fastor << " -> " << fastorTRU << " (in TRU)" << std::endl;
+          auto timeseriesFound = fastOrs.find(fastor);
+          if (timeseriesFound != fastOrs.end()) {
+            LOG(debug) << "Adding FastOR (" << indexFastorInTRU << ") with index " << fastor << " to patch";
+            fastors[indexFastorInTRU] = &(timeseriesFound->second);
+            indexFastorInTRU++;
+          }
+        }
+        auto [patchADC, recpatchtime] = reconstructTriggerPatch(fastors);
+        // Correct for bit shift 12->10 bits due to ALTRO format
+        patchADC = patchADC << 2;
+        LOG(debug) << "Reconstructed patch at index " << ipatch << " with peak time " << static_cast<int>(recpatchtime) << " (time sample " << static_cast<int>(patchtime) << ") and energy " << patchADC;
+        eventPatches.push_back({static_cast<uint8_t>(itru), static_cast<uint8_t>(ipatch), patchtime, patchADC});
+      }
+    }
+    eventTRUs.push_back({static_cast<uint8_t>(itru), static_cast<uint8_t>(l0time), currenttru.isFired(), npatches});
+  }
+  return std::make_tuple(eventTRUs, eventPatches);
+}
+
+std::vector<o2::emcal::CompressedL0TimeSum> RawToCellConverterSpec::buildL0Timesums(const o2::emcal::EventContainer& currentevent, uint8_t l0time) const
+{
+  std::vector<o2::emcal::CompressedL0TimeSum> timesums;
+  for (const auto& [fastorID, timeseries] : currentevent.getTimeSeriesContainer()) {
+    timesums.push_back({fastorID, static_cast<uint16_t>(timeseries.calculateL1TimeSum(l0time) << 2)});
+  }
+  return timesums;
+}
+
+std::tuple<uint16_t, uint8_t> RawToCellConverterSpec::reconstructTriggerPatch(const gsl::span<const FastORTimeSeries*> fastors) const
+{
+  constexpr size_t INTEGRATE_SAMPLES = 4,
+                   MAX_SAMPLES = 12;
+  double maxpatchenergy = 0;
+  uint8_t foundtime = 0;
+  for (size_t itime = 0; itime < MAX_SAMPLES - INTEGRATE_SAMPLES; ++itime) {
+    double currenttimesum = 0;
+    for (size_t isample = 0; isample < INTEGRATE_SAMPLES; ++isample) {
+      for (auto ifastor = 0; ifastor < fastors.size(); ++ifastor) {
+        if (fastors[ifastor]) {
+          currenttimesum += fastors[ifastor]->getADCs()[itime + isample];
+        }
+      }
+    }
+    if (currenttimesum > maxpatchenergy) {
+      maxpatchenergy = currenttimesum;
+      foundtime = itime;
+    }
+  }
+
+  return std::make_tuple(maxpatchenergy, foundtime);
 }
 
 int RawToCellConverterSpec::bookEventCells(const gsl::span<const o2::emcal::RecCellInfo>& cells, bool isLELDMON)
@@ -719,14 +908,22 @@ void RawToCellConverterSpec::handleMinorPageError(const RawReaderMemory::MinorEr
   }
 }
 
-void RawToCellConverterSpec::sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const
+void RawToCellConverterSpec::sendData(framework::ProcessingContext& ctx) const
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", mSubspecification}, cells);
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", mSubspecification}, triggers);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", mSubspecification}, mOutputCells);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", mSubspecification}, mOutputTriggerRecords);
   if (mCreateRawDataErrors) {
-    LOG(debug) << "Sending " << decodingErrors.size() << " decoding errors";
-    ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", mSubspecification}, decodingErrors);
+    LOG(debug) << "Sending " << mOutputDecoderErrors.size() << " decoding errors";
+    ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", mSubspecification}, mOutputDecoderErrors);
+  }
+  if (mDoTriggerReconstruction) {
+    ctx.outputs().snapshot(framework::Output{originEMC, "TRUS", mSubspecification}, mOutputTRUs);
+    ctx.outputs().snapshot(framework::Output{originEMC, "TRUSTRGR", mSubspecification}, mOutputTRUTriggerRecords);
+    ctx.outputs().snapshot(framework::Output{originEMC, "PATCHES", mSubspecification}, mOutputPatches);
+    ctx.outputs().snapshot(framework::Output{originEMC, "PATCHESTRGR", mSubspecification}, mOutputPatchTriggerRecords);
+    ctx.outputs().snapshot(framework::Output{originEMC, "FASTORS", mSubspecification}, mOutputTimesums);
+    ctx.outputs().snapshot(framework::Output{originEMC, "FASTORSTRGR", mSubspecification}, mOutputTimesumTriggerRecords);
   }
 }
 
@@ -739,7 +936,7 @@ RawToCellConverterSpec::ModuleIndexException::ModuleIndexException(int moduleInd
 
 RawToCellConverterSpec::ModuleIndexException::ModuleIndexException(int moduleIndex) : mModuleType(ModuleType_t::LEDMON_MODULE), mIndex(moduleIndex) {}
 
-o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec(bool askDISTSTF, bool disableDecodingErrors, int subspecification)
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec(bool askDISTSTF, bool disableDecodingErrors, bool disableTriggerReconstruction, int subspecification)
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
   std::vector<o2::framework::OutputSpec> outputs;
@@ -748,6 +945,14 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverter
   outputs.emplace_back(originEMC, "CELLSTRGR", subspecification, o2::framework::Lifetime::Timeframe);
   if (!disableDecodingErrors) {
     outputs.emplace_back(originEMC, "DECODERERR", subspecification, o2::framework::Lifetime::Timeframe);
+  }
+  if (!disableTriggerReconstruction) {
+    outputs.emplace_back(originEMC, "TRUS", subspecification, o2::framework::Lifetime::Timeframe);
+    outputs.emplace_back(originEMC, "TRUSTRGR", subspecification, o2::framework::Lifetime::Timeframe);
+    outputs.emplace_back(originEMC, "PATCHES", subspecification, o2::framework::Lifetime::Timeframe);
+    outputs.emplace_back(originEMC, "PATCHESTRGR", subspecification, o2::framework::Lifetime::Timeframe);
+    outputs.emplace_back(originEMC, "FASTORS", subspecification, o2::framework::Lifetime::Timeframe);
+    outputs.emplace_back(originEMC, "FASTORSTRGR", subspecification, o2::framework::Lifetime::Timeframe);
   }
 
   std::vector<o2::framework::InputSpec> inputs{{"stf", o2::framework::ConcreteDataTypeMatcher{originEMC, o2::header::gDataDescriptionRawData}, o2::framework::Lifetime::Timeframe}};
@@ -764,7 +969,7 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverter
     "EMCALRawToCellConverterSpec",
     inputs,
     outputs,
-    o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(subspecification, !disableDecodingErrors, calibhandler),
+    o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(subspecification, !disableDecodingErrors, !disableTriggerReconstruction, calibhandler),
     o2::framework::Options{
       {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}},
       {"maxmessage", o2::framework::VariantType::Int, 100, {"Max. amout of error messages to be displayed"}},

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -53,7 +53,8 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
                                         bool disableRootOutput,
-                                        bool disableDecodingErrors)
+                                        bool disableDecodingErrors,
+                                        bool disableTriggerReconstruction)
 {
 
   const std::unordered_map<std::string, InputType> InputMap{
@@ -173,7 +174,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
       specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC, subspecificationIn, subspecificationOut));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
-      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, disableDecodingErrors, subspecificationOut));
+      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, disableDecodingErrors, disableTriggerReconstruction, subspecificationOut));
     }
   }
 

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -53,6 +53,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
     {"disable-decoding-errors", o2::framework::VariantType::Bool, false, {"disable propagating decoding errors"}},
+    {"disable-trigger-reconstruction", o2::framework::VariantType::Bool, false, {"disable reconstruction of trigger data"}},
     {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"subspecificationIn", o2::framework::VariantType::Int, 0, {"Subspecification for input in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}},
     {"subspecificationOut", o2::framework::VariantType::Int, 0, {"Subspecification for output in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
@@ -86,7 +87,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
                                                   cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),
                                                   cfgc.options().get<bool>("disable-root-output"),
-                                                  cfgc.options().get<bool>("disable-decoding-errors"));
+                                                  cfgc.options().get<bool>("disable-decoding-errors"),
+                                                  cfgc.options().get<bool>("disable-trigger-reconstruction"));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);


### PR DESCRIPTION
- Add decoding of TRU data (FastORs and patch index)
- EMCAL-911: Add handling of TRU data in RecoContainer
- Provide helper classes for TRU- and FastOR decoding
  including the calculation of the L0timesum
- EMCAL-537: Provide data structure for patches, TRUs and
  Timesums
- EMCAL-550: Integration into RecoWorkflow: Output channels
  and option to disable trigger reconstruction