### PR TITLE
SIM: Possible fix for -run5 executables for detectorList

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -124,7 +124,7 @@ class SimConfig
   bool resetFromArguments(int argc, char* argv[]);
 
   // initializes from existing parsed map
-  bool resetFromParsedMap(boost::program_options::variables_map const&);
+  bool resetFromParsedMap(boost::program_options::variables_map const&, bool hasDefaulted = false);
 
   void resetFromConfigData(SimConfigData const& data) { mConfigData = data; }
   SimConfigData const& getConfigData() const { return mConfigData; }
@@ -139,7 +139,7 @@ class SimConfig
   // static helper functions to determine list of active / readout modules
   // can also be used from outside
   static void determineActiveModules(std::vector<std::string> const& input, std::vector<std::string> const& skipped, std::vector<std::string>& active, bool isUpgrade = false);
-  static bool determineActiveModulesList(const std::string& version, std::vector<std::string> const& input, std::vector<std::string> const& skipped, std::vector<std::string>& active);
+  static bool determineActiveModulesList(const std::string& version, std::vector<std::string> const& input, std::vector<std::string> const& skipped, std::vector<std::string>& active, bool print = true);
   static void determineReadoutDetectors(std::vector<std::string> const& active, std::vector<std::string> const& enabledRO, std::vector<std::string> const& skippedRO, std::vector<std::string>& finalRO);
 
   // helper to parse field option

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -81,13 +81,12 @@ struct SimConfigData {
   SimFieldMode mFieldMode = SimFieldMode::kDefault;   // uniform magnetic field
   bool mAsService = false;                            // if simulation should be run as service/deamon (does not exit after run)
   bool mNoGeant = false;                              // if Geant transport should be turned off (when one is only interested in the generated events)
-  bool mIsUpgrade = false;                            // true if the simulation is for Run 5
   std::string mFromCollisionContext = "";             // string denoting a collision context file; If given, this file will be used to determine number of events
   bool mForwardKine = false;                          // true if tracks and event headers are to be published on a FairMQ channel (for reading by other consumers)
   bool mWriteToDisc = true;                           // whether we write simulation products (kine, hits) to disc
   VertexMode mVertexMode = VertexMode::kDiamondParam; // by default we should use die InteractionDiamond parameter
 
-  ClassDefNV(SimConfigData, 4);
+  ClassDefNV(SimConfigData, 5);
 };
 
 // A singleton class which can be used
@@ -172,7 +171,6 @@ class SimConfig
   uint64_t getTimestamp() const { return mConfigData.mTimestamp; }
   int getRunNumber() const { return mConfigData.mRunNumber; }
   bool isNoGeant() const { return mConfigData.mNoGeant; }
-  void setRun5(bool value = true) { mConfigData.mIsUpgrade = value; }
   bool forwardKine() const { return mConfigData.mForwardKine; }
   bool writeToDisc() const { return mConfigData.mWriteToDisc; }
   VertexMode getVertexMode() const { return mConfigData.mVertexMode; }

