### PR TITLE
IT3: Full simulation + Glo-tracking

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
+++ b/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
@@ -9,6 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+#add_compile_options(-O0 -g -fPIC -fno-omit-frame-pointer)
+
 o2_add_library(
   DataFormatsGlobalTracking
   SOURCES src/RecoContainer.cxx
@@ -35,6 +37,7 @@ o2_add_library(
     O2::DataFormatsPHOS
     O2::DataFormatsEMCAL
     O2::GPUDataTypeHeaders
+    $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Reconstruction>
   PRIVATE_LINK_LIBRARIES
     O2::Framework)
 

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -247,6 +247,10 @@ struct DataRequest {
   void requestStrangeTracks(bool mc);
 
   void requestIRFramesITS();
+
+#ifdef ENABLE_UPGRADES
+  void requestIT3Clusters(bool mc);
+#endif
 };
 
 // Helper class to requested data.
@@ -401,6 +405,10 @@ struct RecoContainer {
   void addStrangeTracks(o2::framework::ProcessingContext& pc, bool mc);
 
   void addIRFramesITS(o2::framework::ProcessingContext& pc);
+
+#ifdef ENABLE_UPGRADES
+  void addIT3Clusters(o2::framework::ProcessingContext& pc, bool mc);
+#endif
 
   // custom getters
 

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -1062,8 +1062,8 @@ void RecoContainer::addHMPMatches(ProcessingContext& pc, bool mc)
 void RecoContainer::addITSClusters(ProcessingContext& pc, bool mc)
 {
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) {            // this params need to be queried only once
-    pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alpparITS"); // note: configurable param does not need finaliseCCDB
     pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldictITS");                        // just to trigger the finaliseCCDB
+    pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alpparITS"); // note: configurable param does not need finaliseCCDB
   }
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusITSROF"), CLUSREFS);
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("clusITS"), CLUSTERS);

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -42,6 +42,10 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/CCDBParamSpec.h"
 
+#ifdef ENABLE_UPGRADES
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#endif
+
 using namespace o2::globaltracking;
 using namespace o2::framework;
 namespace o2d = o2::dataformats;
@@ -227,13 +231,28 @@ void DataRequest::requestITSClusters(bool mc)
   addInput({"clusITS", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe});
   addInput({"clusITSPatt", "ITS", "PATTERNS", 0, Lifetime::Timeframe});
   addInput({"clusITSROF", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe});
-  addInput({"cldictITS", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary")});
   addInput({"alpparITS", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam")});
   if (mc) {
     addInput({"clusITSMC", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe});
   }
+  addInput({"cldictITS", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary")});
   requestMap["clusITS"] = mc;
 }
+
+#ifdef ENABLE_UPGRADES
+void DataRequest::requestIT3Clusters(bool mc)
+{
+  addInput({"clusITS", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe});
+  addInput({"clusITSPatt", "ITS", "PATTERNS", 0, Lifetime::Timeframe});
+  addInput({"clusITSROF", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe});
+  addInput({"alpparITS", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam")});
+  if (mc) {
+    addInput({"clusITSMC", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe});
+  }
+  addInput({"cldictIT3", "IT3", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("IT3/Calib/ClusterDictionary")});
+  requestMap["clusIT3"] = mc;
+}
+#endif
 
 void DataRequest::requestMFTClusters(bool mc)
 {
@@ -673,6 +692,13 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
     addITSClusters(pc, req->second);
   }
 
+#ifdef ENABLE_UPGRADES
+  req = reqMap.find("clusIT3");
+  if (req != reqMap.end()) {
+    addIT3Clusters(pc, req->second);
+  }
+#endif
+
   req = reqMap.find("clusMFT");
   if (req != reqMap.end()) {
     addMFTClusters(pc, req->second);
@@ -1036,8 +1062,8 @@ void RecoContainer::addHMPMatches(ProcessingContext& pc, bool mc)
 void RecoContainer::addITSClusters(ProcessingContext& pc, bool mc)
 {
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) {            // this params need to be queried only once
-    pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldictITS");                        // just to trigger the finaliseCCDB
     pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alpparITS"); // note: configurable param does not need finaliseCCDB
+    pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldictITS");                        // just to trigger the finaliseCCDB
   }
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusITSROF"), CLUSREFS);
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("clusITS"), CLUSTERS);
@@ -1046,6 +1072,22 @@ void RecoContainer::addITSClusters(ProcessingContext& pc, bool mc)
     mcITSClusters = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("clusITSMC");
   }
 }
+
+#ifdef ENABLE_UPGRADES
+void RecoContainer::addIT3Clusters(ProcessingContext& pc, bool mc)
+{
+  if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) {            // this params need to be queried only once
+    pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alpparITS"); // note: configurable param does not need finaliseCCDB
+    pc.inputs().get<o2::its3::TopologyDictionary*>("cldictIT3");                          // just to trigger the finaliseCCDB
+  }
+  commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusITSROF"), CLUSREFS);
+  commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("clusITS"), CLUSTERS);
+  commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<unsigned char>>("clusITSPatt"), PATTERNS);
+  if (mc) {
+    mcITSClusters = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("clusITSMC");
+  }
+}
+#endif
 
 //__________________________________________________________
 void RecoContainer::addMFTClusters(ProcessingContext& pc, bool mc)

--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -26,6 +26,7 @@ o2_add_library(DetectorsBase
                        src/GRPGeomHelper.cxx
                        src/Stack.cxx
                        src/VMCSeederService.cxx
+                       src/GlobalParams.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
                                      O2::CommonUtils
                                      O2::DetectorsCommonDataFormats
@@ -57,7 +58,8 @@ o2_target_root_dictionary(DetectorsBase
                                   include/DetectorsBase/MatLayerCylSet.h
                                   include/DetectorsBase/Aligner.h
                                   include/DetectorsBase/Stack.h
-                                  include/DetectorsBase/SimFieldUtils.h)
+                                  include/DetectorsBase/SimFieldUtils.h
+                                  include/DetectorsBase/GlobalParams.h)
 
 if(BUILD_SIMULATION)
   if (NOT APPLE)

--- a/Detectors/Base/include/DetectorsBase/GlobalParams.h
+++ b/Detectors/Base/include/DetectorsBase/GlobalParams.h
@@ -1,0 +1,29 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTORS_BASE_GLOBALPARAMS_H_
+#define DETECTORS_BASE_GLOBALPARAMS_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+
+struct GlobalParams : public o2::conf::ConfigurableParamHelper<GlobalParams> {
+  bool withITS3 = false; // detector geometry includes ITS3
+
+  O2ParamDef(GlobalParams, "GlobalParams");
+};
+
+} // namespace o2
+
+#endif // DETECTORS_BASE_GLOBALPARAMS_H_

--- a/Detectors/Base/src/DetectorsBaseLinkDef.h
+++ b/Detectors/Base/src/DetectorsBaseLinkDef.h
@@ -36,6 +36,9 @@
 #pragma link C++ class o2::base::Aligner + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::base::Aligner> + ;
 
+#pragma link C++ class o2::GlobalParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::GlobalParams> + ;
+
 #pragma link C++ class o2::data::Stack + ;
 
 #endif

--- a/Detectors/Base/src/GlobalParams.cxx
+++ b/Detectors/Base/src/GlobalParams.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsBase/GlobalParams.h"
+O2ParamImpl(o2::GlobalParams);

--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -8,7 +8,7 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-# add_compile_options(-O0 -g -fPIC)
+#add_compile_options(-O0 -g -fPIC -fno-omit-frame-pointer)
 
 o2_add_library(GlobalTracking
                TARGETVARNAME targetName
@@ -22,37 +22,36 @@ o2_add_library(GlobalTracking
                        src/MatchGlobalFwdAssessment.cxx
                        src/MatchGlobalFwdParam.cxx
                        src/MatchTOFParams.cxx
-                       src/MatchITSTPCQC.cxx
-                       src/ITSTPCMatchingQCParams.cxx
-  PUBLIC_LINK_LIBRARIES O2::Framework
-                        O2::DataFormatsTPC
-                        O2::DataFormatsITSMFT
-                        O2::DataFormatsITS
-                        O2::DataFormatsFT0
-                        O2::DataFormatsTOF
-                        O2::DataFormatsHMP
-                        O2::DataFormatsTRD
-                        O2::ITSReconstruction
-                        O2::FT0Reconstruction
-                        O2::TPCFastTransformation
-                        O2::GPUO2Interface
-                        O2::GPUTracking
-                        O2::TPCBase
-                        O2::TPCReconstruction
-                        O2::TPCCalibration
-                        O2::TOFBase
-                        O2::HMPIDReconstruction
-                        O2::TOFCalibration
-                        O2::TOFWorkflowUtils
-                        O2::SimConfig
-                        O2::DataFormatsFT0
-                        O2::DataFormatsGlobalTracking
-                        O2::ITStracking
-                        O2::MFTTracking
-                        O2::MCHTracking
-                        O2::MathUtils
-                        O2::ReconstructionDataFormats
-                        O2::Steer)
+               PUBLIC_LINK_LIBRARIES O2::Framework
+                                     O2::DataFormatsTPC
+                                     O2::DataFormatsITSMFT
+                                     O2::DataFormatsITS
+                                     O2::DataFormatsFT0
+                                     O2::DataFormatsTOF
+                                     O2::DataFormatsHMP
+                                     O2::DataFormatsTRD
+                                     O2::ITSReconstruction
+                                     O2::FT0Reconstruction
+                                     O2::TPCFastTransformation
+                                     O2::GPUO2Interface
+                                     O2::GPUTracking
+                                     O2::TPCBase
+                                     O2::TPCReconstruction
+                                     O2::TPCCalibration
+                                     O2::TOFBase
+                                     O2::HMPIDReconstruction
+                                     O2::TOFCalibration
+                                     O2::TOFWorkflowUtils
+                                     O2::SimConfig
+                                     O2::DataFormatsFT0
+                                     O2::DataFormatsGlobalTracking
+                                     O2::ITStracking
+                                     O2::MFTTracking
+                                     O2::MCHTracking
+                                     O2::MathUtils
+                                     O2::ReconstructionDataFormats
+                                     O2::Steer
+                                     $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Reconstruction>)
 
 o2_target_root_dictionary(GlobalTracking
                           HEADERS include/GlobalTracking/MatchTPCITSParams.h

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -58,6 +58,9 @@
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
 #include "MemoryResources/MemoryResources.h"
 #endif
+#ifdef ENABLE_UPGRADES
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#endif
 
 class TTree;
 
@@ -137,7 +140,7 @@ struct TrackLocTPC : public o2::track::TrackParCov {
   }
   float getSignedDT(float dt) const // account for TPC side in time difference for dt=external_time - tpc.time0
   {
-    return constraint == Constrained ? 0. : (constraint == ASide ? dt : -dt);
+    return constraint == Constrained ? 0.f : (constraint == ASide ? dt : -dt);
   }
 
   ClassDefNV(TrackLocTPC, 2);
@@ -298,12 +301,23 @@ struct ITSChipClustersRefs {
   ///< contaner for sorted cluster indices for certain time window (usually ROF) and reference on the start and N clusters
   ///< for every chip
   using ClusRange = o2::dataformats::RangeReference<int, int>;
-  std::vector<int> clusterID;                                           // indices of sorted clusters
+  std::vector<int> clusterID; // indices of sorted clusters
+
+#ifndef ENABLE_UPGRADES
   std::array<ClusRange, o2::its::RecoGeomHelper::getNChips()> chipRefs; // offset and number of clusters in each chip
   ITSChipClustersRefs(int nclIni = 50000)
   {
     clusterID.reserve(nclIni);
   }
+#else
+  std::vector<ClusRange> chipRefs; // offset and number of clusters in each chip
+  ITSChipClustersRefs(int nchips = o2::its::RecoGeomHelper::getNChips(), int nclIni = 50000)
+  {
+    clusterID.reserve(nclIni);
+    chipRefs.resize(nchips, ClusRange());
+  }
+#endif
+
   void clear()
   {
     clusterID.clear();
@@ -356,7 +370,10 @@ class MatchTPCITS
                       pmr::vector<o2::itsmft::TrkClusRef>& ABTrackletRefs, pmr::vector<o2::dataformats::Triplet<float, float, float>>& calib);
   bool refitABTrack(int iITSAB, const TPCABSeed& seed, pmr::vector<o2::dataformats::TrackTPCITS>& matchedTracks, pmr::vector<int>& ABTrackletClusterIDs, pmr::vector<o2::itsmft::TrkClusRef>& ABTrackletRefs);
 #endif // CLING
-  void setSkipTPCOnly(bool v) { mSkipTPCOnly = v; }
+  void setSkipTPCOnly(bool v)
+  {
+    mSkipTPCOnly = v;
+  }
   void setCosmics(bool v) { mCosmics = v; }
   bool isCosmics() const { return mCosmics; }
   void setNThreads(int n);
@@ -395,6 +412,12 @@ class MatchTPCITS
 
   // ==================== >> DPL-driven input >> =======================
   void setITSDictionary(const o2::itsmft::TopologyDictionary* d) { mITSDict = d; }
+#ifdef ENABLE_UPGRADES
+  void setIT3Dictionary(const o2::its3::TopologyDictionary* d)
+  {
+    mIT3Dict = d;
+  }
+#endif
 
   ///< set flag to use MC truth
   void setMCTruthOn(bool v)
@@ -560,13 +583,13 @@ class MatchTPCITS
   float correctTPCTrack(o2::track::TrackParCov& trc, const TrackLocTPC& tTPC, const InteractionCandidate& cand) const; // RS FIXME will be needed for refit
   //================================================================
 
-  bool mInitDone = false;               ///< flag init already done
-  bool mFieldON = true;                 ///< flag for field ON/OFF
-  bool mCosmics = false;                ///< flag cosmics mode
-  bool mMCTruthON = false;              ///< flag availability of MC truth
-  float mBz = 0;                        ///< nominal Bz
-  int mTFCount = 0;                     ///< internal TF counter for debugger
-  int mNThreads = 1;                    ///< number of OMP threads
+  bool mInitDone = false;  ///< flag init already done
+  bool mFieldON = true;    ///< flag for field ON/OFF
+  bool mCosmics = false;   ///< flag cosmics mode
+  bool mMCTruthON = false; ///< flag availability of MC truth
+  float mBz = 0;           ///< nominal Bz
+  int mTFCount = 0;        ///< internal TF counter for debugger
+  int mNThreads = 1;       ///< number of OMP threads
   int mNHBPerTF = 0;
   int mNTPCOccBinLength = 0; ///< TPC occ. histo bin length in TBs
   float mNTPCOccBinLengthInv;
@@ -646,6 +669,9 @@ class MatchTPCITS
   gsl::span<const unsigned int> mTPCRefitterOccMap; ///< externally set TPC clusters occupancy map
 
   const o2::itsmft::TopologyDictionary* mITSDict{nullptr}; // cluster patterns dictionary
+#ifdef ENABLE_UPGRADES
+  const o2::its3::TopologyDictionary* mIT3Dict{nullptr}; // cluster patterns dictionary
+#endif
 
   const o2::tpc::ClusterNativeAccess* mTPCClusterIdxStruct = nullptr; ///< struct holding the TPC cluster indices
 
@@ -659,9 +685,9 @@ class MatchTPCITS
   size_t mNMatchesControl = 0;
 
   size_t mNABRefsClus = 0;
-  float mAB2MatchGuess = 0.2;                                          // heuristic guess about fraction of AB matches in total matches
-  std::vector<InteractionCandidate> mInteractions;                     ///< possible interaction times
-  std::vector<int> mInteractionMUSLUT;                                 ///< LUT for interactions in 1MUS bins
+  float mAB2MatchGuess = 0.2;                      // heuristic guess about fraction of AB matches in total matches
+  std::vector<InteractionCandidate> mInteractions; ///< possible interaction times
+  std::vector<int> mInteractionMUSLUT;             ///< LUT for interactions in 1MUS bins
 
   ///< container for record the match of TPC track to single ITS track
   std::vector<MatchRecord> mMatchRecordsTPC; // RSS DEQ
@@ -669,13 +695,14 @@ class MatchTPCITS
   std::vector<MatchRecord> mMatchRecordsITS; // RSS DEQ
 
   ////  std::vector<int> mITSROFofTPCBin;    ///< aux structure for mapping of TPC time-bins on ITS ROFs
-  std::vector<BracketF> mITSROFTimes;  ///< min/max times of ITS ROFs in \mus
-  std::vector<TrackLocTPC> mTPCWork;   ///< TPC track params prepared for matching
-  std::vector<TrackLocITS> mITSWork;   ///< ITS track params prepared for matching
+  std::vector<BracketF> mITSROFTimes;       ///< min/max times of ITS ROFs in \mus
+  std::vector<TrackLocTPC> mTPCWork;        ///< TPC track params prepared for matching
+  std::vector<TrackLocITS> mITSWork;        ///< ITS track params prepared for matching
   std::vector<o2::MCCompLabel> mTPCLblWork; ///< TPC track labels
   std::vector<o2::MCCompLabel> mITSLblWork; ///< ITS track labels
-  std::vector<float> mWinnerChi2Refit; ///< vector of refitChi2 for winners
-  std::vector<float> mTBinClOcc;       ///< TPC occupancy histo: i-th entry is the integrated occupancy for ~1 orbit starting from the TB = i*mNTPCOccBinLength
+  std::vector<float> mWinnerChi2Refit;      ///< vector of refitChi2 for winners
+  std::vector<float> mTBinClOcc;            ///< TPC occupancy histo: i-th entry is the integrated occupancy for ~1 orbit starting from the TB = i*mNTPCOccBinLength
+
   // ------------------------------
   std::vector<TPCABSeed> mTPCABSeeds; ///< pool of primary TPC seeds for AB
   ///< indices of selected track entries in mTPCWork (for tracks selected by AfterBurner)

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -11,6 +11,7 @@
 
 #include <TTree.h>
 #include <cassert>
+#include <algorithm>
 
 #include <fairlogger/Logger.h>
 #include "Field/MagneticField.h"
@@ -27,6 +28,7 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "CommonConstants/GeomConstants.h"
 #include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/GlobalParams.h"
 
 #include <Math/SMatrix.h>
 #include <Math/SVector.h>
@@ -43,6 +45,10 @@
 #include "DataFormatsTPC/WorkflowHelper.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "ITStracking/IOUtils.h"
+
+#ifdef ENABLE_UPGRADES
+#include "ITS3Reconstruction/IOUtils.h"
+#endif
 
 #include "GPUO2Interface.h" // Needed for propper settings in GPUParam.h
 #include "GPUParam.h"
@@ -102,7 +108,7 @@ void MatchTPCITS::run(const o2::globaltracking::RecoContainer& inp,
       doMatching(sec);
     }
     mTimer[SWDoMatching].Stop();
-    if (0) { // enabling this creates very verbose output
+    if constexpr (false) { // enabling this creates very verbose output
       mTimer[SWTot].Stop();
       printCandidatesTPC();
       printCandidatesITS();
@@ -112,7 +118,7 @@ void MatchTPCITS::run(const o2::globaltracking::RecoContainer& inp,
     selectBestMatches();
 
     bool fullMatchRefitDone = false;
-    if (mUseFT0 && Params::Instance().runAfterBurner) {
+    if (mUseFT0 && mParams->runAfterBurner) {
       fullMatchRefitDone = runAfterBurner(matchedTracks, matchLabels, ABTrackletLabels, ABTrackletClusterIDs, ABTrackletRefs, calib);
     }
     if (!fullMatchRefitDone) {
@@ -237,7 +243,9 @@ void MatchTPCITS::init()
   }
 #endif
 
-  mRGHelper.init(); // prepare helper for TPC track / ITS clusters matching
+  if (mParams->runAfterBurner) { // only used in AfterBurner
+    mRGHelper.init();            // prepare helper for TPC track / ITS clusters matching
+  }
 
   clear();
 
@@ -635,7 +643,16 @@ bool MatchTPCITS::prepareITSData()
   const auto patterns = inp.getITSClustersPatterns();
   auto pattIt = patterns.begin();
   mITSClustersArray.reserve(clusITS.size());
+#ifdef ENABLE_UPGRADES
+  bool withITS3 = o2::GlobalParams::Instance().withITS3;
+  if (withITS3) {
+    o2::its3::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, mIT3Dict);
+  } else {
+    o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, mITSDict);
+  }
+#else
   o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, mITSDict);
+#endif
 
   // ITS clusters sizes
   mITSClusterSizes.reserve(clusITS.size());
@@ -643,18 +660,26 @@ bool MatchTPCITS::prepareITSData()
   for (auto& clus : clusITS) {
     auto pattID = clus.getPatternID();
     unsigned int npix;
+#ifdef ENABLE_UPGRADES
+    if ((pattID == o2::itsmft::CompCluster::InvalidPatternID) || ((withITS3) ? mIT3Dict->isGroup(pattID) : mITSDict->isGroup(pattID))) { // braces guarantee evaluation order
+#else
     if (pattID == o2::itsmft::CompCluster::InvalidPatternID || mITSDict->isGroup(pattID)) {
+#endif
       o2::itsmft::ClusterPattern patt;
       patt.acquirePattern(pattIt2);
       npix = patt.getNPixels();
     } else {
+#ifdef ENABLE_UPGRADES
+      if (withITS3) {
+        npix = mIT3Dict->getNpixels(pattID);
+      } else {
+        npix = mITSDict->getNpixels(pattID);
+      }
+#else
       npix = mITSDict->getNpixels(pattID);
+#endif
     }
-    if (npix < 255) {
-      mITSClusterSizes.push_back(npix);
-    } else {
-      mITSClusterSizes.push_back(255);
-    }
+    mITSClusterSizes.push_back(std::clamp(npix, 0u, 255u));
   }
 
   if (mMCTruthON) {
@@ -1405,16 +1430,23 @@ void MatchTPCITS::refitWinners(pmr::vector<o2::dataformats::TrackTPCITS>& matche
   LOG(debug) << "Refitting winner matches";
   mWinnerChi2Refit.resize(mITSWork.size(), -1.f);
   int nToFit = (int)tpcToFit.size();
+  unsigned int nFailedRefit{0};
+
 #ifdef WITH_OPENMP
-#pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
+#pragma omp parallel for schedule(dynamic) num_threads(mNThreads) \
+  reduction(+                                                     \
+            : nFailedRefit)
 #endif
   for (int ifit = 0; ifit < nToFit; ifit++) {
     int iTPC = tpcToFit[ifit], iITS;
     const auto& tTPC = mTPCWork[iTPC];
     if (refitTrackTPCITS(ifit, iTPC, iITS, matchedTracks, matchLabels, calib)) {
       mWinnerChi2Refit[iITS] = matchedTracks.back().getChi2Refit();
+    } else {
+      ++nFailedRefit;
     }
   }
+  LOGP(info, "Failed {} TPC-ITS refits out of {}", nFailedRefit, nToFit);
 
   // suppress tracks failed on refit and fill calib/debug data (if needed)
   int last = nToFit;
@@ -1546,7 +1578,7 @@ bool MatchTPCITS::refitTrackTPCITS(int slot, int iTPC, int& iITS, pmr::vector<o2
   auto& trfit = matchedTracks[slot];
   ((o2::track::TrackParCov&)trfit) = (const o2::track::TrackParCov&)tTPC;
   trfit.getParamOut() = (const o2::track::TrackParCov&)tITS; // create a copy of TPC track at xRef
-  trfit.getParamOut().setUserField(0);                  // reset eventual clones flag
+  trfit.getParamOut().setUserField(0);                       // reset eventual clones flag
   trfit.setPID(tTPC.getPID(), true);
   trfit.getParamOut().setPID(tTPC.getPID(), true);
   // in continuos mode the Z of TPC track is meaningless, unless it is CE crossing
@@ -1934,7 +1966,16 @@ bool MatchTPCITS::runAfterBurner(pmr::vector<o2::dataformats::TrackTPCITS>& matc
     return false;
   }
   mTimer[SWABMatch].Start(false);
+
   std::vector<ITSChipClustersRefs> itsChipClRefsBuff(mNThreads);
+#ifdef ENABLE_UPGRADES
+  // with upgrades the datatype changed, hence we need to initialize
+  // each element individually
+  std::generate(itsChipClRefsBuff.begin(), itsChipClRefsBuff.end(), []() {
+    return ITSChipClustersRefs(o2::its::GeometryTGeo::Instance()->getNumberOfChips());
+  });
+#endif
+
 #ifdef WITH_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
 #endif

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 # FIXME: do we actually need a library here, or is the executable enough ?
 
-# add_compile_options(-O0 -g -fPIC)
+#add_compile_options(-O0 -g -fPIC -fno-omit-frame-pointer)
 
 o2_add_library(GlobalTrackingWorkflow
                SOURCES src/TrackWriterTPCITSSpec.cxx
@@ -48,7 +48,8 @@ o2_add_library(GlobalTrackingWorkflow
                                      O2::ITSMFTWorkflow
                                      O2::SimulationDataFormat
                                      O2::DetectorsVertexing
-                                     O2::StrangenessTracking)
+                                     O2::StrangenessTracking
+                                     $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Reconstruction>)
 
 o2_add_executable(driver-workflow
                   COMPONENT_NAME reader

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
@@ -28,6 +28,7 @@
 #include "DetectorsVertexing/SVertexer.h"
 #include "StrangenessTracking/StrangenessTracker.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include "DetectorsBase/GlobalParams.h"
 #include "TStopwatch.h"
 #include "TPCCalibration/VDriftHelper.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
@@ -147,7 +148,7 @@ void SecondaryVertexingSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* ob
   }
   if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
     LOG(info) << "cluster dictionary updated";
-    mStrTracker.setClusterDictionary((const o2::itsmft::TopologyDictionary*)obj);
+    mStrTracker.setClusterDictionaryITS((const o2::itsmft::TopologyDictionary*)obj);
     return;
   }
   if (matcher == ConcreteDataMatcher("GLO", "MEANVERTEX", 0)) {
@@ -164,6 +165,13 @@ void SecondaryVertexingSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* ob
     o2::its::GeometryTGeo::adopt((o2::its::GeometryTGeo*)obj);
     return;
   }
+#ifdef ENABLE_UPGRADES
+  if (matcher == ConcreteDataMatcher("IT3", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated";
+    mStrTracker.setClusterDictionaryIT3((const o2::its3::TopologyDictionary*)obj);
+    return;
+  }
+#endif
 }
 
 void SecondaryVertexingSpec::updateTimeDependentParams(ProcessingContext& pc)
@@ -192,6 +200,12 @@ void SecondaryVertexingSpec::updateTimeDependentParams(ProcessingContext& pc)
       o2::its::GeometryTGeo* geom = o2::its::GeometryTGeo::Instance();
       geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot, o2::math_utils::TransformType::T2G));
     }
+
+#ifdef ENABLE_UPGRADES
+    if (o2::GlobalParams::Instance().withITS3) { // hack to trigger loading dictionary
+      pc.inputs().get<o2::its3::TopologyDictionary*>("cldict");
+    }
+#endif
   }
   // we may have other params which need to be queried regularly
   if (mSrc[GTrackID::TPC]) {
@@ -248,6 +262,11 @@ DataProcessorSpec getSecondaryVertexingSpec(GTrackID::mask_t src, bool enableCas
   if (srcClus.any()) {
     dataRequest->requestClusters(srcClus, useMC);
   }
+#ifdef ENABLE_UPGRADES
+  if (o2::GlobalParams::Instance().withITS3) { // hack to trigger loading dictionary
+    dataRequest->inputs.emplace_back("cldict", "IT3", "CLUSDICT", Lifetime::Condition, ccdbParamSpec("IT3/Calib/ClusterDictionary"));
+  }
+#endif
   dataRequest->requestTracks(src, useMC);
   dataRequest->requestPrimaryVertices(useMC);
   dataRequest->inputs.emplace_back("meanvtx", "GLO", "MEANVERTEX", 0, Lifetime::Condition, ccdbParamSpec("GLO/Calib/MeanVertex", {}, 1));

--- a/Detectors/GlobalTrackingWorkflow/src/StrangenessTrackingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/StrangenessTrackingSpec.cxx
@@ -114,7 +114,7 @@ void StrangenessTrackerSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* ob
   }
   if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
     LOG(info) << "cluster dictionary updated";
-    mTracker.setClusterDictionary((const o2::itsmft::TopologyDictionary*)obj);
+    mTracker.setClusterDictionaryITS((const o2::itsmft::TopologyDictionary*)obj);
     return;
   }
   if (matcher == ConcreteDataMatcher("ITS", "GEOMTGEO", 0)) {
@@ -122,6 +122,13 @@ void StrangenessTrackerSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* ob
     o2::its::GeometryTGeo::adopt((o2::its::GeometryTGeo*)obj);
     return;
   }
+#ifdef ENABLE_UPGRADES
+  if (matcher == ConcreteDataMatcher("IT3", "CLUSDICT", 0)) {
+    LOG(info) << "it3 cluster dictionary updated";
+    mTracker.setClusterDictionaryIT3((const o2::its3::TopologyDictionary*)obj);
+    return;
+  }
+#endif
 }
 
 void StrangenessTrackerSpec::endOfStream(framework::EndOfStreamContext& ec)

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -38,6 +38,7 @@
 #include "DataFormatsTPC/WorkflowHelper.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GlobalParams.h"
 #include "ITSMFTBase/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "GlobalTracking/MatchTPCITSParams.h"
@@ -50,6 +51,10 @@
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "TPCCalibration/VDriftHelper.h"
 #include "TPCCalibration/CorrectionMapsLoader.h"
+
+#ifdef ENABLE_UPGRADES
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#endif
 
 using namespace o2::framework;
 using MCLabelsCl = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
@@ -151,7 +156,7 @@ void TPCITSMatchingDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
     return;
   }
   if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
-    LOG(info) << "cluster dictionary updated";
+    LOG(info) << "its cluster dictionary updated";
     mMatching.setITSDictionary((const o2::itsmft::TopologyDictionary*)obj);
     return;
   }
@@ -162,10 +167,17 @@ void TPCITSMatchingDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
     return;
   }
   if (matcher == ConcreteDataMatcher("ITS", "GEOMTGEO", 0)) {
-    LOG(info) << "ITS GeomtetryTGeo loaded from ccdb";
+    LOG(info) << "ITS GeometryTGeo loaded from ccdb";
     o2::its::GeometryTGeo::adopt((o2::its::GeometryTGeo*)obj);
     return;
   }
