### PR TITLE
Revert "o2-sim: Apply dynamic detector lib loading to all detectors"

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -41,16 +41,6 @@
 
 #include <fairmq/FwdDecls.h>
 
-// macro implementation helper to code unmanged "C" function
-// constructing a detector
-#define O2DetectorCreatorImpl(creatorfuncname, detname)      \
-  extern "C" {                                               \
-  o2::base::Detector* create_detector_##detname(bool active) \
-  {                                                          \
-    return creatorfuncname(active);                          \
-  }                                                          \
-  }
-
 namespace o2::base
 {
 
@@ -311,19 +301,6 @@ class DetImpl : public o2::base::Detector
  public:
   // offer same constructors as base
   using Detector::Detector;
-
-  /// automatic implementation of static Detector factory functions
-  template <typename... Args>
-  static o2::base::Detector* create(Args&&... args)
-  {
-    if constexpr (std::is_constructible_v<Det, Args...>) {
-      return new Det(std::forward<Args>(args)...);
-    } else {
-      static_assert(std::is_constructible_v<Det, Args...>,
-                    "No matching constructor found in Derived class.");
-      return nullptr;
-    }
-  }
 
   // default implementation for getHitBranchNames
   std::string getHitBranchNames(int probe) const override

--- a/Detectors/CPV/simulation/src/Detector.cxx
+++ b/Detectors/CPV/simulation/src/Detector.cxx
@@ -37,7 +37,6 @@
 using namespace o2::cpv;
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::cpv::Detector::create, cpv);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("CPV", active),

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -38,7 +38,6 @@
 using namespace o2::emcal;
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::emcal::Detector::create, emc);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("EMC", active),

--- a/Detectors/FIT/FDD/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FDD/simulation/src/Detector.cxx
@@ -39,7 +39,6 @@ using o2::fdd::Geometry;
 using o2::fdd::Hit;
 
 ClassImp(o2::fdd::Detector);
-O2DetectorCreatorImpl(o2::fdd::Detector::create, fdd);
 
 //_____________________________________________________________________________
 Detector::Detector(Bool_t Active)

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -42,7 +42,6 @@ using namespace o2::ft0;
 using o2::ft0::Geometry;
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::ft0::Detector::create, ft0);
 
 Detector::Detector(Bool_t Active)
   : o2::base::DetImpl<Detector>("FT0", Active), mIdSens1(0), mPMTeff(nullptr), mHits(o2::utils::createSimVector<o2::ft0::HitType>()), mTrackIdTop(-1), mTrackIdMCPtop(-1)

--- a/Detectors/FIT/FV0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Detector.cxx
@@ -30,7 +30,6 @@ using namespace o2::fv0;
 using o2::fv0::Geometry;
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::fv0::Detector::create, fv0);
 
 Detector::Detector()
   : o2::base::DetImpl<Detector>("FV0", kTRUE),

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -1379,4 +1379,3 @@ void Detector::defineOpticalProperties()
 } // end namespace o2
 
 ClassImp(o2::hmpid::Detector);
-O2DetectorCreatorImpl(o2::hmpid::Detector::create, hmp);

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -79,6 +79,12 @@ class Detector : public o2::base::DetImpl<Detector>
   ///         kFALSE for inactive detectors
   Detector(Bool_t active, TString name = "ITS");
 
+  // Factory method
+  static o2::base::Detector* create(const char* name, bool active)
+  {
+    return new Detector(active, name);
+  }
+
   /// Default constructor
   Detector();
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1318,9 +1318,10 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 
 ClassImp(o2::its::Detector);
 
+// Define Factory method for calling from the outside
 extern "C" {
 o2::base::Detector* create_detector_its(const char* name, bool active)
 {
-  return o2::its::Detector::create(active, name);
+  return o2::its::Detector::create(name, active);
 }
 }

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -38,7 +38,6 @@ using o2::itsmft::Hit;
 using namespace o2::mft;
 
 ClassImp(o2::mft::Detector);
-O2DetectorCreatorImpl(o2::mft::Detector::create, mft);
 
 //_____________________________________________________________________________
 Detector::Detector()

--- a/Detectors/MUON/MCH/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Detector.cxx
@@ -20,7 +20,6 @@
 #include "TGeoManager.h"
 
 ClassImp(o2::mch::Detector);
