### PR TITLE
Prevent segfault in GeneratorFromFile

### DIFF
--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -63,6 +63,13 @@ void GeneratorFromFile::SetStartEvent(int start)
 
 bool GeneratorFromFile::rejectOrFixKinematics(TParticle& p)
 {
+  // avoid compute if the particle is not known in the PDG database
+  if (!p.GetPDG()) {
+    LOG(warn) << "Particle with pdg " << p.GetPdgCode() << " not known in DB (not fixing mass)";
+    // still returning true here ... primary will be flagged as non-trackable by primary event generator
+    return true;
+  }
+
   const auto nominalmass = p.GetMass();
   auto mom2 = p.Px() * p.Px() + p.Py() * p.Py() + p.Pz() * p.Pz();
   auto calculatedmass = p.Energy() * p.Energy() - mom2;

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -140,7 +140,7 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
 
   // check the status encoding
   if (!mcgenstatus::isEncoded(generatorStatus) && proc == TMCProcess::kPPrimary) {
-    LOG(fatal) << "Generatror status " << generatorStatus << " of particle is not encoded properly.";
+    LOG(fatal) << "Generator status " << generatorStatus << " of particle is not encoded properly.";
   }
 
   /** add event vertex to track vertex **/
@@ -151,7 +151,7 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
   /** check if particle to be tracked exists in PDG database **/
   auto particlePDG = TDatabasePDG::Instance()->GetParticle(pdgid);
   if (wanttracking && !particlePDG) {
-    LOG(warn) << "Particle to be tracked is not defined in PDG: pdg = " << pdgid;
+    LOG(warn) << "Particle to be tracked is not defined in PDG: pdg = " << pdgid << " (disabling tracking)";
     wanttracking = false;
   }
 


### PR DESCRIPTION
There was a segfault when trying to fetch Mass of a TParticle that does not have an entry in the PDG database.

This commit fixes this by avoiding the call to the Mass function.