### PR TITLE
fix MCH digit time in MC

### DIFF
--- a/Detectors/MUON/MCH/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Simulation/CMakeLists.txt
@@ -21,7 +21,6 @@ o2_add_library(MCHSimulation
                 PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH
                                       O2::DetectorsBase
                                       O2::DetectorsPassive
-                                      O2::DetectorsRaw
                                       O2::MCHBase
                                       O2::MCHGeometryCreator
                                       O2::MCHMappingInterface

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DEDigitizer.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DEDigitizer.h
@@ -43,6 +43,12 @@ class DEDigitizer
    */
   DEDigitizer(int deId, math_utils::Transform3D transformation, std::mt19937& random);
 
+  /** Set the first orbit of the processed TF.
+   *
+   * @param firstTFOrbit TF first orbit
+   */
+  void setFirstTFOrbit(uint32_t firstTFOrbit) { mFirstTFOrbit = firstTFOrbit; }
+
   /** Process one MCH Hit.
    *
    * This will convert the hit eloss into a charge and spread (according
@@ -122,6 +128,8 @@ class DEDigitizer
   std::poisson_distribution<int> mNofNoisyPadsDist; ///< random number of noisy pads generator (poisson distribution)
   std::uniform_int_distribution<int> mPadIdDist;    ///< random pad ID generator (uniform distribution)
   std::uniform_int_distribution<int> mBCDist;       ///< random BC number inside ROF generator (uniform distribution)
+
+  uint32_t mFirstTFOrbit; ///< first orbit of the TF being processed
 
   std::vector<std::vector<Signal>> mSignals; ///< list of signals per pad
 };

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Digitizer.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Digitizer.h
@@ -40,6 +40,9 @@ class Digitizer
    */
   Digitizer(geo::TransformationCreator transformationCreator);
 
+  /// @see DEDigitizer::setFirstTFOrbit
+  void setFirstTFOrbit(uint32_t firstTFOrbit);
+
   /// @see DEDigitizer::processHit
   void processHits(gsl::span<const Hit> hits, const InteractionRecord& collisionTime, int evID, int srcID);
 

--- a/Detectors/MUON/MCH/Simulation/src/DEDigitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/DEDigitizer.cxx
@@ -15,7 +15,6 @@
 #include <cmath>
 #include <limits>
 
-#include "DetectorsRaw/HBFUtils.h"
 #include "MCHSimulation/DigitizerParam.h"
 #include <TGeoGlobalMagField.h>
 #include "Field/MagneticField.h"
@@ -45,6 +44,7 @@ DEDigitizer::DEDigitizer(int deId, math_utils::Transform3D transformation, std::
     mNofNoisyPadsDist{DigitizerParam::Instance().noiseOnlyProba * mSegmentation.nofPads()},
     mPadIdDist{0, mSegmentation.nofPads() - 1},
     mBCDist{0, 3},
+    mFirstTFOrbit{0},
     mSignals(mSegmentation.nofPads())
 {
 }
@@ -281,7 +281,7 @@ DEDigitizer::DigitsAndLabels* DEDigitizer::addNewDigit(std::map<InteractionRecor
                                                        int padid, const Signal& signal, uint32_t nSamples) const
 {
   uint32_t adc = std::round(signal.charge);
-  auto time = signal.rofIR.differenceInBC({0, raw::HBFUtils::Instance().orbitFirst});
+  auto time = signal.rofIR.differenceInBC({0, mFirstTFOrbit});
   nSamples = std::min(nSamples, 0x3FFU); // the number of samples must fit within 10 bits
   bool saturated = false;
   // the charge sum must fit within 20 bits

--- a/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
@@ -24,6 +24,13 @@ Digitizer::Digitizer(geo::TransformationCreator transformationCreator)
   });
 }
 
+void Digitizer::setFirstTFOrbit(uint32_t firstTFOrbit)
+{
+  for (auto& d : mDEDigitizers) {
+    d.second->setFirstTFOrbit(firstTFOrbit);
+  }
+}
+
 void Digitizer::processHits(gsl::span<const Hit> hits, const InteractionRecord& collisionTime, int evID, int srcID)
 {
   for (const auto& hit : hits) {

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -76,6 +76,8 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
       return;
     }
 
+    mDigitizer->setFirstTFOrbit(pc.services().get<o2::framework::TimingInfo>().firstTForbit);
+
     auto tStart = std::chrono::high_resolution_clock::now();
     auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
     context->initSimChains(o2::detectors::DetID::MCH, mSimChains);


### PR DESCRIPTION
The digit time must be w.r.t. to the first orbit of the TF, not the first orbit of the run.