--- a/Common/SimConfig/src/DetectorLists.cxx
+++ b/Common/SimConfig/src/DetectorLists.cxx
@@ -41,13 +41,13 @@ bool parseDetectorMapfromJSON(const std::string& path, DetectorMap_t& map)
   map.clear();
   try {
     for (auto verItr = doc.MemberBegin(); verItr != doc.MemberEnd(); ++verItr) {
-      const auto& version = verItr->name.GetString();
-      DetectorList_t list;
-      const auto& elements = doc[version];
+      const auto& list = verItr->name.GetString();
+      DetectorList_t modules;
+      const auto& elements = doc[list];
       for (const auto& ele : elements.GetArray()) {
-        list.emplace_back(ele.GetString());
+        modules.emplace_back(ele.GetString());
       }
-      map.emplace(version, list);
+      map.emplace(list, modules);
     }
   } catch (const std::exception& e) {
     LOGP(error, "Failed to build detector map from file '{}' with '{}'", path, e.what());
@@ -60,15 +60,15 @@ bool parseDetectorMapfromJSON(const std::string& path, DetectorMap_t& map)
 void printDetMap(const DetectorMap_t& map, const std::string& list)
 {
   if (list.empty()) {
-    LOGP(error, "List of all available versions including their detectors:");
-    for (int i{0}; const auto& [version, elements] : map) {
-      LOGP(error, " - {: >2d}. {}:", i++, version);
-      for (int j{0}; const auto& element : elements) {
+    LOGP(error, "Printing all available lists including their modules:");
+    for (int i{0}; const auto& [list, modules] : map) {
+      LOGP(error, " - {: >2d}. {}:", i++, list);
+      for (int j{0}; const auto& element : modules) {
         LOGP(error, "\t\t* {: >2d}.\t{}", j++, element);
       }
     }
   } else {
-    LOGP(error, "List of available modules for version {}:", list);
+    LOGP(error, "List of available modules for list {}:", list);
     for (int j{0}; const auto& element : map.at(list)) {
       LOGP(error, "\t* {: >2d}.\t{}", j++, element);
     }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -154,26 +154,26 @@ void SimConfig::determineActiveModules(std::vector<std::string> const& inputargs
   filterSkippedElements(activeModules, skippedModules);
 }
 
-bool SimConfig::determineActiveModulesList(const std::string& version, std::vector<std::string> const& inputargs, std::vector<std::string> const& skippedModules, std::vector<std::string>& activeModules, bool print)
+bool SimConfig::determineActiveModulesList(const std::string& list, std::vector<std::string> const& inputargs, std::vector<std::string> const& skippedModules, std::vector<std::string>& activeModules, bool print)
 {
   DetectorList_t modules;
   DetectorMap_t map;
-  if (auto pos = version.find(':'); pos != std::string::npos) {
-    auto pversion = version.substr(0, pos);
-    auto ppath = version.substr(pos + 1);
+  if (auto pos = list.find(':'); pos != std::string::npos) {
+    auto plist = list.substr(0, pos);
+    auto ppath = list.substr(pos + 1);
     if (!parseDetectorMapfromJSON(ppath, map)) {
       LOGP(error, "Could not parse {}; check errors above!", ppath);
       return false;
     }
-    if (map.find(pversion) == map.end()) {
-      LOGP(error, "List {} is not defined in custom JSON file!", pversion);
+    if (map.find(plist) == map.end()) {
+      LOGP(error, "List {} is not defined in custom JSON file!", plist);
       printDetMap(map);
       return false;
     }
-    modules = map[pversion];
-    LOG_IF(info, print) << "Running with list '" << pversion << "' from custom detector list '" << ppath << "'";
+    modules = map[plist];
+    LOG_IF(info, print) << "Running with list '" << plist << "' from custom detector list '" << ppath << "'";
   } else {
-    // Otherwise check 'official' versions which provided in config
+    // Otherwise check 'official' list which provided in config
     auto o2env = std::getenv("O2_ROOT");
     if (!o2env) {
       LOGP(error, "O2_ROOT environment not defined");
@@ -184,13 +184,13 @@ bool SimConfig::determineActiveModulesList(const std::string& version, std::vect
       LOGP(error, "Could not parse {} -> check errors above!", rootpath);
       return false;
     }
-    if (map.find(version) == map.end()) {
-      LOGP(error, "List {} is not defined in 'official' JSON file (located at '{}')!", version, rootpath);
+    if (map.find(list) == map.end()) {
+      LOGP(error, "List {} is not defined in 'official' JSON file (located at '{}')!", list, rootpath);
       printDetMap(map);
       return false;
     }
-    modules = map[version];
-    LOG_IF(info, print) << "Running with official detector list '" << version << "'";
+    modules = map[list];
+    LOG_IF(info, print) << "Running with official detector list '" << list << "'";
   }
   // check if specified modules are in list
   if (inputargs.size() != 1 || inputargs[0] != "all") {
@@ -201,11 +201,11 @@ bool SimConfig::determineActiveModulesList(const std::string& version, std::vect
       }
     }
     if (!diff.empty()) {
-      LOGP(error, "Modules specified that are not present in detector list {}", version);
+      LOGP(error, "Modules specified that are not present in detector list {}", list);
       for (int j{0}; const auto& m : diff) {
         LOGP(info, " - {: <2}. {}", j++, m);
       }
-      printDetMap(map, version);
+      printDetMap(map, list);
       return false;
     }
   }

--- a/DataFormats/Parameters/src/GRPTool.cxx
+++ b/DataFormats/Parameters/src/GRPTool.cxx
@@ -61,7 +61,6 @@ struct Options {
   bool lhciffromccdb = false; // whether only to take GRPLHCIF from CCDB
   std::string publishto = "";
   std::string ccdbhost = "http://alice-ccdb.cern.ch";
-  bool isRun5 = false; // whether or not this is supposed to be a Run5 detector configuration
   std::string vertex = "ccdb";
   std::string configKeyValues = "";
   uint64_t timestamp = 0;
@@ -574,7 +573,6 @@ bool parseOptions(int argc, char* argv[], Options& optvalues)
     desc.add_options()("lhcif-CCDB", "take GRPLHCIF directly from CCDB");
     desc.add_options()("print", "print resulting GRPs");
     desc.add_options()("publishto", bpo::value<std::string>(&optvalues.publishto)->default_value(""), "Base path under which GRP objects should be published on disc. This path can serve as lookup for CCDB queries of the GRP objects.");
-    desc.add_options()("isRun5", bpo::bool_switch(&optvalues.isRun5), "Whether or not to expect a Run5 detector configuration. (deprecated, use detectorList option)");
     desc.add_options()("vertex", bpo::value<std::string>(&optvalues.vertex)->default_value("ccdb"), "How the vertex is to be initialized. Default is CCDB. Alternative is \"Diamond\" which is constructing the mean vertex from the Diamond param via the configKeyValues path");
     desc.add_options()("timestamp", bpo::value<uint64_t>(&optvalues.timestamp)->default_value(0), "Force timestamp to be used (useful when anchoring)");
     desc.add_options()("configKeyValues", bpo::value<std::string>(&optvalues.configKeyValues)->default_value(""), "Semicolon separated key=value strings (e.g.: 'TPC.gasDensity=1;...')");

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -76,22 +76,6 @@ o2_add_executable(primary-server-device-runner
                   SOURCES O2PrimaryServerDeviceRunner.cxx
                   PUBLIC_LINK_LIBRARIES internal::allsim
                   TARGETVARNAME simexe)
-if(ENABLE_UPGRADES)
-o2_add_executable(serial-run5
-                  COMPONENT_NAME sim
-                  SOURCES o2sim.cxx
-                  PUBLIC_LINK_LIBRARIES internal::allsim)
-
-o2_add_executable(sim-run5
-                  SOURCES o2sim_parallel.cxx
-                  PUBLIC_LINK_LIBRARIES internal::allsim O2::Version
-                  TARGETVARNAME simdriverrun5)
-
-o2_add_executable(evalmat-run5
-                  COMPONENT_NAME sim
-                  SOURCES o2sim_evalmat.cxx
-                  PUBLIC_LINK_LIBRARIES internal::allsim)
-endif()
 if(NOT APPLE)
   set_property(TARGET ${simexe} PROPERTY LINK_WHAT_YOU_USE ON)
 endif()
@@ -167,15 +151,6 @@ message(STATUS "SIMENV = ${SIMENV}")
 
 o2_name_target(sim NAME o2simExecutable IS_EXE)
 o2_name_target(sim-serial NAME o2simSerialExecutable IS_EXE)
-if(ENABLE_UPGRADES)
-o2_name_target(sim-serial-run5 NAME o2simSerialRun5Executable IS_EXE)
-o2_name_target(sim-run5 NAME o2simRun5Executable IS_EXE)
-o2_name_target(sim-evalmat-run5 NAME o2simEvalmatRun5Executable IS_EXE)
-
-target_compile_definitions(${o2simSerialRun5Executable} PUBLIC SIM_RUN5)
-target_compile_definitions(${o2simRun5Executable} PUBLIC SIM_RUN5)
-target_compile_definitions(${o2simEvalmatRun5Executable} PUBLIC SIM_RUN5)
-endif()
 if (BUILD_TESTING)
 o2_add_test_command(NAME o2sim_G4
                     WORKING_DIRECTORY ${SIMTESTDIR}

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -261,9 +261,6 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     // init sim config
     auto& vm = GetConfig()->GetVarMap();
     auto& conf = o2::conf::SimConfig::Instance();
-    if (vm.count("isRun5")) {
-      conf.setRun5();
-    }
     conf.resetFromParsedMap(vm);
 
     // update the parameters from an INI/JSON file, if given (overrides code-based version)

--- a/run/O2PrimaryServerDeviceRunner.cxx
+++ b/run/O2PrimaryServerDeviceRunner.cxx
@@ -21,7 +21,6 @@ void addCustomOptions(bpo::options_description& options)
 {
   // append the same options here as used for SimConfig
   o2::conf::SimConfig::initOptions(options);
-  options.add_options()("isRun5", "flag whether a Run5 detector setup is expected");
 }
 
 std::unique_ptr<fair::mq::Device> getDevice(fair::mq::ProgOptions& config)

--- a/run/o2sim.cxx
+++ b/run/o2sim.cxx
@@ -19,9 +19,6 @@ int main(int argc, char* argv[])
   TStopwatch timer;
   timer.Start();
   auto& conf = o2::conf::SimConfig::Instance();
-#ifdef SIM_RUN5
-  conf.setRun5();
-#endif
   if (!conf.resetFromArguments(argc, argv)) {
     return 1;
   }

--- a/run/o2sim_evalmat.cxx
+++ b/run/o2sim_evalmat.cxx
@@ -21,9 +21,6 @@ int main(int argc, char* argv[])
   timer.Start();
 
   auto& conf = o2::conf::SimConfig::Instance();
-#ifdef SIM_RUN5
-  conf.setRun5();
-#endif
   auto& matmapP = o2::conf::MatMapParams::Instance();
   if (!conf.resetFromArguments(argc, argv)) {
     return 1;

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -393,9 +393,6 @@ std::vector<char*> checkArgs(int argc, char* argv[])
 {
   auto conf = o2::conf::SimConfig::make();
   std::vector<std::string> modifiedArgs;
-#ifdef SIM_RUN5
-  conf.setRun5();
-#endif
   if (conf.resetFromArguments(argc, argv)) {
     for (int i = 0; i < argc; ++i) {
       modifiedArgs.push_back(argv[i]);
@@ -483,9 +480,6 @@ int main(int argc, char* argv[])
   }
 
   auto& conf = o2::conf::SimConfig::Instance();
-#ifdef SIM_RUN5
-  conf.setRun5();
-#endif
   if (!conf.resetFromArguments(finalArgs.size(), &finalArgs[0])) {
     return 1;
   }
@@ -494,11 +488,7 @@ int main(int argc, char* argv[])
   if (conf.getNEvents() <= 0 && !conf.asService()) {
     LOG(info) << "No events to be simulated; Switching to non-distributed mode";
     const int Nargs = finalArgs.size() + 1;
-#ifdef SIM_RUN5
-    std::string name("o2-sim-serial-run5");
-#else
     std::string name("o2-sim-serial");
-#endif
     const char* arguments[Nargs];
     arguments[0] = name.c_str();
     for (int i = 1; i < finalArgs.size(); ++i) {
@@ -554,11 +544,7 @@ int main(int argc, char* argv[])
     const std::string config = localconfig;
 
     // copy all arguments into a common vector
-#ifdef SIM_RUN5
-    const int addNArgs = 12;
-#else
     const int addNArgs = 11;
-#endif
     const int Nargs = finalArgs.size() + addNArgs;
     const char* arguments[Nargs];
     arguments[0] = name.c_str();
@@ -572,9 +558,6 @@ int main(int argc, char* argv[])
     arguments[8] = "debug";
     arguments[9] = "--color";
     arguments[10] = "false"; // switch off colored output
-#ifdef SIM_RUN5
-    arguments[11] = "--isRun5";
-#endif
     for (int i = 1; i < finalArgs.size(); ++i) {
       arguments[addNArgs - 1 + i] = finalArgs[i];
     }


### PR DESCRIPTION
Hi @sawenzel, @mconcas noticed that for `o2-sim-serial-run5` the default for the dectorList is ALICE2 which makes IMO little sense.
This MR would fix this by setting the default to ALICE3 for those run5 executables. I however do not like that I have to extend several function calls to propagate a single boolean. What would you suggest to `fix` this (does it even need fixing?). One other idea would be to `clone` the allsim target and add a preprocessor define like `SIM_RUN5`. What do you think?