### PR TITLE
Switch actions from hub to gh cli

### DIFF
--- a/.github/workflows/datamodel-doc.yml
+++ b/.github/workflows/datamodel-doc.yml
@@ -68,9 +68,11 @@ jobs:
           git push -f origin auto-datamodel-doc
 
           # Send pull request
-          # We need to use "hub" ourselves because alisw/pull-request gets
+          # We need to use "gh" ourselves because alisw/pull-request gets
           # confused when multiple repos are checked out.
-          hub pull-request -b AliceO2Group:master -h alibuild:auto-datamodel-doc \
-              --no-edit --no-maintainer-edits -m 'Automatic data model update'   \
-              -m "This update to the data model documentation was automatically created from tonight's O2 dev branch." ||
-            :  # If the PR already exists, hub fails, but we've just force-pushed, so we don't need a new PR.
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh pr create -B \
+          AliceO2Group:master -H alibuild:auto-datamodel-doc \
+          --no-maintainer-edit -t 'Automatic data model update' -b 'This update \
+          to the data model documentation was automatically created from \
+          tonight's O2 dev branch.' || true
+          # If the PR already exists, hub fails, but we've just force-pushed, so we don't need a new PR.

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -126,11 +126,6 @@ jobs:
         git config --global user.name "GitHub Action Bot"
         git commit -m "Updated README" -a || echo "No changes to commit"
         git push origin HEAD:changelog -f
-        GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}  \
-          hub pull-request -f -b dev -h changelog \
-              --no-edit --no-maintainer-edits     \
-              'Auto-generated changelog'          \
-              -m 'The following changelog has been automatically generated.' ||
-            # If the PR already exists, the force-push will have updated it.
-            # It's fine if this step fails.
-            true
+        # If the PR already exists, the force-push will have updated it.
+        # It's fine if this step fails.
+        GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh pr create -B dev -H changelog -t 'Auto-generated changelog' -b 'The following changelog has been automatically generated.' || true


### PR DESCRIPTION
GH actions no longer provide `hub` in the path by default so we're
switching to `gh`.

Follow-up to https://github.com/AliceO2Group/AliceO2/issues/13300

Tagging @vkucera @ktf 