### PR TITLE
ITS: Adding partial error handling in the verifier

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -174,6 +174,15 @@ struct ChipStat {
     ft = c >= 0xf2 && c <= 0xfe;
     return APE_STRIP_START + c - 0xf2;
   }
+
+  // return APE byte that corresponds to the given APE DecErrors
+  static uint8_t getAPEByte(DecErrors c)
+  {
+    if (c < APE_STRIP_START || c > APE_OOT_DATA_MISSING) {
+      return 0xFF;
+    }
+    return 0xF2 + c - APE_STRIP_START;
+  }
   uint32_t getNErrors() const;
   uint32_t addErrors(const ChipPixelData& d, int verbosity);
   void print(bool skipNoErr = true, const std::string& pref = "FEEID") const;


### PR DESCRIPTION
This patch adds the support for the following errors:
 - APE_STRIP_START
 - APE_ILLEGAL_CHIPID
 - APE_DET_TIMEOUT
 - APE_OOT
 - APE_PROTOCOL_ERROR
 - APE_LANE_FIFO_OVERFLOW_ERROR
 - APE_FSM_ERROR
 - APE_PENDING_DETECTOR_EVENT_LIMIT
 - APE_PENDING_LANE_EVENT_LIMIT
 - APE_O2N_ERROR
 - APE_RATE_MISSING_TRG_ERROR