### PR TITLE
QC-1163 Update QC flag type list to be in sync with BKP

### DIFF
--- a/DataFormats/QualityControl/etc/flagTypes.csv
+++ b/DataFormats/QualityControl/etc/flagTypes.csv
@@ -1,15 +1,15 @@
 "id","method","name","bad","obsolete"
-1,"Unknown","Unknown",1,0
-2,"UnknownQuality","Unknown Quality",1,0
-3,"CertifiedByExpert","Certified by Expert",0,0
-10,"NoDetectorData","No Detector Data",1,0
-11,"LimitedAcceptance","Limited acceptance",1,0
-12,"BadPID","Bad PID",1,0
-13,"BadTracking","Bad Tracking",1,0
-14,"BadHadronPID","Bad Hadron PID",1,0
-15,"BadElectronPID","Bad Electron PID",1,0
-16,"BadEMCalorimetry","Bad EM Calorimetry",1,0
-17,"BadPhotonCalorimetry","Bad Photon Calorimetry",1,0
-65500,"ObsoleteFlagExample","Obsolete flag example",1,1
+1,"UnknownQuality","Unknown Quality",1,0
+3,"NoDetectorData","No Detector Data",1,0
+4,"LimitedAcceptanceMCNotReproducible","Limited Acceptance MC Not Reproducible",1,0
+5,"LimitedAcceptanceMCReproducible","Limited Acceptance MC Reproducible",1,0
+6,"BadPID","Bad PID",1,0
+7,"BadTracking","Bad Tracking",1,0
+8,"BadHadronPID","Bad Hadron PID",1,0
+9,"Good","Good",0,0
+10,"Invalid","Invalid",1,0
+11,"BadElectronPID","Bad Electron PID",1,0
+12,"BadEMCalorimetry","Bad EM Calorimetry",1,0
+13,"BadPhotonCalorimetry","Bad Photon Calorimetry",1,0
+14,"Unknown","Unknown",1,0
 65501,"NotBadFlagExample","Not bad flag example",0,0
-65535,"Invalid","Invalid",1,0

--- a/DataFormats/QualityControl/test/testFlagTypes.cxx
+++ b/DataFormats/QualityControl/test/testFlagTypes.cxx
@@ -33,14 +33,14 @@ BOOST_AUTO_TEST_CASE(FlagTypes)
   BOOST_CHECK_EQUAL(fDefault, FlagTypeFactory::Invalid());
 
   auto f1 = FlagTypeFactory::Unknown();
-  BOOST_CHECK_EQUAL(f1.getID(), 1);
+  BOOST_CHECK_EQUAL(f1.getID(), 14);
   BOOST_CHECK_EQUAL(f1.getName(), "Unknown");
   BOOST_CHECK_EQUAL(f1.getBad(), true);
 
-  std::cout << f1 << std::endl;
+  BOOST_CHECK_NO_THROW(std::cout << f1 << std::endl);
 
   auto f2 = f1;
-  BOOST_CHECK_EQUAL(f2.getID(), 1);
+  BOOST_CHECK_EQUAL(f2.getID(), 14);
   BOOST_CHECK_EQUAL(f1.getName(), f2.getName());
   BOOST_CHECK_EQUAL(f2.getName(), "Unknown");
   BOOST_CHECK_EQUAL(f2.getBad(), true);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(FlagTypes)
   BOOST_CHECK(!(f1 < f2));
   BOOST_CHECK(!(f1 > f2));
 
-  auto f3 = FlagTypeFactory::LimitedAcceptance();
-  BOOST_CHECK(f3 > f1);
-  BOOST_CHECK(!(f3 < f1));
+  auto f3 = FlagTypeFactory::LimitedAcceptanceMCNotReproducible();
+  BOOST_CHECK(f3 < f1);
+  BOOST_CHECK(!(f3 > f1));
 }

--- a/DataFormats/QualityControl/test/testQualityControlFlagCollection.cxx
+++ b/DataFormats/QualityControl/test/testQualityControlFlagCollection.cxx
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE(test_QualityControlFlagCollection_Methods)
   QualityControlFlagCollection qcfc2{"Reco checks", "TOF"};
   qcfc2.insert({50, 77, FlagTypeFactory::Invalid()}); // this is a duplicate to an entry in qcfc1
   qcfc2.insert({51, 77, FlagTypeFactory::Invalid()});
-  qcfc2.insert({1234, 3434, FlagTypeFactory::LimitedAcceptance()});
-  qcfc2.insert({50, 77, FlagTypeFactory::LimitedAcceptance()});
+  qcfc2.insert({1234, 3434, FlagTypeFactory::LimitedAcceptanceMCNotReproducible()});
+  qcfc2.insert({50, 77, FlagTypeFactory::LimitedAcceptanceMCNotReproducible()});
   BOOST_CHECK_EQUAL(qcfc2.size(), 4);
 
   // Try merging. Duplicate entries should be left in the 'other' objects.
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(test_QualityControlFlagCollection_IO)
     QualityControlFlagCollection qcfc1{"xyz", "TST"};
     qcfc1.insert({50, 77, FlagTypeFactory::Invalid(), "a comment", "a source"});
     qcfc1.insert({51, 77, FlagTypeFactory::Invalid()});
-    qcfc1.insert({1234, 3434, FlagTypeFactory::LimitedAcceptance()});
-    qcfc1.insert({50, 77, FlagTypeFactory::LimitedAcceptance()});
+    qcfc1.insert({1234, 3434, FlagTypeFactory::LimitedAcceptanceMCNotReproducible()});
+    qcfc1.insert({50, 77, FlagTypeFactory::LimitedAcceptanceMCNotReproducible()});
     qcfc1.insert({43434, 63421, FlagTypeFactory::NotBadFlagExample()});
 
     std::stringstream store;


### PR DESCRIPTION
One exception is NotBadFlagExample, which I will remove later, once QC can use Good.