+#ifdef ENABLE_UPGRADES
+  if (matcher == ConcreteDataMatcher("IT3", "CLUSDICT", 0)) {
+    LOG(info) << "it3 cluster dictionary updated";
+    mMatching.setIT3Dictionary((const o2::its3::TopologyDictionary*)obj);
+    return;
+  }
+#endif
 }
 
 void TPCITSMatchingDPL::updateTimeDependentParams(ProcessingContext& pc)
@@ -239,7 +251,16 @@ DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool 
 
   dataRequest->requestTracks(src, useMC);
   dataRequest->requestTPCClusters(false);
-  dataRequest->requestITSClusters(useMC); // Only ITS clusters labels are needed for the afterburner
+// Only ITS clusters labels are needed for the afterburner and request possibly for ITS3
+#ifdef ENABLE_UPGRADES
+  if (o2::GlobalParams::Instance().withITS3) {
+    dataRequest->requestIT3Clusters(useMC);
+  } else {
+    dataRequest->requestITSClusters(useMC);
+  }
+#else
+  dataRequest->requestITSClusters(useMC);
+#endif
   if (useFT0) {
     dataRequest->requestFT0RecPoints(false);
   }

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -84,7 +84,7 @@ WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcont
   }
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto calib = configcontext.options().get<bool>("produce-calibration-data");
-  auto srcL = src | GID::getSourcesMask("ITS,TPC"); // ITS is neadded always, TPC must be loaded even if bare TPC tracks are not used in matching
+  auto srcL = src | GID::getSourcesMask("ITS,TPC"); // ITS is needed always, TPC must be loaded even if bare TPC tracks are not used in matching
   if (sclOpt.requestCTPLumi) {
     srcL = srcL | GID::getSourcesMask("CTP");
   }

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -333,9 +333,6 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// Sym name of the chip in the given layer/halfbarrel/stave/substave/module
   static const char* composeSymNameChip(int lr, int hba, int sta, int ssta, int mod, int chip, bool isITS3 = false);
 
-  // get tracking frame alpha for ITS3 clusters in global coordinates
-  static float getAlphaFromGlobalITS3(const o2::math_utils::Point3D<float>& gloXYZ);
-
   // create matrix for transformation from tracking frame to local one for ITS3
   const Mat3D getT2LMatrixITS3(int isn, float alpha);
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
@@ -16,6 +16,7 @@
 #include "ITSReconstruction/RecoGeomHelper.h"
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSBase/GeometryTGeo.h"
+#include "Framework/Logger.h"
 
 using namespace o2::its;
 
