### PR TITLE
Ability to access MCEventHeader information in digitization

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
@@ -29,6 +29,11 @@ class TChain;
 namespace o2
 {
 
+namespace steer
+{
+class MCKinematicsReader;
+}
+
 namespace ctp
 {
 class CTPConfiguration;
@@ -84,6 +89,7 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer, public o2::framew
   std::vector<Hit> mHits;                     ///< Vector with input hits
   std::vector<TChain*> mSimChains;
   o2::ctp::CTPConfiguration* mCTPConfig; ///< CTP configuration
+  o2::steer::MCKinematicsReader* mcReader; ///< reader to access MC collision information
 };
 
 /// \brief Create new digitizer spec

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -32,6 +32,7 @@
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "DataFormatsFT0/Digit.h"
 #include "DataFormatsFV0/Digit.h"
+#include <Steer/MCKinematicsReader.h>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -83,6 +84,12 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
   // read collision context from input
   auto context = ctx.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
   context->initSimChains(o2::detectors::DetID::EMC, mSimChains);
+
+  // init the MCKinematicsReader from the digitization context
+  if (mcReader == nullptr) {
+    mcReader = new o2::steer::MCKinematicsReader(context.get());
+  }
+
   auto& timesview = context->getEventRecords();
   LOG(debug) << "GOT " << timesview.size() << " COLLISSION TIMES";
 
@@ -191,6 +198,10 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
 
       mSumDigitizer.setCurrEvID(part.entryID);
       mSumDigitizer.setCurrSrcID(part.sourceID);
+
+      // retrieve information about the MC collision via the MCEventHeader
+      auto& mcEventHeader = mcReader->getMCEventHeader(part.sourceID, part.entryID);
+      mcEventHeader.print();
 
       // get the hits for this event and this source
       mHits.clear();

--- a/Steer/include/Steer/MCKinematicsReader.h
+++ b/Steer/include/Steer/MCKinematicsReader.h
@@ -55,9 +55,17 @@ class MCKinematicsReader
     }
   }
 
+  /// constructing directly from a digitization context
+  MCKinematicsReader(o2::steer::DigitizationContext const* context)
+  {
+    initFromDigitContext(context);
+  }
+
   /// inits the reader from a digitization context
   /// returns true if successful
   bool initFromDigitContext(std::string_view filename);
+
+  bool initFromDigitContext(o2::steer::DigitizationContext const* digicontext);
 
   /// inits the reader from a simple kinematics file
   bool initFromKinematics(std::string_view filename);
@@ -120,6 +128,7 @@ class MCKinematicsReader
   void initIndexedTrackRefs(std::vector<o2::TrackReference>& refs, o2::dataformats::MCTruthContainer<o2::TrackReference>& indexedrefs) const;
 
   DigitizationContext const* mDigitizationContext = nullptr;
+  bool mOwningDigiContext = false;
 
   // chains for each source
   std::vector<TChain*> mInputChains;

--- a/Steer/src/MCKinematicsReader.cxx
+++ b/Steer/src/MCKinematicsReader.cxx
@@ -26,7 +26,7 @@ MCKinematicsReader::~MCKinematicsReader()
   }
   mInputChains.clear();
 
-  if (mDigitizationContext) {
+  if (mDigitizationContext && mOwningDigiContext) {
     delete mDigitizationContext;
   }
 }
@@ -132,17 +132,13 @@ void MCKinematicsReader::loadTrackRefsForSource(int source) const
   }
 }
 
-bool MCKinematicsReader::initFromDigitContext(std::string_view name)
+bool MCKinematicsReader::initFromDigitContext(o2::steer::DigitizationContext const* context)
 {
   if (mInitialized) {
     LOG(info) << "MCKinematicsReader already initialized; doing nothing";
     return false;
   }
 
-  auto context = DigitizationContext::loadFromFile(name);
-  if (!context) {
-    return false;
-  }
   mInitialized = true;
   mDigitizationContext = context;
 
@@ -158,6 +154,21 @@ bool MCKinematicsReader::initFromDigitContext(std::string_view name)
   // the first time for a particular source ...
 
   return true;
+}
+
+bool MCKinematicsReader::initFromDigitContext(std::string_view name)
+{
+  if (mInitialized) {
+    LOG(info) << "MCKinematicsReader already initialized; doing nothing";
+    return false;
+  }
+
+  auto context = DigitizationContext::loadFromFile(name);
+  if (!context) {
+    return false;
+  }
+  mOwningDigiContext = true;
+  return initFromDigitContext(context);
 }
 
 bool MCKinematicsReader::initFromKinematics(std::string_view name)


### PR DESCRIPTION
This commit provides:

* Modifications to MCKinematicsReader to allow construction from an existing DigitizationContext object

* Demonstrating use of MCKinematicsReader in EMCAL digitization to access the Monte-Carlo header information.

** JUST FOR BRAINSTORMING ... DO NOT MERGE YET **