### PR TITLE
ITS Fix for online dead map builder

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TimeDeadMap.h
@@ -132,7 +132,7 @@ class TimeDeadMap
       LOG(warning) << "Requested orbit " << orbit << "from an empty time-dependent map. Doing nothing";
       return (long)orbit;
     }
-    auto closest = mEvolvingDeadMap.lower_bound(orbit);
+    auto closest = mEvolvingDeadMap.upper_bound(orbit);
     if (closest != mEvolvingDeadMap.begin()) {
       --closest;
       mmap = closest->second;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -34,23 +34,23 @@ struct RUDecodeData {
   static constexpr int MaxChipsPerRU = 196; // max number of chips the RU can readout
   static constexpr int MaxLinksPerRU = 3;   // max number of GBT links per RU
 
-  std::array<PayLoadCont, MaxCablesPerRU> cableData{};     // cable data in compressed ALPIDE format
-  std::vector<o2::itsmft::ChipPixelData> chipsData{};      // fully decoded data in 1st nChipsFired chips
-  std::vector<uint16_t> seenChipIDs{};                     // IDs of all chips seen during ROF decoding, including empty ones
-  std::array<int, MaxLinksPerRU> links{};                  // link entry RSTODO: consider removing this and using pointer
-  std::array<uint8_t, MaxCablesPerRU> cableHWID{};         // HW ID of cable whose data is in the corresponding slot of cableData
-  std::array<uint8_t, MaxCablesPerRU> cableLinkID{};       // ID of the GBT link transmitting this cable data
-  std::array<GBTLink*, MaxCablesPerRU> cableLinkPtr{};     // Ptr of the GBT link transmitting this cable data
-  std::unordered_map<uint64_t, uint32_t> linkHBFToDump{};  // FEEID<<32+hbfEntry to dump in case of error
-  int ruSWID = -1;                                         // SW (stave) ID
-  int nChipsFired = 0;     // number of chips with data or with errors
-  int lastChipChecked = 0; // last chips checked among nChipsFired
-  int nNonEmptyLinks = 0;  // number of non-empty links for current ROF
-  int nLinks = 0;          // number of links seen for this TF
-  int nLinksDone = 0;      // number of links finished for this TF
-  int verbosity = 0;       // verbosity level, for -1,0 print only summary data, for 1: print once every error
-  bool ROFRampUpStage = false; // flag that the data come from the ROF rate ramp-up stage
-  GBTCalibData calibData{}; // calibration info from GBT calibration word
+  std::array<PayLoadCont, MaxCablesPerRU> cableData{};                        // cable data in compressed ALPIDE format
+  std::vector<o2::itsmft::ChipPixelData> chipsData{};                         // fully decoded data in 1st nChipsFired chips
+  std::vector<uint16_t> seenChipIDs{};                                        // IDs of all chips seen during ROF decoding, including empty ones
+  std::array<int, MaxLinksPerRU> links{};                                     // link entry RSTODO: consider removing this and using pointer
+  std::array<uint8_t, MaxCablesPerRU> cableHWID{};                            // HW ID of cable whose data is in the corresponding slot of cableData
+  std::array<uint8_t, MaxCablesPerRU> cableLinkID{};                          // ID of the GBT link transmitting this cable data
+  std::array<GBTLink*, MaxCablesPerRU> cableLinkPtr{};                        // Ptr of the GBT link transmitting this cable data
+  std::unordered_map<uint64_t, uint32_t> linkHBFToDump{};                     // FEEID<<32+hbfEntry to dump in case of error
+  int ruSWID = -1;                                                            // SW (stave) ID
+  int nChipsFired = 0;                                                        // number of chips with data or with errors
+  int lastChipChecked = 0;                                                    // last chips checked among nChipsFired
+  int nNonEmptyLinks = 0;                                                     // number of non-empty links for current ROF
+  int nLinks = 0;                                                             // number of links seen for this TF
+  int nLinksDone = 0;                                                         // number of links finished for this TF
+  int verbosity = 0;                                                          // verbosity level, for -1,0 print only summary data, for 1: print once every error
+  bool ROFRampUpStage = false;                                                // flag that the data come from the ROF rate ramp-up stage
+  GBTCalibData calibData{};                                                   // calibration info from GBT calibration word
   std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> chipErrorsTF{}; // vector of chip decoding errors seen in the given TF
   const RUInfo* ruInfo = nullptr;
 
@@ -59,6 +59,10 @@ struct RUDecodeData {
     memset(&links[0], -1, MaxLinksPerRU * sizeof(int));
   }
   void clear();
+  void clearSeenChipIDs()
+  {
+    seenChipIDs.clear();
+  }
   void setROFInfo(ChipPixelData* chipData, const GBTLink* lnk);
   template <class Mapping>
   int decodeROF(const Mapping& mp, const o2::InteractionRecord ir);
@@ -90,7 +94,7 @@ int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir)
     }
     auto cabHW = cableHWID[icab];
     auto chIdGetter = [this, &mp, cabHW](int cid) {
-      //return mp.getGlobalChipID(cid, cabHW, *this->ruInfo);
+      // return mp.getGlobalChipID(cid, cabHW, *this->ruInfo);
       auto chip = mp.getGlobalChipID(cid, cabHW, *this->ruInfo);
       return chip;
     };

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -111,6 +111,8 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
         ru.ROFRampUpStage = mROFRampUpStage;
         mNPixelsFiredROF += ru.decodeROF(mMAP, mInteractionRecord);
         mNChipsFiredROF += ru.nChipsFired;
