### PR TITLE
o2-sim: Apply dynamic detector lib loading to all detectors

### DIFF
--- a/Detectors/CPV/simulation/src/Detector.cxx
+++ b/Detectors/CPV/simulation/src/Detector.cxx
@@ -37,6 +37,7 @@
 using namespace o2::cpv;
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::cpv::Detector::create, cpv);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("CPV", active),

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -38,6 +38,7 @@
 using namespace o2::emcal;
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::emcal::Detector::create, emc);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("EMC", active),

--- a/Detectors/FIT/FDD/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FDD/simulation/src/Detector.cxx
@@ -39,6 +39,7 @@ using o2::fdd::Geometry;
 using o2::fdd::Hit;
 
 ClassImp(o2::fdd::Detector);
+O2DetectorCreatorImpl(o2::fdd::Detector::create, fdd);
 
 //_____________________________________________________________________________
 Detector::Detector(Bool_t Active)

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -42,6 +42,7 @@ using namespace o2::ft0;
 using o2::ft0::Geometry;
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::ft0::Detector::create, ft0);
 
 Detector::Detector(Bool_t Active)
   : o2::base::DetImpl<Detector>("FT0", Active), mIdSens1(0), mPMTeff(nullptr), mHits(o2::utils::createSimVector<o2::ft0::HitType>()), mTrackIdTop(-1), mTrackIdMCPtop(-1)

--- a/Detectors/FIT/FV0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Detector.cxx
@@ -30,6 +30,7 @@ using namespace o2::fv0;
 using o2::fv0::Geometry;
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::fv0::Detector::create, fv0);
 
 Detector::Detector()
   : o2::base::DetImpl<Detector>("FV0", kTRUE),

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -1379,3 +1379,4 @@ void Detector::defineOpticalProperties()
 } // end namespace o2
 
 ClassImp(o2::hmpid::Detector);
+O2DetectorCreatorImpl(o2::hmpid::Detector::create, hmp);

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -79,12 +79,6 @@ class Detector : public o2::base::DetImpl<Detector>
   ///         kFALSE for inactive detectors
   Detector(Bool_t active, TString name = "ITS");
 
-  // Factory method
-  static o2::base::Detector* create(const char* name, bool active)
-  {
-    return new Detector(active, name);
-  }
-
   /// Default constructor
   Detector();
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1318,10 +1318,9 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 
 ClassImp(o2::its::Detector);
 
-// Define Factory method for calling from the outside
 extern "C" {
 o2::base::Detector* create_detector_its(const char* name, bool active)
 {
-  return o2::its::Detector::create(name, active);
+  return o2::its::Detector::create(active, name);
 }
 }

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -38,6 +38,7 @@ using o2::itsmft::Hit;
 using namespace o2::mft;
 
 ClassImp(o2::mft::Detector);
+O2DetectorCreatorImpl(o2::mft::Detector::create, mft);
 
 //_____________________________________________________________________________
 Detector::Detector()

--- a/Detectors/MUON/MCH/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Detector.cxx
@@ -20,6 +20,7 @@
 #include "TGeoManager.h"
 
 ClassImp(o2::mch::Detector);
+O2DetectorCreatorImpl(o2::mch::Detector::create, mch);
 
 namespace o2
 {

--- a/Detectors/MUON/MID/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Detector.cxx
@@ -17,6 +17,7 @@
 #include "FairVolume.h"
 
 ClassImp(o2::mid::Detector);
+O2DetectorCreatorImpl(o2::mid::Detector::create, mid);
 
 namespace o2
 {

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -37,6 +37,7 @@
 using namespace o2::phos;
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::phos::Detector::create, phs);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("PHS", active),

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -26,6 +26,7 @@
 using namespace o2::tof;
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::tof::Detector::create, tof);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("TOF", active), mEventNr(0), mTOFHoles(kTRUE), mHits(o2::utils::createSimVector<HitType>())

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -68,12 +68,6 @@ class Detector : public o2::base::DetImpl<Detector>
    */
   Detector(Bool_t Active);
 
