### PR TITLE
add trk res in TOF match chi2

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -150,8 +150,8 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
         const auto& match = matchesITSTPCTRDTOF[i];
         auto gidx = match.getTrackRef(); // this should be corresponding ITS-TPC-TRD track
         // no need to check isUsed: by construction this ITS-TPC-TRD was not used elsewhere
-        const auto& tofCl = tofClusters[match.getTOFClIndex()];
-        float timeTOFMUS = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+        //        const auto& tofCl = tofClusters[match.getTOFClIndex()];
+        float timeTOFMUS = (match.getSignal() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
         const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
         if (creator(tracksITSTPCTRD[gidx.getIndex()], {i, currentSource}, timeTOFMUS, timeErr)) {
           flagUsed(gidx); // flag used ITS-TPC-TRD tracks
@@ -170,9 +170,9 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
       }
       for (unsigned i = 0; i < matchesTPCTRDTOF.size(); i++) {
         const auto& match = matchesTPCTRDTOF[i];
-        auto gidx = match.getTrackRef(); // this should be corresponding TPC-TRD track
-        const auto& tofCl = tofClusters[match.getTOFClIndex()];
-        float timeTOFMUS = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+        auto gidx = match.getTrackRef();                                                                         // this should be corresponding TPC-TRD track
+                                                                                                                 //        const auto& tofCl = tofClusters[match.getTOFClIndex()];
+        float timeTOFMUS = (match.getSignal() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
         const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
         if (creator(tracksTPCTRD[gidx.getIndex()], {i, currentSource}, timeTOFMUS, timeErr)) {
           flagUsed(gidx); // flag used TPC-TRD tracks
@@ -223,8 +223,8 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
           continue;
         }
         // no need to check isUsed: by construction this ITS-TPC was not used elsewhere
-        const auto& tofCl = tofClusters[match.getTOFClIndex()];
-        float timeTOFMUS = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+        //        const auto& tofCl = tofClusters[match.getTOFClIndex()];
+        float timeTOFMUS = (match.getSignal() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
         const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
         if (creator(tracksTPCITS[gidx.getIndex()], {i, currentSource}, timeTOFMUS, timeErr)) {
           flagUsed(gidx); // flag used ITS-TPC tracks

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -1491,8 +1491,8 @@ void RecoContainer::getTrackTimeITSTPCTRDTOF(GTrackID gid, float& t, float& tErr
 {
   const auto& match = getITSTPCTRDTOFMatches()[gid];
   auto gidx = match.getTrackRef(); // this should be corresponding ITS-TPC-TRD track
-  const auto& tofCl = getTOFClusters()[match.getTOFClIndex()];
-  t = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+  //  const auto& tofCl = getTOFClusters()[match.getTOFClIndex()];
+  t = (match.getSignal() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
   tErr = 0.010f;
 }
 
@@ -1501,8 +1501,8 @@ void RecoContainer::getTrackTimeTPCTRDTOF(GTrackID gid, float& t, float& tErr) c
 {
   const auto& match = getTPCTRDTOFMatches()[gid];
   auto gidx = match.getTrackRef(); // this should be corresponding ITS-TPC-TRD track
-  const auto& tofCl = getTOFClusters()[match.getTOFClIndex()];
-  t = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+  //  const auto& tofCl = getTOFClusters()[match.getTOFClIndex()];
+  t = (match.getSignal() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
   tErr = 0.010f;
 }
 
@@ -1511,8 +1511,8 @@ void RecoContainer::getTrackTimeITSTPCTOF(GTrackID gid, float& t, float& tErr) c
 {
   const auto& match = getITSTPCTOFMatches()[gid];
   auto gidx = match.getTrackRef(); // this should be corresponding ITS-TPC track
-  const auto& tofCl = getTOFClusters()[match.getTOFClIndex()];
-  t = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+  //  const auto& tofCl = getTOFClusters()[match.getTOFClIndex()];
+  t = (match.getSignal() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
   tErr = 0.010f;
 }
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
@@ -58,6 +58,11 @@ class MatchInfoTOF
 
   int getIdLocal() const { return mIdLocal; }
 
+  float getVz() const { return mVz; }
+  void setVz(float val) { mVz = val; }
+  int getChannel() const { return mChannel; }
+  void setChannel(int val) { mChannel = val; }
+
  private:
   int mIdLocal;                      // track id in sector of the pair track-TOFcluster
   float mChi2;                       // chi2 of the pair track-TOFcluster
@@ -69,8 +74,10 @@ class MatchInfoTOF
   float mDZatTOF = 0.0;              ///< DZ position at  TOF
   float mDeltaT = 0.0;               ///< tTOF - TPC (microsec)
   double mSignal = 0.0;              ///< TOF time in ps
+  float mVz = 0.0;                   ///< Vz from TOF match
+  int mChannel = -1;                 ///< channel
 
-  ClassDefNV(MatchInfoTOF, 5);
+  ClassDefNV(MatchInfoTOF, 6);
 };
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOFReco.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOFReco.h
@@ -45,6 +45,13 @@ class MatchInfoTOFReco : public MatchInfoTOF
   float pt() const { return mPt; }
   void setPt(float pt) { mPt = pt; }
 
+  void setResX(float val) { mResX = val; }
+  void setResZ(float val) { mResZ = val; }
+  void setResT(float val) { mResT = val; }
+  float getResX() const { return mResX; }
+  float getResZ() const { return mResZ; }
+  float getResT() const { return mResT; }
+
   void setTrackType(TrackType value) { mTrackType = value; }
   TrackType getTrackType() const { return mTrackType; }
 
@@ -52,7 +59,10 @@ class MatchInfoTOFReco : public MatchInfoTOF
   TrackType mTrackType; ///< track type (TPC, ITSTPC, TPCTRD, ITSTPCTRD)
   bool mFakeMC = false;
   float mPt = 0;
-  ClassDefNV(MatchInfoTOFReco, 4);
+  float mResX = 1;
+  float mResZ = 1;
+  float mResT = 1;
+  ClassDefNV(MatchInfoTOFReco, 5);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -309,6 +309,7 @@ class MatchTOF
   ///< per sector indices of track entry in mTracksWork
   std::array<std::vector<int>, o2::constants::math::NSectors> mTracksSectIndexCache[trkType::SIZE];
   std::array<std::vector<int>, o2::constants::math::NSectors> mTracksSeed[trkType::SIZE];
+  std::vector<float> mVZtpcOnly[o2::constants::math::NSectors];
 
   std::vector<float> mExtraTPCFwdTime[o2::constants::math::NSectors]; ///< track extra params for TPC tracks: Fws Max time
   std::vector<Cluster> mTOFClusWork;                                  ///< track params prepared for matching
@@ -347,7 +348,7 @@ class MatchTOF
   TStopwatch mTimerMatchITSTPC;
   TStopwatch mTimerMatchTPC;
   TStopwatch mTimerDBG;
-  ClassDefNV(MatchTOF, 5);
+  ClassDefNV(MatchTOF, 6);
 };
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOFParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOFParams.h
@@ -23,8 +23,12 @@ namespace globaltracking
 {
 
 struct MatchTOFParams : public o2::conf::ConfigurableParamHelper<MatchTOFParams> {
-  float calibMaxChi2 = 3.0;
-  float nsigmaTimeCut = 4.; // number of sigmas for non-TPC track time resolution to consider
+  float calibMaxChi2 = 3.0;       // max value of Chi2 allowed for using matched tracks in calibration
+  float nsigmaTimeCut = 4.;       // number of sigmas for non-TPC track time resolution to consider
+  float maxResX = 1.;             // max value of track resolution (X dir) used in TOF matching (truncation to that in case it is larger)
+  float maxResZ = 1.;             // max value of track resolution (Z dir) used in TOF matching (truncation to that in case it is larger)
+  float maxChi2 = 10.;            // max value of Chi2 accepted for matching to TOF
+  bool applyPIDcutTPConly = true; // apply PID cut on TPC only tracks
 
   O2ParamDef(MatchTOFParams, "MatchTOF");
 };

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1047,6 +1047,8 @@ void MatchTOF::doMatching(int sec)
         LOG(debug) << "Propagated Track [" << itrk << "]: detId[" << iPropagation << "]  = " << detId[iPropagation][0] << ", " << detId[iPropagation][1] << ", " << detId[iPropagation][2] << ", " << detId[iPropagation][3] << ", " << detId[iPropagation][4];
         float resX = deltaPos[iPropagation][0] - (indices[4] - detId[iPropagation][4]) * Geo::XPAD + posCorr[0]; // readjusting the residuals due to the fact that the propagation fell in a pad that was not exactly the one of the cluster
         float resZ = deltaPos[iPropagation][2] - (indices[3] - detId[iPropagation][3]) * Geo::ZPAD + posCorr[2]; // readjusting the residuals due to the fact that the propagation fell in a pad that was not exactly the one of the cluster
+        float resXor = resX;
+        float resZor = resZ;
         float res = TMath::Sqrt(resX * resX + resZ * resZ);
 
         if (resX < -1.25) { // distance from closest border
@@ -1082,7 +1084,7 @@ void MatchTOF::doMatching(int sec)
           foundCluster = true;
           // set event indexes (to be checked)
           int eventIndexTOFCluster = mTOFClusSectIndexCache[indices[0]][itof];
-          mMatchedTracksPairsSec[sec].emplace_back(cacheTrk[itrk], eventIndexTOFCluster, mTOFClusWork[cacheTOF[itof]].getTime(), chi2, trkLTInt[iPropagation], mTrackGid[sec][type][cacheTrk[itrk]], type, (trefTOF.getTime() - (minTrkTime + maxTrkTime - 100E3) * 0.5) * 1E-6, trefTOF.getZ(), resX, resZ); // subracting 100 ns to max track which was artificially added
+          mMatchedTracksPairsSec[sec].emplace_back(cacheTrk[itrk], eventIndexTOFCluster, mTOFClusWork[cacheTOF[itof]].getTime(), chi2, trkLTInt[iPropagation], mTrackGid[sec][type][cacheTrk[itrk]], type, (trefTOF.getTime() - (minTrkTime + maxTrkTime - 100E3) * 0.5) * 1E-6, trefTOF.getZ(), resXor, resZor); // subracting 100 ns to max track which was artificially added
           mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setPt(pt);
           mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResX(sqrt(1. / errXinv2));
           mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResZ(sqrt(1. / errZinv2));
@@ -1438,6 +1440,8 @@ void MatchTOF::doMatchingForTPC(int sec)
           } else {
             resZ -= (bcClus - BCcand[ibc]) * vdriftInBC * side;
           }
+          float resXor = resX;
+          float resZor = resZ;
           float res = TMath::Sqrt(resX * resX + resZ * resZ);
 
           if (resX < -1.25) { // distance from closest border
@@ -1475,7 +1479,7 @@ void MatchTOF::doMatchingForTPC(int sec)
             // set event indexes (to be checked)
 
             int eventIndexTOFCluster = mTOFClusSectIndexCache[indices[0]][itof];
-            mMatchedTracksPairsSec[sec].emplace_back(cacheTrk[itrk], eventIndexTOFCluster, mTOFClusWork[cacheTOF[itof]].getTime(), chi2, trkLTInt[ibc][iPropagation], mTrackGid[sec][trkType::UNCONS][cacheTrk[itrk]], trkType::UNCONS, trefTOF.getTime() * 1E-6 - tpctime, trefTOF.getZ(), resX, resZ); // TODO: check if this is correct!
+            mMatchedTracksPairsSec[sec].emplace_back(cacheTrk[itrk], eventIndexTOFCluster, mTOFClusWork[cacheTOF[itof]].getTime(), chi2, trkLTInt[ibc][iPropagation], mTrackGid[sec][trkType::UNCONS][cacheTrk[itrk]], trkType::UNCONS, trefTOF.getTime() * 1E-6 - tpctime, trefTOF.getZ(), resXor, resZor); // TODO: check if this is correct!
             mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setPt(pt);
             mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResX(sqrt(1. / errXinv2));
             mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResZ(sqrt(1. / errZinv2));

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -187,7 +187,10 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp, unsigned long f
         }
       } else {
         for (auto& matchingPair : mMatchedTracksPairsSec[sec]) {
-          int bct0 = int((matchingPair.getSignal() - 10000) * Geo::BC_TIME_INPS_INV);
+          int bct0 = int((matchingPair.getSignal() - matchingPair.getLTIntegralOut().getTOF(0) + 5000) * Geo::BC_TIME_INPS_INV); // bc taken assuming speed of light (el) and 5 ns of margin
+          if (bct0 < 0) {                                                                                                        // if negative time (it can happen at the beginng of the TF int was truncated per excess... adjusting)
+            bct0--;
+          }
           float tof = matchingPair.getSignal() - bct0 * Geo::BC_TIME_INPS;
           if (abs(tof - matchingPair.getLTIntegralOut().getTOF(2)) < 600) {
           } else if (abs(tof - matchingPair.getLTIntegralOut().getTOF(3)) < 600) {
@@ -701,6 +704,11 @@ void MatchTOF::addTPCSeed(const o2::tpc::TrackTPC& _tr, o2::dataformats::GlobalT
   o2::track::TrackLTIntegral intLT0; // mTPCTracksWork.back().getLTIntegralOut(); // we get the integrated length from TPC-ITC outward propagation
   // compute track length up to now
   mLTinfos[sector][trkType::UNCONS].emplace_back(intLT0);
+  float vz0 = _tr.getZAt(0, mBz);
+  if (abs(vz0) > 9000) {
+    vz0 = _tr.getZ() - _tr.getX() * _tr.getTgl();
+  }
+  mVZtpcOnly[sector].push_back(vz0);
 
   /*
     const auto& trackTune = TrackTuneParams::Instance();
@@ -841,6 +849,8 @@ void MatchTOF::doMatching(int sec)
     //    Printf("intLT (before doing anything): length = %f, time (Pion) = %f", intLT.getL(), intLT.getTOF(o2::track::PID::Pion));
     float minTrkTime = (trackWork.second.getTimeStamp() - mSigmaTimeCut * trackWork.second.getTimeStampError()) * 1.E6 + timeShift;         // minimum time in ps
     float maxTrkTime = (trackWork.second.getTimeStamp() + mSigmaTimeCut * trackWork.second.getTimeStampError()) * 1.E6 + timeShift + 100E3; // maximum time in ps + 100 ns for slow tracks (beta->0.2)
+    const float sqrt12inv = 1. / sqrt(12.);
+    float resT = (trackWork.second.getTimeStampError() + 100E-3) * sqrt12inv;
     int istep = 1;                                                                                                                          // number of steps
     float step = 1.0;                                                                                                                       // step size in cm
 
@@ -1012,11 +1022,48 @@ void MatchTOF::doMatching(int sec)
       int eventIdTOF;
       int sourceIdTOF;
       for (auto iPropagation = 0; iPropagation < nStripsCrossedInPropagation; iPropagation++) {
+        int bct0 = int((mTOFClusWork[cacheTOF[itof]].getTime() - trkLTInt[iPropagation].getTOF(0) + 5000) * Geo::BC_TIME_INPS_INV); // bc taken assuming speed of light (el) and 5 ns of margin
+        if (bct0 < 0) {                                                                                                             // if negative time (it can happen at the beginng of the TF int was truncated per excess... adjusting)
+          bct0--;
+        }
+        float tof = mTOFClusWork[cacheTOF[itof]].getTime() - bct0 * Geo::BC_TIME_INPS;
+        if (tof - trkLTInt[iPropagation].getTOF(6) > 2000) { // reject tracks slower than triton
+          continue;
+        }
+        float cosangle = TMath::Cos(Geo::getAngles(indices[1], indices[2]) * TMath::DegToRad());
+        const float errXinvMin = 1. / (mMatchParams->maxResX * mMatchParams->maxResX);
+        const float errZinvMin = 1. / (mMatchParams->maxResZ * mMatchParams->maxResZ);
+        float errXinv2 = 1. / (trefTrk.getSigmaY2());
+        float errZinv2 = 1. / (trefTrk.getSigmaZ2() * cosangle); // should be valid only at eta=0
+
+        if (errXinv2 < errXinvMin) {
+          errXinv2 = errXinvMin;
+        }
+        if (errZinv2 < errZinvMin) {
+          errZinv2 = errZinvMin;
+        }
+
         LOG(debug) << "TOF Cluster [" << itof << ", " << cacheTOF[itof] << "]:      indices   = " << indices[0] << ", " << indices[1] << ", " << indices[2] << ", " << indices[3] << ", " << indices[4];
         LOG(debug) << "Propagated Track [" << itrk << "]: detId[" << iPropagation << "]  = " << detId[iPropagation][0] << ", " << detId[iPropagation][1] << ", " << detId[iPropagation][2] << ", " << detId[iPropagation][3] << ", " << detId[iPropagation][4];
         float resX = deltaPos[iPropagation][0] - (indices[4] - detId[iPropagation][4]) * Geo::XPAD + posCorr[0]; // readjusting the residuals due to the fact that the propagation fell in a pad that was not exactly the one of the cluster
         float resZ = deltaPos[iPropagation][2] - (indices[3] - detId[iPropagation][3]) * Geo::ZPAD + posCorr[2]; // readjusting the residuals due to the fact that the propagation fell in a pad that was not exactly the one of the cluster
         float res = TMath::Sqrt(resX * resX + resZ * resZ);
+
+        if (resX < -1.25) { // distance from closest border
+          resX += 1.25;
+        } else if (resX > 1.25) {
+          resX -= 1.25;
+        } else {
+          resX = 1E-3 / (pt + 1E-3); // high-pt should be favoured
+        }
+
+        if (resZ < -1.75) { // distance from closest border
+          resZ += 1.75;
+        } else if (resZ > 1.75) {
+          resZ -= 1.75;
+        } else {
+          resZ = 1E-3 / (pt + 1E-3); // high-pt should be favoured
+        }
 
         LOG(debug) << "resX = " << resX << ", resZ = " << resZ << ", res = " << res;
         if (indices[0] != detId[iPropagation][0]) {
@@ -1028,15 +1075,20 @@ void MatchTOF::doMatching(int sec)
         if (indices[2] != detId[iPropagation][2]) {
           continue;
         }
-        float chi2 = res; // TODO: take into account also the time!
+        float chi2 = 0.5 * (resX * resX * errXinv2 + resZ * resZ * errZinv2); // TODO: take into account also the time!
 
-        if (res < mSpaceTolerance) { // matching ok!
+        if (res < mSpaceTolerance && chi2 < mMatchParams->maxChi2) { // matching ok!
           LOG(debug) << "MATCHING FOUND: We have a match! between track " << mTracksSectIndexCache[type][sec][itrk] << " and TOF cluster " << mTOFClusSectIndexCache[indices[0]][itof];
           foundCluster = true;
           // set event indexes (to be checked)
           int eventIndexTOFCluster = mTOFClusSectIndexCache[indices[0]][itof];
           mMatchedTracksPairsSec[sec].emplace_back(cacheTrk[itrk], eventIndexTOFCluster, mTOFClusWork[cacheTOF[itof]].getTime(), chi2, trkLTInt[iPropagation], mTrackGid[sec][type][cacheTrk[itrk]], type, (trefTOF.getTime() - (minTrkTime + maxTrkTime - 100E3) * 0.5) * 1E-6, trefTOF.getZ(), resX, resZ); // subracting 100 ns to max track which was artificially added
           mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setPt(pt);
+          mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResX(sqrt(1. / errXinv2));
+          mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResZ(sqrt(1. / errZinv2));
+          mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResT(resT);
+          mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setVz(0.0); // not needed for constrained tracks
+          mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setChannel(mainChannel);
         }
       }
     }
@@ -1076,6 +1128,7 @@ void MatchTOF::doMatchingForTPC(int sec)
   std::vector<std::array<o2::track::TrackLTIntegral, 2>> trkLTInt;
   std::vector<std::array<std::array<float, 3>, 2>> deltaPos;
   std::vector<std::array<int, 2>> nStepsInsideSameStrip;
+  std::vector<std::array<float, 2>> Zshift;
 
   LOG(debug) << "Trying to match %d tracks" << cacheTrk.size();
 
@@ -1097,6 +1150,8 @@ void MatchTOF::doMatchingForTPC(int sec)
     double minTrkTime = (tpctime - trackWork.second.getTimeStampError()) * 1.E6 + timeShift;                         // minimum time in ps
     minTrkTime = int(minTrkTime / BCgranularity) * BCgranularity;                                                    // align min to a BC
     double maxTrkTime = (tpctime + mExtraTPCFwdTime[sec][cacheTrk[itrk]]) * 1.E6 + timeShift;                        // maximum time in ps
+    const float sqrt12inv = 1. / sqrt(12.);
+    float resT = (maxTrkTime - minTrkTime) * sqrt12inv;
 
     if (mIsCosmics) {
       for (double tBC = minTrkTime; tBC < maxTrkTime; tBC += BCgranularity) {
@@ -1147,6 +1202,8 @@ void MatchTOF::doMatchingForTPC(int sec)
     detId.reserve(BCcand.size());
     trkLTInt.clear();
     trkLTInt.reserve(BCcand.size());
+    Zshift.clear();
+    Zshift.reserve(BCcand.size());
     deltaPos.clear();
     deltaPos.reserve(BCcand.size());
     nStepsInsideSameStrip.clear();
@@ -1209,6 +1266,8 @@ void MatchTOF::doMatchingForTPC(int sec)
           posFloat[2] = pos[2];
         }
 
+        float ZshiftCurrent = posFloat[2] - pos[2];
+
         Geo::getPadDxDyDz(posFloat, detIdTemp, deltaPosTemp, sec);
 
         if (detIdTemp[2] == -1) {
@@ -1238,6 +1297,7 @@ void MatchTOF::doMatchingForTPC(int sec)
           deltaPos[ibc][nStripsCrossedInPropagation[ibc] - 1][2] = deltaPosTemp[2];
 
           trkLTInt[ibc][nStripsCrossedInPropagation[ibc] - 1] = intLT;
+          Zshift[ibc][nStripsCrossedInPropagation[ibc] - 1] = ZshiftCurrent;
           //          Printf("intLT (after matching to strip %d): length = %f, time (Pion) = %f", nStripsCrossedInPropagation - 1, trkLTInt[nStripsCrossedInPropagation - 1].getL(), trkLTInt[nStripsCrossedInPropagation - 1].getTOF(o2::track::PID::Pion));
           nStepsInsideSameStrip[ibc][nStripsCrossedInPropagation[ibc] - 1]++;
         } else { // a further propagation step in the same strip -> update info (we sum up on all matching with strip - we will divide for the number of steps a bit below)
@@ -1338,6 +1398,37 @@ void MatchTOF::doMatchingForTPC(int sec)
             continue;
           }
 
+          int bct0 = int((mTOFClusWork[cacheTOF[itof]].getTime() - trkLTInt[ibc][iPropagation].getTOF(0) + 5000) * Geo::BC_TIME_INPS_INV); // bc taken assuming speed of light (el) and 5 ns of margin
+          if (bct0 < 0) {                                                                                                                  // if negative time (it can happen at the beginng of the TF int was truncated per excess... adjusting)
+            bct0--;
+          }
+          float tof = mTOFClusWork[cacheTOF[itof]].getTime() - bct0 * Geo::BC_TIME_INPS;
+          if (tof - trkLTInt[ibc][iPropagation].getTOF(6) > 2000) { // reject tracks slower than triton
+            continue;
+          }
+
+          if (mMatchParams->applyPIDcutTPConly) {                                 // for TPC only tracks allowing possibility to apply a PID cut
+            if (abs(tof - trkLTInt[ibc][iPropagation].getTOF(2)) < 2000) {        // pion hypotesis
+            } else if (abs(tof - trkLTInt[ibc][iPropagation].getTOF(3)) < 2000) { // kaon hypoteis
+            } else if (abs(tof - trkLTInt[ibc][iPropagation].getTOF(4)) < 2000) { // proton hypotesis
+            } else {                                                              // reject matching
+              continue;
+            }
+          }
+
+          float cosangle = TMath::Cos(Geo::getAngles(indices[1], indices[2]) * TMath::DegToRad());
+          const float errXinvMin = 1. / (mMatchParams->maxResX * mMatchParams->maxResX);
+          const float errZinvMin = 1. / (mMatchParams->maxResZ * mMatchParams->maxResZ);
+          float errXinv2 = 1. / (trefTrk.getSigmaY2());
+          float errZinv2 = 1. / (trefTrk.getSigmaZ2() * cosangle); // should be valid only at eta=0
+
+          if (errXinv2 < errXinvMin) {
+            errXinv2 = errXinvMin;
+          }
+          if (errZinv2 < errZinvMin) {
+            errZinv2 = errZinvMin;
+          }
+
           LOG(debug) << "TOF Cluster [" << itof << ", " << cacheTOF[itof] << "]:      indices   = " << indices[0] << ", " << indices[1] << ", " << indices[2] << ", " << indices[3] << ", " << indices[4];
           LOG(debug) << "Propagated Track [" << itrk << "]: detId[" << iPropagation << "]  = " << detId[ibc][iPropagation][0] << ", " << detId[ibc][iPropagation][1] << ", " << detId[ibc][iPropagation][2] << ", " << detId[ibc][iPropagation][3] << ", " << detId[ibc][iPropagation][4];
           float resX = deltaPos[ibc][iPropagation][0] - (indices[4] - detId[ibc][iPropagation][4]) * Geo::XPAD + posCorr[0]; // readjusting the residuals due to the fact that the propagation fell in a pad that was not exactly the one of the cluster
@@ -1348,6 +1439,22 @@ void MatchTOF::doMatchingForTPC(int sec)
             resZ -= (bcClus - BCcand[ibc]) * vdriftInBC * side;
           }
           float res = TMath::Sqrt(resX * resX + resZ * resZ);
+
+          if (resX < -1.25) { // distance from closest border
+            resX += 1.25;
+          } else if (resX > 1.25) {
+            resX -= 1.25;
+          } else {
+            resX = 1E-3 / (pt + 1E-3); // high-pt should be favoured
+          }
+
+          if (resZ < -1.75) { // distance from closest border
+            resZ += 1.75;
+          } else if (resZ > 1.75) {
+            resZ -= 1.75;
+          } else {
+            resZ = 1E-3 / (pt + 1E-3); // high-pt should be favoured
+          }
 
           if (indices[0] != detId[ibc][iPropagation][0]) {
             continue;
@@ -1360,15 +1467,21 @@ void MatchTOF::doMatchingForTPC(int sec)
           }
 
           LOG(debug) << "resX = " << resX << ", resZ = " << resZ << ", res = " << res;
-          float chi2 = mIsCosmics ? resX : res; // TODO: take into account also the time!
+          float chi2 = mIsCosmics ? resX : 0.5 * (resX * resX * errXinv2 + resZ * resZ * errZinv2); // TODO: take into account also the time!
 
-          if (res < mSpaceTolerance) { // matching ok!
+          if (res < mSpaceTolerance && chi2 < mMatchParams->maxChi2) { // matching ok!
             LOG(debug) << "MATCHING FOUND: We have a match! between track " << mTracksSectIndexCache[trkType::UNCONS][sec][itrk] << " and TOF cluster " << mTOFClusSectIndexCache[indices[0]][itof];
             foundCluster = true;
             // set event indexes (to be checked)
+
             int eventIndexTOFCluster = mTOFClusSectIndexCache[indices[0]][itof];
             mMatchedTracksPairsSec[sec].emplace_back(cacheTrk[itrk], eventIndexTOFCluster, mTOFClusWork[cacheTOF[itof]].getTime(), chi2, trkLTInt[ibc][iPropagation], mTrackGid[sec][trkType::UNCONS][cacheTrk[itrk]], trkType::UNCONS, trefTOF.getTime() * 1E-6 - tpctime, trefTOF.getZ(), resX, resZ); // TODO: check if this is correct!
             mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setPt(pt);
+            mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResX(sqrt(1. / errXinv2));
+            mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResZ(sqrt(1. / errZinv2));
+            mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setResT(resT);
+            mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setVz(mVZtpcOnly[sec][itrk] + Zshift[ibc][iPropagation]);
+            mMatchedTracksPairsSec[sec][mMatchedTracksPairsSec[sec].size() - 1].setChannel(mainChannel);
           }
         }
       }
@@ -1443,15 +1556,6 @@ void MatchTOF::BestMatches(std::vector<o2::dataformats::MatchInfoTOFReco>& match
 
     int itrk = matchingPair.getIdLocal();
 
-    if (matchedTracksIndex[trkType][itrk] != -1) { // the track was already filled
-      continue;
-    }
-    if (matchedClustersIndex[matchingPair.getTOFClIndex()] != -1) { // the cluster was already filled
-      continue;
-    }
-    matchedTracksIndex[trkType][itrk] = matchedTracks[trkType].size();                      // index of the MatchInfoTOF correspoding to this track
-    matchedClustersIndex[matchingPair.getTOFClIndex()] = matchedTracksIndex[trkType][itrk]; // index of the track that was matched to this cluster
-
     int trkTypeSplitted = trkType;
     auto sourceID = matchingPair.getTrackRef().getSource();
     if (sourceID == o2::dataformats::GlobalTrackID::TPCTRD) {
@@ -1459,6 +1563,48 @@ void MatchTOF::BestMatches(std::vector<o2::dataformats::MatchInfoTOFReco>& match
     } else if (sourceID == o2::dataformats::GlobalTrackID::ITSTPCTRD) {
       trkTypeSplitted = (int)trkType::ITSTPCTRD;
     }
+
+    if (matchedClustersIndex[matchingPair.getTOFClIndex()] != -1) { // the cluster was already filled
+      continue;
+    }
+    if (matchedTracksIndex[trkType][itrk] != -1) { // the track was already filled
+      if (trkType) {                               // not applied for unconstrained tracks (trkType == 0)
+        // let's check if we can use both matching to improve TOF time
+        int pairInd = matchedTracksIndex[trkType][itrk];
+        auto& prevMatching = matchedTracks[trkTypeSplitted][pairInd];
+
+        if (pairInd >= matchedTracks[trkTypeSplitted].size()) {
+          LOG(error) << "Pair index out of range when trying to update TOF time. This should not happen";
+          continue;
+        }
+
+        int istripOld = TOFClusWork[prevMatching.getTOFClIndex()].getMainContributingChannel() / o2::tof::Geo::NPADS;
+        int istripNew = TOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel() / o2::tof::Geo::NPADS;
+
+        if (istripOld != istripNew) { // we accept it only if in a different strip
+          const o2::track::TrackLTIntegral& intLTnew = matchingPair.getLTIntegralOut();
+          const o2::track::TrackLTIntegral& intLTold = prevMatching.getLTIntegralOut();
+
+          const float cinv = 1.E+10 / TMath::C(); // cm/ps
+          float deltaT = (intLTnew.getL() - intLTold.getL()) * cinv;
+
+          float timeNew = TOFClusWork[matchingPair.getTOFClIndex()].getTime() - deltaT;
+          float timeOld = TOFClusWork[prevMatching.getTOFClIndex()].getTime();
+
+          if (fabs(timeNew - timeOld) < 200) {
+            // update time information averaging the two (the second one corrected for the difference in the track length)
+            prevMatching.setSignal((timeNew + timeOld) * 0.5);
+            prevMatching.setChi2(0);                                                                // flag such cases with chi2 equal to zero
+            matchedClustersIndex[matchingPair.getTOFClIndex()] = matchedTracksIndex[trkType][itrk]; // flag also the second cluster as already used
+          }
+        }
+      }
+
+      continue;
+    }
+    matchedTracksIndex[trkType][itrk] = matchedTracks[trkTypeSplitted].size();              // index of the MatchInfoTOF correspoding to this track
+    matchedClustersIndex[matchingPair.getTOFClIndex()] = matchedTracksIndex[trkType][itrk]; // index of the track that was matched to this cluster
+
     matchedTracks[trkTypeSplitted].push_back(matchingPair); // array of MatchInfoTOF
 
     // get fit info


### PR DESCRIPTION
For the moment I assumed that:
1) trk errors are given in the sector reference system
2) Y -> direction along phi wrt sector r.s.
3) Z -> direction along Z (error to be projected considering strip inclination)

matchable output updated with errors info to test different matching algorithms for improvements

Note that all variables added to MatchInfoTOFReco
are stored only in matchable (debug) output (if requested). For matching standard ouput MatchInfoTOF is used