### PR TITLE
ITS-Tracking: introduce multi-ROF seeding vertexer

### DIFF
--- a/DataFormats/Detectors/Common/src/CTFHeader.cxx
+++ b/DataFormats/Detectors/Common/src/CTFHeader.cxx
@@ -18,7 +18,7 @@ using DetID = o2::detectors::DetID;
 /// describe itsel as a string
 std::string CTFHeader::describe() const
 {
-  return fmt::format("Run:{:07d} TF:{} Orbit:{:08d} CteationTime:{} Detectors: {}", run, tfCounter, firstTForbit, creationTime, DetID::getNames(detectors));
+  return fmt::format("Run:{:07d} TF:{} Orbit:{:08d} CreationTime:{} Detectors: {}", run, tfCounter, firstTForbit, creationTime, DetID::getNames(detectors));
 }
 
 void CTFHeader::print() const

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -146,8 +146,8 @@ class Vertex : public VertexBase
   GPUd() void setChi2(float v) { mChi2 = v; }
   GPUd() float getChi2() const { return mChi2; }
 
-  GPUd() const Stamp& getTimeStamp() const { return mTimeStamp; }
-  GPUd() Stamp& getTimeStamp() { return mTimeStamp; }
+  GPUhd() const Stamp& getTimeStamp() const { return mTimeStamp; }
+  GPUhd() Stamp& getTimeStamp() { return mTimeStamp; }
   GPUd() void setTimeStamp(const Stamp& v) { mTimeStamp = v; }
 
  protected:

--- a/DataFormats/common/include/CommonDataFormat/TimeStamp.h
+++ b/DataFormats/common/include/CommonDataFormat/TimeStamp.h
@@ -28,7 +28,7 @@ class TimeStamp
   GPUhdDefault() TimeStamp() CON_DEFAULT;
   GPUhdDefault() ~TimeStamp() CON_DEFAULT;
   GPUdi() TimeStamp(T time) { mTimeStamp = time; }
-  GPUdi() T getTimeStamp() const { return mTimeStamp; }
+  GPUhdi() T getTimeStamp() const { return mTimeStamp; }
   GPUdi() void setTimeStamp(T t) { mTimeStamp = t; }
   GPUdi() bool operator==(const TimeStamp<T>& t) const { return mTimeStamp == t.mTimeStamp; }
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -210,7 +210,7 @@ class TimeFrameGPU : public TimeFrame
   /// interface
   int getNClustersInRofSpan(const int, const int, const int) const;
   IndexTableUtils* getDeviceIndexTableUtils() { return mIndexTableUtilsDevice; }
-  int* getDeviceROframesClusters(const int layer) { return mROframesClustersDevice[layer]; }
+  int* getDeviceROFramesClusters(const int layer) { return mROFramesClustersDevice[layer]; }
   std::vector<std::vector<Vertex>>& getVerticesInChunks() { return mVerticesInChunks; }
   std::vector<std::vector<int>>& getNVerticesInChunks() { return mNVerticesInChunks; }
   std::vector<o2::its::TrackITSExt>& getTrackITSExt() { return mTrackITSExt; }
@@ -218,7 +218,7 @@ class TimeFrameGPU : public TimeFrame
   int getNAllocatedROFs() const { return mNrof; } // Allocated means maximum nROF for each chunk while populated is the number of loaded ones.
   StaticTrackingParameters<nLayers>* getDeviceTrackingParameters() { return mTrackingParamsDevice; }
   Vertex* getDeviceVertices() { return mVerticesDevice; }
-  int* getDeviceROframesPV() { return mROframesPVDevice; }
+  int* getDeviceROFramesPV() { return mROFramesPVDevice; }
   unsigned char* getDeviceUsedClusters(const int);
   const o2::base::Propagator* getChainPropagator();
 
@@ -251,10 +251,10 @@ class TimeFrameGPU : public TimeFrame
   // Device pointers
   StaticTrackingParameters<nLayers>* mTrackingParamsDevice;
   IndexTableUtils* mIndexTableUtilsDevice;
-  std::array<int*, nLayers> mROframesClustersDevice;
+  std::array<int*, nLayers> mROFramesClustersDevice;
   std::array<unsigned char*, nLayers> mUsedClustersDevice;
   Vertex* mVerticesDevice;
-  int* mROframesPVDevice;
+  int* mROFramesPVDevice;
 
   // Hybrid pref
   std::array<Cluster*, nLayers> mClustersDevice;
@@ -314,7 +314,7 @@ size_t TimeFrameGPU<nLayers>::loadChunkData(const size_t chunk, const size_t off
 template <int nLayers>
 inline int TimeFrameGPU<nLayers>::getNClustersInRofSpan(const int rofIdstart, const int rofSpanSize, const int layerId) const
 {
-  return static_cast<int>(mROframesClusters[layerId][(rofIdstart + rofSpanSize) < mROframesClusters.size() ? rofIdstart + rofSpanSize : mROframesClusters.size() - 1] - mROframesClusters[layerId][rofIdstart]);
+  return static_cast<int>(mROFramesClusters[layerId][(rofIdstart + rofSpanSize) < mROFramesClusters.size() ? rofIdstart + rofSpanSize : mROFramesClusters.size() - 1] - mROFramesClusters[layerId][rofIdstart]);
 }
 } // namespace gpu
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -443,21 +443,21 @@ void TimeFrameGPU<nLayers>::initDevice(const int chunks,
       mMemChunks[iChunk].allocate(GpuTimeFrameChunk<nLayers>::computeRofPerChunk(mGpuParams, mAvailMemGB), mGpuStreams[iChunk]);
     }
     for (auto iLayer{0}; iLayer < nLayers; ++iLayer) {
-      checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mROframesClustersDevice[iLayer]), mROframesClusters[iLayer].size() * sizeof(int)));
+      checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mROFramesClustersDevice[iLayer]), mROFramesClusters[iLayer].size() * sizeof(int)));
       checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mUsedClustersDevice[iLayer])), sizeof(unsigned char) * mGpuParams.clustersPerROfCapacity * mNrof));
     }
     checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mVerticesDevice), sizeof(Vertex) * mGpuParams.maxVerticesCapacity));
-    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mROframesPVDevice), sizeof(int) * (mNrof + 1)));
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mROFramesPVDevice), sizeof(int) * (mNrof + 1)));
 
     mFirstInit = false;
   }
   if (maxLayers < nLayers) { // Vertexer
     for (auto iLayer{0}; iLayer < nLayers; ++iLayer) {
-      checkGPUError(cudaMemcpy(mROframesClustersDevice[iLayer], mROframesClusters[iLayer].data(), mROframesClusters[iLayer].size() * sizeof(int), cudaMemcpyHostToDevice));
+      checkGPUError(cudaMemcpy(mROFramesClustersDevice[iLayer], mROFramesClusters[iLayer].data(), mROFramesClusters[iLayer].size() * sizeof(int), cudaMemcpyHostToDevice));
     }
   } else { // Tracker
     checkGPUError(cudaMemcpy(mVerticesDevice, mPrimaryVertices.data(), sizeof(Vertex) * mPrimaryVertices.size(), cudaMemcpyHostToDevice));
-    checkGPUError(cudaMemcpy(mROframesPVDevice, mROframesPV.data(), sizeof(int) * mROframesPV.size(), cudaMemcpyHostToDevice));
+    checkGPUError(cudaMemcpy(mROFramesPVDevice, mROFramesPV.data(), sizeof(int) * mROFramesPV.size(), cudaMemcpyHostToDevice));
     if (!iteration) {
       for (auto iLayer{0}; iLayer < nLayers; ++iLayer) {
         checkGPUError(cudaMemset(mUsedClustersDevice[iLayer], 0, sizeof(unsigned char) * mGpuParams.clustersPerROfCapacity * mNrof));

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
@@ -353,8 +353,8 @@ GPUg() void printTrackletsNotStrided(const Tracklet* t,
 // Compute the tracklets for a given layer
 template <int nLayers = 7>
 GPUg() void computeLayerTrackletsKernelSingleRof(
-  const int rof0,
-  const int maxRofs,
+  const short rof0,
+  const short maxRofs,
   const int layerIndex,
   const Cluster* clustersCurrentLayer,        // input data rof0
   const Cluster* clustersNextLayer,           // input data rof0-delta <rof0< rof0+delta (up to 3 rofs)
@@ -385,8 +385,8 @@ GPUg() void computeLayerTrackletsKernelSingleRof(
     if (usedClustersLayer[currentSortedIndex]) {
       continue;
     }
-    int minRof = (rof0 >= trkPars->DeltaROF) ? rof0 - trkPars->DeltaROF : 0;
-    int maxRof = (rof0 == maxRofs - trkPars->DeltaROF) ? rof0 : rof0 + trkPars->DeltaROF;
+    short minRof = (rof0 >= trkPars->DeltaROF) ? rof0 - trkPars->DeltaROF : 0;
+    short maxRof = (rof0 == static_cast<short>(maxRofs - trkPars->DeltaROF)) ? rof0 : rof0 + trkPars->DeltaROF;
     const float inverseR0{1.f / currentCluster.radius};
     for (int iPrimaryVertex{0}; iPrimaryVertex < nVertices; iPrimaryVertex++) {
       const auto& primaryVertex{vertices[iPrimaryVertex]};
@@ -410,7 +410,7 @@ GPUg() void computeLayerTrackletsKernelSingleRof(
       }
       constexpr int tableSize{256 * 128 + 1}; // hardcoded for the time being
 
-      for (int rof1{minRof}; rof1 <= maxRof; ++rof1) {
+      for (short rof1{minRof}; rof1 <= maxRof; ++rof1) {
         if (!(roFrameClustersNext[rof1 + 1] - roFrameClustersNext[rof1])) { // number of clusters on next layer > 0
           continue;
         }
@@ -561,7 +561,7 @@ GPUg() void computeLayerTrackletsKernelMultipleRof(
                 const float tanL{(currentCluster.zCoordinate - nextCluster.zCoordinate) / (currentCluster.radius - nextCluster.radius)};
                 const size_t stride{currentClusterIndex * maxTrackletsPerCluster};
                 if (storedTracklets < maxTrackletsPerCluster) {
-                  new (trackletsRof0 + stride + storedTracklets) Tracklet{currentSortedIndexChunk, nextClusterIndex, tanL, phi, static_cast<ushort>(rof0), static_cast<ushort>(rof1)};
+                  new (trackletsRof0 + stride + storedTracklets) Tracklet{currentSortedIndexChunk, nextClusterIndex, tanL, phi, static_cast<short>(rof0), static_cast<short>(rof1)};
                 }
                 // else {
                 // printf("its-gpu-tracklet-finder: on rof %d layer: %d: found more tracklets (%d) than maximum allowed per cluster. This is lossy!\n", rof0, layerIndex, storedTracklets);

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -625,8 +625,8 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
         gpu::trackleterKernelMultipleRof<TrackletMode::Layer0Layer1><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),         // const Cluster* clustersNextLayer,    // 0 2
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
-          mTimeFrameGPU->getDeviceROframesClusters(0),                   // const int* sizeNextLClusters,
-          mTimeFrameGPU->getDeviceROframesClusters(1),                   // const int* sizeCurrentLClusters,
+          mTimeFrameGPU->getDeviceROFramesClusters(0),                   // const int* sizeNextLClusters,
+          mTimeFrameGPU->getDeviceROFramesClusters(1),                   // const int* sizeCurrentLClusters,
           mTimeFrameGPU->getChunk(chunkId).getDeviceIndexTables(0),      // const int* nextIndexTables,
           mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),        // Tracklet* Tracklets,
           mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0), // int* foundTracklets,
@@ -639,8 +639,8 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
         gpu::trackleterKernelMultipleRof<TrackletMode::Layer1Layer2><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(2),         // const Cluster* clustersNextLayer,    // 0 2
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
-          mTimeFrameGPU->getDeviceROframesClusters(2),                   // const int* sizeNextLClusters,
-          mTimeFrameGPU->getDeviceROframesClusters(1),                   // const int* sizeCurrentLClusters,
+          mTimeFrameGPU->getDeviceROFramesClusters(2),                   // const int* sizeNextLClusters,
+          mTimeFrameGPU->getDeviceROFramesClusters(1),                   // const int* sizeCurrentLClusters,
           mTimeFrameGPU->getChunk(chunkId).getDeviceIndexTables(2),      // const int* nextIndexTables,
           mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),        // Tracklet* Tracklets,
           mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1), // int* foundTracklets,
@@ -653,8 +653,8 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
         gpu::trackletSelectionKernelMultipleRof<true><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),            // const Cluster* clusters0,               // Clusters on layer 0
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),            // const Cluster* clusters1,               // Clusters on layer 1
-          mTimeFrameGPU->getDeviceROframesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
-          mTimeFrameGPU->getDeviceROframesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
+          mTimeFrameGPU->getDeviceROFramesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
+          mTimeFrameGPU->getDeviceROFramesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
           mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),           // Tracklet* tracklets01,                  // Tracklets on layer 0-1
           mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),           // Tracklet* tracklets12,                  // Tracklets on layer 1-2
           mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0),    // const int* nFoundTracklets01,           // Number of tracklets found on layers 0-1
@@ -686,8 +686,8 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
         gpu::trackletSelectionKernelMultipleRof<false><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),            // const Cluster* clusters0,               // Clusters on layer 0
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),            // const Cluster* clusters1,               // Clusters on layer 1
-          mTimeFrameGPU->getDeviceROframesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
-          mTimeFrameGPU->getDeviceROframesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
+          mTimeFrameGPU->getDeviceROFramesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
+          mTimeFrameGPU->getDeviceROFramesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
           mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),           // Tracklet* tracklets01,                  // Tracklets on layer 0-1
           mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),           // Tracklet* tracklets12,                  // Tracklets on layer 1-2
           mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0),    // const int* nFoundTracklets01,           // Number of tracklets found on layers 0-1
@@ -721,8 +721,8 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
         std::vector<bool> usedLines;
         for (int rofId{0}; rofId < rofs; ++rofId) {
           auto rof = offset + rofId;
-          auto clustersL1offsetRof = mTimeFrameGPU->getROframeClusters(1)[rof] - mTimeFrameGPU->getROframeClusters(1)[offset]; // starting cluster offset for this ROF
-          auto nClustersL1Rof = mTimeFrameGPU->getROframeClusters(1)[rof + 1] - mTimeFrameGPU->getROframeClusters(1)[rof];     // number of clusters for this ROF
+          auto clustersL1offsetRof = mTimeFrameGPU->getROFrameClusters(1)[rof] - mTimeFrameGPU->getROFrameClusters(1)[offset]; // starting cluster offset for this ROF
+          auto nClustersL1Rof = mTimeFrameGPU->getROFrameClusters(1)[rof + 1] - mTimeFrameGPU->getROFrameClusters(1)[rof];     // number of clusters for this ROF
           auto linesOffsetRof = exclusiveFoundLinesHost[clustersL1offsetRof];                                                  // starting line offset for this ROF
           auto nLinesRof = exclusiveFoundLinesHost[clustersL1offsetRof + nClustersL1Rof] - linesOffsetRof;
           gsl::span<const o2::its::Line> linesInRof(lines.data() + linesOffsetRof, static_cast<gsl::span<o2::its::Line>::size_type>(nLinesRof));

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -754,7 +754,7 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
     int start{0};
     for (int rofId{0}; rofId < mTimeFrameGPU->getNVerticesInChunks()[chunkId].size(); ++rofId) {
       gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][rofId])};
-      mTimeFrameGPU->addPrimaryVertices(rofVerts);
+      mTimeFrameGPU->addPrimaryVertices(rofVerts, rofId);
       if (mTimeFrameGPU->hasMCinformation()) {
         // mTimeFrameGPU->getVerticesLabels().emplace_back();
         // TODO: add MC labels

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -754,7 +754,7 @@ void VertexerTraitsGPU::computeTracklets(const int iteration)
     int start{0};
     for (int rofId{0}; rofId < mTimeFrameGPU->getNVerticesInChunks()[chunkId].size(); ++rofId) {
       gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][rofId])};
