### PR TITLE
DPL: improve messages on caught exceptions

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -372,6 +372,9 @@ void DataProcessingDevice::Init()
   auto ref = ServiceRegistryRef{mServiceRegistry};
   auto& context = ref.get<DataProcessorContext>();
   auto& spec = getRunningDevice(mRunningDevice, ref);
+
+  O2_SIGNPOST_ID_FROM_POINTER(cid, device, &context);
+  O2_SIGNPOST_START(device, cid, "Init", "Entering Init callback.");
   context.statelessProcess = spec.algorithm.onProcess;
   context.statefulProcess = nullptr;
   context.error = spec.algorithm.onError;
@@ -412,8 +415,10 @@ void DataProcessingDevice::Init()
       /// FIXME: we should pass the salt in, so that the message
       ///        can access information which were stored in the stream.
       ServiceRegistryRef ref{serviceRegistry, ServiceRegistry::globalDeviceSalt()};
+      auto& context = ref.get<DataProcessorContext>();
       auto& err = error_from_ref(e);
-      LOGP(error, "Exception caught: {} ", err.what);
+      O2_SIGNPOST_ID_FROM_POINTER(cid, device, &context);
+      O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "Init", "Exception caught while in Init: %{public}s. Invoking errorCallback.", err.what);
       demangled_backtrace_symbols(err.backtrace, err.maxBacktrace, STDERR_FILENO);
       auto& stats = ref.get<DataProcessingStats>();
       stats.updateStats({(int)ProcessingStatsId::EXCEPTION_COUNT, DataProcessingStats::Op::Add, 1});
@@ -425,8 +430,10 @@ void DataProcessingDevice::Init()
       auto& err = error_from_ref(e);
       /// FIXME: we should pass the salt in, so that the message
       ///        can access information which were stored in the stream.
-      LOGP(error, "Exception caught: {} ", err.what);
       ServiceRegistryRef ref{serviceRegistry, ServiceRegistry::globalDeviceSalt()};
+      auto& context = ref.get<DataProcessorContext>();
+      O2_SIGNPOST_ID_FROM_POINTER(cid, device, &context);
+      O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "Init", "Exception caught while in Init: %{public}s. Exiting with 1.", err.what);
       demangled_backtrace_symbols(err.backtrace, err.maxBacktrace, STDERR_FILENO);
       auto& stats = ref.get<DataProcessingStats>();
       stats.updateStats({(int)ProcessingStatsId::EXCEPTION_COUNT, DataProcessingStats::Op::Add, 1});
@@ -491,6 +498,7 @@ void DataProcessingDevice::Init()
     ServiceRegistry::Salt streamSalt = ServiceRegistry::streamSalt(si + 1, ServiceRegistry::globalDeviceSalt().dataProcessorId);
     mServiceRegistry.lateBindStreamServices(state, *options, streamSalt);
   }
+  O2_SIGNPOST_END(device, cid, "Init", "Exiting Init callback.");
 }
 
 void on_signal_callback(uv_signal_t* handle, int signum)
@@ -1079,7 +1087,9 @@ void DataProcessingDevice::fillContext(DataProcessorContext& context, DeviceCont
       ///        can access information which were stored in the stream.
       ServiceRegistryRef ref{serviceRegistry, ServiceRegistry::globalDeviceSalt()};
       auto& err = error_from_ref(e);
-      LOGP(error, "Exception caught: {} ", err.what);
+      auto& context = ref.get<DataProcessorContext>();
+      O2_SIGNPOST_ID_FROM_POINTER(cid, device, &context);
+      O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "Run", "Exception while running: %{public}s. Invoking callback.", err.what);
       demangled_backtrace_symbols(err.backtrace, err.maxBacktrace, STDERR_FILENO);
       auto& stats = ref.get<DataProcessingStats>();
       stats.updateStats({(int)ProcessingStatsId::EXCEPTION_COUNT, DataProcessingStats::Op::Add, 1});