-  // Factory method
-  static o2::base::Detector* create(bool active)
-  {
-    return new Detector(active);
-  }
-
   /**      default constructor    */
   Detector();
 

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -3217,10 +3217,4 @@ std::string Detector::getHitBranchNames(int probe) const
 
 ClassImp(o2::tpc::Detector);
 
-// Define Factory method for calling from the outside
-extern "C" {
-o2::base::Detector* create_detector_tpc(bool active)
-{
-  return o2::tpc::Detector::create(active);
-}
-}
+O2DetectorCreatorImpl(o2::tpc::Detector::create, tpc)

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -526,3 +526,4 @@ void Detector::addAlignableVolumes() const
 }
 
 ClassImp(Detector);
+O2DetectorCreatorImpl(o2::trd::Detector::create, trd)

--- a/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
@@ -242,3 +242,4 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 } // namespace o2
 
 ClassImp(o2::ecal::Detector);
+O2DetectorCreatorImpl(o2::ecal::Detector::create, ecl);

--- a/Detectors/Upgrades/ALICE3/FCT/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FCT/simulation/src/Detector.cxx
@@ -575,3 +575,4 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 }
 
 ClassImp(o2::fct::Detector);
+O2DetectorCreatorImpl(o2::fct::Detector::create, fct);

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
@@ -761,3 +761,4 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 }
 
 ClassImp(o2::ft3::Detector);
+O2DetectorCreatorImpl(o2::ft3::Detector::create, ft3);

--- a/Detectors/Upgrades/ALICE3/MID/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/MID/simulation/src/Detector.cxx
@@ -234,3 +234,4 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 }
 } // namespace o2::mi3
 ClassImp(o2::mi3::Detector);
+O2DetectorCreatorImpl(o2::mi3::Detector::create, mi3);

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
@@ -429,3 +429,4 @@ void Detector::prepareLayout()
 } // namespace o2
 
 ClassImp(o2::rich::Detector);
+O2DetectorCreatorImpl(o2::rich::Detector::create, rch);

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Detector.h
@@ -34,12 +34,6 @@ class Detector : public o2::base::DetImpl<Detector>
   Detector();
   ~Detector();
 
-  // Factory method
-  static o2::base::Detector* create(bool active)
-  {
-    return new Detector(active);
-  }
-
   void ConstructGeometry() override;
 
   o2::itsmft::Hit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos,

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -366,11 +366,4 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 } // namespace o2
 
 ClassImp(o2::trk::Detector);
-
-// Define Factory method for calling from the outside
-extern "C" {
-o2::base::Detector* create_detector_trk(bool active)
-{
-  return o2::trk::Detector::create(active);
-}
-}
+O2DetectorCreatorImpl(o2::trk::Detector::create, trk);

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -39,6 +39,7 @@
 using namespace o2::zdc;
 
 ClassImp(o2::zdc::Detector);
+O2DetectorCreatorImpl(o2::zdc::Detector::create, zdc);
 #define kRaddeg TMath::RadToDeg()
 
 //_____________________________________________________________________________

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -14,6 +14,8 @@
 #include "TString.h"
 #include "TSystem.h"
 
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/Detector.h"
 #include "DetectorsPassive/Cave.h"
 #include "DetectorsPassive/Magnet.h"
 #include "DetectorsPassive/Dipole.h"
@@ -23,19 +25,6 @@
 #include "DetectorsPassive/Hall.h"
 #include "DetectorsPassive/Pipe.h"
 #include <Field/MagneticField.h>
