### PR TITLE
Do not const_cast/modify sh.mem. objetcs from upstream procsesses

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -129,7 +129,7 @@ class MCCompLabel
   int getEventID() const { return (mLabel >> nbitsTrackID) & maskEvID; }
   int getSourceID() const { return (mLabel >> (nbitsTrackID + nbitsEvID)) & maskSrcID; }
   uint64_t getTrackEventSourceID() const { return static_cast<uint64_t>(mLabel & maskFull); }
-  void get(int& trackID, int& evID, int& srcID, bool& fake)
+  void get(int& trackID, int& evID, int& srcID, bool& fake) const
   {
     /// parse label
     trackID = getTrackID();

--- a/Detectors/GlobalTracking/include/GlobalTracking/TrackCuts.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/TrackCuts.h
@@ -104,12 +104,11 @@ class TrackCuts
       const auto& tpcTrk = data.getTPCTrack(contributorsGID[GID::TPC]);
       math_utils::Point3D<float> v{}; // vertex not defined?!
       std::array<float, 2> dca;
-      if (tpcTrk.getPt() < mPtTPCCut ||
-          std::abs(tpcTrk.getEta()) > mEtaTPCCut || // TODO: define 2 different values for min and max (***)
-          tpcTrk.getNClusters() < mNTPCClustersCut ||
-          (!(const_cast<o2::tpc::TrackTPC&>(tpcTrk).propagateParamToDCA(v, mBz, &dca, mDCATPCCut)) ||
-           std::abs(dca[0]) > mDCATPCCutY) ||
-          std::hypot(dca[0], dca[1]) > mDCATPCCut) {
+      if (tpcTrk.getPt() < mPtTPCCut || std::abs(tpcTrk.getEta()) > mEtaTPCCut || tpcTrk.getNClusters() < mNTPCClustersCut) { // TODO: define 2 different values for min and max (***)
+        return false;
+      }
+      o2::track::TrackPar trTmp(tpcTrk);
+      if (!trTmp.propagateParamToDCA(v, mBz, &dca, mDCATPCCut) || std::abs(dca[0]) > mDCATPCCutY || std::hypot(dca[0], dca[1]) > mDCATPCCut) {
         return false;
       }
     }

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
@@ -360,12 +360,13 @@ void ImpactParameterStudy::process(o2::globaltracking::RecoContainer& recoData)
             auto pt = trc.getPt();
             o2::gpu::gpustd::array<float, 2> dcaInfo{-999., -999.};
             // LOGP(info, " ---> Bz={}", o2::base::Propagator::Instance()->getNominalBz());
-            if (o2::base::Propagator::Instance()->propagateToDCABxByBz({Pvtx_refitted.getX(), Pvtx_refitted.getY(), Pvtx_refitted.getZ()}, const_cast<o2::track::TrackParCov&>(trc), 2.f, matCorr, &dcaInfo)) {
+            o2::track::TrackPar trcTmp{trc};
+            if (o2::base::Propagator::Instance()->propagateToDCABxByBz({Pvtx_refitted.getX(), Pvtx_refitted.getY(), Pvtx_refitted.getZ()}, trcTmp, 2.f, matCorr, &dcaInfo)) {
               impParRPhi = dcaInfo[0] * toMicrometers;
               impParZ = dcaInfo[1] * toMicrometers;
               mHistoImpParXy->Fill(pt, impParRPhi);
               mHistoImpParZ->Fill(pt, impParZ);
-              double phi = trc.getPhi();
+              double phi = trcTmp.getPhi();
               mHistoImpParXyPhi->Fill(phi, impParRPhi);
               mHistoImpParZPhi->Fill(phi, impParZ);
               if (phi < TMath::Pi()) {
@@ -376,7 +377,7 @@ void ImpactParameterStudy::process(o2::globaltracking::RecoContainer& recoData)
                 mHistoImpParXyBottom->Fill(pt, impParRPhi);
                 mHistoImpParZBottom->Fill(pt, impParZ);
               }
-              double sign = trc.getSign();
+              double sign = trcTmp.getSign();
               if (sign < 0) {
                 mHistoImpParXyNegativeCharge->Fill(pt, impParRPhi);
                 mHistoImpParZNegativeCharge->Fill(pt, impParZ);

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackCheck.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackCheck.cxx
@@ -477,7 +477,7 @@ void TrackCheckStudy::process()
         }
         int trackID, evID, srcID;
         bool fake;
-        const_cast<o2::MCCompLabel&>(lab).get(trackID, evID, srcID, fake);
+        lab.get(trackID, evID, srcID, fake);
         auto& cluster = mClusters[iCluster];
         auto layer = mGeometry->getLayer(cluster.getSensorID());
         mParticleInfo[srcID][evID][trackID].clusters |= (1 << layer);
@@ -510,7 +510,7 @@ void TrackCheckStudy::process()
     }
     int trackID, evID, srcID;
     bool fake;
-    const_cast<o2::MCCompLabel&>(lab).get(trackID, evID, srcID, fake);
+    lab.get(trackID, evID, srcID, fake);
 
     if (srcID == 99) { // skip QED
       unaccounted++;
@@ -723,7 +723,7 @@ void TrackCheckStudy::process()
                     }
 
                     bool fakec;
-                    const_cast<o2::MCCompLabel&>(lab).get(TrackID, EvID, SrcID, fakec);
+                    lab.get(TrackID, EvID, SrcID, fakec);
                     double intHisto = 0;
                     for (int hg = 0; hg < 7; hg++) {
                       if (mParticleInfo[SrcID][EvID][TrackID].pdg == PdgcodeClusterFake[hg] || mParticleInfo[SrcID][EvID][TrackID].pdg == -1 * (PdgcodeClusterFake[hg])) {
@@ -819,7 +819,7 @@ void TrackCheckStudy::process()
     }
     int trackID, evID, srcID;
     bool fake;
-    const_cast<o2::MCCompLabel&>(lab).get(trackID, evID, srcID, fake);
+    lab.get(trackID, evID, srcID, fake);
     if (srcID == 99) {
       continue; // skip QED
     }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -58,8 +58,8 @@ class ROframe final
   const TrackingFrameInfo& getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const;
   const MCCompLabel& getClusterFirstLabel(int layerId, const Cluster& cl) const;
   const MCCompLabel& getClusterFirstLabel(int layerId, const int clId) const;
-  gsl::span<o2::MCCompLabel> getClusterLabels(int layerId, const int clId) const;
-  gsl::span<o2::MCCompLabel> getClusterLabels(int layerId, const Cluster& cl) const;
+  const gsl::span<const o2::MCCompLabel> getClusterLabels(int layerId, const int clId) const;
+  const gsl::span<const o2::MCCompLabel> getClusterLabels(int layerId, const Cluster& cl) const;
   int getClusterExternalIndex(int layerId, const int clId) const;
   std::vector<int> getTracksId(const int layerId, const std::vector<Cluster>& cl);
 
@@ -75,7 +75,7 @@ class ROframe final
 
  private:
   const int mROframeId;
-  o2::dataformats::MCTruthContainer<MCCompLabel>* mMClabels = nullptr;
+  const o2::dataformats::MCTruthContainer<MCCompLabel>* mMClabels = nullptr;
   std::vector<float3> mPrimaryVertices;
   std::vector<std::vector<Cluster>> mClusters;
   std::vector<std::vector<TrackingFrameInfo>> mTrackingFrameInfo;
@@ -115,12 +115,12 @@ inline const MCCompLabel& ROframe::getClusterFirstLabel(int layerId, const int c
   return *(mMClabels->getLabels(getClusterExternalIndex(layerId, clId)).begin());
 }
 
-inline gsl::span<o2::MCCompLabel> ROframe::getClusterLabels(int layerId, const int clId) const
+inline const gsl::span<const o2::MCCompLabel> ROframe::getClusterLabels(int layerId, const int clId) const
 {
   return mMClabels->getLabels(getClusterExternalIndex(layerId, clId));
 }
 
-inline gsl::span<o2::MCCompLabel> ROframe::getClusterLabels(int layerId, const Cluster& cl) const
+inline const gsl::span<const o2::MCCompLabel> ROframe::getClusterLabels(int layerId, const Cluster& cl) const
 {
   return getClusterLabels(layerId, cl.clusterId);
 }
@@ -153,7 +153,7 @@ void ROframe::addTrackingFrameInfoToLayer(int layer, T&&... values)
 
 inline void ROframe::setMClabelsContainer(const dataformats::MCTruthContainer<MCCompLabel>* ptr)
 {
-  mMClabels = const_cast<dataformats::MCTruthContainer<MCCompLabel>*>(ptr);
+  mMClabels = ptr;
 }
 
 inline void ROframe::addClusterExternalIndexToLayer(int layer, const int idx)


### PR DESCRIPTION
The tracks produced in the tracks and supposedly stored in the AOD as is were modified but the QC tasks after const_casting objects in the shared memory. It looks like only standalone TPC tracks were affected (were propagated to the DCA) so the damage was limited.