-      mTimeFrameGPU->addPrimaryVertices(rofVerts, rofId);
+      mTimeFrameGPU->addPrimaryVertices(rofVerts, rofId, 0);
       if (mTimeFrameGPU->hasMCinformation()) {
         // mTimeFrameGPU->getVerticesLabels().emplace_back();
         // TODO: add MC labels

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -178,7 +178,7 @@ GPUg() void trackleterKernelSingleRof(
   Tracklet* Tracklets,
   int* foundTracklets,
   const IndexTableUtils* utils,
-  const int rofId,
+  const short rofId,
   const size_t maxTrackletsPerCluster = 1e2)
 {
   const int phiBins{utils->getNphiBins()};
@@ -234,15 +234,15 @@ GPUg() void trackleterKernelMultipleRof(
   Tracklet* Tracklets,
   int* foundTracklets,
   const IndexTableUtils* utils,
-  const unsigned int startRofId,
-  const unsigned int rofSize,
+  const short startRofId,
+  const short rofSize,
   const float phiCut,
   const size_t maxTrackletsPerCluster = 1e2)
 {
   const int phiBins{utils->getNphiBins()};
   const int zBins{utils->getNzBins()};
-  for (unsigned int iRof{blockIdx.x}; iRof < rofSize; iRof += gridDim.x) {
-    auto rof = iRof + startRofId;
+  for (auto iRof{blockIdx.x}; iRof < rofSize; iRof += gridDim.x) {
+    short rof = static_cast<short>(iRof) + startRofId;
     auto* clustersNextLayerRof = clustersNextLayer + (sizeNextLClusters[rof] - sizeNextLClusters[startRofId]);
     auto* clustersCurrentLayerRof = clustersCurrentLayer + (sizeCurrentLClusters[rof] - sizeCurrentLClusters[startRofId]);
     auto nClustersNextLayerRof = sizeNextLClusters[rof + 1] - sizeNextLClusters[rof];
@@ -273,9 +273,9 @@ GPUg() void trackleterKernelMultipleRof(
             if (o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(currentCluster.phi, nextCluster.phi)) < phiCut) {
               if (storedTracklets < maxTrackletsPerCluster) {
                 if constexpr (Mode == TrackletMode::Layer0Layer1) {
-                  new (TrackletsRof + stride + storedTracklets) Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, static_cast<int>(rof), static_cast<int>(rof)};
+                  new (TrackletsRof + stride + storedTracklets) Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, rof, rof};
                 } else {
-                  new (TrackletsRof + stride + storedTracklets) Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, static_cast<int>(rof), static_cast<int>(rof)};
+                  new (TrackletsRof + stride + storedTracklets) Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, rof, rof};
                 }
                 ++storedTracklets;
               }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_ITSMFT_TRACKING_LINE_H_
-#define O2_ITSMFT_TRACKING_LINE_H_
+#ifndef O2_ITS_CLUSTERLINES_H
+#define O2_ITS_CLUSTERLINES_H
 
 #include <array>
 #include <vector>
@@ -19,11 +19,8 @@
 #include "ITStracking/Tracklet.h"
 #include "GPUCommonMath.h"
 
-namespace o2
+namespace o2::its
 {
-namespace its
-{
-
 struct Line final {
   GPUhd() Line();
   GPUhd() Line(const Line&);
@@ -31,7 +28,7 @@ struct Line final {
   GPUhd() Line(const float firstPoint[3], const float secondPoint[3]);
   GPUhd() Line(const Tracklet&, const Cluster*, const Cluster*);
 
-  inline static float getDistanceFromPoint(const Line& line, const std::array<float, 3>& point);
+  static float getDistanceFromPoint(const Line& line, const std::array<float, 3>& point);
   GPUhd() static float getDistanceFromPoint(const Line& line, const float point[3]);
   static std::array<float, 6> getDCAComponents(const Line& line, const std::array<float, 3> point);
   GPUhd() static void getDCAComponents(const Line& line, const float point[3], float destArray[6]);
@@ -39,12 +36,14 @@ struct Line final {
   static bool areParallel(const Line&, const Line&, const float precision = 1e-14);
   GPUhd() unsigned char isEmpty() const { return (originPoint[0] == 0.f && originPoint[1] == 0.f && originPoint[2] == 0.f) &&
                                                  (cosinesDirector[0] == 0.f && cosinesDirector[1] == 0.f && cosinesDirector[2] == 0.f); }
+  GPUhdi() auto getDeltaROF() const { return rof[1] - rof[0]; }
   GPUhd() void print() const;
   bool operator==(const Line&) const;
   bool operator!=(const Line&) const;
+  const short getMinROF() const { return rof[0] < rof[1] ? rof[0] : rof[1]; }
 
-  float originPoint[3], cosinesDirector[3];         // std::array<float, 3> originPoint, cosinesDirector;
-  float weightMatrix[6] = {1., 0., 0., 1., 0., 1.}; // std::array<float, 6> weightMatrix;
+  float originPoint[3], cosinesDirector[3];
+  float weightMatrix[6] = {1., 0., 0., 1., 0., 1.};
   // weightMatrix is a symmetric matrix internally stored as
   //    0 --> row = 0, col = 0
   //    1 --> 0,1
@@ -52,11 +51,13 @@ struct Line final {
   //    3 --> 1,1
   //    4 --> 1,2
   //    5 --> 2,2
-  // Debug quantities
+  short rof[2];
 };
 
 GPUhdi() Line::Line() : weightMatrix{1., 0., 0., 1., 0., 1.}
 {
+  rof[0] = 0;
+  rof[1] = 0;
 }
 
 GPUhdi() Line::Line(const Line& other)
@@ -67,6 +68,9 @@ GPUhdi() Line::Line(const Line& other)
   }
   for (int i{0}; i < 6; ++i) {
     weightMatrix[i] = other.weightMatrix[i];
+  }
+  for (int i{0}; i < 2; ++i) {
+    rof[i] = other.rof[i];
   }
 }
 
@@ -83,6 +87,9 @@ GPUhdi() Line::Line(const float firstPoint[3], const float secondPoint[3])
   for (int index{0}; index < 3; ++index) {
     cosinesDirector[index] *= inverseNorm;
   }
+
+  rof[0] = 0;
+  rof[1] = 0;
 }
 
 GPUhdi() Line::Line(const Tracklet& tracklet, const Cluster* innerClusters, const Cluster* outerClusters)
@@ -101,6 +108,9 @@ GPUhdi() Line::Line(const Tracklet& tracklet, const Cluster* innerClusters, cons
   for (int index{0}; index < 3; ++index) {
     cosinesDirector[index] *= inverseNorm;
   }
+
+  rof[0] = tracklet.rof[0];
+  rof[1] = tracklet.rof[1];
 }
 
 // static functions:
@@ -198,8 +208,8 @@ inline bool Line::operator!=(const Line& rhs) const
 
 GPUhdi() void Line::print() const
 {
-  printf("Line: originPoint = (%f, %f, %f), cosinesDirector = (%f, %f, %f)\n",
-         originPoint[0], originPoint[1], originPoint[2], cosinesDirector[0], cosinesDirector[1], cosinesDirector[2]);
+  printf("Line: originPoint = (%f, %f, %f), cosinesDirector = (%f, %f, %f), rofs = (%u, %u)\n",
+         originPoint[0], originPoint[1], originPoint[2], cosinesDirector[0], cosinesDirector[1], cosinesDirector[2], rof[0], rof[1]);
 }
 
 class ClusterLines final
@@ -211,11 +221,13 @@ class ClusterLines final
   ClusterLines(const Line& firstLine, const Line& secondLine);
   void add(const int& lineLabel, const Line& line, const bool& weight = false);
   void computeClusterCentroid();
+  void updateROFPoll(const Line&);
   inline std::vector<int>& getLabels()
   {
     return mLabels;
   }
   inline int getSize() const { return mLabels.size(); }
+  inline short getROF() const { return mROF; }
   inline std::array<float, 3> getVertex() const { return mVertex; }
   inline std::array<float, 6> getRMS2() const { return mRMS2; }
   inline float getAvgDistance2() const { return mAvgDistance2; }
@@ -230,8 +242,9 @@ class ClusterLines final
   std::array<float, 3> mVertex = {0.f};       // cluster centroid position
   std::array<float, 6> mRMS2 = {0.f};         // symmetric matrix: diagonal is RMS2
   float mAvgDistance2 = 0.f;                  // substitute for chi2
+  int mROFWeight = 0;                         // rof weight for voting
+  short mROF = -1;                            // rof
 };
 
-} // namespace its
-} // namespace o2
-#endif /* O2_ITSMFT_TRACKING_LINE_H_ */
+} // namespace o2::its
+#endif /* O2_ITS_CLUSTERLINES_H */

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -40,7 +40,7 @@ struct Line final {
   GPUhd() void print() const;
   bool operator==(const Line&) const;
   bool operator!=(const Line&) const;
-  const short getMinROF() const { return rof[0] < rof[1] ? rof[0] : rof[1]; }
+  short getMinROF() const { return rof[0] < rof[1] ? rof[0] : rof[1]; }
 
   float originPoint[3], cosinesDirector[3];
   float weightMatrix[6] = {1., 0., 0., 1., 0., 1.};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -56,8 +56,8 @@ struct Line final {
 
 GPUhdi() Line::Line() : weightMatrix{1., 0., 0., 1., 0., 1.}
 {
-  rof[0] = 0;
-  rof[1] = 0;
+  rof[0] = -1;
+  rof[1] = -1;
 }
 
 GPUhdi() Line::Line(const Line& other)
@@ -88,8 +88,8 @@ GPUhdi() Line::Line(const float firstPoint[3], const float secondPoint[3])
     cosinesDirector[index] *= inverseNorm;
   }
 
-  rof[0] = 0;
-  rof[1] = 0;
+  rof[0] = -1;
+  rof[1] = -1;
 }
 
 GPUhdi() Line::Line(const Tracklet& tracklet, const Cluster* innerClusters, const Cluster* outerClusters)
@@ -208,7 +208,7 @@ inline bool Line::operator!=(const Line& rhs) const
 
 GPUhdi() void Line::print() const
 {
-  printf("Line: originPoint = (%f, %f, %f), cosinesDirector = (%f, %f, %f), rofs = (%u, %u)\n",
+  printf("Line: originPoint = (%f, %f, %f), cosinesDirector = (%f, %f, %f), rofs = (%hd, %hd)\n",
          originPoint[0], originPoint[1], originPoint[2], cosinesDirector[0], cosinesDirector[1], cosinesDirector[2], rof[0], rof[1]);
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -114,7 +114,7 @@ struct VertexingParameters {
   std::vector<float> LayerRadii = {2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f};
   int ZBins{1};
   int PhiBins{128};
-
+  int deltaRof = 0;
   float zCut = 0.002f;
   float phiCut = 0.005f;
   float pairCut = 0.04f;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -78,12 +78,12 @@ class TimeFrame
   friend class TimeFrameGPU;
   TimeFrame(int nLayers = 7);
   const Vertex& getPrimaryVertex(const int) const;
-  gsl::span<const Vertex> getPrimaryVertices(int rof) const;
+  gsl::span<const Vertex> getPrimaryVertices(int rofId) const;
   gsl::span<const Vertex> getPrimaryVertices(int romin, int romax) const;
-  gsl::span<const std::pair<MCCompLabel, float>> getPrimaryVerticesMCRecInfo(const int rof) const;
-  gsl::span<const std::array<float, 2>> getPrimaryVerticesXAlpha(int tf) const;
+  gsl::span<const std::pair<MCCompLabel, float>> getPrimaryVerticesMCRecInfo(const int rofId) const;
+  gsl::span<const std::array<float, 2>> getPrimaryVerticesXAlpha(int rofId) const;
   void fillPrimaryVerticesXandAlpha();
-  int getPrimaryVerticesNum(int rofID = -1) const;
+  int getPrimaryVerticesNum(int rofId = -1) const;
   void addPrimaryVertices(const std::vector<Vertex>& vertices);
   void addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, float>>& labels);
   void addPrimaryVertices(const gsl::span<const Vertex>& vertices);
@@ -104,7 +104,7 @@ class TimeFrame
   std::vector<int>& getTotVertIteration() { return mTotVertPerIteration; }
   bool empty() const;
   bool isGPU() const { return mIsGPU; }
-  int getSortedIndex(int rof, int layer, int i) const;
+  int getSortedIndex(int rofId, int layer, int i) const;
   int getSortedStartIndex(const int, const int) const;
   int getNrof() const;
 
@@ -170,10 +170,10 @@ class TimeFrame
   std::vector<std::vector<int>>& getCellsNeighbours();
   std::vector<std::vector<int>>& getCellsNeighboursLUT();
   std::vector<Road<5>>& getRoads();
-  std::vector<TrackITSExt>& getTracks(int rof) { return mTracks[rof]; }
-  std::vector<MCCompLabel>& getTracksLabel(const int rof) { return mTracksLabel[rof]; }
-  std::vector<MCCompLabel>& getLinesLabel(const int rof) { return mLinesLabels[rof]; }
-  std::vector<std::pair<MCCompLabel, float>>& getVerticesMCRecInfo() { return mVerticesMCRecInfo; }
+  std::vector<TrackITSExt>& getTracks(int rofId) { return mTracks[rofId]; }
+  std::vector<MCCompLabel>& getTracksLabel(const int rofId) { return mTracksLabel[rofId]; }
+  std::vector<MCCompLabel>& getLinesLabel(const int rofId) { return mLinesLabels[rofId]; }
+    std::vector<std::pair<MCCompLabel, float>>& getVerticesMCRecInfo() { return mVerticesMCRecInfo; }
 
   int getNumberOfClusters() const;
   int getNumberOfCells() const;
@@ -191,13 +191,13 @@ class TimeFrame
   // Vertexer
   void computeTrackletsPerROFScans();
   void computeTracletsPerClusterScans();
-  int& getNTrackletsROF(int rof, int combId);
-  std::vector<Line>& getLines(int rof);
+  int& getNTrackletsROF(int rofId, int combId);
+  std::vector<Line>& getLines(int rofId);
   int getNLinesTotal() const
   {
     return std::accumulate(mLines.begin(), mLines.end(), 0, [](int sum, const auto& l) { return sum + l.size(); });
   }
-  std::vector<ClusterLines>& getTrackletClusters(int rof);
+  std::vector<ClusterLines>& getTrackletClusters(int rofId);
   gsl::span<const Tracklet> getFoundTracklets(int rofId, int combId) const;
   gsl::span<Tracklet> getFoundTracklets(int rofId, int combId);
   gsl::span<const MCCompLabel> getLabelsFoundTracklets(int rofId, int combId) const;
@@ -207,6 +207,7 @@ class TimeFrame
   int getTotalClustersPerROFrange(int rofMin, int range, int layerId) const;
   std::array<float, 2>& getBeamXY() { return mBeamPos; }
   unsigned int& getNoVertexROF() { return mNoVertexROF; }
+  void insertLateVertex(const Vertex& vertex);
   // \Vertexer
 
   void initialiseRoadLabels();
@@ -342,19 +343,19 @@ class TimeFrame
 
 inline const Vertex& TimeFrame::getPrimaryVertex(const int vertexIndex) const { return mPrimaryVertices[vertexIndex]; }
 
-inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int rof) const
+inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int rofId) const
 {
-  const int start = mROFramesPV[rof];
-  const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
-  int delta = mMultiplicityCutMask[rof] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  const int start = mROFramesPV[rofId];
+  const int stop_idx = rofId >= mNrof - 1 ? mNrof : rofId + 1;
+  int delta = mMultiplicityCutMask[rofId] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&mPrimaryVertices[start], static_cast<gsl::span<const Vertex>::size_type>(delta)};
 }
 
-inline gsl::span<const std::pair<MCCompLabel, float>> TimeFrame::getPrimaryVerticesMCRecInfo(const int rof) const
+inline gsl::span<const std::pair<MCCompLabel, float>> TimeFrame::getPrimaryVerticesMCRecInfo(const int rofId) const
 {
-  const int start = mROFramesPV[rof];
-  const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
-  int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  const int start = mROFramesPV[rofId];
+  const int stop_idx = rofId >= mNrof - 1 ? mNrof : rofId + 1;
+  int delta = mMultiplicityCutMask[rofId] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&(mVerticesMCRecInfo[start]), static_cast<gsl::span<const std::pair<MCCompLabel, float>>::size_type>(delta)};
 }
 
@@ -363,24 +364,24 @@ inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int romin, int roma
   return {&mPrimaryVertices[mROFramesPV[romin]], static_cast<gsl::span<const Vertex>::size_type>(mROFramesPV[romax + 1] - mROFramesPV[romin])};
 }
 
