### PR TITLE
Allow for smooth move to the new naming of QC flags

### DIFF
--- a/DataFormats/QualityControl/CMakeLists.txt
+++ b/DataFormats/QualityControl/CMakeLists.txt
@@ -43,7 +43,9 @@ o2_add_library(DataFormatsQualityControl
         )
 
 o2_target_root_dictionary(DataFormatsQualityControl
-                          HEADERS include/DataFormatsQualityControl/FlagReasons.h
+                          HEADERS include/DataFormatsQualityControl/FlagType.h
+                                  include/DataFormatsQualityControl/FlagReasons.h
+                                  include/DataFormatsQualityControl/QualityControlFlag.h
                                   include/DataFormatsQualityControl/TimeRangeFlag.h
                                   include/DataFormatsQualityControl/TimeRangeFlagCollection.h)
 

--- a/DataFormats/QualityControl/include/DataFormatsQualityControl/FlagType.h
+++ b/DataFormats/QualityControl/include/DataFormatsQualityControl/FlagType.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_QUALITYCONTROL_FLAGTYPE_H
+#define O2_QUALITYCONTROL_FLAGTYPE_H
+
+#include "DataFormatsQualityControl/FlagReasons.h"
+
+namespace o2::quality_control
+{
+using FlagType = o2::quality_control::FlagReason;
+}
+
+#endif // O2_QUALITYCONTROL_FLAGTYPE_H

--- a/DataFormats/QualityControl/include/DataFormatsQualityControl/FlagTypeFactory.h
+++ b/DataFormats/QualityControl/include/DataFormatsQualityControl/FlagTypeFactory.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_QUALITYCONTROL_FLAGTYPEFACTORY_H
+#define O2_QUALITYCONTROL_FLAGTYPEFACTORY_H
+
+#include "DataFormatsQualityControl/FlagReasonFactory.h"
+
+namespace o2::quality_control
+{
+using FlagTypeFactory = o2::quality_control::FlagReasonFactory;
+}
+
+#endif // O2_QUALITYCONTROL_FLAGTYPEFACTORY_H

--- a/DataFormats/QualityControl/include/DataFormatsQualityControl/QualityControlFlag.h
+++ b/DataFormats/QualityControl/include/DataFormatsQualityControl/QualityControlFlag.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_QUALITYCONTROL_QCFLAG_H
+#define O2_QUALITYCONTROL_QCFLAG_H
+
+#include "DataFormatsQualityControl/TimeRangeFlag.h"
+
+namespace o2::quality_control
+{
+using QualityControlFlag = o2::quality_control::TimeRangeFlag;
+}
+
+#endif // O2_QUALITYCONTROL_QCFLAG_H

--- a/DataFormats/QualityControl/include/DataFormatsQualityControl/QualityControlFlagCollection.h
+++ b/DataFormats/QualityControl/include/DataFormatsQualityControl/QualityControlFlagCollection.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_QUALITYCONTROL_QCFLAGCOLLECTION_H
+#define O2_QUALITYCONTROL_QCFLAGCOLLECTION_H
+
+#include "DataFormatsQualityControl/TimeRangeFlagCollection.h"
+
+namespace o2::quality_control
+{
+using QualityControlFlagCollection = o2::quality_control::TimeRangeFlagCollection;
+}
+
+#endif // O2_QUALITYCONTROL_QCFLAGCOLLECTION_H

--- a/DataFormats/QualityControl/test/testFlagReasons.cxx
+++ b/DataFormats/QualityControl/test/testFlagReasons.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#define BOOST_TEST_MODULE Test quality_control FlagReasons class
+#define BOOST_TEST_MODULE Test quality_control FlagTypes class
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
@@ -19,20 +19,20 @@
 #include <iostream>
 
 // o2 includes
-#include "DataFormatsQualityControl/FlagReasons.h"
-#include "DataFormatsQualityControl/FlagReasonFactory.h"
+#include "DataFormatsQualityControl/FlagType.h"
+#include "DataFormatsQualityControl/FlagTypeFactory.h"
 
 using namespace o2::quality_control;
 
