### PR TITLE
ITS: Add second iteration for the seeding vertexer

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -141,7 +141,7 @@ class Vertex : public VertexBase
   GPUd() ushort getFlags() const { return mBits; }
   GPUd() bool isFlagSet(uint f) const { return mBits & (FlagsMask & f); }
   GPUd() void setFlags(ushort f) { mBits |= FlagsMask & f; }
-  GPUd() void resetFrags(ushort f = FlagsMask) { mBits &= ~(FlagsMask & f); }
+  GPUd() void resetFlags(ushort f = FlagsMask) { mBits &= ~(FlagsMask & f); }
 
   GPUd() void setChi2(float v) { mChi2 = v; }
   GPUd() float getChi2() const { return mChi2; }

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexerTraitsGPU.h
@@ -42,11 +42,11 @@ class VertexerTraitsGPU : public VertexerTraits
  public:
   VertexerTraitsGPU();
   ~VertexerTraitsGPU() override;
-  void initialise(const TrackingParameters&) override;
+  void initialise(const TrackingParameters&, const int& iteration = 0) override;
   void adoptTimeFrame(TimeFrame*) override;
-  void computeTracklets() override;
-  void computeTrackletMatching() override;
-  void computeVertices() override;
+  void computeTracklets(const int& iteration = 0) override;
+  void computeTrackletMatching(const int& iteration = 0) override;
+  void computeVertices(const int& iteration = 0) override;
 
   // Hybrid
   void initialiseHybrid(const TrackingParameters& pars) override { VertexerTraits::initialise(pars); }
@@ -55,7 +55,7 @@ class VertexerTraitsGPU : public VertexerTraits
   void computeTrackletMatchingHybrid() override { VertexerTraits::computeTrackletMatching(); }
   void computeVerticesHybrid() override { VertexerTraits::computeVertices(); }
 
-  void updateVertexingParameters(const VertexingParameters&, const TimeFrameGPUParameters&) override;
+  void updateVertexingParameters(const std::vector<VertexingParameters>&, const TimeFrameGPUParameters&) override;
 
   void computeVerticesHist();
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexerTraitsGPU.h
@@ -42,11 +42,11 @@ class VertexerTraitsGPU : public VertexerTraits
  public:
   VertexerTraitsGPU();
   ~VertexerTraitsGPU() override;
-  void initialise(const TrackingParameters&, const int& iteration = 0) override;
+  void initialise(const TrackingParameters&, const int iteration = 0) override;
   void adoptTimeFrame(TimeFrame*) override;
-  void computeTracklets(const int& iteration = 0) override;
-  void computeTrackletMatching(const int& iteration = 0) override;
-  void computeVertices(const int& iteration = 0) override;
+  void computeTracklets(const int iteration = 0) override;
+  void computeTrackletMatching(const int iteration = 0) override;
+  void computeVertices(const int iteration = 0) override;
 
   // Hybrid
   void initialiseHybrid(const TrackingParameters& pars) override { VertexerTraits::initialise(pars); }

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -95,7 +95,7 @@ VertexerTraitsGPU::~VertexerTraitsGPU()
 {
 }
 
-void VertexerTraitsGPU::initialise(const TrackingParameters& trackingParams, const int& iteration)
+void VertexerTraitsGPU::initialise(const TrackingParameters& trackingParams, const int iteration)
 {
   mTimeFrameGPU->initialise(0, trackingParams, 3, &mIndexTableUtils, &mTfGPUParams);
 }
@@ -607,7 +607,7 @@ void VertexerTraitsGPU::updateVertexingParameters(const std::vector<VertexingPar
   }
 }
 
-void VertexerTraitsGPU::computeTracklets(const int& iteration)
+void VertexerTraitsGPU::computeTracklets(const int iteration)
 {
   if (!mTimeFrameGPU->getClusters().size()) {
     return;
@@ -769,11 +769,11 @@ void VertexerTraitsGPU::computeTracklets(const int& iteration)
   mTimeFrameGPU->wipe(3);
 }
 
-void VertexerTraitsGPU::computeTrackletMatching(const int& iteration)
+void VertexerTraitsGPU::computeTrackletMatching(const int iteration)
 {
 }
 
-void VertexerTraitsGPU::computeVertices(const int& iteration)
+void VertexerTraitsGPU::computeVertices(const int iteration)
 {
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -760,7 +760,7 @@ void VertexerTraitsGPU::computeTracklets(const int& iteration)
       gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][rofId])};
       mTimeFrameGPU->addPrimaryVertices(rofVerts);
       if (mTimeFrameGPU->hasMCinformation()) {
-        mTimeFrameGPU->getVerticesLabels().emplace_back();
+        // mTimeFrameGPU->getVerticesLabels().emplace_back();
         // TODO: add MC labels
       }
       start += mTimeFrameGPU->getNVerticesInChunks()[chunkId][rofId];

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -98,6 +98,7 @@ struct TrackingParameters {
   bool FindShortTracks = false;
   bool PerPrimaryVertexProcessing = false;
   bool SaveTimeBenchmarks = false;
+  bool skipSecondIterationVerticesInDeltaRof = false;
 };
 
 inline int TrackingParameters::CellMinimumLevel()
@@ -106,7 +107,7 @@ inline int TrackingParameters::CellMinimumLevel()
 }
 
 struct VertexingParameters {
-  int nIterations = 1;        // Number of vertexing passes to perform
+  int nIterations = 1;         // Number of vertexing passes to perform
   int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round
   bool allowSingleContribClusters = false;
   std::vector<float> LayerZ = {16.333f + 1, 16.333f + 1, 16.333f + 1, 42.140f + 1, 42.140f + 1, 73.745f + 1, 73.745f + 1};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -98,7 +98,8 @@ struct TrackingParameters {
   bool FindShortTracks = false;
   bool PerPrimaryVertexProcessing = false;
   bool SaveTimeBenchmarks = false;
-  bool skipSecondIterationVerticesInDeltaRof = false;
+  bool SkipDeltaRofIfsecondIterationVtx = false;
+  bool DoUPCIteration = false;
 };
 
 inline int TrackingParameters::CellMinimumLevel()

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -106,6 +106,8 @@ inline int TrackingParameters::CellMinimumLevel()
 }
 
 struct VertexingParameters {
+  bool nIterations = 1;        // Number of vertexing passes to perform
+  int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round
   bool allowSingleContribClusters = false;
   std::vector<float> LayerZ = {16.333f + 1, 16.333f + 1, 16.333f + 1, 42.140f + 1, 42.140f + 1, 73.745f + 1, 73.745f + 1};
   std::vector<float> LayerRadii = {2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -106,7 +106,7 @@ inline int TrackingParameters::CellMinimumLevel()
 }
 
 struct VertexingParameters {
-  bool nIterations = 1;        // Number of vertexing passes to perform
+  int nIterations = 1;        // Number of vertexing passes to perform
   int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round
   bool allowSingleContribClusters = false;
   std::vector<float> LayerZ = {16.333f + 1, 16.333f + 1, 16.333f + 1, 42.140f + 1, 42.140f + 1, 73.745f + 1, 73.745f + 1};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -98,7 +98,6 @@ struct TrackingParameters {
   bool FindShortTracks = false;
   bool PerPrimaryVertexProcessing = false;
   bool SaveTimeBenchmarks = false;
-  bool SkipDeltaRofIfsecondIterationVtx = false;
   bool DoUPCIteration = false;
 };
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -101,6 +101,7 @@ class TimeFrame
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
 
   int getTotalClusters() const;
+  std::vector<int>& getTotVertIteration() { return mTotVertPerIteration; }
   bool empty() const;
   bool isGPU() const { return mIsGPU; }
   int getSortedIndex(int rof, int layer, int i) const;
@@ -289,7 +290,6 @@ class TimeFrame
  private:
   float mBz = 5.;
   unsigned int mNTotalLowPtVertices = 0;
-  unsigned int mNoVertexROF = 0;
   int mBeamPosWeight = 0;
   std::array<float, 2> mBeamPos = {0.f, 0.f};
   bool isBeamPositionOverridden = false;
@@ -320,6 +320,8 @@ class TimeFrame
   std::vector<std::vector<MCCompLabel>> mLinesLabels;
   std::vector<std::pair<MCCompLabel, float>> mVerticesMCRecInfo;
   std::array<uint32_t, 2> mTotalTracklets = {0, 0};
+  unsigned int mNoVertexROF = 0;
+  std::vector<int> mTotVertPerIteration;
   // \Vertexer
 };
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -80,14 +80,16 @@ class TimeFrame
   const Vertex& getPrimaryVertex(const int) const;
   gsl::span<const Vertex> getPrimaryVertices(int tf) const;
   gsl::span<const Vertex> getPrimaryVertices(int romin, int romax) const;
-  gsl::span<const std::vector<MCCompLabel>> getPrimaryVerticesLabels(const int rof) const;
+  gsl::span<const std::pair<MCCompLabel, float>> getPrimaryVerticesMCRecInfo(const int rof) const;
   gsl::span<const std::array<float, 2>> getPrimaryVerticesXAlpha(int tf) const;
   void fillPrimaryVerticesXandAlpha();
   int getPrimaryVerticesNum(int rofID = -1) const;
   void addPrimaryVertices(const std::vector<Vertex>& vertices);
+  void addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, float>>& labels);
   void addPrimaryVertices(const gsl::span<const Vertex>& vertices);
   void addPrimaryVertices(const std::vector<lightVertex>&);
   void addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int& rofId);
+  void addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int& rofId);
   void removePrimaryVerticesInROf(const int rofId);
   int loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const itsmft::Cluster> clusters,
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
@@ -169,7 +171,7 @@ class TimeFrame
   std::vector<TrackITSExt>& getTracks(int rof) { return mTracks[rof]; }
   std::vector<MCCompLabel>& getTracksLabel(const int rof) { return mTracksLabel[rof]; }
   std::vector<MCCompLabel>& getLinesLabel(const int rof) { return mLinesLabels[rof]; }
-  std::vector<std::vector<MCCompLabel>>& getVerticesLabels() { return mVerticesLabels; }
+  std::vector<std::pair<MCCompLabel, float>>& getVerticesMCRecInfo() { return mVerticesMCRecInfo; }
 
   int getNumberOfClusters() const;
   int getNumberOfCells() const;
@@ -316,7 +318,7 @@ class TimeFrame
   std::vector<std::vector<ClusterLines>> mTrackletClusters;
   std::vector<std::vector<int>> mTrackletsIndexROf;
   std::vector<std::vector<MCCompLabel>> mLinesLabels;
-  std::vector<std::vector<MCCompLabel>> mVerticesLabels;
+  std::vector<std::pair<MCCompLabel, float>> mVerticesMCRecInfo;
   std::array<uint32_t, 2> mTotalTracklets = {0, 0};
   // \Vertexer
 };