-inline gsl::span<const std::array<float, 2>> TimeFrame::getPrimaryVerticesXAlpha(int rof) const
+inline gsl::span<const std::array<float, 2>> TimeFrame::getPrimaryVerticesXAlpha(int rofId) const
 {
-  const int start = mROFramesPV[rof];
-  const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
-  int delta = mMultiplicityCutMask[rof] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  const int start = mROFramesPV[rofId];
+  const int stop_idx = rofId >= mNrof - 1 ? mNrof : rofId + 1;
+  int delta = mMultiplicityCutMask[rofId] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&(mPValphaX[start]), static_cast<gsl::span<const std::array<float, 2>>::size_type>(delta)};
 }
 
-inline int TimeFrame::getPrimaryVerticesNum(int rofID) const
+inline int TimeFrame::getPrimaryVerticesNum(int rofId) const
 {
-  return rofID < 0 ? mPrimaryVertices.size() : mROFramesPV[rofID + 1] - mROFramesPV[rofID];
+  return rofId < 0 ? mPrimaryVertices.size() : mROFramesPV[rofId + 1] - mROFramesPV[rofId];
 }
 
 inline bool TimeFrame::empty() const { return getTotalClusters() == 0; }
 
-inline int TimeFrame::getSortedIndex(int rof, int layer, int index) const { return mROFramesClusters[layer][rof] + index; }
+inline int TimeFrame::getSortedIndex(int rofId, int layer, int index) const { return mROFramesClusters[layer][rofId] + index; }
 
-inline int TimeFrame::getSortedStartIndex(const int rof, const int layer) const { return mROFramesClusters[layer][rof]; }
+inline int TimeFrame::getSortedStartIndex(const int rofId, const int layer) const { return mROFramesClusters[layer][rofId]; }
 
 inline int TimeFrame::getNrof() const { return mNrof; }
 
@@ -507,14 +508,14 @@ inline gsl::span<int> TimeFrame::getIndexTable(int rofId, int layer)
           static_cast<gsl::span<int>::size_type>(mIndexTableUtils.getNphiBins() * mIndexTableUtils.getNzBins() + 1)};
 }
 
-inline std::vector<Line>& TimeFrame::getLines(int rof)
+inline std::vector<Line>& TimeFrame::getLines(int rofId)
 {
-  return mLines[rof];
+  return mLines[rofId];
 }
 
-inline std::vector<ClusterLines>& TimeFrame::getTrackletClusters(int rof)
+inline std::vector<ClusterLines>& TimeFrame::getTrackletClusters(int rofId)
 {
-  return mTrackletClusters[rof];
+  return mTrackletClusters[rofId];
 }
 
 template <typename... T>
@@ -597,9 +598,9 @@ inline gsl::span<int> TimeFrame::getExclusiveNTrackletsCluster(int rofId, int co
   return {&mNTrackletsPerClusterSum[combId][clusStartIdx], static_cast<gsl::span<int>::size_type>(mROFramesClusters[1][rofId + 1] - clusStartIdx)};
 }
 
-inline int& TimeFrame::getNTrackletsROF(int rof, int combId)
+inline int& TimeFrame::getNTrackletsROF(int rofId, int combId)
 {
-  return mNTrackletsPerROF[combId][rof];
+  return mNTrackletsPerROF[combId][rofId];
 }
 
 inline bool TimeFrame::isRoadFake(int i) const
@@ -708,6 +709,15 @@ inline size_t TimeFrame::getNumberOfUsedClusters() const
     nClusters += std::count(layer.begin(), layer.end(), true);
   }
   return nClusters;
+}
+
+inline void TimeFrame::insertLateVertex(const Vertex& vertex)
+{
+  int rofId = vertex.getTimeStamp().getTimeStamp();
+  mPrimaryVertices.insert(mPrimaryVertices.begin() + mROFramesPV[rofId + 1], vertex); // inserted at the end of sequence of vertices belonging to rofId
+  for (int i = rofId + 1; i < mROFramesPV.size(); ++i) {
+    mROFramesPV[i] += 1;
+  }
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -210,7 +210,7 @@ class TimeFrame
   int getTotalClustersPerROFrange(int rofMin, int range, int layerId) const;
   std::array<float, 2>& getBeamXY() { return mBeamPos; }
   unsigned int& getNoVertexROF() { return mNoVertexROF; }
-  void insertLateVertex(const Vertex& vertex);
+  void insertPastVertex(const Vertex& vertex);
   // \Vertexer
 
   void initialiseRoadLabels();
@@ -732,10 +732,10 @@ inline size_t TimeFrame::getNumberOfUsedClusters() const
   return nClusters;
 }
 
-inline void TimeFrame::insertLateVertex(const Vertex& vertex)
+inline void TimeFrame::insertPastVertex(const Vertex& vertex)
 {
   int rofId = vertex.getTimeStamp().getTimeStamp();
-  mPrimaryVertices.insert(mPrimaryVertices.begin() + mROFramesPV[rofId + 1], vertex); // inserted at the end of sequence of vertices belonging to rofId
+  mPrimaryVertices.insert(mPrimaryVertices.begin() + mROFramesPV[rofId], vertex);
   for (int i = rofId + 1; i < mROFramesPV.size(); ++i) {
     mROFramesPV[i] += 1;
   }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -78,7 +78,7 @@ class TimeFrame
   friend class TimeFrameGPU;
   TimeFrame(int nLayers = 7);
   const Vertex& getPrimaryVertex(const int) const;
-  gsl::span<const Vertex> getPrimaryVertices(int tf) const;
+  gsl::span<const Vertex> getPrimaryVertices(int rof) const;
   gsl::span<const Vertex> getPrimaryVertices(int romin, int romax) const;
   gsl::span<const std::pair<MCCompLabel, float>> getPrimaryVerticesMCRecInfo(const int rof) const;
   gsl::span<const std::array<float, 2>> getPrimaryVerticesXAlpha(int tf) const;
@@ -128,8 +128,8 @@ class TimeFrame
   gsl::span<const Cluster> getClustersOnLayer(int rofId, int layerId) const;
   gsl::span<const Cluster> getClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const Cluster> getUnsortedClustersOnLayer(int rofId, int layerId) const;
-  gsl::span<const int> getROframesClustersPerROFrange(int rofMin, int range, int layerId) const;
-  gsl::span<const int> getROframeClusters(int layerId) const;
+  gsl::span<const int> getROFramesClustersPerROFrange(int rofMin, int range, int layerId) const;
+  gsl::span<const int> getROFrameClusters(int layerId) const;
   gsl::span<const int> getNClustersROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const int> getIndexTablePerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<int> getIndexTable(int rofId, int layerId);
@@ -151,11 +151,12 @@ class TimeFrame
   void resetRofPV()
   {
     mPrimaryVertices.clear();
-    mROframesPV.resize(1, 0);
+    mROFramesPV.resize(1, 0);
   };
 
   bool isClusterUsed(int layer, int clusterId) const;
   void markUsedCluster(int layer, int clusterId);
+  gsl::span<unsigned char> getUsedClusters(const int layer);
 
   std::vector<std::vector<Tracklet>>& getTracklets();
   std::vector<std::vector<int>>& getTrackletsLookupTable();
@@ -183,15 +184,19 @@ class TimeFrame
 
   bool checkMemory(unsigned long max) { return getArtefactsMemory() < max; }
   unsigned long getArtefactsMemory();
-  int getROfCutClusterMult() const { return mCutClusterMult; };
-  int getROfCutVertexMult() const { return mCutVertexMult; };
-  int getROfCutAllMult() const { return mCutClusterMult + mCutVertexMult; }
+  int getROFCutClusterMult() const { return mCutClusterMult; };
+  int getROFCutVertexMult() const { return mCutVertexMult; };
+  int getROFCutAllMult() const { return mCutClusterMult + mCutVertexMult; }
 
   // Vertexer
   void computeTrackletsScans(const int nThreads = 1);
-  int& getNTrackletsROf(int tf, int combId);
-  std::vector<Line>& getLines(int tf);
-  std::vector<ClusterLines>& getTrackletClusters(int tf);
+  int& getNTrackletsROF(int rof, int combId);
+  std::vector<Line>& getLines(int rof);
+  int getNLinesTotal() const
+  {
+    return std::accumulate(mLines.begin(), mLines.end(), 0, [](int sum, const auto& l) { return sum + l.size(); });
+  }
+  std::vector<ClusterLines>& getTrackletClusters(int rof);
   gsl::span<const Tracklet> getFoundTracklets(int rofId, int combId) const;
   gsl::span<Tracklet> getFoundTracklets(int rofId, int combId);
   gsl::span<const MCCompLabel> getLabelsFoundTracklets(int rofId, int combId) const;
@@ -261,15 +266,15 @@ class TimeFrame
   std::vector<std::vector<Cluster>> mClusters;
   std::vector<std::vector<TrackingFrameInfo>> mTrackingFrameInfo;
   std::vector<std::vector<int>> mClusterExternalIndices;
-  std::vector<std::vector<int>> mROframesClusters;
+  std::vector<std::vector<int>> mROFramesClusters;
   const dataformats::MCTruthContainer<MCCompLabel>* mClusterLabels = nullptr;
-  std::array<std::vector<int>, 2> mNTrackletsPerCluster; // TODO: remove in favour of mNTrackletsPerROf
+  std::array<std::vector<int>, 2> mNTrackletsPerCluster; // TODO: remove in favour of mNTrackletsPerROF
   std::vector<std::vector<int>> mNClustersPerROF;
   std::vector<std::vector<int>> mIndexTables;
   std::vector<std::vector<int>> mTrackletsLookupTable;
   std::vector<std::vector<unsigned char>> mUsedClusters;
   int mNrof = 0;
-  std::vector<int> mROframesPV = {0};
+  std::vector<int> mROFramesPV = {0};
   std::vector<Vertex> mPrimaryVertices;
 
   // State if memory will be externally managed.
@@ -320,10 +325,10 @@ class TimeFrame
   int mCutVertexMult;
 
   // Vertexer
-  std::vector<std::vector<int>> mNTrackletsPerROf;
+  std::vector<std::vector<int>> mNTrackletsPerROF;
   std::vector<std::vector<Line>> mLines;
   std::vector<std::vector<ClusterLines>> mTrackletClusters;
-  std::vector<std::vector<int>> mTrackletsIndexROf;
+  std::vector<std::vector<int>> mTrackletsIndexROF;
   std::vector<std::vector<MCCompLabel>> mLinesLabels;
   std::vector<std::pair<MCCompLabel, float>> mVerticesMCRecInfo;
   std::array<uint32_t, 2> mTotalTracklets = {0, 0};
@@ -336,15 +341,15 @@ inline const Vertex& TimeFrame::getPrimaryVertex(const int vertexIndex) const { 
 
 inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int rof) const
 {
-  const int start = mROframesPV[rof];
+  const int start = mROFramesPV[rof];
   const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
-  int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  int delta = mMultiplicityCutMask[rof] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&mPrimaryVertices[start], static_cast<gsl::span<const Vertex>::size_type>(delta)};
 }
 
 inline gsl::span<const std::pair<MCCompLabel, float>> TimeFrame::getPrimaryVerticesMCRecInfo(const int rof) const
 {
-  const int start = mROframesPV[rof];
+  const int start = mROFramesPV[rof];
   const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
   int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&(mVerticesMCRecInfo[start]), static_cast<gsl::span<const std::pair<MCCompLabel, float>>::size_type>(delta)};
@@ -352,27 +357,27 @@ inline gsl::span<const std::pair<MCCompLabel, float>> TimeFrame::getPrimaryVerti
 
 inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int romin, int romax) const
 {
-  return {&mPrimaryVertices[mROframesPV[romin]], static_cast<gsl::span<const Vertex>::size_type>(mROframesPV[romax + 1] - mROframesPV[romin])};
+  return {&mPrimaryVertices[mROFramesPV[romin]], static_cast<gsl::span<const Vertex>::size_type>(mROFramesPV[romax + 1] - mROFramesPV[romin])};
 }
 
 inline gsl::span<const std::array<float, 2>> TimeFrame::getPrimaryVerticesXAlpha(int rof) const
 {
-  const int start = mROframesPV[rof];
+  const int start = mROFramesPV[rof];
   const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
-  int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  int delta = mMultiplicityCutMask[rof] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&(mPValphaX[start]), static_cast<gsl::span<const std::array<float, 2>>::size_type>(delta)};
 }
 
 inline int TimeFrame::getPrimaryVerticesNum(int rofID) const
 {
-  return rofID < 0 ? mPrimaryVertices.size() : mROframesPV[rofID + 1] - mROframesPV[rofID];
+  return rofID < 0 ? mPrimaryVertices.size() : mROFramesPV[rofID + 1] - mROFramesPV[rofID];
 }
 
 inline bool TimeFrame::empty() const { return getTotalClusters() == 0; }
 
-inline int TimeFrame::getSortedIndex(int rof, int layer, int index) const { return mROframesClusters[layer][rof] + index; }
+inline int TimeFrame::getSortedIndex(int rof, int layer, int index) const { return mROFramesClusters[layer][rof] + index; }
 
-inline int TimeFrame::getSortedStartIndex(const int rof, const int layer) const { return mROframesClusters[layer][rof]; }
+inline int TimeFrame::getSortedStartIndex(const int rof, const int layer) const { return mROFramesClusters[layer][rof]; }
 
 inline int TimeFrame::getNrof() const { return mNrof; }
 
@@ -387,9 +392,9 @@ inline float TimeFrame::getBeamX() const { return mBeamPos[0]; }
 
 inline float TimeFrame::getBeamY() const { return mBeamPos[1]; }
 
-inline gsl::span<const int> TimeFrame::getROframeClusters(int layerId) const
+inline gsl::span<const int> TimeFrame::getROFrameClusters(int layerId) const
 {
-  return {&mROframesClusters[layerId][0], static_cast<gsl::span<const int>::size_type>(mROframesClusters[layerId].size())};
+  return {&mROFramesClusters[layerId][0], static_cast<gsl::span<const int>::size_type>(mROFramesClusters[layerId].size())};
 }
 
 inline gsl::span<Cluster> TimeFrame::getClustersOnLayer(int rofId, int layerId)
@@ -397,8 +402,8 @@ inline gsl::span<Cluster> TimeFrame::getClustersOnLayer(int rofId, int layerId)
   if (rofId < 0 || rofId >= mNrof) {
     return gsl::span<Cluster>();
   }
-  int startIdx{mROframesClusters[layerId][rofId]};
-  return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROframesClusters[layerId][rofId + 1] - startIdx)};
+  int startIdx{mROFramesClusters[layerId][rofId]};
+  return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROFramesClusters[layerId][rofId + 1] - startIdx)};
 }
 
 inline gsl::span<const Cluster> TimeFrame::getClustersOnLayer(int rofId, int layerId) const
@@ -406,8 +411,8 @@ inline gsl::span<const Cluster> TimeFrame::getClustersOnLayer(int rofId, int lay
   if (rofId < 0 || rofId >= mNrof) {
     return gsl::span<const Cluster>();
   }
-  int startIdx{mROframesClusters[layerId][rofId]};
-  return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROframesClusters[layerId][rofId + 1] - startIdx)};
+  int startIdx{mROFramesClusters[layerId][rofId]};
+  return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROFramesClusters[layerId][rofId + 1] - startIdx)};
 }
 
 inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, int range, int layerId) const
@@ -415,15 +420,15 @@ inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, in
   if (rofMin < 0 || rofMin >= mNrof) {
     return gsl::span<const Cluster>();
   }
-  int startIdx{mROframesClusters[layerId][rofMin]}; // First cluster of rofMin
-  int endIdx{mROframesClusters[layerId][std::min(rofMin + range, mNrof)]};
+  int startIdx{mROFramesClusters[layerId][rofMin]}; // First cluster of rofMin
+  int endIdx{mROFramesClusters[layerId][std::min(rofMin + range, mNrof)]};
   return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(endIdx - startIdx)};
 }
 
-inline gsl::span<const int> TimeFrame::getROframesClustersPerROFrange(int rofMin, int range, int layerId) const
+inline gsl::span<const int> TimeFrame::getROFramesClustersPerROFrange(int rofMin, int range, int layerId) const
 {
   int chkdRange{std::min(range, mNrof - rofMin)};
-  return {&mROframesClusters[layerId][rofMin], static_cast<gsl::span<int>::size_type>(chkdRange)};
+  return {&mROFramesClusters[layerId][rofMin], static_cast<gsl::span<int>::size_type>(chkdRange)};
 }
 
 inline gsl::span<const int> TimeFrame::getNClustersROFrange(int rofMin, int range, int layerId) const