-#include <MFTSimulation/Detector.h>
-#include <MCHSimulation/Detector.h>
-#include <MIDSimulation/Detector.h>
-#include <EMCALSimulation/Detector.h>
-#include <TOFSimulation/Detector.h>
-#include <TRDSimulation/Detector.h>
-#include <FT0Simulation/Detector.h>
-#include <FV0Simulation/Detector.h>
-#include <FDDSimulation/Detector.h>
-#include <HMPIDSimulation/Detector.h>
-#include <PHOSSimulation/Detector.h>
-#include <CPVSimulation/Detector.h>
-#include <ZDCSimulation/Detector.h>
 #include <DetectorsPassive/Cave.h>
 #include <DetectorsPassive/FrameStructure.h>
 #include <SimConfig/SimConfig.h>
@@ -49,12 +38,6 @@
 #endif
 
 #ifdef ENABLE_UPGRADES
-#include <FT3Simulation/Detector.h>
-#include <FCTSimulation/Detector.h>
-#include <IOTOFSimulation/Detector.h>
-#include <RICHSimulation/Detector.h>
-#include <ECalSimulation/Detector.h>
-#include <MI3Simulation/Detector.h>
 #include <Alice3DetectorsPassive/Pipe.h>
 #include <Alice3DetectorsPassive/Absorber.h>
 #include <Alice3DetectorsPassive/Magnet.h>
