### PR TITLE
modify TPC sector tracklet selection

### DIFF
--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -99,6 +99,8 @@ AddOptionRTC(trackMergerFactor2K, float, 2.0f * 2.0f, "", 0, "factor2K for track
 AddOptionRTC(trackMergerFactor2General, float, 3.5f * 3.5f, "", 0, "General factor for track merging")
 AddOptionRTC(rejectEdgeClustersMargin, float, 0.f, "", 0, "Margin in cm of Y position when rejecting edge clusters based on uncorrected track Y")
 AddOptionRTC(rejectEdgeClustersSigmaMargin, float, 0.f, "", 0, "Margin factor for trackSigmaY when rejecting edge clusters based on uncorrected track Y")
+AddOptionRTC(trackletMaxSharedFraction, float, 0.1f, "", 0, "Max fraction of shared clusters for tracklet")
+AddOptionRTC(trackletMinSharedNormFactor, float, 0.f, "", 0, "Max shared defined as trackletMinSharedNormFactor*max(current_nhits,trackletMinSharedNormFactor*minHits,1)")
 AddOptionRTC(maxTimeBinAboveThresholdIn1000Bin, unsigned short, 500, "", 0, "Except pad from cluster finding if total number of charges in a fragment is above this baseline (disable = 0)")
 AddOptionRTC(maxConsecTimeBinAboveThreshold, unsigned short, 200, "", 0, "Except pad from cluster finding if number of consecutive charges in a fragment is above this baseline (disable = 0)")
 AddOptionRTC(noisyPadSaturationThreshold, unsigned short, 700, "", 0, "Threshold where a timebin is considered saturated, disabling the noisy pad check for that pad")


### PR DESCRIPTION
2 new options were added to steer tracklet shared clusters fraction handling instead of 0.1 hardcoded cut on the current tracklet length.

1) `GPU_rec_tpc.trackletMaxSharedFraction` (default =0.1, as previously hardcoded value): sets max. fraction of shared clusters but the reference wrt which this fraction is defined depends on the following parameter

2) `GPU_rec_tpc.trackletMinSharedNormFactor` (default =0 to be close to previous behaviour): max shared clusters (abs) number defined as `GPU_rec_tpc.trackletMinSharedNormFactor*max(current_nhits, GPU_rec_tpc.trackletMinSharedNormFactor*minHits,1)` where 
`current_nhits` is the current number of the validated tracklet clusters 
`minHits` is the minimum hits requested for a tracker of a given q/pT, defined as https://github.com/AliceO2Group/AliceO2/blob/bc32b5a3fe4ca3ca40b41233e1ee42af2ce3d994/GPU/GPUTracking/Definitions/GPUDefConstantsAndSettings.h#L33 


So, with  `GPU_rec_tpc.trackletMinSharedNormFactor=1;GPU_rec_tpc.trackletMaxSharedFraction=0.3`  for a tracklet of e.g. pT>200 MeV (minHits=29) the tracklet will be killed if it has more than 8 shared clusters at its 1st 29 contributing pad-rows and after that if it has >30% of shared wrt its current length.
Note that at the tracklet selection stage the cluster is considered as shared for a given tracklet if the weight assigned to the cluster is higher than the weight of the tracklet (i.e. the clusters is used by longer/better tracklet. There is some inconsistency in such definition since it does not account for possible suppression of this cluster in this better tracklet).
