### PR TITLE
Remove unneeded pack_to_tuple_t helper

### DIFF
--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -49,6 +49,9 @@ expressions::BindingNode getMatchingIndexNode()
 
 template <typename T1, typename GroupingPolicy, typename BP, typename G, typename... As>
 struct GroupedCombinationsGenerator {
+  template <typename P>
+  using pack_to_tuple_t = decltype(std::apply([](auto... t) { return std::tuple(t...); }, P{}));
+
   using GroupedIteratorType = pack_to_tuple_t<interleaved_pack_t<repeated_type_pack_t<typename G::iterator, sizeof...(As)>, pack<As...>>>;
 
   struct GroupedIterator : public GroupingPolicy {

--- a/Framework/Foundation/include/Framework/Pack.h
+++ b/Framework/Foundation/include/Framework/Pack.h
@@ -317,15 +317,6 @@ constexpr auto unique_pack(pack<T, Ts...>, PT p2)
 template <typename P>
 using unique_pack_t = decltype(unique_pack(P{}, pack<>{}));
 
-template <typename... Ts>
-inline constexpr std::tuple<Ts...> pack_to_tuple(pack<Ts...>)
-{
-  return std::tuple<Ts...>{};
-}
-
-template <typename P>
-using pack_to_tuple_t = decltype(pack_to_tuple(P{}));
-
 template <typename T, std::size_t... Is>
 inline auto sequence_to_pack(std::integer_sequence<std::size_t, Is...>)
 {

--- a/Framework/Foundation/test/test_FunctionalHelpers.cxx
+++ b/Framework/Foundation/test/test_FunctionalHelpers.cxx
@@ -58,7 +58,6 @@ TEST_CASE("TestOverride")
 
   static_assert(std::is_same_v<unique_pack_t<pack<int, float, int, float, char, char>>, pack<char, float, int>>, "pack should not have duplicated types");
   static_assert(std::is_same_v<interleaved_pack_t<pack<int, float, int>, pack<char, bool, char>>, pack<int, char, float, bool, int, char>>, "interleaved packs of the same size");
-  static_assert(std::is_same_v<pack_to_tuple_t<pack<int, float, char>>, std::tuple<int, float, char>>, "pack should become a tuple");
   static_assert(std::is_same_v<repeated_type_pack_t<float, 5>, pack<float, float, float, float, float>>, "pack should have float repeated 5 times");
 
   struct ForwardDeclared;


### PR DESCRIPTION
Remove unneeded pack_to_tuple_t helper

Drop the pack_to_tuple_t helper which is not particularly needed
and adds an implicit dependency of "Framework/Pack.h" on <tuple>.