@@ -331,12 +333,12 @@ inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int rof) const
   return {&mPrimaryVertices[start], static_cast<gsl::span<const Vertex>::size_type>(delta)};
 }
 
-inline gsl::span<const std::vector<MCCompLabel>> TimeFrame::getPrimaryVerticesLabels(const int rof) const
+inline gsl::span<const std::pair<MCCompLabel, float>> TimeFrame::getPrimaryVerticesMCRecInfo(const int rof) const
 {
   const int start = mROframesPV[rof];
   const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
   int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
-  return {&mVerticesLabels[start], static_cast<gsl::span<const Vertex>::size_type>(delta)};
+  return {&(mVerticesMCRecInfo[start]), static_cast<gsl::span<const std::pair<MCCompLabel, float>>::size_type>(delta)};
 }
 
 inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int romin, int romax) const

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -195,6 +195,7 @@ class TimeFrame
   uint32_t getTotalTrackletsTF(const int iLayer) { return mTotalTracklets[iLayer]; }
   int getTotalClustersPerROFrange(int rofMin, int range, int layerId) const;
   std::array<float, 2>& getBeamXY() { return mBeamPos; }
+  unsigned int& getNoVertexROF() { return mNoVertexROF; }
   // \Vertexer
 
   void initialiseRoadLabels();
@@ -220,7 +221,7 @@ class TimeFrame
     }
   }
 
-  virtual void setDevicePropagator(const o2::base::PropagatorImpl<float>*){};
+  virtual void setDevicePropagator(const o2::base::PropagatorImpl<float>*) {};
   const o2::base::PropagatorImpl<float>* getDevicePropagator() const { return mPropagatorDevice; }
 
   template <typename... T>
@@ -233,6 +234,7 @@ class TimeFrame
 
   void setExtAllocator(bool ext) { mExtAllocator = ext; }
   bool getExtAllocator() const { return mExtAllocator; }
+
   /// Debug and printing
   void checkTrackletLUTs();
   void printROFoffsets();
@@ -283,6 +285,8 @@ class TimeFrame
 
  private:
   float mBz = 5.;
+  unsigned int mNTotalLowPtVertices = 0;
+  unsigned int mNoVertexROF = 0;
   int mBeamPosWeight = 0;
   std::array<float, 2> mBeamPos = {0.f, 0.f};
   bool isBeamPositionOverridden = false;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -208,6 +208,7 @@ class TimeFrame
   bool isRoadFake(int i) const;
 
   void setMultiplicityCutMask(const std::vector<bool>& cutMask) { mMultiplicityCutMask = cutMask; }
+  void flipMultiplicityCutMask() { mMultiplicityCutMask.flip(); }
 
   int hasBogusClusters() const { return std::accumulate(mBogusClusters.begin(), mBogusClusters.end(), 0); }
 
@@ -225,7 +226,10 @@ class TimeFrame
     }
   }
 
-  virtual void setDevicePropagator(const o2::base::PropagatorImpl<float>*){};
+  virtual void setDevicePropagator(const o2::base::PropagatorImpl<float>*)
+  {
+    return;
+  };
   const o2::base::PropagatorImpl<float>* getDevicePropagator() const { return mPropagatorDevice; }
 
   template <typename... T>
@@ -288,6 +292,7 @@ class TimeFrame
   }
 
  private:
+  void prepareClusters(const TrackingParameters& trkParam, const int maxLayers);
   float mBz = 5.;
   unsigned int mNTotalLowPtVertices = 0;
   int mBeamPosWeight = 0;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -88,8 +88,8 @@ class TimeFrame
   void addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, float>>& labels);
   void addPrimaryVertices(const gsl::span<const Vertex>& vertices);
   void addPrimaryVertices(const std::vector<lightVertex>&);
-  void addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int& rofId);
-  void addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int& rofId);
+  void addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int rofId);
+  void addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int rofId);
   void removePrimaryVerticesInROf(const int rofId);
   int loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const itsmft::Cluster> clusters,
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
@@ -225,7 +225,7 @@ class TimeFrame
     }
   }
 
-  virtual void setDevicePropagator(const o2::base::PropagatorImpl<float>*) {};
+  virtual void setDevicePropagator(const o2::base::PropagatorImpl<float>*){};
   const o2::base::PropagatorImpl<float>* getDevicePropagator() const { return mPropagatorDevice; }
 
   template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -208,7 +208,8 @@ class TimeFrame
   bool isRoadFake(int i) const;
 
   void setMultiplicityCutMask(const std::vector<bool>& cutMask) { mMultiplicityCutMask = cutMask; }
-  void flipMultiplicityCutMask() { mMultiplicityCutMask.flip(); }
+  void setROFMask(const std::vector<bool>& rofMask) { mROFMask = rofMask; }
+  void swapMasks() { mMultiplicityCutMask.swap(mROFMask); }
 
   int hasBogusClusters() const { return std::accumulate(mBogusClusters.begin(), mBogusClusters.end(), 0); }
 
@@ -305,6 +306,7 @@ class TimeFrame
   std::vector<float> mPositionResolution;
   std::vector<uint8_t> mClusterSize;
   std::vector<bool> mMultiplicityCutMask;
+  std::vector<bool> mROFMask;
   std::vector<std::array<float, 2>> mPValphaX; /// PV x and alpha for track propagation
   std::vector<std::vector<MCCompLabel>> mTrackletLabels;
   std::vector<std::vector<MCCompLabel>> mCellLabels;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -87,6 +87,7 @@ class TimeFrame
   void addPrimaryVertices(const std::vector<Vertex>& vertices);
   void addPrimaryVertices(const gsl::span<const Vertex>& vertices);
   void addPrimaryVertices(const std::vector<lightVertex>&);
+  void addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int& rofId);
   void removePrimaryVerticesInROf(const int rofId);
   int loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const itsmft::Cluster> clusters,
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
@@ -143,7 +144,7 @@ class TimeFrame
   std::vector<MCCompLabel>& getCellsLabel(int layer) { return mCellLabels[layer]; }
 
   bool hasMCinformation() const;
-  void initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers = 7);
+  void initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers = 7, bool resetVertices = true);
   void resetRofPV()
   {
     mPrimaryVertices.clear();

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -120,6 +120,7 @@ inline float TrackerTraits::getBz() const
 inline void TrackerTraits::UpdateTrackingParameters(const std::vector<TrackingParameters>& trkPars)
 {
   mTrkParams = trkPars;
+  LOGP(info, "TrackerTraits::updateTrackingParameters size of pars is {}", mTrkParams.size());
 }
 
 inline const int4 TrackerTraits::getBinsRect(const int layerIndex, float phi, float maxdeltaphi, float z, float maxdeltaz)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -120,7 +120,6 @@ inline float TrackerTraits::getBz() const
 inline void TrackerTraits::UpdateTrackingParameters(const std::vector<TrackingParameters>& trkPars)
 {
   mTrkParams = trkPars;
-  LOGP(info, "TrackerTraits::updateTrackingParameters size of pars is {}", mTrkParams.size());
 }
 
 inline const int4 TrackerTraits::getBinsRect(const int layerIndex, float phi, float maxdeltaphi, float z, float maxdeltaz)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -22,8 +22,8 @@ namespace its
 
 struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerParamConfig> {
 
-  int nIterations = 1; // Number of vertexing passes to perform
-  int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round 
+  int nIterations = 1;         // Number of vertexing passes to perform
+  int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round
   bool allowSingleContribClusters = false;
 
   // geometrical cuts
@@ -82,6 +82,7 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   bool saveTimeBenchmarks = false;
   bool overrideBeamEstimation = false; // used by gpuwf only
   int trackingMode = -1;               // -1: unset, 0=sync, 1=async, 2=cosmics used by gpuwf only
+  bool skipSecondIterationVerticesInDeltaRof = true;
 
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
 };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -22,7 +22,7 @@ namespace its
 
 struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerParamConfig> {
 
-  bool nIterations = 1; // Number of vertexing passes to perform
+  int nIterations = 1; // Number of vertexing passes to perform
   int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round 
   bool allowSingleContribClusters = false;
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -82,7 +82,6 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   bool saveTimeBenchmarks = false;
   bool overrideBeamEstimation = false; // used by gpuwf only
   int trackingMode = -1;               // -1: unset, 0=sync, 1=async, 2=cosmics used by gpuwf only
-  bool skipDeltaRofIfsecondIterationVtx = false;
   bool doUPCIteration = false;
 
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -82,7 +82,8 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   bool saveTimeBenchmarks = false;
   bool overrideBeamEstimation = false; // used by gpuwf only
   int trackingMode = -1;               // -1: unset, 0=sync, 1=async, 2=cosmics used by gpuwf only
-  bool skipSecondIterationVerticesInDeltaRof = true;
+  bool skipDeltaRofIfsecondIterationVtx = false;
+  bool doUPCIteration = false;
 
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
 };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -22,6 +22,8 @@ namespace its
 
 struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerParamConfig> {
 
+  bool nIterations = 1; // Number of vertexing passes to perform
+  int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round 
   bool allowSingleContribClusters = false;
 
   // geometrical cuts

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -53,7 +53,8 @@ class Vertexer
   Vertexer& operator=(const Vertexer&) = delete;
 
   void adoptTimeFrame(TimeFrame& tf);
-  VertexingParameters& getVertParameters() const;
+  std::vector<VertexingParameters>& getVertParameters() const;
+  void setParameters(std::vector<VertexingParameters>& vertParams);
   void getGlobalConfiguration();
 
   std::vector<Vertex> exportVertices();
@@ -62,8 +63,6 @@ class Vertexer
   float clustersToVertices(std::function<void(std::string s)> = [](std::string s) { std::cout << s << std::endl; });
   float clustersToVerticesHybrid(std::function<void(std::string s)> = [](std::string s) { std::cout << s << std::endl; });
   void filterMCTracklets();
-  void validateTracklets();
-  void validateTrackletsHybrid();
 
   template <typename... T>
   void findTracklets(T&&... args);
@@ -71,7 +70,11 @@ class Vertexer
   void findTrackletsHybrid(T&&... args);
 
   void findTrivialMCTracklets();
-  void findVertices();
+  template <typename... T>
+  void validateTracklets(T&&... args);
+  void validateTrackletsHybrid();
+  template <typename... T>
+  void findVertices(T&&... args);
   void findVerticesHybrid();
   void findHistVertices();
 
@@ -95,6 +98,8 @@ class Vertexer
 
   VertexerTraits* mTraits = nullptr; /// Observer pointer, not owned by this class
   TimeFrame* mTimeFrame = nullptr;   /// Observer pointer, not owned by this class
+
+  std::vector<VertexingParameters> mVertParams;
 };
 
 template <typename... T>
@@ -109,9 +114,14 @@ void Vertexer::findTracklets(T&&... args)
   mTraits->computeTracklets(std::forward<T>(args)...);
 }
 
