### PR TITLE
Fix for HepMC: Actually take into account mEventsToSkip

### DIFF
--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -87,6 +87,11 @@ void GeneratorHepMC::setup(const GeneratorFileOrCmdParam& param0,
   mPrune = param.prune;
   setEventsToSkip(param.eventsToSkip);
 
+  // we are skipping ahead in the HepMC stream now
+  for (int i = 0; i < mEventsToSkip; ++i) {
+    generateEvent();
+  }
+
   if (param.version != 0 and mCmd.empty()) {
     LOG(warn) << "The key \"HepMC.version\" is no longer used when "
               << "reading from files. The format version of the input files "
@@ -100,8 +105,9 @@ Bool_t GeneratorHepMC::generateEvent()
   LOG(debug) << "Generating an event";
   /** generate event **/
   int tries = 0;
+  constexpr int max_tries = 3;
   do {
-    LOG(debug) << " try # " << ++tries;
+    LOG(debug) << " try # " << tries;
     if (not mReader and not makeReader()) {
       return false;
     }
@@ -114,8 +120,13 @@ Bool_t GeneratorHepMC::generateEvent()
       mEvent->set_units(HepMC3::Units::GEV, HepMC3::Units::MM);
       LOG(debug) << "Read one event " << mEvent->event_number();
       return true;
+    } else {
+      LOG(error) << "Event reading from HepMC failed ...";
     }
-  } while (true);
+    tries++;
+  } while (tries < max_tries);
+
+  LOG(fatal) << "HepMC event gen failed (Does the file/stream have enough events)?";
 
   /** failure **/
   return false;


### PR DESCRIPTION
The option HepMC.eventsToSkip existed with the purpose to skip the first couple of events. This is useful to share an HepMC file among multiple timeframes or MC-jobs. Jobs can skip ahead to the correct event.

Unfortunately, the skipping itself was not implemented and the option had no effect. This commit is fixing this.

In addition, this commit avoids a potential infinite hang under error conditions.