### PR TITLE
AOD: Add TPC time0 option B

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -338,7 +338,6 @@ class AODProducerWorkflowDPL : public Task
   uint32_t mTrackSignal = 0xFFFFFF00;          // 15 bits
   uint32_t mTrackTime = 0xFFFFFFFF;            // use full float precision for time
   uint32_t mTrackTimeError = 0xFFFFFF00;       // 15 bits
-  uint32_t mTPCTrackTimeError = 0xFFFFFFFF;    // use full float precision for tpc-only tracks
   uint32_t mTrackPosEMCAL = 0xFFFFFF00;        // 15 bits
   uint32_t mTracklets = 0xFFFFFF00;            // 15 bits
   uint32_t mMcParticleW = 0xFFFFFFF0;          // 19 bits

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -338,6 +338,7 @@ class AODProducerWorkflowDPL : public Task
   uint32_t mTrackSignal = 0xFFFFFF00;          // 15 bits
   uint32_t mTrackTime = 0xFFFFFFFF;            // use full float precision for time
   uint32_t mTrackTimeError = 0xFFFFFF00;       // 15 bits
+  uint32_t mTPCTrackTimeError = 0xFFFFFFFF;    // use full float precision for tpc-only tracks
   uint32_t mTrackPosEMCAL = 0xFFFFFF00;        // 15 bits
   uint32_t mTracklets = 0xFFFFFF00;            // 15 bits
   uint32_t mMcParticleW = 0xFFFFFFF0;          // 19 bits
@@ -389,6 +390,7 @@ class AODProducerWorkflowDPL : public Task
     float trackTimeRes = -999.f;
     int diffBCRef = 0; // offset of time reference BC from the start of the orbit
     int bcSlice[2] = {-1, -1};