-BOOST_AUTO_TEST_CASE(FlagReasons)
+BOOST_AUTO_TEST_CASE(FlagTypes)
 {
-  static_assert(std::is_constructible<FlagReason, uint16_t, const char*, bool>::value == false,
-                "FlagReason should not be constructible outside of its static methods and the factory.");
+  static_assert(std::is_constructible<FlagType, uint16_t, const char*, bool>::value == false,
+                "FlagType should not be constructible outside of its static methods and the factory.");
 
-  FlagReason rDefault;
-  BOOST_CHECK_EQUAL(rDefault, FlagReasonFactory::Invalid());
+  FlagType rDefault;
+  BOOST_CHECK_EQUAL(rDefault, FlagTypeFactory::Invalid());
 
-  auto r1 = FlagReasonFactory::Unknown();
+  auto r1 = FlagTypeFactory::Unknown();
   BOOST_CHECK_EQUAL(r1.getID(), 1);
   BOOST_CHECK_EQUAL(r1.getName(), "Unknown");
   BOOST_CHECK_EQUAL(r1.getBad(), true);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(FlagReasons)
   BOOST_CHECK(!(r1 < r2));
   BOOST_CHECK(!(r1 > r2));
 
-  auto r3 = FlagReasonFactory::LimitedAcceptance();
+  auto r3 = FlagTypeFactory::LimitedAcceptance();
   BOOST_CHECK(r3 > r1);
   BOOST_CHECK(!(r3 < r1));
 }

--- a/DataFormats/QualityControl/test/testTimeRangeFlag.cxx
+++ b/DataFormats/QualityControl/test/testTimeRangeFlag.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#define BOOST_TEST_MODULE Test quality_control TimeRangeFlag class
+#define BOOST_TEST_MODULE Test quality_control QualityControlFlag class
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
@@ -17,13 +17,13 @@
 #include <boost/test/unit_test.hpp>
 
 // o2 includes
-#include "DataFormatsQualityControl/TimeRangeFlag.h"
+#include "DataFormatsQualityControl/QualityControlFlag.h"
 
 using namespace o2::quality_control;
 
