### PR TITLE
Pythia8 seeding improvements

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -163,6 +163,12 @@ class GeneratorPythia8 : public Generator
 
   typedef std::function<bool(const Pythia8::Particle&)> UserFilterFcn;
 
+  /// A function allowing to set the initial value used in seeding Pythia.
+  /// The function needs to be called before GeneratorPythia8::Init is invoked.
+  /// The function value will be true upon success, or false if either Init has already been called or if the see is smaller than 0.
+  /// For values of seed >= 0, a truncation to the range [0:90000000] will automatically take place via a modulus operation.
+  bool setInitialSeed(long seed);
+
  protected:
   /** copy constructor **/
   GeneratorPythia8(const GeneratorPythia8&);
@@ -251,6 +257,9 @@ class GeneratorPythia8 : public Generator
   void getNfreeSpec(const Pythia8::Info& info, int& nFreenProj, int& nFreepProj, int& nFreenTarg, int& nFreepTarg);
   /** @} */
 
+  /// performs seeding of the random state of Pythia (called from Init)
+  void seedGenerator();
+
   /** Pythia8 **/
   Pythia8::Pythia mPythia; //!
 
@@ -269,6 +278,12 @@ class GeneratorPythia8 : public Generator
   void initUserFilterCallback();
 
   bool mApplyPruning = false;
+  bool mIsInitialized = false; // if Init function has been called
+  long mInitialRNGSeed = -1;   // initial seed for Pythia random number state;
+                               // will be transported to Pythia in the Init function through the Pythia::readString("Random:seed") mechanism.
+                               // Value of -1 means unitialized; 0 will be time-dependent and values >1 <= MAX_SEED concrete reproducible seeding
+
+  constexpr static long MAX_SEED = 900000000;
 
   ClassDefOverride(GeneratorPythia8, 1);
 

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -69,13 +69,9 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
   auto makePythia8Gen = [](std::string& config) {
     auto gen = new o2::eventgen::GeneratorPythia8();
     if (!config.empty()) {
-      LOG(info) << "Reading \'Pythia8\' base configuration: " << config << std::endl;
-      gen->readFile(config);
+      LOG(info) << "Setting \'Pythia8\' base configuration: " << config << std::endl;
+      gen->setConfig(config); // assign config; will be executed in Init function
     }
-    auto seed = (gRandom->TRandom::GetSeed() % 900000000);
-    LOG(info) << "Using random seed from gRandom % 900000000: " << seed;
-    gen->readString("Random:setSeed on");
-    gen->readString("Random:seed " + std::to_string(seed));
     return gen;
   };
 #endif


### PR DESCRIPTION
This commit improves the seeding of Pythia8 in O2. The seeding...

(a) ... is now done as part of the object's Init function automatically.
    Users are no longer required to provide own seeding logic,
    which can significantly simplify the setup.
    By default, Pythia8 will seed against ROOT TRandom::GetSeed,
    which is itself set to values of the command line option `--seed`,
    used in the o2-sim ... or o2-sim-dpl-eventgen execetuables (which
    are the 2 places undertaking event generation). This setup guarantees
    that

    ```
    o2-sim-dpl-eventgen --generator pythiapp --seed x
    ```
    will result in different event sequences when x changes.

(b) Users can simply set the seed via a `setInitialSeed` function
    on the GeneratorPythia8 object. The function must be called before
    GeneratorPythia8::Init is executed. So calling it right after the constructor
    is fine.

    Example code (e.g., inside user Generator macro) is:

    ```
    auto mygen = new o2::eventgen::GeneratorPythia8();
    long seed = atol(getenv(ALIEN_PROC_ID));
    if(!mygen->setInitialSeed(seed)) {
      std::cerr << "seeding failed";
    }
    ```

In result, the commit leads to a simplification of the Pythia8 setup also in GeneratorFactory.