### PR TITLE
DPL Analyis: introduce value based has_type

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1466,7 +1466,7 @@ class Table
     auto getId() const
     {
       using decayed = std::decay_t<TI>;
-      if constexpr (framework::has_type_v<decayed, bindings_pack_t>) { // index to another table
+      if constexpr (framework::has_type<decayed>(bindings_pack_t{})) { // index to another table
         constexpr auto idx = framework::has_type_at_v<decayed>(bindings_pack_t{});
         return framework::pack_element_t<idx, external_index_columns_t>::getId();
       } else if constexpr (std::is_same_v<decayed, Parent>) { // self index
@@ -2777,12 +2777,12 @@ struct Join : TableWrap<Ts...>::table_t {
   }
 
   template <typename T>
-  static constexpr bool contains()
+  static consteval bool contains()
   {
     if constexpr (is_type_with_originals_v<T>) {
       return contains(typename T::originals{});
     } else {
-      return framework::has_type_v<T, originals>;
+      return framework::has_type<T>(originals{});
     }
   }
 

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -90,7 +90,7 @@ struct WritingCursor<soa::Table<PC...>> {
     if constexpr (soa::is_soa_iterator_v<T>) {
       return arg.globalIndex();
     } else {
-      static_assert(!framework::has_type_v<T, framework::pack<PC...>>, "Argument type mismatch");
+      static_assert(!framework::has_type<T>(framework::pack<PC...>{}), "Argument type mismatch");
       return arg;
     }
   }

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -50,7 +50,7 @@ struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy
   {
     static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
     if constexpr (std::is_same_v<G, TG>) {
-      static_assert(std::conjunction_v<framework::has_type<As, pack<T2s...>>...>, "You didn't subscribed to all tables requested for mixing");
+      static_assert((framework::has_type<As>(pack<T2s...>{}) && ...), "You didn't subscribed to all tables requested for mixing");
       comb.setTables(grouping, associated);
     }
   }

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -240,7 +240,7 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   template <typename T, typename T2>
   auto getBinningValue(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    if constexpr (has_type_v<T2, pack<Ls...>>) {
+    if constexpr (has_type<T2>(pack<Ls...>{})) {
       if (globalIndex != -1) {
         rowIterator.setCursor(globalIndex);
       }

--- a/Framework/Foundation/test/test_FunctionalHelpers.cxx
+++ b/Framework/Foundation/test/test_FunctionalHelpers.cxx
@@ -28,6 +28,8 @@ struct TestStruct {
 TEST_CASE("TestOverride")
 {
   static_assert(pack_size(pack<int, float>{}) == 2, "Bad size for the pack");
+  static_assert(has_type<int>(pack<int, float>{}) == true, "int should be in the pack");
+  static_assert(has_type<double>(pack<int, float>{}) == false, "double should not be in the pack");
   static_assert(has_type_v<int, pack<int, float>> == true, "int should be in the pack");
   static_assert(has_type_v<double, pack<int, float>> == false, "double should not be in the pack");
   static_assert(has_type_conditional_v<std::is_same, int, pack<int, float>> == true, "int should be in the pack");
@@ -43,7 +45,7 @@ TEST_CASE("TestOverride")
   static_assert(std::is_same_v<selected_pack_multicondition<is_same_as_second_t, pack<int>, pack<int, float, char>>, pack<int>>, "multiselector should select int");
   static_assert(std::is_same_v<filtered_pack<is_int_t, int, float, char>, pack<float, char>>, "filter should remove int");
   static_assert(std::is_same_v<intersected_pack_t<pack<int, float, char>, pack<float, double>>, pack<float>>, "filter intersect two packs");
-  static_assert(has_type_v<pack_element_t<0, pack<int>>, pack<int>> == true, "foo");
+  static_assert(has_type<pack_element_t<0, pack<int>>>(pack<int>{}) == true, "foo");
   print_pack<intersected_pack_t<pack<int>, pack<int>>>();
   print_pack<intersected_pack_t<pack<TestStruct<0, -1>, int>, pack<TestStruct<0, -1>, float>>>();
   static_assert(std::is_same_v<intersected_pack_t<pack<TestStruct<0, -1>, int>, pack<TestStruct<0, -1>, float>>, pack<TestStruct<0, -1>>>, "filter intersect two packs");


### PR DESCRIPTION
DPL Analyis: introduce value based has_type

Using the std::disjunction is recursive in the pack elements,
therefore slow. This version allow to expand the pack without recursive
type creations and seems to be compiled much faster.

We keep the old version around because it's still needed in some places
in O2Physics and therefore we need to do an incremental migration.