-inline VertexingParameters& Vertexer::getVertParameters() const
+inline std::vector<VertexingParameters>& Vertexer::getVertParameters() const
 {
   return mTraits->getVertexingParameters();
+}
+
+inline void Vertexer::setParameters(std::vector<VertexingParameters>& vertParams)
+{
+  mTraits->setVertexingParameters(vertParams);
 }
 
 inline void Vertexer::dumpTraits()
@@ -119,14 +129,16 @@ inline void Vertexer::dumpTraits()
   mTraits->dumpVertexerTraits();
 }
 
-inline void Vertexer::validateTracklets()
+template <typename... T>
+inline void Vertexer::validateTracklets(T&&... args)
 {
-  mTraits->computeTrackletMatching();
+  mTraits->computeTrackletMatching(std::forward<T>(args)...);
 }
 
-inline void Vertexer::findVertices()
+template <typename... T>
+inline void Vertexer::findVertices(T&&... args)
 {
-  mTraits->computeVertices();
+  mTraits->computeVertices(std::forward<T>(args)...);
 }
 
 template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -121,7 +121,7 @@ inline std::vector<VertexingParameters>& Vertexer::getVertParameters() const
 
 inline void Vertexer::setParameters(std::vector<VertexingParameters>& vertParams)
 {
-  mTraits->setVertexingParameters(vertParams);
+  mVertParams = vertParams;
 }
 
 inline void Vertexer::dumpTraits()

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -62,10 +62,10 @@ class VertexerTraits
   GPUhd() static const int2 getPhiBins(float phi, float deltaPhi, const IndexTableUtils&);
 
   // virtual vertexer interface
-  virtual void initialise(const TrackingParameters& trackingParams, const int& iteration = 0);
-  virtual void computeTracklets(const int& iteration = 0);
-  virtual void computeTrackletMatching(const int& iteration = 0);
-  virtual void computeVertices(const int& iteration = 0);
+  virtual void initialise(const TrackingParameters& trackingParams, const int iteration = 0);
+  virtual void computeTracklets(const int iteration = 0);
+  virtual void computeTrackletMatching(const int iteration = 0);
+  virtual void computeVertices(const int iteration = 0);
   virtual void adoptTimeFrame(TimeFrame* tf);
   virtual void updateVertexingParameters(const std::vector<VertexingParameters>& vrtPar, const TimeFrameGPUParameters& gpuTfPar);
   // Hybrid
@@ -84,7 +84,7 @@ class VertexerTraits
                             std::vector<int>&,
                             TimeFrame*,
                             std::vector<o2::MCCompLabel>*,
-                            const int& iteration = 0);
+                            const int iteration = 0);
 
   static const std::vector<std::pair<int, int>> selectClusters(const int* indexTable,
                                                                const std::array<int, 4>& selectedBinsRect,
@@ -127,7 +127,7 @@ class VertexerTraits
   TimeFrame* mTimeFrame = nullptr;
 };
 
-inline void VertexerTraits::initialise(const TrackingParameters& trackingParams, const int& iteration)
+inline void VertexerTraits::initialise(const TrackingParameters& trackingParams, const int iteration)
 {
   mTimeFrame->initialise(0, trackingParams, 3, (bool)(!iteration)); // iteration for initialisation must be 0 for correctly resetting the frame, we need to pass the non-reset flag for vertices as well, tho.
   setIsGPU(false);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -114,7 +114,7 @@ class VertexerTraits
 
 inline void VertexerTraits::initialise(const TrackingParameters& trackingParams, const int& iteration)
 {
-  mTimeFrame->initialise(0, trackingParams, 3);
+  mTimeFrame->initialise(0, trackingParams, 3, (bool)(!iteration)); // iteration for initialisation must be 0 for correctly resetting the frame, we need to pass the non-reset flag for vertices as well, tho.
   setIsGPU(false);
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -100,6 +100,21 @@ class VertexerTraits
   void setNThreads(int n);
   int getNThreads() const { return mNThreads; }
 
+  template <typename T = o2::MCCompLabel>
+  static std::pair<T, float> computeMain(const std::vector<T>& elements)
+  {
+    T elem;
+    size_t maxCount = 0;
+    for (auto& element : elements) {
+      size_t count = std::count(elements.begin(), elements.end(), element);
+      if (count > maxCount) {
+        maxCount = count;
+        elem = element;
+      }
+    }
+    return std::make_pair(elem, static_cast<float>(maxCount) / elements.size());
+  }
+
  protected:
   unsigned char mIsGPU;
   int mNThreads = 1;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -62,12 +62,12 @@ class VertexerTraits
   GPUhd() static const int2 getPhiBins(float phi, float deltaPhi, const IndexTableUtils&);
 
   // virtual vertexer interface
-  virtual void initialise(const TrackingParameters& trackingParams);
-  virtual void computeTracklets();
-  virtual void computeTrackletMatching();
-  virtual void computeVertices();
+  virtual void initialise(const TrackingParameters& trackingParams, const int& iteration = 0);
+  virtual void computeTracklets(const int& iteration = 0);
+  virtual void computeTrackletMatching(const int& iteration = 0);
+  virtual void computeVertices(const int& iteration = 0);
   virtual void adoptTimeFrame(TimeFrame* tf);
-  virtual void updateVertexingParameters(const VertexingParameters& vrtPar, const TimeFrameGPUParameters& gpuTfPar);
+  virtual void updateVertexingParameters(const std::vector<VertexingParameters>& vrtPar, const TimeFrameGPUParameters& gpuTfPar);
   // Hybrid
   virtual void initialiseHybrid(const TrackingParameters& trackingParams) { initialise(trackingParams); };
   virtual void computeTrackletsHybrid() { computeTracklets(); };
@@ -83,16 +83,18 @@ class VertexerTraits
                             std::vector<Vertex>&,
                             std::vector<int>&,
                             TimeFrame*,
-                            std::vector<o2::MCCompLabel>*);
+                            std::vector<o2::MCCompLabel>*,
+                            const int& iteration = 0);
 
   static const std::vector<std::pair<int, int>> selectClusters(const int* indexTable,
                                                                const std::array<int, 4>& selectedBinsRect,
                                                                const IndexTableUtils& utils);
 
   // utils
-  VertexingParameters& getVertexingParameters() { return mVrtParams; }
-  VertexingParameters getVertexingParameters() const { return mVrtParams; }
+  std::vector<VertexingParameters>& getVertexingParameters() { return mVrtParams; }
+  std::vector<VertexingParameters> getVertexingParameters() const { return mVrtParams; }
   void setIsGPU(const unsigned char isgpu) { mIsGPU = isgpu; };
+  void setVertexingParameters(std::vector<VertexingParameters>& vertParams) { mVrtParams = vertParams; }
   unsigned char getIsGPU() const { return mIsGPU; };
   void dumpVertexerTraits();
   void setNThreads(int n);
@@ -102,7 +104,7 @@ class VertexerTraits
   unsigned char mIsGPU;
   int mNThreads = 1;
 
-  VertexingParameters mVrtParams;
+  std::vector<VertexingParameters> mVrtParams;
   IndexTableUtils mIndexTableUtils;
   std::vector<lightVertex> mVertices;
 
@@ -110,7 +112,7 @@ class VertexerTraits
   TimeFrame* mTimeFrame = nullptr;
 };
 
-inline void VertexerTraits::initialise(const TrackingParameters& trackingParams)
+inline void VertexerTraits::initialise(const TrackingParameters& trackingParams, const int& iteration)
 {
   mTimeFrame->initialise(0, trackingParams, 3);
   setIsGPU(false);

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -92,6 +92,14 @@ void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices)
   mROframesPV.push_back(mPrimaryVertices.size());
 }
 
+void TimeFrame::addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int& rofId)
+{
+  mPrimaryVertices.insert(mPrimaryVertices.begin() + mROframesPV[rofId], vertices.begin(), vertices.end());
+  for (int i = rofId + 1; i < mROframesPV.size(); ++i) {
+    mROframesPV[i] += vertices.size();
+  }
+}
+
 void TimeFrame::addPrimaryVertices(const gsl::span<const Vertex>& vertices)
 {
   for (const auto& vertex : vertices) {
@@ -248,17 +256,19 @@ int TimeFrame::getTotalClusters() const
   return int(totalClusters);
 }
 
-void TimeFrame::initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers)
+void TimeFrame::initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers, bool resetVertices)
 {
   if (iteration == 0) {
     mNoVertexROF = 0;
-    if (maxLayers < trkParam.NLayers) {
+    if (maxLayers < trkParam.NLayers && resetVertices) {
       resetRofPV();
     }
     deepVectorClear(mTracks);
     deepVectorClear(mTracksLabel);
     deepVectorClear(mLinesLabels);
-    deepVectorClear(mVerticesLabels);
+    if (resetVertices) {
+      deepVectorClear(mVerticesLabels);
+    }
     mTracks.resize(mNrof);
     mTracksLabel.resize(mNrof);
     mLinesLabels.resize(mNrof);

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -269,9 +269,9 @@ int TimeFrame::getTotalClusters() const
 void TimeFrame::initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers, bool resetVertices)
 {
   if (iteration == 0) {
-    mNoVertexROF = 0;
     if (maxLayers < trkParam.NLayers && resetVertices) {
       resetRofPV();
+      deepVectorClear(mTotVertPerIteration);
     }
     deepVectorClear(mTracks);
     deepVectorClear(mTracksLabel);
@@ -386,7 +386,8 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
       }
     }
   }
-
+  mTotVertPerIteration.resize(1 + iteration);
+  mNoVertexROF = 0;
   deepVectorClear(mRoads);
   deepVectorClear(mRoadLabels);
 

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -266,6 +266,73 @@ int TimeFrame::getTotalClusters() const
   return int(totalClusters);
 }
 