-O2DetectorCreatorImpl(o2::mch::Detector::create, mch);
 
 namespace o2
 {

--- a/Detectors/MUON/MID/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Detector.cxx
@@ -17,7 +17,6 @@
 #include "FairVolume.h"
 
 ClassImp(o2::mid::Detector);
-O2DetectorCreatorImpl(o2::mid::Detector::create, mid);
 
 namespace o2
 {

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -37,7 +37,6 @@
 using namespace o2::phos;
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::phos::Detector::create, phs);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("PHS", active),

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -26,7 +26,6 @@
 using namespace o2::tof;
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::tof::Detector::create, tof);
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("TOF", active), mEventNr(0), mTOFHoles(kTRUE), mHits(o2::utils::createSimVector<HitType>())

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -68,6 +68,12 @@ class Detector : public o2::base::DetImpl<Detector>
    */
   Detector(Bool_t Active);
 
+  // Factory method
+  static o2::base::Detector* create(bool active)
+  {
+    return new Detector(active);
+  }
+
   /**      default constructor    */
   Detector();
 

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -3217,4 +3217,10 @@ std::string Detector::getHitBranchNames(int probe) const
 
 ClassImp(o2::tpc::Detector);
 
-O2DetectorCreatorImpl(o2::tpc::Detector::create, tpc)
+// Define Factory method for calling from the outside
+extern "C" {
+o2::base::Detector* create_detector_tpc(bool active)
+{
+  return o2::tpc::Detector::create(active);
+}
+}

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -526,4 +526,3 @@ void Detector::addAlignableVolumes() const
 }
 
 ClassImp(Detector);
-O2DetectorCreatorImpl(o2::trd::Detector::create, trd)

--- a/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/ECal/simulation/src/Detector.cxx
@@ -242,4 +242,3 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 } // namespace o2
 
 ClassImp(o2::ecal::Detector);
-O2DetectorCreatorImpl(o2::ecal::Detector::create, ecl);

--- a/Detectors/Upgrades/ALICE3/FCT/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FCT/simulation/src/Detector.cxx
@@ -575,4 +575,3 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 }
 
 ClassImp(o2::fct::Detector);
-O2DetectorCreatorImpl(o2::fct::Detector::create, fct);

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
@@ -761,4 +761,3 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 }
 
 ClassImp(o2::ft3::Detector);
-O2DetectorCreatorImpl(o2::ft3::Detector::create, ft3);

--- a/Detectors/Upgrades/ALICE3/MID/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/MID/simulation/src/Detector.cxx
@@ -234,4 +234,3 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 }
 } // namespace o2::mi3
 ClassImp(o2::mi3::Detector);
-O2DetectorCreatorImpl(o2::mi3::Detector::create, mi3);

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/Detector.cxx
@@ -429,4 +429,3 @@ void Detector::prepareLayout()
 } // namespace o2
 
 ClassImp(o2::rich::Detector);
-O2DetectorCreatorImpl(o2::rich::Detector::create, rch);

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Detector.h
@@ -34,6 +34,12 @@ class Detector : public o2::base::DetImpl<Detector>
   Detector();
   ~Detector();
 
+  // Factory method
+  static o2::base::Detector* create(bool active)
+  {
+    return new Detector(active);
+  }
+
   void ConstructGeometry() override;
 
   o2::itsmft::Hit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos,

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -366,4 +366,11 @@ o2::itsmft::Hit* Detector::addHit(int trackID, int detID, const TVector3& startP
 } // namespace o2
 
 ClassImp(o2::trk::Detector);
-O2DetectorCreatorImpl(o2::trk::Detector::create, trk);
+
+// Define Factory method for calling from the outside
+extern "C" {
+o2::base::Detector* create_detector_trk(bool active)
+{
+  return o2::trk::Detector::create(active);
+}
+}

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -39,7 +39,6 @@
 using namespace o2::zdc;
 
 ClassImp(o2::zdc::Detector);
-O2DetectorCreatorImpl(o2::zdc::Detector::create, zdc);
 #define kRaddeg TMath::RadToDeg()
 
 //_____________________________________________________________________________

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -14,8 +14,6 @@
 #include "TString.h"
 #include "TSystem.h"
 
-#include "DetectorsCommonDataFormats/DetID.h"
-#include "DetectorsBase/Detector.h"
 #include "DetectorsPassive/Cave.h"
 #include "DetectorsPassive/Magnet.h"
 #include "DetectorsPassive/Dipole.h"
