### PR TITLE
Add EP angle to McCollisions for debugging

### DIFF
--- a/Detectors/AOD/src/AODMcProducerHelpers.cxx
+++ b/Detectors/AOD/src/AODMcProducerHelpers.cxx
@@ -65,8 +65,9 @@ short updateMCCollisions(const CollisionCursor& cursor,
          truncateFloatFraction(header.GetZ(), mask),
          truncateFloatFraction(time, mask),
          truncateFloatFraction(weight, mask),
-         header.GetB()/*,
-         getEventInfo(header, Key::planeAngle, header.GetRotZ())*/);
+         header.GetB() /*,
+          getEventInfo(header, Key::planeAngle, header.GetRotZ())*/
+  );
   return encodedGeneratorId;
 }
 //--------------------------------------------------------------------

--- a/Detectors/AOD/src/AODMcProducerHelpers.cxx
+++ b/Detectors/AOD/src/AODMcProducerHelpers.cxx
@@ -65,7 +65,8 @@ short updateMCCollisions(const CollisionCursor& cursor,
          truncateFloatFraction(header.GetZ(), mask),
          truncateFloatFraction(time, mask),
          truncateFloatFraction(weight, mask),
-         header.GetB());
+         header.GetB()/*,
+         getEventInfo(header, Key::planeAngle, header.GetRotZ())*/);
   return encodedGeneratorId;
 }
 //--------------------------------------------------------------------

--- a/Detectors/AOD/src/StandaloneAODProducer.cxx
+++ b/Detectors/AOD/src/StandaloneAODProducer.cxx
@@ -86,7 +86,7 @@ void fillMCollisionTable(o2::steer::MCKinematicsReader const& mcreader)
     //                  mccollision::PosX, mccollision::PosY, mccollision::PosZ, mccollision::T, mccollision::Weight,
     //                 mccollision::ImpactParameter);
 
-    mcCollCursor(0, 0 /*bcID*/, 0 /*genID*/, header.GetX(), header.GetY(), header.GetZ(), time, 1. /*weight*/, header.GetB());
+    mcCollCursor(0, 0 /*bcID*/, 0 /*genID*/, header.GetX(), header.GetY(), header.GetZ(), time, 1. /*weight*/, header.GetB()/*, 0.0*/);
 
     index++;
   }

--- a/Detectors/AOD/src/StandaloneAODProducer.cxx
+++ b/Detectors/AOD/src/StandaloneAODProducer.cxx
@@ -86,7 +86,7 @@ void fillMCollisionTable(o2::steer::MCKinematicsReader const& mcreader)
     //                  mccollision::PosX, mccollision::PosY, mccollision::PosZ, mccollision::T, mccollision::Weight,
     //                 mccollision::ImpactParameter);
 
-    mcCollCursor(0, 0 /*bcID*/, 0 /*genID*/, header.GetX(), header.GetY(), header.GetZ(), time, 1. /*weight*/, header.GetB()/*, 0.0*/);
+    mcCollCursor(0, 0 /*bcID*/, 0 /*genID*/, header.GetX(), header.GetY(), header.GetZ(), time, 1. /*weight*/, header.GetB() /*, 0.0*/);
 
     index++;
   }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1549,6 +1549,7 @@ DECLARE_SOA_COLUMN(PosZ, posZ, float);                       //! Z vertex positi
 DECLARE_SOA_COLUMN(T, t, float);                             //! Collision time relative to given bc in ns
 DECLARE_SOA_COLUMN(Weight, weight, float);                   //! MC weight
 DECLARE_SOA_COLUMN(ImpactParameter, impactParameter, float); //! Impact parameter for A-A
+DECLARE_SOA_COLUMN(EventPlaneAngle, eventPlaneAngle, float); //! Event plane angle for A-A
 DECLARE_SOA_DYNAMIC_COLUMN(GetGeneratorId, getGeneratorId,   //! The global generator ID which might have been assigned by the user
                            [](short generatorsID) -> int { return o2::mcgenid::getGeneratorId(generatorsID); });
 DECLARE_SOA_DYNAMIC_COLUMN(GetSubGeneratorId, getSubGeneratorId, //! A specific sub-generator ID in case the generator has some sub-generator logic
@@ -1558,7 +1559,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(GetSourceId, getSourceId, //! The source ID to differ
 
 } // namespace mccollision
 
-DECLARE_SOA_TABLE(McCollisions, "AOD", "MCCOLLISION", //! MC collision table
+DECLARE_SOA_TABLE(McCollisions_000, "AOD", "MCCOLLISION", //! MC collision table
                   o2::soa::Index<>, mccollision::BCId,
                   mccollision::GeneratorsID,
                   mccollision::PosX, mccollision::PosY, mccollision::PosZ,
@@ -1567,7 +1568,18 @@ DECLARE_SOA_TABLE(McCollisions, "AOD", "MCCOLLISION", //! MC collision table
                   mccollision::GetGeneratorId<mccollision::GeneratorsID>,
                   mccollision::GetSubGeneratorId<mccollision::GeneratorsID>,
                   mccollision::GetSourceId<mccollision::GeneratorsID>);
+DECLARE_SOA_TABLE_VERSIONED(McCollisions_001, "AOD", "MCCOLLISION", 1, //! MC collision table with event plane
+                            o2::soa::Index<>, mccollision::BCId,
+                            mccollision::GeneratorsID,
+                            mccollision::PosX, mccollision::PosY, mccollision::PosZ,
+                            mccollision::T, mccollision::Weight,
+                            mccollision::ImpactParameter,
+                            mccollision::EventPlaneAngle,
+                            mccollision::GetGeneratorId<mccollision::GeneratorsID>,
+                            mccollision::GetSubGeneratorId<mccollision::GeneratorsID>,
+                            mccollision::GetSourceId<mccollision::GeneratorsID>);
 
+using McCollisions = McCollisions_000;
 using McCollision = McCollisions::iterator;
 
 namespace mcparticle

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -657,6 +657,8 @@ void GeneratorPythia8::updateHeader(o2::dataformats::MCEventHeader* eventHeader)
     /** set impact parameter **/
     eventHeader->SetB(hiinfo->b());
     eventHeader->putInfo<double>(Key::impactParameter, hiinfo->b());
+    /** set event plane angle **/
+    eventHeader->putInfo<double>(Key::planeAngle, hiinfo->phi());
     auto bImp = hiinfo->b();
     /** set Ncoll, Npart and Nremn **/
     int nColl, nPart;


### PR DESCRIPTION
This PR adds the event plane (reaction plane -> the angle of inclination of the impact parameter from PYTHIA) to the `McCollisions` table. It is necessary as a development for the v2 MC closure testing. Note that, if the data model change is accepted, a converter will be written and committed to O2Physics before the `McCollisions` table version is actually bumped to `001`. 

The current size of the `McCollisions` table in our Pb-Pb MC is 0.002% of all compressed space, and it is comprised of 6 floats and one short. Adding one float to it will result in negligible disk space use that is well worth the cost. I would be happy to present the case for this in one of the WP4+WP14 meetings, of course. Thank you! 

Tagging @sawenzel @pzhristov @ktf 