### PR TITLE
Data: Change default compression mode to recommended settings

### DIFF
--- a/Framework/AODMerger/src/aodMerger.cxx
+++ b/Framework/AODMerger/src/aodMerger.cxx
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
   std::map<std::string, int> offsets;
   std::map<std::string, int> unassignedIndexOffset;
 
-  auto outputFile = TFile::Open(outputFileName.c_str(), "RECREATE", "", 501);
+  auto outputFile = TFile::Open(outputFileName.c_str(), "RECREATE", "", 505);
   TDirectory* outputDir = nullptr;
   long currentDirSize = 0;
 

--- a/Framework/AODMerger/src/aodThinner.cxx
+++ b/Framework/AODMerger/src/aodThinner.cxx
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
   TStopwatch clock;
   clock.Start(kTRUE);
 
-  auto outputFile = TFile::Open(outputFileName.c_str(), (bOverwrite) ? "RECREATE" : "CREATE", "", 501);
+  auto outputFile = TFile::Open(outputFileName.c_str(), (bOverwrite) ? "RECREATE" : "CREATE", "", 505);
   if (outputFile == nullptr) {
     printf("Error: File %s exists or cannot be created!\n", outputFileName.c_str());
     return 1;

--- a/Framework/Core/src/DataOutputDirector.cxx
+++ b/Framework/Core/src/DataOutputDirector.cxx
@@ -501,7 +501,7 @@ FileAndFolder DataOutputDirector::getFileFolder(DataOutputDescriptor* dodesc, ui
       auto fn = resdirname + "/" + mfilenameBases[ind] + ".root";
       delete mfilePtrs[ind];
       mParentMaps[ind]->Clear();
-      mfilePtrs[ind] = TFile::Open(fn.c_str(), mfileMode.c_str(), "", 501);
+      mfilePtrs[ind] = TFile::Open(fn.c_str(), mfileMode.c_str(), "", 505);
     }
     fileAndFolder.file = mfilePtrs[ind];
 

--- a/Framework/Utils/include/DPLUtils/RootTreeWriter.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeWriter.h
@@ -309,7 +309,7 @@ class RootTreeWriter
   /// branch definition provided to the constructor.
   void init(const char* filename, const char* treename, const char* treetitle = nullptr)
   {
-    mFile = std::make_unique<TFile>(filename, "RECREATE");
+    mFile = std::make_unique<TFile>(filename, "RECREATE", "", 505);
     mTree = std::make_unique<TTree>(treename, treetitle != nullptr ? treetitle : treename);
     mTree->SetDirectory(mFile.get());
     mTreeStructure->setup(mBranchSpecs, mTree.get());


### PR DESCRIPTION
As described [here](https://root.cern/doc/master/structROOT_1_1RCompressionSetting.html) for ZSTD recommended is 505 not 501. After measuring it, throughput/compression/peak memory usage stay stay almost unchanged but measured aod size reduces by 5%.

@pzhristov should the first go to the apass4 cherry-picks?
@jgrosseo I realised later in the thinner/merger also not optimal compression settings are applied, so I propagated the changes also into them. Do they look fine to you, or does this fiddle with anything in the logic of them? I of course checked the thinner and did not see anything different before and after (except reduced file-size).

For the last commit I am not 100% sure, while this sets the compression to reflect what we have in the aods, I do not know what is used by root by default (the documentation is spotty IMO; it says compile time default, wherever this is set).