### PR TITLE
AOD: Fix aod-thinner for new-ish datamodel changes

### DIFF
--- a/Framework/AODMerger/src/aodThinner.cxx
+++ b/Framework/AODMerger/src/aodThinner.cxx
@@ -26,7 +26,6 @@
 #include "TGrid.h"
 #include "TMap.h"
 #include "TLeaf.h"
-#include "TError.h"
 
 #include "aodMerger.h"
 
@@ -250,7 +249,9 @@ int main(int argc, char* argv[])
     // If any (%ITSClusterMap or %ITSClusterSizes) of these are not found, continuation is not possible, hence fataling
     if (!bTPClsFindable || !bTRDPattern || !bTOFChi2 ||
         (!bITSClusterMap && !bITSClusterSizes)) {
-      Fatal("Sanity-Check", "Branch detection failed for trackextra.[(fITSClusterMap=%d,fITSClusterSizes=%d),fTPCNClsFindable=%d,fTRDPattern=%d,fTOFChi2=%d]", bITSClusterMap, bITSClusterSizes, bTPClsFindable, bTRDPattern, bTOFChi2);
+      printf("    *** FATAL *** Branch detection failed for trackextra.[(fITSClusterMap=%d,fITSClusterSizes=%d),fTPCNClsFindable=%d,fTRDPattern=%d,fTOFChi2=%d]", bITSClusterMap, bITSClusterSizes, bTPClsFindable, bTRDPattern, bTOFChi2);
+      exitCode = 10;
+      break;
     }
 
     int fIndexCollisions = 0;

--- a/Framework/AODMerger/src/aodThinner.cxx
+++ b/Framework/AODMerger/src/aodThinner.cxx
@@ -249,7 +249,7 @@ int main(int argc, char* argv[])
     // If any (%ITSClusterMap or %ITSClusterSizes) of these are not found, continuation is not possible, hence fataling
     if (!bTPClsFindable || !bTRDPattern || !bTOFChi2 ||
         (!bITSClusterMap && !bITSClusterSizes)) {
-      printf("    *** FATAL *** Branch detection failed for trackextra.[(fITSClusterMap=%d,fITSClusterSizes=%d),fTPCNClsFindable=%d,fTRDPattern=%d,fTOFChi2=%d]", bITSClusterMap, bITSClusterSizes, bTPClsFindable, bTRDPattern, bTOFChi2);
+      printf("    *** FATAL *** Branch detection failed in %s for trackextra.[(fITSClusterMap=%d,fITSClusterSizes=%d),fTPCNClsFindable=%d,fTRDPattern=%d,fTOFChi2=%d]\n", dfName, bITSClusterMap, bITSClusterSizes, bTPClsFindable, bTRDPattern, bTOFChi2);
       exitCode = 10;
       break;
     }
@@ -423,6 +423,7 @@ int main(int argc, char* argv[])
   if (exitCode != 0) {
     printf("Removing incomplete output file %s.\n", outputFile->GetName());
     gSystem->Unlink(outputFile->GetName());
+    return exitCode; // skip output below
   }
 
   clock.Stop();

--- a/Framework/AODMerger/src/aodThinner.cxx
+++ b/Framework/AODMerger/src/aodThinner.cxx
@@ -26,6 +26,7 @@
 #include "TGrid.h"
 #include "TMap.h"
 #include "TLeaf.h"
+#include "TError.h"
 
 #include "aodMerger.h"
 
@@ -245,6 +246,13 @@ int main(int argc, char* argv[])
       }
     }
 
+    // Sanity-Check
+    // If any (%ITSClusterMap or %ITSClusterSizes) of these are not found, continuation is not possible, hence fataling
+    if (!bTPClsFindable || !bTRDPattern || !bTOFChi2 ||
+        (!bITSClusterMap && !bITSClusterSizes)) {
+      Fatal("Sanity-Check", "Branch detection failed for trackextra.[(fITSClusterMap=%d,fITSClusterSizes=%d),fTPCNClsFindable=%d,fTRDPattern=%d,fTOFChi2=%d]", bITSClusterMap, bITSClusterSizes, bTPClsFindable, bTRDPattern, bTOFChi2);
+    }
+
     int fIndexCollisions = 0;
     track_iu->SetBranchAddress("fIndexCollisions", &fIndexCollisions);
 
@@ -258,12 +266,10 @@ int main(int argc, char* argv[])
       // Flag collisions
       hasCollision[i] = (fIndexCollisions >= 0);
 
-      // Remove TPC only tracks, if (opt.) they are not assoc. to a V0
-      if ((!bTPClsFindable || tpcNClsFindable > 0.) &&
+      // Remove TPC only tracks, if they are not assoc. to a V0
+      if (tpcNClsFindable > 0 && TRDPattern == 0 && TOFChi2 < -1. &&
           (!bITSClusterMap || ITSClusterMap == 0) &&
           (!bITSClusterSizes || ITSClusterSizes == 0) &&
-          (!bTRDPattern || TRDPattern == 0) &&
-          (!bTOFChi2 || TOFChi2 < -1.) &&
           (keepV0TPCs.find(i) == keepV0TPCs.end())) {
         counter++;
       } else {

--- a/Framework/AODMerger/src/aodThinner.cxx
+++ b/Framework/AODMerger/src/aodThinner.cxx
@@ -214,7 +214,9 @@ int main(int argc, char* argv[])
     uint8_t tpcNClsFindable = 0;
     bool bTPClsFindable = false;
     uint8_t ITSClusterMap = 0;
+    UInt_t ITSClusterSizes = 0;
     bool bITSClusterMap = false;
+    bool bITSClusterSizes = false;
     uint8_t TRDPattern = 0;
     bool bTRDPattern = false;
     float_t TOFChi2 = 0;
@@ -231,6 +233,9 @@ int main(int argc, char* argv[])
       } else if (brName == "fITSClusterMap") {
         trackExtraTree->SetBranchAddress("fITSClusterMap", &ITSClusterMap);
         bITSClusterMap = true;
+      } else if (brName == "fITSClusterSizes") {
+        trackExtraTree->SetBranchAddress("fITSClusterSizes", &ITSClusterSizes);
+        bITSClusterSizes = true;
       } else if (brName == "fTRDPattern") {
         trackExtraTree->SetBranchAddress("fTRDPattern", &TRDPattern);
         bTRDPattern = true;
@@ -256,6 +261,7 @@ int main(int argc, char* argv[])
       // Remove TPC only tracks, if (opt.) they are not assoc. to a V0
       if ((!bTPClsFindable || tpcNClsFindable > 0.) &&
           (!bITSClusterMap || ITSClusterMap == 0) &&
+          (!bITSClusterSizes || ITSClusterSizes == 0) &&
           (!bTRDPattern || TRDPattern == 0) &&
           (!bTOFChi2 || TOFChi2 < -1.) &&
           (keepV0TPCs.find(i) == keepV0TPCs.end())) {


### PR DESCRIPTION
Credit to @ddobrigk for finding it.

aod-thinner is not agnostic to the data model and when the data model for ITS clusters was changed in #12044 ITSClusterMap was effectively changed to  ITSClusterSizes. Changes were not propagated to the thinner since probably at the time it was planned to only do this on 2022.

 Shows depleted ITS-TPC tracks when iterating on 2023 data.
[plotThin_my.pdf](https://github.com/user-attachments/files/15740967/plotThin_my.pdf)

Shows depletion is recovered after fix.
[plotThin.pdf](https://github.com/user-attachments/files/15740969/plotThin.pdf)


Nota bene, maybe effort should be put in to make it agnostic in the future.