### PR TITLE
GPU TPC: Track time constrain must consider TPCFastTransform::getT0()

### DIFF
--- a/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
@@ -234,20 +234,21 @@ GPUdii() void GPUTPCGMO2Output::Thread<GPUTPCGMO2Output::output>(int nBlocks, in
         // estimate max/min time increments which still keep track in the physical limits of the TPC
         const float tmin = CAMath::Min(t1, t2);
         const float maxDriftTime = merger.GetConstantMem()->calibObjects.fastTransformHelper->getCorrMap()->getMaxDriftTime(t1 > t2 ? sector1 : sector2);
+        const float clusterT0 = merger.GetConstantMem()->calibObjects.fastTransformHelper->getCorrMap()->getT0();
         const float tmax = CAMath::Min(tmin + maxDriftTime, CAMath::Max(t1, t2));
         float delta = 0.f;
         if (time0 + maxDriftTime < tmax) {
           delta = tmax - time0 - maxDriftTime;
         }
-        if (tmin < time0 + delta) {
-          delta = tmin - time0;
+        if (tmin - clusterT0 < time0 + delta) {
+          delta = tmin - clusterT0 - time0;
         }
         if (delta != 0.f) {
           time0 += delta;
           const float deltaZ = merger.GetConstantMem()->calibObjects.fastTransformHelper->getCorrMap()->convDeltaTimeToDeltaZinTimeFrame(sector2, delta);
           oTrack.setZ(oTrack.getZ() + deltaZ);
         }
-        tFwd = tmin - time0;
+        tFwd = tmin - clusterT0 - time0;
         tBwd = time0 - tmax + maxDriftTime;
       }
     }

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -1015,7 +1015,7 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMerger* GPUrestrict() merge
     float deltaT = merger->GetConstantMem()->calibObjects.fastTransformHelper->getCorrMap()->convDeltaZtoDeltaTimeInTimeFrame(slice, deltaZ);
     mTZOffset += deltaT;
     mP[1] -= deltaZ;
-    const float maxT = CAMath::Min(tz1, tz2);
+    const float maxT = CAMath::Min(tz1, tz2) - merger->GetConstantMem()->calibObjects.fastTransformHelper->getCorrMap()->getT0();
     const float minT = CAMath::Max(tz1, tz2) - merger->GetConstantMem()->calibObjects.fastTransformHelper->getCorrMap()->getMaxDriftTime(slice);
     // printf("T Check: Clusters %f %f, min %f max %f vtx %f\n", tz1, tz2, minT, maxT, mTZOffset);
     deltaT = 0.f;


### PR DESCRIPTION
@shahor02 : This should fix the constraining of the TPC tracks.

I didn't check yet if we have a similar problem in the CTF skimming, which also uses TPCFastTransform max drift time, to check compatibility of tracks with the allowed BCs. Do we need to check that, or are the margins anyway large enough?