### PR TITLE
[MCH] add dsIndex key for muonview

### DIFF
--- a/Detectors/MUON/MCH/GlobalMapping/src/global-mapper.cxx
+++ b/Detectors/MUON/MCH/GlobalMapping/src/global-mapper.cxx
@@ -122,8 +122,6 @@ void dcs2json()
 
 std::vector<DualSampaInfo> computeDualSampaInfos()
 {
-  uint16_t dsBin{0};
-
   auto elec2det = createElec2DetMapper<ElectronicMapperGenerated>();
   auto det2elec = createDet2ElecMapper<ElectronicMapperGenerated>();
   auto solar2FeeLink = createSolar2FeeLinkMapper<ElectronicMapperGenerated>();
@@ -210,6 +208,8 @@ void solar2json(bool mchview)
         if (mchview) {
           writer.Key("dsbin");
           writer.Int(dsi.dsBinX);
+          writer.Key("dsIndex");
+          writer.Int(dsi.dsBin);
         } else {
           writer.Key("binX");
           writer.Int(dsi.dsBinX);


### PR DESCRIPTION
The `o2-mch-global-mapper` executable allows to generate the mapping used in muonview (solars.json). The mapping currently in use contains the Dual Sampa index among other keys for each DS, but the executable in O2/dev was not updated to add this key. This is fixed by this PR.