@@ -436,7 +441,7 @@ inline int TimeFrame::getTotalClustersPerROFrange(int rofMin, int range, int lay
 {
   int startIdx{rofMin}; // First cluster of rofMin
   int endIdx{std::min(rofMin + range, mNrof)};
-  return mROframesClusters[layerId][endIdx] - mROframesClusters[layerId][startIdx];
+  return mROFramesClusters[layerId][endIdx] - mROFramesClusters[layerId][startIdx];
 }
 
 inline gsl::span<const int> TimeFrame::getIndexTablePerROFrange(int rofMin, int range, int layerId) const
@@ -448,7 +453,7 @@ inline gsl::span<const int> TimeFrame::getIndexTablePerROFrange(int rofMin, int 
 
 inline int TimeFrame::getClusterROF(int iLayer, int iCluster)
 {
-  return std::lower_bound(mROframesClusters[iLayer].begin(), mROframesClusters[iLayer].end(), iCluster + 1) - mROframesClusters[iLayer].begin() - 1;
+  return std::lower_bound(mROFramesClusters[iLayer].begin(), mROFramesClusters[iLayer].end(), iCluster + 1) - mROFramesClusters[iLayer].begin() - 1;
 }
 
 inline gsl::span<const Cluster> TimeFrame::getUnsortedClustersOnLayer(int rofId, int layerId) const
@@ -456,8 +461,8 @@ inline gsl::span<const Cluster> TimeFrame::getUnsortedClustersOnLayer(int rofId,
   if (rofId < 0 || rofId >= mNrof) {
     return gsl::span<const Cluster>();
   }
-  int startIdx{mROframesClusters[layerId][rofId]};
-  return {&mUnsortedClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROframesClusters[layerId][rofId + 1] - startIdx)};
+  int startIdx{mROFramesClusters[layerId][rofId]};
+  return {&mUnsortedClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROFramesClusters[layerId][rofId + 1] - startIdx)};
 }
 
 inline const std::vector<TrackingFrameInfo>& TimeFrame::getTrackingFrameInfoOnLayer(int layerId) const
@@ -536,6 +541,11 @@ inline bool TimeFrame::isClusterUsed(int layer, int clusterId) const
   return mUsedClusters[layer][clusterId];
 }
 
+inline gsl::span<unsigned char> TimeFrame::getUsedClusters(const int layer)
+{
+  return {&mUsedClusters[layer][0], static_cast<gsl::span<unsigned char>::size_type>(mUsedClusters[layer].size())};
+}
+
 inline void TimeFrame::markUsedCluster(int layer, int clusterId) { mUsedClusters[layer][clusterId] = true; }
 
 inline std::vector<std::vector<Tracklet>>& TimeFrame::getTracklets()
@@ -570,13 +580,13 @@ inline gsl::span<int> TimeFrame::getNTrackletsCluster(int rofId, int combId)
   if (rofId < 0 || rofId >= mNrof) {
     return gsl::span<int>();
   }
-  auto startIdx{mROframesClusters[1][rofId]};
-  return {&mNTrackletsPerCluster[combId][startIdx], static_cast<gsl::span<int>::size_type>(mROframesClusters[1][rofId + 1] - startIdx)};
+  auto startIdx{mROFramesClusters[1][rofId]};
+  return {&mNTrackletsPerCluster[combId][startIdx], static_cast<gsl::span<int>::size_type>(mROFramesClusters[1][rofId + 1] - startIdx)};
 }
 
-inline int& TimeFrame::getNTrackletsROf(int rof, int combId)
+inline int& TimeFrame::getNTrackletsROF(int rof, int combId)
 {
-  return mNTrackletsPerROf[combId][rof];
+  return mNTrackletsPerROF[combId][rof];
 }
 
 inline bool TimeFrame::isRoadFake(int i) const
@@ -611,8 +621,8 @@ inline gsl::span<Tracklet> TimeFrame::getFoundTracklets(int rofId, int combId)
   if (rofId < 0 || rofId >= mNrof) {
     return gsl::span<Tracklet>();
   }
-  auto startIdx{mNTrackletsPerROf[combId][rofId]};
-  return {&mTracklets[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROf[combId][rofId + 1] - startIdx)};
+  auto startIdx{mNTrackletsPerROF[combId][rofId]};
+  return {&mTracklets[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROF[combId][rofId + 1] - startIdx)};
 }
 
 inline gsl::span<const Tracklet> TimeFrame::getFoundTracklets(int rofId, int combId) const
@@ -620,8 +630,8 @@ inline gsl::span<const Tracklet> TimeFrame::getFoundTracklets(int rofId, int com
   if (rofId < 0 || rofId >= mNrof) {
     return gsl::span<const Tracklet>();
   }
-  auto startIdx{mNTrackletsPerROf[combId][rofId]};
-  return {&mTracklets[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROf[combId][rofId + 1] - startIdx)};
+  auto startIdx{mNTrackletsPerROF[combId][rofId]};
+  return {&mTracklets[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROF[combId][rofId + 1] - startIdx)};
 }
 
 inline gsl::span<const MCCompLabel> TimeFrame::getLabelsFoundTracklets(int rofId, int combId) const
@@ -629,8 +639,8 @@ inline gsl::span<const MCCompLabel> TimeFrame::getLabelsFoundTracklets(int rofId
   if (rofId < 0 || rofId >= mNrof || !hasMCinformation()) {
     return gsl::span<const MCCompLabel>();
   }
-  auto startIdx{mNTrackletsPerROf[combId][rofId]};
-  return {&mTrackletLabels[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROf[combId][rofId + 1] - startIdx)};
+  auto startIdx{mNTrackletsPerROF[combId][rofId]};
+  return {&mTrackletLabels[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROF[combId][rofId + 1] - startIdx)};
 }
 
 inline int TimeFrame::getNumberOfClusters() const

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -128,6 +128,8 @@ class TimeFrame
   gsl::span<const Cluster> getClustersOnLayer(int rofId, int layerId) const;
   gsl::span<const Cluster> getClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const Cluster> getUnsortedClustersOnLayer(int rofId, int layerId) const;
+  gsl::span<unsigned char> getUsedClustersROF(int rofId, int layerId);
+  gsl::span<const unsigned char> getUsedClustersROF(int rofId, int layerId) const;
   gsl::span<const int> getROFramesClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const int> getROFrameClusters(int layerId) const;
   gsl::span<const int> getNClustersROFrange(int rofMin, int range, int layerId) const;
@@ -150,7 +152,8 @@ class TimeFrame
   void initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers = 7, bool resetVertices = true);
   void resetRofPV()
   {
-    mPrimaryVertices.clear();
+    // mPrimaryVertices.clear();
+    deepVectorClear(mPrimaryVertices);
     mROFramesPV.resize(1, 0);
   };
 
@@ -271,7 +274,7 @@ class TimeFrame
   std::vector<std::vector<int>> mClusterExternalIndices;
   std::vector<std::vector<int>> mROFramesClusters;
   const dataformats::MCTruthContainer<MCCompLabel>* mClusterLabels = nullptr;
-  std::array<std::vector<int>, 2> mNTrackletsPerCluster; // TODO: remove in favour of mNTrackletsPerROF
+  std::array<std::vector<int>, 2> mNTrackletsPerCluster;
   std::array<std::vector<int>, 2> mNTrackletsPerClusterSum;
   std::vector<std::vector<int>> mNClustersPerROF;
   std::vector<std::vector<int>> mIndexTables;
@@ -417,6 +420,24 @@ inline gsl::span<const Cluster> TimeFrame::getClustersOnLayer(int rofId, int lay
   }
   int startIdx{mROFramesClusters[layerId][rofId]};
   return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROFramesClusters[layerId][rofId + 1] - startIdx)};
+}
+
+inline gsl::span<unsigned char> TimeFrame::getUsedClustersROF(int rofId, int layerId)
+{
+  if (rofId < 0 || rofId >= mNrof) {
+    return gsl::span<unsigned char>();
+  }
+  int startIdx{mROFramesClusters[layerId][rofId]};
+  return {&mUsedClusters[layerId][startIdx], static_cast<gsl::span<unsigned char>::size_type>(mROFramesClusters[layerId][rofId + 1] - startIdx)};
+}
+
+inline gsl::span<const unsigned char> TimeFrame::getUsedClustersROF(int rofId, int layerId) const
+{
+  if (rofId < 0 || rofId >= mNrof) {
+    return gsl::span<const unsigned char>();
+  }
+  int startIdx{mROFramesClusters[layerId][rofId]};
+  return {&mUsedClusters[layerId][startIdx], static_cast<gsl::span<unsigned char>::size_type>(mROFramesClusters[layerId][rofId + 1] - startIdx)};
 }
 
 inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, int range, int layerId) const

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -189,7 +189,8 @@ class TimeFrame
   int getROFCutAllMult() const { return mCutClusterMult + mCutVertexMult; }
 
   // Vertexer
-  void computeTrackletsScans(const int nThreads = 1);
+  void computeTrackletsPerROFScans();
+  void computeTracletsPerClusterScans();
   int& getNTrackletsROF(int rof, int combId);
   std::vector<Line>& getLines(int rof);
   int getNLinesTotal() const
@@ -201,6 +202,7 @@ class TimeFrame
   gsl::span<Tracklet> getFoundTracklets(int rofId, int combId);
   gsl::span<const MCCompLabel> getLabelsFoundTracklets(int rofId, int combId) const;
   gsl::span<int> getNTrackletsCluster(int rofId, int combId);
+  gsl::span<int> getExclusiveNTrackletsCluster(int rofId, int combId);
   uint32_t getTotalTrackletsTF(const int iLayer) { return mTotalTracklets[iLayer]; }
   int getTotalClustersPerROFrange(int rofMin, int range, int layerId) const;
   std::array<float, 2>& getBeamXY() { return mBeamPos; }
@@ -269,6 +271,7 @@ class TimeFrame
   std::vector<std::vector<int>> mROFramesClusters;
   const dataformats::MCTruthContainer<MCCompLabel>* mClusterLabels = nullptr;
   std::array<std::vector<int>, 2> mNTrackletsPerCluster; // TODO: remove in favour of mNTrackletsPerROF
+  std::array<std::vector<int>, 2> mNTrackletsPerClusterSum;
   std::vector<std::vector<int>> mNClustersPerROF;
   std::vector<std::vector<int>> mIndexTables;
   std::vector<std::vector<int>> mTrackletsLookupTable;
@@ -582,6 +585,16 @@ inline gsl::span<int> TimeFrame::getNTrackletsCluster(int rofId, int combId)
   }
   auto startIdx{mROFramesClusters[1][rofId]};
   return {&mNTrackletsPerCluster[combId][startIdx], static_cast<gsl::span<int>::size_type>(mROFramesClusters[1][rofId + 1] - startIdx)};
+}
+
+inline gsl::span<int> TimeFrame::getExclusiveNTrackletsCluster(int rofId, int combId)
+{
+  if (rofId < 0 || rofId >= mNrof) {
+    return gsl::span<int>();
+  }
+  auto clusStartIdx{mROFramesClusters[1][rofId]};
+
+  return {&mNTrackletsPerClusterSum[combId][clusStartIdx], static_cast<gsl::span<int>::size_type>(mROFramesClusters[1][rofId + 1] - clusStartIdx)};
 }
 
 inline int& TimeFrame::getNTrackletsROF(int rof, int combId)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -86,8 +86,8 @@ class TimeFrame
   int getPrimaryVerticesNum(int rofId = -1) const;
   void addPrimaryVertices(const std::vector<Vertex>& vertices);
   void addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, float>>& labels);
-  void addPrimaryVertices(const gsl::span<const Vertex>& vertices);
-  void addPrimaryVertices(const std::vector<lightVertex>&);
+  void addPrimaryVertices(const std::vector<Vertex>& vertices, const int rofId);
+  void addPrimaryVertices(const gsl::span<const Vertex>& vertices, const int rofId);
   void addPrimaryVerticesInROF(const std::vector<Vertex>& vertices, const int rofId);
   void addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCCompLabel, float>>& labels, const int rofId);
   void removePrimaryVerticesInROf(const int rofId);
@@ -358,7 +358,7 @@ inline gsl::span<const std::pair<MCCompLabel, float>> TimeFrame::getPrimaryVerti
 {
   const int start = mROFramesPV[rofId];
   const int stop_idx = rofId >= mNrof - 1 ? mNrof : rofId + 1;
-  int delta = mMultiplicityCutMask[rofId] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  int delta = mMultiplicityCutMask[rofId] ? mROFramesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&(mVerticesMCRecInfo[start]), static_cast<gsl::span<const std::pair<MCCompLabel, float>>::size_type>(delta)};
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -25,6 +25,8 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   int nIterations = 1;         // Number of vertexing passes to perform
   int vertPerRofThreshold = 0; // Maximum number of vertices per ROF to trigger second a round
   bool allowSingleContribClusters = false;
+  // Number of ROFs to be considered for the vertexing
+  int deltaRof = 0;
 
   // geometrical cuts
   float zCut = 0.002f;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -32,8 +32,8 @@ namespace its
 
 struct Tracklet final {
   GPUhdi() Tracklet();
-  GPUhdi() Tracklet(const int, const int, const Cluster&, const Cluster&, int rof0, int rof1);
-  GPUhdi() Tracklet(const int, const int, float tanL, float phi, int rof0, int rof1);
+  GPUhdi() Tracklet(const int, const int, const Cluster&, const Cluster&, short rof0, short rof1);
+  GPUhdi() Tracklet(const int, const int, float tanL, float phi, short rof0, short rof1);
   GPUhdi() bool operator==(const Tracklet&) const;
   GPUhdi() bool operator!=(const Tracklet&) const;
   GPUhdi() unsigned char isEmpty() const
@@ -58,34 +58,34 @@ struct Tracklet final {
   int secondClusterIndex;
   float tanLambda;
   float phi;
-  unsigned short rof[2];
+  short rof[2];
 };
 
 GPUhdi() Tracklet::Tracklet() : firstClusterIndex{-1}, secondClusterIndex{-1}, tanLambda{0.0f}, phi{0.0f}
 {
-  rof[0] = 0;
-  rof[1] = 0;
+  rof[0] = -1;
+  rof[1] = -1;
 }
 
 GPUhdi() Tracklet::Tracklet(const int firstClusterOrderingIndex, const int secondClusterOrderingIndex,
-                            const Cluster& firstCluster, const Cluster& secondCluster, int rof0 = -1, int rof1 = -1)
+                            const Cluster& firstCluster, const Cluster& secondCluster, short rof0 = -1, short rof1 = -1)
   : firstClusterIndex{firstClusterOrderingIndex},
     secondClusterIndex{secondClusterOrderingIndex},
     tanLambda{(firstCluster.zCoordinate - secondCluster.zCoordinate) /
               (firstCluster.radius - secondCluster.radius)},
     phi{o2::gpu::GPUCommonMath::ATan2(firstCluster.yCoordinate - secondCluster.yCoordinate,
                                       firstCluster.xCoordinate - secondCluster.xCoordinate)},
-    rof{static_cast<unsigned short>(rof0), static_cast<unsigned short>(rof1)}
+    rof{static_cast<short>(rof0), static_cast<short>(rof1)}
 {
   // Nothing to do
 }
 
-GPUhdi() Tracklet::Tracklet(const int idx0, const int idx1, float tanL, float phi, int rof0, int rof1)
+GPUhdi() Tracklet::Tracklet(const int idx0, const int idx1, float tanL, float phi, short rof0, short rof1)
   : firstClusterIndex{idx0},
     secondClusterIndex{idx1},
     tanLambda{tanL},
     phi{phi},
