### PR TITLE
CCDB: ensure the right number of bytes is deleted for libuv handlers

### DIFF
--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -136,7 +136,54 @@ void closeHandles(uv_handle_t* handle, void* arg)
 void onUVClose(uv_handle_t* handle)
 {
   if (handle != nullptr) {
-    delete handle;
+    // libuv handlers use c-style polymorphism, so deleting uv_handle_t* pointing to a derived class will in fact delete wrong number of bytes.
+    // As ugly as it is, it seems we have to check for all the possible types here.
+    switch (handle->type) {
+      case UV_NAMED_PIPE:
+        delete (uv_pipe_t*)handle;
+        break;
+      case UV_TTY:
+        delete (uv_stream_t*)handle;
+        break;
+      case UV_TCP:
+        delete (uv_tcp_t*)handle;
+        break;
+      case UV_UDP:
+        delete (uv_udp_t*)handle;
+        break;
+      case UV_PREPARE:
+        delete (uv_prepare_t*)handle;
+        break;
+      case UV_CHECK:
+        delete (uv_check_t*)handle;
+        break;
+      case UV_IDLE:
+        delete (uv_idle_t*)handle;
+        break;
+      case UV_ASYNC:
+        delete (uv_async_t*)handle;
+        break;
+      case UV_TIMER:
+        delete (uv_timer_t*)handle;
+        break;
+      case UV_PROCESS:
+        delete (uv_process_t*)handle;
+        break;
+      case UV_FS_EVENT:
+        delete (uv_fs_event_t*)handle;
+        break;
+      case UV_POLL:
+        delete (uv_poll_t*)handle;
+        break;
+      case UV_FS_POLL:
+        delete (uv_fs_poll_t*)handle;
+        return;
+      case UV_SIGNAL:
+        delete (uv_signal_t*)handle;
+        break;
+      default:
+        delete handle;
+    }
   }
 }
 

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(test_with_break)
 void onUVClose(uv_handle_t* handle)
 {
   if (handle != nullptr) {
-    delete handle;
+    free(handle);
   }
 }
 
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(external_loop_test)
   uv_loop_init(uvLoop);
 
   // Prepare test timer. It will be used to check whether the downloader affects external handles.
-  auto testTimer = new uv_timer_t();
+  auto testTimer = (uv_timer_t*)malloc(sizeof(uv_timer_t));
   uv_timer_init(uvLoop, testTimer);
   uv_timer_start(testTimer, testTimerCB, 10, 10);
 
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(external_loop_test)
   // The reason for that are the uv_poll handles attached to the curl multi handle.
   // The multi handle must be cleaned (via destuctor) before poll handles attached to them are removed (via walking and closing).
   delete downloader;
-  while (uv_loop_alive(uvLoop) && uv_loop_close(uvLoop) == UV_EBUSY) {
+  while (uv_loop_alive(uvLoop) || uv_loop_close(uvLoop) == UV_EBUSY) {
     uv_walk(uvLoop, closeAllHandles, nullptr);
     uv_run(uvLoop, UV_RUN_ONCE);
   }


### PR DESCRIPTION
libuv handlers use c-style polymorphism, so deleting uv_handle_t* pointing to a derived class will in fact delete wrong number of bytes. As ugly as it is, it seems we have to check for all the possible types here.

The problem has been noticed with AddressSanitizer:
```
W	6	==4830==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x60e0001e16e0 in thread T0: task="alio2-cr1-hv-gw01.cern.ch:/opt/git/ControlWorkflows/tasks/jit-cd2f2834da7ac943a17d6874dec53f825d9865a5-qc-pp-FDD-Quality@00552903229b92bff98c32ea79a875b8379a5e31#2oPDp5Pdrqa"
W	6	object passed to delete has wrong type: task="alio2-cr1-hv-gw01.cern.ch:/opt/git/ControlWorkflows/tasks/jit-cd2f2834da7ac943a17d6874dec53f825d9865a5-qc-pp-FDD-Quality@00552903229b92bff98c32ea79a875b8379a5e31#2oPDp5Pdrqa"
W	6	size of the allocated type: 152 bytes; task="alio2-cr1-hv-gw01.cern.ch:/opt/git/ControlWorkflows/tasks/jit-cd2f2834da7ac943a17d6874dec53f825d9865a5-qc-pp-FDD-Quality@00552903229b92bff98c32ea79a875b8379a5e31#2oPDp5Pdrqa"
W	6	size of the deallocated type: 96 bytes. task="alio2-cr1-hv-gw01.cern.ch:/opt/git/ControlWorkflows/tasks/jit-cd2f2834da7ac943a17d6874dec53f825d9865a5-qc-pp-FDD-Quality@00552903229b92bff98c32ea79a875b8379a5e31#2oPDp5Pdrqa"
```
