### PR TITLE
DPL: do not print internal error in case we rewinded

### DIFF
--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -26,7 +26,6 @@
 namespace o2::framework
 {
 
-
 /// This class keeps the information relative to a given slot in the cache, in
 /// particular which variables are associated to it (and indirectly which
 /// timeslice which is always mapped to the variable 0) and wether we should
@@ -130,7 +129,7 @@ class TimesliceIndex
   /// and the oldest possible timeslice in-fly which is still dirty.
   [[nodiscard]] OldestInputInfo getOldestPossibleInput() const;
   [[nodiscard]] OldestOutputInfo getOldestPossibleOutput() const;
-  OldestOutputInfo updateOldestPossibleOutput();
+  OldestOutputInfo updateOldestPossibleOutput(bool rewinded);
   [[nodiscard]] InputChannelInfo const& getChannelInfo(ChannelIndex channel) const;
 
   // Reset the TimesliceIndex to its initial state

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -560,7 +560,7 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "postForwardingCallbacks", "We are the first one in the topology, we need to update the oldest possible timeslice");
       auto& timesliceIndex = ctx.services().get<TimesliceIndex>();
       auto& relayer = ctx.services().get<DataRelayer>();
-      timesliceIndex.updateOldestPossibleOutput();
+      timesliceIndex.updateOldestPossibleOutput(decongestion->nextEnumerationTimesliceRewinded);
       auto& proxy = ctx.services().get<FairMQDeviceProxy>();
       auto oldestPossibleOutput = relayer.getOldestPossibleOutput();
       if (decongestion->nextEnumerationTimesliceRewinded && decongestion->nextEnumerationTimeslice < oldestPossibleOutput.timeslice.value) {
@@ -632,7 +632,7 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       O2_SIGNPOST_EVENT_EMIT(data_processor_context, cid, "oldest_possible_timeslice", "Received oldest possible timeframe %" PRIu64 " from channel %d",
                              (uint64_t)oldestPossibleTimeslice, channel.value);
       relayer.setOldestPossibleInput({oldestPossibleTimeslice}, channel);
-      timesliceIndex.updateOldestPossibleOutput();
+      timesliceIndex.updateOldestPossibleOutput(decongestion.nextEnumerationTimesliceRewinded);
       auto oldestPossibleOutput = relayer.getOldestPossibleOutput();
 
       if (oldestPossibleOutput.timeslice.value == decongestion.lastTimeslice) {

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -759,7 +759,7 @@ void DataRelayer::getReadyToProcess(std::vector<DataRelayer::RecordAction>& comp
         break;
     }
   }
-  mTimesliceIndex.updateOldestPossibleOutput();
+  mTimesliceIndex.updateOldestPossibleOutput(false);
   LOGP(debug, "DataRelayer::getReadyToProcess results notDirty:{}, consume:{}, consumeExisting:{}, process:{}, discard:{}, wait:{}",
        notDirty, countConsume, countConsumeExisting, countProcess,
        countDiscard, countWait);

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -98,7 +98,7 @@ ExpirationHandler::Creator LifetimeHelpers::enumDrivenCreation(size_t start, siz
         // associated with this.
         LOG(debug) << "Oldest possible input is " << decongestion.nextEnumerationTimeslice;
         [[maybe_unused]] auto newOldest = index.setOldestPossibleInput({decongestion.nextEnumerationTimeslice}, channelIndex);
-        index.updateOldestPossibleOutput();
+        index.updateOldestPossibleOutput(decongestion.nextEnumerationTimesliceRewinded);
         return slot;
       }
     }
@@ -143,7 +143,7 @@ ExpirationHandler::Creator LifetimeHelpers::timeDrivenCreation(std::vector<std::
     // Nothing to do if the time has not expired yet.
     if (timerHasFired == false) {
       [[maybe_unused]] auto newOldest = index.setOldestPossibleInput({decongestion.nextEnumerationTimeslice}, channelIndex);
-      index.updateOldestPossibleOutput();
+      index.updateOldestPossibleOutput(decongestion.nextEnumerationTimesliceRewinded);
       return TimesliceSlot{TimesliceSlot::INVALID};
     }
     // Get the first time we were invoked.
@@ -168,7 +168,7 @@ ExpirationHandler::Creator LifetimeHelpers::timeDrivenCreation(std::vector<std::
       auto& variables = index.getVariablesForSlot(slot);
       if (VariableContextHelpers::getTimeslice(variables).value == current) {
         [[maybe_unused]] auto newOldest = index.setOldestPossibleInput({decongestion.nextEnumerationTimeslice}, channelIndex);
-        index.updateOldestPossibleOutput();
+        index.updateOldestPossibleOutput(decongestion.nextEnumerationTimesliceRewinded);
         return TimesliceSlot{TimesliceSlot::INVALID};
       }
     }
@@ -192,7 +192,7 @@ ExpirationHandler::Creator LifetimeHelpers::timeDrivenCreation(std::vector<std::
     }
 
     auto newOldest = index.setOldestPossibleInput({decongestion.nextEnumerationTimeslice}, channelIndex);
-    index.updateOldestPossibleOutput();
+    index.updateOldestPossibleOutput(decongestion.nextEnumerationTimesliceRewinded);
     return slot;
   };
 }
