### PR TITLE
ITS: Fix placement of REGION HEADERS during ALPIDE data encoding

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
@@ -59,8 +59,9 @@ int AlpideCoder::encodeChip(PayLoadCont& buffer, const o2::itsmft::ChipPixelData
       int nfoundInRegion = procRegion(buffer, ir);
       nfound += nfoundInRegion;
       // If the region was unpopulated, we remove REGION HEADER flag.
-      if (!nfoundInRegion)
+      if (!nfoundInRegion) {
         buffer.erase(1);
+      }
     }
     buffer.addFast(makeChipTrailer(roflags));
     resetMap();


### PR DESCRIPTION
REGION HEADERS must be placed exactly once per region with detected hits, not before every hit within a region.