+void TimeFrame::prepareClusters(const TrackingParameters& trkParam, const int maxLayers)
+{
+  std::vector<ClusterHelper> cHelper;
+  std::vector<int> clsPerBin(trkParam.PhiBins * trkParam.ZBins, 0);
+  for (int rof{0}; rof < mNrof; ++rof) {
+    if ((int)mMultiplicityCutMask.size() == mNrof && !mMultiplicityCutMask[rof]) {
+      continue;
+    }
+    for (int iLayer{0}; iLayer < std::min(trkParam.NLayers, maxLayers); ++iLayer) {
+      std::fill(clsPerBin.begin(), clsPerBin.end(), 0);
+      const auto unsortedClusters{getUnsortedClustersOnLayer(rof, iLayer)};
+      const int clustersNum{static_cast<int>(unsortedClusters.size())};
+
+      deepVectorClear(cHelper);
+      cHelper.resize(clustersNum);
+
+      for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
+
+        const Cluster& c = unsortedClusters[iCluster];
+        ClusterHelper& h = cHelper[iCluster];
+        float x = c.xCoordinate - mBeamPos[0];
+        float y = c.yCoordinate - mBeamPos[1];
+        const float& z = c.zCoordinate;
+        float phi = math_utils::computePhi(x, y);
+        int zBin{mIndexTableUtils.getZBinIndex(iLayer, z)};
+        if (zBin < 0) {
+          zBin = 0;
+          mBogusClusters[iLayer]++;
+        } else if (zBin >= trkParam.ZBins) {
+          zBin = trkParam.ZBins - 1;
+          mBogusClusters[iLayer]++;
+        }
+        int bin = mIndexTableUtils.getBinIndex(zBin, mIndexTableUtils.getPhiBinIndex(phi));
+        h.phi = phi;
+        h.r = math_utils::hypot(x, y);
+        mMinR[iLayer] = o2::gpu::GPUCommonMath::Min(h.r, mMinR[iLayer]);
+        mMaxR[iLayer] = o2::gpu::GPUCommonMath::Max(h.r, mMaxR[iLayer]);
+        h.bin = bin;
+        h.ind = clsPerBin[bin]++;
+      }
+      std::vector<int> lutPerBin(clsPerBin.size());
+      lutPerBin[0] = 0;
+      for (unsigned int iB{1}; iB < lutPerBin.size(); ++iB) {
+        lutPerBin[iB] = lutPerBin[iB - 1] + clsPerBin[iB - 1];
+      }
+
+      auto clusters2beSorted{getClustersOnLayer(rof, iLayer)};
+      for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
+        const ClusterHelper& h = cHelper[iCluster];
+
+        Cluster& c = clusters2beSorted[lutPerBin[h.bin] + h.ind];
+        c = unsortedClusters[iCluster];
+        c.phi = h.phi;
+        c.radius = h.r;
+        c.indexTableBinIndex = h.bin;
+      }
+
+      for (unsigned int iB{0}; iB < clsPerBin.size(); ++iB) {
+        mIndexTables[iLayer][rof * (trkParam.ZBins * trkParam.PhiBins + 1) + iB] = lutPerBin[iB];
+      }
+      for (auto iB{clsPerBin.size()}; iB < (trkParam.ZBins * trkParam.PhiBins + 1); iB++) {
+        mIndexTables[iLayer][rof * (trkParam.ZBins * trkParam.PhiBins + 1) + iB] = clustersNum;
+      }
+    }
+  }
+}
+
 void TimeFrame::initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers, bool resetVertices)
 {
   if (iteration == 0) {
@@ -311,9 +378,6 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
       v = std::vector<int>(mNrof + 1, 0);
     }
 
-    std::vector<ClusterHelper> cHelper;
-    std::vector<int> clsPerBin(trkParam.PhiBins * trkParam.ZBins, 0);
-
     for (int iLayer{0}; iLayer < trkParam.NLayers; ++iLayer) {
       if (trkParam.SystErrorY2[iLayer] > 0.f || trkParam.SystErrorZ2[iLayer] > 0.f) {
         for (auto& tfInfo : mTrackingFrameInfo[iLayer]) {
@@ -323,69 +387,11 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
         }
       }
     }
-
-    for (int rof{0}; rof < mNrof; ++rof) {
-      if ((int)mMultiplicityCutMask.size() == mNrof && !mMultiplicityCutMask[rof]) {
-        continue;
-      }
-      for (int iLayer{0}; iLayer < std::min(trkParam.NLayers, maxLayers); ++iLayer) {
-        std::fill(clsPerBin.begin(), clsPerBin.end(), 0);
-        const auto unsortedClusters{getUnsortedClustersOnLayer(rof, iLayer)};
-        const int clustersNum{static_cast<int>(unsortedClusters.size())};
-
-        deepVectorClear(cHelper);
-        cHelper.resize(clustersNum);
-
-        for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
-
-          const Cluster& c = unsortedClusters[iCluster];
-          ClusterHelper& h = cHelper[iCluster];
-          float x = c.xCoordinate - mBeamPos[0];
-          float y = c.yCoordinate - mBeamPos[1];
-          const float& z = c.zCoordinate;
-          float phi = math_utils::computePhi(x, y);
-          int zBin{mIndexTableUtils.getZBinIndex(iLayer, z)};
-          if (zBin < 0) {
-            zBin = 0;
-            mBogusClusters[iLayer]++;
-          } else if (zBin >= trkParam.ZBins) {
-            zBin = trkParam.ZBins - 1;
-            mBogusClusters[iLayer]++;
-          }
-          int bin = mIndexTableUtils.getBinIndex(zBin, mIndexTableUtils.getPhiBinIndex(phi));
-          h.phi = phi;
-          h.r = math_utils::hypot(x, y);
-          mMinR[iLayer] = o2::gpu::GPUCommonMath::Min(h.r, mMinR[iLayer]);
-          mMaxR[iLayer] = o2::gpu::GPUCommonMath::Max(h.r, mMaxR[iLayer]);
-          h.bin = bin;
-          h.ind = clsPerBin[bin]++;
-        }
-        std::vector<int> lutPerBin(clsPerBin.size());
-        lutPerBin[0] = 0;
-        for (unsigned int iB{1}; iB < lutPerBin.size(); ++iB) {
-          lutPerBin[iB] = lutPerBin[iB - 1] + clsPerBin[iB - 1];
-        }
-
-        auto clusters2beSorted{getClustersOnLayer(rof, iLayer)};
-        for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
-          const ClusterHelper& h = cHelper[iCluster];
-
-          Cluster& c = clusters2beSorted[lutPerBin[h.bin] + h.ind];
-          c = unsortedClusters[iCluster];
-          c.phi = h.phi;
-          c.radius = h.r;
-          c.indexTableBinIndex = h.bin;
-        }
-
-        for (unsigned int iB{0}; iB < clsPerBin.size(); ++iB) {
-          mIndexTables[iLayer][rof * (trkParam.ZBins * trkParam.PhiBins + 1) + iB] = lutPerBin[iB];
-        }
-        for (auto iB{clsPerBin.size()}; iB < (trkParam.ZBins * trkParam.PhiBins + 1); iB++) {
-          mIndexTables[iLayer][rof * (trkParam.ZBins * trkParam.PhiBins + 1) + iB] = clustersNum;
-        }
-      }
-    }
   }
+  if (iteration == 0 || iteration == 3) {
+    prepareClusters(trkParam, maxLayers);
+  }
+
   mTotVertPerIteration.resize(1 + iteration);
   mNoVertexROF = 0;
   deepVectorClear(mRoads);

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -92,12 +92,22 @@ void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices)
   mROframesPV.push_back(mPrimaryVertices.size());
 }
 
+void TimeFrame::addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, float>>& labels)
+{
+  mVerticesMCRecInfo.insert(mVerticesMCRecInfo.end(), labels.begin(), labels.end());
+}
+
 void TimeFrame::addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int& rofId)
 {
   mPrimaryVertices.insert(mPrimaryVertices.begin() + mROframesPV[rofId], vertices.begin(), vertices.end());
   for (int i = rofId + 1; i < mROframesPV.size(); ++i) {
     mROframesPV[i] += vertices.size();
   }
+}
+
+void TimeFrame::addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int& rofId)
+{
+  mVerticesMCRecInfo.insert(mVerticesMCRecInfo.begin() + mROframesPV[rofId], labels.begin(), labels.end());
 }
 
 void TimeFrame::addPrimaryVertices(const gsl::span<const Vertex>& vertices)
@@ -267,7 +277,7 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     deepVectorClear(mTracksLabel);
     deepVectorClear(mLinesLabels);
     if (resetVertices) {
-      deepVectorClear(mVerticesLabels);
+      deepVectorClear(mVerticesMCRecInfo);
     }
     mTracks.resize(mNrof);
     mTracksLabel.resize(mNrof);

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -97,7 +97,7 @@ void TimeFrame::addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, floa
   mVerticesMCRecInfo.insert(mVerticesMCRecInfo.end(), labels.begin(), labels.end());
 }
 
-void TimeFrame::addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int& rofId)
+void TimeFrame::addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int rofId)
 {
   mPrimaryVertices.insert(mPrimaryVertices.begin() + mROframesPV[rofId], vertices.begin(), vertices.end());
   for (int i = rofId + 1; i < mROframesPV.size(); ++i) {
@@ -105,7 +105,7 @@ void TimeFrame::addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, con
   }
 }
 
-void TimeFrame::addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int& rofId)
+void TimeFrame::addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int rofId)
 {
   mVerticesMCRecInfo.insert(mVerticesMCRecInfo.begin() + mROframesPV[rofId], labels.begin(), labels.end());
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -251,6 +251,7 @@ int TimeFrame::getTotalClusters() const
 void TimeFrame::initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers)
 {
   if (iteration == 0) {
+    mNoVertexROF = 0;
     if (maxLayers < trkParam.NLayers) {
       resetRofPV();
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -57,7 +57,9 @@ void Tracker::clustersToTracks(std::function<void(std::string s)> logger, std::f
   }
 
   for (int iteration = 0; iteration < (int)mTrkParams.size(); ++iteration) {
-
+    if (iteration == 3 && mTrkParams[0].DoUPCIteration) {
+      mTimeFrame->flipMultiplicityCutMask();
+    }
     logger(fmt::format("ITS Tracking iteration {} summary:", iteration));
     double timeTracklets{0.}, timeCells{0.}, timeNeighbours{0.}, timeRoads{0.};
     int nTracklets{0}, nCells{0}, nNeighbours{0}, nTracks{-static_cast<int>(mTimeFrame->getNumberOfTracks())};

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -477,7 +477,8 @@ void Tracker::getGlobalConfiguration()
       }
     }
     params.DeltaROF = tc.deltaRof;
-    params.skipSecondIterationVerticesInDeltaRof = tc.skipSecondIterationVerticesInDeltaRof;
+    params.SkipDeltaRofIfsecondIterationVtx = tc.skipDeltaRofIfsecondIterationVtx;
+    params.DoUPCIteration = tc.doUPCIteration;
     params.MaxChi2ClusterAttachment = tc.maxChi2ClusterAttachment > 0 ? tc.maxChi2ClusterAttachment : params.MaxChi2ClusterAttachment;
     params.MaxChi2NDF = tc.maxChi2NDF > 0 ? tc.maxChi2NDF : params.MaxChi2NDF;
     params.PhiBins = tc.LUTbinsPhi > 0 ? tc.LUTbinsPhi : params.PhiBins;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -477,6 +477,7 @@ void Tracker::getGlobalConfiguration()
       }
     }
     params.DeltaROF = tc.deltaRof;