@@ -442,7 +442,6 @@ ExpirationHandler::Handler LifetimeHelpers::enumerate(ConcreteDataMatcher const&
     *(counter_t*)payload->GetData() = *counter;
     ref.payload = std::move(payload);
     (*counter)++;
-
   };
 }
 

--- a/Framework/Core/src/TimesliceIndex.cxx
+++ b/Framework/Core/src/TimesliceIndex.cxx
@@ -192,7 +192,7 @@ bool TimesliceIndex::validateSlot(TimesliceSlot slot, TimesliceId currentOldest)
   return true;
 }
 
-TimesliceIndex::OldestOutputInfo TimesliceIndex::updateOldestPossibleOutput()
+TimesliceIndex::OldestOutputInfo TimesliceIndex::updateOldestPossibleOutput(bool rewinded)
 {
   auto oldestInput = getOldestPossibleInput();
   OldestOutputInfo result{oldestInput.timeslice, oldestInput.channel};
@@ -223,7 +223,7 @@ TimesliceIndex::OldestOutputInfo TimesliceIndex::updateOldestPossibleOutput()
                              mOldestPossibleOutput.timeslice.value, result.timeslice.value);
     }
   }
-  if (mOldestPossibleOutput.timeslice.value > result.timeslice.value) {
+  if (rewinded == false && mOldestPossibleOutput.timeslice.value > result.timeslice.value) {
     LOG(error) << "DPL internal error - oldestPossibleOutput decreased from " << mOldestPossibleOutput.timeslice.value << " to " << result.timeslice.value;
   }
   mOldestPossibleOutput = result;

--- a/Framework/Core/test/test_TimesliceIndex.cxx
+++ b/Framework/Core/test/test_TimesliceIndex.cxx
@@ -119,7 +119,7 @@ TEST_CASE("TestOldestPossibleTimeslice")
       bool invalidated = index.validateSlot(TimesliceSlot{i}, oldest.timeslice);
       INFO("Slot " << i << " valid: " << invalidated);
     }
-    index.updateOldestPossibleOutput();
+    index.updateOldestPossibleOutput(false);
     REQUIRE(slot.index == 1);
     REQUIRE(action == TimesliceIndex::ActionTaken::ReplaceUnused);
   }
@@ -142,21 +142,21 @@ TEST_CASE("TestOldestPossibleTimeslice")
   for (size_t i = 0; i < 3; ++i) {
     bool invalidated = index.validateSlot(TimesliceSlot{i}, oldest.timeslice);
   }
-  index.updateOldestPossibleOutput();
+  index.updateOldestPossibleOutput(false);
   REQUIRE(index.getOldestPossibleInput().timeslice.value == 10);
   REQUIRE(index.getOldestPossibleOutput().timeslice.value == 9);
   oldest = index.setOldestPossibleInput({11}, {1});
   for (size_t i = 0; i < 3; ++i) {
     bool invalidated = index.validateSlot(TimesliceSlot{i}, oldest.timeslice);
   }
-  index.updateOldestPossibleOutput();
+  index.updateOldestPossibleOutput(false);
   REQUIRE(index.getOldestPossibleInput().timeslice.value == 10);
   REQUIRE(index.getOldestPossibleOutput().timeslice.value == 9);
   // We fake the fact that we have processed the slot 0;
   index.markAsDirty({1}, false);
-  index.updateOldestPossibleOutput();
+  index.updateOldestPossibleOutput(false);
   REQUIRE(index.getOldestPossibleOutput().timeslice.value == 9);
   index.markAsInvalid({1});
-  index.updateOldestPossibleOutput();
+  index.updateOldestPossibleOutput(false);
   REQUIRE(index.getOldestPossibleOutput().timeslice.value == 10);
 }


### PR DESCRIPTION
DPL: do not print internal error in case we rewinded

When rewinding the timeframe because no data was actually sent,
we expect that the oldest possible timeframe can go back and the
message is therefore wrong.
