### PR TITLE
Update of TPC Splines: non-uniform grid for TPC residuals

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -318,9 +318,14 @@ class TrackResiduals
   void getVoxelCoordinates(int isec, int ix, int ip, int iz, float& x, float& p, float& z) const;
 
   /// Calculates the x-coordinate for given x bin.
-  /// \param i Bin index
+  /// \param ix Bin index in x
   /// \return Coordinate in X
-  float getX(int i) const;
+  float getX(int ix) const;
+
+  /// Calculates the max y/x-coordinate for given x bin taking the dead zone into account.
+  /// \param ix Bin index in x
+  /// \return Max coordinate in Y/X
+  float getMaxY2X(int ix) const;
 
   /// Calculates the y/x-coordinate.
   /// \param ix Bin index in X
@@ -553,9 +558,15 @@ inline float TrackResiduals::getDXI(int ix) const
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getX(int i) const
+inline float TrackResiduals::getX(int ix) const
 {
-  return mUniformBins[VoxX] ? param::MinX + (i + 0.5) * mDX : param::RowX[i];
+  return mUniformBins[VoxX] ? param::MinX + (ix + 0.5) * mDX : param::RowX[ix];
+}
+
+//_____________________________________________________
+inline float TrackResiduals::getMaxY2X(int ix) const
+{
+  return mMaxY2X[ix];
 }
 
 //_____________________________________________________

--- a/GPU/TPCFastTransformation/Spline1DSpec.h
+++ b/GPU/TPCFastTransformation/Spline1DSpec.h
@@ -315,6 +315,14 @@ class Spline1DSpec<DataT, YdimT, 0> : public Spline1DContainer<DataT>
   {
     const auto nYdimTmp = SplineUtil::getNdim<YdimT>(inpYdim);
     const auto nYdim = nYdimTmp.get();
+
+    if (u < (DataT)0) {
+      u = (DataT)0;
+    }
+    if (u > (DataT)TBase::getUmax()) {
+      u = (DataT)TBase::getUmax();
+    }
+
     T uu = T(u - knotL.u);
     T li = T(knotL.Li);
     T v = uu * li; // scaled u
@@ -339,11 +347,19 @@ class Spline1DSpec<DataT, YdimT, 0> : public Spline1DContainer<DataT>
   }
 
   template <typename T>
-  GPUd() static void getUderivatives(const Knot& knotL, DataT u,
-                                     T& dSl, T& dDl, T& dSr, T& dDr)
+  GPUd() void getUderivatives(const Knot& knotL, DataT u,
+                              T& dSl, T& dDl, T& dSr, T& dDr) const
   {
     /// Get derivatives of the interpolated value {S(u): 1D -> nYdim} at the segment [knotL, next knotR]
     /// over the spline values Sl, Sr and the slopes Dl, Dr
+
+    if (u < (DataT)0) {
+      u = (DataT)0;
+    }
+    if (u > (DataT)TBase::getUmax()) {
+      u = (DataT)TBase::getUmax();
+    }
+
     u = u - knotL.u;
     T v = u * T(knotL.Li); // scaled u
     T vm1 = v - 1.;

--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.h
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.h
@@ -457,9 +457,17 @@ GPUdi() int TPCFastSpaceChargeCorrection::getCorrection(int slice, int row, floa
   float dxuv[3];
   spline.interpolateU(splineData, gridU, gridV, dxuv);
   const auto& info = getSliceRowInfo(slice, row);
-  dx = GPUCommonMath::Max(info.minCorr[0], GPUCommonMath::Min(info.maxCorr[0], dxuv[0]));
-  du = GPUCommonMath::Max(info.minCorr[1], GPUCommonMath::Min(info.maxCorr[1], dxuv[1]));
-  dv = GPUCommonMath::Max(info.minCorr[2], GPUCommonMath::Min(info.maxCorr[2], dxuv[2]));
+  float s = v / info.gridV0;
+  if (s < 0.) {
+    s = 0.;
+  }
+  if (s > 1.) {
+    s = 1.;
+  }
+
+  dx = GPUCommonMath::Max(info.minCorr[0], GPUCommonMath::Min(info.maxCorr[0], s * dxuv[0]));
+  du = GPUCommonMath::Max(info.minCorr[1], GPUCommonMath::Min(info.maxCorr[1], s * dxuv[1]));
+  dv = GPUCommonMath::Max(info.minCorr[2], GPUCommonMath::Min(info.maxCorr[2], s * dxuv[2]));
   return 0;
 }
 
@@ -472,9 +480,16 @@ GPUdi() int TPCFastSpaceChargeCorrection::getCorrectionOld(int slice, int row, f
   float dxuv[3];
   spline.interpolateUold(splineData, gridU, gridV, dxuv);
   const auto& info = getSliceRowInfo(slice, row);
-  dx = GPUCommonMath::Max(info.minCorr[0], GPUCommonMath::Min(info.maxCorr[0], dxuv[0]));
-  du = GPUCommonMath::Max(info.minCorr[1], GPUCommonMath::Min(info.maxCorr[1], dxuv[1]));
-  dv = GPUCommonMath::Max(info.minCorr[2], GPUCommonMath::Min(info.maxCorr[2], dxuv[2]));
+  float s = v / info.gridV0;
+  if (s < 0.) {
+    s = 0.;
+  }
+  if (s > 1.) {
+    s = 1.;
+  }
+  dx = GPUCommonMath::Max(info.minCorr[0], GPUCommonMath::Min(info.maxCorr[0], s * dxuv[0]));
+  du = GPUCommonMath::Max(info.minCorr[1], GPUCommonMath::Min(info.maxCorr[1], s * dxuv[1]));
+  dv = GPUCommonMath::Max(info.minCorr[2], GPUCommonMath::Min(info.maxCorr[2], s * dxuv[2]));
   return 0;
 }
 

--- a/GPU/TPCFastTransformation/TPCFastTransformGeo.h
+++ b/GPU/TPCFastTransformation/TPCFastTransformGeo.h
@@ -52,8 +52,15 @@ class TPCFastTransformGeo
     float scaleUtoSU; ///< scale for su (scaled u ) coordinate
     float scaleSUtoU; ///< scale for u coordinate
 
+    /// get U min
+    GPUd() float getUmin() const { return u0; }
+
+    /// get U max
+    GPUd() float getUmax() const { return -u0; }
+
     /// get width in U
     GPUd() float getUwidth() const { return -2.f * u0; }
+
 #ifndef GPUCA_ALIROOT_LIB
     ClassDefNV(RowInfo, 1);
 #endif
@@ -113,6 +120,9 @@ class TPCFastTransformGeo
 
   /// Gives number of TPC rows
   GPUd() int getNumberOfRows() const { return mNumberOfRows; }
+
+  /// Gives number of TPC rows
+  GPUd() static constexpr int getMaxNumberOfRows() { return MaxNumberOfRows; }
 
   /// Gives slice info
   GPUd() const SliceInfo& getSliceInfo(int slice) const;

--- a/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
+++ b/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
@@ -138,6 +138,7 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root",
   o2::tpc::TPCFastSpaceChargeCorrectionHelper* corrHelper = o2::tpc::TPCFastSpaceChargeCorrectionHelper::instance();
 
   corrHelper->setNthreadsToMaximum();
+  // corrHelper->setNthreads(1);
 
   auto corrPtr = corrHelper->createFromTrackResiduals(trackResiduals, voxResTree, useSmoothed, invertSigns);
 
@@ -304,6 +305,11 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root",
       correctionX *= -1.;
       correctionY *= -1.;
       correctionZ *= -1.;
+    }
+
+    if (voxEntries > 0.) { // use mean statistical positions instead of the bin centers:
+      y = x * v->stat[o2::tpc::TrackResiduals::VoxF];
+      z = x * v->stat[o2::tpc::TrackResiduals::VoxZ];
     }
 
     float u, v, cx, cu, cv, cy, cz;

