### PR TITLE
[Strangeness tracking] Enable 3body strangeness tracking by default

### DIFF
--- a/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/StrangenessTrackingConfigParam.h
+++ b/Detectors/Vertexing/StrangenessTracking/include/StrangenessTracking/StrangenessTrackingConfigParam.h
@@ -33,7 +33,7 @@ struct StrangenessTrackingParamConfig : public o2::conf::ConfigurableParamHelper
   float mMaxChi2 = 50;         // Maximum matching chi2
   bool mVertexMatching = true; // Flag to enable/disable vertex matching
   bool mSkipTPC = true;        // Flag to enable/disable TPC only tracks
-  bool mSkip3Body = true;      // Flag to enable/disable Decay3Body tracking
+  bool mSkip3Body = false;     // Flag to enable/disable Decay3Body tracking
 
   O2ParamDef(StrangenessTrackingParamConfig, "strtracker");
 };

--- a/Detectors/Vertexing/StrangenessTracking/src/StrangenessTracker.cxx
+++ b/Detectors/Vertexing/StrangenessTracking/src/StrangenessTracker.cxx
@@ -242,58 +242,62 @@ void StrangenessTracker::processCascade(int iCasc, const Cascade& casc, const Ca
 
 void StrangenessTracker::process3Body(int i3Body, const Decay3Body& dec3body, const Decay3BodyIndex& dec3bodyIdx, int iThread)
 {
-  ClusAttachments structClus;
-  auto& daughterTracks = mDaughterTracks[iThread];
-  daughterTracks.resize(3); // resize to 3 prongs
+  if (!mStrParams->mSkip3Body) {
+    ClusAttachments structClus;
+    auto& daughterTracks = mDaughterTracks[iThread];
+    daughterTracks.resize(3); // resize to 3 prongs
 
-  StrangeTrack strangeTrack;
-  strangeTrack.mPartType = dataformats::kStrkThreeBody;
-  auto dec3bodyR = std::sqrt(dec3body.calcR2());
-  auto iBins3Body = mUtils.getBinRect(dec3body.getEta(), dec3body.getPhi(), mStrParams->mEtaBinSize, mStrParams->mPhiBinSize);
-  for (int& iBin3Body : iBins3Body) {
-    for (int iTrack{mTracksIdxTable[iBin3Body]}; iTrack < TMath::Min(mTracksIdxTable[iBin3Body + 1], int(mSortedITStracks.size())); iTrack++) {
-      strangeTrack.mMother = (o2::track::TrackParCovF)dec3body;
-      /// TODO: indices of daughters...
-      daughterTracks[kV0DauPos] = dec3body.getProng(kV0DauPos); // proton
-      daughterTracks[kV0DauNeg] = dec3body.getProng(kV0DauNeg); // pion
-      daughterTracks[kBach] = dec3body.getProng(kBach);         // deuteron
-      const auto& itsTrack = mSortedITStracks[iTrack];
-      const auto& ITSindexRef = mSortedITSindexes[iTrack];
-      if (mStrParams->mVertexMatching && (mITSvtxBrackets[ITSindexRef].getMin() > dec3bodyIdx.getVertexID() || mITSvtxBrackets[ITSindexRef].getMax() < dec3bodyIdx.getVertexID())) {
-        continue;
-      }
-      if (matchDecayToITStrack(dec3bodyR, strangeTrack, structClus, itsTrack, daughterTracks, iThread)) {
-        auto propInstance = o2::base::Propagator::Instance();
-        o2::track::TrackParCov decayVtxTrackClone = strangeTrack.mMother; // clone track and propagate to decay vertex
-        if (!propInstance->propagateToX(decayVtxTrackClone, strangeTrack.mDecayVtx[0], getBz(), o2::base::PropagatorImpl<float>::MAX_SIN_PHI, o2::base::PropagatorImpl<float>::MAX_STEP, mCorrType)) {
-          LOG(debug) << "Mother propagation to decay vertex failed";
+    StrangeTrack strangeTrack;
+    strangeTrack.mPartType = dataformats::kStrkThreeBody;
+    auto dec3bodyR = std::sqrt(dec3body.calcR2());
+    auto iBins3Body = mUtils.getBinRect(dec3body.getEta(), dec3body.getPhi(), mStrParams->mEtaBinSize, mStrParams->mPhiBinSize);
+    for (int& iBin3Body : iBins3Body) {
+      for (int iTrack{mTracksIdxTable[iBin3Body]}; iTrack < TMath::Min(mTracksIdxTable[iBin3Body + 1], int(mSortedITStracks.size())); iTrack++) {
+        strangeTrack.mMother = (o2::track::TrackParCovF)dec3body;
+        /// TODO: indices of daughters...
+        daughterTracks[kV0DauPos] = dec3body.getProng(kV0DauPos); // proton
+        daughterTracks[kV0DauNeg] = dec3body.getProng(kV0DauNeg); // pion
+        daughterTracks[kBach] = dec3body.getProng(kBach);         // deuteron
+        const auto& itsTrack = mSortedITStracks[iTrack];
+        const auto& ITSindexRef = mSortedITSindexes[iTrack];
+        if (mStrParams->mVertexMatching && (mITSvtxBrackets[ITSindexRef].getMin() > dec3bodyIdx.getVertexID() || mITSvtxBrackets[ITSindexRef].getMax() < dec3bodyIdx.getVertexID())) {
           continue;
         }
-        decayVtxTrackClone.getPxPyPzGlo(strangeTrack.mDecayMom);
-        std::array<float, 3> momPos, momNeg, momBach;
-        mFitter4Body[iThread].propagateTracksToVertex();
-        mFitter4Body[iThread].getTrack(kV0DauPos).getPxPyPzGlo(momPos);
-        mFitter4Body[iThread].getTrack(kV0DauNeg).getPxPyPzGlo(momNeg);
-        mFitter4Body[iThread].getTrack(kBach).getPxPyPzGlo(momBach);
-        /// TODO: mother mass
-        if (daughterTracks[kBach].getCharge() > 0) {
-          strangeTrack.mMasses[0] = calcMotherMass3body(momPos, momNeg, momBach, PID::Proton, PID::Pion, PID::Deuteron);
-        } else {
-          strangeTrack.mMasses[0] = calcMotherMass3body(momPos, momNeg, momBach, PID::Pion, PID::Proton, PID::Deuteron);
-        }
+        if (matchDecayToITStrack(dec3bodyR, strangeTrack, structClus, itsTrack, daughterTracks, iThread)) {
+          auto propInstance = o2::base::Propagator::Instance();
+          o2::track::TrackParCov decayVtxTrackClone = strangeTrack.mMother; // clone track and propagate to decay vertex
+          if (!propInstance->propagateToX(decayVtxTrackClone, strangeTrack.mDecayVtx[0], getBz(), o2::base::PropagatorImpl<float>::MAX_SIN_PHI, o2::base::PropagatorImpl<float>::MAX_STEP, mCorrType)) {
+            LOG(debug) << "Mother propagation to decay vertex failed";
+            continue;
+          }
+          decayVtxTrackClone.getPxPyPzGlo(strangeTrack.mDecayMom);
+          std::array<float, 3> momPos, momNeg, momBach;
+          mFitter4Body[iThread].propagateTracksToVertex();
+          mFitter4Body[iThread].getTrack(kV0DauPos).getPxPyPzGlo(momPos);
+          mFitter4Body[iThread].getTrack(kV0DauNeg).getPxPyPzGlo(momNeg);
+          mFitter4Body[iThread].getTrack(kBach).getPxPyPzGlo(momBach);
+          /// TODO: mother mass
+          if (daughterTracks[kBach].getCharge() > 0) {
+            strangeTrack.mMasses[0] = calcMotherMass3body(momPos, momNeg, momBach, PID::Proton, PID::Pion, PID::Deuteron);
+          } else {
+            strangeTrack.mMasses[0] = calcMotherMass3body(momPos, momNeg, momBach, PID::Pion, PID::Proton, PID::Deuteron);
+          }
 
-        LOG(debug) << "ITS Track matched with a dec3body decay topology ....";
-        LOG(debug) << "Number of ITS track clusters attached: " << itsTrack.getNumberOfClusters();
-        strangeTrack.mDecayRef = i3Body;
-        strangeTrack.mITSRef = mSortedITSindexes[iTrack];
-        mStrangeTrackVec[iThread].push_back(strangeTrack);
-        mClusAttachments[iThread].push_back(structClus);
-        if (mMCTruthON) {
-          auto lab = getStrangeTrackLabel(itsTrack, strangeTrack, structClus);
-          mStrangeTrackLabels[iThread].push_back(lab);
+          LOG(debug) << "ITS Track matched with a dec3body decay topology ....";
+          LOG(debug) << "Number of ITS track clusters attached: " << itsTrack.getNumberOfClusters();
+          strangeTrack.mDecayRef = i3Body;
+          strangeTrack.mITSRef = mSortedITSindexes[iTrack];
+          mStrangeTrackVec[iThread].push_back(strangeTrack);
+          mClusAttachments[iThread].push_back(structClus);
+          if (mMCTruthON) {
+            auto lab = getStrangeTrackLabel(itsTrack, strangeTrack, structClus);
+            mStrangeTrackLabels[iThread].push_back(lab);
+          }
         }
       }
     }
+  } else {
+    return;
   }
 }
 

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -1182,6 +1182,11 @@ int SVertexer::check3bodyDecays(const V0Index& v0Idx, const V0& v0, float rv0, s
       m3bodyTmp[ithread].push_back(candidate3B);
     }
     m3bodyIdxTmp[ithread].emplace_back(decay3bodyVtxID, v0Idx.getProngID(0), v0Idx.getProngID(1), bach.gid);
+    
+    Decay3BodyIndex decay3bodyIdx(decay3bodyVtxID, v0Idx.getProngID(0), v0Idx.getProngID(1), bach.gid);
+    if (mStrTracker) {
+      mStrTracker->process3Body(m3bodyIdxTmp[ithread].size()-1, candidate3B, decay3bodyIdx, ithread);
+    }
   }
   return m3bodyIdxTmp[ithread].size() - n3BodyIni;
 }

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -1182,10 +1182,10 @@ int SVertexer::check3bodyDecays(const V0Index& v0Idx, const V0& v0, float rv0, s
       m3bodyTmp[ithread].push_back(candidate3B);
     }
     m3bodyIdxTmp[ithread].emplace_back(decay3bodyVtxID, v0Idx.getProngID(0), v0Idx.getProngID(1), bach.gid);
-    
+
     Decay3BodyIndex decay3bodyIdx(decay3bodyVtxID, v0Idx.getProngID(0), v0Idx.getProngID(1), bach.gid);
     if (mStrTracker) {
-      mStrTracker->process3Body(m3bodyIdxTmp[ithread].size()-1, candidate3B, decay3bodyIdx, ithread);
+      mStrTracker->process3Body(m3bodyIdxTmp[ithread].size() - 1, candidate3B, decay3bodyIdx, ithread);
     }
   }
   return m3bodyIdxTmp[ithread].size() - n3BodyIni;


### PR DESCRIPTION
Dear @chiarazampolli and @shahor02 ,

Would it be possible to enable this feature (tracking of decay3bodys) in the strangeness tracker by default?
I tested the strangeness tracker with and without the feature enabled locally on some pp and PbPb CTFs to check the timing overhead. I got the following results:
-  **pp:** Test on two CTFs from Run 543113 (70063 events), I found a less than 3% increase in CPU time when adding the 3body tracking compared to without 
- **PbPb:** Test on 4 CTFs from Run 544122 (1330 events), I found that the timing overhead is negligible, the CPU times were comparable when running with and without the 3body tracking enabled

Could you let me know if anything else is needed?
I am also tagging @fmazzasc with whom I was discussing.

Thanks in advance! :)
