### PR TITLE
QC-1172 Do not use sampling policies which are turned off

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/DataSamplingPolicy.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSamplingPolicy.h
@@ -86,11 +86,13 @@ class DataSamplingPolicy
   std::string getFairMQOutputChannelName() const;
   uint32_t getTotalAcceptedMessages() const;
   uint32_t getTotalEvaluatedMessages() const;
+  bool isActive() const;
 
   static header::DataOrigin createPolicyDataOrigin();
   static header::DataDescription createPolicyDataDescription(std::string policyName, size_t id);
 
  private:
+  bool mActive = true;
   std::string mName;
   PathMap mPaths;
   std::vector<std::unique_ptr<DataSamplingCondition>> mConditions;

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -67,6 +67,7 @@ void DataSampling::DoGenerateInfrastructure(Dispatcher& dispatcher, WorkflowSpec
       auto policy = DataSamplingPolicy::fromConfiguration(policyConfig.second);
       if (!policy.isActive()) {
         LOG(debug) << "The data sampling policy '" << policy.getName() << "' is inactive, skipping...";
+        continue;
       }
       if (ids.count(policy.getName()) == 1) {
         LOG(error) << "A policy with the same id has already been encountered (" + policy.getName() + ")";

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -65,6 +65,9 @@ void DataSampling::DoGenerateInfrastructure(Dispatcher& dispatcher, WorkflowSpec
     // We don't want the Dispatcher to exit due to one faulty Policy
     try {
       auto policy = DataSamplingPolicy::fromConfiguration(policyConfig.second);
+      if (!policy.isActive()) {
+        LOG(debug) << "The data sampling policy '" << policy.getName() << "' is inactive, skipping...";
+      }
       if (ids.count(policy.getName()) == 1) {
         LOG(error) << "A policy with the same id has already been encountered (" + policy.getName() + ")";
       }

--- a/Utilities/DataSampling/src/DataSamplingPolicy.cxx
+++ b/Utilities/DataSampling/src/DataSamplingPolicy.cxx
@@ -52,7 +52,9 @@ void DataSamplingPolicy::setFairMQOutputChannel(std::string channel)
 DataSamplingPolicy DataSamplingPolicy::fromConfiguration(const ptree& config)
 {
   auto name = config.get<std::string>("id");
+
   DataSamplingPolicy policy(name);
+  policy.mActive = config.get<bool>("active", "true");
 
   size_t outputId = 0;
   std::vector<InputSpec> inputSpecs = DataDescriptorQueryBuilder::parse(config.get<std::string>("query").c_str());
@@ -164,6 +166,11 @@ uint32_t DataSamplingPolicy::getTotalAcceptedMessages() const
 uint32_t DataSamplingPolicy::getTotalEvaluatedMessages() const
 {
   return mTotalEvaluatedMessages;
+}
+
+bool DataSamplingPolicy::isActive() const
+{
+  return mActive;
 }
 
 header::DataOrigin DataSamplingPolicy::createPolicyDataOrigin()

--- a/Utilities/DataSampling/test/test_DataSampling.cxx
+++ b/Utilities/DataSampling/test/test_DataSampling.cxx
@@ -64,6 +64,13 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
                        });
   BOOST_CHECK(input != disp->inputs.end());
 
+  // a policy which is switched off
+  input = std::find_if(disp->inputs.begin(), disp->inputs.end(),
+                       [](const InputSpec& in) {
+                         return DataSpecUtils::match(in, DataOrigin("Y"), DataDescription("Z"), 0) && in.lifetime == Lifetime::Timeframe;
+                       });
+  BOOST_CHECK(input == disp->inputs.end());
+
   auto output = std::find_if(disp->outputs.begin(), disp->outputs.end(),
                              [](const OutputSpec& out) {
                                return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters0", 0}) && out.lifetime == Lifetime::QA;

--- a/Utilities/DataSampling/test/test_DataSampling.json
+++ b/Utilities/DataSampling/test/test_DataSampling.json
@@ -1,23 +1,29 @@
 {
-  "dataSamplingPolicies" : [
+  "dataSamplingPolicies": [
     {
-      "id" : "tpcclusters",
-      "active" : "true",
-      "query" : "clusters:TPC/CLUSTERS;clusters_p:TPC/CLUSTERS_P",
-      "samplingConditions" : [],
-      "bindLocation" : "local"
+      "id": "tpcclusters",
+      "active": "true",
+      "query": "clusters:TPC/CLUSTERS;clusters_p:TPC/CLUSTERS_P",
+      "samplingConditions": [],
+      "bindLocation": "local"
     },
     {
-      "id" : "tpcraw",
-      "active" : "true",
-      "machines" : [
+      "id": "tpcraw",
+      "active": "true",
+      "machines": [
         "machineA",
         "machineB"
       ],
-      "port" : "1234",
-      "query" : "clusters:TPC/RAWDATA",
-      "outputs" : "clusters:TPC/SMP_RAWDATA",
-      "samplingConditions" : []
+      "port": "1234",
+      "query": "clusters:TPC/RAWDATA",
+      "outputs": "clusters:TPC/SMP_RAWDATA",
+      "samplingConditions": []
+    },
+    {
+      "id": "switched-off",
+      "active": "false",
+      "query": "x:Y/Z",
+      "samplingConditions": []
     }
   ]
 }


### PR DESCRIPTION
In the early O2 days, the disabled policies were still the Dispatcher to allow for enabling them during a run by reconfiguring the Dispatcher without modifying the topology. Knowing that this feature will not come before Run 4 on the ECS and ODC side, we can change change this behaviour, as it is seen as a bug. In particular, it does not allow to programmatically enable/disable sampling policies depending on the availability of data in async reco.