+    params.skipSecondIterationVerticesInDeltaRof = tc.skipSecondIterationVerticesInDeltaRof;
     params.MaxChi2ClusterAttachment = tc.maxChi2ClusterAttachment > 0 ? tc.maxChi2ClusterAttachment : params.MaxChi2ClusterAttachment;
     params.MaxChi2NDF = tc.maxChi2NDF > 0 ? tc.maxChi2NDF : params.MaxChi2NDF;
     params.PhiBins = tc.LUTbinsPhi > 0 ? tc.LUTbinsPhi : params.PhiBins;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -58,7 +58,7 @@ void Tracker::clustersToTracks(std::function<void(std::string s)> logger, std::f
 
   for (int iteration = 0; iteration < (int)mTrkParams.size(); ++iteration) {
     if (iteration == 3 && mTrkParams[0].DoUPCIteration) {
-      mTimeFrame->flipMultiplicityCutMask();
+      mTimeFrame->swapMasks();
     }
     logger(fmt::format("ITS Tracking iteration {} summary:", iteration));
     double timeTracklets{0.}, timeCells{0.}, timeNeighbours{0.}, timeRoads{0.};
@@ -479,7 +479,6 @@ void Tracker::getGlobalConfiguration()
       }
     }
     params.DeltaROF = tc.deltaRof;
