### PR TITLE
AOD: Abstract TrackTimeRes + Getter

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -253,7 +253,7 @@ DECLARE_SOA_COLUMN(TOFExpMom, tofExpMom, float);                                
 DECLARE_SOA_COLUMN(TrackEtaEMCAL, trackEtaEmcal, float);                                      //!
 DECLARE_SOA_COLUMN(TrackPhiEMCAL, trackPhiEmcal, float);                                      //!
 DECLARE_SOA_COLUMN(TrackTime, trackTime, float);                                              //! Estimated time of the track in ns wrt collision().bc() or ambiguoustrack.bcSlice()[0]
-DECLARE_SOA_COLUMN_FULL(TrackTimeResInternal, trackTimeResInternal, float, "fTrackTimeRes");   //! Internal resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange)
+DECLARE_SOA_COLUMN_FULL(TrackTimeResInternal, trackTimeResInternal, float, "fTrackTimeRes");  //! Internal resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange), use abstracted getter, e.g., track.trackTimeRes() for correct results
 
 // expression columns changing between versions have to be declared in different namespaces
 
@@ -329,18 +329,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(TPCDeltaTBwd, tpcDeltaTBwd, //! Delta Backward of tra
                              return enc.getDeltaTBwd();
                            });
 } // namespace extensions
-
-// Implementation for the getter of the track time error
-DECLARE_SOA_DYNAMIC_COLUMN(TrackTimeRes, trackTimeRes, //! Getter for TrackTimeRes
-                           [](float timeErr, uint32_t flags) -> float {
-                             // Mirror previous behaviour for track error
-                             if (flags & TrackFlags::TrackTimeAsym) {
-                               o2::aod::track::extensions::TPCTimeErrEncoding enc;
-                               enc.encoding.timeErr = timeErr;
-                               return 0.5 * (enc.getDeltaTFwd() + enc.getDeltaTBwd());
-                             }
-                             return timeErr;
-                           });
 } // namespace v001
 
 DECLARE_SOA_DYNAMIC_COLUMN(HasITS, hasITS, //! Flag to check if track has a ITS match
@@ -405,6 +393,19 @@ DECLARE_SOA_DYNAMIC_COLUMN(TRDHasCrossing, trdPattern, //! Flag to check if at l
 
 DECLARE_SOA_DYNAMIC_COLUMN(TRDNLayers, trdPattern, //! Number of TRD tracklets in a Track
                            [](uint8_t trdPattern) -> std::size_t { return std::bitset<6>(trdPattern).count(); });
+
+// Implementation for the getter of the track time error
+DECLARE_SOA_DYNAMIC_COLUMN(TrackTimeRes, trackTimeRes, //! Getter for TrackTimeRes
+                           [](float timeErr, uint32_t flags) -> float {
+                             if (flags & TrackFlags::TrackTimeAsym) {
+                               // Mirror previous behaviour for TPC track error
+                               o2::aod::track::extensions::TPCTimeErrEncoding enc;
+                               enc.encoding.timeErr = timeErr;
+                               return 0.5 * (enc.getDeltaTFwd() + enc.getDeltaTBwd());
+                             }
+                             // Transparently return the value if no flag is set
+                             return timeErr;
+                           });
 } // namespace track
 
 DECLARE_SOA_TABLE_FULL(StoredTracks, "Tracks", "AOD", "TRACK", //! On disk version of the track parameters at collision vertex
@@ -508,7 +509,7 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
                        track::TPCFoundOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                        track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                        track::TrackEtaEMCAL, track::TrackPhiEMCAL,
-                       track::TrackTime, track::TrackTimeResInternal, track::v001::TrackTimeRes<track::TrackTimeResInternal, track::Flags>);
+                       track::TrackTime, track::TrackTimeResInternal, track::TrackTimeRes<track::TrackTimeResInternal, track::Flags>);
 
 DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "TRACKEXTRA", 1, // On disk version of TracksExtra, version 1
                                  track::TPCInnerParam, track::Flags, track::ITSClusterSizes,
@@ -528,7 +529,7 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "T
                                  track::TPCFoundOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                                  track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                                  track::TrackEtaEMCAL, track::TrackPhiEMCAL,
-                                 track::TrackTime, track::TrackTimeResInternal, track::v001::TrackTimeRes<track::TrackTimeResInternal, track::Flags>);
+                                 track::TrackTime, track::TrackTimeResInternal, track::TrackTimeRes<track::TrackTimeResInternal, track::Flags>);
 
 DECLARE_SOA_EXTENDED_TABLE(TracksExtra_000, StoredTracksExtra_000, "TRACKEXTRA", //! Additional track information (clusters, PID, etc.)
                            track::DetectorMap);

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -253,7 +253,7 @@ DECLARE_SOA_COLUMN(TOFExpMom, tofExpMom, float);                                
 DECLARE_SOA_COLUMN(TrackEtaEMCAL, trackEtaEmcal, float);                                      //!
 DECLARE_SOA_COLUMN(TrackPhiEMCAL, trackPhiEmcal, float);                                      //!
 DECLARE_SOA_COLUMN(TrackTime, trackTime, float);                                              //! Estimated time of the track in ns wrt collision().bc() or ambiguoustrack.bcSlice()[0]
-DECLARE_SOA_COLUMN_FULL(TrackTimeResInternal, trackTimeResInternal, float, "trackTimeRes");   //! Internal resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange)
+DECLARE_SOA_COLUMN_FULL(TrackTimeResInternal, trackTimeResInternal, float, "fTrackTimeRes");   //! Internal resolution of the track time in ns (see TrackFlags::TrackTimeResIsRange)
 
 // expression columns changing between versions have to be declared in different namespaces
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -340,7 +340,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(HasTRD, hasTRD, //! Flag to check if track has a TRD 
 DECLARE_SOA_DYNAMIC_COLUMN(HasTOF, hasTOF, //! Flag to check if track has a TOF measurement
                            [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::TOF; });
 DECLARE_SOA_DYNAMIC_COLUMN(IsPVContributor, isPVContributor, //! Run 3: Has this track contributed to the collision vertex fit
-                           [](uint8_t flags) -> bool { return (flags & o2::aod::track::PVContributor) == o2::aod::track::PVContributor; });
+                           [](uint32_t flags) -> bool { return (flags & o2::aod::track::PVContributor) == o2::aod::track::PVContributor; });
 DECLARE_SOA_DYNAMIC_COLUMN(PIDForTracking, pidForTracking, //! PID hypothesis used during tracking. See the constants in the class PID in PID.h
                            [](uint32_t flags) -> uint32_t { return flags >> 28; });
 DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsFound, tpcNClsFound, //! Number of found TPC clusters


### PR DESCRIPTION
@jgrosseo as discussed, this abstracts the track time value and substitutes transparently with a new getter. Once the tpc t0 time is ready I will rebase