### PR TITLE
PHS: fix segfault when reading TRU flags in AltroDecoder.cxx

### DIFF
--- a/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx
@@ -312,6 +312,11 @@ void AltroDecoder::readTRUFlags(short hwAddress, int payloadSize)
       return;
     }
     int timeBin = mBunchwords[currentsample + 1] + 1; // +1 for further convenience
+    if (timeBin > 128) {                              // corrupted sample: add error and ignore the reast of bunchwords
+      // 1: wrong TRU header
+      mOutputHWErrors.emplace_back(mddl, kGeneralTRUErr, static_cast<char>(2)); // PAYLOAD_DECODING
+      return;
+    }
     int istart = currentsample + 2;
     int iend = istart + std::min(bunchlength, static_cast<int>(mBunchwords.size()) - currentsample - 2);
     currentsample += bunchlength + 2;


### PR DESCRIPTION
Hi! This is fix for seg fault when reading TRU flags in AltroDecoder.cxx
```
#1  o2::phos::AltroDecoder::readTRUFlags (this=0x5f99a00, hwAddress=2162, payloadSize=562) at /local/workspace/DailyBuilds/WeeklyO2Release/daily-tags.twINNhnLlC/SOURCES/O2/epn-20240419/epn-20240419/Detectors/PHOS/reconstruction/src/AltroDecoder.cxx:348
```