-    params.SkipDeltaRofIfsecondIterationVtx = tc.skipDeltaRofIfsecondIterationVtx;
     params.DoUPCIteration = tc.doUPCIteration;
     params.MaxChi2ClusterAttachment = tc.maxChi2ClusterAttachment > 0 ? tc.maxChi2ClusterAttachment : params.MaxChi2ClusterAttachment;
     params.MaxChi2NDF = tc.maxChi2NDF > 0 ? tc.maxChi2NDF : params.MaxChi2NDF;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -454,6 +454,7 @@ void Tracker::rectifyClusterIndices()
 
 void Tracker::getGlobalConfiguration()
 {
+  LOGP(info, "tracker::getGlobalConfiguration size of pars is {}", mTrkParams.size());
   auto& tc = o2::its::TrackerParamConfig::Instance();
   tc.printKeyValues(true, true);
   if (tc.useMatCorrTGeo) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -98,11 +98,8 @@ void TrackerTraits::computeLayerTracklets(const int iteration, int iROFslice, in
 
         for (int iV{startVtx}; iV < endVtx; ++iV) {
           auto& primaryVertex{primaryVertices[iV]};
-          if (mTrkParams[iteration].SkipDeltaRofIfsecondIterationVtx) {
-            if (primaryVertex.isFlagSet(1)) {
-              minRof = std::max(startROF, rof0); // same logic but setting like deltaRof=0
-              maxRof = std::min(endROF - 1, rof0);
-            }
+          if (primaryVertex.isFlagSet(1) && iteration != 3) {
+            continue;
           }
           const float resolution = o2::gpu::CAMath::Sqrt(Sq(mTrkParams[iteration].PVres) / primaryVertex.getNContributors() + Sq(tf->getPositionResolution(iLayer)));
 

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -98,6 +98,12 @@ void TrackerTraits::computeLayerTracklets(const int iteration, int iROFslice, in
 
         for (int iV{startVtx}; iV < endVtx; ++iV) {
           auto& primaryVertex{primaryVertices[iV]};
+          if (mTrkParams[iteration].SkipDeltaRofIfsecondIterationVtx) {
+            if (primaryVertex.isFlagSet(1)) {
+              minRof = std::max(startROF, rof0); // same logic but setting like deltaRof=0
+              maxRof = std::min(endROF - 1, rof0);
+            }
+          }
           const float resolution = o2::gpu::CAMath::Sqrt(Sq(mTrkParams[iteration].PVres) / primaryVertex.getNContributors() + Sq(tf->getPositionResolution(iLayer)));
 
           const float tanLambda{(currentCluster.zCoordinate - primaryVertex.getZ()) * inverseR0};

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -70,8 +70,8 @@ void TrackerTraits::computeLayerTracklets(const int iteration, int iROFslice, in
 
   const Vertex diamondVert({mTrkParams[iteration].Diamond[0], mTrkParams[iteration].Diamond[1], mTrkParams[iteration].Diamond[2]}, {25.e-6f, 0.f, 0.f, 25.e-6f, 0.f, 36.f}, 1, 1.f);
   gsl::span<const Vertex> diamondSpan(&diamondVert, 1);
-  int startROF{mTrkParams[iteration].nROFsPerIterations > 0 ? std::max(iROFslice * mTrkParams[iteration].nROFsPerIterations - mTrkParams[iteration].DeltaROF, 0) : 0};
-  int endROF{mTrkParams[iteration].nROFsPerIterations > 0 ? std::min((iROFslice + 1) * mTrkParams[iteration].nROFsPerIterations + mTrkParams[iteration].DeltaROF, tf->getNrof()) : tf->getNrof()};
+  int startROF{mTrkParams[iteration].nROFsPerIterations > 0 ? iROFslice * mTrkParams[iteration].nROFsPerIterations : 0};
+  int endROF{mTrkParams[iteration].nROFsPerIterations > 0 ? (iROFslice + 1) * mTrkParams[iteration].nROFsPerIterations + mTrkParams[iteration].DeltaROF : tf->getNrof()};
   for (int rof0{startROF}; rof0 < endROF; ++rof0) {
     gsl::span<const Vertex> primaryVertices = mTrkParams[iteration].UseDiamond ? diamondSpan : tf->getPrimaryVertices(rof0);
     const int startVtx{iVertex >= 0 ? iVertex : 0};

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -41,6 +41,7 @@ void ITSTrackingInterface::initialise()
   }
   if (mMode == TrackingMode::Async) {
     trackParams.resize(3);
+    vertParams.resize(2); // The number of actual iterations will be set as a configKeyVal to allow for pp/PbPb choice
     for (auto& param : trackParams) {
       param.ZBins = 64;
       param.PhiBins = 32;
@@ -52,12 +53,10 @@ void ITSTrackingInterface::initialise()
     trackParams[2].TrackletMinPt = 0.1f;
     trackParams[2].CellDeltaTanLambdaSigma *= 4.;
     trackParams[2].MinTrackLength = 4;
-    LOGP(info, "Initializing tracker in async. phase reconstruction with {} passes", trackParams.size());
-    vertParams.resize(2); // The number of actual iterations will be set as a configKeyVal to allow for pp/PbPb choice
+    LOGP(info, "Initializing tracker in async. phase reconstruction with {} passes for tracking and {}/{} for vertexing", trackParams.size(), vertParams[0].nIterations, vertParams.size());
     vertParams[1].phiCut = 0.015f;
     vertParams[1].tanLambdaCut = 0.015f;
     vertParams[1].vertPerRofThreshold = 0;
-
   } else if (mMode == TrackingMode::Sync) {
     trackParams.resize(1);
     trackParams[0].ZBins = 64;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -224,7 +224,13 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
     }
   }
   LOG(info) << fmt::format(" - rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, rofspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);
-  LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} vertices found in {}/{} ROFs", vertexerElapsedTime, mTimeFrame->getPrimaryVerticesNum(), rofspan.size() - mTimeFrame->getNoVertexROF(), rofspan.size());
+  LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} ({} + {}) vertices found in {}/{} ROFs",
+                           vertexerElapsedTime,
+                           mTimeFrame->getPrimaryVerticesNum(),
+                           mTimeFrame->getTotVertIteration()[0],
+                           o2::its::VertexerParamConfig::Instance().nIterations > 1 ? mTimeFrame->getTotVertIteration()[1] : 0,
+                           rofspan.size() - mTimeFrame->getNoVertexROF(),
+                           rofspan.size());
 
   if (mOverrideBeamEstimation) {
     LOG(info) << fmt::format(" - Beam position set to: {}, {} from meanvertex object", mTimeFrame->getBeamX(), mTimeFrame->getBeamY());

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -53,7 +53,7 @@ void ITSTrackingInterface::initialise()
     trackParams[2].TrackletMinPt = 0.1f;
     trackParams[2].CellDeltaTanLambdaSigma *= 4.;
     trackParams[2].MinTrackLength = 4;
-    LOGP(info, "Initializing tracker in async. phase reconstruction with {} passes for tracking and {}/{} for vertexing", trackParams.size(), vertParams[0].nIterations, vertParams.size());
+    LOGP(info, "Initializing tracker in async. phase reconstruction with {} passes for tracking and {}/{} for vertexing", trackParams.size(), o2::its::VertexerParamConfig::Instance().nIterations, vertParams.size());
     vertParams[1].phiCut = 0.015f;
     vertParams[1].tanLambdaCut = 0.015f;
     vertParams[1].vertPerRofThreshold = 0;

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -43,7 +43,6 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
   TrackingParameters trkPars;
   TimeFrameGPUParameters tfGPUpar;
   mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
-  LOGP(info, "[1].phiCut {} [1].tanLambdaCut {}", mVertParams[1].phiCut, mVertParams[1].tanLambdaCut);
   for (int iteration = 0; iteration < std::min(mVertParams[0].nIterations, (int)mVertParams.size()); ++iteration) {
     logger(fmt::format("ITS Seeding vertexer iteration {} summary:", iteration));
     trkPars.PhiBins = mTraits->getVertexingParameters()[0].PhiBins;

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -41,7 +41,10 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
 {
   float total{0.f};
   TrackingParameters trkPars;
-  for (int iteration = 0; iteration < (int)mVertParams.size(); ++iteration) {
+  TimeFrameGPUParameters tfGPUpar;
+  mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
+  for (int iteration = 0; iteration < std::min(mVertParams[0].nIterations, (int)mVertParams.size()); ++iteration) {
+    logger(fmt::format("ITS Seeding vertexer iteration {} summary:", iteration));
     trkPars.PhiBins = mTraits->getVertexingParameters()[0].PhiBins;
     trkPars.ZBins = mTraits->getVertexingParameters()[0].ZBins;
     total += evaluateTask(&Vertexer::initialiseVertexer, "Vertexer initialisation", logger, trkPars, iteration);
@@ -72,7 +75,6 @@ void Vertexer::getGlobalConfiguration()
   auto& vc = o2::its::VertexerParamConfig::Instance();
   vc.printKeyValues(true, true);
   auto& grc = o2::its::GpuRecoParamConfig::Instance();
-  LOGP(info, "size of mVertParams: {}", mVertParams.size());
   for (auto& verPar : mVertParams) {
     verPar.allowSingleContribClusters = vc.allowSingleContribClusters;
     verPar.zCut = vc.zCut;
@@ -93,8 +95,6 @@ void Vertexer::getGlobalConfiguration()
     verPar.ZBins = vc.ZBins;
     verPar.PhiBins = vc.PhiBins;
   }
-  TimeFrameGPUParameters tfGPUpar;
-  mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
 }
 
 void Vertexer::adoptTimeFrame(TimeFrame& tf)

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -43,6 +43,7 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
   TrackingParameters trkPars;
   TimeFrameGPUParameters tfGPUpar;
   mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
+  LOGP(info, "[1].phiCut {} [1].tanLambdaCut {}", mVertParams[1].phiCut, mVertParams[1].tanLambdaCut);
   for (int iteration = 0; iteration < std::min(mVertParams[0].nIterations, (int)mVertParams.size()); ++iteration) {
     logger(fmt::format("ITS Seeding vertexer iteration {} summary:", iteration));
     trkPars.PhiBins = mTraits->getVertexingParameters()[0].PhiBins;
@@ -75,26 +76,28 @@ void Vertexer::getGlobalConfiguration()
   auto& vc = o2::its::VertexerParamConfig::Instance();
   vc.printKeyValues(true, true);
   auto& grc = o2::its::GpuRecoParamConfig::Instance();
-  for (auto& verPar : mVertParams) {
-    verPar.allowSingleContribClusters = vc.allowSingleContribClusters;
-    verPar.zCut = vc.zCut;
-    verPar.phiCut = vc.phiCut;
-    verPar.pairCut = vc.pairCut;
-    verPar.clusterCut = vc.clusterCut;
-    verPar.histPairCut = vc.histPairCut;
-    verPar.tanLambdaCut = vc.tanLambdaCut;
-    verPar.lowMultBeamDistCut = vc.lowMultBeamDistCut;
-    verPar.vertNsigmaCut = vc.vertNsigmaCut;
-    verPar.vertRadiusSigma = vc.vertRadiusSigma;
-    verPar.trackletSigma = vc.trackletSigma;
-    verPar.maxZPositionAllowed = vc.maxZPositionAllowed;
-    verPar.clusterContributorsCut = vc.clusterContributorsCut;
-    verPar.maxTrackletsPerCluster = vc.maxTrackletsPerCluster;
-    verPar.phiSpan = vc.phiSpan;
-    verPar.nThreads = vc.nThreads;
-    verPar.ZBins = vc.ZBins;
-    verPar.PhiBins = vc.PhiBins;
-  }
+
+  // This is odd: we override only the parameters for the first iteration.
+  // Variations for the next iterations are set in the trackingInterfrace.
+  mVertParams[0].nIterations = vc.nIterations;
+  mVertParams[0].allowSingleContribClusters = vc.allowSingleContribClusters;
+  mVertParams[0].zCut = vc.zCut;
+  mVertParams[0].phiCut = vc.phiCut;
+  mVertParams[0].pairCut = vc.pairCut;
+  mVertParams[0].clusterCut = vc.clusterCut;
+  mVertParams[0].histPairCut = vc.histPairCut;
+  mVertParams[0].tanLambdaCut = vc.tanLambdaCut;
+  mVertParams[0].lowMultBeamDistCut = vc.lowMultBeamDistCut;
+  mVertParams[0].vertNsigmaCut = vc.vertNsigmaCut;
+  mVertParams[0].vertRadiusSigma = vc.vertRadiusSigma;
+  mVertParams[0].trackletSigma = vc.trackletSigma;
+  mVertParams[0].maxZPositionAllowed = vc.maxZPositionAllowed;
+  mVertParams[0].clusterContributorsCut = vc.clusterContributorsCut;
+  mVertParams[0].maxTrackletsPerCluster = vc.maxTrackletsPerCluster;
+  mVertParams[0].phiSpan = vc.phiSpan;
+  mVertParams[0].nThreads = vc.nThreads;
+  mVertParams[0].ZBins = vc.ZBins;
+  mVertParams[0].PhiBins = vc.PhiBins;
 }
 
 void Vertexer::adoptTimeFrame(TimeFrame& tf)

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -161,16 +161,12 @@ const std::vector<std::pair<int, int>> VertexerTraits::selectClusters(const int*
 void VertexerTraits::updateVertexingParameters(const std::vector<VertexingParameters>& vrtPar, const TimeFrameGPUParameters& tfPar)
 {
   mVrtParams = vrtPar;
-  LOGP(info, "here1");
   mIndexTableUtils.setTrackingParameters(vrtPar[0]);
-  LOGP(info, "here2");
   for (auto& par : mVrtParams) {
     par.phiSpan = static_cast<int>(std::ceil(mIndexTableUtils.getNphiBins() * par.phiCut / constants::math::TwoPi));
     par.zSpan = static_cast<int>(std::ceil(par.zCut * mIndexTableUtils.getInverseZCoordinate(0)));
   }
-  LOGP(info, "here3");
   setNThreads(vrtPar[0].nThreads);
-  LOGP(info, "here4");
 }
 
 void VertexerTraits::computeTracklets(const int& iteration)

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -158,17 +158,22 @@ const std::vector<std::pair<int, int>> VertexerTraits::selectClusters(const int*
   return filteredBins;
 }
 
-void VertexerTraits::updateVertexingParameters(const VertexingParameters& vrtPar, const TimeFrameGPUParameters& tfPar)
+void VertexerTraits::updateVertexingParameters(const std::vector<VertexingParameters>& vrtPar, const TimeFrameGPUParameters& tfPar)
 {
   mVrtParams = vrtPar;
-  mIndexTableUtils.setTrackingParameters(vrtPar);
-  mVrtParams.phiSpan = static_cast<int>(std::ceil(mIndexTableUtils.getNphiBins() * mVrtParams.phiCut /
-                                                  constants::math::TwoPi));
-  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * mIndexTableUtils.getInverseZCoordinate(0)));
-  setNThreads(mVrtParams.nThreads);
+  LOGP(info, "here1");
+  mIndexTableUtils.setTrackingParameters(vrtPar[0]);
+  LOGP(info, "here2");
+  for (auto& par : mVrtParams) {
+    par.phiSpan = static_cast<int>(std::ceil(mIndexTableUtils.getNphiBins() * par.phiCut / constants::math::TwoPi));
+    par.zSpan = static_cast<int>(std::ceil(par.zCut * mIndexTableUtils.getInverseZCoordinate(0)));
+  }
+  LOGP(info, "here3");
+  setNThreads(vrtPar[0].nThreads);
+  LOGP(info, "here4");
 }
 
-void VertexerTraits::computeTracklets()
+void VertexerTraits::computeTracklets(const int& iteration)
 {
 #pragma omp parallel num_threads(mNThreads)
   {
@@ -178,24 +183,24 @@ void VertexerTraits::computeTracklets()
         mTimeFrame->getClustersOnLayer(rofId, 0),
         mTimeFrame->getClustersOnLayer(rofId, 1),
         mTimeFrame->getIndexTable(rofId, 0).data(),
-        mVrtParams.phiCut,
+        mVrtParams[iteration].phiCut,
         mTimeFrame->getTracklets()[0],
         mTimeFrame->getNTrackletsCluster(rofId, 0),
         mIndexTableUtils,
         rofId,
         0,
-        mVrtParams.maxTrackletsPerCluster);
+        mVrtParams[iteration].maxTrackletsPerCluster);
       trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
         mTimeFrame->getClustersOnLayer(rofId, 2),
         mTimeFrame->getClustersOnLayer(rofId, 1),
         mTimeFrame->getIndexTable(rofId, 2).data(),
-        mVrtParams.phiCut,
+        mVrtParams[iteration].phiCut,
         mTimeFrame->getTracklets()[1],
         mTimeFrame->getNTrackletsCluster(rofId, 1),
         mIndexTableUtils,
         rofId,
         0,
-        mVrtParams.maxTrackletsPerCluster);
+        mVrtParams[iteration].maxTrackletsPerCluster);
       mTimeFrame->getNTrackletsROf(rofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 0).begin(), mTimeFrame->getNTrackletsCluster(rofId, 0).end(), 0);
       mTimeFrame->getNTrackletsROf(rofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 1).begin(), mTimeFrame->getNTrackletsCluster(rofId, 1).end(), 0);
     }
@@ -212,24 +217,24 @@ void VertexerTraits::computeTracklets()
         mTimeFrame->getClustersOnLayer(rofId, 0),
         mTimeFrame->getClustersOnLayer(rofId, 1),
         mTimeFrame->getIndexTable(rofId, 0).data(),
-        mVrtParams.phiCut,
+        mVrtParams[iteration].phiCut,
         mTimeFrame->getTracklets()[0],
         mTimeFrame->getNTrackletsCluster(rofId, 0),
         mIndexTableUtils,
         rofId,
         mTimeFrame->getNTrackletsROf(rofId, 0),
-        mVrtParams.maxTrackletsPerCluster);
+        mVrtParams[iteration].maxTrackletsPerCluster);
       trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
         mTimeFrame->getClustersOnLayer(rofId, 2),
         mTimeFrame->getClustersOnLayer(rofId, 1),
         mTimeFrame->getIndexTable(rofId, 2).data(),
-        mVrtParams.phiCut,
+        mVrtParams[iteration].phiCut,
         mTimeFrame->getTracklets()[1],
         mTimeFrame->getNTrackletsCluster(rofId, 1),
         mIndexTableUtils,
         rofId,
         mTimeFrame->getNTrackletsROf(rofId, 1),
-        mVrtParams.maxTrackletsPerCluster);
+        mVrtParams[iteration].maxTrackletsPerCluster);
     }
   }
 
@@ -292,7 +297,7 @@ void VertexerTraits::computeTracklets()
 #endif
 } // namespace its
 
-void VertexerTraits::computeTrackletMatching()
+void VertexerTraits::computeTrackletMatching(const int& iteration)
 {
 #pragma omp parallel for num_threads(mNThreads) schedule(dynamic)
   for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
@@ -307,8 +312,8 @@ void VertexerTraits::computeTrackletMatching()
       mTimeFrame->getLines(rofId),
       mTimeFrame->getLabelsFoundTracklets(rofId, 0),
       mTimeFrame->getLinesLabel(rofId),
-      mVrtParams.tanLambdaCut,
-      mVrtParams.phiCut);
+      mVrtParams[iteration].tanLambdaCut,
+      mVrtParams[iteration].phiCut);
   }
 
 #ifdef VTX_DEBUG
@@ -342,10 +347,10 @@ void VertexerTraits::computeTrackletMatching()
 #endif
 }
 
