### PR TITLE
Add Flow Mapper for synthetic v2 addition

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -40,6 +40,7 @@ o2_add_library(Generators
                        src/GeneratorTParticle.cxx
                        src/GeneratorTParticleParam.cxx
                        src/GeneratorService.cxx
+                       src/FlowMapper.cxx
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8Param.cxx>
@@ -82,6 +83,7 @@ set(headers
     include/Generators/GeneratorTParticleParam.h
     include/Generators/GeneratorService.h
     include/Generators/BoxGenerator.h
+    include/Generators/FlowMapper.h
     )
 
 if(pythia_FOUND)

--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -1,0 +1,77 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EVENTGEN_FLOWMAPPER_H_
+#define ALICEO2_EVENTGEN_FLOWMAPPER_H_
+
+#include "TH1D.h"
+#include "TH3D.h"
+#include "TF1.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+// this class implements a mapper that introduces a synthetic v2 
+// into an otherwise uniform initial distribution of phis. It can 
+// be used, for instance, to create artificial flow of realistic
+// intensity in PYTHIA simulations. 
+
+// The input histograms are to be read from the CCDB and can 
+// be customized if necessary. Multiple copies of this mapper
+// could be used in case different species should have different 
+// additional flow. 
+
+// N.B.: the main advantages of this mapper is that: 
+//       1) it preserves total number of particles 
+//       2) it retains a (distorted) event structure from 
+//          an original event generator (e.g. PYTHIA)
+
+class FlowMapper {
+public:
+  //Constructor
+  FlowMapper();
+  
+  void Setv2VsPt(TH1D *hv2VsPtProvided);
+  void SetEccVsB(TH1D *hEccVsBProvided);
+  
+  void CreateLUT(); //to be called if all is set
+  TH3D *GetLUT();
+
+  Double_t MapPhi(Double_t lPhiInput, TH3D *hLUT, Double_t b, Double_t pt);
+  
+  long binsPhi; // number of phi bins to use
+  double precision = 1e-6; // could be studied
+  double derivative = 1e-4; // could be studied
+  
+  TH1D *hv2vsPt; // input v2 vs pT from measurement
+  TH1D *hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
+  
+  // Cumulative function to be inverted
+  TF1 *fCumulative;
+  
+  // the look-up table
+  TH3D *hLUT;
+
+  ClassDef(FlowMapper, 1);
+};
+
+/*****************************************************************/
+/*****************************************************************/
+
+} // namespace eventgen
+} // namespace o2
+
+#endif /* ALICEO2_EVENTGEN_FLOWMAPPER_H_ */

--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -48,22 +48,26 @@ class FlowMapper
   void Setv2VsPt(TH1D hv2VsPtProvided);
   void SetEccVsB(TH1D hEccVsBProvided);
 
+  void SetNBinsPhi(long mBinsPhiProvided) { mBinsPhi = mBinsPhiProvided; };
+  void SetPrecision(long mPrecisionProvided) { mPrecision = mPrecisionProvided; };
+  void SetDerivative(long mDerivativeProvided) { mDerivative = mDerivativeProvided; };
+
   void CreateLUT(); // to be called if all is set
 
-  Double_t MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt);
+  Double_t MapPhi(Double_t lPhiInput, Double_t b, Double_t pt);
 
-  long binsPhi;             // number of phi bins to use
-  double precision = 1e-6;  // could be studied
-  double derivative = 1e-4; // could be studied
+  long mBinsPhi;             // number of phi bins to use
+  double mPrecision = 1e-6;  // precision threshold for numerical inversion success
+  double mDerivative = 1e-4; // delta-X for derivative calculation
 
-  std::unique_ptr<TH1D> hv2vsPt; // input v2 vs pT from measurement
-  std::unique_ptr<TH1D> hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
+  std::unique_ptr<TH1D> mhv2vsPt; // input v2 vs pT from measurement
+  std::unique_ptr<TH1D> mhEccVsB; // ecc vs B (from Glauber MC or elsewhere)
 
   // Cumulative function to be inverted
-  std::unique_ptr<TF1> fCumulative;
+  std::unique_ptr<TF1> mCumulative;
 
   // the look-up table
-  std::unique_ptr<TH3D> hLUT;
+  std::unique_ptr<TH3D> mhLUT;
 
   ClassDef(FlowMapper, 1);
 };

--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -44,24 +44,24 @@ class FlowMapper
  public:
   // Constructor
   FlowMapper();
-  
+
   void Setv2VsPt(TH1D hv2VsPtProvided);
   void SetEccVsB(TH1D hEccVsBProvided);
-  
-  void CreateLUT(); //to be called if all is set
+
+  void CreateLUT(); // to be called if all is set
 
   Double_t MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt);
 
   long binsPhi;             // number of phi bins to use
   double precision = 1e-6;  // could be studied
   double derivative = 1e-4; // could be studied
-  
+
   std::unique_ptr<TH1D> hv2vsPt; // input v2 vs pT from measurement
   std::unique_ptr<TH1D> hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
-  
+
   // Cumulative function to be inverted
   std::unique_ptr<TF1> fCumulative;
-  
+
   // the look-up table
   std::unique_ptr<TH3D> hLUT;
 