@@ -1092,15 +1102,18 @@ void DataProcessingDevice::fillContext(DataProcessorContext& context, DeviceCont
       auto& err = error_from_ref(e);
       /// FIXME: we should pass the salt in, so that the message
       ///        can access information which were stored in the stream.
-      LOGP(error, "Exception caught: {} ", err.what);
       ServiceRegistryRef ref{serviceRegistry, ServiceRegistry::globalDeviceSalt()};
+      auto& context = ref.get<DataProcessorContext>();
+      O2_SIGNPOST_ID_FROM_POINTER(cid, device, &context);
       demangled_backtrace_symbols(err.backtrace, err.maxBacktrace, STDERR_FILENO);
       auto& stats = ref.get<DataProcessingStats>();
       stats.updateStats({(int)ProcessingStatsId::EXCEPTION_COUNT, DataProcessingStats::Op::Add, 1});
       switch (errorPolicy) {
         case TerminationPolicy::QUIT:
+          O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "Run", "Exception while running: %{public}s. Rethrowing.", err.what);
           throw e;
         default:
+          O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "Run", "Exception while running: %{public}s. Skipping to next timeframe.", err.what);
           break;
       }
     };
@@ -1148,6 +1161,9 @@ void DataProcessingDevice::PreRun()
 {
   auto ref = ServiceRegistryRef{mServiceRegistry};
   auto& state = ref.get<DeviceState>();
+
+  O2_SIGNPOST_ID_FROM_POINTER(cid, device, state.loop);
+  O2_SIGNPOST_START(device, cid, "PreRun", "Entering PreRun callback.");
   state.quitRequested = false;
   state.streaming = StreamingState::Streaming;
   for (auto& info : state.inputChannelInfos) {
@@ -1168,13 +1184,16 @@ void DataProcessingDevice::PreRun()
       context.preStartStreamCallbacks(streamRef);
     }
   } catch (std::exception& e) {
-    LOGP(error, "Exception caught: {} ", e.what());
+    O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "PreRun", "Exception of type std::exception caught in PreRun: %{public}s. Rethrowing.", e.what());
+    O2_SIGNPOST_END(device, cid, "PreRun", "Exiting PreRun due to exception thrown.");
     throw;
   } catch (o2::framework::RuntimeErrorRef& e) {
     auto& err = error_from_ref(e);
-    LOGP(error, "Exception caught: {} ", err.what);
+    O2_SIGNPOST_EVENT_EMIT_ERROR(device, cid, "PreRun", "Exception of type o2::framework::RuntimeErrorRef caught in PreRun: %{public}s. Rethrowing.", err.what);
+    O2_SIGNPOST_END(device, cid, "PreRun", "Exiting PreRun due to exception thrown.");
     throw;
   } catch (...) {
+    O2_SIGNPOST_END(device, cid, "PreRun", "Unknown exception being thrown. Rethrowing.");
     throw;
   }
 
@@ -1189,6 +1208,7 @@ void DataProcessingDevice::PreRun()
 
   auto& monitoring = ref.get<Monitoring>();
   monitoring.send(Metric{(uint64_t)1, "device_state"}.addTag(Key::Subsystem, Value::DPL));
+  O2_SIGNPOST_END(device, cid, "PreRun", "Exiting PreRun callback.");
 }
 
 void DataProcessingDevice::PostRun()

--- a/Framework/Core/test/test_AllCrashTypes.sh
+++ b/Framework/Core/test/test_AllCrashTypes.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -e
 echo $PATH
 printf "ok\nTesting runtime-init..."
-o2-framework-crashing-workflow --crash-type=runtime-init --completion-policy=quit -b --run | grep -q "Exception caught: This is a std::runtime_error" || { printf "runtime error not found" ; exit 1; }
+o2-framework-crashing-workflow --crash-type=runtime-init --completion-policy=quit -b --run | grep -q "Exception caught while in Init: This is a std::runtime_error. Exiting with 1." || { printf "runtime error not found" ; exit 1; }
 printf "ok\nTesting framework-init..."
-o2-framework-crashing-workflow --crash-type=framework-init --completion-policy=quit -b --run | grep -q "Exception caught: This is a o2::framework::runtime_error" || { printf "framework error not found" ;  exit 1; }
+o2-framework-crashing-workflow --crash-type=framework-init --completion-policy=quit -b --run | grep -q "Exception caught while in Init: This is a o2::framework::runtime_error. Exiting with 1." || { printf "framework error not found" ;  exit 1; }
 printf "ok\nTesting framework-run..."
 o2-framework-crashing-workflow --crash-type=framework-run --completion-policy=quit -b --run | grep -q "Unhandled o2::framework::runtime_error reached the top of main of o2-framework-crashing-workflow, device shutting down. Reason: This is a o2::framework::runtime_error" || { printf "framework error not found" ; exit 1; }
 printf "ok\nTesting runtime-run..."


### PR DESCRIPTION
DPL: improve messages on caught exceptions

- Provide a bit of context in the printout
- Use signposts
