### PR TITLE
[QC-1171] CCDB api should timeout

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -629,6 +629,7 @@ class CcdbApi //: public DatabaseInterface
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
   int mCurlRetries = 3;
   int mCurlDelayRetries = 100000; // in microseconds
+  size_t mCurlTimeout = 120; // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
 
   ClassDefNV(CcdbApi, 1);
 };

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -629,7 +629,7 @@ class CcdbApi //: public DatabaseInterface
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
   int mCurlRetries = 3;
   int mCurlDelayRetries = 100000; // in microseconds
-  size_t mCurlTimeout = 120; // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
+  size_t mCurlTimeout = 120;      // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
 
   ClassDefNV(CcdbApi, 1);
 };

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -629,7 +629,7 @@ class CcdbApi //: public DatabaseInterface
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
   int mCurlRetries = 3;
   int mCurlDelayRetries = 100000; // in microseconds
-  size_t mCurlTimeout = 120;      // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
+  size_t mCurlTimeout = 15;      // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
 
   ClassDefNV(CcdbApi, 1);
 };

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -629,7 +629,7 @@ class CcdbApi //: public DatabaseInterface
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
   int mCurlRetries = 3;
   int mCurlDelayRetries = 100000; // in microseconds
-  size_t mCurlTimeout = 15;      // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
+  size_t mCurlTimeout = 15;       // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
 
   ClassDefNV(CcdbApi, 1);
 };

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -417,8 +417,13 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
       res = CURL_perform(curl);
       /* Check for errors */
       if (res != CURLE_OK) {
-        LOGP(alarm, "curl_easy_perform() failed: {}", curl_easy_strerror(res));
+        if(res == CURLE_OPERATION_TIMEDOUT) {
+          LOGP(alarm, "curl_easy_perform() timed out. Consider increasing the timeout using the env var `ALICEO2_CCDB_CURL_TIMEOUT` (seconds)");
+        } else { // generic message
+          LOGP(alarm, "curl_easy_perform() failed: {}", curl_easy_strerror(res));
+        }
         returnValue = res;
+
       }
     }
 

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -224,7 +224,6 @@ void CcdbApi::init(std::string const& host)
     }
   } else { // set a default depending on the deployment mode
     o2::framework::DeploymentMode deploymentMode = o2::framework::DefaultsHelpers::deploymentMode();
-    LOG(info) << "deploymentMode : " << static_cast<std::underlying_type<o2::framework::DeploymentMode>::type>(deploymentMode);
     if (deploymentMode == o2::framework::DeploymentMode::OnlineDDS ||
         deploymentMode == o2::framework::DeploymentMode::OnlineAUX ||
         deploymentMode == o2::framework::DeploymentMode::OnlineECS) {

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -230,7 +230,7 @@ void CcdbApi::init(std::string const& host)
       mCurlTimeout = 5;
     } else if (deploymentMode == o2::framework::DeploymentMode::Grid ||
                deploymentMode == o2::framework::DeploymentMode::FST) {
-      mCurlTimeout = 120;
+      mCurlTimeout = 15;
     } else if (deploymentMode == o2::framework::DeploymentMode::Local) {
       mCurlTimeout = 1;
     }

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -417,13 +417,12 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
       res = CURL_perform(curl);
       /* Check for errors */
       if (res != CURLE_OK) {
-        if(res == CURLE_OPERATION_TIMEDOUT) {
+        if (res == CURLE_OPERATION_TIMEDOUT) {
           LOGP(alarm, "curl_easy_perform() timed out. Consider increasing the timeout using the env var `ALICEO2_CCDB_CURL_TIMEOUT` (seconds)");
         } else { // generic message
           LOGP(alarm, "curl_easy_perform() failed: {}", curl_easy_strerror(res));
         }
         returnValue = res;
-
       }
     }
 

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -382,6 +382,7 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, mUniqueAgentID.c_str());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1L);
 
     CURLcode res = CURL_LAST;
 

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -216,6 +216,28 @@ void CcdbApi::init(std::string const& host)
 
   mNeedAlienToken = (host.find("https://") != std::string::npos) || (host.find("alice-ccdb.cern.ch") != std::string::npos);
 
+  // Set the curl timeout. It can be forced with an env var or it has different defaults based on the deployment mode.
+  if (getenv("ALICEO2_CCDB_CURL_TIMEOUT")) {
+    auto timeout = atoi(getenv("ALICEO2_CCDB_CURL_TIMEOUT"));
+    if (timeout >= 0) { // if valid int
+      mCurlTimeout = timeout;
+    }
+  } else { // set a default depending on the deployment mode
+    o2::framework::DeploymentMode deploymentMode = o2::framework::DefaultsHelpers::deploymentMode();
+    LOG(info) << "deploymentMode : " << static_cast<std::underlying_type<o2::framework::DeploymentMode>::type>(deploymentMode);
+    if (deploymentMode == o2::framework::DeploymentMode::OnlineDDS ||
+        deploymentMode == o2::framework::DeploymentMode::OnlineAUX ||
+        deploymentMode == o2::framework::DeploymentMode::OnlineECS) {
+      mCurlTimeout = 5;
+    } else if (deploymentMode == o2::framework::DeploymentMode::Grid ||
+               deploymentMode == o2::framework::DeploymentMode::FST) {
+      mCurlTimeout = 120;
+    } else if (deploymentMode == o2::framework::DeploymentMode::Local) {
+      mCurlTimeout = 1;
+    }
+  }
+  LOG(debug) << "Curl timeout set to " << mCurlTimeout << " seconds";
+
   LOGP(info, "Init CcdApi with UserAgentID: {}, Host: {}{}", mUniqueAgentID, host,
        mInSnapshotMode ? "(snapshot readonly mode)" : snapshotReport.c_str());
 }
@@ -382,7 +404,7 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, mUniqueAgentID.c_str());
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, mCurlTimeout);
 
     CURLcode res = CURL_LAST;
 


### PR DESCRIPTION
The CCDB api never times out. If the server we are trying to reach is unreachable (e.g. QCDB from outside CERN), the workflow will just hang with no clear messages. Moreover, trying to kill it will also fail. 

This is a proposal to introduce a timeout of 1 second. 
