### PR TITLE
[EMCAL-565, EMCAL-566] Keep start TS info in case of across-run calib.

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -88,6 +88,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool requireSameRunType = true;                      ///< if loading calib objects from previous run, require it to be the same run type
   int tsDiffMax = 48;                                  ///< if loading calib objects from previous run, limit time between the object being stored and loaded again (in hours)
   unsigned int minNEventsSaveSlot = 100000;            ///< minimum amount a slot has to have in order to be taken into accoutn in finalize slot. THis is also relevant if the slot should be saved at the EOR
+  bool useStaticStartTimeSlot = true;                  ///< if set to true, allows to use the start timestamp set manually. This is important if data from a previous run was loaded as otherwise, the start-timestamp will not include data from the previous run
 
   // Parameters for pedestal calibration
   short maxPedestalRMS = 10; ///< Maximum value for RMS for pedestals (has to be tuned)


### PR DESCRIPTION
- The calibration objects for the bad and time calibration are stored in a root file at the end of run, and loaded at the start of the new run
- Here, the timestamp was not propagated and as such, the timestamps in the ccdb were not covering the actual ranges of the corresponding data
- This (rarely) leads to some seftover bad channels at the end of the run, or for short runs
- Now, the timestamp is saved in the root-file with a granularity of seconds, and read in during the next run.
- As the previous histograms did not contain the timestamp in seconds, a protection is implemented that, if the histogram only contains 3 bins, the start TS is neglected (This will only happen once!)