### PR TITLE
ITS: Introducing verifier for the ALPIDE decoder

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -132,6 +132,13 @@ class ChipMappingMFT
   ///< convert cable iterator ID to its position on the ActiveLanes word in the GBT.header for given RU type
   uint8_t cablePos(uint8_t ruType, uint8_t id) const { return mCablePos[ruType][id]; }
 
+  ///< get chipID on module from chip global SW ID, cable SW ID and stave (RU) info
+  uint16_t getLocalChipID(uint16_t globalID, int cableHW, const RUInfo& ruInfo) const
+  {
+    /// TODO
+    return 0xffff;
+  }
+
   ///< get chip global SW ID from chipID on module, cable SW ID and stave (RU) info
   uint16_t getGlobalChipID(uint16_t chOnModuleHW, int cableHW, const RUInfo& ruInfo) const
   {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -177,6 +177,7 @@ struct ChipStat {
   uint32_t getNErrors() const;
   uint32_t addErrors(uint32_t mask, uint16_t chID, int verbosity);
   uint32_t addErrors(const ChipPixelData& d, int verbosity);
+  static std::string reportErrors(const ChipPixelData& d);
   void print(bool skipNoErr = true, const std::string& pref = "FEEID") const;
 
   ClassDefNV(ChipStat, 1);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -36,6 +36,8 @@ struct RUDecodeData {
 
   std::array<PayLoadCont, MaxCablesPerRU> cableData{};                        // cable data in compressed ALPIDE format
   std::vector<o2::itsmft::ChipPixelData> chipsData{};                         // fully decoded data in 1st nChipsFired chips
+  std::map<int, ChipPixelData*> seenChips{};                                  // Map that records chip data by global ID
+  std::vector<uint16_t> seenChipIDsInCable{};                                 // IDs of chips seen in the current cable
   std::vector<uint16_t> seenChipIDs{};                                        // IDs of all chips seen during ROF decoding, including empty ones
   std::array<int, MaxLinksPerRU> links{};                                     // link entry RSTODO: consider removing this and using pointer
   std::array<uint8_t, MaxCablesPerRU> cableHWID{};                            // HW ID of cable whose data is in the corresponding slot of cableData
@@ -65,7 +67,7 @@ struct RUDecodeData {
   }
   void setROFInfo(ChipPixelData* chipData, const GBTLink* lnk);
   template <class Mapping>
-  int decodeROF(const Mapping& mp, const o2::InteractionRecord ir);
+  int decodeROF(const Mapping& mp, const o2::InteractionRecord ir, bool verifyDecoder);
   void fillChipStatistics(int icab, const ChipPixelData* chipData);
   void dumpcabledata(int icab);
   bool checkLinkInSync(int icab, const o2::InteractionRecord ir);
@@ -75,7 +77,7 @@ struct RUDecodeData {
 ///_________________________________________________________________
 /// decode single readout frame, the cable's data must be filled in advance via GBTLink::collectROFCableData
 template <class Mapping>
-int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir)
+int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir, bool verifyDecoder)
 {
   nChipsFired = 0;
   lastChipChecked = 0;
@@ -98,11 +100,25 @@ int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir)
       auto chip = mp.getGlobalChipID(cid, cabHW, *this->ruInfo);
       return chip;
     };
+    auto localChipIdGetter = [this, &mp, cabHW](int gid) {
+      auto localID = mp.getLocalChipID(gid, cabHW, *this->ruInfo);
+      return localID;
+    };
+
     int ret = 0;
     // dumpcabledata(icab);
 
-    while ((ret = AlpideCoder::decodeChip(*chipData, cableData[icab], seenChipIDs, chIdGetter)) || chipData->isErrorSet()) { // we register only chips with hits or errors flags set
+    std::vector<uint16_t>* seenChipIDsPtr = &seenChipIDs;
+    if (verifyDecoder) {
+      seenChipIDsInCable.clear();
+      seenChipIDsPtr = &seenChipIDsInCable;
+      seenChips.clear();
+    }
+    while ((ret = AlpideCoder::decodeChip(*chipData, cableData[icab], *seenChipIDsPtr, chIdGetter)) || chipData->isErrorSet()) { // we register only chips with hits or errors flags set
       setROFInfo(chipData, cableLinkPtr[icab]);
+      if (verifyDecoder) {
+        seenChips[chipData->getChipID()] = chipData;
+      }
       auto nhits = chipData->getData().size();
       if (nhits && doneChips[chipData->getChipID()]) {
         if (chipData->getChipID() == chipsData[nChipsFired - 1].getChipID()) {
@@ -131,6 +147,12 @@ int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir)
       if (ret < 0) {
         break; // negative code was returned by decoder: abandon cable data
       }
+    }
+    if (verifyDecoder) {
+      AlpideCoder::verifyDecodedCable(seenChips, cableData[icab],
+                                      seenChipIDsInCable, localChipIdGetter,
+                                      chIdGetter);
+      seenChipIDs.insert(seenChipIDs.end(), seenChipIDsInCable.begin(), seenChipIDsInCable.end());
     }
     cableData[icab].clear();
   }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -107,6 +107,9 @@ class RawPixelDecoder final : public PixelReader
   void setAllowEmptyROFs(bool v) { mAlloEmptyROFs = v; }
   bool getAllowEmptyROFs() const { return mAlloEmptyROFs; }
 
+  void setVerifyDecoder(bool v) { mVerifyDecoder = v; }
+  bool getVerifyDecoder() const { return mVerifyDecoder; }
+
   void setInstanceID(size_t i) { mInstanceID = i; }
   void setNInstances(size_t n) { mNInstances = n; }
   auto getInstanceID() const { return mInstanceID; }
@@ -160,6 +163,7 @@ class RawPixelDecoder final : public PixelReader
   bool mAlloEmptyROFs = false;                                                        // do not skip empty ROFs
   bool mROFRampUpStage = false;                                                       // are we still in the ROF ramp up stage?
   bool mSkipRampUpData = false;
+  bool mVerifyDecoder = false;
   int mVerbosity = 0;
   int mNThreads = 1; // number of decoding threads
   // statistics

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -92,6 +92,20 @@ void ChipStat::print(bool skipNoErr, const std::string& pref) const
 }
 
 ///_________________________________________________________________
+/// print chip decoding statistics
+std::string ChipStat::reportErrors(const ChipPixelData& d)
+{
+  std::string res;
+  for (int i = NErrorsDefined; i--;) {
+    if (d.getErrorFlags() & (0x1UL << i)) {
+      res += ErrNames[i];
+      res += " ";
+    }
+  }
+  return res;
+}
+
+///_________________________________________________________________
 /// print link decoding statistics
 void GBTLinkDecodingStat::print(bool skipNoErr) const
 {

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -109,7 +109,7 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
       auto& ru = mRUDecodeVec[iru];
       if (ru.nNonEmptyLinks) {
         ru.ROFRampUpStage = mROFRampUpStage;
-        mNPixelsFiredROF += ru.decodeROF(mMAP, mInteractionRecord);
+        mNPixelsFiredROF += ru.decodeROF(mMAP, mInteractionRecord, mVerifyDecoder);
         mNChipsFiredROF += ru.nChipsFired;
       } else {
         ru.clearSeenChipIDs();

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -46,6 +46,7 @@ struct STFDecoderInp {
   bool doSquashing = false;
   bool askSTFDist = true;
   bool allowReporting = true;
+  bool verifyDecoder = false;
   o2::header::DataOrigin origin{"NIL"};
   std::string deviceName{};
   std::string inputSpec{};
@@ -79,6 +80,7 @@ class STFDecoder : public Task
   bool mAllowReporting = true;
   bool mApplyNoiseMap = true;
   bool mUseClusterDictionary = true;
+  bool mVerifyDecoder = false;
   int mDumpOnError = 0;
   int mNThreads = 1;
   int mVerbosity = 0;

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -47,7 +47,7 @@ using namespace o2::framework;
 ///_______________________________________
 template <class Mapping>
 STFDecoder<Mapping>::STFDecoder(const STFDecoderInp& inp, std::shared_ptr<o2::base::GRPGeomRequest> gr)
-  : mDoClusters(inp.doClusters), mDoPatterns(inp.doPatterns), mDoDigits(inp.doDigits), mDoCalibData(inp.doCalib), mAllowReporting(inp.allowReporting), mInputSpec(inp.inputSpec), mGGCCDBRequest(gr)
+  : mDoClusters(inp.doClusters), mDoPatterns(inp.doPatterns), mDoDigits(inp.doDigits), mDoCalibData(inp.doCalib), mAllowReporting(inp.allowReporting), mVerifyDecoder(inp.verifyDecoder), mInputSpec(inp.inputSpec), mGGCCDBRequest(gr)
 {
   mSelfName = o2::utils::Str::concat_string(Mapping::getName(), "STFDecoder");
   mTimer.Stop();
@@ -98,6 +98,7 @@ void STFDecoder<Mapping>::init(InitContext& ic)
     mDecoder->setAllowEmptyROFs(ic.options().get<bool>("allow-empty-rofs"));
     mDecoder->setRawDumpDirectory(dumpDir);
     mDecoder->setFillCalibData(mDoCalibData);
+    mDecoder->setVerifyDecoder(mVerifyDecoder);
     bool ignoreRampUp = !ic.options().get<bool>("accept-rof-rampup-data");
     mDecoder->setSkipRampUpData(ignoreRampUp);
   } catch (const std::exception& e) {

--- a/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
@@ -22,6 +22,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<ConfigParamSpec> options{
+    ConfigParamSpec{"verify", VariantType::Bool, false, {"verify ALPIDE decoder by re-encoding the data"}},
     ConfigParamSpec{"runmft", VariantType::Bool, false, {"source detector is MFT (default ITS)"}},
     ConfigParamSpec{"no-clusters", VariantType::Bool, false, {"do not produce clusters (def: produce)"}},
     ConfigParamSpec{"no-cluster-patterns", VariantType::Bool, false, {"do not produce clusters patterns (def: produce)"}},
@@ -50,6 +51,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   inp.doCalib = cfgc.options().get<bool>("enable-calib-data");
   inp.doSquashing = cfgc.options().get<bool>("squash-overflow-pixels");
   inp.askSTFDist = !cfgc.options().get<bool>("ignore-dist-stf");
+  inp.verifyDecoder = cfgc.options().get<bool>("verify");
   inp.inputSpec = cfgc.options().get<std::string>("dataspec");
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));


### PR DESCRIPTION
The verifier is based on encoding the decoded ChipPixelData back into the ALPIDE format and comparing it to the raw data from the cable.

Currently, the verifier only works for ITS chip mapping. To enable it, pass '--verify' flag to the o2-itsmft-stf-decoder-workflow executable.