### PR TITLE
[EMCAL-1144] Fix operator+ in EMCAL Hit

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Hit.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Hit.h
@@ -22,6 +22,8 @@ namespace emcal
 /// \class Hit
 /// \brief EMCAL simulation hit information
 /// \ingroup EMCALbase
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since August 31st, 2017
 class Hit : public o2::BasicXYZEHit<float>
 {
  public:
@@ -63,11 +65,6 @@ class Hit : public o2::BasicXYZEHit<float>
   /// \return This point with the summed energy loss
   Hit& operator+=(const Hit& rhs);
 
-  /// \brief Creates a new point base on this point but adding the energy loss of the right hand side
-  /// \param rhs Hit to add to
-  /// \return New EMAL point base on this point
-  Hit operator+(const Hit& rhs) const;
-
   /// \brief Destructor
   ~Hit() = default;
 
@@ -99,6 +96,16 @@ class Hit : public o2::BasicXYZEHit<float>
   ClassDefNV(Hit, 1);
 };
 
+/// \brief Creates a new point base on this point but adding the energy loss of the right hand side
+/// \param lhs Left hand side of the sum
+/// \param rhs Right hand side of the sum
+/// \return New EMAL point base on this point
+Hit operator+(const Hit& lhs, const Hit& rhs);
+
+/// \brief Output stream operator for EMCAL hits
+/// \param stream Stream to write on
+/// \param point Hit to be printed
+/// \return Stream after printing
 std::ostream& operator<<(std::ostream& stream, const Hit& point);
 } // namespace emcal
 } // namespace o2

--- a/Detectors/EMCAL/base/src/Hit.cxx
+++ b/Detectors/EMCAL/base/src/Hit.cxx
@@ -32,7 +32,7 @@ Bool_t Hit::operator<(const Hit& rhs) const
 
 Bool_t Hit::operator==(const Hit& rhs) const
 {
-  return (GetDetectorID() == GetDetectorID()) && (GetTrackID() == rhs.GetTrackID());
+  return (GetDetectorID() == rhs.GetDetectorID()) && (GetTrackID() == rhs.GetTrackID());
 }
 
 Hit& Hit::operator+=(const Hit& rhs)
@@ -41,14 +41,14 @@ Hit& Hit::operator+=(const Hit& rhs)
   return *this;
 }
 
-Hit Hit::operator+(const Hit& rhs) const
+Hit o2::emcal::operator+(const Hit& lhs, const Hit& rhs)
 {
-  Hit result(*this);
+  Hit result(lhs);
   result.SetEnergyLoss(result.GetEnergyLoss() + rhs.GetEnergyLoss());
-  return *this;
+  return result;
 }
 
-std::ostream& operator<<(std::ostream& stream, const Hit& p)
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const Hit& p)
 {
   p.PrintStream(stream);
   return stream;

--- a/Detectors/EMCAL/doxymodules.h
+++ b/Detectors/EMCAL/doxymodules.h
@@ -35,8 +35,13 @@
  * EMCAL calibration objects for
  * - Bad channel map
  * - Time calibration
+ * - Time slewing parameters
  * - Gain calibration
  * - Temperature calibration
+ * - FEE DCS parameters
+ * - Pedestal data
+ * In addition providing an interface convenient CCDB access and methods
+ * to recalibrate add cell level.
  */
 
 /**
@@ -44,8 +49,10 @@
  * @brief EMCAL bad channel calibration
  * @ingroup DetectorEMCAL
  *
- * Performs the EMCal bad channel calibration.
- *
+ * EMCAL calibrator performing
+ * - Bad channel calibration
+ * - Time calibration
+ * and corresponding workflows for calibration tasks.
  */
 
 /**


### PR DESCRIPTION
- operator+ must be declared outside the class as
  binary operator
- Return object should be copy of the lhs hit and
  sum of the two energy losses
In addition:
- Fixing namespace of operator<<
- Updating doxymodules.h with new features in
  calibration part.