### PR TITLE
ITS Calib: log changes in noisecalib + new finalize-eor flag for thr calibration

### DIFF
--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -105,13 +105,13 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
     done = (++mNPartsDone == partInfo[1]);
     mStrobeCounter += partInfo[2];
     mCalibrator->setNStrobes(mStrobeCounter);
-    LOGP(info, "Received accumulated map {} of {} with {} ROFs, total number of maps = {} and strobes = {}", partInfo[0] + 1, partInfo[1], partInfo[2], mNPartsDone, mCalibrator->getNStrobes());
+    LOGP(important, "Received accumulated map {} of {} with {} ROFs, total number of maps = {} and strobes = {}", partInfo[0] + 1, partInfo[1], partInfo[2], mNPartsDone, mCalibrator->getNStrobes());
   }
   if (done || pc.transitionState() == TransitionHandlingState::Requested) {
     if (done) {
-      LOG(info) << "Minimum number of noise counts has been reached !";
+      LOG(important) << "Minimum number of noise counts has been reached !";
     } else {
-      LOG(info) << "Run stop is requested, sending output";
+      LOG(important) << "Run stop is requested, sending output";
     }
     if (mMode == ProcessingMode::Full || mMode == ProcessingMode::Normalize) {
       sendOutput(pc.outputs());
@@ -134,7 +134,7 @@ void NoiseCalibratorSpec::sendAccumulatedMap(DataAllocator& output)
   outInf.push_back(mCalibrator->getNInstances());
   outInf.push_back(mCalibrator->getNStrobes());
   output.snapshot(Output{"ITS", "NOISEMAPPARTINF", (unsigned int)mCalibrator->getInstanceID()}, outInf);
-  LOGP(info, "Sending accumulated map with {} ROFs processed", mCalibrator->getNStrobes());
+  LOGP(important, "Sending accumulated map with {} ROFs processed", mCalibrator->getNStrobes());
 }
 
 void NoiseCalibratorSpec::sendOutput(DataAllocator& output)
@@ -271,9 +271,9 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useClusters, int pmode)
       inputs.emplace_back("ROframes", "ITS", "DIGITSROF", 0, Lifetime::Timeframe);
     }
   } else {
-    useClusters = false;                                                                                         // not needed for normalization
-    inputs.emplace_back("mapspart", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPART"}, Lifetime::Sporadic);         // for normalization of multiple inputs only
-    inputs.emplace_back("mapspartInfo", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPARTINF"}, Lifetime::Sporadic);  // for normalization of multiple inputs only
+    useClusters = false;                                                                                        // not needed for normalization
+    inputs.emplace_back("mapspart", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPART"}, Lifetime::Sporadic);        // for normalization of multiple inputs only
+    inputs.emplace_back("mapspartInfo", ConcreteDataTypeMatcher{"ITS", "NOISEMAPPARTINF"}, Lifetime::Sporadic); // for normalization of multiple inputs only
   }
   if (md == NoiseCalibratorSpec::ProcessingMode::Full || md == NoiseCalibratorSpec::ProcessingMode::Normalize) {
     inputs.emplace_back("confdbmap", "ITS", "CONFDBMAP", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/Confdbmap"));

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -217,7 +217,7 @@ class ITSThresholdCalibrator : public Task
 
   int mTFCounter = 0;
   bool mVerboseOutput = false;
-  bool isFinalizeEos = false;
+  bool isForceEor = false;
   std::string mMetaType;
   std::string mOutputDir;
   std::string mMetafileDir = "/dev/null";
@@ -284,7 +284,7 @@ class ITSThresholdCalibrator : public Task
   // To set min and max ITHR and VCASN in the tuning scans
   short int inMinVcasn = 30;
   short int inMaxVcasn = 100;
-  short int inMinIthr = 30;
+  short int inMinIthr = 15;
   short int inMaxIthr = 100;
 
   // Flag to enable most-probable value calculation


### PR DESCRIPTION
Threshold calibration
- Old flag `finalize-at-eos` had no meaning anymore. 
- New flag `force-calculation-eor` is introduced to force the calculation of average quantities at EOR in case a series of chips did not complete the scan. If at least 1 chip on the same link had completed the scan, the calculation of the avg is started on all chips of the link including those which got stuck during the calibration scan
- New lower limit for ITHR set to 15 DAC based on latest ITHR tuning scan

NoiseCalibration
- Changed a couple of `LOG(info)` to `LOG(important)` to make them appearing in infologger. Useful feature which avoid to connect to EPNs to check these important log messages. cc @shahor02 

