### PR TITLE
V0: cleanup unused AP cuts

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -123,14 +123,9 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;                                                                                               // enable Mass Hypothesis check
-  bool checkV0AP = false;                                                                                                      // enable Armenteros-Podolanski check
   float pidCutsPhoton[SVertexHypothesis::NPIDParams] = {0.001, 20, 0.10, 20, 0.10, 0.0, 0.0, 0.0, 0.0};                        // Photon
-  float pidCutsPhotonAP_qT = 0.04;                                                                                             // Loose Armenteros-Podolanski q_T cut for photons in case mass-hypothesis was good
   float pidCutsK0[SVertexHypothesis::NPIDParams] = {0., 20, 0., 5.0, 0.0, 2.84798e-03, 9.84206e-04, 3.31951e-03, 2.39438};     // K0
-  float pidCutsK0AP_qT = 0.6;                                                                                                  // Loose Armenteros-Podolanski q_T cut for K0s in case mass-hypothesis was good
   float pidCutsLambda[SVertexHypothesis::NPIDParams] = {0., 20, 0., 5.0, 0.0, 1.09004e-03, 2.62291e-04, 8.93179e-03, 2.83121}; // Lambda
-  float pidCutsLambdaAP_qT = 0.9;                                                                                              // Loose Armenteros-Podolanski q_T cut for Lambda in case mass-hypothesis was good
-  float pidCutsLambdaAP_a = 0.9;                                                                                               // Loose Armenteros-Podolanski alpha cut for Lambda in case mass-hypothesis was good
   float pidCutsHTriton[SVertexHypothesis::NPIDParams] = {0.0025, 14, 0.07, 14, 0.0, 0.5, 0.0, 0.0, 0.0};                       // HyperTriton
   float pidCutsHhydrog4[SVertexHypothesis::NPIDParams] = {0.0025, 14, 0.07, 14, 0.0, 0.5, 0.0, 0.0, 0.0};                      // Hyperhydrog4 - Need to update
   //

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -690,40 +690,6 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
     }
   }
 
-  // apply loose Armenteros-Podolanski cut to photons and K0
-  // the AP space and mass space correlated very well, and should in theory already be detected above but every bit helps
-  if (mSVParams->checkV0Hypothesis && mSVParams->checkV0AP &&
-      (hypCheckStatus[HypV0::Photon] || hypCheckStatus[HypV0::K0] || goodLamForCascade || goodALamForCascade)) {
-    float pV0Abs = std::sqrt(p2V0);
-    float pPos = std::sqrt(p2Pos);
-    float p1 = (pV0[0] * pP[0] + pV0[1] * pP[1] + pV0[2] * pP[2]) /
-               (pV0Abs * pPos);
-    float p2 = (pV0[0] * pN[0] + pV0[1] * pN[1] + pV0[2] * pN[2]) /
-               (pV0Abs * seedN.getP());
-    float pL1 = p1 * seedP.getP();
-    float pL2 = p2 * seedN.getP();
-    float alpha = (pL1 - pL2) / (pL1 + pL2);
-    float pT1 = pPos * std::sqrt(1 - p1);
-    if (hypCheckStatus[HypV0::Photon] && pT1 > mSVParams->pidCutsPhotonAP_qT) {
-      hypCheckStatus[HypV0::Photon] = false;
-    }
-    if (hypCheckStatus[HypV0::K0] && pT1 < mSVParams->pidCutsK0AP_qT) {
-      hypCheckStatus[HypV0::K0] = false;
-    }
-    if ((goodLamForCascade || goodALamForCascade) && std::abs(alpha) > mSVParams->pidCutsLambdaAP_a && pT1 > mSVParams->pidCutsLambdaAP_qT) {
-      goodLamForCascade = false;
-      goodALamForCascade = false;
-    }
-    // Check if any good hypothesis remains
-    goodHyp = false;
-    for (int ipid = 0; ipid < nPID; ipid++) {
-      if (hypCheckStatus[ipid]) {
-        goodHyp = true;
-        break;
-      }
-    }
-  }
-
   // apply mass selections for 3-body decay
   bool good3bodyV0Hyp = false;
   for (int ipid = 2; ipid < 4; ipid++) {


### PR DESCRIPTION
No Armenteros-Podolanski selection cuts were ever applied and are not planned to be applied. Thus we can safely remove this.

Nota Bene for me: The code right now is anyway bugged. Fixes include ->
 - float pT1 = pPos * std::sqrt( 1 - p1 * p1 );
 - selection params need to be adjusted