### PR TITLE
Flow mapper tool: improve handling of input objects

### DIFF
--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -49,7 +49,7 @@ class FlowMapper
   void SetPrecision(long mPrecisionProvided) { mPrecision = mPrecisionProvided; };
   void SetDerivative(long mDerivativeProvided) { mDerivative = mDerivativeProvided; };
 
-  void CreateLUT(TH1D *mhv2vsPt, TH1D *mhEccVsB);
+  void CreateLUT(TH1D* mhv2vsPt, TH1D* mhEccVsB);
 
   Double_t MapPhi(Double_t lPhiInput, Double_t b, Double_t pt);
 

--- a/Generators/include/Generators/FlowMapper.h
+++ b/Generators/include/Generators/FlowMapper.h
@@ -45,23 +45,17 @@ class FlowMapper
   // Constructor
   FlowMapper();
 
-  void Setv2VsPt(TH1D hv2VsPtProvided);
-  void SetEccVsB(TH1D hEccVsBProvided);
-
   void SetNBinsPhi(long mBinsPhiProvided) { mBinsPhi = mBinsPhiProvided; };
   void SetPrecision(long mPrecisionProvided) { mPrecision = mPrecisionProvided; };
   void SetDerivative(long mDerivativeProvided) { mDerivative = mDerivativeProvided; };
 
-  void CreateLUT(); // to be called if all is set
+  void CreateLUT(TH1D *mhv2vsPt, TH1D *mhEccVsB);
 
   Double_t MapPhi(Double_t lPhiInput, Double_t b, Double_t pt);
 
   long mBinsPhi;             // number of phi bins to use
   double mPrecision = 1e-6;  // precision threshold for numerical inversion success
   double mDerivative = 1e-4; // delta-X for derivative calculation
-
-  std::unique_ptr<TH1D> mhv2vsPt; // input v2 vs pT from measurement
-  std::unique_ptr<TH1D> mhEccVsB; // ecc vs B (from Glauber MC or elsewhere)
 
   // Cumulative function to be inverted
   std::unique_ptr<TF1> mCumulative;

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -30,24 +30,14 @@ FlowMapper::FlowMapper()
   mBinsPhi = 4000; // a first guess
 }
 
-void FlowMapper::Setv2VsPt(TH1D hv2VsPtProvided)
-{
-  // Sets the v2 vs pT to be used.
-  mhv2vsPt = std::make_unique<TH1D>(hv2VsPtProvided);
-}
-void FlowMapper::SetEccVsB(TH1D hEccVsBProvided)
-{
-  // Sets the v2 vs pT to be used.
-  mhEccVsB = std::make_unique<TH1D>(hEccVsBProvided);
-}
-void FlowMapper::CreateLUT()
+void FlowMapper::CreateLUT(TH1D *mhv2vsPt, TH1D *mhEccVsB)
 {
   if (!mhv2vsPt) {
-    LOG(fatal) << "You did not specify a v2 vs pT histogram!";
+    LOG(fatal) << "You did not specify a valid v2 vs pT histogram!";
     return;
   }
   if (!mhEccVsB) {
-    LOG(fatal) << "You did not specify an ecc vs B histogram!";
+    LOG(fatal) << "You did not specify a valid ecc vs B histogram!";
     return;
   }
   LOG(info) << "Proceeding to creating a look-up table...";
@@ -71,6 +61,7 @@ void FlowMapper::CreateLUT()
   // std::make_unique<TH1F>("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
 
   mhLUT = std::make_unique<TH3D>("mhLUT", "", nbinsB, binsB.data(), nbinsPt, binsPt.data(), nbinsPhi, binsPhi.data());
+  mhLUT->SetDirectory(0); // just in case context is incorrect
 
   // loop over each centrality (b) bin
   for (int ic = 0; ic < nbinsB; ic++) {

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -30,7 +30,7 @@ FlowMapper::FlowMapper()
   mBinsPhi = 4000; // a first guess
 }
 
-void FlowMapper::CreateLUT(TH1D *mhv2vsPt, TH1D *mhEccVsB)
+void FlowMapper::CreateLUT(TH1D* mhv2vsPt, TH1D* mhEccVsB)
 {
   if (!mhv2vsPt) {
     LOG(fatal) << "You did not specify a valid v2 vs pT histogram!";

--- a/Generators/src/FlowMapper.cxx
+++ b/Generators/src/FlowMapper.cxx
@@ -61,7 +61,7 @@ void FlowMapper::CreateLUT(TH1D* mhv2vsPt, TH1D* mhEccVsB)
   // std::make_unique<TH1F>("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
 
   mhLUT = std::make_unique<TH3D>("mhLUT", "", nbinsB, binsB.data(), nbinsPt, binsPt.data(), nbinsPhi, binsPhi.data());
-  mhLUT->SetDirectory(0); // just in case context is incorrect
+  mhLUT->SetDirectory(nullptr); // just in case context is incorrect
 
   // loop over each centrality (b) bin
   for (int ic = 0; ic < nbinsB; ic++) {


### PR DESCRIPTION
This PR handles the LUT creation in a more modular way and removes data members that were actually unnecessary for the object itself to work as intended. The old data members are now provided as input for the `CreateLUT` function and it is assumed that proper handling of the pointer will be used in the invoking generator macro, which is easy and simpler.