-BOOST_AUTO_TEST_CASE(test_TimeRangeFlag)
+BOOST_AUTO_TEST_CASE(test_QualityControlFlag)
 {
-  TimeRangeFlag trf1{12, 34, FlagReasonFactory::BadTracking(), "comment", "source"};
+  QualityControlFlag trf1{12, 34, FlagReasonFactory::BadTracking(), "comment", "source"};
 
   BOOST_CHECK_EQUAL(trf1.getStart(), 12);
   BOOST_CHECK_EQUAL(trf1.getEnd(), 34);
@@ -31,9 +31,9 @@ BOOST_AUTO_TEST_CASE(test_TimeRangeFlag)
   BOOST_CHECK_EQUAL(trf1.getComment(), "comment");
   BOOST_CHECK_EQUAL(trf1.getSource(), "source");
 
-  BOOST_CHECK_THROW((TimeRangeFlag{12, 0, FlagReasonFactory::BadTracking()}), std::runtime_error);
+  BOOST_CHECK_THROW((QualityControlFlag{12, 0, FlagReasonFactory::BadTracking()}), std::runtime_error);
 
-  TimeRangeFlag trf2{10, 34, FlagReasonFactory::BadTracking(), "comment", "source"};
+  QualityControlFlag trf2{10, 34, FlagReasonFactory::BadTracking(), "comment", "source"};
 
   BOOST_CHECK(trf1 > trf2);
   BOOST_CHECK(!(trf1 < trf2));

--- a/DataFormats/QualityControl/test/testTimeRangeFlagCollection.cxx
+++ b/DataFormats/QualityControl/test/testTimeRangeFlagCollection.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#define BOOST_TEST_MODULE Test quality_control TimeRangeFlagCollection class
+#define BOOST_TEST_MODULE Test quality_control QualityControlFlagCollection class
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
@@ -18,20 +18,21 @@
 // STL
 #include <sstream>
 // o2 includes
-#include "DataFormatsQualityControl/TimeRangeFlagCollection.h"
-#include "DataFormatsQualityControl/TimeRangeFlag.h"
+#include "DataFormatsQualityControl/QualityControlFlagCollection.h"
+#include "DataFormatsQualityControl/QualityControlFlag.h"
+#include "DataFormatsQualityControl/FlagTypeFactory.h"
 
 using namespace o2::quality_control;
 
-BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_Methods)
+BOOST_AUTO_TEST_CASE(test_QualityControlFlagCollection_Methods)
 {
-  TimeRangeFlag trf1{12, 34, FlagReasonFactory::BadTracking(), "comment", "source"};
-  TimeRangeFlag trf2{10, 34, FlagReasonFactory::BadTracking(), "comment", "source"};
+  QualityControlFlag trf1{12, 34, FlagTypeFactory::BadTracking(), "comment", "source"};
+  QualityControlFlag trf2{10, 34, FlagTypeFactory::BadTracking(), "comment", "source"};
 
-  TimeRangeFlagCollection trfc1{"Raw data checks", "TOF", {10, 20000}, 12345, "LHC22k5", "passMC", "qc_mc"};
+  QualityControlFlagCollection trfc1{"Raw data checks", "TOF", {10, 20000}, 12345, "LHC22k5", "passMC", "qc_mc"};
   trfc1.insert(trf1); // by copy
   trfc1.insert(trf2);
-  trfc1.insert({50, 77, FlagReasonFactory::Invalid()}); // by move
+  trfc1.insert({50, 77, FlagTypeFactory::Invalid()}); // by move
   BOOST_CHECK_EQUAL(trfc1.size(), 3);
   BOOST_CHECK_EQUAL(trfc1.getName(), "Raw data checks");
   BOOST_CHECK_EQUAL(trfc1.getDetector(), "TOF");
@@ -42,16 +43,16 @@ BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_Methods)
   BOOST_CHECK_EQUAL(trfc1.getPassName(), "passMC");
   BOOST_CHECK_EQUAL(trfc1.getProvenance(), "qc_mc");
 
-  TimeRangeFlagCollection trfc2{"Reco checks", "TOF"};
-  trfc2.insert({50, 77, FlagReasonFactory::Invalid()}); // this is a duplicate to an entry in trfc1
-  trfc2.insert({51, 77, FlagReasonFactory::Invalid()});
-  trfc2.insert({1234, 3434, FlagReasonFactory::LimitedAcceptance()});
-  trfc2.insert({50, 77, FlagReasonFactory::LimitedAcceptance()});
+  QualityControlFlagCollection trfc2{"Reco checks", "TOF"};
+  trfc2.insert({50, 77, FlagTypeFactory::Invalid()}); // this is a duplicate to an entry in trfc1
+  trfc2.insert({51, 77, FlagTypeFactory::Invalid()});
+  trfc2.insert({1234, 3434, FlagTypeFactory::LimitedAcceptance()});
+  trfc2.insert({50, 77, FlagTypeFactory::LimitedAcceptance()});
   BOOST_CHECK_EQUAL(trfc2.size(), 4);
 
   // Try merging. Duplicate entries should be left in the 'other' objects.
   // Notice that we merge the two partial TRFCs into the third, which covers all cases
-  TimeRangeFlagCollection trfc3{"ALL", "TOF"};
+  QualityControlFlagCollection trfc3{"ALL", "TOF"};
   trfc3.merge(trfc1);
   trfc3.merge(trfc2);
   BOOST_CHECK_EQUAL(trfc1.size(), 0);
@@ -59,14 +60,14 @@ BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_Methods)
   BOOST_CHECK_EQUAL(trfc3.size(), 6);
 
   // Try const merging. It should copy the elements and keep the 'other' intact.