+    bool isTPConly = false; // not to be written out
   };
 
   struct TrackQA {

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2456,7 +2456,8 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
       p.setDeltaTFwd(tpcOrig.getDeltaTFwd());
       p.setDeltaTBwd(tpcOrig.getDeltaTBwd());
       extraInfoHolder.trackTimeRes = p.getTimeErr();
-      extraInfoHolder.trackTime = tpcOrig.getTime0() * mTPCBinNS - bcOfTimeRef * o2::constants::lhc::LHCBunchSpacingNS;
+      extraInfoHolder.trackTime = float(tpcOrig.getTime0() * mTPCBinNS - bcOfTimeRef * o2::constants::lhc::LHCBunchSpacingNS);
+      extraInfoHolder.diffBCRef = int(bcOfTimeRef);
       extraInfoHolder.isTPConly = true; // no truncation
       extraInfoHolder.flags |= o2::aod::track::TrackTimeAsym;
     } else if (src == GIndex::ITSTPC) { // its-tpc matched tracks have gaussian time error and the time was not set above

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -321,6 +321,13 @@ void AODProducerWorkflowDPL::addToTracksTable(TracksCursorType& tracksCursor, Tr
 template <typename TracksExtraCursorType>
 void AODProducerWorkflowDPL::addToTracksExtraTable(TracksExtraCursorType& tracksExtraCursor, TrackExtraInfo& extraInfoHolder)
 {
+  // In case of TPC-only tracks, do not truncate the time error since we encapsulate there a special encoding of
+  // the deltaFwd/Bwd times
+  auto trackTimeRes = extraInfoHolder.trackTimeRes;
+  if (!extraInfoHolder.isTPConly) {
+    trackTimeRes = truncateFloatFraction(trackTimeRes, mTrackTimeError);
+  }
+
   // extra
   tracksExtraCursor(truncateFloatFraction(extraInfoHolder.tpcInnerParam, mTrack1Pt),
                     extraInfoHolder.flags,
@@ -341,7 +348,7 @@ void AODProducerWorkflowDPL::addToTracksExtraTable(TracksExtraCursorType& tracks
                     truncateFloatFraction(extraInfoHolder.trackEtaEMCAL, mTrackPosEMCAL),
                     truncateFloatFraction(extraInfoHolder.trackPhiEMCAL, mTrackPosEMCAL),
                     truncateFloatFraction(extraInfoHolder.trackTime, mTrackTime),
-                    truncateFloatFraction(extraInfoHolder.trackTimeRes, (extraInfoHolder.isTPConly) ? mTPCTrackTimeError : mTrackTimeError));
+                    trackTimeRes);
 }
 
 template <typename TracksQACursorType>

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -306,6 +306,29 @@ DECLARE_SOA_DYNAMIC_COLUMN(ITSClsSizeInLayer, itsClsSizeInLayer, //! Size of the
                              return (itsClusterSizes >> (layer * 4)) & 0xf;
                            });
 
+namespace extensions
+{
+using TPCTimeErrEncoding = o2::aod::track::extensions::TPCTimeErrEncoding;
+DECLARE_SOA_DYNAMIC_COLUMN(TPCDeltaTFwd, tpcDeltaTFwd, //! Delta Forward of track time in TPC time bis
+                           [](float timeErr, uint32_t trackType) -> float {
+                             if (!(trackType & TrackFlags::TrackTimeAsym)) {
+                               return TPCTimeErrEncoding::invalidValue;
+                             }
+                             TPCTimeErrEncoding enc;
+                             enc.encoding.timeErr = timeErr;
+                             return enc.getDeltaTFwd();
+                           });
+
+DECLARE_SOA_DYNAMIC_COLUMN(TPCDeltaTBwd, tpcDeltaTBwd, //! Delta Backward of track time in TPC time bis
+                           [](float timeErr, uint32_t trackType) -> float {
+                             if (!(trackType & TrackFlags::TrackTimeAsym)) {
+                               return TPCTimeErrEncoding::invalidValue;
+                             }
+                             TPCTimeErrEncoding p;
+                             p.encoding.timeErr = timeErr;
+                             return p.getDeltaTBwd();
+                           });
+} // namespace extensions
 } // namespace v001
 
 DECLARE_SOA_DYNAMIC_COLUMN(HasITS, hasITS, //! Flag to check if track has a ITS match
@@ -477,8 +500,8 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
 DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "TRACKEXTRA", 1, // On disk version of TracksExtra, version 1
                                  track::TPCInnerParam, track::Flags, track::ITSClusterSizes,
                                  track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
-                                 track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
-                                 track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
+                                 track::TPCNClsShared, track::v001::extensions::TPCDeltaTFwd<track::TrackTimeRes, track::Flags>, track::v001::extensions::TPCDeltaTBwd<track::TrackTimeRes, track::Flags>,
+                                 track::TRDPattern, track::ITSChi2NCl, track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
                                  track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
                                  track::PIDForTracking<track::Flags>,
                                  track::IsPVContributor<track::Flags>,

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -11,6 +11,8 @@
 #ifndef O2_FRAMEWORK_DATATYPES_H_
 #define O2_FRAMEWORK_DATATYPES_H_
 
+#include "CommonConstants/LHCConstants.h"
+
 #include <cstdint>
 #include <limits>
 
@@ -84,10 +86,12 @@ struct TPCTimeErrEncoding {
 
   // Use all 16 bits of uint16_t to encode delta scale with max precision
   // e.g., TPCTrack::mDeltaFwd * timeScaler
-  // max range for the time deltas is 0 - <512 (1<<9) tpc time bins
+  // max range for the time deltas is 0 - <512 (1<<9) TPC time bins
   static constexpr float timeScaler{(1 << 16) / (1 << 9)};
   // bogus value to max incorrect usae immedately obvious
   static constexpr float invalidValue{std::numeric_limits<float>::min()};
+  // convert TPC time bins to ns
+  static constexpr float TPCBinNS = 8 * o2::constants::lhc::LHCBunchSpacingNS;
 
   void setDeltaTFwd(float fwd)
   {
@@ -100,11 +104,11 @@ struct TPCTimeErrEncoding {
 
   float getDeltaTFwd() const
   {
-    return static_cast<float>(encoding.deltas.timeForward) / timeScaler;
+    return static_cast<float>(encoding.deltas.timeForward) / timeScaler * TPCBinNS;
   }
   float getDeltaTBwd() const
   {
-    return static_cast<float>(encoding.deltas.timeBackward) / timeScaler;
+    return static_cast<float>(encoding.deltas.timeBackward) / timeScaler * TPCBinNS;
   }
 };
 } // namespace extensions

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -12,6 +12,7 @@
 #define O2_FRAMEWORK_DATATYPES_H_
 
 #include <cstdint>
+#include <limits>
 
 namespace o2::aod::collision
 {
@@ -34,10 +35,11 @@ enum TrackTypeEnum : uint8_t {
   Run2Track = 254,
   Run2Tracklet = 255
 };
-enum TrackFlags {
+enum TrackFlags : uint32_t {
   TrackTimeResIsRange = 0x1, // Gaussian or range
   PVContributor = 0x2,       // This track has contributed to the collision vertex fit
   OrphanTrack = 0x4,         // Track has no association with any collision vertex
+  TrackTimeAsym = 0x8,       // track with an asymmetric time range
   // NOTE Highest 4 (29..32) bits reserved for PID hypothesis
 };
 enum TrackFlagsRun2Enum {
@@ -62,6 +64,50 @@ enum TRDTrackPattern : uint8_t {
   HasNeighbor = 0x40,
   HasCrossing = 0x80,
 };
+namespace extensions
+{
+struct TPCTimeErrEncoding {
+  // TPC delta forward & backward packing
+  union TPCDeltaTime {
+    struct {
+      uint16_t timeForward;
+      uint16_t timeBackward;
+    } __attribute__((packed)) deltas;
+    float timeErr;
+  } encoding;
+  static_assert(sizeof(float) == 2 * sizeof(uint16_t));
+
+  float getTimeErr() const
+  {
+    return encoding.timeErr;
+  }
+
+  // Use all 16 bits of uint16_t to encode delta scale with max precision
+  // e.g., TPCTrack::mDeltaFwd * timeScaler
+  // max range for the time deltas is 0 - <512 (1<<9) tpc time bins
+  static constexpr float timeScaler{(1 << 16) / (1 << 9)};
+  // bogus value to max incorrect usae immedately obvious
+  static constexpr float invalidValue{std::numeric_limits<float>::min()};
+
+  void setDeltaTFwd(float fwd)
+  {
+    encoding.deltas.timeForward = static_cast<uint16_t>(fwd * timeScaler);
+  }
+  void setDeltaTBwd(float bwd)
+  {
+    encoding.deltas.timeBackward = static_cast<uint16_t>(bwd * timeScaler);
+  }
+
+  float getDeltaTFwd() const
+  {
+    return static_cast<float>(encoding.deltas.timeForward) / timeScaler;
+  }
+  float getDeltaTBwd() const
+  {
+    return static_cast<float>(encoding.deltas.timeBackward) / timeScaler;
+  }
+};
+} // namespace extensions
 } // namespace o2::aod::track
 
 namespace o2::aod::fwdtrack


### PR DESCRIPTION
As proposed today in https://indico.cern.ch/event/1416151/ this would implement option b (e.g. the inclusion of the time0 for tpc-only track with encoding of the deltaFwd/Bwd).

@miranov25 If you could please have a look in to the proposal and code to solve also your request for inclusion of t0, this would be much appreciated?