--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -44,27 +44,26 @@ class FlowMapper
  public:
   // Constructor
   FlowMapper();
-
-  void Setv2VsPt(TH1D* hv2VsPtProvided);
-  void SetEccVsB(TH1D* hEccVsBProvided);
-
-  void CreateLUT(); // to be called if all is set
-  TH3D* GetLUT();
+  
+  void Setv2VsPt(TH1D hv2VsPtProvided);
+  void SetEccVsB(TH1D hEccVsBProvided);
+  
+  void CreateLUT(); //to be called if all is set
 
   Double_t MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt);
 
   long binsPhi;             // number of phi bins to use
   double precision = 1e-6;  // could be studied
   double derivative = 1e-4; // could be studied
-
-  TH1D* hv2vsPt; // input v2 vs pT from measurement
-  TH1D* hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
-
+  
+  std::unique_ptr<TH1D> hv2vsPt; // input v2 vs pT from measurement
+  std::unique_ptr<TH1D> hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
+  
   // Cumulative function to be inverted
-  TF1* fCumulative;
-
+  std::unique_ptr<TF1> fCumulative;
+  
   // the look-up table
-  TH3D* hLUT;
+  std::unique_ptr<TH3D> hLUT;
 
   ClassDef(FlowMapper, 1);
 };

--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -24,46 +24,47 @@ namespace eventgen
 /*****************************************************************/
 /*****************************************************************/
 
-// this class implements a mapper that introduces a synthetic v2 
-// into an otherwise uniform initial distribution of phis. It can 
+// this class implements a mapper that introduces a synthetic v2
+// into an otherwise uniform initial distribution of phis. It can
 // be used, for instance, to create artificial flow of realistic
-// intensity in PYTHIA simulations. 
+// intensity in PYTHIA simulations.
 
-// The input histograms are to be read from the CCDB and can 
+// The input histograms are to be read from the CCDB and can
 // be customized if necessary. Multiple copies of this mapper
-// could be used in case different species should have different 
-// additional flow. 
+// could be used in case different species should have different
+// additional flow.
 
-// N.B.: the main advantages of this mapper is that: 
-//       1) it preserves total number of particles 
-//       2) it retains a (distorted) event structure from 
+// N.B.: the main advantages of this mapper is that:
+//       1) it preserves total number of particles
+//       2) it retains a (distorted) event structure from
 //          an original event generator (e.g. PYTHIA)
 
-class FlowMapper {
-public:
-  //Constructor
+class FlowMapper
+{
+ public:
+  // Constructor
   FlowMapper();
-  
-  void Setv2VsPt(TH1D *hv2VsPtProvided);
-  void SetEccVsB(TH1D *hEccVsBProvided);
-  
-  void CreateLUT(); //to be called if all is set
-  TH3D *GetLUT();
 
-  Double_t MapPhi(Double_t lPhiInput, TH3D *hLUT, Double_t b, Double_t pt);
-  
-  long binsPhi; // number of phi bins to use
-  double precision = 1e-6; // could be studied
+  void Setv2VsPt(TH1D* hv2VsPtProvided);
+  void SetEccVsB(TH1D* hEccVsBProvided);
+
+  void CreateLUT(); // to be called if all is set
+  TH3D* GetLUT();
+
+  Double_t MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt);
+
+  long binsPhi;             // number of phi bins to use
+  double precision = 1e-6;  // could be studied
   double derivative = 1e-4; // could be studied
-  
-  TH1D *hv2vsPt; // input v2 vs pT from measurement
-  TH1D *hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
-  
+
+  TH1D* hv2vsPt; // input v2 vs pT from measurement
+  TH1D* hEccVsB; // ecc vs B (from Glauber MC or elsewhere)
+
   // Cumulative function to be inverted
-  TF1 *fCumulative;
-  
+  TF1* fCumulative;
+
   // the look-up table
-  TH3D *hLUT;
+  TH3D* hLUT;
 
   ClassDef(FlowMapper, 1);
 };

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -110,8 +110,9 @@ Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t
   // Avoid interpolation problems in dimension: pT
   Double_t lMaxPt = hLUT->GetYaxis()->GetBinCenter(hLUT->GetYaxis()->GetNbins());
   Double_t lMinPt = hLUT->GetYaxis()->GetBinCenter(1);
-  if (pt > lMaxPt)
+  if (pt > lMaxPt){
     pt = lMaxPt; // avoid interpolation problems at edge
+  }
 
   Double_t phiWidth = hLUT->GetZaxis()->GetBinWidth(1); // any bin, assume constant
 

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -26,15 +26,17 @@ namespace eventgen
 FlowMapper::FlowMapper()
 {
   // base constructor. Creates cumulative function only so that's already in place but not much else.
-  fCumulative = std::make_unique<TF1>("fCumulative","x+[0]*TMath::Sin(2*x)", 0,2*TMath::Pi());
+  fCumulative = std::make_unique<TF1>("fCumulative", "x+[0]*TMath::Sin(2*x)", 0, 2 * TMath::Pi());
   binsPhi = 4000; // a first guess
 }
 