-    rof{static_cast<unsigned short>(rof0), static_cast<unsigned short>(rof1)}
+    rof{static_cast<short>(rof0), static_cast<short>(rof1)}
 {
   // Nothing to do
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -21,6 +21,10 @@
 #include "GPUCommonMath.h"
 #include "GPUCommonDef.h"
 
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <string>
+#endif
+
 namespace o2
 {
 namespace its
@@ -42,6 +46,13 @@ struct Tracklet final {
   GPUhdi() void dump(const int, const int);
   GPUhdi() void dump(const int, const int) const;
   GPUhdi() unsigned char operator<(const Tracklet&) const;
+#ifndef GPUCA_GPUCODE_DEVICE
+  std::string asString() const
+  {
+    return "fClIdx: " + std::to_string(firstClusterIndex) + " sClIdx: " + std::to_string(secondClusterIndex) +
+           " rof1: " + std::to_string(rof[0]) + " rof2: " + std::to_string(rof[1]);
+  }
+#endif
 
   int firstClusterIndex;
   int secondClusterIndex;
@@ -79,7 +90,7 @@ GPUhdi() Tracklet::Tracklet(const int idx0, const int idx1, float tanL, float ph
   // Nothing to do
 }
 
-GPUhdi() bool Tracklet::operator==(const Tracklet & rhs) const
+GPUhdi() bool Tracklet::operator==(const Tracklet& rhs) const
 {
   return this->firstClusterIndex == rhs.firstClusterIndex &&
          this->secondClusterIndex == rhs.secondClusterIndex &&
@@ -89,7 +100,7 @@ GPUhdi() bool Tracklet::operator==(const Tracklet & rhs) const
          this->rof[1] == rhs.rof[1];
 }
 
-GPUhdi() bool Tracklet::operator!=(const Tracklet & rhs) const
+GPUhdi() bool Tracklet::operator!=(const Tracklet& rhs) const
 {
   return this->firstClusterIndex != rhs.firstClusterIndex ||
          this->secondClusterIndex != rhs.secondClusterIndex ||
@@ -97,33 +108,13 @@ GPUhdi() bool Tracklet::operator!=(const Tracklet & rhs) const
          this->phi != rhs.phi;
 }
 
-GPUhdi() unsigned char Tracklet::operator<(const Tracklet & t) const
+GPUhdi() unsigned char Tracklet::operator<(const Tracklet& t) const
 {
   if (isEmpty()) {
     return false;
   }
   return true;
 }
-
-// GPUhdi() void Tracklet::dump()
-// {
-//   printf("fClIdx: %d sClIdx: %d  rof1: %hu rof2: %hu phi: %f tl: %f \n", firstClusterIndex, secondClusterIndex, rof[0], rof[1], phi, tanLambda);
-// }
-
-// GPUhdi() void Tracklet::dump() const
-// {
-//   printf("fClIdx: %d sClIdx: %d  rof1: %hu rof2: %hu phi: %f tl: %f \n", firstClusterIndex, secondClusterIndex, rof[0], rof[1], phi, tanLambda);
-// }
-
-// GPUhdi() void Tracklet::dump(const int offsetFirst, const int offsetSecond)
-// {
-//   printf("fClIdx: %d sClIdx: %d  rof1: %hu rof2: %hu phi: %f tl: %f \n", firstClusterIndex + offsetFirst, secondClusterIndex + offsetSecond, rof[0], rof[1], phi, tanLambda);
-// }
-
-// GPUhdi() void Tracklet::dump(const int offsetFirst, const int offsetSecond) const
-// {
-//   printf("fClIdx: %d sClIdx: %d  rof1: %hu rof2: %hu phi: %f tl: %f \n", firstClusterIndex + offsetFirst, secondClusterIndex + offsetSecond, rof[0], rof[1], phi, tanLambda);
-// }
 
 GPUhdi() void Tracklet::dump(const int offsetFirst, const int offsetSecond)
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -50,7 +50,7 @@ struct Tracklet final {
   std::string asString() const
   {
     return "fClIdx: " + std::to_string(firstClusterIndex) + " sClIdx: " + std::to_string(secondClusterIndex) +
-           " rof1: " + std::to_string(rof[0]) + " rof2: " + std::to_string(rof[1]);
+           " rof1: " + std::to_string(rof[0]) + " rof2: " + std::to_string(rof[1]) + " delta: " + std::to_string(getDeltaRof());
   }
 #endif
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -36,6 +36,7 @@ struct Tracklet final {
   {
     return firstClusterIndex < 0 || secondClusterIndex < 0;
   }
+  GPUhdi() auto getDeltaRof() const { return rof[1] - rof[0]; }
   GPUhdi() void dump();
   GPUhdi() void dump() const;
   GPUhdi() void dump(const int, const int);
@@ -78,7 +79,7 @@ GPUhdi() Tracklet::Tracklet(const int idx0, const int idx1, float tanL, float ph
   // Nothing to do
 }
 
-GPUhdi() bool Tracklet::operator==(const Tracklet& rhs) const
+GPUhdi() bool Tracklet::operator==(const Tracklet & rhs) const
 {
   return this->firstClusterIndex == rhs.firstClusterIndex &&
          this->secondClusterIndex == rhs.secondClusterIndex &&
@@ -88,7 +89,7 @@ GPUhdi() bool Tracklet::operator==(const Tracklet& rhs) const
          this->rof[1] == rhs.rof[1];
 }
 
-GPUhdi() bool Tracklet::operator!=(const Tracklet& rhs) const
+GPUhdi() bool Tracklet::operator!=(const Tracklet & rhs) const
 {
   return this->firstClusterIndex != rhs.firstClusterIndex ||
          this->secondClusterIndex != rhs.secondClusterIndex ||
@@ -96,7 +97,7 @@ GPUhdi() bool Tracklet::operator!=(const Tracklet& rhs) const
          this->phi != rhs.phi;
 }
 
-GPUhdi() unsigned char Tracklet::operator<(const Tracklet& t) const
+GPUhdi() unsigned char Tracklet::operator<(const Tracklet & t) const
 {
   if (isEmpty()) {
     return false;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -95,7 +95,7 @@ class Vertexer
   float evaluateTask(void (Vertexer::*)(T...), const char*, std::function<void(std::string s)> logger, T&&... args);
   void printEpilog(std::function<void(std::string s)> logger,
                    bool isHybrid,
-                   const unsigned int trackletN01, const unsigned int trackletN12, const unsigned selectedN,
+                   const unsigned int trackletN01, const unsigned int trackletN12, const unsigned selectedN, const unsigned int vertexN,
                    const float initT, const float trackletT, const float selecT, const float vertexT);
 
  private:

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -93,7 +93,10 @@ class Vertexer
   void dumpTraits();
   template <typename... T>
   float evaluateTask(void (Vertexer::*)(T...), const char*, std::function<void(std::string s)> logger, T&&... args);
-  void printEpilog(std::function<void(std::string s)> logger, const float total);
+  void printEpilog(std::function<void(std::string s)> logger,
+                   bool isHybrid,
+                   const unsigned int trackletN01, const unsigned int trackletN12, const unsigned selectedN,
+                   const float initT, const float trackletT, const float selecT, const float vertexT);
 
  private:
   std::uint32_t mTimeFrameCounter = 0;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -121,7 +121,6 @@ class VertexerTraits
 
   std::vector<VertexingParameters> mVrtParams;
   IndexTableUtils mIndexTableUtils;
-  std::vector<lightVertex> mVertices;
 
   // Frame related quantities
   TimeFrame* mTimeFrame = nullptr;

--- a/Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
@@ -369,15 +369,24 @@ bool ClusterLines::operator==(const ClusterLines& rhs) const
 
 GPUhdi() void ClusterLines::updateROFPoll(const Line& line)
 {
-  // Boyer-Moore voting for rof label
-  if (mROFWeight == 0) {
+  // option 1: Boyer-Moore voting for rof label
+  // if (mROFWeight == 0) {
+  //   mROF = line.getMinROF();
+  //   mROFWeight = 1;
+  // } else {
+  //   if (mROF == line.getMinROF()) {
+  //     mROFWeight++;
+  //   } else {
+  //     mROFWeight--;
+  //   }
+  // }
+
+  // option 2
+  if (mROF == -1) {
     mROF = line.getMinROF();
-    mROFWeight = 1;
   } else {
-    if (mROF == line.getMinROF()) {
-      mROFWeight++;
-    } else {
-      mROFWeight--;
+    if (line.getMinROF() < mROF) {
+      mROF = line.getMinROF();
     }
   }
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -73,9 +73,9 @@ TimeFrame::TimeFrame(int nLayers)
   mTrackingFrameInfo.resize(nLayers);
   mClusterExternalIndices.resize(nLayers);
   mUsedClusters.resize(nLayers);
-  mROframesClusters.resize(nLayers, {0}); /// TBC: if resetting the timeframe is required, then this has to be done
+  mROFramesClusters.resize(nLayers, {0}); /// TBC: if resetting the timeframe is required, then this has to be done
   mNClustersPerROF.resize(nLayers);
-  mTrackletsIndexROf.resize(2, {0});
+  mTrackletsIndexROF.resize(2, {0});
 }
 
 void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices)
@@ -89,7 +89,7 @@ void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices)
       mBeamPosWeight += w;
     }
   }
-  mROframesPV.push_back(mPrimaryVertices.size());
+  mROFramesPV.push_back(mPrimaryVertices.size());
 }
 
 void TimeFrame::addPrimaryVerticesLabels(std::vector<std::pair<MCCompLabel, float>>& labels)
@@ -121,7 +121,7 @@ void TimeFrame::addPrimaryVertices(const gsl::span<const Vertex>& vertices)
       mBeamPosWeight += w;
     }
   }
-  mROframesPV.push_back(mPrimaryVertices.size());
+  mROFramesPV.push_back(mPrimaryVertices.size());
 }
 
 void TimeFrame::addPrimaryVertices(const std::vector<lightVertex>& lVertices)
@@ -159,10 +159,10 @@ int TimeFrame::loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const
   }
 
   for (unsigned int iL{0}; iL < mUnsortedClusters.size(); ++iL) {
-    mNClustersPerROF[iL].push_back(mUnsortedClusters[iL].size() - mROframesClusters[iL].back());
-    mROframesClusters[iL].push_back(mUnsortedClusters[iL].size());
+    mNClustersPerROF[iL].push_back(mUnsortedClusters[iL].size() - mROFramesClusters[iL].back());
+    mROFramesClusters[iL].push_back(mUnsortedClusters[iL].size());
     if (iL < 2) {
-      mTrackletsIndexROf[iL].push_back(mUnsortedClusters[1].size()); // Tracklets used in vertexer are always computed starting from L1
+      mTrackletsIndexROF[iL].push_back(mUnsortedClusters[1].size()); // Tracklets used in vertexer are always computed starting from L1
     }
   }
   if (mcLabels) {
@@ -182,10 +182,10 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
     deepVectorClear(mUnsortedClusters[iLayer]);
     deepVectorClear(mTrackingFrameInfo[iLayer]);
     deepVectorClear(mClusterExternalIndices[iLayer]);
-    mROframesClusters[iLayer].resize(1, 0);
+    mROFramesClusters[iLayer].resize(1, 0);
 
     if (iLayer < 2) {
-      deepVectorClear(mTrackletsIndexROf[iLayer]);
+      deepVectorClear(mTrackletsIndexROF[iLayer]);
     }
   }
 
@@ -241,8 +241,8 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
       addClusterExternalIndexToLayer(layer, clusterId);
     }
     for (unsigned int iL{0}; iL < mUnsortedClusters.size(); ++iL) {
-      // mNClustersPerROF[iL].push_back(mUnsortedClusters[iL].size() - mROframesClusters[iL].back());
-      mROframesClusters[iL].push_back(mUnsortedClusters[iL].size());
+      // mNClustersPerROF[iL].push_back(mUnsortedClusters[iL].size() - mROFramesClusters[iL].back());
+      mROFramesClusters[iL].push_back(mUnsortedClusters[iL].size());
     }
     mNrof++;
   }
@@ -373,8 +373,8 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     mIndexTables.resize(mClusters.size(), std::vector<int>(mNrof * (trkParam.ZBins * trkParam.PhiBins + 1), 0));
     mLines.resize(mNrof);
     mTrackletClusters.resize(mNrof);
-    mNTrackletsPerROf.resize(2);
-    for (auto& v : mNTrackletsPerROf) {
+    mNTrackletsPerROF.resize(2);
+    for (auto& v : mNTrackletsPerROF) {
       v = std::vector<int>(mNrof + 1, 0);
     }
 
@@ -502,9 +502,9 @@ void TimeFrame::resizeVectors(int nLayers)
   mTrackingFrameInfo.resize(nLayers);
   mClusterExternalIndices.resize(nLayers);
   mUsedClusters.resize(nLayers);
-  mROframesClusters.resize(nLayers, {0});
+  mROFramesClusters.resize(nLayers, {0});
   mNClustersPerROF.resize(nLayers);
-  mTrackletsIndexROf.resize(2, {0});
+  mTrackletsIndexROF.resize(2, {0});
 }
 
 void TimeFrame::printTrackletLUTonLayer(int i)
