### PR TITLE
[FOCAL-98] Optimizing the hit processing in FOCAL

### DIFF
--- a/Detectors/FOCAL/base/include/FOCALBase/Hit.h
+++ b/Detectors/FOCAL/base/include/FOCALBase/Hit.h
@@ -14,6 +14,7 @@
 #include <iosfwd>
 #include "SimulationDataFormat/BaseHits.h"
 #include "CommonUtils/ShmAllocator.h"
+#include <boost/container_hash/hash.hpp>
 
 namespace o2::focal
 {
@@ -33,6 +34,39 @@ class Hit : public o2::BasicXYZEHit<float>
     EPIXELS, ///< ECAL pixels
     HCAL,    ///< HCAL
     UNKNOWN  ///< Undefined
+  };
+
+  /// \struct HitID
+  /// \brief Mapped information of a channel
+  struct HitID {
+    int mParentID;   ///< parentID of the track creating this hit
+    uint8_t mRow;    ///< Row of the hit in the calorimeter
+    uint8_t mColumn; ///< Column of the hit in the calorimeter
+    uint8_t mLayer;  ///< Layer the was hit
+
+    bool operator==(const HitID& other) const
+    {
+      return mParentID == other.mParentID && mRow == other.mRow && mColumn == other.mColumn && mLayer == other.mLayer;
+    }
+    friend std::ostream& operator<<(std::ostream& stream, const Hit::HitID& channel);
+  };
+
+  /// \struct HitIDHasher
+  /// \brief Hash functor for hit ID
+  struct HitIDHasher {
+
+    /// \brief Functor implementation
+    /// \param s Hit for which to determine a hash value
+    /// \return hash value for channel ID
+    size_t operator()(const HitID& s) const
+    {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, s.mParentID);
+      boost::hash_combine(seed, s.mRow);
+      boost::hash_combine(seed, s.mColumn);
+      boost::hash_combine(seed, s.mLayer);
+      return seed;
+    }
   };
 
   /// \brief Dummy constructor

--- a/Detectors/FOCAL/simulation/include/FOCALSimulation/Detector.h
+++ b/Detectors/FOCAL/simulation/include/FOCALSimulation/Detector.h
@@ -184,13 +184,14 @@ class Detector : public o2::base::DetImpl<Detector>
 
   Geometry* mGeometry; //!<! Geometry pointer
 
-  int mMedSensHCal = 0; //!<! Sensitive Medium for HCal
+  int mMedSensHCal = 0;    //!<! Sensitive Medium for HCal
   int mMedSensECalPad = 0; //!<! Sensitive Medium for ECal Pads
   int mMedSensECalPix = 0; //!<! Sensitive Medium for ECal Pixels
 
   std::vector<const Composition*> mGeoCompositions; //!<! list of FOCAL compositions
 
-  std::vector<o2::focal::Hit>* mHits; ///< Container with hits
+  std::vector<o2::focal::Hit>* mHits;                                              ///< Container with hits
+  std::unordered_map<Hit::HitID, unsigned int, Hit::HitIDHasher> mHitIndexMapping; ///< Mapping the hits to a cell in the detector
 
   std::unordered_map<int, int> mSuperParentsIndices; //!<! Super parent indices (track index - superparent index)
   std::unordered_map<int, Parent> mSuperParents;     //!<! Super parent kine info (superparent index - superparent object)


### PR DESCRIPTION
Optimizing the hit processing in the FOCAL detector by using hash ID and inverse std::unordered_map instead of the linear for the hit which can be exhausting.