### PR TITLE
Data Model change: bump McCollisions to 001

### DIFF
--- a/Detectors/AOD/src/AODMcProducerHelpers.cxx
+++ b/Detectors/AOD/src/AODMcProducerHelpers.cxx
@@ -65,8 +65,8 @@ short updateMCCollisions(const CollisionCursor& cursor,
          truncateFloatFraction(header.GetZ(), mask),
          truncateFloatFraction(time, mask),
          truncateFloatFraction(weight, mask),
-         header.GetB() /*,
-          getEventInfo(header, Key::planeAngle, header.GetRotZ())*/
+         header.GetB(),
+         getEventInfo(header, Key::planeAngle, header.GetRotZ())
   );
   return encodedGeneratorId;
 }

--- a/Detectors/AOD/src/AODMcProducerHelpers.cxx
+++ b/Detectors/AOD/src/AODMcProducerHelpers.cxx
@@ -66,8 +66,7 @@ short updateMCCollisions(const CollisionCursor& cursor,
          truncateFloatFraction(time, mask),
          truncateFloatFraction(weight, mask),
          header.GetB(),
-         getEventInfo(header, Key::planeAngle, header.GetRotZ())
-  );
+         getEventInfo(header, Key::planeAngle, header.GetRotZ()));
   return encodedGeneratorId;
 }
 //--------------------------------------------------------------------

--- a/Detectors/AOD/src/StandaloneAODProducer.cxx
+++ b/Detectors/AOD/src/StandaloneAODProducer.cxx
@@ -86,7 +86,7 @@ void fillMCollisionTable(o2::steer::MCKinematicsReader const& mcreader)
     //                  mccollision::PosX, mccollision::PosY, mccollision::PosZ, mccollision::T, mccollision::Weight,
     //                 mccollision::ImpactParameter);
 
-    mcCollCursor(0, 0 /*bcID*/, 0 /*genID*/, header.GetX(), header.GetY(), header.GetZ(), time, 1. /*weight*/, header.GetB() /*, 0.0*/);
+    mcCollCursor(0, 0 /*bcID*/, 0 /*genID*/, header.GetX(), header.GetY(), header.GetZ(), time, 1. /*weight*/, header.GetB(), 0.0);
 
     index++;
   }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1579,7 +1579,7 @@ DECLARE_SOA_TABLE_VERSIONED(McCollisions_001, "AOD", "MCCOLLISION", 1, //! MC co
                             mccollision::GetSubGeneratorId<mccollision::GeneratorsID>,
                             mccollision::GetSourceId<mccollision::GeneratorsID>);
 
-using McCollisions = McCollisions_000;
+using McCollisions = McCollisions_001;
 using McCollision = McCollisions::iterator;
 
 namespace mcparticle


### PR DESCRIPTION
This change is the one that counts: creating as draft first! 

With this change, `McCollisions` is bumped to version 001, in which we now also store the event plane from PYTHIA. This has been tested to work just fine; note that this requires a McCollision converter in O2Physics that has just been merged today as well. I will move to ready for review once the converter is also created as a core service on hyperloop. 