### PR TITLE
DPL Analysis: do not copy the Configurable<> when creating PlaceholderNode in filter

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -551,7 +551,8 @@ struct OptionManager {
       if constexpr (requires { x.prefix; }) {
         homogeneous_apply_refs<true>([prefix = x.prefix]<typename C>(C& y) { // apend group prefix if set
           if constexpr (requires { y.name; }) {
-            y.name = prefix + "." + y.name;
+            y.name.insert(0, 1, '.');
+            y.name.insert(0, prefix);
           }
           return true;
         },

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -131,6 +131,22 @@ TEST_CASE("TestTreeParsing")
   REQUIRE(ptfilterspecs[0].left == (DatumSpec{std::string{"fPt"}, typeid(o2::aod::track::Pt).hash_code(), atype::FLOAT}));
   REQUIRE(ptfilterspecs[0].right == (DatumSpec{LiteralNode::var_t{0.5f}, atype::FLOAT}));
   REQUIRE(ptfilterspecs[0].result == (DatumSpec{0u, atype::BOOL}));
+
+  struct : ConfigurableGroup {
+    std::string prefix = "prefix";
+    Configurable<float> pTCut{"pTCut", 1.0f, "Lower pT limit"};
+  } group;
+  Filter ptfilter2 = o2::aod::track::pt > group.pTCut;
+  group.pTCut.name.insert(0, 1, '.');
+  group.pTCut.name.insert(0, group.prefix);
+  REQUIRE(ptfilter2.node->self.index() == 2);
+  REQUIRE(ptfilter2.node->left->self.index() == 1);
+  REQUIRE(ptfilter2.node->right->self.index() == 3);
+  REQUIRE(std::get<PlaceholderNode>(ptfilter2.node->right->self).name == "prefix.pTCut");
+  auto ptfilterspecs2 = createOperations(ptfilter2);
+  REQUIRE(ptfilterspecs2[0].left == (DatumSpec{std::string{"fPt"}, typeid(o2::aod::track::Pt).hash_code(), atype::FLOAT}));
+  REQUIRE(ptfilterspecs2[0].right == (DatumSpec{LiteralNode::var_t{1.0f}, atype::FLOAT}));
+  REQUIRE(ptfilterspecs2[0].result == (DatumSpec{0u, atype::BOOL}));
 }
 
 TEST_CASE("TestGandivaTreeCreation")


### PR DESCRIPTION
* Do not copy the configurable
* Do not reallocate name string of the configurable
* Make placeholder name a reference to track changes in the name of the configurable