### PR TITLE
TPC: dEdx calculation class is extended

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/CalculatedEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalculatedEdx.h
@@ -25,6 +25,7 @@
 #include "CorrectionMapsHelper.h"
 #include "CommonUtils/TreeStreamRedirector.h"
 #include "TRandom.h"
+#include "TString.h"
 #include <vector>
 
 namespace o2::tpc
@@ -149,6 +150,10 @@ class CalculatedEdx
   /// load calibration objects from CCDB
   /// \param runNumberOrTimeStamp run number or time stamp
   void loadCalibsFromCCDB(long runNumberOrTimeStamp);
+
+  /// load calibration objects from local CCDB folder
+  /// \param localCCDBFolder local CCDB folder
+  void loadCalibsFromLocalCCDBFolder(const char* localCCDBFolder);
 
  private:
   std::vector<TrackTPC>* mTracks{nullptr};                       ///< vector containing the tpc tracks which will be processed

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalculatedEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalculatedEdx.h
@@ -24,8 +24,6 @@
 #include "CalibdEdxContainer.h"
 #include "CorrectionMapsHelper.h"
 #include "CommonUtils/TreeStreamRedirector.h"
-#include "TRandom.h"
-#include "TString.h"
 #include <vector>
 
 namespace o2::tpc
@@ -103,6 +101,12 @@ class CalculatedEdx
   /// \param maxMissingCl maximum number of missing clusters for subthreshold check
   void setMaxMissingCl(int maxMissingCl) { mMaxMissingCl = maxMissingCl; }
 
+  /// \param minChargeTotThreshold upper limit for the possible minimum charge tot in subthreshold treatment
+  void setMinChargeTotThreshold(float minChargeTotThreshold) { mMinChargeTotThreshold = minChargeTotThreshold; }
+
+  /// \param minChargeMaxThreshold upper limit for the possible minimum charge max in subthreshold treatment
+  void setMinChargeMaxThreshold(float minChargeMaxThreshold) { mMinChargeMaxThreshold = minChargeMaxThreshold; }
+
   /// set the debug streamer
   void setStreamer(const char* debugRootFile) { mStreamer = std::make_unique<o2::utils::TreeStreamRedirector>(debugRootFile, "recreate"); };
 
@@ -111,6 +115,12 @@ class CalculatedEdx
 
   /// \return returns maxMissingCl for subthreshold cluster treatment
   int getMaxMissingCl() { return mMaxMissingCl; }
+
+  /// \return returns the upper limit for the possible minimum charge tot in subthreshold treatment
+  float getMinChargeTotThreshold() { return mMinChargeTotThreshold; }
+
+  /// \return returns the upper limit for the possible minimum charge max in subthreshold treatment
+  float getMinChargeMaxThreshold() { return mMinChargeMaxThreshold; }
 
   /// fill missing clusters with minimum charge (method=0) or minimum charge/2 (method=1) or Landau (method=2)
   void fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method);
@@ -165,6 +175,8 @@ class CalculatedEdx
   std::unique_ptr<o2::gpu::GPUO2InterfaceRefit> mRefit{nullptr}; ///< TPC refitter used for TPC tracks refit during the reconstruction
 
   int mMaxMissingCl{1};                                                ///< maximum number of missing clusters for subthreshold check
+  float mMinChargeTotThreshold{50};                                    ///< upper limit for minimum charge tot value in subthreshold treatment, i.e for a high dEdx track adding a minimum value of 500 to track as a virtual charge doesn't make sense
+  float mMinChargeMaxThreshold{50};                                    ///< upper limit for minimum charge max value in subthreshold treatment, i.e for a high dEdx track adding a minimum value of 500 to track as a virtual charge doesn't make sense
   float mFieldNominalGPUBz{5};                                         ///< magnetic field in kG, used for track propagation
   bool mPropagateTrack{false};                                         ///< propagating the track instead of performing a refit
   bool mDebug{false};                                                  ///< use the debug streamer


### PR DESCRIPTION
Standalone dEdx calculation class is extended:

- New subthreshold cluster treatment is added.
- Cluster mask is implemented to exclude single, edge, split and subthreshold clusters from dEdx calculation. Also an option to exclude sector boundaries from subthreshold cluster treatment is added.
-  `o2::gpu::GPUO2InterfaceRefit::fillSharedClustersAndOccupancyMap` is added for the function `RefitTrackAsGPU`