-void FlowMapper::Setv2VsPt(TH1D hv2VsPtProvided) {
+void FlowMapper::Setv2VsPt(TH1D hv2VsPtProvided)
+{
   // Sets the v2 vs pT to be used.
   hv2vsPt = std::make_unique<TH1D>(hv2VsPtProvided);
 }
-void FlowMapper::SetEccVsB(TH1D hEccVsBProvided) {
+void FlowMapper::SetEccVsB(TH1D hEccVsBProvided)
+{
   // Sets the v2 vs pT to be used.
   hEccVsB = std::make_unique<TH1D>(hEccVsBProvided);
 }
@@ -52,24 +54,24 @@ void FlowMapper::CreateLUT()
   const Long_t nbinsB = hEccVsB->GetNbinsX();
   const Long_t nbinsPt = hv2vsPt->GetNbinsX();
   const Long_t nbinsPhi = binsPhi; // constant in this context necessary
-  std::vector<double> binsB(nbinsB+1,0);
-  std::vector<double> binsPt(nbinsPt+1,0);
-  std::vector<double> binsPhi(nbinsPhi+1,0);
-  
-  for(int ii=0; ii<nbinsB+1; ii++){
-    binsB[ii] = hEccVsB->GetBinLowEdge(ii+1);
+  std::vector<double> binsB(nbinsB + 1, 0);
+  std::vector<double> binsPt(nbinsPt + 1, 0);
+  std::vector<double> binsPhi(nbinsPhi + 1, 0);
+
+  for (int ii = 0; ii < nbinsB + 1; ii++) {
+    binsB[ii] = hEccVsB->GetBinLowEdge(ii + 1);
   }
-  for(int ii=0; ii<nbinsPt+1; ii++){
-    binsPt[ii] = hv2vsPt->GetBinLowEdge(ii+1);
+  for (int ii = 0; ii < nbinsPt + 1; ii++) {
+    binsPt[ii] = hv2vsPt->GetBinLowEdge(ii + 1);
   }
-  for(int ii=0; ii<nbinsPhi+1; ii++){
-    binsPhi[ii] = static_cast<Double_t>(ii)*2*TMath::Pi()/static_cast<Double_t>(nbinsPhi);
+  for (int ii = 0; ii < nbinsPhi + 1; ii++) {
+    binsPhi[ii] = static_cast<Double_t>(ii) * 2 * TMath::Pi() / static_cast<Double_t>(nbinsPhi);
   }
 
-  //std::make_unique<TH1F>("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
-  
+  // std::make_unique<TH1F>("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
+
   hLUT = std::make_unique<TH3D>("hLUT", "", nbinsB, binsB.data(), nbinsPt, binsPt.data(), nbinsPhi, binsPhi.data());
-  
+
   // loop over each centrality (b) bin
   for (int ic = 0; ic < nbinsB; ic++) {
     // loop over each pt bin
@@ -99,9 +101,10 @@ void FlowMapper::CreateLUT()
   }
 }
 
-Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D *hLUT, Double_t b, Double_t pt){
-  Int_t lLowestPeriod = TMath::Floor( lPhiInput/(2*TMath::Pi()) );
-  Double_t lPhiOld = lPhiInput - 2*lLowestPeriod*TMath::Pi();
+Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt)
+{
+  Int_t lLowestPeriod = TMath::Floor(lPhiInput / (2 * TMath::Pi()));
+  Double_t lPhiOld = lPhiInput - 2 * lLowestPeriod * TMath::Pi();
   Double_t lPhiNew = lPhiOld;
 
   // Avoid interpolation problems in dimension: pT

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -1,0 +1,149 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Generators/FlowMapper.h"
+#include "TH1D.h"
+#include "TH3D.h"
+#include "TF1.h"
+#include <fairlogger/Logger.h>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+FlowMapper::FlowMapper() {
+  // base constructor. Creates cumulative function only so that's already in place but not much else.
+  fCumulative = new TF1("fCumulative","x+[0]*TMath::Sin(2*x)", 0,2*TMath::Pi());
+  hv2vsPt = 0x0;
+  hEccVsB = 0x0;
+  hLUT = 0x0;
+  
+  binsPhi = 4000; // a first guess
+}
+
+void FlowMapper::Setv2VsPt(TH1D *hv2VsPtProvided) {
+  // Sets the v2 vs pT to be used.
+  hv2vsPt = hv2VsPtProvided;
+}
+void FlowMapper::SetEccVsB(TH1D *hEccVsBProvided) {
+  // Sets the v2 vs pT to be used.
+  hEccVsB = hEccVsBProvided;
+}
+void FlowMapper::CreateLUT() {
+  if( ! hv2vsPt ){
+    LOG(fatal)<<"You did not specify a v2 vs pT histogram!";
+    return;
+  }
+  if( ! hEccVsB ){
+    LOG(fatal)<<"You did not specify an ecc vs B histogram!";
+    return;
+  }
+  LOG(info)<<"Proceeding to creating a look-up table...";
+  const Long_t nbinsB = hEccVsB->GetNbinsX();
+  const Long_t nbinsPt = hv2vsPt->GetNbinsX();
+  const Long_t nbinsPhi = binsPhi; // constant in this context necessary
+  Double_t binsB[nbinsB+1], binsPt[nbinsPt+1], binsPhi[nbinsPhi+1];
+  
+  for(int ii=0; ii<nbinsB+1; ii++)
+    binsB[ii] = hEccVsB->GetBinLowEdge(ii+1);
+  for(int ii=0; ii<nbinsPt+1; ii++)
+    binsPt[ii] = hv2vsPt->GetBinLowEdge(ii+1);
+  for(int ii=0; ii<nbinsPhi+1; ii++)
+    binsPhi[ii] = static_cast<Double_t>(ii)*2*TMath::Pi()/static_cast<Double_t>(nbinsPhi);
+  
+  hLUT = new TH3D("hLUT", "", nbinsB, binsB, nbinsPt, binsPt, nbinsPhi, binsPhi);
+  
+  // loop over each centrality (b) bin
+  for(int ic=0; ic<nbinsB; ic++){
+    // loop over each pt bin
+    for(int ip=0; ip<nbinsPt; ip++){
+      // find target v2 value and set cumulative for inversion
+      double v2target = hv2vsPt->GetBinContent(ip+1) * hEccVsB->GetBinContent(ic+1);
+      LOG(info)<<"At b ~ "<<hEccVsB->GetBinCenter(ic+1)<<", pt ~ "<<hv2vsPt->GetBinCenter(ip+1)<<", ref v2 is "<<hv2vsPt->GetBinContent(ip+1)<<", scale is "<< hEccVsB->GetBinContent(ic+1)<<", target v2 is "<<v2target<<", inverting...";
+      fCumulative->SetParameter(0, v2target); // set up
+      for(Int_t ia=0; ia<nbinsPhi; ia++){
+        //Look systematically for the X value that gives this Y
+        //There are probably better ways of doing this, but OK
+        Double_t lY = hLUT -> GetZaxis() -> GetBinCenter (ia+1) ;
+        Double_t lX = lY; //a first reasonable guess
+        Bool_t lConverged = kFALSE ;
+        while ( !lConverged ){
+          Double_t lDistance = fCumulative->Eval(lX) - lY;
+          if ( TMath::Abs(lDistance) < precision ) {
+            lConverged = kTRUE;
+            break;
+          }
+          Double_t lDerivativeValue = derivative/(fCumulative->Eval(lX+derivative)-fCumulative->Eval(lX));
+          lX=lX-lDistance*lDerivativeValue*0.25; //0.5: speed factor, don't overshoot but control reasonable
+        }
+        hLUT->SetBinContent(ic+1, ip+1, ia+1, lX);
+      }
+    }
+  }
+  
+}
+
+TH3D* FlowMapper::GetLUT() {
+  if( !hLUT ){
+    LOG(info)<<"LUT was not created! Returning null pointer, beware";
+    return 0x0;
+  }
+  return hLUT;
+}
+
+Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D *hLUT, Double_t b, Double_t pt){
+  Int_t lLowestPeriod = TMath::Floor( lPhiInput/(2*TMath::Pi()) );
+  Double_t lPhiOld = lPhiInput - 2*lLowestPeriod*TMath::Pi();
+  Double_t lPhiNew = lPhiOld;
+  
+  // Avoid interpolation problems in dimension: pT
+  Double_t lMaxPt = hLUT->GetYaxis()->GetBinCenter(hLUT->GetYaxis()->GetNbins());
+  Double_t lMinPt = hLUT->GetYaxis()->GetBinCenter(1);
+  if(pt>lMaxPt) pt = lMaxPt; // avoid interpolation problems at edge
+  
+  Double_t phiWidth = hLUT->GetZaxis()->GetBinWidth(1); // any bin, assume constant
+  
+  // Valid if not at edges. If at edges, that's ok, do not map
+  bool validPhi = lPhiNew>phiWidth/2.0f && lPhiNew< 2.0*TMath::Pi()-phiWidth/2.0f;
+  
+  // If at very high b, do not map
+  bool validB = b < hLUT->GetXaxis()->GetBinCenter(hLUT->GetXaxis()->GetNbins());
+  Double_t minB = hLUT->GetXaxis()->GetBinCenter(1);
+  
+  if(validPhi && validB){
+    
+    Double_t scaleFactor = 1.0; // no need if not special conditions
+    if(pt<lMinPt){
+      scaleFactor *= pt/lMinPt; // downscale the difference, zero at zero pT
+      pt = lMinPt;
+    }
+    if(b<minB){
+      scaleFactor *= b/minB; // downscale the difference, zero at zero b
+      b = minB;
+    }
+    lPhiNew = hLUT->Interpolate(b, pt, lPhiOld);
+    
+    lPhiNew = scaleFactor*lPhiNew + (1.0-scaleFactor)*lPhiOld;
+  }
+  return lPhiNew + 2.0*lLowestPeriod*TMath::Pi();
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */
+
+ClassImp(o2::eventgen::FlowMapper);

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -23,121 +23,127 @@ namespace eventgen
 /*****************************************************************/
 /*****************************************************************/
 
-FlowMapper::FlowMapper() {
+FlowMapper::FlowMapper()
+{
   // base constructor. Creates cumulative function only so that's already in place but not much else.
-  fCumulative = new TF1("fCumulative","x+[0]*TMath::Sin(2*x)", 0,2*TMath::Pi());
+  fCumulative = new TF1("fCumulative", "x+[0]*TMath::Sin(2*x)", 0, 2 * TMath::Pi());
   hv2vsPt = 0x0;
   hEccVsB = 0x0;
   hLUT = 0x0;
-  
+
   binsPhi = 4000; // a first guess
 }
 
-void FlowMapper::Setv2VsPt(TH1D *hv2VsPtProvided) {
+void FlowMapper::Setv2VsPt(TH1D* hv2VsPtProvided)
+{
   // Sets the v2 vs pT to be used.
   hv2vsPt = hv2VsPtProvided;
 }
-void FlowMapper::SetEccVsB(TH1D *hEccVsBProvided) {
+void FlowMapper::SetEccVsB(TH1D* hEccVsBProvided)
+{
   // Sets the v2 vs pT to be used.
   hEccVsB = hEccVsBProvided;
 }
-void FlowMapper::CreateLUT() {
-  if( ! hv2vsPt ){
-    LOG(fatal)<<"You did not specify a v2 vs pT histogram!";
+void FlowMapper::CreateLUT()
+{
+  if (!hv2vsPt) {
+    LOG(fatal) << "You did not specify a v2 vs pT histogram!";
     return;
   }
-  if( ! hEccVsB ){
-    LOG(fatal)<<"You did not specify an ecc vs B histogram!";
+  if (!hEccVsB) {
+    LOG(fatal) << "You did not specify an ecc vs B histogram!";
     return;
   }
-  LOG(info)<<"Proceeding to creating a look-up table...";
+  LOG(info) << "Proceeding to creating a look-up table...";
   const Long_t nbinsB = hEccVsB->GetNbinsX();
   const Long_t nbinsPt = hv2vsPt->GetNbinsX();
   const Long_t nbinsPhi = binsPhi; // constant in this context necessary
-  Double_t binsB[nbinsB+1], binsPt[nbinsPt+1], binsPhi[nbinsPhi+1];
-  
-  for(int ii=0; ii<nbinsB+1; ii++)
-    binsB[ii] = hEccVsB->GetBinLowEdge(ii+1);
-  for(int ii=0; ii<nbinsPt+1; ii++)
-    binsPt[ii] = hv2vsPt->GetBinLowEdge(ii+1);
-  for(int ii=0; ii<nbinsPhi+1; ii++)
-    binsPhi[ii] = static_cast<Double_t>(ii)*2*TMath::Pi()/static_cast<Double_t>(nbinsPhi);
-  
+  Double_t binsB[nbinsB + 1], binsPt[nbinsPt + 1], binsPhi[nbinsPhi + 1];
+
+  for (int ii = 0; ii < nbinsB + 1; ii++)
+    binsB[ii] = hEccVsB->GetBinLowEdge(ii + 1);
+  for (int ii = 0; ii < nbinsPt + 1; ii++)
+    binsPt[ii] = hv2vsPt->GetBinLowEdge(ii + 1);
+  for (int ii = 0; ii < nbinsPhi + 1; ii++)
+    binsPhi[ii] = static_cast<Double_t>(ii) * 2 * TMath::Pi() / static_cast<Double_t>(nbinsPhi);
+
   hLUT = new TH3D("hLUT", "", nbinsB, binsB, nbinsPt, binsPt, nbinsPhi, binsPhi);
-  
+
   // loop over each centrality (b) bin
-  for(int ic=0; ic<nbinsB; ic++){
+  for (int ic = 0; ic < nbinsB; ic++) {
     // loop over each pt bin
-    for(int ip=0; ip<nbinsPt; ip++){
+    for (int ip = 0; ip < nbinsPt; ip++) {
       // find target v2 value and set cumulative for inversion
-      double v2target = hv2vsPt->GetBinContent(ip+1) * hEccVsB->GetBinContent(ic+1);
-      LOG(info)<<"At b ~ "<<hEccVsB->GetBinCenter(ic+1)<<", pt ~ "<<hv2vsPt->GetBinCenter(ip+1)<<", ref v2 is "<<hv2vsPt->GetBinContent(ip+1)<<", scale is "<< hEccVsB->GetBinContent(ic+1)<<", target v2 is "<<v2target<<", inverting...";
+      double v2target = hv2vsPt->GetBinContent(ip + 1) * hEccVsB->GetBinContent(ic + 1);
+      LOG(info) << "At b ~ " << hEccVsB->GetBinCenter(ic + 1) << ", pt ~ " << hv2vsPt->GetBinCenter(ip + 1) << ", ref v2 is " << hv2vsPt->GetBinContent(ip + 1) << ", scale is " << hEccVsB->GetBinContent(ic + 1) << ", target v2 is " << v2target << ", inverting...";
       fCumulative->SetParameter(0, v2target); // set up
-      for(Int_t ia=0; ia<nbinsPhi; ia++){
-        //Look systematically for the X value that gives this Y
-        //There are probably better ways of doing this, but OK
-        Double_t lY = hLUT -> GetZaxis() -> GetBinCenter (ia+1) ;
-        Double_t lX = lY; //a first reasonable guess
-        Bool_t lConverged = kFALSE ;
-        while ( !lConverged ){
+      for (Int_t ia = 0; ia < nbinsPhi; ia++) {
+        // Look systematically for the X value that gives this Y
+        // There are probably better ways of doing this, but OK
+        Double_t lY = hLUT->GetZaxis()->GetBinCenter(ia + 1);
+        Double_t lX = lY; // a first reasonable guess
+        Bool_t lConverged = kFALSE;
+        while (!lConverged) {
           Double_t lDistance = fCumulative->Eval(lX) - lY;
-          if ( TMath::Abs(lDistance) < precision ) {
+          if (TMath::Abs(lDistance) < precision) {
             lConverged = kTRUE;
             break;
           }
-          Double_t lDerivativeValue = derivative/(fCumulative->Eval(lX+derivative)-fCumulative->Eval(lX));
-          lX=lX-lDistance*lDerivativeValue*0.25; //0.5: speed factor, don't overshoot but control reasonable
+          Double_t lDerivativeValue = derivative / (fCumulative->Eval(lX + derivative) - fCumulative->Eval(lX));
+          lX = lX - lDistance * lDerivativeValue * 0.25; // 0.5: speed factor, don't overshoot but control reasonable
         }
-        hLUT->SetBinContent(ic+1, ip+1, ia+1, lX);
+        hLUT->SetBinContent(ic + 1, ip + 1, ia + 1, lX);
       }
     }
   }
-  
 }
 
-TH3D* FlowMapper::GetLUT() {
-  if( !hLUT ){
-    LOG(info)<<"LUT was not created! Returning null pointer, beware";
+TH3D* FlowMapper::GetLUT()
+{
+  if (!hLUT) {
+    LOG(info) << "LUT was not created! Returning null pointer, beware";
     return 0x0;
   }
   return hLUT;
 }
 
-Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D *hLUT, Double_t b, Double_t pt){
-  Int_t lLowestPeriod = TMath::Floor( lPhiInput/(2*TMath::Pi()) );
-  Double_t lPhiOld = lPhiInput - 2*lLowestPeriod*TMath::Pi();
+Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt)
+{
+  Int_t lLowestPeriod = TMath::Floor(lPhiInput / (2 * TMath::Pi()));
+  Double_t lPhiOld = lPhiInput - 2 * lLowestPeriod * TMath::Pi();
   Double_t lPhiNew = lPhiOld;
-  
+
   // Avoid interpolation problems in dimension: pT
   Double_t lMaxPt = hLUT->GetYaxis()->GetBinCenter(hLUT->GetYaxis()->GetNbins());
   Double_t lMinPt = hLUT->GetYaxis()->GetBinCenter(1);
-  if(pt>lMaxPt) pt = lMaxPt; // avoid interpolation problems at edge
-  
+  if (pt > lMaxPt)
+    pt = lMaxPt; // avoid interpolation problems at edge
+
   Double_t phiWidth = hLUT->GetZaxis()->GetBinWidth(1); // any bin, assume constant
-  
+
   // Valid if not at edges. If at edges, that's ok, do not map
-  bool validPhi = lPhiNew>phiWidth/2.0f && lPhiNew< 2.0*TMath::Pi()-phiWidth/2.0f;
-  
+  bool validPhi = lPhiNew > phiWidth / 2.0f && lPhiNew < 2.0 * TMath::Pi() - phiWidth / 2.0f;
+
   // If at very high b, do not map
   bool validB = b < hLUT->GetXaxis()->GetBinCenter(hLUT->GetXaxis()->GetNbins());
   Double_t minB = hLUT->GetXaxis()->GetBinCenter(1);
-  
-  if(validPhi && validB){
-    
+
+  if (validPhi && validB) {
+
     Double_t scaleFactor = 1.0; // no need if not special conditions
-    if(pt<lMinPt){
-      scaleFactor *= pt/lMinPt; // downscale the difference, zero at zero pT
+    if (pt < lMinPt) {
+      scaleFactor *= pt / lMinPt; // downscale the difference, zero at zero pT
       pt = lMinPt;
     }
-    if(b<minB){
-      scaleFactor *= b/minB; // downscale the difference, zero at zero b
+    if (b < minB) {
+      scaleFactor *= b / minB; // downscale the difference, zero at zero b
       b = minB;
     }
     lPhiNew = hLUT->Interpolate(b, pt, lPhiOld);
-    
-    lPhiNew = scaleFactor*lPhiNew + (1.0-scaleFactor)*lPhiOld;
+
+    lPhiNew = scaleFactor * lPhiNew + (1.0 - scaleFactor) * lPhiOld;
   }
-  return lPhiNew + 2.0*lLowestPeriod*TMath::Pi();
+  return lPhiNew + 2.0 * lLowestPeriod * TMath::Pi();
 }
 
 /*****************************************************************/

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -26,43 +26,43 @@ namespace eventgen
 FlowMapper::FlowMapper()
 {
   // base constructor. Creates cumulative function only so that's already in place but not much else.
-  fCumulative = std::make_unique<TF1>("fCumulative", "x+[0]*TMath::Sin(2*x)", 0, 2 * TMath::Pi());
-  binsPhi = 4000; // a first guess
+  mCumulative = std::make_unique<TF1>("mCumulative", "x+[0]*TMath::Sin(2*x)", 0, 2 * TMath::Pi());
+  mBinsPhi = 4000; // a first guess
 }
 
 void FlowMapper::Setv2VsPt(TH1D hv2VsPtProvided)
 {
   // Sets the v2 vs pT to be used.
-  hv2vsPt = std::make_unique<TH1D>(hv2VsPtProvided);
+  mhv2vsPt = std::make_unique<TH1D>(hv2VsPtProvided);
 }
 void FlowMapper::SetEccVsB(TH1D hEccVsBProvided)
 {
   // Sets the v2 vs pT to be used.
-  hEccVsB = std::make_unique<TH1D>(hEccVsBProvided);
+  mhEccVsB = std::make_unique<TH1D>(hEccVsBProvided);
 }
 void FlowMapper::CreateLUT()
 {
-  if (!hv2vsPt) {
+  if (!mhv2vsPt) {
     LOG(fatal) << "You did not specify a v2 vs pT histogram!";
     return;
   }
-  if (!hEccVsB) {
+  if (!mhEccVsB) {
     LOG(fatal) << "You did not specify an ecc vs B histogram!";
     return;
   }
   LOG(info) << "Proceeding to creating a look-up table...";
-  const Long_t nbinsB = hEccVsB->GetNbinsX();
-  const Long_t nbinsPt = hv2vsPt->GetNbinsX();
-  const Long_t nbinsPhi = binsPhi; // constant in this context necessary
+  const Long_t nbinsB = mhEccVsB->GetNbinsX();
+  const Long_t nbinsPt = mhv2vsPt->GetNbinsX();
+  const Long_t nbinsPhi = mBinsPhi; // constant in this context necessary
   std::vector<double> binsB(nbinsB + 1, 0);
   std::vector<double> binsPt(nbinsPt + 1, 0);
   std::vector<double> binsPhi(nbinsPhi + 1, 0);
 
   for (int ii = 0; ii < nbinsB + 1; ii++) {
-    binsB[ii] = hEccVsB->GetBinLowEdge(ii + 1);
+    binsB[ii] = mhEccVsB->GetBinLowEdge(ii + 1);
   }
   for (int ii = 0; ii < nbinsPt + 1; ii++) {
-    binsPt[ii] = hv2vsPt->GetBinLowEdge(ii + 1);
+    binsPt[ii] = mhv2vsPt->GetBinLowEdge(ii + 1);
   }
   for (int ii = 0; ii < nbinsPhi + 1; ii++) {
     binsPhi[ii] = static_cast<Double_t>(ii) * 2 * TMath::Pi() / static_cast<Double_t>(nbinsPhi);
@@ -70,58 +70,58 @@ void FlowMapper::CreateLUT()
 
   // std::make_unique<TH1F>("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
 
-  hLUT = std::make_unique<TH3D>("hLUT", "", nbinsB, binsB.data(), nbinsPt, binsPt.data(), nbinsPhi, binsPhi.data());
+  mhLUT = std::make_unique<TH3D>("mhLUT", "", nbinsB, binsB.data(), nbinsPt, binsPt.data(), nbinsPhi, binsPhi.data());
 
   // loop over each centrality (b) bin
   for (int ic = 0; ic < nbinsB; ic++) {
     // loop over each pt bin
     for (int ip = 0; ip < nbinsPt; ip++) {
       // find target v2 value and set cumulative for inversion
-      double v2target = hv2vsPt->GetBinContent(ip + 1) * hEccVsB->GetBinContent(ic + 1);
-      LOG(info) << "At b ~ " << hEccVsB->GetBinCenter(ic + 1) << ", pt ~ " << hv2vsPt->GetBinCenter(ip + 1) << ", ref v2 is " << hv2vsPt->GetBinContent(ip + 1) << ", scale is " << hEccVsB->GetBinContent(ic + 1) << ", target v2 is " << v2target << ", inverting...";
-      fCumulative->SetParameter(0, v2target); // set up
+      double v2target = mhv2vsPt->GetBinContent(ip + 1) * mhEccVsB->GetBinContent(ic + 1);
+      LOG(info) << "At b ~ " << mhEccVsB->GetBinCenter(ic + 1) << ", pt ~ " << mhv2vsPt->GetBinCenter(ip + 1) << ", ref v2 is " << mhv2vsPt->GetBinContent(ip + 1) << ", scale is " << mhEccVsB->GetBinContent(ic + 1) << ", target v2 is " << v2target << ", inverting...";
+      mCumulative->SetParameter(0, v2target); // set up
       for (Int_t ia = 0; ia < nbinsPhi; ia++) {
         // Look systematically for the X value that gives this Y
         // There are probably better ways of doing this, but OK
-        Double_t lY = hLUT->GetZaxis()->GetBinCenter(ia + 1);
+        Double_t lY = mhLUT->GetZaxis()->GetBinCenter(ia + 1);
         Double_t lX = lY; // a first reasonable guess
         Bool_t lConverged = kFALSE;
         while (!lConverged) {
-          Double_t lDistance = fCumulative->Eval(lX) - lY;
-          if (TMath::Abs(lDistance) < precision) {
+          Double_t lDistance = mCumulative->Eval(lX) - lY;
+          if (TMath::Abs(lDistance) < mPrecision) {
             lConverged = kTRUE;
             break;
           }
-          Double_t lDerivativeValue = derivative / (fCumulative->Eval(lX + derivative) - fCumulative->Eval(lX));
+          Double_t lDerivativeValue = mDerivative / (mCumulative->Eval(lX + mDerivative) - mCumulative->Eval(lX));
           lX = lX - lDistance * lDerivativeValue * 0.25; // 0.5: speed factor, don't overshoot but control reasonable
         }
-        hLUT->SetBinContent(ic + 1, ip + 1, ia + 1, lX);
+        mhLUT->SetBinContent(ic + 1, ip + 1, ia + 1, lX);
       }
     }
   }
 }
 
-Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t pt)
+Double_t FlowMapper::MapPhi(Double_t lPhiInput, Double_t b, Double_t pt)
 {
   Int_t lLowestPeriod = TMath::Floor(lPhiInput / (2 * TMath::Pi()));
   Double_t lPhiOld = lPhiInput - 2 * lLowestPeriod * TMath::Pi();
   Double_t lPhiNew = lPhiOld;
 
   // Avoid interpolation problems in dimension: pT
-  Double_t lMaxPt = hLUT->GetYaxis()->GetBinCenter(hLUT->GetYaxis()->GetNbins());
-  Double_t lMinPt = hLUT->GetYaxis()->GetBinCenter(1);
+  Double_t lMaxPt = mhLUT->GetYaxis()->GetBinCenter(mhLUT->GetYaxis()->GetNbins());
+  Double_t lMinPt = mhLUT->GetYaxis()->GetBinCenter(1);
   if (pt > lMaxPt) {
     pt = lMaxPt; // avoid interpolation problems at edge
   }
 
-  Double_t phiWidth = hLUT->GetZaxis()->GetBinWidth(1); // any bin, assume constant
+  Double_t phiWidth = mhLUT->GetZaxis()->GetBinWidth(1); // any bin, assume constant
 
   // Valid if not at edges. If at edges, that's ok, do not map
   bool validPhi = lPhiNew > phiWidth / 2.0f && lPhiNew < 2.0 * TMath::Pi() - phiWidth / 2.0f;
 
   // If at very high b, do not map
-  bool validB = b < hLUT->GetXaxis()->GetBinCenter(hLUT->GetXaxis()->GetNbins());
-  Double_t minB = hLUT->GetXaxis()->GetBinCenter(1);
+  bool validB = b < mhLUT->GetXaxis()->GetBinCenter(mhLUT->GetXaxis()->GetNbins());
+  Double_t minB = mhLUT->GetXaxis()->GetBinCenter(1);
 
   if (validPhi && validB) {
 
@@ -134,7 +134,7 @@ Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t
       scaleFactor *= b / minB; // downscale the difference, zero at zero b
       b = minB;
     }
-    lPhiNew = hLUT->Interpolate(b, pt, lPhiOld);
+    lPhiNew = mhLUT->Interpolate(b, pt, lPhiOld);
 
     lPhiNew = scaleFactor * lPhiNew + (1.0 - scaleFactor) * lPhiOld;
   }

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -110,7 +110,7 @@ Double_t FlowMapper::MapPhi(Double_t lPhiInput, TH3D* hLUT, Double_t b, Double_t
   // Avoid interpolation problems in dimension: pT
   Double_t lMaxPt = hLUT->GetYaxis()->GetBinCenter(hLUT->GetYaxis()->GetNbins());
   Double_t lMinPt = hLUT->GetYaxis()->GetBinCenter(1);
-  if (pt > lMaxPt){
+  if (pt > lMaxPt) {
     pt = lMaxPt; // avoid interpolation problems at edge
   }
 

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -74,5 +74,6 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorFileOrCmdParam> + ;
 
 #pragma link C++ class o2::eventgen::BoxGenerator + ;
+#pragma link C++ class o2::eventgen::FlowMapper + ;
 
 #endif


### PR DESCRIPTION
This PR, related also to #13287, adds a Flow Mapping utility that works via rotating a set of phi angles with respect to an event plane in a controlled manner such as to provide a realistic azimuthal anisotropy (to order n = 2) in generators such as PYTHIA. It works by afterburning any particle sample after hadronization, preserving the number of particles but laying them out differently in azimuth.

The implementation itself is based around the calculation of a phiOld -> phiNew look-up table that has as dimensions phiOld, impact parameter and transverse momentum. The LUT is calculated using the inversion of the cumulative function that is desired at each (impact parameter, pT) bin and intermediate values of any of the three relevant variables in the LUT are always calculated using linear interpolation. Special care is taken to ensure that v2 -> 0 as b -> 0 and pT -> 0. 

The LUT calculation takes as input a v2 vs pT curve (typically from measured data) and eccentricity vs b curve (typically from glauber MC). The v2 vs pT is provided in a base centrality (typically 40-50%) and the eccentricity values are used as scaling variable for other centralities. 

More details here: https://www.dropbox.com/scl/fi/ss57me45ykp2f6960a2gt/DDChinellato-SynthV2Gen-01.pdf?rlkey=pph4d1286giy3sd65rz136010&dl=0 