@@ -30,9 +31,9 @@ void RecoGeomHelper::RecoChip::updateLimits(const o2::math_utils::Point3D<float>
 //_____________________________________________________________________
 void RecoGeomHelper::RecoChip::print() const
 {
-  printf("Ch#%4d Alp: %+.3f X:%5.2f %+6.3f<y<%+6.3f  %+6.3f<z<%+6.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f}\n",
-         id, alp, xRef, yRange.getMin(), yRange.getMax(), zRange.getMin(), zRange.getMax(),
-         xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1());
+  LOGF(info, "Ch#%4d Alp: %+.3f X:%5.2f %+6.3f<y<%+6.3f  %+6.3f<z<%+6.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f}\n",
+       id, alp, xRef, yRange.getMin(), yRange.getMax(), zRange.getMin(), zRange.getMax(),
+       xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1());
 }
 
 //_____________________________________________________________________
@@ -77,10 +78,10 @@ void RecoGeomHelper::RecoLadder::init()
 void RecoGeomHelper::RecoLadder::print() const
 {
   assert(overlapWithNext != Undefined || chips.size() == 0); // make sure there are no undefined ladders after init is done
-  printf("Ladder %3d  %.3f<phi[<%.3f>]<%.3f dPhiH:%.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f} | %3d chips | OvlNext: %s\n",
-         id, phiRange.getMin(), phiMean, phiRange.getMax(), dphiH,
-         xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1(), (int)chips.size(),
-         overlapWithNext == Undefined ? "N/A" : ((overlapWithNext == NoOverlap ? "NO" : (overlapWithNext == Above ? "Above" : "Below"))));
+  LOGF(info, "Ladder %3d  %.3f<phi[<%.3f>]<%.3f dPhiH:%.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f} | %3d chips | OvlNext: %s\n",
+       id, phiRange.getMin(), phiMean, phiRange.getMax(), dphiH,
+       xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1(), (int)chips.size(),
+       overlapWithNext == Undefined ? "N/A" : ((overlapWithNext == NoOverlap ? "NO" : (overlapWithNext == Above ? "Above" : "Below"))));
   for (const auto& ch : chips) {
     ch.print();
   }
@@ -220,8 +221,8 @@ void RecoGeomHelper::RecoLayer::updateLimits(const o2::math_utils::Point3D<float
 //_____________________________________________________________________
 void RecoGeomHelper::RecoLayer::print() const
 {
-  printf("\nLayer %d %.2f<r<%.2f %+.2f<z<%+.2f  %d ladders\n",
-         id, rRange.getMin(), rRange.getMax(), zRange.getMin(), zRange.getMax(), (int)ladders.size());
+  LOGF(info, "\nLayer %d %.2f<r<%.2f %+.2f<z<%+.2f  %d ladders\n",
+       id, rRange.getMin(), rRange.getMax(), zRange.getMin(), zRange.getMax(), (int)ladders.size());
   for (const auto& ld : ladders) {
     ld.print();
   }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -136,7 +136,8 @@ class TimeFrame
   const gsl::span<const MCCompLabel> getClusterLabels(int layerId, const Cluster& cl) const;
   const gsl::span<const MCCompLabel> getClusterLabels(int layerId, const int clId) const;
   int getClusterExternalIndex(int layerId, const int clId) const;
-  int getClusterSize(int clusterId);
+  int getClusterSize(int clusterId) const;
+  void setClusterSize(const std::vector<uint8_t>& v) { mClusterSize = v; };
 
   std::vector<MCCompLabel>& getTrackletsLabel(int layer) { return mTrackletLabels[layer]; }
   std::vector<MCCompLabel>& getCellsLabel(int layer) { return mCellLabels[layer]; }
@@ -463,7 +464,7 @@ inline const gsl::span<const MCCompLabel> TimeFrame::getClusterLabels(int layerI
   return mClusterLabels->getLabels(mClusterExternalIndices[layerId][clId]);
 }
 
-inline int TimeFrame::getClusterSize(int clusterId)
+inline int TimeFrame::getClusterSize(int clusterId) const
 {
   return mClusterSize[clusterId];
 }

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -40,6 +40,10 @@
 #include "DataFormatsITSMFT/TrkClusRef.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 
+#ifdef ENABLE_UPGRADES
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#endif
+
 namespace o2
 {
 namespace trd
@@ -98,9 +102,12 @@ class TRDGlobalTracking : public o2::framework::Task
   gsl::span<const int> mITSTrackClusIdx;                              ///< input ITS track cluster indices span
   gsl::span<const int> mITSABTrackClusIdx;                            ///< input ITSAB track cluster indices span
   std::vector<o2::BaseCluster<float>> mITSClustersArray;              ///< ITS clusters created in run() method from compact clusters
-  const o2::itsmft::TopologyDictionary* mITSDict = nullptr;           ///< cluster patterns dictionary
-  std::array<float, 5> mCovDiagInner{};                               ///< total cov.matrix extra diagonal error from TrackTuneParams
-  std::array<float, 5> mCovDiagOuter{};                               ///< total cov.matrix extra diagonal error from TrackTuneParams
+  const o2::itsmft::TopologyDictionary* mITSDict = nullptr;           ///< ITS cluster patterns dictionary
+#ifdef ENABLE_UPGRADES
+  const o2::its3::TopologyDictionary* mIT3Dict = nullptr; ///< IT3 cluster patterns dictionary
+#endif
+  std::array<float, 5> mCovDiagInner{}; ///< total cov.matrix extra diagonal error from TrackTuneParams
+  std::array<float, 5> mCovDiagOuter{}; ///< total cov.matrix extra diagonal error from TrackTuneParams
   // PID
   PIDPolicy mPolicy{PIDPolicy::DEFAULT}; ///< Model to load an evaluate
   std::unique_ptr<PIDBase> mBase;        ///< PID engine

--- a/Detectors/Upgrades/ITS3/README.md
+++ b/Detectors/Upgrades/ITS3/README.md
@@ -30,15 +30,24 @@ This just caches the ccdb object to reduce calls in case we are testing.
 
 ```bash
 export IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE=1
-export ALICEO2_CCDB_LOCALCACHE=$PWD/ccdb
+export ALICEO2_CCDB_LOCALCACHE=${PWD}/ccdb
 ```
+
+Simulate diamond
+
+``` bash
+# append to o2-sim
+--configKeyValues="Diamond.width[2]=6.;""
+```
+
+### Local Tracking
 
 1. Simulate
 
 Simulate PIPE and ITS3
 
 ```bash
-o2-sim -g pythia8pp -j10 -m PIPE IT3 --run 303901 -n1000 #--configKeyValues "Diamond.width[2]=6.;"
+o2-sim -g pythia8pp -j10 -m PIPE IT3 --run 303901 -n1000
 ```
 
 In the previous command:
@@ -51,7 +60,7 @@ In the previous command:
 2. Digitization
 
 ```bash
-o2-sim-digitizer-workflow -b --interactionRate 50000 --run --configKeyValues="HBFUtils.runNumber=303901;"
+o2-sim-digitizer-workflow -b --interactionRate 50000 --run --configKeyValues="HBFUtils.runNumber=303901;" --onlyDet IT3
 root -x -l ${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckDigitsITS3.C++
 ```
 
@@ -59,19 +68,31 @@ root -x -l ${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckD
 
 ```bash
 o2-its3-reco-workflow -b --run --tracking-mode async --configKeyValues "HBFUtils.runNumber=303901;"
-root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckTracksITS3.C++("o2trac_its3.root", "o2clus_it3.root", "o2sim_Kine.root", "o2sim_grp.root", "o2sim_geometry-aligned.root", false)'
+root -x -l ${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C++
+root -x -l ${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckTracksITS3.C++
+```
+
+### Global Tracking
+
+1. Simulate
+
+Simulate all detectors but replacing ITS with IT3
+
+```bash
+o2-sim -g pythia8pp -j10 -m PIPE IT3 --run 303901 -n10
 ```
 
 ## Creating CCDB Objects
 
-### Create Full geometry + Aligned + GeometryTGeo
+### !TODO! Create Full geometry + Aligned + GeometryTGeo
 
 ```bash
 # Create Full Geometry
-o2-sim -m PIPE IT3 TPC TRD TOF PHS CPV EMC HMP MFT MCH MID ZDC FT0 FV0 FDD CTP FOC TST --run 303901 -n0
+o2-sim --withIT3 --run 303901 -n0 --field ccdb
 cp o2sim_geometry.root ${ALICEO2_CCDB_LOCALCACHE}/GLO/Config/Geometry/snapshot.root
 o2-create-aligned-geometry-workflow -b --configKeyValues "HBFUtils.startTime=1547978230000" --condition-remap="file://${ALICEO2_CCDB_LOCALCACHE}=GLO/Config/Geometry"
 cp o2sim_geometry-aligned.root ${ALICEO2_CCDB_LOCALCACHE}/GLO/Config/GeometryAligned/snapshot.root
+cp its_GeometryTGeo.root ${ALICEO2_CCDB_LOCALCACHE}/ITS/Config/Geometry/snapshot.root
 ```
 
 ### Regenerating the TopologyDictionary
@@ -105,9 +126,9 @@ o2-its3-reco-workflow -b --tracking-mode off \
 4. Check Clusters
 
 ```bash
-root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C++("o2clus_it3.root", "o2sim_HitsIT3.root", "o2sim_geometry-aligned.root", "IT3dictionary.root")'
-root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CompareClustersAndDigits.C++("o2clus_it3.root", "it3digits.root","IT3dictionary.root", "o2sim_HitsIT3.root", "o2sim_geometry-aligned.root")'
-root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckClusterSize.C++("o2clus_it3.root", "o2sim_Kine.root", "IT3dictionary.root", false)'
+root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C++("o2clus_its.root", "o2sim_HitsIT3.root", "o2sim_geometry-aligned.root", "IT3dictionary.root")'
+root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CompareClustersAndDigits.C++("o2clus_its.root", "it3digits.root","IT3dictionary.root", "o2sim_HitsIT3.root", "o2sim_geometry-aligned.root")'
+root -x -l '${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckClusterSize.C++("o2clus_its.root", "o2sim_Kine.root", "IT3dictionary.root", false)'
 ```
 
 ### Using external generators based on AliRoot

--- a/Detectors/Upgrades/ITS3/README.md
+++ b/Detectors/Upgrades/ITS3/README.md
@@ -79,7 +79,7 @@ root -x -l ${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CheckT
 Simulate all detectors but replacing ITS with IT3
 
 ```bash
-o2-sim -g pythia8pp -j10 -m PIPE IT3 --run 303901 -n10
+o2-sim -g pythia8pp -j10 --detectorList ALICE2.1 --run 303901 -n20 -m IT3
 ```
 
 ## Creating CCDB Objects
@@ -88,7 +88,7 @@ o2-sim -g pythia8pp -j10 -m PIPE IT3 --run 303901 -n10
 
 ```bash
 # Create Full Geometry
-o2-sim --withIT3 --run 303901 -n0 --field ccdb
+o2-sim -g pythia8pp -j10 --detectorList ALICE2.1 --run 303901 -n0
 cp o2sim_geometry.root ${ALICEO2_CCDB_LOCALCACHE}/GLO/Config/Geometry/snapshot.root
 o2-create-aligned-geometry-workflow -b --configKeyValues "HBFUtils.startTime=1547978230000" --condition-remap="file://${ALICEO2_CCDB_LOCALCACHE}=GLO/Config/Geometry"
 cp o2sim_geometry-aligned.root ${ALICEO2_CCDB_LOCALCACHE}/GLO/Config/GeometryAligned/snapshot.root
@@ -107,7 +107,7 @@ o2-its3-reco-workflow -b --tracking-mode off \
     --ignore-cluster-dictionary --run
 ```
 
-2. Creating the Topology Dictionary
+2. Creating the TopologyDictionary
 
 ```bash
 root -x -l ${ALIBUILD_WORK_DIR}/../O2/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C++

--- a/Detectors/Upgrades/ITS3/base/include/ITS3Base/SegmentationSuperAlpide.h
+++ b/Detectors/Upgrades/ITS3/base/include/ITS3Base/SegmentationSuperAlpide.h
@@ -53,6 +53,11 @@ class SegmentationSuperAlpide
   // |           |          |
   // x----------------------x
  public:
+  virtual ~SegmentationSuperAlpide() = default;
+  SegmentationSuperAlpide(const SegmentationSuperAlpide&) = default;
+  SegmentationSuperAlpide(SegmentationSuperAlpide&&) = delete;
+  SegmentationSuperAlpide& operator=(const SegmentationSuperAlpide&) = delete;
+  SegmentationSuperAlpide& operator=(SegmentationSuperAlpide&&) = delete;
   constexpr SegmentationSuperAlpide(int layer) : mLayer{layer} {}
 
   static constexpr int mNCols{constants::pixelarray::nCols};
@@ -185,8 +190,8 @@ class SegmentationSuperAlpide
   template <typename T>
   [[nodiscard]] bool isValid(T const row, T const col) const noexcept
   {
-    namespace cp = constants::pixelarray;
     if constexpr (std::is_floating_point_v<T>) { // compares in local coord.
+      namespace cp = constants::pixelarray;
       return !static_cast<bool>(row <= -cp::width / 2. || cp::width / 2. <= row || col <= -cp::length / 2. || cp::length / 2. <= col);
     } else { // compares in rows/cols
       return !static_cast<bool>(row < 0 || row >= static_cast<int>(mNRows) || col < 0 || col >= static_cast<int>(mNCols));

--- a/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
@@ -54,6 +54,7 @@ o2_add_test_root_macro(CheckDCA.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
+                                             O2::Steer
                        LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CreateDictionariesITS3.C

--- a/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
@@ -56,18 +56,6 @@ o2_add_test_root_macro(CreateDictionariesITS3.C
                                              O2::DetectorsBase
                        LABELS its3 COMPILE_ONLY)
 
-                       # o2_add_test_root_macro(CheckSquasherITS3.C
-#                        PUBLIC_LINK_LIBRARIES O2::ITSBase
-#                                              O2::ITS3Base
-#                                              O2::ITSMFTBase
-#                                              O2::ITSMFTSimulation
-#                                              O2::ITS3Simulation
-#                                              O2::ITS3Reconstruction
-#                                              O2::MathUtils
-#                                              O2::SimulationDataFormat
-#                                              O2::DetectorsBase
-#                        LABELS its3)
-
 o2_add_test_root_macro(buildMatBudLUT.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
                                              O2::ITS3Base
@@ -153,6 +141,18 @@ o2_add_test_root_macro(CheckSuperAlpideSegmentTrans.C
                        LABELS its3 COMPILE_ONLY)
 
 o2_add_test_root_macro(CompareClustersAndDigits.C
+                       PUBLIC_LINK_LIBRARIES O2::ITSBase
+                                             O2::ITS3Base
+                                             O2::ITSMFTBase
+                                             O2::ITSMFTSimulation
+                                             O2::ITS3Simulation
+                                             O2::ITS3Reconstruction
+                                             O2::MathUtils
+                                             O2::SimulationDataFormat
+                                             O2::DetectorsBase
+                       LABELS its3 COMPILE_ONLY)
+
+o2_add_test_root_macro(CheckROFs.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
                                              O2::ITS3Base
                                              O2::ITSMFTBase

--- a/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
@@ -44,6 +44,18 @@ o2_add_test_root_macro(CheckTracksITS3.C
                                              O2::DetectorsBase
                        LABELS its3 COMPILE_ONLY)
 
+o2_add_test_root_macro(CheckDCA.C
+                       PUBLIC_LINK_LIBRARIES O2::ITSBase
+                                             O2::ITS3Base
+                                             O2::ITSMFTBase
+                                             O2::ITSMFTSimulation
+                                             O2::ITS3Simulation
+                                             O2::ITS3Reconstruction
+                                             O2::MathUtils
+                                             O2::SimulationDataFormat
+                                             O2::DetectorsBase
+                       LABELS its3 COMPILE_ONLY)
+
 o2_add_test_root_macro(CreateDictionariesITS3.C
                        PUBLIC_LINK_LIBRARIES O2::ITSBase
                                              O2::ITS3Base

--- a/Detectors/Upgrades/ITS3/macros/test/CheckClusterSize.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckClusterSize.C
@@ -68,7 +68,7 @@ inline auto hist_map(unsigned short id)
   return std::clamp(id, static_cast<unsigned short>(0), static_cast<unsigned short>(6)) / 2;
 }
 
-void CheckClusterSize(std::string clusFileName = "o2clus_it3.root",
+void CheckClusterSize(std::string clusFileName = "o2clus_its.root",
                       std::string kineFileName = "o2sim_Kine.root",
                       std::string dictFileName = "", bool batch = true)
 {
@@ -186,10 +186,10 @@ void CheckClusterSize(std::string clusFileName = "o2clus_it3.root",
   auto clusTree = clusFile->Get<TTree>("o2sim");
   std::vector<CompClusterExt> clusArr;
   std::vector<CompClusterExt>* clusArrP{&clusArr};
-  clusTree->SetBranchAddress("IT3ClusterComp", &clusArrP);
+  clusTree->SetBranchAddress("ITSClusterComp", &clusArrP);
   std::vector<unsigned char> patterns;
   std::vector<unsigned char>* patternsPtr{&patterns};
-  clusTree->SetBranchAddress("IT3ClusterPatt", &patternsPtr);
+  clusTree->SetBranchAddress("ITSClusterPatt", &patternsPtr);
 
   // MC tracks
   std::unique_ptr<TFile> kineFile(TFile::Open(kineFileName.data()));
@@ -207,7 +207,7 @@ void CheckClusterSize(std::string clusFileName = "o2clus_it3.root",
 
   // Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
-  clusTree->SetBranchAddress("IT3ClusterMCTruth", &clusLabArr);
+  clusTree->SetBranchAddress("ITSClusterMCTruth", &clusLabArr);
 
   std::cout << "** Filling particle table ... " << std::flush;
   int lastEventIDcl = -1;
@@ -233,7 +233,7 @@ void CheckClusterSize(std::string clusFileName = "o2clus_it3.root",
   // ROFrecords
   std::vector<ROFRec> rofRecVec;
   std::vector<ROFRec>* rofRecVecP{&rofRecVec};
-  clusTree->SetBranchAddress("IT3ClustersROF", &rofRecVecP);
+  clusTree->SetBranchAddress("ITSClustersROF", &rofRecVecP);
   clusTree->GetEntry(0);
   int nROFRec = (int)rofRecVec.size();
   auto pattIt = patternsPtr->cbegin();

--- a/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C
@@ -39,8 +39,8 @@
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 #endif
 
-void CheckClustersITS3(std::string clusfile = "o2clus_it3.root", std::string hitfile = "o2sim_HitsIT3.root",
-                       std::string inputGeom = "o2sim_geometry.root", std::string dictfile = "", bool batch = false)
+void CheckClustersITS3(std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim_HitsIT3.root",
+                       std::string inputGeom = "o2sim_geometry.root", std::string dictfile = "ccdb/IT3/Calib/ClusterDictionary/snapshot.root", bool batch = false)
 {
   gROOT->SetBatch(batch);
 
@@ -82,9 +82,9 @@ void CheckClustersITS3(std::string clusfile = "o2clus_it3.root", std::string hit
   TFile fileC(clusfile.data());
   auto* clusTree = dynamic_cast<TTree*>(fileC.Get("o2sim"));
   std::vector<CompClusterExt>* clusArr = nullptr;
-  clusTree->SetBranchAddress("IT3ClusterComp", &clusArr);
+  clusTree->SetBranchAddress("ITSClusterComp", &clusArr);
   std::vector<unsigned char>* patternsPtr = nullptr;
-  auto pattBranch = clusTree->GetBranch("IT3ClusterPatt");
+  auto pattBranch = clusTree->GetBranch("ITSClusterPatt");
   if (pattBranch != nullptr) {
     pattBranch->SetAddress(&patternsPtr);
   }
@@ -102,14 +102,14 @@ void CheckClustersITS3(std::string clusfile = "o2clus_it3.root", std::string hit
 
   // ROFrecords
   std::vector<ROFRec> rofRecVec, *rofRecVecP = &rofRecVec;
-  clusTree->SetBranchAddress("IT3ClustersROF", &rofRecVecP);
+  clusTree->SetBranchAddress("ITSClustersROF", &rofRecVecP);
 
   // Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
   std::vector<MC2ROF> mc2rofVec, *mc2rofVecP = &mc2rofVec;
-  if ((hitTree != nullptr) && (clusTree->GetBranch("IT3ClusterMCTruth") != nullptr)) {
-    clusTree->SetBranchAddress("IT3ClusterMCTruth", &clusLabArr);
-    clusTree->SetBranchAddress("IT3ClustersMC2ROF", &mc2rofVecP);
+  if ((hitTree != nullptr) && (clusTree->GetBranch("ITSClusterMCTruth") != nullptr)) {
+    clusTree->SetBranchAddress("ITSClusterMCTruth", &clusLabArr);
+    clusTree->SetBranchAddress("ITSClustersMC2ROF", &mc2rofVecP);
   }
 
   clusTree->GetEntry(0);

--- a/Detectors/Upgrades/ITS3/macros/test/CheckDCA.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckDCA.C
@@ -1,0 +1,899 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CheckDCA.C
+/// \brief Simple macro to check ITS3 impact parameter resolution
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TROOT.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include "TEfficiency.h"
+#include <TClonesArray.h>
+#include <TFile.h>
+#include <TF1.h>
+#include <TH2F.h>
+#include <TLegend.h>
+#include <TPad.h>
+#include <TTree.h>
+#include "TGeoGlobalMagField.h"
+
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DetectorsBase/Propagator.h"
+#include "Field/MagneticField.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "DetectorsBase/Propagator.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/Vertex.h"
+#include "ReconstructionDataFormats/DCA.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCUtils.h"
+#include "SimulationDataFormat/TrackReference.h"
+#include "Steer/MCKinematicsReader.h"
+
+#include <array>
+#include <map>
+#include <iostream>
+#include <vector>
+#include <filesystem>
+#include <optional>
+#include <regex>
+#endif
+
+namespace fs = std::filesystem;
+
+constexpr auto mMatCorr{o2::base::Propagator::MatCorrType::USEMatCorrNONE};
+constexpr float mMaxStep{2};
+
+constexpr float rapMax{0.9};
+
+std::vector<fs::path> find_dirs(fs::path const& dir, std::function<bool(fs::path const&)> filter, std::optional<std::function<bool(fs::path const&, fs::path const&)>> sort = std::nullopt)
+{
+  std::vector<fs::path> result;
+  if (fs::exists(dir)) { // Find Dirs matching filter
+    for (auto const& entry : fs::recursive_directory_iterator(dir, fs::directory_options::follow_directory_symlink)) {
+      if (fs::is_directory(entry) && filter(entry)) {
+        result.emplace_back(entry);
+      }
+    }
+  }
+  if (sort) { // Optionally sort paths
+    std::sort(result.begin(), result.end(), *sort);
+  }
+  return result;
+}
+
+void CheckDCA(const std::string& collisioncontextFileName = "collisioncontext.root",
+              const std::string& tpcTracksFileName = "tpctracks.root",
+              const std::string& itsTracksFileName = "o2trac_its.root",
+              const std::string& itstpcTracksFileName = "o2match_itstpc.root",
+              const std::string& magFileName = "o2sim_grp.root")
+{
+  gROOT->SetBatch();
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(kRainBow);
+  gStyle->SetPadLeftMargin(0.16);
+  gStyle->SetPadTickX(1);
+  gStyle->SetPadTickY(1);
+  gErrorIgnoreLevel = 2001; // suppress warnings
+
+  const int nPtBins = 35;
+  const int nPtBinsEff = 39;
+  double ptLimits[nPtBins] = {0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2., 2.2, 2.5, 3., 4., 5., 6., 8., 10., 15., 20.};
+  double ptLimitsEff[nPtBinsEff] = {0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2., 2.2, 2.5, 3., 4., 5., 6., 8., 10., 15., 20.};
+
+  const std::regex tf_pattern(R"(tf\d+)");
+  auto tf_matcher = [&tf_pattern](fs::path const& p) -> bool {
+    return std::regex_search(p.string(), tf_pattern);
+  };
+  auto tf_sorter = [&tf_pattern](fs::path const& a, fs::path const& b) -> bool {
+    const auto &as = a.string(), &bs = b.string();
+    std::smatch am, bm;
+    if (std::regex_search(as, am, tf_pattern) && std::regex_search(bs, bm, tf_pattern)) {
+      return std::stoi(am.str().substr(2)) < std::stoi(bm.str().substr(2));
+    } else {
+      LOGP(fatal, "TF Regex matching failed");
+      return false;
+    }
+  };
+
+  const int nSpecies = 4;
+  std::array<int, nSpecies> pdgCodes{11, 211, 321, 2212};
+  auto fGaus = new TF1("fGaus", "gaus", -200., 200.);
+  std::map<int, std::string> partNames = {
+    {11, "Electrons"},
+    {211, "Pions"},
+    {321, "Kaons"},
+    {2212, "Protons"}};
+  std::map<int, int> colors{{11, kOrange + 7}, {211, kRed + 1}, {321, kAzure + 4}, {2212, kGreen + 2}};
+  /// ITS
+  std::map<int, TH1F*> hDcaxyResAllLayersITS = {
+    {11, new TH1F("hDcaxyResElectronsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcaxyResPionsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcaxyResKaonsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcaxyResProtonsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcazResAllLayersITS = {
+    {11, new TH1F("hDcazResElectronsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcazResPionsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcazResKaonsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcazResProtonsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hPtResAllLayersITS = {
+    {11, new TH1F("hPtResElectronsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hPtResPionsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hPtResKaonsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hPtResProtonsAllLayersITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcaxyResNoFirstLayerITS = {
+    {11, new TH1F("hDcaxyResElectronsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcaxyResPionsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcaxyResKaonsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcaxyResProtonsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcazResNoFirstLayerITS = {
+    {11, new TH1F("hDcazResElectronsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcazResPionsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcazResKaonsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcazResProtonsNoFirstLayerITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcaxyReskAnyITS = {
+    {11, new TH1F("hDcaxyResElectronskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcaxyResPionskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcaxyResKaonskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcaxyResProtonskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcazReskAnyITS = {
+    {11, new TH1F("hDcazResElectronskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcazResPionskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcazResKaonskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcazResProtonskAnyITS", "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)}};
+
+  std::map<int, TH2F*> hDcaxyVsPtAllLayersITS = {
+    {11, new TH2F("hDcaxyVsPtElectronsAllLayersITS", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPtPionsAllLayersITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPtKaonsAllLayersITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPtProtonsAllLayersITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPtAllLayersITS = {
+    {11, new TH2F("hDcazVsPtElectronsAllLayersITS", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPtPionsAllLayersITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPtKaonsAllLayersITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPtProtonsAllLayersITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcaxyVsPhiAllLayersITS = {
+    {11, new TH2F("hDcaxyVsPhiElectronsAllLayersITS", "ITS Electrons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPhiPionsAllLayersITS", "ITS Pions (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPhiKaonsAllLayersITS", "ITS Kaons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPhiProtonsAllLayersITS", "ITS Protons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPhiAllLayersITS = {
+    {11, new TH2F("hDcazVsPhiElectronsAllLayersITS", "ITS Electrons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPhiPionsAllLayersITS", "ITS Pions (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPhiKaonsAllLayersITS", "ITS Kaons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPhiProtonsAllLayersITS", "ITS Protons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcaxyVsPtNoFirstLayerITS = {
+    {11, new TH2F("hDcaxyVsPtElectronsNoFirstLayerITS", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPtPionsNoFirstLayerITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPtKaonsNoFirstLayerITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPtProtonsNoFirstLayerITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPtNoFirstLayerITS = {
+    {11, new TH2F("hDcazVsPtElectronsNoFirstLayerITS", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPtPionsNoFirstLayerITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPtKaonsNoFirstLayerITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPtProtonsNoFirstLayerITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPtkAnyITS = {
+    {11, new TH2F("hDcazVsPtElectronskAnyITS ", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPtPionskAnyITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPtKaonskAnyITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPtProtonskAnyITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcaxyVsPtkAnyITS = {
+    {11, new TH2F("hDcaxyVsPtElectronskAnyITS", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPtPionskAnyITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPtKaonskAnyITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPtProtonskAnyITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDeltaPtVsPtAllLayersITS = {
+    {11, new TH2F("hDeltaPtVsPtElectronsAllLayersITS", "ITS Electrons;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)},
+    {211, new TH2F("hDeltaPtVsPtPionsAllLayersITS", "ITS Pions;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)},
+    {321, new TH2F("hDeltaPtVsPtKaonsAllLayersITS", "ITS Kaons;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)},
+    {2212, new TH2F("hDeltaPtVsPtProtonsAllLayersITS", "ITS Protons;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)}};
+  // ITS-TPC
+  std::map<int, TH1F*> hDcaxyResAllLayersITSTPC = {
+    {11, new TH1F("hDcaxyResElectronsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcaxyResPionsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcaxyResKaonsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcaxyResProtonsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcazResAllLayersITSTPC = {
+    {11, new TH1F("hDcazResElectronsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcazResPionsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcazResKaonsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcazResProtonsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hPtResAllLayersITSTPC = {
+    {11, new TH1F("hPtResElectronsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hPtResPionsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hPtResKaonsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hPtResProtonsAllLayersITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcaxyResNoFirstLayerITSTPC = {
+    {11, new TH1F("hDcaxyResElectronsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcaxyResPionsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcaxyResKaonsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcaxyResProtonsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcazResNoFirstLayerITSTPC = {
+    {11, new TH1F("hDcazResElectronsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcazResPionsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcazResKaonsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcazResProtonsNoFirstLayerITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcaxyReskAnyITSTPC = {
+    {11, new TH1F("hDcaxyResElectronskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcaxyResPionskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcaxyResKaonskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcaxyResProtonskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits)}};
+  std::map<int, TH1F*> hDcazReskAnyITSTPC = {
+    {11, new TH1F("hDcazResElectronskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {211, new TH1F("hDcazResPionskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {321, new TH1F("hDcazResKaonskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)},
+    {2212, new TH1F("hDcazResProtonskAnyITSTPC", "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits)}};
+
+  std::map<int, TH2F*> hDcaxyVsPtAllLayersITSTPC = {
+    {11, new TH2F("hDcaxyVsPtElectronsAllLayersITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPtPionsAllLayersITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPtKaonsAllLayersITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPtProtonsAllLayersITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPtAllLayersITSTPC = {
+    {11, new TH2F("hDcazVsPtElectronsAllLayersITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPtPionsAllLayersITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPtKaonsAllLayersITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPtProtonsAllLayersITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcaxyVsPhiAllLayersITSTPC = {
+    {11, new TH2F("hDcaxyVsPhiElectronsAllLayersITSTPC", "ITS-TPC Electrons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPhiPionsAllLayersITSTPC", "ITS-TPC Pions (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPhiKaonsAllLayersITSTPC", "ITS-TPC Kaons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPhiProtonsAllLayersITSTPC", "ITS-TPC Protons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{xy}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPhiAllLayersITSTPC = {
+    {11, new TH2F("hDcazVsPhiElectronsAllLayersITSTPC", "ITS-TPC Electrons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPhiPionsAllLayersITSTPC", "ITS-TPC Pions (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPhiKaonsAllLayersITSTPC", "ITS-TPC Kaons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPhiProtonsAllLayersITSTPC", "ITS-TPC Protons (>2 Gev);#varphi (rad);#sigma(DCA_{#it{z}}) (#mum)", 100, 0.f, 2 * TMath::Pi(), 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcaxyVsPtNoFirstLayerITSTPC = {
+    {11, new TH2F("hDcaxyVsPtElectronsNoFirstLayerITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPtPionsNoFirstLayerITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPtKaonsNoFirstLayerITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPtProtonsNoFirstLayerITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPtNoFirstLayerITSTPC = {
+    {11, new TH2F("hDcazVsPtElectronsNoFirstLayerITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPtPionsNoFirstLayerITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPtKaonsNoFirstLayerITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPtProtonsNoFirstLayerITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcazVsPtkAnyITSTPC = {
+    {11, new TH2F("hDcazVsPtElectronskAnyITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcazVsPtPionskAnyITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcazVsPtKaonskAnyITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcazVsPtProtonskAnyITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDcaxyVsPtkAnyITSTPC = {
+    {11, new TH2F("hDcaxyVsPtElectronskAnyITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {211, new TH2F("hDcaxyVsPtPionskAnyITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {321, new TH2F("hDcaxyVsPtKaonskAnyITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)},
+    {2212, new TH2F("hDcaxyVsPtProtonskAnyITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)", nPtBins - 1, ptLimits, 1000, -500, 500)}};
+  std::map<int, TH2F*> hDeltaPtVsPtAllLayersITSTPC = {
+    {11, new TH2F("hDeltaPtVsPtElectronsAllLayersITSTPC", "ITS-TPC Electrons;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)},
+    {211, new TH2F("hDeltaPtVsPtPionsAllLayersITSTPC", "ITS-TPC Pions;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)},
+    {321, new TH2F("hDeltaPtVsPtKaonsAllLayersITSTPC", "ITS-TPC Kaons;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)},
+    {2212, new TH2F("hDeltaPtVsPtProtonsAllLayersITSTPC", "ITS-TPC Protons;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})", nPtBins - 1, ptLimits, 200, -0.2, 0.2)}};
+
+  o2::dataformats::VertexBase collision;
+  o2::dataformats::DCA impactParameter;
+
+  const auto origWD{fs::current_path()};
+  for (const auto& tfDir : find_dirs(fs::current_path(), tf_matcher, tf_sorter)) {
+    LOGP(info, "Analysing {}", tfDir.c_str());
+    fs::current_path(tfDir);
+
+    // MC Information
+    o2::steer::MCKinematicsReader mcReader(collisioncontextFileName);
+
+    // Magnetic field and Propagator should not change over tfs
+    float bz{-999};
+    static bool initOnce{false};
+    if (!initOnce) {
+      initOnce = true;
+      o2::base::Propagator::initFieldFromGRP(magFileName);
+      bz = o2::base::Propagator::Instance()->getNominalBz();
+    }
+
+    // ITS Tracks
+    std::unique_ptr<TFile> fITSTracks(TFile::Open(itsTracksFileName.c_str(), "READ"));
+    auto tITSTracks = fITSTracks->Get<TTree>("o2sim");
+    std::vector<o2::its::TrackITS> itsTracks, *itsTracksPtr{&itsTracks};
+    tITSTracks->SetBranchAddress("ITSTrack", &itsTracksPtr);
+    std::vector<o2::MCCompLabel> itsTrkLab, *itsTrkLabPtr{&itsTrkLab};
+    tITSTracks->SetBranchAddress("ITSTrackMCTruth", &itsTrkLabPtr);
+
+    for (Long64_t iEntry{0}; tITSTracks->LoadTree(iEntry) >= 0; ++iEntry) {
+      tITSTracks->GetEntry(iEntry);
+      for (size_t iTrk{0}; iTrk < itsTracks.size(); ++iTrk) {
+        auto trk = itsTracks[iTrk];
+        const auto& lbl = itsTrkLab[iTrk];
+        if (!lbl.isValid()) {
+          continue;
+        }
+
+        const auto& mcEvent = mcReader.getMCEventHeader(lbl.getSourceID(), lbl.getEventID());
+        const auto& mcTrack = mcReader.getTrack(lbl);
+        const auto& pContainer = mcReader.getTracks(lbl.getSourceID(), lbl.getEventID());
+        if (!o2::mcutils::MCTrackNavigator::isPhysicalPrimary(*mcTrack, pContainer) || !(std::abs(mcTrack->GetEta()) < rapMax)) {
+          continue;
+        }
+        auto pdg = std::abs(mcTrack->GetPdgCode());
+        if (pdg != 11 && pdg != 211 && pdg != 321 && pdg != 2212) {
+          continue;
+        }
+
+        collision.setXYZ(mcEvent.GetX(), mcEvent.GetY(), mcEvent.GetZ());
+        if (!o2::base::Propagator::Instance()->propagateToDCA(collision, trk, bz, mMaxStep, mMatCorr, &impactParameter)) {
+          continue;
+        }
+
+        auto ptReco = trk.getPt();
+        auto ptGen = mcTrack->GetPt();
+        auto deltaPt = (1. / ptReco - 1. / ptGen) / (1. / ptGen);
+        auto dcaXY = impactParameter.getY() * 10000;
+        auto dcaZ = impactParameter.getZ() * 10000;
+        auto phiReco = trk.getPhi();
+
+        if (trk.getNumberOfClusters() == 7) {
+          hDcaxyVsPtAllLayersITS[pdg]->Fill(ptGen, dcaXY);
+          hDcazVsPtAllLayersITS[pdg]->Fill(ptGen, dcaZ);
+          hDeltaPtVsPtAllLayersITS[pdg]->Fill(ptGen, deltaPt);
+          if (ptGen > 2.) {
+            hDcaxyVsPhiAllLayersITS[pdg]->Fill(phiReco, dcaXY);
+            hDcazVsPhiAllLayersITS[pdg]->Fill(phiReco, dcaZ);
+          }
+        } else if (!trk.hasHitOnLayer(0)) {
+          hDcaxyVsPtNoFirstLayerITS[pdg]->Fill(ptGen, dcaXY);
+          hDcazVsPtNoFirstLayerITS[pdg]->Fill(ptGen, dcaZ);
+        } else {
+          hDcaxyVsPtkAnyITS[pdg]->Fill(ptGen, dcaXY);
+          hDcazVsPtkAnyITS[pdg]->Fill(ptGen, dcaZ);
+        }
+      }
+    }
+
+    // ITS-TPC Tracks
+    std::unique_ptr<TFile> fITSTPCTracks(TFile::Open(itstpcTracksFileName.c_str(), "READ"));
+    auto tITSTPCTracks = fITSTPCTracks->Get<TTree>("matchTPCITS");
+    std::vector<o2::dataformats::TrackTPCITS> itstpcTracks, *itstpcTracksPtr{&itstpcTracks};
+    tITSTPCTracks->SetBranchAddress("TPCITS", &itstpcTracksPtr);
+    std::vector<o2::MCCompLabel> itstpcTrkLab, *itstpcTrkLabPtr{&itstpcTrkLab};
+    tITSTPCTracks->SetBranchAddress("MatchMCTruth", &itstpcTrkLabPtr);
+    // TPC Tracks
+    std::unique_ptr<TFile> fTPCTracks(TFile::Open(tpcTracksFileName.c_str(), "READ"));
+    auto tTPCTracks = fTPCTracks->Get<TTree>("tpcrec");
+    std::vector<o2::tpc::TrackTPC> tpcTracks, *tpcTracksPtr{&tpcTracks};
+    tTPCTracks->SetBranchAddress("TPCTracks", &tpcTracksPtr);
+    std::vector<o2::MCCompLabel> tpcTrkLab, *tpcTrkLabPtr{&tpcTrkLab};
+    tTPCTracks->SetBranchAddress("TPCTracksMCTruth", &tpcTrkLabPtr);
+    for (Long64_t iEntry{0}; tITSTPCTracks->LoadTree(iEntry) >= 0; ++iEntry) {
+      tITSTPCTracks->GetEntry(iEntry);
+      tITSTracks->GetEntry(iEntry);
+      tTPCTracks->GetEntry(iEntry);
+      for (size_t iTrk{0}; iTrk < itstpcTracks.size(); ++iTrk) {
+        auto trk = itstpcTracks[iTrk];
+        const auto& lbl = itstpcTrkLab[iTrk];
+
+        const auto& trkITS = itsTracks[trk.getRefITS().getIndex()];
+        const auto& trkITSLbl = itsTrkLab[trk.getRefITS().getIndex()];
+        const auto& trkTPC = tpcTracks[trk.getRefTPC().getIndex()];
+        const auto& trkTPCLbl = tpcTrkLab[trk.getRefTPC().getIndex()];
+        if (!lbl.isValid() || trkITSLbl != trkTPCLbl) {
+          continue;
+        }
+
+        const auto& mcEvent = mcReader.getMCEventHeader(lbl.getSourceID(), lbl.getEventID());
+        const auto& mcTrack = mcReader.getTrack(lbl);
+        const auto& pContainer = mcReader.getTracks(lbl.getSourceID(), lbl.getEventID());
+        if (!o2::mcutils::MCTrackNavigator::isPhysicalPrimary(*mcTrack, pContainer) || !(std::abs(mcTrack->GetEta()) < rapMax)) {
+          continue;
+        }
+
+        auto pdg = std::abs(mcTrack->GetPdgCode());
+        if (pdg != 11 && pdg != 211 && pdg != 321 && pdg != 2212) {
+          continue;
+        }
+
+        collision.setXYZ(mcEvent.GetX(), mcEvent.GetY(), mcEvent.GetZ());
+        if (!o2::base::Propagator::Instance()->propagateToDCA(collision, trk, bz, mMaxStep, mMatCorr, &impactParameter)) {
+          continue;
+        }
+
+        auto ptReco = trk.getPt();
+        auto ptGen = mcTrack->GetPt();
+        auto deltaPt = (1. / ptReco - 1. / ptGen) / (1. / ptGen);
+        auto dcaXY = impactParameter.getY() * 10000;
+        auto dcaZ = impactParameter.getZ() * 10000;
+        auto phiReco = trk.getPhi();
+
+        if (trkITS.getNumberOfClusters() == 7) {
+          hDcaxyVsPtAllLayersITSTPC[pdg]->Fill(ptGen, dcaXY);
+          hDcazVsPtAllLayersITSTPC[pdg]->Fill(ptGen, dcaZ);
+          hDeltaPtVsPtAllLayersITSTPC[pdg]->Fill(ptGen, deltaPt);
+          if (ptGen > 2.) {
+            hDcaxyVsPhiAllLayersITSTPC[pdg]->Fill(phiReco, dcaXY);
+            hDcazVsPhiAllLayersITSTPC[pdg]->Fill(phiReco, dcaZ);
+          }
+        } else if (!trkITS.hasHitOnLayer(0) && !trkITS.hasHitOnLayer(1) && !trkITS.hasHitOnLayer(2)) {
+          hDcaxyVsPtNoFirstLayerITSTPC[pdg]->Fill(ptGen, dcaXY);
+          hDcazVsPtNoFirstLayerITSTPC[pdg]->Fill(ptGen, dcaZ);
+        } else {
+          hDcaxyVsPtkAnyITSTPC[pdg]->Fill(ptGen, dcaXY);
+          hDcazVsPtkAnyITSTPC[pdg]->Fill(ptGen, dcaZ);
+        }
+      }
+    }
+  }
+  fs::current_path(origWD); // restore original wd
+
+  TH1D* hProj;
+  for (const auto& pdgCode : pdgCodes) {
+    for (auto iPt{0}; iPt < nPtBins; ++iPt) {
+      // ITS
+      auto ptMin = hDcaxyVsPtAllLayersITS[pdgCode]->GetXaxis()->GetBinLowEdge(iPt + 1);
+      float minFit = (ptMin < 1.) ? -200. : -50.;
+      float maxFit = (ptMin < 1.) ? 200. : 50.;
+
+      hProj = hDeltaPtVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDeltaPt%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0");
+      hPtResAllLayersITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hPtResAllLayersITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcaxyVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcaxyResAllLayersITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcaxyResAllLayersITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcazVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcazResAllLayersITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcazResAllLayersITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcaxyVsPtNoFirstLayerITS[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcaxyResNoFirstLayerITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcaxyResNoFirstLayerITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcazVsPtNoFirstLayerITS[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcazResNoFirstLayerITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcazResNoFirstLayerITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcaxyVsPtkAnyITS[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcaxyReskAnyITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcaxyReskAnyITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcazVsPtkAnyITS[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcazReskAnyITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcazReskAnyITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      // ITS-TPC
+      hProj = hDeltaPtVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDeltaPt%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0");
+      hPtResAllLayersITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hPtResAllLayersITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      ptMin = hDcaxyVsPtAllLayersITSTPC[pdgCode]->GetXaxis()->GetBinLowEdge(iPt + 1);
+      minFit = (ptMin < 1.) ? -200. : -50.;
+      maxFit = (ptMin < 1.) ? 200. : 50.;
+
+      hProj = hDcaxyVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcaxyResAllLayersITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcaxyResAllLayersITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcazVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcazResAllLayersITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcazResAllLayersITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcaxyVsPtNoFirstLayerITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcazVsPtNoFirstLayerITSTPC[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcazResNoFirstLayerITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcazResNoFirstLayerITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcaxyVsPtkAnyITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcaxyReskAnyITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcaxyReskAnyITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+
+      hProj = hDcazVsPtkAnyITSTPC[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hDcazReskAnyITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
+      hDcazReskAnyITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
+    }
+  }
+
+  // Style
+  for (const auto& pdgCode : pdgCodes) {
+    // ITS
+    hPtResAllLayersITS[pdgCode]->SetLineWidth(2);
+    hPtResAllLayersITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hPtResAllLayersITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hPtResAllLayersITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    hDcaxyResAllLayersITS[pdgCode]->SetLineWidth(2);
+    hDcaxyResAllLayersITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcaxyResAllLayersITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcaxyResAllLayersITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    hDcazResAllLayersITS[pdgCode]->SetLineWidth(2);
+    hDcazResAllLayersITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcazResAllLayersITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcazResAllLayersITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    hDcaxyResNoFirstLayerITS[pdgCode]->SetLineWidth(2);
+    hDcaxyResNoFirstLayerITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcaxyResNoFirstLayerITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcaxyResNoFirstLayerITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    hDcazResNoFirstLayerITS[pdgCode]->SetLineWidth(2);
+    hDcazResNoFirstLayerITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcazResNoFirstLayerITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcazResNoFirstLayerITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    hDcaxyReskAnyITS[pdgCode]->SetLineWidth(2);
+    hDcaxyReskAnyITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcaxyReskAnyITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcaxyReskAnyITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    hDcazReskAnyITS[pdgCode]->SetLineWidth(2);
+    hDcazReskAnyITS[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcazReskAnyITS[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcazReskAnyITS[pdgCode]->SetMarkerStyle(kFullCircle);
+
+    // ITS-TPC
+    hPtResAllLayersITSTPC[pdgCode]->SetLineWidth(2);
+    hPtResAllLayersITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hPtResAllLayersITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hPtResAllLayersITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+
+    hDcaxyResAllLayersITSTPC[pdgCode]->SetLineWidth(2);
+    hDcaxyResAllLayersITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcaxyResAllLayersITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcaxyResAllLayersITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+
+    hDcazResAllLayersITSTPC[pdgCode]->SetLineWidth(2);
+    hDcazResAllLayersITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcazResAllLayersITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcazResAllLayersITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+
+    hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetLineWidth(2);
+    hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+
+    hDcazResNoFirstLayerITSTPC[pdgCode]->SetLineWidth(2);
+    hDcazResNoFirstLayerITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcazResNoFirstLayerITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcazResNoFirstLayerITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+
+    hDcaxyReskAnyITSTPC[pdgCode]->SetLineWidth(2);
+    hDcaxyReskAnyITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcaxyReskAnyITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcaxyReskAnyITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+
+    hDcazReskAnyITSTPC[pdgCode]->SetLineWidth(2);
+    hDcazReskAnyITSTPC[pdgCode]->SetMarkerColor(colors[pdgCode]);
+    hDcazReskAnyITSTPC[pdgCode]->SetLineColor(colors[pdgCode]);
+    hDcazReskAnyITSTPC[pdgCode]->SetMarkerStyle(kOpenCircle);
+  }
+
+  /// Output
+  // ITS
+  auto canvPtDeltaITS = new TCanvas("canvPtDeltaITS", "", 1500, 500);
+  canvPtDeltaITS->Divide(nSpecies, 1);
+  canvPtDeltaITS->cd(1)->SetLogz();
+  hDeltaPtVsPtAllLayersITS[11]->Draw("colz");
+  canvPtDeltaITS->cd(2)->SetLogz();
+  hDeltaPtVsPtAllLayersITS[211]->Draw("colz");
+  canvPtDeltaITS->cd(3)->SetLogz();
+  hDeltaPtVsPtAllLayersITS[321]->Draw("colz");
+  canvPtDeltaITS->cd(4)->SetLogz();
+  hDeltaPtVsPtAllLayersITS[2212]->Draw("colz");
+
+  auto canvDcaVsPtITS = new TCanvas("canvDcaVsPtITS", "", 1500, 1000);
+  canvDcaVsPtITS->Divide(nSpecies, 2);
+  canvDcaVsPtITS->cd(1)->SetLogz();
+  hDcaxyVsPtAllLayersITS[11]->Draw("colz");
+  canvDcaVsPtITS->cd(2)->SetLogz();
+  hDcaxyVsPtAllLayersITS[211]->Draw("colz");
+  canvDcaVsPtITS->cd(3)->SetLogz();
+  hDcaxyVsPtAllLayersITS[321]->Draw("colz");
+  canvDcaVsPtITS->cd(4)->SetLogz();
+  hDcaxyVsPtAllLayersITS[2212]->Draw("colz");
+  canvDcaVsPtITS->cd(5)->SetLogz();
+  hDcazVsPtAllLayersITS[11]->Draw("colz");
+  canvDcaVsPtITS->cd(6)->SetLogz();
+  hDcazVsPtAllLayersITS[211]->Draw("colz");
+  canvDcaVsPtITS->cd(7)->SetLogz();
+  hDcazVsPtAllLayersITS[321]->Draw("colz");
+  canvDcaVsPtITS->cd(8)->SetLogz();
+  hDcazVsPtAllLayersITS[2212]->Draw("colz");
+
+  auto canvPtResITS = new TCanvas("canvPtResITS", "", 500, 500);
+  canvPtResITS->DrawFrame(ptLimits[0], 0., ptLimits[nPtBins - 1], 0.2, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})");
+  for (const auto& pdgCode : pdgCodes) {
+    hPtResAllLayersITS[pdgCode]->Draw("same");
+  }
+
+  auto canvDcaxyResITS = new TCanvas("canvDcaxyResITS", "", 500, 500);
+  canvDcaxyResITS->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyResITS->SetLogx();
+  canvDcaxyResITS->SetLogy();
+  canvDcaxyResITS->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcaxyResAllLayersITS[pdgCode]->Draw("same");
+  }
+
+  auto canvDcazResITS = new TCanvas("canvDcazResITS", "", 500, 500);
+  canvDcazResITS->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazResITS->SetLogx();
+  canvDcazResITS->SetLogy();
+  canvDcazResITS->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcazResAllLayersITS[pdgCode]->Draw("same");
+  }
+
+  auto canvDcaxyResNoFirstLayerITS = new TCanvas("canvDcaxyResNoFirstLayerITS", "", 500, 500);
+  canvDcaxyResNoFirstLayerITS->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyResNoFirstLayerITS->SetLogx();
+  canvDcaxyResNoFirstLayerITS->SetLogy();
+  canvDcaxyResNoFirstLayerITS->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcaxyResNoFirstLayerITS[pdgCode]->Draw("same");
+  }
+
+  auto canvDcazResNoFirstLayerITS = new TCanvas("canvDcazResNoFirstLayerITS", "", 500, 500);
+  canvDcazResNoFirstLayerITS->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazResNoFirstLayerITS->SetLogx();
+  canvDcazResNoFirstLayerITS->SetLogy();
+  canvDcazResNoFirstLayerITS->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcazResNoFirstLayerITS[pdgCode]->Draw("same");
+  }
+
+  auto canvDcaxyReskAnyITS = new TCanvas("canvDcaxyReskAnyITS", "", 500, 500);
+  canvDcaxyReskAnyITS->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyReskAnyITS->SetLogx();
+  canvDcaxyReskAnyITS->SetLogy();
+  canvDcaxyReskAnyITS->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcaxyReskAnyITS[pdgCode]->Draw("same");
+  }
+
+  auto canvDcazReskAnyITS = new TCanvas("canvDcazReskAnyITS", "", 500, 500);
+  canvDcazReskAnyITS->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazReskAnyITS->SetLogx();
+  canvDcazReskAnyITS->SetLogy();
+  canvDcazReskAnyITS->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcazReskAnyITS[pdgCode]->Draw("same");
+  }
+
+  // ITS-TPC
+  auto canvPtDeltaITSTPC = new TCanvas("canvPtDeltaITSTPC", "", 1500, 500);
+  canvPtDeltaITSTPC->Divide(nSpecies, 1);
+  canvPtDeltaITSTPC->cd(1)->SetLogz();
+  hDeltaPtVsPtAllLayersITSTPC[11]->Draw("colz");
+  canvPtDeltaITSTPC->cd(2)->SetLogz();
+  hDeltaPtVsPtAllLayersITSTPC[211]->Draw("colz");
+  canvPtDeltaITSTPC->cd(3)->SetLogz();
+  hDeltaPtVsPtAllLayersITSTPC[321]->Draw("colz");
+  canvPtDeltaITSTPC->cd(4)->SetLogz();
+  hDeltaPtVsPtAllLayersITSTPC[2212]->Draw("colz");
+
+  auto canvDcaVsPtITSTPC = new TCanvas("canvDcaVsPtITSTPC", "", 1500, 1000);
+  canvDcaVsPtITSTPC->Divide(nSpecies, 2);
+  canvDcaVsPtITSTPC->cd(1)->SetLogz();
+  hDcaxyVsPtAllLayersITSTPC[11]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(2)->SetLogz();
+  hDcaxyVsPtAllLayersITSTPC[211]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(3)->SetLogz();
+  hDcaxyVsPtAllLayersITSTPC[321]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(4)->SetLogz();
+  hDcaxyVsPtAllLayersITSTPC[2212]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(5)->SetLogz();
+  hDcazVsPtAllLayersITSTPC[11]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(6)->SetLogz();
+  hDcazVsPtAllLayersITSTPC[211]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(7)->SetLogz();
+  hDcazVsPtAllLayersITSTPC[321]->Draw("colz");
+  canvDcaVsPtITSTPC->cd(8)->SetLogz();
+  hDcazVsPtAllLayersITSTPC[2212]->Draw("colz");
+
+  auto canvPtResITSTPC = new TCanvas("canvPtResITSTPC", "", 500, 500);
+  canvPtResITSTPC->DrawFrame(ptLimits[0], 0., ptLimits[nPtBins - 1], 0.2, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})");
+  for (const auto& pdgCode : pdgCodes) {
+    hPtResAllLayersITSTPC[pdgCode]->Draw("same");
+  }
+
+  auto canvDcaxyResITSTPC = new TCanvas("canvDcaxyResITSTPC", "", 500, 500);
+  canvDcaxyResITSTPC->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyResITSTPC->SetLogx();
+  canvDcaxyResITSTPC->SetLogy();
+  canvDcaxyResITSTPC->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcaxyResAllLayersITSTPC[pdgCode]->Draw("same");
+  }
+
+  auto canvDcazResITSTPC = new TCanvas("canvDcazResITSTPC", "", 500, 500);
+  canvDcazResITSTPC->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazResITSTPC->SetLogx();
+  canvDcazResITSTPC->SetLogy();
+  canvDcazResITSTPC->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcazResAllLayersITSTPC[pdgCode]->Draw("same");
+  }
+
+  auto canvDcaxyResNoFirstLayerITSTPC = new TCanvas("canvDcaxyResNoFirstLayerITSTPC", "", 500, 500);
+  canvDcaxyResNoFirstLayerITSTPC->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyResNoFirstLayerITSTPC->SetLogx();
+  canvDcaxyResNoFirstLayerITSTPC->SetLogy();
+  canvDcaxyResNoFirstLayerITSTPC->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcaxyResNoFirstLayerITSTPC[pdgCode]->Draw("same");
+  }
+
+  auto canvDcazResNoFirstLayerITSTPC = new TCanvas("canvDcazResNoFirstLayerITSTPC", "", 500, 500);
+  canvDcazResNoFirstLayerITSTPC->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazResNoFirstLayerITSTPC->SetLogx();
+  canvDcazResNoFirstLayerITSTPC->SetLogy();
+  canvDcazResNoFirstLayerITSTPC->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcazResNoFirstLayerITSTPC[pdgCode]->Draw("same");
+  }
+
+  auto canvDcaxyReskAnyITSTPC = new TCanvas("canvDcaxyReskAnyITSTPC", "", 500, 500);
+  canvDcaxyReskAnyITSTPC->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyReskAnyITSTPC->SetLogx();
+  canvDcaxyReskAnyITSTPC->SetLogy();
+  canvDcaxyReskAnyITSTPC->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcaxyReskAnyITSTPC[pdgCode]->Draw("same");
+  }
+
+  auto canvDcazReskAnyITSTPC = new TCanvas("canvDcazReskAnyITSTPC", "", 500, 500);
+  canvDcazReskAnyITSTPC->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS-TPC;#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazReskAnyITSTPC->SetLogx();
+  canvDcazReskAnyITSTPC->SetLogy();
+  canvDcazReskAnyITSTPC->SetGrid();
+  for (const auto& pdgCode : pdgCodes) {
+    hDcazReskAnyITSTPC[pdgCode]->Draw("same");
+  }
+
+  // Compare ITS-TPC resolution;
+  auto canvDcaxyResComp = new TCanvas("canvDcaxyResAllLayersComp", "", 500, 500);
+  canvDcaxyResComp->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS vs. ITS-TPC (all layers);#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{xy}}) (#mum)");
+  canvDcaxyResComp->SetLogx();
+  canvDcaxyResComp->SetLogy();
+  canvDcaxyResComp->SetGrid();
+  hDcaxyResAllLayersITS[211]->Draw("same");
+  hDcaxyResAllLayersITSTPC[211]->Draw("same");
+  gPad->BuildLegend(0.8, 0.8, 0.94, 0.94);
+
+  auto canvDcazResComp = new TCanvas("canvDcazResAllLayersComp", "", 500, 500);
+  canvDcazResComp->DrawFrame(ptLimits[0], 1., ptLimits[nPtBins - 1], 1.e3, "ITS vs. ITS-TPC (all layers);#it{p}_{T} (GeV/#it{c});#sigma(DCA_{#it{z}}) (#mum)");
+  canvDcazResComp->SetLogx();
+  canvDcazResComp->SetLogy();
+  canvDcazResComp->SetGrid();
+  hDcazResAllLayersITS[211]->Draw("same");
+  hDcazResAllLayersITSTPC[211]->Draw("same");
+  gPad->BuildLegend(0.8, 0.8, 0.94, 0.94);
+
+  auto canvPtResComp = new TCanvas("canvPtResAllLayersComp", "", 500, 500);
+  canvPtResComp->DrawFrame(ptLimits[0], 0., ptLimits[nPtBins - 1], 0.2, "ITS vs. ITS-TPC (all layers);#it{p}_{T} (GeV/#it{c});#sigma(#Delta#it{p}_{T}/#it{p}_{T})");
+  canvPtResComp->SetLogx();
+  canvPtResComp->SetGrid();
+  hPtResAllLayersITS[211]->Draw("same");
+  hPtResAllLayersITSTPC[211]->Draw("same");
+  gPad->BuildLegend(0.8, 0.8, 0.94, 0.94);
+
+  auto canvDcaPtComp = new TCanvas("canvDcaPtAllLayersComp", "", 500, 500);
+  canvDcaPtComp->Divide(2, 2);
+  canvDcaPtComp->cd(1);
+  hDcaxyVsPtAllLayersITS[211]->Draw();
+  canvDcaPtComp->cd(2);
+  hDcazVsPtAllLayersITS[211]->Draw();
+  canvDcaPtComp->cd(3);
+  hDcaxyVsPtAllLayersITSTPC[211]->Draw();
+  canvDcaPtComp->cd(4);
+  hDcazVsPtAllLayersITSTPC[211]->Draw();
+
+  auto canvDcaPhiComp = new TCanvas("canvDcaPhiAllLayersComp", "", 500, 500);
+  canvDcaPhiComp->Divide(2, 2);
+  canvDcaPhiComp->cd(1);
+  hDcaxyVsPhiAllLayersITS[211]->Draw();
+  canvDcaPhiComp->cd(2);
+  hDcazVsPhiAllLayersITS[211]->Draw();
+  canvDcaPhiComp->cd(3);
+  hDcaxyVsPhiAllLayersITSTPC[211]->Draw();
+  canvDcaPhiComp->cd(4);
+  hDcazVsPhiAllLayersITSTPC[211]->Draw();
+
+  // Write
+  TFile outFile("checkDCA.root", "RECREATE");
+  outFile.mkdir("ITS");
+  outFile.cd("ITS");
+  gDirectory->WriteTObject(canvPtResITS);
+  gDirectory->WriteTObject(canvDcaxyResITS);
+  gDirectory->WriteTObject(canvDcazResITS);
+  gDirectory->WriteTObject(canvDcazResNoFirstLayerITS);
+  gDirectory->WriteTObject(canvDcaxyResNoFirstLayerITS);
+  gDirectory->WriteTObject(canvDcaxyReskAnyITS);
+  gDirectory->WriteTObject(canvDcazReskAnyITS);
+  gDirectory->WriteTObject(canvPtDeltaITS);
+  gDirectory->WriteTObject(canvDcaVsPtITS);
+
+  outFile.mkdir("ITS-TPC");
+  outFile.cd("ITS-TPC");
+  gDirectory->WriteTObject(canvPtResITSTPC);
+  gDirectory->WriteTObject(canvDcaxyResITSTPC);
+  gDirectory->WriteTObject(canvDcazResITSTPC);
+  gDirectory->WriteTObject(canvDcazResNoFirstLayerITSTPC);
+  gDirectory->WriteTObject(canvDcaxyResNoFirstLayerITSTPC);
+  gDirectory->WriteTObject(canvDcaxyReskAnyITSTPC);
+  gDirectory->WriteTObject(canvDcazReskAnyITSTPC);
+  gDirectory->WriteTObject(canvPtDeltaITSTPC);
+  gDirectory->WriteTObject(canvDcaVsPtITSTPC);
+
+  outFile.mkdir("Compare");
+  outFile.cd("Compare");
+  gDirectory->WriteTObject(canvDcaxyResComp);
+  gDirectory->WriteTObject(canvDcazResComp);
+  gDirectory->WriteTObject(canvPtResComp);
+  gDirectory->WriteTObject(canvDcaPtComp);
+  gDirectory->WriteTObject(canvDcaPhiComp);
+
+  for (const auto& pdgCode : pdgCodes) {
+    const char* dirName = partNames[pdgCode].c_str();
+    auto dir = outFile.mkdir(dirName);
+    outFile.cd(dirName);
+
+    gDirectory->mkdir("ITS");
+    gDirectory->cd("ITS");
+    gDirectory->WriteTObject(hDeltaPtVsPtAllLayersITS[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyVsPtAllLayersITS[pdgCode]);
+    gDirectory->WriteTObject(hDcazVsPtAllLayersITS[pdgCode]);
+    gDirectory->WriteTObject(hDcazResAllLayersITS[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyResAllLayersITS[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyVsPtNoFirstLayerITS[pdgCode]);
+    gDirectory->WriteTObject(hDcazVsPtNoFirstLayerITS[pdgCode]);
+    gDirectory->WriteTObject(hDcazResNoFirstLayerITS[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyResNoFirstLayerITS[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyVsPhiAllLayersITS[pdgCode]);
+    gDirectory->WriteTObject(hDcazVsPhiAllLayersITS[pdgCode]);
+
+    dir->cd();
+    gDirectory->mkdir("ITS-TPC");
+    gDirectory->cd("ITS-TPC");
+    gDirectory->WriteTObject(hDeltaPtVsPtAllLayersITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyVsPtAllLayersITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcazVsPtAllLayersITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcazResAllLayersITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyResAllLayersITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyVsPtNoFirstLayerITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcazVsPtNoFirstLayerITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcazResNoFirstLayerITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyResNoFirstLayerITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcaxyVsPhiAllLayersITSTPC[pdgCode]);
+    gDirectory->WriteTObject(hDcazVsPhiAllLayersITSTPC[pdgCode]);
+  }
+}

--- a/Detectors/Upgrades/ITS3/macros/test/CheckDCA.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckDCA.C
@@ -22,6 +22,7 @@
 #include <TLegend.h>
 #include <TPad.h>
 #include <TTree.h>
+#include <TList.h>
 #include <TSystem.h>
 
 #include "DataFormatsITS/TrackITS.h"
@@ -462,6 +463,20 @@ void CheckDCA(const std::string& collisioncontextFileName = "collisioncontext.ro
 
   LOGP(info, "Projecting Plots");
   TH1* hProj;
+  const char* fitOpt{"QWMER"};
+  /* const char* fitOpt{"Q"}; */
+  std::map<int, TList*> lProjITS = {
+    {11, new TList()},
+    {211, new TList()},
+    {321, new TList()},
+    {2212, new TList()},
+  };
+  std::map<int, TList*> lProjITSTPC = {
+    {11, new TList()},
+    {211, new TList()},
+    {321, new TList()},
+    {2212, new TList()},
+  };
   for (const auto& pdgCode : pdgCodes) {
     for (auto iPt{0}; iPt < nPtBins; ++iPt) {
       // ITS
@@ -469,44 +484,52 @@ void CheckDCA(const std::string& collisioncontextFileName = "collisioncontext.ro
       float minFit = (ptMin < 1.) ? -200. : -50.;
       float maxFit = (ptMin < 1.) ? 200. : 50.;
 
-      hProj = hDeltaPtVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDeltaPt%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0");
+      hProj = hDeltaPtVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDeltaPtAll%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt);
+      lProjITS[pdgCode]->Add(hProj);
       hPtResAllLayersITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hPtResAllLayersITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcaxyVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcaxyVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDcaxyAll%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITS[pdgCode]->Add(hProj);
       hDcaxyResAllLayersITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcaxyResAllLayersITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcazVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcazVsPtAllLayersITS[pdgCode]->ProjectionY(Form("hProjDcazAll%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITS[pdgCode]->Add(hProj);
       hDcazResAllLayersITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcazResAllLayersITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcaxyVsPtNoFirstLayerITS[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcaxyVsPtNoFirstLayerITS[pdgCode]->ProjectionY(Form("hProjDcaxyNoFirst%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITS[pdgCode]->Add(hProj);
       hDcaxyResNoFirstLayerITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcaxyResNoFirstLayerITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcazVsPtNoFirstLayerITS[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcazVsPtNoFirstLayerITS[pdgCode]->ProjectionY(Form("hProjDcazNoFirst%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITS[pdgCode]->Add(hProj);
       hDcazResNoFirstLayerITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcazResNoFirstLayerITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcaxyVsPtkAnyITS[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcaxyVsPtkAnyITS[pdgCode]->ProjectionY(Form("hProjDcaxyAny%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITS[pdgCode]->Add(hProj);
       hDcaxyReskAnyITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcaxyReskAnyITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcazVsPtkAnyITS[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcazVsPtkAnyITS[pdgCode]->ProjectionY(Form("hProjDcazAny%d__%dITS", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITS[pdgCode]->Add(hProj);
       hDcazReskAnyITS[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcazReskAnyITS[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
       // ITS-TPC
-      hProj = hDeltaPtVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDeltaPt%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0");
+      hProj = hDeltaPtVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDeltaPtAll%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hPtResAllLayersITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hPtResAllLayersITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
@@ -514,33 +537,39 @@ void CheckDCA(const std::string& collisioncontextFileName = "collisioncontext.ro
       minFit = (ptMin < 1.) ? -200. : -50.;
       maxFit = (ptMin < 1.) ? 200. : 50.;
 
-      hProj = hDcaxyVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcaxyVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxyAll%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hDcaxyResAllLayersITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcaxyResAllLayersITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcazVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcazVsPtAllLayersITSTPC[pdgCode]->ProjectionY(Form("hProjDcazAll%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hDcazResAllLayersITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcazResAllLayersITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcaxyVsPtNoFirstLayerITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcaxyVsPtNoFirstLayerITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxyNoFirst%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcaxyResNoFirstLayerITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcazVsPtNoFirstLayerITSTPC[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcazVsPtNoFirstLayerITSTPC[pdgCode]->ProjectionY(Form("hProjDcazNoFirst%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hDcazResNoFirstLayerITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcazResNoFirstLayerITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcaxyVsPtkAnyITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxy%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcaxyVsPtkAnyITSTPC[pdgCode]->ProjectionY(Form("hProjDcaxAnty%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hDcaxyReskAnyITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcaxyReskAnyITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
 
-      hProj = hDcazVsPtkAnyITSTPC[pdgCode]->ProjectionY(Form("hProjDcaz%d%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
-      hProj->Fit("fGaus", "Q0", "", minFit, maxFit);
+      hProj = hDcazVsPtkAnyITSTPC[pdgCode]->ProjectionY(Form("hProjDcazAny%d__%dITSTPC", pdgCode, iPt), iPt + 1, iPt + 1);
+      hProj->Fit("fGaus", fitOpt, "", minFit, maxFit);
+      lProjITSTPC[pdgCode]->Add(hProj);
       hDcazReskAnyITSTPC[pdgCode]->SetBinContent(iPt + 1, fGaus->GetParameter(2));
       hDcazReskAnyITSTPC[pdgCode]->SetBinError(iPt + 1, fGaus->GetParError(2));
     }
@@ -907,6 +936,11 @@ void CheckDCA(const std::string& collisioncontextFileName = "collisioncontext.ro
     gDirectory->WriteTObject(hDcaxyResNoFirstLayerITS[pdgCode]);
     gDirectory->WriteTObject(hDcaxyVsPhiAllLayersITS[pdgCode]);
     gDirectory->WriteTObject(hDcazVsPhiAllLayersITS[pdgCode]);
+    gDirectory->mkdir("projections");
+    gDirectory->cd("projections");
+    for (TObject* obj : *lProjITS[pdgCode]) {
+      obj->Write();
+    }
 
     dir->cd();
     gDirectory->mkdir("ITS-TPC");
@@ -922,5 +956,10 @@ void CheckDCA(const std::string& collisioncontextFileName = "collisioncontext.ro
     gDirectory->WriteTObject(hDcaxyResNoFirstLayerITSTPC[pdgCode]);
     gDirectory->WriteTObject(hDcaxyVsPhiAllLayersITSTPC[pdgCode]);
     gDirectory->WriteTObject(hDcazVsPhiAllLayersITSTPC[pdgCode]);
+    gDirectory->mkdir("projections");
+    gDirectory->cd("projections");
+    for (TObject* obj : *lProjITSTPC[pdgCode]) {
+      obj->Write();
+    }
   }
 }

--- a/Detectors/Upgrades/ITS3/macros/test/CheckROFs.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckROFs.C
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CheckROFs.C
+/// \brief Simple macro to check ITS3 ROFs
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TROOT.h>
+#include <TCanvas.h>
+#include "TEfficiency.h"
+#include <TClonesArray.h>
+#include <TFile.h>
+#include <TH2F.h>
+#include <THStack.h>
+#include <TLegend.h>
+#include <TGraph.h>
+#include <TPad.h>
+#include <TTree.h>
+
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <vector>
+#include <span>
+#endif
+
+void CheckROFs(std::string_view tracfile = "tf1/o2trac_its.root")
+{
+  TFile::Open(tracfile.data());
+  TTree* recTree = (TTree*)gFile->Get("o2sim");
+  std::vector<o2::its::TrackITS> recArr, *recArrPtr{&recArr};
+  recTree->SetBranchAddress("ITSTrack", &recArrPtr);
+  std::vector<o2::itsmft::ROFRecord> rofs, *rofsPtr{&rofs};
+  recTree->SetBranchAddress("ITSTracksROF", &rofsPtr);
+
+  std::vector<size_t> nTracksROF;
+
+  for (int iEntry{0}; recTree->LoadTree(iEntry) >= 0; ++iEntry) {
+    recTree->GetEntry(iEntry);
+
+    for (const auto& rof : rofs) {
+      auto trcs = std::span{recArr.cbegin() + rof.getFirstEntry(), recArr.cbegin() + rof.getFirstEntry() + rof.getNEntries()};
+      nTracksROF.push_back(trcs.size());
+    }
+  }
+
+  auto gNTracks = new TGraph(nTracksROF.size());
+  gNTracks->GetXaxis()->SetTitle("rof");
+  gNTracks->GetYaxis()->SetTitle("nTracks");
+  for (int i{0}; i < nTracksROF.size(); ++i) {
+    gNTracks->SetPoint(i, i, nTracksROF[i]);
+  }
+  gNTracks->Draw("apl");
+}

--- a/Detectors/Upgrades/ITS3/macros/test/CheckTracksITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckTracksITS3.C
@@ -70,12 +70,12 @@ struct ParticleInfo {
 
 #pragma link C++ class ParticleInfo + ;
 
-void CheckTracksITS3(const std::string& tracfile = "o2trac_its3.root",
-                     const std::string& clusfile = "o2clus_it3.root",
+void CheckTracksITS3(const std::string& tracfile = "o2trac_its.root",
+                     const std::string& clusfile = "o2clus_its.root",
                      const std::string& kinefile = "o2sim_Kine.root",
                      const std::string& magfile = "o2sim_grp.root",
                      const std::string& inputGeom = "o2sim_geometry.root",
-                     bool batch = true)
+                     bool batch = false)
 {
   gROOT->SetBatch(batch);
 
@@ -104,19 +104,19 @@ void CheckTracksITS3(const std::string& tracfile = "o2trac_its3.root",
   TTree* clusTree = (TTree*)gFile->Get("o2sim");
   std::vector<o2::itsmft::CompClusterExt>* clusArr = nullptr;
   std::vector<CompClusterExt>* clusArrITS = nullptr;
-  clusTree->SetBranchAddress("IT3ClusterComp", &clusArr);
+  clusTree->SetBranchAddress("ITSClusterComp", &clusArr);
   // Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
-  clusTree->SetBranchAddress("IT3ClusterMCTruth", &clusLabArr);
+  clusTree->SetBranchAddress("ITSClusterMCTruth", &clusLabArr);
 
   // Reconstructed tracks
   TFile::Open(tracfile.data());
   TTree* recTree = (TTree*)gFile->Get("o2sim");
   std::vector<TrackITS>* recArr = nullptr;
-  recTree->SetBranchAddress("IT3Track", &recArr);
+  recTree->SetBranchAddress("ITSTrack", &recArr);
   // Track MC labels
   std::vector<o2::MCCompLabel>* trkLabArr = nullptr;
-  recTree->SetBranchAddress("IT3TrackMCTruth", &trkLabArr);
+  recTree->SetBranchAddress("ITSTrackMCTruth", &trkLabArr);
 
   std::cout << "** Filling particle table ... " << std::flush;
   int lastEventIDcl = -1, cf = 0;

--- a/Detectors/Upgrades/ITS3/reconstruction/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/reconstruction/CMakeLists.txt
@@ -8,6 +8,9 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
+#
+
+#add_compile_options(-O0 -g -fPIC -fno-omit-frame-pointer)
 
 o2_add_library(ITS3Reconstruction
                TARGETVARNAME targetName

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/Clusterer.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/Clusterer.h
@@ -121,8 +121,8 @@ class Clusterer
   };
 
   struct ClustererThread {
-    int id = -1;
     Clusterer* parent = nullptr; // parent clusterer
+    int id = -1;
     // buffers for entries in preClusterIndices in 2 columns, to avoid boundary checks, we reserve
     // extra elements in the beginning and the end
     int* column1 = nullptr;

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
@@ -10,35 +10,55 @@
 // or submit itself to any jurisdiction.
 #include <gsl/gsl>
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "ReconstructionDataFormats/BaseCluster.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#include "ITStracking/TimeFrame.h"
+#include "ITStracking/IOUtils.h"
+#include "ITS3Base/SegmentationSuperAlpide.h"
+#include "ITS3Base/SpecsV2.h"
 
-namespace o2
+namespace o2::its3::ioutils
 {
-namespace its
+using SSAlpide = o2::its3::SegmentationSuperAlpide;
+constexpr float DefClusErrorRow = o2::its3::SegmentationSuperAlpide::mPitchRow * 0.5;
+constexpr float DefClusErrorCol = o2::its3::SegmentationSuperAlpide::mPitchCol * 0.5;
+constexpr float DefClusError2Row = DefClusErrorRow * DefClusErrorRow;
+constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
+
+template <class iterator, typename T = float>
+o2::math_utils::Point3D<T> extractClusterData(const itsmft::CompClusterExt& c, iterator& iter, const its3::TopologyDictionary* dict, T& sig2y, T& sig2z)
 {
-class TimeFrame;
+  auto pattID = c.getPatternID();
+  // Dummy COG errors (about half pixel size)
+  sig2y = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusErrorRow : o2::its::ioutils::DefClusErrorRow;
+  sig2z = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusErrorCol : o2::its::ioutils::DefClusErrorCol;
+  if (pattID != itsmft::CompCluster::InvalidPatternID) {
+    sig2y = dict->getErr2X(pattID);
+    sig2z = dict->getErr2Z(pattID);
+    if (!dict->isGroup(pattID)) {
+      return dict->getClusterCoordinates<T>(c);
+    } else {
+      o2::itsmft::ClusterPattern patt(iter);
+      return dict->getClusterCoordinates<T>(c, patt);
+    }
+  } else {
+    o2::itsmft::ClusterPattern patt(iter);
+    return dict->getClusterCoordinates<T>(c, patt, false);
+  }
 }
-namespace itsmft
-{
-class ROFRecord;
-class CompClusterExt;
-} // namespace itsmft
 
-namespace dataformats
-{
-class MCCompLabel;
-} // namespace dataformats
-namespace its3
-{
-class TopologyDictionary;
+void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
+                            gsl::span<const unsigned char>::iterator& pattIt,
+                            std::vector<o2::BaseCluster<float>>& output,
+                            const its3::TopologyDictionary* dict);
 
-namespace ioutils
-{
 int loadROFrameDataITS3(its::TimeFrame* tf,
                         gsl::span<o2::itsmft::ROFRecord> rofs,
                         gsl::span<const itsmft::CompClusterExt> clusters,
                         gsl::span<const unsigned char>::iterator& pattIt,
                         const its3::TopologyDictionary* dict,
                         const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
-}
-} // namespace its3
-} // namespace o2
+
+} // namespace o2::its3::ioutils

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
@@ -35,8 +35,8 @@ o2::math_utils::Point3D<T> extractClusterData(const itsmft::CompClusterExt& c, i
   sig2y = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusErrorRow : o2::its::ioutils::DefClusErrorRow;
   sig2z = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusErrorCol : o2::its::ioutils::DefClusErrorCol;
   if (pattID != itsmft::CompCluster::InvalidPatternID) {
-    sig2y = dict->getErr2X(pattID);
-    sig2z = dict->getErr2Z(pattID);
+    sig2y = dict->getErr2X(pattID) * sig2y; // Error is given in detector coordinates
+    sig2z = dict->getErr2Z(pattID) * sig2z;
     if (!dict->isGroup(pattID)) {
       return dict->getClusterCoordinates<T>(c);
     } else {

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
@@ -32,8 +32,8 @@ o2::math_utils::Point3D<T> extractClusterData(const itsmft::CompClusterExt& c, i
 {
   auto pattID = c.getPatternID();
   // Dummy COG errors (about half pixel size)
-  sig2y = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusErrorRow : o2::its::ioutils::DefClusErrorRow;
-  sig2z = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusErrorCol : o2::its::ioutils::DefClusErrorCol;
+  sig2y = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusError2Row : o2::its::ioutils::DefClusError2Row;
+  sig2z = (constants::detID::isDetITS3(c.getSensorID())) ? DefClusError2Col : o2::its::ioutils::DefClusError2Col;
   if (pattID != itsmft::CompCluster::InvalidPatternID) {
     sig2y = dict->getErr2X(pattID) * sig2y; // Error is given in detector coordinates
     sig2z = dict->getErr2Z(pattID) * sig2z;

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
@@ -120,9 +120,12 @@ class TopologyDictionary
   /// Returns the local position of a compact cluster
 
   /// Returns the local position of a compact cluster
-  math_utils::Point3D<float> getClusterCoordinates(const itsmft::CompClusterExt& cl) const;
+  template <typename T = float>
+  math_utils::Point3D<T> getClusterCoordinates(const itsmft::CompClusterExt& cl) const;
+
   /// Returns the local position of a compact cluster
-  static math_utils::Point3D<float> getClusterCoordinates(const itsmft::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup = true);
+  template <typename T = float>
+  static math_utils::Point3D<T> getClusterCoordinates(const itsmft::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup = true);
 
   static TopologyDictionary* loadFrom(const std::string& fileName = "", const std::string& objName = "ccdb_object");
 

--- a/Detectors/Upgrades/ITS3/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/BuildTopologyDictionary.cxx
@@ -43,8 +43,8 @@ void BuildTopologyDictionary::accountTopology(const itsmft::ClusterTopology& clu
       topInf.mZmean = dZ;
       topoStat.countsWithBias = 1;
     } else { // assign expected sigmas from the pixel X, Z sizes
-      topInf.mXsigma2 = SegmentationSuperAlpide::mPitchRow * SegmentationSuperAlpide::mPitchRow / 12.f / (float)std::min(10, topInf.mSizeX);
-      topInf.mZsigma2 = SegmentationSuperAlpide::mPitchCol * SegmentationSuperAlpide::mPitchCol / 12.f / (float)std::min(10, topInf.mSizeZ);
+      topInf.mXsigma2 = 1.f / 12.f / (float)std::min(10, topInf.mSizeX);
+      topInf.mZsigma2 = 1.f / 12.f / (float)std::min(10, topInf.mSizeZ);
     }
     mMapInfo.emplace(cluster.getHash(), topInf);
   } else {

--- a/Detectors/Upgrades/ITS3/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/BuildTopologyDictionary.cxx
@@ -36,8 +36,6 @@ void BuildTopologyDictionary::accountTopology(const itsmft::ClusterTopology& clu
     //___________________DEFINING_TOPOLOGY_CHARACTERISTICS__________________
     itsmft::TopologyInfo topInf;
     topInf.mPattern.setPattern(cluster.getPattern().data());
-    int& rs = topInf.mSizeX = cluster.getRowSpan();
-    int& cs = topInf.mSizeZ = cluster.getColumnSpan();
     //__________________COG_Determination_____________
     topInf.mNpixels = cluster.getClusterPattern().getCOG(topInf.mCOGx, topInf.mCOGz);
     if (useDf) {
@@ -153,7 +151,7 @@ void BuildTopologyDictionary::groupRareTopologies()
   LOG(info) << "Number of clusters: " << mTotClusters;
 
   double totFreq = 0.;
-  for (int j = 0; j < mNCommonTopologies; j++) {
+  for (unsigned int j = 0; j < mNCommonTopologies; j++) {
     itsmft::GroupStruct gr;
     gr.mHash = mTopologyFrequency[j].second;
     gr.mFrequency = ((double)(mTopologyFrequency[j].first)) / mTotClusters;
@@ -272,7 +270,7 @@ void BuildTopologyDictionary::groupRareTopologies()
 
 std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& DB)
 {
-  for (int i = 0; i < DB.mNCommonTopologies; i++) {
+  for (unsigned int i = 0; i < DB.mNCommonTopologies; i++) {
     const unsigned long& hash = DB.mTopologyFrequency[i].second;
     os << "Hash: " << hash << '\n';
     os << "counts: " << DB.mTopologyMap.find(hash)->second.countsTotal;

--- a/Detectors/Upgrades/ITS3/reconstruction/src/Clusterer.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/Clusterer.cxx
@@ -39,7 +39,6 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
     nThreads = 1;
   }
   auto autoDecode = reader.getDecodeNextAuto();
-  int rofcount{0};
   do {
     if (autoDecode) {
       reader.setDecodeNextAuto(false); // internally do not autodecode
@@ -79,7 +78,7 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
     if (nThreads > mThreads.size()) {
       int oldSz = mThreads.size();
       mThreads.resize(nThreads);
-      for (int i = oldSz; i < nThreads; i++) {
+      for (size_t i = oldSz; i < nThreads; i++) {
         mThreads[i] = std::make_unique<ClustererThread>(this, i);
       }
     }
@@ -108,10 +107,10 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
       mTimerMerge.Start(false);
 #endif
       size_t nClTot = 0, nPattTot = 0;
-      int chid = 0, thrStatIdx[nThreads];
+      int chid = 0;
+      std::vector<size_t> thrStatIdx(nThreads, 0);
       for (int ith = 0; ith < nThreads; ith++) {
         std::sort(mThreads[ith]->stats.begin(), mThreads[ith]->stats.end(), [](const ThreadStat& a, const ThreadStat& b) { return a.firstChip < b.firstChip; });
-        thrStatIdx[ith] = 0;
         nClTot += mThreads[ith]->compClusters.size();
         nPattTot += mThreads[ith]->patterns.size();
       }
@@ -129,7 +128,6 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
             thrStatIdx[ith]++;
             chid += stat.nChips; // next chip to look
             const auto clbeg = mThreads[ith]->compClusters.begin() + stat.firstClus;
-            auto szold = compClus->size();
             compClus->insert(compClus->end(), clbeg, clbeg + stat.nClus);
             if (patterns) {
               const auto ptbeg = mThreads[ith]->patterns.begin() + stat.firstPatt;
@@ -177,7 +175,6 @@ void Clusterer::ClustererThread::process(uint16_t chip, uint16_t nChips, CompClu
         parent->mMaxRowColDiffToMask != 0 ? curChipData->maskFiredInSample(parent->mChipsOld[chipID], parent->mMaxRowColDiffToMask) : curChipData->maskFiredInSample(parent->mChipsOld[chipID]);
       }
     }
-    auto nclus0 = compClusPtr->size();
     auto validPixID = curChipData->getFirstUnmasked();
     auto npix = curChipData->getData().size();
     LOGP(debug, "ClustererThread: Chip={}  npix={} validPixID={} -> valid={} -> singleHit={}", chipID, npix, validPixID, validPixID < npix, validPixID + 1 == npix);
@@ -210,7 +207,7 @@ void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClus
                                             PatternCont* patternsPtr, const ConstMCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
 {
   const auto& pixData = curChipData->getData();
-  for (int i1 = 0; i1 < preClusterHeads.size(); ++i1) {
+  for (size_t i1 = 0; i1 < preClusterHeads.size(); ++i1) {
     auto ci = preClusterIndices[i1];
     if (ci < 0) {
       continue;
@@ -234,7 +231,7 @@ void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClus
       next = pixEntry.first;
     }
     preClusterIndices[i1] = -1;
-    for (int i2 = i1 + 1; i2 < preClusterHeads.size(); ++i2) {
+    for (size_t i2 = i1 + 1; i2 < preClusterHeads.size(); ++i2) {
       if (preClusterIndices[i2] != ci) {
         continue;
       }

--- a/Detectors/Upgrades/ITS3/reconstruction/src/Clusterer.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/Clusterer.cxx
@@ -309,9 +309,7 @@ void Clusterer::ClustererThread::finishChipSingleHitFast(uint32_t hit, ChipPixel
   // add to compact clusters, which must be always filled
   unsigned char patt[ClusterPattern::MaxPatternBytes]{0x1 << (7 - (0 % 8))}; // unrolled 1 hit version of full loop in finishChip
   uint16_t pattID = (parent->mPattIdConverter.size() == 0) ? CompCluster::InvalidPatternID : parent->mPattIdConverter.findGroupID(1, 1, patt);
-  LOGP(debug, "PattID: findGroupID(1,1,{})={}", patt[0], pattID);
   if ((pattID == CompCluster::InvalidPatternID || parent->mPattIdConverter.isGroup(pattID)) && patternsPtr) {
-    LOGP(debug, "ClustererThread: Invalid or Group?");
     patternsPtr->emplace_back(1); // rowspan
     patternsPtr->emplace_back(1); // colspan
     patternsPtr->insert(patternsPtr->end(), std::begin(patt), std::begin(patt) + 1);

--- a/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
@@ -64,6 +64,10 @@ int loadROFrameDataITS3(its::TimeFrame* tf,
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
 
   tf->mNrof = 0;
+
+  std::vector<uint8_t> clusterSizeVec;
+  clusterSizeVec.reserve(clusters.size());
+
   for (auto& rof : rofs) {
     for (int clusterId{rof.getFirstEntry()}; clusterId < rof.getFirstEntry() + rof.getNEntries(); ++clusterId) {
       auto& c = clusters[clusterId];
@@ -76,23 +80,28 @@ int loadROFrameDataITS3(its::TimeFrame* tf,
       float sigmaY2 = o2::its::ioutils::DefClusError2Row, sigmaZ2 = o2::its::ioutils::DefClusError2Col, sigmaYZ = 0; // Dummy COG errors (about half pixel size)
       float pitchRow = isITS3 ? SSAlpide::mPitchRow : o2::itsmft::SegmentationAlpide::PitchRow;
       float pitchCol = isITS3 ? SSAlpide::mPitchCol : o2::itsmft::SegmentationAlpide::PitchCol;
+      unsigned int clusterSize{0};
       if (pattID != itsmft::CompCluster::InvalidPatternID) {
         sigmaY2 = dict->getErr2X(pattID) * pitchRow * pitchRow;
         sigmaZ2 = dict->getErr2Z(pattID) * pitchCol * pitchCol;
         if (!dict->isGroup(pattID)) {
           locXYZ = dict->getClusterCoordinates(c);
+          clusterSize = dict->getNpixels(pattID);
         } else {
           o2::itsmft::ClusterPattern patt(pattIt);
           locXYZ = dict->getClusterCoordinates(c, patt);
           sigmaY2 = patt.getRowSpan() * patt.getRowSpan() * pitchRow * pitchRow / 12.;
           sigmaZ2 = patt.getColumnSpan() * patt.getColumnSpan() * pitchCol * pitchCol / 12.;
+          clusterSize = patt.getNPixels();
         }
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
         sigmaY2 = patt.getRowSpan() * patt.getRowSpan() * pitchRow * pitchRow / 12.;
         sigmaZ2 = patt.getColumnSpan() * patt.getColumnSpan() * pitchCol * pitchCol / 12.;
         locXYZ = dict->getClusterCoordinates(c, patt, false);
+        clusterSize = patt.getNPixels();
       }
+      clusterSizeVec.push_back(std::clamp(clusterSize, 0u, 255u));
 
       // Transformation to the local --> global
       auto gloXYZ = geom->getMatrixL2G(sensorID) * locXYZ;
@@ -121,6 +130,8 @@ int loadROFrameDataITS3(its::TimeFrame* tf,
     }
     tf->mNrof++;
   }
+
+  tf->setClusterSize(clusterSizeVec);
 
   for (auto& v : tf->mNTrackletsPerCluster) {
     v.resize(tf->getUnsortedClusters()[1].size());

--- a/Detectors/Upgrades/ITS3/reconstruction/src/TopologyDictionary.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/TopologyDictionary.cxx
@@ -133,9 +133,10 @@ TH1F* TopologyDictionary::getTopologyDistribution(const std::string_view hname) 
   return histo;
 }
 
-math_utils::Point3D<float> TopologyDictionary::getClusterCoordinates(const itsmft::CompClusterExt& cl) const
+template <typename T>
+math_utils::Point3D<T> TopologyDictionary::getClusterCoordinates(const itsmft::CompClusterExt& cl) const
 {
-  math_utils::Point3D<float> locCl;
+  math_utils::Point3D<T> locCl;
   if (!its3::constants::detID::isDetITS3(cl.getSensorID())) {
     o2::itsmft::SegmentationAlpide::detectorToLocalUnchecked(cl.getRow(), cl.getCol(), locCl);
     locCl.SetX(locCl.X() + this->getXCOG(cl.getPatternID()) * itsmft::SegmentationAlpide::PitchRow);
@@ -152,7 +153,8 @@ math_utils::Point3D<float> TopologyDictionary::getClusterCoordinates(const itsmf
   return locCl;
 }
 
-math_utils::Point3D<float> TopologyDictionary::getClusterCoordinates(const itsmft::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup)
+template <typename T>
+math_utils::Point3D<T> TopologyDictionary::getClusterCoordinates(const itsmft::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup)
 {
   auto refRow = cl.getRow();
   auto refCol = cl.getCol();
@@ -162,7 +164,7 @@ math_utils::Point3D<float> TopologyDictionary::getClusterCoordinates(const itsmf
     refRow -= round(xCOG);
     refCol -= round(zCOG);
   }
-  math_utils::Point3D<float> locCl;
+  math_utils::Point3D<T> locCl;
   if (!its3::constants::detID::isDetITS3(cl.getSensorID())) {
     o2::itsmft::SegmentationAlpide::detectorToLocalUnchecked(refRow + xCOG, refCol + zCOG, locCl);
   } else {
@@ -189,5 +191,9 @@ TopologyDictionary* TopologyDictionary::loadFrom(const std::string& fname, const
   }
   return dict;
 }
+
+// Explicitly instaniate templates
+template math_utils::Point3D<float> TopologyDictionary::getClusterCoordinates<float>(const itsmft::CompClusterExt& cl) const;
+template math_utils::Point3D<float> TopologyDictionary::getClusterCoordinates<float>(const itsmft::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup);
 
 } // namespace o2::its3

--- a/Detectors/Upgrades/ITS3/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/Digitizer.cxx
@@ -34,7 +34,6 @@ using namespace o2::its3;
 
 void Digitizer::init()
 {
-  mGeometry->Print();
   const int numOfChips = mGeometry->getNumberOfChips();
   mChips.resize(numOfChips);
   for (int i = numOfChips; i--;) {
@@ -137,7 +136,7 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
     rcROF.setFirstEntry(mDigits->size()); // start of current ROF in digits
 
     auto& extra = *(mExtraBuff.front().get());
-    for (int iChip{0}; iChip < mChips.size(); ++iChip) {
+    for (size_t iChip{0}; iChip < mChips.size(); ++iChip) {
       auto& chip = mChips[iChip];
       if (constants::detID::isDetITS3(iChip)) { // Check if this is a chip of ITS3
         chip.addNoise(mROFrameMin, mROFrameMin, &mParams, SuperSegmentation::mNRows, SuperSegmentation::mNCols);
@@ -189,6 +188,12 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
 void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID)
 {
   // convert single hit to digits
+  int chipID = hit.GetDetectorID();
+  auto& chip = mChips[chipID];
+  // if (chip.isDisabled()) { // right now we do not have 'dead' chips
+  //   LOG(debug) << "skip disabled chip " << chipID;
+  //   return;
+  // }
   float timeInROF = hit.GetTime() * sec2ns;
   if (timeInROF > 20e3) {
     const int maxWarn = 10;
@@ -368,7 +373,6 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
 
   // fire the pixels assuming Poisson(n_response_electrons)
   o2::MCCompLabel lbl(hit.GetTrackID(), evID, srcID, false);
-  auto& chip = mChips[detID];
   auto roFrameAbs = mNewROFrame + roFrameRel;
   for (int irow = rowSpan; irow--;) {
     uint16_t rowIS = irow + rowS;

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -215,7 +215,7 @@ void ITS3Layer::createSegment()
   mSegment = new TGeoVolumeAssembly(its3TGeo::getITS3SegmentPattern(mNLayer));
   mSegment->VisibleDaughters();
 
-  for (int i{0}; i < nRSUs; ++i) {
+  for (size_t i{0}; i < nRSUs; ++i) {
     auto zMove = new TGeoTranslation(0, 0, +i * constants::rsu::length + constants::rsu::databackbone::length + constants::pixelarray::length / 2.);
     mSegment->AddNode(mRSU, i, zMove);
   }
@@ -249,7 +249,7 @@ void ITS3Layer::createChip()
   mChip = new TGeoVolumeAssembly(its3TGeo::getITS3ChipPattern(mNLayer));
   mChip->VisibleDaughters();
 
-  for (int i{0}; i < constants::nSegments[mNLayer]; ++i) {
+  for (unsigned int i{0}; i < constants::nSegments[mNLayer]; ++i) {
     double phiOffset = constants::segment::width / mR * o2m::Rad2Deg;
     auto rot = new TGeoRotation("", 0, 0, phiOffset * i);
     mChip->AddNode(mSegment, i, rot);
@@ -285,8 +285,8 @@ void ITS3Layer::createCarbonForm()
   auto zMoveHringA = new TGeoTranslation(0, 0, -constants::segment::lec::length + HringLength / 2. + constants::segment::length - HringLength);
 
   // Longerons are made by same material
-  auto longeronR = new TGeoTubeSeg(Form("longeronR%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2, phiSta, phiSta + phiLongeronsCover);
-  auto longeronL = new TGeoTubeSeg(Form("longeronL%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2, phiEnd - phiLongeronsCover, phiEnd);
+  [[maybe_unused]] auto longeronR = new TGeoTubeSeg(Form("longeronR%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2, phiSta, phiSta + phiLongeronsCover);
+  [[maybe_unused]] auto longeronL = new TGeoTubeSeg(Form("longeronL%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2, phiEnd - phiLongeronsCover, phiEnd);
   TString nameLongerons = Form("longeronR%d + longeronL%d", mNLayer, mNLayer);
   auto longerons = new TGeoCompositeShape(nameLongerons);
   auto longeronsVol = new TGeoVolume(Form("longerons%d", mNLayer), longerons, mCarbon);
@@ -311,7 +311,7 @@ TGeoCompositeShape* ITS3Layer::getHringShape(TGeoTubeSeg* Hring)
   for (int iHoles = 0; iHoles < nHoles[mNLayer]; iHoles++) {
     double phiHole = phiHolesSta + stepPhiHoles * iHoles;
     TString nameHole = Form("hole_%d_%d", iHoles, mNLayer);
-    auto hole = new TGeoTube(nameHole, 0, radiusHoles[mNLayer], 3 * Hring->GetDz());
+    [[maybe_unused]] auto hole = new TGeoTube(nameHole, 0, radiusHoles[mNLayer], 3 * Hring->GetDz());
     // move hole to the hring radius
     auto zMoveHole = new TGeoTranslation(Form("zMoveHole_%d_%d", iHoles, mNLayer), radiusHring * cos(phiHole * o2m::Deg2Rad), radiusHring * sin(phiHole * o2m::Deg2Rad), 0);
     zMoveHole->RegisterYourself();

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/ClusterReaderSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/ClusterReaderSpec.h
@@ -47,7 +47,7 @@ class ClusterReader : public Task
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mClusterMCTruth, *mClusterMCTruthPtr = &mClusterMCTruth;
   std::vector<o2::itsmft::MC2ROFRecord> mClusMC2ROFs, *mClusMC2ROFsPtr = &mClusMC2ROFs;
 
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginIT3;
+  o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
 
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
@@ -55,8 +55,9 @@ class ClusterReader : public Task
   bool mUseMC = true;       // use MC truth
   bool mUsePatterns = true; // send patterns
 
-  std::string mDetName = "IT3";
-  std::string mDetNameLC = "it3";
+  std::string mDetName = "ITS"; // pretending to be ITS
+  std::string mDetNameLC = "its";
+  std::string mDetNameReal = "IT3";
   std::string mFileName = "";
   std::string mClusTreeName = "o2sim";
   std::string mClusROFBranchName = "ClustersROF";

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/ClustererSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/ClustererSpec.h
@@ -37,12 +37,12 @@ class ClustererDPL : public Task
  private:
   void updateTimeDependentParams(ProcessingContext& pc);
 
-  int mState = 0;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   bool mUseMC = true;
+  int mState = 0;
   int mNThreads = 1;
   bool mUseClusterDictionary = true;
   std::unique_ptr<o2::its3::Clusterer> mClusterer = nullptr;
-  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
 };
 
 /// create a processor spec

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackReaderSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackReaderSpec.h
@@ -60,13 +60,13 @@ class TrackReader : public o2::framework::Task
   std::unique_ptr<TTree> mTree;
   std::string mInputFileName = "";
   std::string mTrackTreeName = "o2sim";
-  std::string mROFBranchName = "IT3TracksROF";
-  std::string mTrackBranchName = "IT3Track";
-  std::string mClusIdxBranchName = "IT3TrackClusIdx";
+  std::string mROFBranchName = "ITSTracksROF";
+  std::string mTrackBranchName = "ITSTrack";
+  std::string mClusIdxBranchName = "ITSTrackClusIdx";
   std::string mVertexBranchName = "Vertices";
   std::string mVertexROFBranchName = "VerticesROF";
-  std::string mTrackMCTruthBranchName = "IT3TrackMCTruth";
-  std::string mTrackMCVertTruthBranchName = "IT3VertexMCTruth";
+  std::string mTrackMCTruthBranchName = "ITSTrackMCTruth";
+  std::string mTrackMCVertTruthBranchName = "ITSVertexMCTruth";
 };
 
 /// create a processor spec

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
@@ -49,14 +49,14 @@ class TrackerDPL : public framework::Task
  private:
   void updateTimeDependentParams(framework::ProcessingContext& pc);
 
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest{};
   bool mIsMC{false};
-  bool mRunVertexer{true};
-  bool mCosmicsProcessing{false};
   int mUseTriggers{0};
   std::string mMode{"sync"};
-  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest{};
-  o2::its3::TopologyDictionary* mDict{};
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain{};
+  bool mRunVertexer{true};
+  bool mCosmicsProcessing{false};
+  o2::its3::TopologyDictionary* mDict{};
   std::unique_ptr<o2::gpu::GPUChainITS> mChainITS{};
   std::unique_ptr<its::Tracker> mTracker{};
   std::unique_ptr<its::Vertexer> mVertexer{};

--- a/Detectors/Upgrades/ITS3/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/ClusterReaderSpec.cxx
@@ -48,7 +48,7 @@ void ClusterReader::run(ProcessingContext& pc)
   auto ent = mTree->GetReadEntry() + 1;
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
-  LOG(info) << mDetName << "ClusterReader pushes " << mClusROFRec.size() << " ROFRecords,"
+  LOG(info) << mDetNameReal << "ClusterReader pushes " << mClusROFRec.size() << " ROFRecords,"
             << mClusterCompArray.size() << " compact clusters at entry " << ent;
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
@@ -114,7 +114,7 @@ DataProcessorSpec getITS3ClusterReaderSpec(bool useMC, bool usePatterns)
     outputSpec,
     AlgorithmSpec{adaptFromTask<ClusterReader>(useMC, usePatterns)},
     Options{
-      {"its3-cluster-infile", VariantType::String, "o2clus_it3.root", {"Name of the input cluster file"}},
+      {"its-cluster-infile", VariantType::String, "o2clus_its.root", {"Name of the input cluster file"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 }
 

--- a/Detectors/Upgrades/ITS3/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/ClusterWriterSpec.cxx
@@ -48,22 +48,22 @@ DataProcessorSpec getClusterWriterSpec(bool useMC)
     LOG(info) << "ITS3ClusterWriter pulled " << *compClustersSize << " clusters, in " << rofs.size() << " RO frames";
   };
   return MakeRootTreeWriterSpec("its3-cluster-writer",
-                                "o2clus_it3.root",
+                                "o2clus_its.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with ITS clusters"},
-                                BranchDefinition<CompClusType>{InputSpec{"compclus", "IT3", "COMPCLUSTERS", 0},
-                                                               "IT3ClusterComp",
+                                BranchDefinition<CompClusType>{InputSpec{"compclus", "ITS", "COMPCLUSTERS", 0},
+                                                               "ITSClusterComp",
                                                                compClustersSizeGetter},
-                                BranchDefinition<PatternsType>{InputSpec{"patterns", "IT3", "PATTERNS", 0},
-                                                               "IT3ClusterPatt"},
-                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "IT3", "CLUSTERSROF", 0},
-                                                               "IT3ClustersROF",
+                                BranchDefinition<PatternsType>{InputSpec{"patterns", "ITS", "PATTERNS", 0},
+                                                               "ITSClusterPatt"},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "ITS", "CLUSTERSROF", 0},
+                                                               "ITSClustersROF",
                                                                logger},
-                                BranchDefinition<LabelsType>{InputSpec{"labels", "IT3", "CLUSTERSMCTR", 0},
-                                                             "IT3ClusterMCTruth",
+                                BranchDefinition<LabelsType>{InputSpec{"labels", "ITS", "CLUSTERSMCTR", 0},
+                                                             "ITSClusterMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "IT3", "CLUSTERSMC2ROF", 0},
-                                                             "IT3ClustersMC2ROF",
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0},
+                                                             "ITSClustersMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""})();
 }

--- a/Detectors/Upgrades/ITS3/workflow/src/ClustererSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/ClustererSpec.cxx
@@ -74,7 +74,7 @@ void ClustererDPL::run(ProcessingContext& pc)
     reader.setDigitsMCTruth(labels.getIndexedSize() > 0 ? &labels : nullptr);
   }
   reader.init();
-  auto orig = o2::header::gDataOriginIT3;
+  auto orig = o2::header::gDataOriginITS;
   std::vector<o2::itsmft::CompClusterExt> clusCompVec;
   std::vector<o2::itsmft::ROFRecord> clusROFVec;
   std::vector<unsigned char> clusPattVec;
@@ -99,7 +99,7 @@ void ClustererDPL::run(ProcessingContext& pc)
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
   // -> consider recalculationg maxROF
-  LOG(info) << "ITSClusterer pushed " << clusCompVec.size() << " clusters, in " << clusROFVec.size() << " RO frames";
+  LOG(info) << "ITS3Clusterer pushed " << clusCompVec.size() << " clusters, in " << clusROFVec.size() << " RO frames";
 }
 
 ///_______________________________________
@@ -185,15 +185,15 @@ DataProcessorSpec getClustererSpec(bool useMC)
                                                               inputs,
                                                               true);
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("IT3", "COMPCLUSTERS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "PATTERNS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "PATTERNS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "IT3", "DIGITSMCTR", 0, Lifetime::Timeframe);
     inputs.emplace_back("MC2ROframes", "IT3", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
-    outputs.emplace_back("IT3", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("IT3", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackReaderSpec.cxx
@@ -44,11 +44,11 @@ void TrackReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(info) << "Pushing " << mTracks.size() << " track in " << mROFRec.size() << " ROFs at entry " << ent;
-  pc.outputs().snapshot(Output{mOrigin, "IT3TrackROF", 0}, mROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "ITSTrackROF", 0}, mROFRec);
   pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0}, mTracks);
   pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0}, mClusInd);
-  pc.outputs().snapshot(Output{"IT3", "VERTICES", 0}, mVertices);
-  pc.outputs().snapshot(Output{"IT3", "VERTICESROF", 0}, mVerticesROFRec);
+  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0}, mVertices);
+  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0}, mVerticesROFRec);
   if (mUseMC) {
     pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0}, mMCTruth);
     pc.outputs().snapshot(Output{mOrigin, "VERTICESMCTR", 0}, mMCVertTruth);
@@ -96,14 +96,14 @@ void TrackReader::connectTree(const std::string& filename)
 DataProcessorSpec getITS3TrackReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("IT3", "IT3TrackROF", 0, Lifetime::Timeframe);
-  outputSpec.emplace_back("IT3", "TRACKS", 0, Lifetime::Timeframe);
-  outputSpec.emplace_back("IT3", "TRACKCLSID", 0, Lifetime::Timeframe);
-  outputSpec.emplace_back("IT3", "VERTICES", 0, Lifetime::Timeframe);
-  outputSpec.emplace_back("IT3", "VERTICESROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
   if (useMC) {
-    outputSpec.emplace_back("IT3", "TRACKSMCTR", 0, Lifetime::Timeframe);
-    outputSpec.emplace_back("IT3", "VERTICESMCTR", 0, Lifetime::Timeframe);
+    outputSpec.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
+    outputSpec.emplace_back("ITS", "VERTICESMCTR", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{
@@ -112,7 +112,7 @@ DataProcessorSpec getITS3TrackReaderSpec(bool useMC)
     outputSpec,
     AlgorithmSpec{adaptFromTask<TrackReader>(useMC)},
     Options{
-      {"its3-tracks-infile", VariantType::String, "o2trac_its3.root", {"Name of the input ITS3 track file"}},
+      {"its-tracks-infile", VariantType::String, "o2trac_its.root", {"Name of the input ITS3 track file"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 }
 

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackWriterSpec.cxx
@@ -46,31 +46,31 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
   auto logger = [tracksSize](std::vector<o2::itsmft::ROFRecord> const& rofs) {
     LOG(info) << "ITS3TrackWriter pulled " << *tracksSize << " tracks, in " << rofs.size() << " RO frames";
   };
-  return MakeRootTreeWriterSpec("its3-track-writer",
-                                "o2trac_its3.root",
+  return MakeRootTreeWriterSpec("its-track-writer",
+                                "o2trac_its.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with IT3 tracks"},
-                                BranchDefinition<std::vector<o2::its::TrackITS>>{InputSpec{"tracks", "IT3", "TRACKS", 0},
-                                                                                 "IT3Track",
+                                BranchDefinition<std::vector<o2::its::TrackITS>>{InputSpec{"tracks", "ITS", "TRACKS", 0},
+                                                                                 "ITSTrack",
                                                                                  tracksSizeGetter},
-                                BranchDefinition<std::vector<int>>{InputSpec{"trackClIdx", "IT3", "TRACKCLSID", 0},
-                                                                   "IT3TrackClusIdx"},
-                                BranchDefinition<std::vector<Vertex>>{InputSpec{"vertices", "IT3", "VERTICES", 0},
+                                BranchDefinition<std::vector<int>>{InputSpec{"trackClIdx", "ITS", "TRACKCLSID", 0},
+                                                                   "ITSTrackClusIdx"},
+                                BranchDefinition<std::vector<Vertex>>{InputSpec{"vertices", "ITS", "VERTICES", 0},
                                                                       "Vertices"},
-                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"vtxROF", "IT3", "VERTICESROF", 0},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"vtxROF", "ITS", "VERTICESROF", 0},
                                                                                      "VerticesROF"},
-                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "IT3", "IT3TrackROF", 0},
-                                                                                     "IT3TracksROF",
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "ITS", "ITSTrackROF", 0},
+                                                                                     "ITSTracksROF",
                                                                                      logger},
-                                BranchDefinition<LabelsType>{InputSpec{"labels", "IT3", "TRACKSMCTR", 0},
-                                                             "IT3TrackMCTruth",
+                                BranchDefinition<LabelsType>{InputSpec{"labels", "ITS", "TRACKSMCTR", 0},
+                                                             "ITSTrackMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<LabelsType>{InputSpec{"labelsVertices", "IT3", "VERTICESMCTR", 0},
-                                                             "IT3VertexMCTruth",
+                                BranchDefinition<LabelsType>{InputSpec{"labelsVertices", "ITS", "VERTICESMCTR", 0},
+                                                             "ITSVertexMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "IT3", "IT3TrackMC2ROF", 0},
-                                                             "IT3TracksMC2ROF",
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSTrackMC2ROF", 0},
+                                                             "ITSTracksMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""})();
 }

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -286,6 +286,7 @@ void TrackerDPL::run(ProcessingContext& pc)
         for (int ic = TrackITSExt::MaxClusters; (ic--) != 0;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
           auto clid = trc.getClusterIndex(ic);
           if (clid >= 0) {
+            trc.setClusterSize(ic, timeFrame->getClusterSize(clid));
             allClusIdx.push_back(clid);
             nclf++;
           }

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -282,7 +282,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (unsigned int iTrk{0}; iTrk < tracks.size(); ++iTrk) {
         auto& trc{tracks[iTrk]};
         trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
-        int nclf = 0;
+        int nclf = 0, ncl = (int)allClusIdx.size();
         for (int ic = TrackITSExt::MaxClusters; (ic--) != 0;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
           auto clid = trc.getClusterIndex(ic);
           if (clid >= 0) {

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -156,10 +156,11 @@ void TrackerDPL::run(ProcessingContext& pc)
   // we therefore need a copy of the vector rather than an object created directly on the input data,
   // the output vector however is created directly inside the message memory thus avoiding copy by
   // snapshot
+  auto orig = o2::header::gDataOriginITS;
   auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"IT3", "IT3TrackROF", 0}, rofsinput.begin(), rofsinput.end());
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{orig, "ITSTrackROF", 0}, rofsinput.begin(), rofsinput.end());
 
-  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"IT3", "IRFRAMES", 0});
+  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{orig, "IRFRAMES", 0});
 
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
   int nBCPerTF = alpParams.roFrameLengthInBC;
@@ -175,15 +176,15 @@ void TrackerDPL::run(ProcessingContext& pc)
     LOG(info) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
   }
 
-  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"IT3", "TRACKCLSID", 0});
+  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{orig, "TRACKCLSID", 0});
   std::vector<o2::MCCompLabel> trackLabels;
   std::vector<MCCompLabel> verticesLabels;
-  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"IT3", "TRACKS", 0});
+  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{orig, "TRACKS", 0});
   std::vector<o2::MCCompLabel> allTrackLabels;
   std::vector<o2::MCCompLabel> allVerticesLabels;
 
-  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"IT3", "VERTICESROF", 0});
-  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"IT3", "VERTICES", 0});
+  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{orig, "VERTICESROF", 0});
+  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{orig, "VERTICES", 0});
 
   TimeFrame* timeFrame = mChainITS->GetITSTimeframe();
   timeFrame->resizeVectors(7);
@@ -211,7 +212,7 @@ void TrackerDPL::run(ProcessingContext& pc)
     vertexerElapsedTime = mVertexer->clustersToVertices(logger);
   }
   const auto& multEstConf = FastMultEstConfig::Instance(); // parameters for mult estimation and cuts
-  for (auto iRof{0}; iRof < rofspan.size(); ++iRof) {
+  for (size_t iRof{0}; iRof < rofspan.size(); ++iRof) {
     std::vector<Vertex> vtxVecLoc;
     auto& vtxROF = vertROFvec.emplace_back(rofspan[iRof]);
     vtxROF.setFirstEntry(vertices.size());
@@ -219,7 +220,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
       vtxROF.setNEntries(vtxSpan.size());
       bool selROF = vtxSpan.size() == 0;
-      for (auto iV{0}; iV < vtxSpan.size(); ++iV) {
+      for (size_t iV{0}; iV < vtxSpan.size(); ++iV) {
         auto& v = vtxSpan[iV];
         if (multEstConf.isVtxMultCutRequested() && !multEstConf.isPassingVtxMultCut(v.getNContributors())) {
           continue; // skip vertex of unwanted multiplicity
@@ -270,7 +271,6 @@ void TrackerDPL::run(ProcessingContext& pc)
       trackLabels = timeFrame->getTracksLabel(iROF);
       auto number{tracks.size()};
       auto first{allTracks.size()};
-      int offset = -rof.getFirstEntry(); // cluster entry!!!
       rof.setFirstEntry(first);
       rof.setNEntries(number);
       if (processingMask[iROF]) {
@@ -282,8 +282,8 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (unsigned int iTrk{0}; iTrk < tracks.size(); ++iTrk) {
         auto& trc{tracks[iTrk]};
         trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
-        int ncl = trc.getNumberOfClusters(), nclf = 0;
-        for (int ic = TrackITSExt::MaxClusters; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
+        int nclf = 0;
+        for (int ic = TrackITSExt::MaxClusters; (ic--) != 0;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
           auto clid = trc.getClusterIndex(ic);
           if (clid >= 0) {
             allClusIdx.push_back(clid);
@@ -300,9 +300,9 @@ void TrackerDPL::run(ProcessingContext& pc)
       LOGP(info, "ITS3Tracker pushed {} track labels", allTrackLabels.size());
       LOGP(info, "ITS3Tracker pushed {} vertex labels", allVerticesLabels.size());
 
-      pc.outputs().snapshot(Output{"IT3", "TRACKSMCTR", 0}, allTrackLabels);
-      pc.outputs().snapshot(Output{"IT3", "VERTICESMCTR", 0}, allVerticesLabels);
-      pc.outputs().snapshot(Output{"IT3", "IT3TrackMC2ROF", 0}, mc2rofs);
+      pc.outputs().snapshot(Output{orig, "TRACKSMCTR", 0}, allTrackLabels);
+      pc.outputs().snapshot(Output{orig, "VERTICESMCTR", 0}, allVerticesLabels);
+      pc.outputs().snapshot(Output{orig, "ITSTrackMC2ROF", 0}, mc2rofs);
     }
   }
   mTimer.Stop();
@@ -341,7 +341,7 @@ void TrackerDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
     return;
   }
   if (matcher == ConcreteDataMatcher("ITS", "GEOMTGEO", 0)) {
-    LOG(info) << "IT3 GeomtetryTGeo loaded from ccdb";
+    LOG(info) << "IT3 GeometryTGeo loaded from ccdb";
     o2::its::GeometryTGeo::adopt((o2::its::GeometryTGeo*)obj);
     return;
   }
@@ -363,11 +363,11 @@ void TrackerDPL::endOfStream(EndOfStreamContext& ec)
 DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType)
 {
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("compClusters", "IT3", "COMPCLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("patterns", "IT3", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "IT3", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
   if (trgType == 1) {
-    inputs.emplace_back("phystrig", "IT3", "PHYSTRIG", 0, Lifetime::Timeframe);
+    inputs.emplace_back("phystrig", "ITS", "PHYSTRIG", 0, Lifetime::Timeframe);
   } else if (trgType == 2) {
     inputs.emplace_back("phystrig", "TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   }
@@ -382,24 +382,24 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, co
                                                               inputs,
                                                               true);
 
-  if (!useGeom) {
+  if (!useGeom) { // load light-weight geometry
     inputs.emplace_back("itsTGeo", "ITS", "GEOMTGEO", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/Geometry"));
   }
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("IT3", "TRACKS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "TRACKCLSID", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "IT3TrackROF", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "VERTICES", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "VERTICESROF", 0, Lifetime::Timeframe);
-  outputs.emplace_back("IT3", "IRFRAMES", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "IRFRAMES", 0, Lifetime::Timeframe);
 
   if (useMC) {
-    inputs.emplace_back("labels", "IT3", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "IT3", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
-    outputs.emplace_back("IT3", "VERTICESMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("IT3", "TRACKSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("IT3", "IT3TrackMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "VERTICESMCTR", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/Upgrades/ITS3/workflow/src/its3-reco-workflow.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/its3-reco-workflow.cxx
@@ -87,5 +87,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // write the configuration used for the reco workflow
   o2::conf::ConfigurableParam::writeINI("o2its3recoflow_configuration.ini");
 
-  return std::move(wf);
+  return wf;
 }


### PR DESCRIPTION
This PR aims to incorporate IT3 into the global-reconstruction chain + make simulation a bit easier:
 - Finds IT3-TPC(-TRD,-TOF) matches, the relevant workflows have now a 'GlobalParams.withITS3' option
 - Reflects the necessary changes in IT3 code

The flags and functionality is hidden behind the compile flag 'ENABLE_UPGRADES' + the default is off.
I tested the full simulation chain for ENABLE_UPGRADES=On/Off + w. & w/o. IT3. 

I can also make different PRs (however reviewers want :)). A brief overview:
 - TRD: 4 Files (since the matching uses ITS clusters, need to optionally load different topology dictionary)
 - ITS: 3 Files (change calculation for normal of IT3 + change printf to LOGF when printing the RecoGeomHelper)
 - ITS-TPC: 7 Files, getting matching to work
 - Rest is IT3 only changes