--- a/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
+++ b/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
@@ -21,8 +21,6 @@
 /// root -l TPCFastTransformInit.C'("debugVoxRes.root")'
 ///
 
-#include "Algorithm/RangeTokenizer.h"
-
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 
 #include <filesystem>
@@ -40,6 +38,8 @@
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 #include "TPCCalibration/TPCFastSpaceChargeCorrectionHelper.h"
 #endif
+
+#include "Algorithm/RangeTokenizer.h"
 
 using namespace o2::tpc;
 using namespace o2::gpu;
@@ -99,8 +99,9 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root",
   trackResiduals.setZ2XBinning(z2xBins);
   trackResiduals.init();
 
-  {
-    std::cout << "input track residuals: " << std::endl;
+  { // debug output
+
+    std::cout << " ===== input track residuals ==== " << std::endl;
     std::cout << "voxel tree y2xBins: " << y2xBins.size() << std::endl;
 
     for (auto y2x : y2xBins) {
@@ -127,6 +128,7 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root",
     for (int i = 0; i < nZ2Xbins; i++) {
       std::cout << "getZ2X(bin) : " << trackResiduals.getZ2X(i) << std::endl;
     }
+    std::cout << " ==================================== " << std::endl;
   }
 
   std::cout << "create fast transformation ... " << std::endl;
@@ -310,6 +312,7 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root",
     geo.convUVtoLocal(iRoc, u + cu, v + cv, cy, cz);
     cy -= y;
     cz -= z;
+
     double d[3] = {cx - correctionX, cy - correctionY, cz - correctionZ};
     if (voxEntries >= 1.) {
       for (int i = 0; i < 3; i++) {
@@ -317,8 +320,8 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root",
           maxDiff[i] = d[i];
           maxDiffRoc[i] = iRoc;
           maxDiffRow[i] = iRow;
-          std::cout << " roc " << iRoc << " row " << iRow << " xyz " << i
-                    << " diff " << d[i] << " entries " << voxEntries << " y " << y2xBin << " z " << z2xBin << std::endl;
+          // std::cout << " roc " << iRoc << " row " << iRow << " xyz " << i
+          //  << " diff " << d[i] << " entries " << voxEntries << " y " << y2xBin << " z " << z2xBin << std::endl;
         }
         sumDiff[i] += d[i] * d[i];
       }


### PR DESCRIPTION

The PR contains several commits:

- non-uniform grid that corresponds to the track residual voxels

-  limits for SC correction values per TPC row
-  multithreaded reading of the residual tree
- fix propagation of the track residual data to the TPC row edges
-  fix initialization of the track residuals in the test macro