@@ -545,9 +545,9 @@ void TimeFrame::printCellLUTs()
 
 void TimeFrame::printVertices()
 {
-  std::cout << "Vertices in ROF (nROF = " << mNrof << ", lut size = " << mROframesPV.size() << ")" << std::endl;
-  for (unsigned int iR{0}; iR < mROframesPV.size(); ++iR) {
-    std::cout << mROframesPV[iR] << "\t";
+  std::cout << "Vertices in ROF (nROF = " << mNrof << ", lut size = " << mROFramesPV.size() << ")" << std::endl;
+  for (unsigned int iR{0}; iR < mROFramesPV.size(); ++iR) {
+    std::cout << mROFramesPV[iR] << "\t";
   }
   std::cout << "\n\n Vertices:" << std::endl;
   for (unsigned int iV{0}; iV < mPrimaryVertices.size(); ++iV) {
@@ -559,9 +559,9 @@ void TimeFrame::printVertices()
 void TimeFrame::printROFoffsets()
 {
   std::cout << "--------" << std::endl;
-  for (unsigned int iLayer{0}; iLayer < mROframesClusters.size(); ++iLayer) {
+  for (unsigned int iLayer{0}; iLayer < mROFramesClusters.size(); ++iLayer) {
     std::cout << "Layer " << iLayer << std::endl;
-    for (auto value : mROframesClusters[iLayer]) {
+    for (auto value : mROFramesClusters[iLayer]) {
       std::cout << value << "\t";
     }
     std::cout << std::endl;
@@ -584,8 +584,8 @@ void TimeFrame::computeTrackletsScans(const int nThreads)
 {
   // #pragma omp parallel for num_threads(nThreads > 1 ? 2 : nThreads)
   for (ushort iLayer = 0; iLayer < 2; ++iLayer) {
-    mTotalTracklets[iLayer] = std::accumulate(mNTrackletsPerROf[iLayer].begin(), mNTrackletsPerROf[iLayer].end(), 0);
-    std::exclusive_scan(mNTrackletsPerROf[iLayer].begin(), mNTrackletsPerROf[iLayer].end(), mNTrackletsPerROf[iLayer].begin(), 0);
+    mTotalTracklets[iLayer] = std::accumulate(mNTrackletsPerROF[iLayer].begin(), mNTrackletsPerROF[iLayer].end(), 0);
+    std::exclusive_scan(mNTrackletsPerROF[iLayer].begin(), mNTrackletsPerROF[iLayer].end(), mNTrackletsPerROF[iLayer].begin(), 0);
   }
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -78,11 +78,10 @@ TimeFrame::TimeFrame(int nLayers)
   mTrackletsIndexROF.resize(2, {0});
 }
 
-void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices)
+void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices, const int rofId)
 {
-  auto rofId = mROFramesPV.size() - 1;
   for (const auto& vertex : vertices) {
-    if (vertex.getTimeStamp() != rofId) {
+    if (vertex.getTimeStamp().getTimeStamp() != rofId) {
       insertLateVertex(vertex);
     } else {
       mPrimaryVertices.emplace_back(vertex);
@@ -117,11 +116,8 @@ void TimeFrame::addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCComp
 
 void TimeFrame::addPrimaryVertices(const gsl::span<const Vertex>& vertices)
 {
-  auto rofId = mROFramesPV.size();
+  // auto rofId = mROFramesPV.size();
   for (const auto& vertex : vertices) {
-    if (vertex.getTimeStamp() != rofId) {
-      LOG(warning) << "Vertex timestamp mismatch: " << vertex.getTimeStamp() << " vs " << rofId;
-    }
     mPrimaryVertices.emplace_back(vertex);
     if (!isBeamPositionOverridden) {
       const int w{vertex.getNContributors()};
@@ -133,15 +129,15 @@ void TimeFrame::addPrimaryVertices(const gsl::span<const Vertex>& vertices)
   mROFramesPV.push_back(mPrimaryVertices.size());
 }
 
-void TimeFrame::addPrimaryVertices(const std::vector<lightVertex>& lVertices)
-{
-  std::vector<Vertex> vertices;
-  for (auto& vertex : lVertices) {
-    vertices.emplace_back(o2::math_utils::Point3D<float>(vertex.mX, vertex.mY, vertex.mZ), vertex.mRMS2, vertex.mContributors, vertex.mAvgDistance2);
-    vertices.back().setTimeStamp(vertex.mTimeStamp);
-  }
-  addPrimaryVertices(vertices);
-}
+// void TimeFrame::addPrimaryVertices(const std::vector<lightVertex>& lVertices)
+// {
+//   std::vector<Vertex> vertices;
+//   for (auto& vertex : lVertices) {
+//     vertices.emplace_back(o2::math_utils::Point3D<float>(vertex.mX, vertex.mY, vertex.mZ), vertex.mRMS2, vertex.mContributors, vertex.mAvgDistance2);
+//     vertices.back().setTimeStamp(vertex.mTimeStamp);
+//   }
+//   addPrimaryVertices(vertices);
+// }
 
 int TimeFrame::loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const itsmft::Cluster> clusters,
                                const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
@@ -195,6 +191,8 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
 
     if (iLayer < 2) {
       deepVectorClear(mTrackletsIndexROF[iLayer]);
+      deepVectorClear(mNTrackletsPerCluster[iLayer]);
+      deepVectorClear(mNTrackletsPerClusterSum[iLayer]);
     }
   }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -80,8 +80,13 @@ TimeFrame::TimeFrame(int nLayers)
 
 void TimeFrame::addPrimaryVertices(const std::vector<Vertex>& vertices)
 {
+  auto rofId = mROFramesPV.size() - 1;
   for (const auto& vertex : vertices) {
-    mPrimaryVertices.emplace_back(vertex);
+    if (vertex.getTimeStamp() != rofId) {
+      insertLateVertex(vertex);
+    } else {
+      mPrimaryVertices.emplace_back(vertex);
+    }
     if (!isBeamPositionOverridden) {
       const int w{vertex.getNContributors()};
       mBeamPos[0] = (mBeamPos[0] * mBeamPosWeight + vertex.getX() * w) / (mBeamPosWeight + w);
@@ -112,7 +117,11 @@ void TimeFrame::addPrimaryVerticesLabelsInROF(const std::vector<std::pair<MCComp
 
 void TimeFrame::addPrimaryVertices(const gsl::span<const Vertex>& vertices)
 {
+  auto rofId = mROFramesPV.size();
   for (const auto& vertex : vertices) {
+    if (vertex.getTimeStamp() != rofId) {
+      LOG(warning) << "Vertex timestamp mismatch: " << vertex.getTimeStamp() << " vs " << rofId;
+    }
     mPrimaryVertices.emplace_back(vertex);
     if (!isBeamPositionOverridden) {
       const int w{vertex.getNContributors()};

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -104,10 +104,10 @@ void Tracker::clustersToTracks(std::function<void(std::string s)> logger, std::f
       }
       iVertex++;
     } while (iVertex < maxNvertices);
-    logger(fmt::format("- Tracklet finding: {} tracklets found in {:.2f} ms", nTracklets, timeTracklets));
-    logger(fmt::format("- Cell finding: {} cells found in {:.2f} ms", nCells, timeCells));
-    logger(fmt::format("- Neighbours finding: {} neighbours found in {:.2f} ms", nNeighbours, timeNeighbours));
-    logger(fmt::format("- Track finding: {} tracks found in {:.2f} ms", nTracks + mTimeFrame->getNumberOfTracks(), timeRoads));
+    logger(fmt::format(" - Tracklet finding: {} tracklets found in {:.2f} ms", nTracklets, timeTracklets));
+    logger(fmt::format(" - Cell finding: {} cells found in {:.2f} ms", nCells, timeCells));
+    logger(fmt::format(" - Neighbours finding: {} neighbours found in {:.2f} ms", nNeighbours, timeNeighbours));
+    logger(fmt::format(" - Track finding: {} tracks found in {:.2f} ms", nTracks + mTimeFrame->getNumberOfTracks(), timeRoads));
     total += timeTracklets + timeCells + timeNeighbours + timeRoads;
     total += evaluateTask(&Tracker::extendTracks, "Extending tracks", logger, iteration);
   }

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -456,7 +456,6 @@ void Tracker::rectifyClusterIndices()
 
 void Tracker::getGlobalConfiguration()
 {
-  LOGP(info, "tracker::getGlobalConfiguration size of pars is {}", mTrkParams.size());
   auto& tc = o2::its::TrackerParamConfig::Instance();
   tc.printKeyValues(true, true);
   if (tc.useMatCorrTGeo) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -236,7 +236,7 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
       for (auto& v : vtxVecLoc) {
         vertices.push_back(v);
       }
-      mTimeFrame->addPrimaryVertices(vtxVecLoc);
+      mTimeFrame->addPrimaryVertices(vtxVecLoc, iRof);
     }
   }
   if (mRunVertexer) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -63,6 +63,7 @@ void ITSTrackingInterface::initialise()
     vertParams[1].phiCut = 0.015f;
     vertParams[1].tanLambdaCut = 0.015f;
     vertParams[1].vertPerRofThreshold = 0;
+    vertParams[1].deltaRof = 0;
   } else if (mMode == TrackingMode::Sync) {
     trackParams.resize(1);
     trackParams[0].ZBins = 64;
@@ -249,7 +250,6 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
                              trackROFspan.size());
     LOG(info) << fmt::format("FastMultEst: rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, trackROFspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);
   }
-
   if (mOverrideBeamEstimation) {
     LOG(info) << fmt::format(" - Beam position set to: {}, {} from meanvertex object", mTimeFrame->getBeamX(), mTimeFrame->getBeamY());
   } else {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -237,7 +237,7 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
       for (auto& v : vtxVecLoc) {
         vertices.push_back(v);
       }
-      mTimeFrame->addPrimaryVertices(vtxVecLoc, iRof);
+      mTimeFrame->addPrimaryVertices(vtxVecLoc, iRof, 0);
     }
   }
   if (mRunVertexer) {

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -39,26 +39,30 @@ Vertexer::Vertexer(VertexerTraits* traits)
 
 float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
 {
-  float total{0.f};
+  float timeTracklet, timeSelection, timeVertexing, timeInit;
+  unsigned int nTracklets01, nTracklets12, nSelectedTracklets;
   TrackingParameters trkPars;
-  TimeFrameGPUParameters tfGPUpar;
-  mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
   for (int iteration = 0; iteration < std::min(mVertParams[0].nIterations, (int)mVertParams.size()); ++iteration) {
     logger(fmt::format("ITS Seeding vertexer iteration {} summary:", iteration));
     trkPars.PhiBins = mTraits->getVertexingParameters()[0].PhiBins;
     trkPars.ZBins = mTraits->getVertexingParameters()[0].ZBins;
-    total += evaluateTask(&Vertexer::initialiseVertexer, "Vertexer initialisation", logger, trkPars, iteration);
-    total += evaluateTask(&Vertexer::findTracklets, "Vertexer tracklet finding", logger, iteration);
-    total += evaluateTask(&Vertexer::validateTracklets, "Vertexer adjacent tracklets validation", logger, iteration);
-    total += evaluateTask(&Vertexer::findVertices, "Vertexer vertex finding", logger, iteration);
+    timeInit += evaluateTask(
+      &Vertexer::initialiseVertexer, "Vertexer initialisation", [](std::string) {}, trkPars);
+    timeTracklet = evaluateTask(&Vertexer::findTracklets, "Vertexer tracklet finding", [](std::string) {});
+    nTracklets01 = mTimeFrame->getTotalTrackletsTF(0);
+    nTracklets12 = mTimeFrame->getTotalTrackletsTF(1);
+    timeSelection = evaluateTask(&Vertexer::validateTracklets, "Vertexer adjacent tracklets validation", [](std::string) {});
+    nSelectedTracklets = mTimeFrame->getNLinesTotal();
+    timeVertexing = evaluateTask(&Vertexer::findVertices, "Vertexer vertex finding", [](std::string) {});
   }
-  printEpilog(logger, total);
-  return total;
+  printEpilog(logger, false, nTracklets01, nTracklets12, nSelectedTracklets, timeInit, timeTracklet, timeSelection, timeVertexing);
+  return timeInit + timeTracklet + timeSelection + timeVertexing;
 }
 
 float Vertexer::clustersToVerticesHybrid(std::function<void(std::string s)> logger)
 {
-  float total{0.f};
+  float timeTracklet, timeSelection, timeVertexing, timeInit;
+  unsigned int nTracklets01, nTracklets12, nSelectedTracklets;
   TrackingParameters trkPars;
   TimeFrameGPUParameters tfGPUpar;
   mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
@@ -66,13 +70,16 @@ float Vertexer::clustersToVerticesHybrid(std::function<void(std::string s)> logg
     logger(fmt::format("ITS Hybrid seeding vertexer iteration {} summary:", iteration));
     trkPars.PhiBins = mTraits->getVertexingParameters()[0].PhiBins;
     trkPars.ZBins = mTraits->getVertexingParameters()[0].ZBins;
-    total += evaluateTask(&Vertexer::initialiseVertexerHybrid, "Hybrid Vertexer initialisation", logger, trkPars, iteration);
-    total += evaluateTask(&Vertexer::findTrackletsHybrid, "Hybrid Vertexer tracklet finding", logger, iteration);
-    total += evaluateTask(&Vertexer::validateTrackletsHybrid, "Hybrid Vertexer adjacent tracklets validation", logger, iteration);
-    total += evaluateTask(&Vertexer::findVerticesHybrid, "Hybrid Vertexer vertex finding", logger, iteration);
+    timeInit += evaluateTask(&Vertexer::initialiseVertexerHybrid, "Hybrid Vertexer initialisation", [](std::string) {}, trkPars, iteration);
+    timeTracklet += evaluateTask(&Vertexer::findTrackletsHybrid, "Hybrid Vertexer tracklet finding", [](std::string) {}, iteration);
+    nTracklets01 = mTimeFrame->getTotalTrackletsTF(0);
+    nTracklets12 = mTimeFrame->getTotalTrackletsTF(1);
+    timeSelection += evaluateTask(&Vertexer::validateTrackletsHybrid, "Hybrid Vertexer adjacent tracklets validation", [](std::string) {}, iteration);
+    nSelectedTracklets = mTimeFrame->getNLinesTotal();
+    timeVertexing += evaluateTask(&Vertexer::findVerticesHybrid, "Hybrid Vertexer vertex finding", [](std::string) {}, iteration);
   }
-  printEpilog(logger, total);
-  return total;
+  printEpilog(logger, false, nTracklets01, nTracklets12, nSelectedTracklets, timeInit, timeTracklet, timeSelection, timeVertexing);
+  return timeInit + timeTracklet + timeSelection + timeVertexing;
 }
 
 void Vertexer::getGlobalConfiguration()
@@ -84,6 +91,7 @@ void Vertexer::getGlobalConfiguration()
   // This is odd: we override only the parameters for the first iteration.
   // Variations for the next iterations are set in the trackingInterfrace.
   mVertParams[0].nIterations = vc.nIterations;
+  verPar.deltaRof[0] = vc.deltaRof;
   mVertParams[0].allowSingleContribClusters = vc.allowSingleContribClusters;
   mVertParams[0].zCut = vc.zCut;
   mVertParams[0].phiCut = vc.phiCut;
@@ -110,8 +118,15 @@ void Vertexer::adoptTimeFrame(TimeFrame& tf)
   mTraits->adoptTimeFrame(&tf);
 }
 
-void Vertexer::printEpilog(std::function<void(std::string s)> logger, const float total)
+void Vertexer::printEpilog(std::function<void(std::string s)> logger,
+                           bool isHybrid,
+                           const unsigned int trackletN01, const unsigned int trackletN12, const unsigned selectedN,
+                           const float initT, const float trackletT, const float selecT, const float vertexT)
 {
+  float total = initT + trackletT + selecT + vertexT;
+  logger(fmt::format(" - {}Vertexer: trackleting found {}|{} tracklets, completed in: {} ms", isHybrid ? "Hybrid" : "", trackletN01, trackletN12, trackletT));
+  logger(fmt::format(" - {}Vertexer: selected {} tracklets, completed in: {} ms", isHybrid ? "Hybrid" : "", selectedN, selecT));
+  logger(fmt::format(" - {}Vertexer: vertexing completed in: {} ms", isHybrid ? "Hybrid" : "", vertexT));
   logger(fmt::format(" - Timeframe {} vertexing completed in: {} ms, using {} thread(s).", mTimeFrameCounter++, total, mTraits->getNThreads()));
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -79,12 +79,16 @@ float Vertexer::clustersToVerticesHybrid(std::function<void(std::string s)> logg
     logger(fmt::format("ITS Hybrid seeding vertexer iteration {} summary:", iteration));
     trkPars.PhiBins = mTraits->getVertexingParameters()[0].PhiBins;
     trkPars.ZBins = mTraits->getVertexingParameters()[0].ZBins;
-    auto timeInitIteration = evaluateTask(&Vertexer::initialiseVertexerHybrid, "Hybrid Vertexer initialisation", [](std::string) {}, trkPars, iteration);
-    auto timeSelectionIteration = evaluateTask(&Vertexer::findTrackletsHybrid, "Hybrid Vertexer tracklet finding", [](std::string) {}, iteration);
+    auto timeInitIteration = evaluateTask(
+      &Vertexer::initialiseVertexerHybrid, "Hybrid Vertexer initialisation", [](std::string) {}, trkPars, iteration);
+    auto timeTrackletIteration = evaluateTask(
+      &Vertexer::findTrackletsHybrid, "Hybrid Vertexer tracklet finding", [](std::string) {}, iteration);
     nTracklets01 = mTimeFrame->getTotalTrackletsTF(0);
     nTracklets12 = mTimeFrame->getTotalTrackletsTF(1);
-    auto timeSelectionIteration = evaluateTask(&Vertexer::validateTrackletsHybrid, "Hybrid Vertexer adjacent tracklets validation", [](std::string) {}, iteration);
-    auto timeVertexingIteration = evaluateTask(&Vertexer::findVerticesHybrid, "Hybrid Vertexer vertex finding", [](std::string) {}, iteration);
+    auto timeSelectionIteration = evaluateTask(
+      &Vertexer::validateTrackletsHybrid, "Hybrid Vertexer adjacent tracklets validation", [](std::string) {}, iteration);
+    auto timeVertexingIteration = evaluateTask(
+      &Vertexer::findVerticesHybrid, "Hybrid Vertexer vertex finding", [](std::string) {}, iteration);
 
     printEpilog(logger, false, nTracklets01, nTracklets12, mTimeFrame->getNLinesTotal(), mTimeFrame->getTotVertIteration().size(), timeInit, timeTracklet, timeSelection, timeVertexing);
     timeInit += timeInitIteration;

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -50,11 +50,14 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
     trkPars.ZBins = mTraits->getVertexingParameters()[0].ZBins;
     auto timeInitIteration = evaluateTask(
       &Vertexer::initialiseVertexer, "Vertexer initialisation", [](std::string) {}, trkPars, iteration);
-    auto timeTrackletIteration = evaluateTask(&Vertexer::findTracklets, "Vertexer tracklet finding", [](std::string) {}, iteration);
+    auto timeTrackletIteration = evaluateTask(
+      &Vertexer::findTracklets, "Vertexer tracklet finding", [](std::string) {}, iteration);
     nTracklets01 = mTimeFrame->getTotalTrackletsTF(0);
     nTracklets12 = mTimeFrame->getTotalTrackletsTF(1);
-    auto timeSelectionIteration = evaluateTask(&Vertexer::validateTracklets, "Vertexer tracklets validation", [](std::string) {}, iteration);
-    auto timeVertexingIteration = evaluateTask(&Vertexer::findVertices, "Vertexer vertex finding", [](std::string) {}, iteration);
+    auto timeSelectionIteration = evaluateTask(
+      &Vertexer::validateTracklets, "Vertexer tracklets validation", [](std::string) {}, iteration);
+    auto timeVertexingIteration = evaluateTask(
+      &Vertexer::findVertices, "Vertexer vertex finding", [](std::string) {}, iteration);
     printEpilog(logger, false, nTracklets01, nTracklets12, mTimeFrame->getNLinesTotal(), mTimeFrame->getTotVertIteration()[iteration], timeInitIteration, timeTrackletIteration, timeSelectionIteration, timeVertexingIteration);
     timeInit += timeInitIteration;
     timeTracklet += timeTrackletIteration;
@@ -89,6 +92,8 @@ float Vertexer::clustersToVerticesHybrid(std::function<void(std::string s)> logg
     timeSelection += timeSelectionIteration;
     timeVertexing += timeVertexingIteration;
   }
+
+  return timeInit + timeTracklet + timeSelection + timeVertexing;
 }
 
 void Vertexer::getGlobalConfiguration()

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -42,7 +42,7 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
   TrackingParameters trkPars;
   TimeFrameGPUParameters tfGPUpar;
   mTraits->updateVertexingParameters(mVertParams, tfGPUpar);
-  float timeTracklet, timeSelection, timeVertexing, timeInit;
+  float timeTracklet{0.f}, timeSelection{0.f}, timeVertexing{0.f}, timeInit{0.f};
   for (int iteration = 0; iteration < std::min(mVertParams[0].nIterations, (int)mVertParams.size()); ++iteration) {
     unsigned int nTracklets01, nTracklets12;
     logger(fmt::format("ITS Seeding vertexer iteration {} summary:", iteration));
@@ -53,7 +53,7 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
     auto timeTrackletIteration = evaluateTask(&Vertexer::findTracklets, "Vertexer tracklet finding", [](std::string) {}, iteration);
     nTracklets01 = mTimeFrame->getTotalTrackletsTF(0);
     nTracklets12 = mTimeFrame->getTotalTrackletsTF(1);
-    auto timeSelectionIteration = evaluateTask(&Vertexer::validateTracklets, "Vertexer adjacent tracklets validation", [](std::string) {}, iteration);
+    auto timeSelectionIteration = evaluateTask(&Vertexer::validateTracklets, "Vertexer tracklets validation", [](std::string) {}, iteration);
     auto timeVertexingIteration = evaluateTask(&Vertexer::findVertices, "Vertexer vertex finding", [](std::string) {}, iteration);
     printEpilog(logger, false, nTracklets01, nTracklets12, mTimeFrame->getNLinesTotal(), mTimeFrame->getTotVertIteration()[iteration], timeInitIteration, timeTrackletIteration, timeSelectionIteration, timeVertexingIteration);
     timeInit += timeInitIteration;

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -193,13 +193,13 @@ void VertexerTraits::computeTracklets(const int iteration)
 #pragma omp for schedule(dynamic)
     for (int pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) { // Pivot rofId: the rof for which the tracklets are computed
       bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-      int startROF{std::max(0, pivotRofId - mVrtParams.deltaRof)};
+      int startROF{std::max(0, pivotRofId - mVrtParams[iteration].deltaRof)};
       int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
       for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
         trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
           !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(), // Clusters to be matched with the next layer in target rof
           !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),  // Clusters to be matched with the current layer in pivot rof
-                    mTimeFrame->getUsedClustersROF(targetRofId, 0),   // Span of the used clusters in the target rof
+          mTimeFrame->getUsedClustersROF(targetRofId, 0),                                   // Span of the used clusters in the target rof
           mTimeFrame->getIndexTable(targetRofId, 0).data(),                                 // Index table to access the data on the next layer in target rof
           mVrtParams[iteration].phiCut,
           mTimeFrame->getTracklets()[0],                   // Flat tracklet buffer
@@ -345,8 +345,8 @@ void VertexerTraits::computeTrackletMatching(const int iteration)
     }
     mTimeFrame->getLines(pivotRofId).reserve(mTimeFrame->getNTrackletsCluster(pivotRofId, 0).size());
     std::vector<bool> usedTracklets(mTimeFrame->getFoundTracklets(pivotRofId, 0).size(), false);
-    int startROF{std::max(0, pivotRofId - mVrtParams.deltaRof)};
-    int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams.deltaRof + 1)};
+    int startROF{std::max(0, pivotRofId - mVrtParams[iteration].deltaRof)};
+    int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
     for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
       trackletSelectionKernelHost(
         mTimeFrame->getClustersOnLayer(targetRofId, 0),
@@ -363,8 +363,8 @@ void VertexerTraits::computeTrackletMatching(const int iteration)
         mTimeFrame->getLinesLabel(pivotRofId),
         pivotRofId,
         targetRofId,
-        mVrtParams.tanLambdaCut,
-        mVrtParams.phiCut);
+        mVrtParams[iteration].tanLambdaCut,
+        mVrtParams[iteration].phiCut);
     }
   }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -79,7 +79,6 @@ void trackleterKernelHost(
         // loop on clusters next layer
         for (int iNextLayerClusterIndex{firstRowClusterIndex}; iNextLayerClusterIndex < maxRowClusterIndex && iNextLayerClusterIndex < static_cast<int>(clustersNextLayer.size()); ++iNextLayerClusterIndex) {
           if (usedClustersNextLayer[iNextLayerClusterIndex]) {
-            LOGP(warning, "skipping used cluster");
             continue;
           }
           const Cluster& nextCluster{clustersNextLayer[iNextLayerClusterIndex]};
@@ -530,17 +529,16 @@ void VertexerTraits::computeVertices(const int iteration)
       }
     }
     if (!iteration) {
-      mTimeFrame->addPrimaryVertices(vertices, rofId);
+      mTimeFrame->addPrimaryVertices(vertices, rofId, iteration);
       if (mTimeFrame->hasMCinformation()) {
         mTimeFrame->addPrimaryVerticesLabels(polls);
       }
     } else {
-      mTimeFrame->addPrimaryVerticesInROF(vertices, rofId);
+      mTimeFrame->addPrimaryVerticesInROF(vertices, rofId, iteration);
       if (mTimeFrame->hasMCinformation()) {
         mTimeFrame->addPrimaryVerticesLabelsInROF(polls, rofId);
       }
     }
-    mTimeFrame->getTotVertIteration()[iteration] += vertices.size();
     if (!vertices.size() && !(iteration && (int)mTimeFrame->getPrimaryVertices(rofId).size() > mVrtParams[iteration].vertPerRofThreshold)) {
       mTimeFrame->getNoVertexROF()++;
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -135,8 +135,8 @@ void trackletSelectionKernelHost(
         if (tracklet01.rof[0] != targetRofId || tracklet12.rof[1] != targetRofId) {
           continue;
         }
-        const float deltaTanLambda{o2::gpu::GPUCommonMath::Abs(tracklet01.tanLambda - tracklets12[iTracklet12].tanLambda)};
-        const float deltaPhi{o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(tracklet01.phi, tracklets12[iTracklet12].phi))};
+        const float deltaTanLambda{o2::gpu::GPUCommonMath::Abs(tracklet01.tanLambda - tracklet12.tanLambda)};
+        const float deltaPhi{o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(tracklet01.phi, tracklet12.phi))};
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedClusters0[tracklet01.firstClusterIndex] = true;
           usedClusters2[tracklet12.secondClusterIndex] = true;
@@ -530,7 +530,7 @@ void VertexerTraits::computeVertices(const int iteration)
       }
     }
     if (!iteration) {
-      mTimeFrame->addPrimaryVertices(vertices);
+      mTimeFrame->addPrimaryVertices(vertices, rofId);
       if (mTimeFrame->hasMCinformation()) {
         mTimeFrame->addPrimaryVerticesLabels(polls);
       }

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -54,8 +54,8 @@ void trackleterKernelHost(
   std::vector<Tracklet>& tracklets,
   gsl::span<int> foundTracklets,
   const IndexTableUtils& utils,
-  const int pivotRof,
-  const int targetRof,
+  const short pivotRof,
+  const short targetRof,
   gsl::span<int> rofFoundTrackletsOffsets, // we want to change those, to keep track of the offset in deltaRof>0
   const int maxTrackletsPerCluster = static_cast<int>(2e3))
 {
@@ -118,8 +118,8 @@ void trackletSelectionKernelHost(
   std::vector<Line>& lines,
   const gsl::span<const MCCompLabel>& trackletLabels,
   std::vector<MCCompLabel>& linesLabels,
-  const int pivotRofId,
-  const int targetRofId,
+  const short pivotRofId,
+  const short targetRofId,
   const float tanLambdaCut = 0.025f,
   const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(1e2))
@@ -190,10 +190,10 @@ void VertexerTraits::computeTracklets(const int iteration)
 #pragma omp parallel num_threads(mNThreads)
   {
 #pragma omp for schedule(dynamic)
-    for (int pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) { // Pivot rofId: the rof for which the tracklets are computed
+    for (short pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) { // Pivot rofId: the rof for which the tracklets are computed
       bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-      int startROF{std::max(0, pivotRofId - mVrtParams[iteration].deltaRof)};
-      int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
+      short startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
+      short endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
       for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
         trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
           !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(), // Clusters to be matched with the next layer in target rof
@@ -235,8 +235,8 @@ void VertexerTraits::computeTracklets(const int iteration)
 #pragma omp for schedule(dynamic)
     for (int pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) {
       bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-      int startROF{std::max(0, pivotRofId - mVrtParams[iteration].deltaRof)};
-      int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
+      short startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
+      short endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
       auto mobileOffset0 = mTimeFrame->getNTrackletsROF(pivotRofId, 0);
       auto mobileOffset1 = mTimeFrame->getNTrackletsROF(pivotRofId, 1);
       for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
@@ -344,8 +344,8 @@ void VertexerTraits::computeTrackletMatching(const int iteration)
     }
     mTimeFrame->getLines(pivotRofId).reserve(mTimeFrame->getNTrackletsCluster(pivotRofId, 0).size());
     std::vector<bool> usedTracklets(mTimeFrame->getFoundTracklets(pivotRofId, 0).size(), false);
-    int startROF{std::max(0, pivotRofId - mVrtParams[iteration].deltaRof)};
-    int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
+    int startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
+    int endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
     for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
       trackletSelectionKernelHost(
         mTimeFrame->getClustersOnLayer(targetRofId, 0),

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -46,8 +46,9 @@ float smallestAngleDifference(float a, float b)
 
 template <TrackletMode Mode, bool EvalRun>
 void trackleterKernelHost(
-  const gsl::span<const Cluster>& clustersNextLayer,    // 0 2
-  const gsl::span<const Cluster>& clustersCurrentLayer, // 1 1
+  const gsl::span<const Cluster>& clustersNextLayer,     // 0 2
+  const gsl::span<const Cluster>& clustersCurrentLayer,  // 1 1
+  const gsl::span<unsigned char>& usedClustersNextLayer, // 0 2
   int* indexTableNext,
   const float phiCut,
   std::vector<Tracklet>& tracklets,
@@ -77,6 +78,10 @@ void trackleterKernelHost(
         const int maxRowClusterIndex{indexTableNext[firstBinIndex + ZBins]};
         // loop on clusters next layer
         for (int iNextLayerClusterIndex{firstRowClusterIndex}; iNextLayerClusterIndex < maxRowClusterIndex && iNextLayerClusterIndex < static_cast<int>(clustersNextLayer.size()); ++iNextLayerClusterIndex) {
+          if (usedClustersNextLayer[iNextLayerClusterIndex]) {
+            LOGP(warning, "skipping used cluster");
+            continue;
+          }
           const Cluster& nextCluster{clustersNextLayer[iNextLayerClusterIndex]};
           if (o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(currentCluster.phi, nextCluster.phi)) < phiCut) {
             if (storedTracklets < maxTrackletsPerCluster) {
@@ -104,6 +109,8 @@ void trackleterKernelHost(
 void trackletSelectionKernelHost(
   const gsl::span<const Cluster> clusters0, // 0
   const gsl::span<const Cluster> clusters1, // 1
+  gsl::span<unsigned char> usedClusters0,   // Layer 0
+  gsl::span<unsigned char> usedClusters2,   // Layer 2
   const gsl::span<const Tracklet>& tracklets01,
   const gsl::span<const Tracklet>& tracklets12,
   std::vector<bool>& usedTracklets,
@@ -112,7 +119,8 @@ void trackletSelectionKernelHost(
   std::vector<Line>& lines,
   const gsl::span<const MCCompLabel>& trackletLabels,
   std::vector<MCCompLabel>& linesLabels,
-  const int rofDist = 0, // signed rof distance to consider for the tracklet to be promoted, so to be sure taht clusters0 and clusters1 are consistent with tracklet indices
+  const int pivotRofId,
+  const int targetRofId,
   const float tanLambdaCut = 0.025f,
   const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(1e2))
@@ -124,12 +132,14 @@ void trackletSelectionKernelHost(
       for (int iTracklet01{offset01}; iTracklet01 < offset01 + foundTracklets01[iCurrentLayerClusterIndex]; ++iTracklet01) {
         const auto& tracklet01{tracklets01[iTracklet01]};
         const auto& tracklet12{tracklets12[iTracklet12]};
-        if (tracklet01.getDeltaRof() != rofDist || o2::gpu::GPUCommonMath::Abs(tracklet01.rof[0] - tracklet12.rof[1]) > 1) {
+        if (tracklet01.rof[0] != targetRofId || tracklet12.rof[1] != targetRofId) {
           continue;
         }
         const float deltaTanLambda{o2::gpu::GPUCommonMath::Abs(tracklet01.tanLambda - tracklets12[iTracklet12].tanLambda)};
         const float deltaPhi{o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(tracklet01.phi, tracklets12[iTracklet12].phi))};
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
+          usedClusters0[tracklet01.firstClusterIndex] = true;
+          usedClusters2[tracklet12.secondClusterIndex] = true;
           usedTracklets[iTracklet01] = true;
           lines.emplace_back(tracklet01, clusters0.data(), clusters1.data());
           if (trackletLabels.size()) {
@@ -189,6 +199,7 @@ void VertexerTraits::computeTracklets(const int iteration)
         trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
           !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(), // Clusters to be matched with the next layer in target rof
           !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),  // Clusters to be matched with the current layer in pivot rof
+                    mTimeFrame->getUsedClustersROF(targetRofId, 0),   // Span of the used clusters in the target rof
           mTimeFrame->getIndexTable(targetRofId, 0).data(),                                 // Index table to access the data on the next layer in target rof
           mVrtParams[iteration].phiCut,
           mTimeFrame->getTracklets()[0],                   // Flat tracklet buffer
@@ -201,6 +212,7 @@ void VertexerTraits::computeTracklets(const int iteration)
         trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
           !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
           !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getUsedClustersROF(targetRofId, 2),
           mTimeFrame->getIndexTable(targetRofId, 2).data(),
           mVrtParams[iteration].phiCut,
           mTimeFrame->getTracklets()[1],
@@ -232,6 +244,7 @@ void VertexerTraits::computeTracklets(const int iteration)
         trackleterKernelHost<TrackletMode::Layer0Layer1, false>(
           !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(),
           !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getUsedClustersROF(targetRofId, 0),
           mTimeFrame->getIndexTable(targetRofId, 0).data(),
           mVrtParams[iteration].phiCut,
           mTimeFrame->getTracklets()[0],
@@ -244,6 +257,7 @@ void VertexerTraits::computeTracklets(const int iteration)
         trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
           !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
           !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getUsedClustersROF(targetRofId, 2),
           mTimeFrame->getIndexTable(targetRofId, 2).data(),
           mVrtParams[iteration].phiCut,
           mTimeFrame->getTracklets()[1],
@@ -337,6 +351,8 @@ void VertexerTraits::computeTrackletMatching(const int iteration)
       trackletSelectionKernelHost(
         mTimeFrame->getClustersOnLayer(targetRofId, 0),
         mTimeFrame->getClustersOnLayer(pivotRofId, 1),
+        mTimeFrame->getUsedClustersROF(targetRofId, 0),
+        mTimeFrame->getUsedClustersROF(targetRofId, 2),
         mTimeFrame->getFoundTracklets(pivotRofId, 0),
         mTimeFrame->getFoundTracklets(pivotRofId, 1),
         usedTracklets,
@@ -345,7 +361,8 @@ void VertexerTraits::computeTrackletMatching(const int iteration)
         mTimeFrame->getLines(pivotRofId),
         mTimeFrame->getLabelsFoundTracklets(pivotRofId, 0),
         mTimeFrame->getLinesLabel(pivotRofId),
-        pivotRofId - targetRofId, // delta-rof
+        pivotRofId,
+        targetRofId,
         mVrtParams.tanLambdaCut,
         mVrtParams.phiCut);
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -19,7 +19,7 @@
 #include "ITStracking/VertexerTraits.h"
 #include "ITStracking/ClusterLines.h"
 #include "ITStracking/Tracklet.h"
-
+#define VTX_DEBUG
 #ifdef VTX_DEBUG
 #include "TTree.h"
 #include "TFile.h"
@@ -44,7 +44,7 @@ float smallestAngleDifference(float a, float b)
   return (diff < -constants::math::Pi) ? diff + constants::math::TwoPi : ((diff > constants::math::Pi) ? diff - constants::math::TwoPi : diff);
 }
 
-template <TrackletMode Mode, bool DryRun>
+template <TrackletMode Mode, bool EvalRun>
 void trackleterKernelHost(
   const gsl::span<const Cluster>& clustersNextLayer,    // 0 2
   const gsl::span<const Cluster>& clustersCurrentLayer, // 1 1
@@ -53,14 +53,15 @@ void trackleterKernelHost(
   std::vector<Tracklet>& tracklets,
   gsl::span<int> foundTracklets,
   const IndexTableUtils& utils,
-  const int rof,
-  const int rofFoundTrackletsOffset,
+  const int pivotRof,
+  const int targetRof,
+  int* rofFoundTrackletsOffset, // we want to change that, to keep track of the offset in deltaRof>0
   const int maxTrackletsPerCluster = static_cast<int>(2e3))
 {
   const int PhiBins{utils.getNphiBins()};
   const int ZBins{utils.getNzBins()};
   // loop on layer1 clusters
-  int cumulativeStoredTracklets{0};
+  // int cumulativeStoredTracklets{rofFoundTrackletsOffset};
   for (int iCurrentLayerClusterIndex = 0; iCurrentLayerClusterIndex < clustersCurrentLayer.size(); ++iCurrentLayerClusterIndex) {
     int storedTracklets{0};
     const Cluster& currentCluster{clustersCurrentLayer[iCurrentLayerClusterIndex]};
@@ -80,11 +81,11 @@ void trackleterKernelHost(
           const Cluster& nextCluster{clustersNextLayer[iNextLayerClusterIndex]};
           if (o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(currentCluster.phi, nextCluster.phi)) < phiCut) {
             if (storedTracklets < maxTrackletsPerCluster) {
-              if constexpr (!DryRun) {
+              if constexpr (!EvalRun) {
                 if constexpr (Mode == TrackletMode::Layer0Layer1) {
-                  tracklets[rofFoundTrackletsOffset + cumulativeStoredTracklets + storedTracklets] = Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, rof, rof};
+                  tracklets[*rofFoundTrackletsOffset + storedTracklets] = Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, targetRof, pivotRof};
                 } else {
-                  tracklets[rofFoundTrackletsOffset + cumulativeStoredTracklets + storedTracklets] = Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, rof, rof};
+                  tracklets[*rofFoundTrackletsOffset + storedTracklets] = Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, pivotRof, targetRof};
                 }
               }
               ++storedTracklets;
@@ -93,10 +94,10 @@ void trackleterKernelHost(
         }
       }
     }
-    if constexpr (DryRun) {
-      foundTracklets[iCurrentLayerClusterIndex] = storedTracklets;
+    if constexpr (EvalRun) {
+      foundTracklets[iCurrentLayerClusterIndex] += storedTracklets;
     } else {
-      cumulativeStoredTracklets += storedTracklets;
+      *rofFoundTrackletsOffset += storedTracklets;
     }
   }
 }
@@ -106,26 +107,32 @@ void trackletSelectionKernelHost(
   const gsl::span<const Cluster> clusters1, // 1
   const gsl::span<const Tracklet>& tracklets01,
   const gsl::span<const Tracklet>& tracklets12,
+  std::vector<bool>& usedTracklets,
   const gsl::span<int> foundTracklets01,
   const gsl::span<int> foundTracklets12,
-  std::vector<Line>& destTracklets,
+  std::vector<Line>& lines,
   const gsl::span<const MCCompLabel>& trackletLabels,
   std::vector<MCCompLabel>& linesLabels,
+  const int rofDist = 0, // signed rof distance to consider for the tracklet to be promoted, so to be sure taht clusters0 and clusters1 are consistent with tracklet indices
   const float tanLambdaCut = 0.025f,
   const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(1e2))
 {
   int offset01{0}, offset12{0};
-  std::vector<bool> usedTracklets(tracklets01.size(), false);
   for (unsigned int iCurrentLayerClusterIndex{0}; iCurrentLayerClusterIndex < clusters1.size(); ++iCurrentLayerClusterIndex) {
     int validTracklets{0};
     for (int iTracklet12{offset12}; iTracklet12 < offset12 + foundTracklets12[iCurrentLayerClusterIndex]; ++iTracklet12) {
       for (int iTracklet01{offset01}; iTracklet01 < offset01 + foundTracklets01[iCurrentLayerClusterIndex]; ++iTracklet01) {
-        const float deltaTanLambda{o2::gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].tanLambda - tracklets12[iTracklet12].tanLambda)};
-        const float deltaPhi{o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(tracklets01[iTracklet01].phi, tracklets12[iTracklet12].phi))};
+        const auto& tracklet01{tracklets01[iTracklet01]};
+        if (tracklet01.getDeltaRof() != rofDist) {
+          continue;
+        }
+        const float deltaTanLambda{o2::gpu::GPUCommonMath::Abs(tracklet01.tanLambda - tracklets12[iTracklet12].tanLambda)};
+        const float deltaPhi{o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(tracklet01.phi, tracklets12[iTracklet12].phi))};
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedTracklets[iTracklet01] = true;
-          destTracklets.emplace_back(tracklets01[iTracklet01], clusters0.data(), clusters1.data());
+          LOGP(info, "\t validated a tracklet over {}/{} with deltarof={}", tracklets01.size(), tracklets12.size(), tracklet01.getDeltaRof());
+          lines.emplace_back(tracklet01, clusters0.data(), clusters1.data());
           if (trackletLabels.size()) {
             linesLabels.emplace_back(trackletLabels[iTracklet01]);
           }
@@ -175,32 +182,38 @@ void VertexerTraits::computeTracklets(const int iteration)
 #pragma omp parallel num_threads(mNThreads)
   {
 #pragma omp for schedule(dynamic)
-    for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
-      bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(rofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-      trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 0) : gsl::span<Cluster>(),
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 1) : gsl::span<Cluster>(),
-        mTimeFrame->getIndexTable(rofId, 0).data(),
-        mVrtParams[iteration].phiCut,
-        mTimeFrame->getTracklets()[0],
-        mTimeFrame->getNTrackletsCluster(rofId, 0),
-        mIndexTableUtils,
-        rofId,
-        0,
-        mVrtParams[iteration].maxTrackletsPerCluster);
-      trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 2) : gsl::span<Cluster>(),
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 1) : gsl::span<Cluster>(),
-        mTimeFrame->getIndexTable(rofId, 2).data(),
-        mVrtParams[iteration].phiCut,
-        mTimeFrame->getTracklets()[1],
-        mTimeFrame->getNTrackletsCluster(rofId, 1),
-        mIndexTableUtils,
-        rofId,
-        0,
-        mVrtParams[iteration].maxTrackletsPerCluster);
-      mTimeFrame->getNTrackletsROf(rofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 0).begin(), mTimeFrame->getNTrackletsCluster(rofId, 0).end(), 0);
-      mTimeFrame->getNTrackletsROf(rofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 1).begin(), mTimeFrame->getNTrackletsCluster(rofId, 1).end(), 0);
+    for (int pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) { // Pivot rofId: the rof for which the tracklets are computed
+      bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
+      int startROF{std::max(0, pivotRofId - mVrtParams.deltaRof)};
+      int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
+      for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
+        trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(), // Clusters to be matched with the next layer in target rof
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),  // Clusters to be matched with the current layer in pivot rof
+          mTimeFrame->getIndexTable(targetRofId, 0).data(),                                 // Index table to access the data on the next layer in target rof
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[0],                   // Flat tracklet buffer
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 0), // Span of the number of tracklets per each cluster in pivot rof
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          nullptr, // Offset in the tracklet buffer
+          mVrtParams[iteration].maxTrackletsPerCluster);
+        trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getIndexTable(targetRofId, 2).data(),
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[1],
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 1), // Span of the number of tracklets per each cluster in pivot rof
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          nullptr, // Offset in the tracklet buffer
+          mVrtParams[iteration].maxTrackletsPerCluster);
+      }
+      mTimeFrame->getNTrackletsROF(pivotRofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(pivotRofId, 0).begin(), mTimeFrame->getNTrackletsCluster(pivotRofId, 0).end(), 0);
+      mTimeFrame->getNTrackletsROF(pivotRofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(pivotRofId, 1).begin(), mTimeFrame->getNTrackletsCluster(pivotRofId, 1).end(), 0);
     }
 #pragma omp single
     mTimeFrame->computeTrackletsScans(mNThreads);
@@ -210,30 +223,38 @@ void VertexerTraits::computeTracklets(const int iteration)
     mTimeFrame->getTracklets()[1].resize(mTimeFrame->getTotalTrackletsTF(1));
 
 #pragma omp for schedule(dynamic)
-    for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
-      bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(rofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-      trackleterKernelHost<TrackletMode::Layer0Layer1, false>(
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 0) : gsl::span<Cluster>(),
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 1) : gsl::span<Cluster>(),
-        mTimeFrame->getIndexTable(rofId, 0).data(),
-        mVrtParams[iteration].phiCut,
-        mTimeFrame->getTracklets()[0],
-        mTimeFrame->getNTrackletsCluster(rofId, 0),
-        mIndexTableUtils,
-        rofId,
-        mTimeFrame->getNTrackletsROf(rofId, 0),
-        mVrtParams[iteration].maxTrackletsPerCluster);
-      trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 2) : gsl::span<Cluster>(),
-        !skipROF ? mTimeFrame->getClustersOnLayer(rofId, 1) : gsl::span<Cluster>(),
-        mTimeFrame->getIndexTable(rofId, 2).data(),
-        mVrtParams[iteration].phiCut,
-        mTimeFrame->getTracklets()[1],
-        mTimeFrame->getNTrackletsCluster(rofId, 1),
-        mIndexTableUtils,
-        rofId,
-        mTimeFrame->getNTrackletsROf(rofId, 1),
-        mVrtParams[iteration].maxTrackletsPerCluster);
+    for (int pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) {
+      bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
+      int startROF{std::max(0, pivotRofId - mVrtParams[iteration].deltaRof)};
+      int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams[iteration].deltaRof + 1)};
+      auto mobileOffset0 = mTimeFrame->getNTrackletsROF(pivotRofId, 0);
+      auto mobileOffset1 = mTimeFrame->getNTrackletsROF(pivotRofId, 1);
+      for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
+        trackleterKernelHost<TrackletMode::Layer0Layer1, false>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(),
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getIndexTable(targetRofId, 0).data(),
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[0],
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 0),
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          &mobileOffset0,
+          mVrtParams[iteration].maxTrackletsPerCluster);
+        trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getIndexTable(targetRofId, 2).data(),
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[1],
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 1),
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          &mobileOffset1,
+          mVrtParams[iteration].maxTrackletsPerCluster);
+      }
     }
   }
 
