### PR TITLE
ITS: Accounting for empty chipID vector after decoding

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -120,7 +120,7 @@ int RUDecodeData::decodeROF(const Mapping& mp, const o2::InteractionRecord ir, b
         auto ID = chipData->getChipID();
         // Since the errored chips are not recorded, we need to add them
         // separately
-        if (seenChipIDsInCable.back() != ID) {
+        if (seenChipIDsInCable.empty() || seenChipIDsInCable.back() != ID) {
           seenChipIDsInCable.push_back(ID);
         }
         seenChips[ID] = chipData;


### PR DESCRIPTION
The current implementation causes a segfault for empty chipID vector