@@ -25,6 +23,19 @@
 #include "DetectorsPassive/Hall.h"
 #include "DetectorsPassive/Pipe.h"
 #include <Field/MagneticField.h>
+#include <MFTSimulation/Detector.h>
+#include <MCHSimulation/Detector.h>
+#include <MIDSimulation/Detector.h>
+#include <EMCALSimulation/Detector.h>
+#include <TOFSimulation/Detector.h>
+#include <TRDSimulation/Detector.h>
+#include <FT0Simulation/Detector.h>
+#include <FV0Simulation/Detector.h>
+#include <FDDSimulation/Detector.h>
+#include <HMPIDSimulation/Detector.h>
+#include <PHOSSimulation/Detector.h>
+#include <CPVSimulation/Detector.h>
+#include <ZDCSimulation/Detector.h>
 #include <DetectorsPassive/Cave.h>
 #include <DetectorsPassive/FrameStructure.h>
 #include <SimConfig/SimConfig.h>
@@ -38,6 +49,12 @@
 #endif
 
 #ifdef ENABLE_UPGRADES
+#include <FT3Simulation/Detector.h>
+#include <FCTSimulation/Detector.h>
+#include <IOTOFSimulation/Detector.h>
+#include <RICHSimulation/Detector.h>
+#include <ECalSimulation/Detector.h>
+#include <MI3Simulation/Detector.h>
 #include <Alice3DetectorsPassive/Pipe.h>
 #include <Alice3DetectorsPassive/Absorber.h>
 #include <Alice3DetectorsPassive/Magnet.h>
@@ -194,14 +211,12 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("TOF")) {
     // TOF
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2TOFSimulation", "create_detector_tof", isReadout("TOF")));
+    addReadoutDetector(new o2::tof::Detector(isReadout("TOF")));
   }
 
   if (isActivated("TRD")) {
     // TRD
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2TRDSimulation", "create_detector_trd", isReadout("TRD")));
+    addReadoutDetector(new o2::trd::Detector(isReadout("TRD")));
   }
 
   if (isActivated("TPC")) {
@@ -224,38 +239,32 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("FT3")) {
     // ALICE 3 FT3
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2FT3Simulation", "create_detector_ft3", isReadout("FT3")));
+    addReadoutDetector(new o2::ft3::Detector(isReadout("FT3")));
   }
 
   if (isActivated("FCT")) {
     // ALICE 3 FCT
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2FCTSimulation", "create_detector_fct", isReadout("FCT")));
+    addReadoutDetector(new o2::fct::Detector(isReadout("FCT")));
   }
 
   if (isActivated("TF3")) {
     // ALICE 3 tofs
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2IOTOFSimulation", "create_detector_tf3", isReadout("TF3")));
+    addReadoutDetector(new o2::iotof::Detector(isReadout("TF3")));
   }
 
   if (isActivated("RCH")) {
     // ALICE 3 RICH
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2RICHSimulation", "create_detector_rch", isReadout("RCH")));
+    addReadoutDetector(new o2::rich::Detector(isReadout("RCH")));
   }
 
   if (isActivated("ECL")) {
     // ALICE 3 ECAL
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2ECalSimulation", "create_detector_ecl", isReadout("ECL")));
+    addReadoutDetector(new o2::ecal::Detector(isReadout("ECL")));
   }
 
   if (isActivated("MI3")) {
     // ALICE 3 MID
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2MI3Simulation", "create_detector_mi3", isReadout("MI3")));
+    addReadoutDetector(new o2::mi3::Detector(isReadout("MI3")));
   }
 #endif
 