@@ -242,7 +263,7 @@ void VertexerTraits::computeTracklets(const int iteration)
     for (auto& trk : mTimeFrame->getTracklets()[0]) {
       MCCompLabel label;
       int sortedId0{mTimeFrame->getSortedIndex(trk.rof[0], 0, trk.firstClusterIndex)};
-      int sortedId1{mTimeFrame->getSortedIndex(trk.rof[0], 1, trk.secondClusterIndex)};
+      int sortedId1{mTimeFrame->getSortedIndex(trk.rof[1], 1, trk.secondClusterIndex)};
       for (auto& lab0 : mTimeFrame->getClusterLabels(0, mTimeFrame->getClusters()[0][sortedId0].clusterId)) {
         for (auto& lab1 : mTimeFrame->getClusterLabels(1, mTimeFrame->getClusters()[1][sortedId1].clusterId)) {
           if (lab0 == lab1 && lab0.isValid()) {
@@ -299,23 +320,31 @@ void VertexerTraits::computeTracklets(const int iteration)
 void VertexerTraits::computeTrackletMatching(const int iteration)
 {
 #pragma omp parallel for num_threads(mNThreads) schedule(dynamic)
-  for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
-    if (iteration && (int)mTimeFrame->getPrimaryVertices(rofId).size() > mVrtParams[iteration].vertPerRofThreshold) {
+  for (int pivotRofId = 0; pivotRofId < mTimeFrame->getNrof(); ++pivotRofId) {
+    if (iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold) {
       continue;
     }
-    mTimeFrame->getLines(rofId).reserve(mTimeFrame->getNTrackletsCluster(rofId, 0).size());
-    trackletSelectionKernelHost(
-      mTimeFrame->getClustersOnLayer(rofId, 0),
-      mTimeFrame->getClustersOnLayer(rofId, 1),
-      mTimeFrame->getFoundTracklets(rofId, 0),
-      mTimeFrame->getFoundTracklets(rofId, 1),
-      mTimeFrame->getNTrackletsCluster(rofId, 0),
-      mTimeFrame->getNTrackletsCluster(rofId, 1),
-      mTimeFrame->getLines(rofId),
-      mTimeFrame->getLabelsFoundTracklets(rofId, 0),
-      mTimeFrame->getLinesLabel(rofId),
-      mVrtParams[iteration].tanLambdaCut,
-      mVrtParams[iteration].phiCut);
+    mTimeFrame->getLines(pivotRofId).reserve(mTimeFrame->getNTrackletsCluster(pivotRofId, 0).size());
+    std::vector<bool> usedTracklets(mTimeFrame->getFoundTracklets(pivotRofId, 0).size(), false);
+    int startROF{std::max(0, pivotRofId - mVrtParams.deltaRof)};
+    int endROF{std::min(mTimeFrame->getNrof(), pivotRofId + mVrtParams.deltaRof + 1)};
+    for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
+      LOGP(info, "Matching tracklets from rof {} to rof {}, delta={}", pivotRofId, targetRofId, pivotRofId - targetRofId);
+      trackletSelectionKernelHost(
+        mTimeFrame->getClustersOnLayer(targetRofId, 0),
+        mTimeFrame->getClustersOnLayer(pivotRofId, 1),
+        mTimeFrame->getFoundTracklets(pivotRofId, 0),
+        mTimeFrame->getFoundTracklets(pivotRofId, 1),
+        usedTracklets,
+        mTimeFrame->getNTrackletsCluster(pivotRofId, 0),
+        mTimeFrame->getNTrackletsCluster(pivotRofId, 1),
+        mTimeFrame->getLines(pivotRofId),
+        mTimeFrame->getLabelsFoundTracklets(pivotRofId, 0),
+        mTimeFrame->getLinesLabel(pivotRofId),
+        pivotRofId - targetRofId,
+        mVrtParams.tanLambdaCut,
+        mVrtParams.phiCut);
+    }
   }
 
 #ifdef VTX_DEBUG

--- a/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
@@ -115,7 +115,7 @@ int loadROFrameDataITS3(its::TimeFrame* tf,
       tf->addClusterExternalIndexToLayer(layer, clusterId);
     }
     for (unsigned int iL{0}; iL < tf->getUnsortedClusters().size(); ++iL) {
-      tf->mROframesClusters[iL].push_back(tf->getUnsortedClusters()[iL].size());
+      tf->mROFramesClusters[iL].push_back(tf->getUnsortedClusters()[iL].size());
     }
     tf->mNrof++;
   }

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -252,7 +252,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (auto& v : vtxVecLoc) {
         vertices.push_back(v);
       }
-      timeFrame->addPrimaryVertices(vtxVecLoc, iRof);
+      timeFrame->addPrimaryVertices(vtxVecLoc, iRof, 0);
     }
   }
   // LOG(info) << fmt::format(" - rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, rofspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -252,7 +252,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (auto& v : vtxVecLoc) {
         vertices.push_back(v);
       }
-      timeFrame->addPrimaryVertices(vtxVecLoc);
+      timeFrame->addPrimaryVertices(vtxVecLoc, iRof);
     }
   }
   // LOG(info) << fmt::format(" - rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, rofspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);


### PR DESCRIPTION
The rationale is the same as the Tracking one:
- `ITSVertexerParam.deltaRof=1` to enable it.
- If enabled, it looks for clusters in the neighbour ROFs.
- Sets deltaRof=0 in UPC iterations.