-  TimeRangeFlagCollection trfc4{"ALL", "TOF"};
+  QualityControlFlagCollection trfc4{"ALL", "TOF"};
   const auto& constTrfc3 = trfc3;
   trfc4.merge(constTrfc3);
   BOOST_CHECK_EQUAL(trfc3.size(), 6);
   BOOST_CHECK_EQUAL(trfc4.size(), 6);
 
   // Try merging different detectors - it should throw.
-  TimeRangeFlagCollection trfc5{"ALL", "TPC"};
+  QualityControlFlagCollection trfc5{"ALL", "TPC"};
   BOOST_CHECK_THROW(trfc5.merge(trfc3), std::runtime_error);
   BOOST_CHECK_THROW(trfc5.merge(constTrfc3), std::runtime_error);
 
@@ -79,31 +80,31 @@ BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_Methods)
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_IO)
+BOOST_AUTO_TEST_CASE(test_QualityControlFlagCollection_IO)
 {
   {
-    TimeRangeFlagCollection trfc1{"xyz", "TST"};
+    QualityControlFlagCollection trfc1{"xyz", "TST"};
 
     std::stringstream store;
     trfc1.streamTo(store);
 
-    TimeRangeFlagCollection trfc2{"xyz", "TST"};
+    QualityControlFlagCollection trfc2{"xyz", "TST"};
     trfc2.streamFrom(store);
 
     BOOST_CHECK_EQUAL(trfc2.size(), 0);
   }
   {
-    TimeRangeFlagCollection trfc1{"xyz", "TST"};
-    trfc1.insert({50, 77, FlagReasonFactory::Invalid(), "a comment", "a source"});
-    trfc1.insert({51, 77, FlagReasonFactory::Invalid()});
-    trfc1.insert({1234, 3434, FlagReasonFactory::LimitedAcceptance()});
-    trfc1.insert({50, 77, FlagReasonFactory::LimitedAcceptance()});
-    trfc1.insert({43434, 63421, FlagReasonFactory::NotBadFlagExample()});
+    QualityControlFlagCollection trfc1{"xyz", "TST"};
+    trfc1.insert({50, 77, FlagTypeFactory::Invalid(), "a comment", "a source"});
+    trfc1.insert({51, 77, FlagTypeFactory::Invalid()});
+    trfc1.insert({1234, 3434, FlagTypeFactory::LimitedAcceptance()});
+    trfc1.insert({50, 77, FlagTypeFactory::LimitedAcceptance()});
+    trfc1.insert({43434, 63421, FlagTypeFactory::NotBadFlagExample()});
 
     std::stringstream store;
     trfc1.streamTo(store);
 
-    TimeRangeFlagCollection trfc2{"xyz", "TST"};
+    QualityControlFlagCollection trfc2{"xyz", "TST"};
     trfc2.streamFrom(store);
 
     BOOST_REQUIRE_EQUAL(trfc1.size(), trfc2.size());
@@ -115,7 +116,7 @@ BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_IO)
     std::stringstream store;
     store << "start,end,flag_id,invalid,header,format\n";
     store << R"(123,345,11,"fdsa",1,"comment","source")";
-    TimeRangeFlagCollection trfc1{"A", "TST"};
+    QualityControlFlagCollection trfc1{"A", "TST"};
     BOOST_CHECK_THROW(trfc1.streamFrom(store), std::runtime_error);
   }
   {
@@ -128,7 +129,7 @@ BOOST_AUTO_TEST_CASE(test_TimeRangeFlagCollection_IO)
     store << R"(123,345,,"fdsa",1,"comment","source")" << '\n';
     store << R"(123,345,11,"",1,"comment","source")" << '\n';
     store << R"(123,345,11,"fdsa",,"comment","source")" << '\n';
-    TimeRangeFlagCollection trfc1{"A", "TST"};
+    QualityControlFlagCollection trfc1{"A", "TST"};
     BOOST_CHECK_NO_THROW(trfc1.streamFrom(store));
     BOOST_CHECK_EQUAL(trfc1.size(), 0);
   }


### PR DESCRIPTION
This allows to smoothly move to the updated names on the QualityControl side. The names come from discussion in: https://its.cern.ch/jira/browse/ORCT-200