### PR TITLE
Add separate upload and download timemouts for CCDBApi

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -629,7 +629,8 @@ class CcdbApi //: public DatabaseInterface
   static std::unique_ptr<TJAlienCredentials> mJAlienCredentials; // access JAliEn credentials
   int mCurlRetries = 3;
   int mCurlDelayRetries = 100000; // in microseconds
-  size_t mCurlTimeout = 15;       // in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT, updated according to the deployment mode
+  size_t mCurlTimeoutDownload = 15; // download timeout in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT_DOWNLOAD, updated according to the deployment mode
+  size_t mCurlTimeoutUpload = 15;   // upload timeout in seconds, can be configured via ALICEO2_CCDB_CURL_TIMEOUT_UPLOAD, updated according to the deployment mode
 
   ClassDefNV(CcdbApi, 1);
 };


### PR DESCRIPTION
The reason for this change: if the remote server is busy, having a short, 1s timeout for uploads may lead to multiple uploads of the same object.

@costing I see that only  `storeAsBinaryFile` was setting a timeout https://github.com/AliceO2Group/AliceO2/blob/62859c83eb64adc8d3f611ab979eb9ec447096cf/CCDB/src/CcdbApi.cxx#L406-L417, while other operations:

https://github.com/AliceO2Group/AliceO2/blob/62859c83eb64adc8d3f611ab979eb9ec447096cf/CCDB/src/CcdbApi.cxx#L708
https://github.com/AliceO2Group/AliceO2/blob/62859c83eb64adc8d3f611ab979eb9ec447096cf/CCDB/src/CcdbApi.cxx#L993
https://github.com/AliceO2Group/AliceO2/blob/62859c83eb64adc8d3f611ab979eb9ec447096cf/CCDB/src/CcdbApi.cxx#L1188
etc. don't have it (that said, now the downloads are done with the CCDBDownloader which was setting its independent hardcoded timeout). Is it ok to leave the methods which are currently not setting the timeout as they are?


