### PR TITLE
CCDB: Ensure CCDBDownloader's libuv loop is properly deleted

### DIFF
--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -114,7 +114,7 @@ CCDBDownloader::~CCDBDownloader()
 
   if (!mExternalLoop) {
     // Schedule all handles to close. Execute loop to allow them to execute their destructors.
-    while (uv_loop_alive(mUVLoop) && uv_loop_close(mUVLoop) == UV_EBUSY) {
+    while (uv_loop_alive(mUVLoop) || (uv_loop_close(mUVLoop) == UV_EBUSY)) {
       uv_walk(mUVLoop, closeHandles, this);
       uv_run(mUVLoop, UV_RUN_ONCE);
     }


### PR DESCRIPTION
My valgrind checks were showing that the internal CCDBDownloader's libuv loop resources were not fully released. With this fix, valgrind is happy.

The change is based on the following premises:
- `uv_loop_alive` returns true if there are *active* handles
- `uv_loop_close` returns `UV_EBUSY` if there are *open* handles.
- we need to succesfully call `uv_loop_close` to clear `mUVLoop` resources

Thus, in case that we would not have *active* handles, we would never close *open* ones, and consequently would not manage to call `uv_loop_close` without getting `UV_EBUSY`.