### PR TITLE
Data: Change default compression mode to recommended settings

### DIFF
--- a/Framework/Core/src/DataOutputDirector.cxx
+++ b/Framework/Core/src/DataOutputDirector.cxx
@@ -501,7 +501,7 @@ FileAndFolder DataOutputDirector::getFileFolder(DataOutputDescriptor* dodesc, ui
       auto fn = resdirname + "/" + mfilenameBases[ind] + ".root";
       delete mfilePtrs[ind];
       mParentMaps[ind]->Clear();
-      mfilePtrs[ind] = TFile::Open(fn.c_str(), mfileMode.c_str(), "", 501);
+      mfilePtrs[ind] = TFile::Open(fn.c_str(), mfileMode.c_str(), "", 505);
     }
     fileAndFolder.file = mfilePtrs[ind];
 


### PR DESCRIPTION
As described [here](https://root.cern/doc/master/structROOT_1_1RCompressionSetting.html) for ZSTD recommended is 505 not 501. After measuring it, throughput/compression/peak memory usage stay stay almost unchanged but measured aod size reduces by 5%.

@pzhristov should this go to the pass4 cherry-picks?