@@ -211,12 +194,14 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("TOF")) {
     // TOF
-    addReadoutDetector(new o2::tof::Detector(isReadout("TOF")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2TOFSimulation", "create_detector_tof", isReadout("TOF")));
   }
 
   if (isActivated("TRD")) {
     // TRD
-    addReadoutDetector(new o2::trd::Detector(isReadout("TRD")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2TRDSimulation", "create_detector_trd", isReadout("TRD")));
   }
 
   if (isActivated("TPC")) {
@@ -239,32 +224,38 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("FT3")) {
     // ALICE 3 FT3
-    addReadoutDetector(new o2::ft3::Detector(isReadout("FT3")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2FT3Simulation", "create_detector_ft3", isReadout("FT3")));
   }
 
   if (isActivated("FCT")) {
     // ALICE 3 FCT
-    addReadoutDetector(new o2::fct::Detector(isReadout("FCT")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2FCTSimulation", "create_detector_fct", isReadout("FCT")));
   }
 
   if (isActivated("TF3")) {
     // ALICE 3 tofs
-    addReadoutDetector(new o2::iotof::Detector(isReadout("TF3")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2IOTOFSimulation", "create_detector_tf3", isReadout("TF3")));
   }
 
   if (isActivated("RCH")) {
     // ALICE 3 RICH
-    addReadoutDetector(new o2::rich::Detector(isReadout("RCH")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2RICHSimulation", "create_detector_rch", isReadout("RCH")));
   }
 
   if (isActivated("ECL")) {
     // ALICE 3 ECAL
-    addReadoutDetector(new o2::ecal::Detector(isReadout("ECL")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2ECalSimulation", "create_detector_ecl", isReadout("ECL")));
   }
 
   if (isActivated("MI3")) {
     // ALICE 3 MID
-    addReadoutDetector(new o2::mi3::Detector(isReadout("MI3")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2MI3Simulation", "create_detector_mi3", isReadout("MI3")));
   }
 #endif
 
@@ -276,57 +267,68 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("MFT")) {
     // mft
-    addReadoutDetector(new o2::mft::Detector(isReadout("MFT")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2MFTSimulation", "create_detector_mft", isReadout("MFT")));
   }
 
   if (isActivated("MCH")) {
     // mch
-    addReadoutDetector(new o2::mch::Detector(isReadout("MCH")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2MCHSimulation", "create_detector_mch", isReadout("MCH")));
   }
 
   if (isActivated("MID")) {
     // mid
-    addReadoutDetector(new o2::mid::Detector(isReadout("MID")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2MIDSimulation", "create_detector_mid", isReadout("MID")));
   }
 
   if (isActivated("EMC")) {
     // emcal
-    addReadoutDetector(new o2::emcal::Detector(isReadout("EMC")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2EMCALSimulation", "create_detector_emc", isReadout("EMC")));
   }
 
   if (isActivated("PHS")) {
     // phos
-    addReadoutDetector(new o2::phos::Detector(isReadout("PHS")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2PHOSSimulation", "create_detector_phs", isReadout("PHS")));
   }
 
   if (isActivated("CPV")) {
     // cpv
-    addReadoutDetector(new o2::cpv::Detector(isReadout("CPV")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2CPVSimulation", "create_detector_cpv", isReadout("CPV")));
   }
 
   if (isActivated("FT0")) {
     // FIT-T0
-    addReadoutDetector(new o2::ft0::Detector(isReadout("FT0")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2FT0Simulation", "create_detector_ft0", isReadout("FT0")));
   }
 
   if (isActivated("FV0")) {
     // FIT-V0
-    addReadoutDetector(new o2::fv0::Detector(isReadout("FV0")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2FV0Simulation", "create_detector_fv0", isReadout("FV0")));
   }
 
   if (isActivated("FDD")) {
     // FIT-FDD
-    addReadoutDetector(new o2::fdd::Detector(isReadout("FDD")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2FDDSimulation", "create_detector_fdd", isReadout("FDD")));
   }
 
   if (isActivated("HMP")) {
     // HMP
-    addReadoutDetector(new o2::hmpid::Detector(isReadout("HMP")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2HMPIDSimulation", "create_detector_hmp", isReadout("HMP")));
   }
 
   if (isActivated("ZDC")) {
     // ZDC
-    addReadoutDetector(new o2::zdc::Detector(isReadout("ZDC")));
+    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
+      "O2ZDCSimulation", "create_detector_zdc", isReadout("ZDC")));
   }
 
   if (geomonly) {

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -20,32 +20,9 @@ target_link_libraries(allsim
                                 O2::SimSetup
                                 O2::SimulationDataFormat
                                 FairMQ::FairMQ
-                                O2::CPVSimulation
                                 O2::DetectorsPassive
-                                O2::EMCALSimulation
-                                O2::FDDSimulation
                                 O2::Field
-                                O2::HMPIDSimulation
-                                O2::ITSSimulation
-                                O2::MCHSimulation
-                                O2::MFTSimulation
-                                O2::MIDSimulation
-                                O2::PHOSSimulation
-                                O2::FT0Simulation
-                                O2::TOFSimulation
-                                O2::TPCSimulation
-                                O2::TRDSimulation
-                                O2::FV0Simulation
-                                O2::ZDCSimulation
                                 $<$<BOOL:${ENABLE_UPGRADES}>:O2::Alice3DetectorsPassive>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Simulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::TRKSimulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::FT3Simulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::FCTSimulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::IOTOFSimulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::RICHSimulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::ECalSimulation>
-                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::MI3Simulation>
                                 O2::Generators)
 
 add_library(internal::allsim ALIAS allsim)

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -41,21 +41,6 @@
 
 #include "O2HitMerger.h"
 #include "O2SimDevice.h"
-#include <TPCSimulation/Detector.h>
-#include <ITSSimulation/Detector.h>
-#include <MFTSimulation/Detector.h>
-#include <EMCALSimulation/Detector.h>
-#include <TOFSimulation/Detector.h>
-#include <TRDSimulation/Detector.h>
-#include <FT0Simulation/Detector.h>
-#include <FV0Simulation/Detector.h>
-#include <FDDSimulation/Detector.h>
-#include <HMPIDSimulation/Detector.h>
-#include <PHOSSimulation/Detector.h>
-#include <CPVSimulation/Detector.h>
-#include <MCHSimulation/Detector.h>
-#include <MIDSimulation/Detector.h>
-#include <ZDCSimulation/Detector.h>
 
 #include "CommonUtils/ShmManager.h"
 #include <map>
@@ -67,18 +52,6 @@
 #include <functional>
 
 #include "SimPublishChannelHelper.h"
-
-#ifdef ENABLE_UPGRADES
-#include <TRKSimulation/Detector.h>
-#include <FT3Simulation/Detector.h>
-#include <FCTSimulation/Detector.h>
-#include <ITS3Simulation/DescriptorInnerBarrelITS3.h>
-#include <IOTOFSimulation/Detector.h>
-#include <RICHSimulation/Detector.h>
-#include <ECalSimulation/Detector.h>
-#include <MI3Simulation/Detector.h>
-#endif
-
 #include <tbb/concurrent_unordered_map.h>
 
 namespace o2
@@ -923,96 +896,119 @@ void O2HitMerger::initDetInstances()
     }
 
     if (i == DetID::TPC) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::tpc::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2TPCSimulation", "create_detector_tpc", true));
       counter++;
     }
     if (i == DetID::ITS) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::its::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, const char*, bool>(
+        "O2ITSSimulation", "create_detector_its", "ITS", true));
       counter++;
     }
     if (i == DetID::MFT) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::mft::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2MFTSimulation", "create_detector_mft", true));
       counter++;
     }
     if (i == DetID::TRD) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::trd::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2TRDSimulation", "create_detector_trd", true));
       counter++;
     }
     if (i == DetID::PHS) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::phos::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2PHOSSimulation", "create_detector_phs", true));
       counter++;
     }
     if (i == DetID::CPV) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::cpv::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2CPVSimulation", "create_detector_cpv", true));
       counter++;
     }
     if (i == DetID::EMC) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::emcal::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2EMCALSimulation", "create_detector_emc", true));
       counter++;
     }
     if (i == DetID::HMP) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::hmpid::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2HMPIDSimulation", "create_detector_hmp", true));
       counter++;
     }
     if (i == DetID::TOF) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::tof::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2TOFSimulation", "create_detector_tof", true));
       counter++;
     }
     if (i == DetID::FT0) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::ft0::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2FT0Simulation", "create_detector_ft0", true));
       counter++;
     }
     if (i == DetID::FV0) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::fv0::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2FV0Simulation", "create_detector_fv0", true));
       counter++;
     }
     if (i == DetID::FDD) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::fdd::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2FDDSimulation", "create_detector_fdd", true));
       counter++;
     }
     if (i == DetID::MCH) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::mch::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2MCHSimulation", "create_detector_mch", true));
       counter++;
     }
     if (i == DetID::MID) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::mid::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2MIDSimulation", "create_detector_mid", true));
       counter++;
     }
     if (i == DetID::ZDC) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::zdc::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2ZDCSimulation", "create_detector_zdc", true));
       counter++;
     }
 #ifdef ENABLE_UPGRADES
     if (i == DetID::IT3) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::its::Detector>(true, "IT3"));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, const char*, bool>(
+        "O2ITSSimulation", "create_detector_its", "IT3", true));
       counter++;
     }
     if (i == DetID::TRK) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::trk::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2TRKSimulation", "create_detector_trk", "TRK", true));
       counter++;
     }
     if (i == DetID::FT3) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::ft3::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2FT3Simulation", "create_detector_ft3", true));
       counter++;
     }
     if (i == DetID::FCT) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::fct::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2FCTSimulation", "create_detector_fct", true));
       counter++;
     }
     if (i == DetID::TF3) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::iotof::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2IOTOFSimulation", "create_detector_tf3", true));
       counter++;
     }
     if (i == DetID::RCH) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::rich::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2RICHSimulation", "create_detector_rch", true));
       counter++;
     }
     if (i == DetID::MI3) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::mi3::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2MI3Simulation", "create_detector_mi3", true));
       counter++;
     }
     if (i == DetID::ECL) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::ecal::Detector>(true));
+      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
+        "O2ECalSimulation", "create_detector_ecl", true));
       counter++;
     }
 #endif


### PR DESCRIPTION
* code reduction:
- automatic factory method via DetImpl base class
- helper macro to implement extern "C" hooks

* application of dynamic loading during geometry construction and in the HitMerger

* removal of detector linking to o2-sim in CMakeFile

The benefit is ~60MB of memory reduction when only simulating single detectors `o2-sim-serial -m TPC` and a faster load time in general.