@@ -267,68 +276,57 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("MFT")) {
     // mft
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2MFTSimulation", "create_detector_mft", isReadout("MFT")));
+    addReadoutDetector(new o2::mft::Detector(isReadout("MFT")));
   }
 
   if (isActivated("MCH")) {
     // mch
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2MCHSimulation", "create_detector_mch", isReadout("MCH")));
+    addReadoutDetector(new o2::mch::Detector(isReadout("MCH")));
   }
 
   if (isActivated("MID")) {
     // mid
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2MIDSimulation", "create_detector_mid", isReadout("MID")));
+    addReadoutDetector(new o2::mid::Detector(isReadout("MID")));
   }
 
   if (isActivated("EMC")) {
     // emcal
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2EMCALSimulation", "create_detector_emc", isReadout("EMC")));
+    addReadoutDetector(new o2::emcal::Detector(isReadout("EMC")));
   }
 
   if (isActivated("PHS")) {
     // phos
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2PHOSSimulation", "create_detector_phs", isReadout("PHS")));
+    addReadoutDetector(new o2::phos::Detector(isReadout("PHS")));
   }
 
   if (isActivated("CPV")) {
     // cpv
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2CPVSimulation", "create_detector_cpv", isReadout("CPV")));
+    addReadoutDetector(new o2::cpv::Detector(isReadout("CPV")));
   }
 
   if (isActivated("FT0")) {
     // FIT-T0
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2FT0Simulation", "create_detector_ft0", isReadout("FT0")));
+    addReadoutDetector(new o2::ft0::Detector(isReadout("FT0")));
   }
 
   if (isActivated("FV0")) {
     // FIT-V0
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2FV0Simulation", "create_detector_fv0", isReadout("FV0")));
+    addReadoutDetector(new o2::fv0::Detector(isReadout("FV0")));
   }
 
   if (isActivated("FDD")) {
     // FIT-FDD
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2FDDSimulation", "create_detector_fdd", isReadout("FDD")));
+    addReadoutDetector(new o2::fdd::Detector(isReadout("FDD")));
   }
 
   if (isActivated("HMP")) {
     // HMP
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2HMPIDSimulation", "create_detector_hmp", isReadout("HMP")));
+    addReadoutDetector(new o2::hmpid::Detector(isReadout("HMP")));
   }
 
   if (isActivated("ZDC")) {
     // ZDC
-    addReadoutDetector(o2::conf::SimDLLoader::Instance().executeFunctionAlias<Return, bool>(
-      "O2ZDCSimulation", "create_detector_zdc", isReadout("ZDC")));
+    addReadoutDetector(new o2::zdc::Detector(isReadout("ZDC")));
   }
 
   if (geomonly) {

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -20,9 +20,32 @@ target_link_libraries(allsim
                                 O2::SimSetup
                                 O2::SimulationDataFormat
                                 FairMQ::FairMQ
+                                O2::CPVSimulation
                                 O2::DetectorsPassive
+                                O2::EMCALSimulation
+                                O2::FDDSimulation
                                 O2::Field
+                                O2::HMPIDSimulation
+                                O2::ITSSimulation
+                                O2::MCHSimulation
+                                O2::MFTSimulation
+                                O2::MIDSimulation
+                                O2::PHOSSimulation
+                                O2::FT0Simulation
+                                O2::TOFSimulation
+                                O2::TPCSimulation
+                                O2::TRDSimulation
+                                O2::FV0Simulation
+                                O2::ZDCSimulation
                                 $<$<BOOL:${ENABLE_UPGRADES}>:O2::Alice3DetectorsPassive>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Simulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::TRKSimulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::FT3Simulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::FCTSimulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::IOTOFSimulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::RICHSimulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::ECalSimulation>
+                                $<$<BOOL:${ENABLE_UPGRADES}>:O2::MI3Simulation>
                                 O2::Generators)
 
 add_library(internal::allsim ALIAS allsim)

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -41,6 +41,21 @@
 
 #include "O2HitMerger.h"
 #include "O2SimDevice.h"
+#include <TPCSimulation/Detector.h>
+#include <ITSSimulation/Detector.h>
+#include <MFTSimulation/Detector.h>
+#include <EMCALSimulation/Detector.h>
+#include <TOFSimulation/Detector.h>
+#include <TRDSimulation/Detector.h>
+#include <FT0Simulation/Detector.h>
+#include <FV0Simulation/Detector.h>
+#include <FDDSimulation/Detector.h>
+#include <HMPIDSimulation/Detector.h>
+#include <PHOSSimulation/Detector.h>
+#include <CPVSimulation/Detector.h>
+#include <MCHSimulation/Detector.h>
+#include <MIDSimulation/Detector.h>
+#include <ZDCSimulation/Detector.h>
 
 #include "CommonUtils/ShmManager.h"
 #include <map>
@@ -52,6 +67,18 @@
 #include <functional>
 
 #include "SimPublishChannelHelper.h"
+
+#ifdef ENABLE_UPGRADES
+#include <TRKSimulation/Detector.h>
+#include <FT3Simulation/Detector.h>
+#include <FCTSimulation/Detector.h>
+#include <ITS3Simulation/DescriptorInnerBarrelITS3.h>
+#include <IOTOFSimulation/Detector.h>
+#include <RICHSimulation/Detector.h>
+#include <ECalSimulation/Detector.h>
+#include <MI3Simulation/Detector.h>
+#endif
+
 #include <tbb/concurrent_unordered_map.h>
 
 namespace o2
@@ -896,119 +923,96 @@ void O2HitMerger::initDetInstances()
     }
 
     if (i == DetID::TPC) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2TPCSimulation", "create_detector_tpc", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::tpc::Detector>(true));
       counter++;
     }
     if (i == DetID::ITS) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, const char*, bool>(
-        "O2ITSSimulation", "create_detector_its", "ITS", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::its::Detector>(true));
       counter++;
     }
     if (i == DetID::MFT) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2MFTSimulation", "create_detector_mft", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::mft::Detector>(true));
       counter++;
     }
     if (i == DetID::TRD) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2TRDSimulation", "create_detector_trd", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::trd::Detector>(true));
       counter++;
     }
     if (i == DetID::PHS) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2PHOSSimulation", "create_detector_phs", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::phos::Detector>(true));
       counter++;
     }
     if (i == DetID::CPV) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2CPVSimulation", "create_detector_cpv", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::cpv::Detector>(true));
       counter++;
     }
     if (i == DetID::EMC) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2EMCALSimulation", "create_detector_emc", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::emcal::Detector>(true));
       counter++;
     }
     if (i == DetID::HMP) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2HMPIDSimulation", "create_detector_hmp", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::hmpid::Detector>(true));
       counter++;
     }
     if (i == DetID::TOF) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2TOFSimulation", "create_detector_tof", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::tof::Detector>(true));
       counter++;
     }
     if (i == DetID::FT0) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2FT0Simulation", "create_detector_ft0", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::ft0::Detector>(true));
       counter++;
     }
     if (i == DetID::FV0) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2FV0Simulation", "create_detector_fv0", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::fv0::Detector>(true));
       counter++;
     }
     if (i == DetID::FDD) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2FDDSimulation", "create_detector_fdd", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::fdd::Detector>(true));
       counter++;
     }
     if (i == DetID::MCH) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2MCHSimulation", "create_detector_mch", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::mch::Detector>(true));
       counter++;
     }
     if (i == DetID::MID) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2MIDSimulation", "create_detector_mid", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::mid::Detector>(true));
       counter++;
     }
     if (i == DetID::ZDC) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2ZDCSimulation", "create_detector_zdc", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::zdc::Detector>(true));
       counter++;
     }
 #ifdef ENABLE_UPGRADES
     if (i == DetID::IT3) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, const char*, bool>(
-        "O2ITSSimulation", "create_detector_its", "IT3", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::its::Detector>(true, "IT3"));
       counter++;
     }
     if (i == DetID::TRK) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2TRKSimulation", "create_detector_trk", "TRK", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::trk::Detector>(true));
       counter++;
     }
     if (i == DetID::FT3) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2FT3Simulation", "create_detector_ft3", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::ft3::Detector>(true));
       counter++;
     }
     if (i == DetID::FCT) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2FCTSimulation", "create_detector_fct", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::fct::Detector>(true));
       counter++;
     }
     if (i == DetID::TF3) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2IOTOFSimulation", "create_detector_tf3", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::iotof::Detector>(true));
       counter++;
     }
     if (i == DetID::RCH) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2RICHSimulation", "create_detector_rch", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::rich::Detector>(true));
       counter++;
     }
     if (i == DetID::MI3) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2MI3Simulation", "create_detector_mi3", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::mi3::Detector>(true));
       counter++;
     }
     if (i == DetID::ECL) {
-      mDetectorInstances[i].reset(o2::conf::SimDLLoader::Instance().executeFunctionAlias<o2::base::Detector*, bool>(
-        "O2ECalSimulation", "create_detector_ecl", true));
+      mDetectorInstances[i] = std::move(std::make_unique<o2::ecal::Detector>(true));
       counter++;
     }
 #endif


### PR DESCRIPTION
This reverts commit 9ddc990c75e898ac6c0e39cd5b45c01328c6a1b0.

There are some other things (e.g., correct order of initialization of ConfigKey parameters) , affected by this commit, which need to be addressed and worked out first.