### PR TITLE
TRD gain calibration don't create TCanvas

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -454,7 +454,7 @@ template <typename Container>
 void TimeSlotCalibration<Container>::print() const
 {
   for (int i = 0; i < getNSlots(); i++) {
-    LOG(info) << "Slot #" << i << " of " << getNSlots();
+    LOG(info) << "Slot #" << i + 1 << " of " << getNSlots();
     getSlot(i).print();
   }
 }

--- a/Detectors/TRD/calibration/src/CalibratorGain.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorGain.cxx
@@ -52,6 +52,7 @@ void CalibratorGain::initProcessing()
   if (mInitDone) {
     return;
   }
+  LOG(info) << "Initializing the processing";
   for (int iDet = 0; iDet < MAXCHAMBER; ++iDet) {
     mdEdxhists[iDet] = std::make_unique<TH1F>(Form("hdEdx%d", iDet), "dEdx", NBINSGAINCALIB, 0., NBINSGAINCALIB);
   }
@@ -129,7 +130,7 @@ void CalibratorGain::finalizeSlot(Slot& slot)
 
     // Fitting histogram
     mFitFunction->SetParameter(0, mdEdxhists[iDet]->GetMean() / 1.25);
-    int fitStatus = mdEdxhists[iDet]->Fit("fitConvLandau", "LQB", "", 1, NBINSGAINCALIB - 4);
+    int fitStatus = mdEdxhists[iDet]->Fit("fitConvLandau", "LQB0", "", 1, NBINSGAINCALIB - 4);
 
     if (fitStatus != 0) {
       LOGF(warn, "Fit for chamber %i failed, nEntries: %d", iDet, nEntries);


### PR DESCRIPTION
Whenever `finalizeSlot` is called the memory usage increases by about 380 MB. This does not fix the memory leak of the TRD gain calibration, but at least avoids that a canvas is created.
I observe something very strange when trying to reproduce the issue. Using a simple reproducer below I see a constant increase in memory:
```
root [0] 
Processing gainCalib.C...
Info in <ROOT::Math::ParameterSettings>: lower/upper bounds outside current parameter value. The value will be set to (low+up)/2 
MemVirtual (478996), MemResident (398112)
MemVirtual (479280), MemResident (398376)
MemVirtual (479796), MemResident (398904)
MemVirtual (480088), MemResident (399168)
MemVirtual (480584), MemResident (399696)
MemVirtual (481220), MemResident (400224)
MemVirtual (481584), MemResident (400488)
MemVirtual (481948), MemResident (401016)
MemVirtual (482416), MemResident (401544)
MemVirtual (482776), MemResident (401808)
MemVirtual (483416), MemResident (402336)
MemVirtual (483728), MemResident (402864)
MemVirtual (484216), MemResident (403392)
MemVirtual (484576), MemResident (403656)
MemVirtual (484940), MemResident (404184)
MemVirtual (485352), MemResident (404448)
MemVirtual (485876), MemResident (404976)
MemVirtual (486240), MemResident (405240)
MemVirtual (487252), MemResident (405768)
MemVirtual (487984), MemResident (406296)

```
But when I use the ROOT compiled locally without the alice sw stack then the memory remains constant. This is both with an older version 6.26 I had lying around and with 6.31.
```
root [0] 
Processing gainCalib.C...
Info in <ROOT::Math::ParameterSettings>: lower/upper bounds outside current parameter value. The value will be set to (low+up)/2 
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
MemVirtual (400408), MemResident (316084)
```
Does someone have an idea what could be the problem?