+      } else {
+        ru.clearSeenChipIDs();
       }
     }
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -107,7 +107,7 @@ class ITSMFTDeadMapBuilder : public Task
 
   std::string mDataSource = "chipsstatus";
 
-  int mTFSampling = 1000;
+  int mTFSampling = 350;
   std::string mSamplingMode = "first-orbit-run"; // Use this default to ensure process of first TF. At the moment, use any other option to sample on absolute orbit value.
 
   o2::itsmft::TimeDeadMap mMapObject;

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -284,7 +284,7 @@ void ITSMFTDeadMapBuilder::PrepareOutputCcdb(EndOfStreamContext* ec, std::string
 
   else if (!ccdburl.empty()) { // send from this workflow
 
-    LOG(important) << mSelfName << "sending object " << ccdburl << "/browse/" << info.getPath() << "/" << info.getFileName()
+    LOG(important) << mSelfName << " sending object " << ccdburl << "/browse/" << info.getPath() << "/" << info.getFileName()
                    << " of size " << image->size() << " bytes, valid for "
                    << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
@@ -378,7 +378,7 @@ DataProcessorSpec getITSMFTDeadMapBuilderSpec(std::string datasource, bool doMFT
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<ITSMFTDeadMapBuilder>(datasource, doMFT)},
-    Options{{"tf-sampling", VariantType::Int, 1000, {"Process every Nth TF. Selection according to first TF orbit."}},
+    Options{{"tf-sampling", VariantType::Int, 350, {"Process every Nth TF. Selection according to first TF orbit."}},
             {"sampling-mode", VariantType::String, "first-orbit-run", {"Use absolute orbit value or offset from first processed orbit."}},
             {"tf-length", VariantType::Int, 32, {"Orbits per TF."}},
             {"skip-static-map", VariantType::Bool, false, {"Do not fill static part of the map."}},

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -633,8 +633,8 @@ workflow_has_parameter AOD && [[ ! -z "$AOD_SOURCES" ]] && add_W o2-aod-producer
 # extra workflows in case we want to extra ITS/MFT info for dead channel maps to then go to CCDB for MC
 : ${ALIEN_JDL_PROCESSITSDEADMAP:=}
 : ${ALIEN_JDL_PROCESSMFTDEADMAP:=}
-[[ $ALIEN_JDL_PROCESSITSDEADMAP == 1 ]] && has_detector ITS && add_W o2-itsmft-deadmap-builder-workflow " --local-output --output-dir . --source clusters --tf-sampling 1000"
-[[ $ALIEN_JDL_PROCESSMFTDEADMAP == 1 ]] && has_detector MFT && add_W o2-itsmft-deadmap-builder-workflow " --runmft --local-output --output-dir . --source clusters --tf-sampling 1000"
+[[ $ALIEN_JDL_PROCESSITSDEADMAP == 1 ]] && has_detector ITS && add_W o2-itsmft-deadmap-builder-workflow " --local-output --output-dir . --source clusters --tf-sampling 350"
+[[ $ALIEN_JDL_PROCESSMFTDEADMAP == 1 ]] && has_detector MFT && add_W o2-itsmft-deadmap-builder-workflow " --runmft --local-output --output-dir . --source clusters --tf-sampling 350"
 
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Here:
+ Fix for vector of chip seen not being updated when RU data have no active links
+ TF sampling reduced from 1/1000 to 1/350 (in the workflow defaults --> will be used online). 1/350 corresponds to one sampled TF per second.
+ Minor changes

cc @MauriceCoke @IsakovAD @iravasen 