-void VertexerTraits::computeVertices()
+void VertexerTraits::computeVertices(const int& iteration)
 {
 
-  auto nsigmaCut{std::min(mVrtParams.vertNsigmaCut * mVrtParams.vertNsigmaCut * (mVrtParams.vertRadiusSigma * mVrtParams.vertRadiusSigma + mVrtParams.trackletSigma * mVrtParams.trackletSigma), 1.98f)};
+  auto nsigmaCut{std::min(mVrtParams[iteration].vertNsigmaCut * mVrtParams[iteration].vertNsigmaCut * (mVrtParams[iteration].vertRadiusSigma * mVrtParams[iteration].vertRadiusSigma + mVrtParams[iteration].trackletSigma * mVrtParams[iteration].trackletSigma), 1.98f)};
   std::vector<Vertex> vertices;
 #ifdef VTX_DEBUG
   std::vector<std::vector<ClusterLines>> dbg_clusLines(mTimeFrame->getNrof());
@@ -364,7 +369,7 @@ void VertexerTraits::computeVertices()
           continue;
         }
         auto dca{Line::getDCA(mTimeFrame->getLines(rofId)[line1], mTimeFrame->getLines(rofId)[line2])};
-        if (dca < mVrtParams.pairCut) {
+        if (dca < mVrtParams[iteration].pairCut) {
           mTimeFrame->getTrackletClusters(rofId).emplace_back(line1, mTimeFrame->getLines(rofId)[line1], line2, mTimeFrame->getLines(rofId)[line2]);
           std::array<float, 3> tmpVertex{mTimeFrame->getTrackletClusters(rofId).back().getVertex()};
           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
@@ -377,7 +382,7 @@ void VertexerTraits::computeVertices()
             if (usedTracklets[tracklet3]) {
               continue;
             }
-            if (Line::getDistanceFromPoint(mTimeFrame->getLines(rofId)[tracklet3], tmpVertex) < mVrtParams.pairCut) {
+            if (Line::getDistanceFromPoint(mTimeFrame->getLines(rofId)[tracklet3], tmpVertex) < mVrtParams[iteration].pairCut) {
               mTimeFrame->getTrackletClusters(rofId).back().add(tracklet3, mTimeFrame->getLines(rofId)[tracklet3]);
               usedTracklets[tracklet3] = true;
               tmpVertex = mTimeFrame->getTrackletClusters(rofId).back().getVertex();
@@ -387,12 +392,12 @@ void VertexerTraits::computeVertices()
         }
       }
     }
-    if (mVrtParams.allowSingleContribClusters) {
+    if (mVrtParams[iteration].allowSingleContribClusters) {
       auto beamLine = Line{{mTimeFrame->getBeamX(), mTimeFrame->getBeamY(), -50.f}, {mTimeFrame->getBeamX(), mTimeFrame->getBeamY(), 50.f}}; // use beam position as contributor
       for (size_t iLine{0}; iLine < numTracklets; ++iLine) {
         if (!usedTracklets[iLine]) {
           auto dca = Line::getDCA(mTimeFrame->getLines(rofId)[iLine], beamLine);
-          if (dca < mVrtParams.pairCut) {
+          if (dca < mVrtParams[iteration].pairCut) {
             mTimeFrame->getTrackletClusters(rofId).emplace_back(iLine, mTimeFrame->getLines(rofId)[iLine], -1, beamLine); // beamline must be passed as second line argument
           }
         }
@@ -408,11 +413,11 @@ void VertexerTraits::computeVertices()
       std::array<float, 3> vertex2{};
       for (int iCluster2{iCluster1 + 1}; iCluster2 < noClustersVec[rofId]; ++iCluster2) {
         vertex2 = mTimeFrame->getTrackletClusters(rofId)[iCluster2].getVertex();
-        if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
+        if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams[iteration].clusterCut) {
           float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
                          (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
                          (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
-          if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
+          if (distance < mVrtParams[iteration].pairCut * mVrtParams[iteration].pairCut) {
             for (auto label : mTimeFrame->getTrackletClusters(rofId)[iCluster2].getLabels()) {
               mTimeFrame->getTrackletClusters(rofId)[iCluster1].add(label, mTimeFrame->getLines(rofId)[label]);
               vertex1 = mTimeFrame->getTrackletClusters(rofId)[iCluster1].getVertex();
@@ -439,8 +444,8 @@ void VertexerTraits::computeVertices()
       bool lowMultCandidate{false};
       double beamDistance2{(mTimeFrame->getBeamX() - mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0]) * (mTimeFrame->getBeamX() - mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0]) +
                            (mTimeFrame->getBeamY() - mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1]) * (mTimeFrame->getBeamY() - mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1])};
-      if (atLeastOneFound && (lowMultCandidate = mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize() < mVrtParams.clusterContributorsCut)) { // We might have pile up with nContr > cut.
-        lowMultCandidate &= (beamDistance2 < mVrtParams.lowMultBeamDistCut * mVrtParams.lowMultBeamDistCut);
+      if (atLeastOneFound && (lowMultCandidate = mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize() < mVrtParams[iteration].clusterContributorsCut)) { // We might have pile up with nContr > cut.
+        lowMultCandidate &= (beamDistance2 < mVrtParams[iteration].lowMultBeamDistCut * mVrtParams[iteration].lowMultBeamDistCut);
         if (!lowMultCandidate) { // Not the first cluster and not a low multiplicity candidate, we can remove it
           mTimeFrame->getTrackletClusters(rofId).erase(mTimeFrame->getTrackletClusters(rofId).begin() + iCluster);
           noClustersVec[rofId]--;
@@ -448,7 +453,7 @@ void VertexerTraits::computeVertices()
         }
       }
 
-      if (beamDistance2 < nsigmaCut && std::abs(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2]) < mVrtParams.maxZPositionAllowed) {
+      if (beamDistance2 < nsigmaCut && std::abs(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2]) < mVrtParams[iteration].maxZPositionAllowed) {
         atLeastOneFound = true;
         vertices.emplace_back(o2::math_utils::Point3D<float>(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0],
                                                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1],
@@ -468,6 +473,9 @@ void VertexerTraits::computeVertices()
       }
     }
     mTimeFrame->addPrimaryVertices(vertices);
+    if (!vertices.size()) {
+      mTimeFrame->getNoVertexROF()++;
+    }
   }
 #ifdef VTX_DEBUG
   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
@@ -511,10 +519,11 @@ void VertexerTraits::computeVerticesInRof(int rofId,
                                           std::vector<Vertex>& vertices,
                                           std::vector<int>& verticesInRof,
                                           TimeFrame* tf,
-                                          std::vector<o2::MCCompLabel>* labels)
+                                          std::vector<o2::MCCompLabel>* labels,
+                                          const int& iteration)
 {
   int foundVertices{0};
-  auto nsigmaCut{std::min(mVrtParams.vertNsigmaCut * mVrtParams.vertNsigmaCut * (mVrtParams.vertRadiusSigma * mVrtParams.vertRadiusSigma + mVrtParams.trackletSigma * mVrtParams.trackletSigma), 1.98f)};
+  auto nsigmaCut{std::min(mVrtParams[iteration].vertNsigmaCut * mVrtParams[iteration].vertNsigmaCut * (mVrtParams[iteration].vertRadiusSigma * mVrtParams[iteration].vertRadiusSigma + mVrtParams[iteration].trackletSigma * mVrtParams[iteration].trackletSigma), 1.98f)};
   const int numTracklets{static_cast<int>(lines.size())};
   for (int line1{0}; line1 < numTracklets; ++line1) {
     if (usedLines[line1]) {
@@ -525,7 +534,7 @@ void VertexerTraits::computeVerticesInRof(int rofId,
         continue;
       }
       auto dca{Line::getDCA(lines[line1], lines[line2])};
-      if (dca < mVrtParams.pairCut) {
+      if (dca < mVrtParams[iteration].pairCut) {
         clusterLines.emplace_back(line1, lines[line1], line2, lines[line2]);
         std::array<float, 3> tmpVertex{clusterLines.back().getVertex()};
         if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
@@ -538,7 +547,7 @@ void VertexerTraits::computeVerticesInRof(int rofId,
           if (usedLines[tracklet3]) {
             continue;
           }
-          if (Line::getDistanceFromPoint(lines[tracklet3], tmpVertex) < mVrtParams.pairCut) {
+          if (Line::getDistanceFromPoint(lines[tracklet3], tmpVertex) < mVrtParams[iteration].pairCut) {
             clusterLines.back().add(tracklet3, lines[tracklet3]);
             usedLines[tracklet3] = true;
             tmpVertex = clusterLines.back().getVertex();
@@ -549,12 +558,12 @@ void VertexerTraits::computeVerticesInRof(int rofId,
     }
   }
 
-  if (mVrtParams.allowSingleContribClusters) {
+  if (mVrtParams[iteration].allowSingleContribClusters) {
     auto beamLine = Line{{tf->getBeamX(), tf->getBeamY(), -50.f}, {tf->getBeamX(), tf->getBeamY(), 50.f}}; // use beam position as contributor
     for (size_t iLine{0}; iLine < numTracklets; ++iLine) {
       if (!usedLines[iLine]) {
         auto dca = Line::getDCA(lines[iLine], beamLine);
-        if (dca < mVrtParams.pairCut) {
+        if (dca < mVrtParams[iteration].pairCut) {
           clusterLines.emplace_back(iLine, lines[iLine], -1, beamLine); // beamline must be passed as second line argument
         }
       }
@@ -569,11 +578,11 @@ void VertexerTraits::computeVerticesInRof(int rofId,
     std::array<float, 3> vertex2{};
     for (int iCluster2{iCluster1 + 1}; iCluster2 < nClusters; ++iCluster2) {
       vertex2 = clusterLines[iCluster2].getVertex();
-      if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
+      if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams[iteration].clusterCut) {
         float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
                        (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
                        (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
-        if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
+        if (distance < mVrtParams[iteration].pairCut * mVrtParams[iteration].pairCut) {
           for (auto label : clusterLines[iCluster2].getLabels()) {
             clusterLines[iCluster1].add(label, lines[label]);
             vertex1 = clusterLines[iCluster1].getVertex();
@@ -594,15 +603,15 @@ void VertexerTraits::computeVerticesInRof(int rofId,
     double beamDistance2{(tf->getBeamX() - clusterLines[iCluster].getVertex()[0]) * (tf->getBeamX() - clusterLines[iCluster].getVertex()[0]) +
                          (tf->getBeamY() - clusterLines[iCluster].getVertex()[1]) * (tf->getBeamY() - clusterLines[iCluster].getVertex()[1])};
 
-    if (atLeastOneFound && (lowMultCandidate = clusterLines[iCluster].getSize() < mVrtParams.clusterContributorsCut)) { // We might have pile up with nContr > cut.
-      lowMultCandidate &= (beamDistance2 < mVrtParams.lowMultBeamDistCut * mVrtParams.lowMultBeamDistCut);
+    if (atLeastOneFound && (lowMultCandidate = clusterLines[iCluster].getSize() < mVrtParams[iteration].clusterContributorsCut)) { // We might have pile up with nContr > cut.
+      lowMultCandidate &= (beamDistance2 < mVrtParams[iteration].lowMultBeamDistCut * mVrtParams[iteration].lowMultBeamDistCut);
       if (!lowMultCandidate) { // Not the first cluster and not a low multiplicity candidate, we can remove it
         clusterLines.erase(clusterLines.begin() + iCluster);
         nClusters--;
         continue;
       }
     }
-    if (beamDistance2 < nsigmaCut && std::abs(clusterLines[iCluster].getVertex()[2]) < mVrtParams.maxZPositionAllowed) {
+    if (beamDistance2 < nsigmaCut && std::abs(clusterLines[iCluster].getVertex()[2]) < mVrtParams[iteration].maxZPositionAllowed) {
       atLeastOneFound = true;
       ++foundVertices;
       vertices.emplace_back(o2::math_utils::Point3D<float>(clusterLines[iCluster].getVertex()[0],

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -170,7 +170,7 @@ void VertexerTraits::updateVertexingParameters(const std::vector<VertexingParame
 }
 
 // Main functions
-void VertexerTraits::computeTracklets(const int& iteration)
+void VertexerTraits::computeTracklets(const int iteration)
 {
 #pragma omp parallel num_threads(mNThreads)
   {
@@ -296,7 +296,7 @@ void VertexerTraits::computeTracklets(const int& iteration)
 #endif
 } // namespace its
 
-void VertexerTraits::computeTrackletMatching(const int& iteration)
+void VertexerTraits::computeTrackletMatching(const int iteration)
 {
 #pragma omp parallel for num_threads(mNThreads) schedule(dynamic)
   for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
@@ -349,7 +349,7 @@ void VertexerTraits::computeTrackletMatching(const int& iteration)
 #endif
 }
 
-void VertexerTraits::computeVertices(const int& iteration)
+void VertexerTraits::computeVertices(const int iteration)
 {
   auto nsigmaCut{std::min(mVrtParams[iteration].vertNsigmaCut * mVrtParams[iteration].vertNsigmaCut * (mVrtParams[iteration].vertRadiusSigma * mVrtParams[iteration].vertRadiusSigma + mVrtParams[iteration].trackletSigma * mVrtParams[iteration].trackletSigma), 1.98f)};
   std::vector<Vertex> vertices;
@@ -538,7 +538,7 @@ void VertexerTraits::computeVerticesInRof(int rofId,
                                           std::vector<int>& verticesInRof,
                                           TimeFrame* tf,
                                           std::vector<o2::MCCompLabel>* labels,
-                                          const int& iteration)
+                                          const int iteration)
 {
   int foundVertices{0};
   auto nsigmaCut{std::min(mVrtParams[iteration].vertNsigmaCut * mVrtParams[iteration].vertNsigmaCut * (mVrtParams[iteration].vertRadiusSigma * mVrtParams[iteration].vertRadiusSigma + mVrtParams[iteration].trackletSigma * mVrtParams[iteration].trackletSigma), 1.98f)};

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -351,7 +351,6 @@ void VertexerTraits::computeTrackletMatching(const int& iteration)
 
 void VertexerTraits::computeVertices(const int& iteration)
 {
-
   auto nsigmaCut{std::min(mVrtParams[iteration].vertNsigmaCut * mVrtParams[iteration].vertNsigmaCut * (mVrtParams[iteration].vertRadiusSigma * mVrtParams[iteration].vertRadiusSigma + mVrtParams[iteration].trackletSigma * mVrtParams[iteration].trackletSigma), 1.98f)};
   std::vector<Vertex> vertices;
   std::vector<std::pair<o2::MCCompLabel, float>> polls;
@@ -436,7 +435,6 @@ void VertexerTraits::computeVertices(const int& iteration)
       }
     }
   }
-  int tmpTotVerts{0};
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
     vertices.clear();
     std::sort(mTimeFrame->getTrackletClusters(rofId).begin(), mTimeFrame->getTrackletClusters(rofId).end(),
@@ -491,12 +489,11 @@ void VertexerTraits::computeVertices(const int& iteration)
         mTimeFrame->addPrimaryVerticesLabelsInROF(polls, rofId);
       }
     }
-    tmpTotVerts += vertices.size();
-    if (!vertices.size() && !iteration) {
+    mTimeFrame->getTotVertIteration()[iteration] += vertices.size();
+    if (!vertices.size() && !(iteration && (int)mTimeFrame->getPrimaryVertices(rofId).size() > mVrtParams[iteration].vertPerRofThreshold)) {
       mTimeFrame->getNoVertexROF()++;
     }
   }
-  LOGP(info, "=> Total vertices found in iteration {}: {}", iteration, tmpTotVerts);
 #ifdef VTX_DEBUG
   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
   TTree* ln_clus_lines_tree = new TTree("clusterlines", "tf");

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -469,6 +469,7 @@ void VertexerTraits::computeVertices(const int& iteration)
                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getAvgDistance2()); // In place of chi2
 
         vertices.back().setTimeStamp(rofId);
+        vertices.back().setFlags(iteration);
         if (mTimeFrame->hasMCinformation()) {
           std::vector<o2::MCCompLabel> labels;
           for (auto& index : mTimeFrame->getTrackletClusters(rofId)[iCluster].getLabels()) {

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -72,7 +72,10 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                 BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSTrackMC2ROF", 0},
                                                              "ITSTracksMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
-                                                             ""})();
+                                                             ""},
+                                BranchDefinition<std::vector<float>>{InputSpec{"purityVertices", "ITS", "VERTICESMCPUR", 0},
+                                                                     "ITSVertexMCPurity", (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                                     ""})();
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -114,6 +114,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, int trgType, const st
     inputs.emplace_back("itsmclabels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
     inputs.emplace_back("ITSMC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "VERTICESMCTR", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "VERTICESMCPUR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
   }

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackWriterSpec.cxx
@@ -69,6 +69,8 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                                              "ITSVertexMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
+                                BranchDefinition<std::vector<float>>{InputSpec{"purityVertices", "ITS", "VERTICESMCPUR", 0},
+                                                                     "ITSVertexMCPurity", (useMC ? 1 : 0), ""},
                                 BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSTrackMC2ROF", 0},
                                                              "ITSTracksMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -182,6 +182,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{orig, "TRACKS", 0});
   std::vector<o2::MCCompLabel> allTrackLabels;
   std::vector<o2::MCCompLabel> allVerticesLabels;
+  std::vector<float> allVerticesPurities;
 
   auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{orig, "VERTICESROF", 0});
   auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{orig, "VERTICES", 0});
@@ -212,12 +213,16 @@ void TrackerDPL::run(ProcessingContext& pc)
     vertexerElapsedTime = mVertexer->clustersToVertices(logger);
   }
   const auto& multEstConf = FastMultEstConfig::Instance(); // parameters for mult estimation and cuts
+    gsl::span<const std::pair<MCCompLabel, float>> vMCRecInfo;
   for (size_t iRof{0}; iRof < rofspan.size(); ++iRof) {
     std::vector<Vertex> vtxVecLoc;
     auto& vtxROF = vertROFvec.emplace_back(rofspan[iRof]);
     vtxROF.setFirstEntry(vertices.size());
     if (mRunVertexer) {
       auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
+            if (mIsMC) {
+        vMCRecInfo = timeFrame->getPrimaryVerticesMCRecInfo(iRof);
+      }
       vtxROF.setNEntries(vtxSpan.size());
       bool selROF = vtxSpan.size() == 0;
       for (size_t iV{0}; iV < vtxSpan.size(); ++iV) {
@@ -228,8 +233,8 @@ void TrackerDPL::run(ProcessingContext& pc)
         selROF = true;
         vertices.push_back(v);
         if (mIsMC) {
-          auto vLabels = timeFrame->getPrimaryVerticesLabels(iRof)[iV];
-          std::copy(vLabels.begin(), vLabels.end(), std::back_inserter(allVerticesLabels));
+          allVerticesLabels.push_back(vMCRecInfo[iV].first);
+          allVerticesPurities.push_back(vMCRecInfo[iV].second);
         }
       }
       if (processingMask[iRof] && !selROF) { // passed selection in clusters and not in vertex multiplicity
@@ -303,6 +308,7 @@ void TrackerDPL::run(ProcessingContext& pc)
 
       pc.outputs().snapshot(Output{orig, "TRACKSMCTR", 0}, allTrackLabels);
       pc.outputs().snapshot(Output{orig, "VERTICESMCTR", 0}, allVerticesLabels);
+      pc.outputs().snapshot(Output{orig, "VERTICESMCPUR", 0}, allVerticesPurities);
       pc.outputs().snapshot(Output{orig, "ITSTrackMC2ROF", 0}, mc2rofs);
     }
   }

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -213,14 +213,14 @@ void TrackerDPL::run(ProcessingContext& pc)
     vertexerElapsedTime = mVertexer->clustersToVertices(logger);
   }
   const auto& multEstConf = FastMultEstConfig::Instance(); // parameters for mult estimation and cuts
-    gsl::span<const std::pair<MCCompLabel, float>> vMCRecInfo;
+  gsl::span<const std::pair<MCCompLabel, float>> vMCRecInfo;
   for (size_t iRof{0}; iRof < rofspan.size(); ++iRof) {
     std::vector<Vertex> vtxVecLoc;
     auto& vtxROF = vertROFvec.emplace_back(rofspan[iRof]);
     vtxROF.setFirstEntry(vertices.size());
     if (mRunVertexer) {
       auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
-            if (mIsMC) {
+      if (mIsMC) {
         vMCRecInfo = timeFrame->getPrimaryVerticesMCRecInfo(iRof);
       }
       vtxROF.setNEntries(vtxSpan.size());


### PR DESCRIPTION
- `ITSVertexerParam.nIterations=2`: performs the second iteration for the vertexer with hard-coded UPC configurations.
- `ITSCATrackerParam.doUPCIteration=true`: performs a 4th iteration on the ROFs tagged by containing tagged vertices.

**EDIT**: 
The tracking completely ignores UPC vertices in its first three iterations but will not ignore any ROF (so that clusters can be considered also from ones that are without a vertex or do have an UPC).
Conversely, the fourth iteration will ignore all the rofs that do not contain a UPC vertex.

This will maintain consistency when comparing "hadronic" reconstruction with and without UPC settings.