### PR TITLE
[MCH] add StatusMap IO and a converter to RejectList

### DIFF
--- a/Detectors/MUON/MCH/IO/CMakeLists.txt
+++ b/Detectors/MUON/MCH/IO/CMakeLists.txt
@@ -97,3 +97,19 @@ o2_add_executable(tracks-writer-workflow
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::MCHIO)
 
+o2_add_executable(statusmaps-reader-workflow
+        SOURCES src/StatusMapReaderSpec.cxx src/statusmaps-reader-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES
+          O2::DPLUtils
+          O2::DetectorsRaw
+          O2::MCHStatus
+          )
+
+o2_add_executable(statusmaps-writer-workflow
+        SOURCES src/StatusMapWriterSpec.cxx src/statusmaps-writer-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES
+          O2::DPLUtils
+          O2::MCHStatus
+          )

--- a/Detectors/MUON/MCH/IO/README.md
+++ b/Detectors/MUON/MCH/IO/README.md
@@ -14,6 +14,8 @@
 * [Cluster writer](#cluster-writer)
 * [Track reader](#track-reader)
 * [Track writer](#track-writer)
+* [StatusMap reader](#statusmap-reader)
+* [StatusMap writer](#statusmap-writer)
 
 <!-- vim-markdown-toc -->
 
@@ -125,4 +127,22 @@ Does the same kind of work as the [track sink](#track-sink) but the output is in
 Option `--digits` allows to also write the associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) from the input message with the data description "TRACKDIGITS".
 
 Option `--enable-mc` allows to also write the track MC labels from the input message with the data description "TRACKLABELS".
+
+## StatusMap reader
+
+```shell
+o2-mch-statusmaps-reader-workflow --infile mchstatusmaps.root
+```
+
+Send the status map ([StatusMap](../Status/include/MCHStatus/StatusMap.h)) of the current time frame, with the data description "STATUSMAP".
+
+Option `--input-dir` allows to set the name of the directory containing the input file (default = current directory).
+
+## StatusMap writer
+
+```shell
+o2-mch-statusmaps-writer-workflow
+```
+
+Take as input the status map ([StatusMap](../Status/include/MCHStatus/StatusMap.h)) of the current time frame, with the data description "STATUSMAP", and write it in the root file "mchstatusmaps.root".
 

--- a/Detectors/MUON/MCH/IO/src/StatusMapReaderSpec.cxx
+++ b/Detectors/MUON/MCH/IO/src/StatusMapReaderSpec.cxx
@@ -1,0 +1,70 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "StatusMapReaderSpec.h"
+
+#include <memory>
+#include <string>
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/InitContext.h"
+#include "Framework/Lifetime.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/Task.h"
+
+#include "DPLUtils/RootTreeReader.h"
+#include "CommonUtils/StringUtils.h"
+#include "MCHStatus/StatusMap.h"
+
+using namespace o2::framework;
+
+namespace o2::mch
+{
+
+struct StatusMapReader {
+  std::unique_ptr<RootTreeReader> mTreeReader;
+
+  void init(InitContext& ic)
+  {
+    auto fileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")), ic.options().get<std::string>("infile"));
+    mTreeReader = std::make_unique<RootTreeReader>(
+      "o2sim",
+      fileName.c_str(),
+      -1,
+      RootTreeReader::PublishingMode::Single,
+      RootTreeReader::BranchDefinition<StatusMap>{Output{"MCH", "STATUSMAP", 0}, "statusmaps"});
+  }
+
+  void run(ProcessingContext& pc)
+  {
+    if (mTreeReader->next()) {
+      (*mTreeReader)(pc);
+    } else {
+      pc.services().get<ControlService>().endOfStream();
+    }
+  }
+};
+
+DataProcessorSpec getStatusMapReaderSpec(const char* specName)
+{
+  return DataProcessorSpec{
+    specName,
+    Inputs{},
+    Outputs{OutputSpec{{"statusmaps"}, "MCH", "STATUSMAP", 0, Lifetime::Timeframe}},
+    adaptFromTask<StatusMapReader>(),
+    Options{{"infile", VariantType::String, "mchstatusmaps.root", {"name of the input status map file"}},
+            {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/IO/src/StatusMapReaderSpec.h
+++ b/Detectors/MUON/MCH/IO/src/StatusMapReaderSpec.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_WORKFLOW_STATUSMAP_READER_SPEC_H
+#define O2_MCH_WORKFLOW_STATUSMAP_READER_SPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::mch
+{
+framework::DataProcessorSpec getStatusMapReaderSpec(const char* specName = "mch-statusmap-reader");
+}
+
+#endif

--- a/Detectors/MUON/MCH/IO/src/StatusMapWriterSpec.cxx
+++ b/Detectors/MUON/MCH/IO/src/StatusMapWriterSpec.cxx
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "StatusMapWriterSpec.h"
+
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "MCHStatus/StatusMap.h"
+
+using namespace o2::framework;
+
+namespace o2::mch
+{
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getStatusMapWriterSpec(const char* specName)
+{
+  return MakeRootTreeWriterSpec(specName,
+                                "mchstatusmaps.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MCH StatusMaps"},
+                                BranchDefinition<StatusMap>{InputSpec{"statusmaps", "MCH", "STATUSMAP"}, "statusmaps"})();
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/IO/src/StatusMapWriterSpec.h
+++ b/Detectors/MUON/MCH/IO/src/StatusMapWriterSpec.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_WORKFLOW_STATUSMAP_WRITER_SPEC_H
+#define O2_MCH_WORKFLOW_STATUSMAP_WRITER_SPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::mch
+{
+framework::DataProcessorSpec getStatusMapWriterSpec(const char* specName = "mch-statusmap-writer");
+}
+
+#endif

--- a/Detectors/MUON/MCH/IO/src/statusmaps-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/IO/src/statusmaps-reader-workflow.cxx
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/CallbacksPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "StatusMapReaderSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
+{
+  WorkflowSpec wf{o2::mch::getStatusMapReaderSpec("mch-statusmap-reader")};
+  o2::raw::HBFUtilsInitializer hbfIni(config, wf);
+  return wf;
+}

--- a/Detectors/MUON/MCH/IO/src/statusmaps-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/IO/src/statusmaps-writer-workflow.cxx
@@ -1,0 +1,29 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include "Framework/CompletionPolicyHelpers.h"
+#include "StatusMapWriterSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  return WorkflowSpec{o2::mch::getStatusMapWriterSpec("mch-statusmap-writer")};
+}

--- a/Detectors/MUON/MCH/Status/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Status/CMakeLists.txt
@@ -35,6 +35,19 @@ o2_add_executable(
     O2::MCHStatus
     )
 
+o2_add_executable(
+  statusmap-to-rejectlist
+  COMPONENT_NAME mch
+  SOURCES src/statusmap-to-rejectlist.cxx
+  PUBLIC_LINK_LIBRARIES
+    ROOT::TreePlayer
+    O2::CCDB
+    O2::DataFormatsMCH
+    O2::Framework
+    O2::MCHGlobalMapping
+    O2::MCHStatus
+    )
+
 if(BUILD_TESTING)
 
   o2_add_test(

--- a/Detectors/MUON/MCH/Status/src/statusmap-to-rejectlist.cxx
+++ b/Detectors/MUON/MCH/Status/src/statusmap-to-rejectlist.cxx
@@ -1,0 +1,225 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @author Philippe Pillot
+
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+#include <TFile.h>
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+
+#include "CCDB/CcdbApi.h"
+#include "DataFormatsMCH/DsChannelId.h"
+#include "Framework/Logger.h"
+#include "MCHGlobalMapping/ChannelCode.h"
+#include "MCHStatus/StatusMap.h"
+
+namespace po = boost::program_options;
+
+using BadChannelsVector = std::vector<o2::mch::DsChannelId>;
+
+//____________________________________________________________________________________
+std::tuple<TFile*, TTreeReader*> loadData(const std::string inFile)
+{
+  /// open the input file and get the intput tree
+
+  TFile* f = TFile::Open(inFile.c_str(), "READ");
+  if (!f || f->IsZombie()) {
+    LOG(error) << "opening file " << inFile << " failed";
+    exit(2);
+  }
+
+  TTreeReader* r = new TTreeReader("o2sim", f);
+  if (r->IsZombie()) {
+    LOG(error) << "tree o2sim not found";
+    exit(2);
+  }
+
+  return std::make_tuple(f, r);
+}
+
+//____________________________________________________________________________________
+int size(const std::map<int, std::vector<int>>& badChannels)
+{
+  /// return the total number of bad channels
+
+  int n = 0;
+
+  for (const auto& channels : badChannels) {
+    n += channels.second.size();
+  }
+
+  return n;
+};
+
+//____________________________________________________________________________________
+void printContent(const std::string inFile, const uint32_t mask)
+{
+  /// print the content of the status maps with the given mask
+
+  auto [dataFile, dataReader] = loadData(inFile);
+  TTreeReaderValue<o2::mch::StatusMap> statusMap(*dataReader, "statusmaps");
+
+  int iTF(-1);
+  int firstTF(-1);
+  int lastTF(-1);
+  std::map<int, std::vector<int>> currentBadChannels{};
+
+  while (dataReader->Next()) {
+    ++iTF;
+
+    // record the first status map
+    if (firstTF < 0) {
+      firstTF = iTF;
+      lastTF = iTF;
+      currentBadChannels = o2::mch::applyMask(*statusMap, mask);
+      continue;
+    }
+
+    auto badChannels = o2::mch::applyMask(*statusMap, mask);
+
+    // extend the TF range of the current status map if it did not change
+    if (badChannels == currentBadChannels) {
+      lastTF = iTF;
+      continue;
+    }
+
+    // print the current status map
+    LOGP(info, "TF [{}, {}]: the status map contains {} bad channels in {} detection element{} (using statusMask=0x{:x})",
+         firstTF, lastTF, size(currentBadChannels), currentBadChannels.size(), currentBadChannels.size() > 1 ? "s" : "", mask);
+
+    // update the current status map
+    firstTF = iTF;
+    lastTF = iTF;
+    currentBadChannels = badChannels;
+  }
+
+  // print the last status map
+  LOGP(info, "TF [{}, {}]: the status map contains {} bad channels in {} detection element{} (using statusMask=0x{:x})",
+       firstTF, lastTF, size(currentBadChannels), currentBadChannels.size(), currentBadChannels.size() > 1 ? "s" : "", mask);
+
+  dataFile->Close();
+}
+
+//____________________________________________________________________________________
+BadChannelsVector statusMap2RejectList(const std::string inFile, const size_t iTF, const uint32_t mask)
+{
+  /// convert the status map of the given TF into a reject list with the given mask
+
+  auto [dataFile, dataReader] = loadData(inFile);
+  TTreeReaderValue<o2::mch::StatusMap> statusMap(*dataReader, "statusmaps");
+
+  if (dataReader->SetEntry(iTF) != TTreeReader::kEntryValid) {
+    LOGP(error, "invalid TF index {} (number of TFs = {})", iTF, dataReader->GetEntries());
+    exit(3);
+  }
+
+  BadChannelsVector bv;
+
+  for (const auto& status : *statusMap) {
+    auto channel = status.first;
+    if (!channel.isValid()) {
+      LOG(error) << "invalid channel";
+    }
+    if ((mask & status.second) != 0) {
+      const auto c = o2::mch::DsChannelId(channel.getSolarId(), channel.getElinkId(), channel.getChannel());
+      bv.emplace_back(c);
+    }
+  }
+
+  dataFile->Close();
+
+  LOGP(info, "the reject list contains {} bad channels (using statusMask=0x{:x})", bv.size(), mask);
+
+  return bv;
+}
+
+//____________________________________________________________________________________
+void uploadRejectList(const std::string ccdbUrl, uint64_t startTS, uint64_t endTS, const BadChannelsVector& bv)
+{
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbUrl);
+  std::map<std::string, std::string> md;
+
+  LOGP(info, "storing MCH RejectList (valid from {} to {}) to MCH/Calib/RejectList",
+       startTS, endTS);
+
+  api.storeAsTFileAny(&bv, "MCH/Calib/RejectList", md, startTS, endTS);
+}
+
+//____________________________________________________________________________________
+int main(int argc, char** argv)
+{
+  po::variables_map vm;
+  po::options_description usage("Usage");
+
+  std::string ccdbUrl;
+  uint64_t startTS;
+  uint64_t endTS;
+  std::string inFile;
+  size_t iTF;
+  uint32_t mask;
+  bool print;
+
+  auto tnow = std::chrono::system_clock::now().time_since_epoch();
+  using namespace std::chrono_literals;
+  auto tend = tnow + 24h;
+  uint64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(tnow).count();
+  uint64_t end = std::chrono::duration_cast<std::chrono::milliseconds>(tend).count();
+
+  uint32_t defaultMask = o2::mch::StatusMap::kBadPedestal | o2::mch::StatusMap::kRejectList | o2::mch::StatusMap::kBadHV;
+
+  // clang-format off
+  usage.add_options()
+      ("help,h", "produce help message")
+      ("ccdb,c",po::value<std::string>(&ccdbUrl)->default_value("http://localhost:6464"),"ccdb url")
+      ("starttimestamp,st",po::value<uint64_t>(&startTS)->default_value(now),"timestamp for query or put - (default=now)")
+      ("endtimestamp,et", po::value<uint64_t>(&endTS)->default_value(end), "end of validity (for put) - default=1 day from now")
+      ("infile,f",po::value<std::string>(&inFile)->default_value("mchstatusmaps.root"),"input file of StatusMap objects")
+      ("tf,i", po::value<size_t>(&iTF)->default_value(0), "index of the TF to process")
+      ("mask,m", po::value<uint32_t>(&mask)->default_value(defaultMask), "mask to apply to the statusMap to produce the RejectList")
+      ("print,p",po::bool_switch(&print),"print the content of the input file without processing it")
+        ;
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(usage);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).run(), vm);
+
+  if (vm.count("help")) {
+    LOG(info) << "This program converts a StatusMap to a RejectList CCDB object";
+    LOG(info) << usage;
+    return 2;
+  }
+
+  try {
+    po::notify(vm);
+  } catch (boost::program_options::error& e) {
+    LOG(error) << e.what();
+    exit(1);
+  }
+
+  if (print) {
+    printContent(inFile, mask);
+  } else {
+    auto bv = statusMap2RejectList(inFile, iTF, mask);
+    uploadRejectList(ccdbUrl, startTS, endTS, bv);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
- add workflows to read/write the status map of each TF from/to a root file
- add an executable to print the content of the root file and convert a status map into a reject list uploaded to a local CCDB
