### PR TITLE
DPL: demote error to warning when dropping on a stop transition

### DIFF
--- a/Framework/Core/include/Framework/DefaultsHelpers.h
+++ b/Framework/Core/include/Framework/DefaultsHelpers.h
@@ -18,6 +18,8 @@ enum struct DeploymentMode;
 
 struct DefaultsHelpers {
   static DeploymentMode deploymentMode();
+  /// @true if running online
+  static bool onlineDeploymentMode();
   /// get max number of timeslices in the queue
   static unsigned int pipelineLength();
 };

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -848,8 +848,7 @@ o2::framework::ServiceSpec CommonServices::dataProcessingStats()
       bool enableDebugMetrics = true;
 #endif
       bool arrowAndResourceLimitingMetrics = false;
-      DeploymentMode deploymentMode = DefaultsHelpers::deploymentMode();
-      if (deploymentMode != DeploymentMode::OnlineDDS && deploymentMode != DeploymentMode::OnlineECS && deploymentMode != DeploymentMode::OnlineAUX && deploymentMode != DeploymentMode::FST) {
+      if (!DefaultsHelpers::onlineDeploymentMode() && DefaultsHelpers::deploymentMode() != DeploymentMode::FST) {
         arrowAndResourceLimitingMetrics = true;
       }
       // Input proxies should not report cpu_usage_fraction,
@@ -1243,8 +1242,7 @@ std::vector<ServiceSpec> CommonServices::defaultServices(std::string extraPlugin
     objectCache(),
     ccdbSupportSpec()};
 
-  DeploymentMode deploymentMode = DefaultsHelpers::deploymentMode();
-  if (deploymentMode != DeploymentMode::OnlineDDS && deploymentMode != DeploymentMode::OnlineECS && deploymentMode != DeploymentMode::OnlineAUX && deploymentMode != DeploymentMode::FST) {
+  if (!DefaultsHelpers::onlineDeploymentMode() && DefaultsHelpers::deploymentMode() != DeploymentMode::FST) {
     specs.push_back(ArrowSupport::arrowBackendSpec());
   }
   specs.push_back(CommonMessageBackends::fairMQBackendSpec());
@@ -1253,7 +1251,7 @@ std::vector<ServiceSpec> CommonServices::defaultServices(std::string extraPlugin
 
   std::string loadableServicesStr = extraPlugins;
   // Do not load InfoLogger by default if we are not at P2.
-  if (deploymentMode == DeploymentMode::OnlineDDS || deploymentMode == DeploymentMode::OnlineECS || deploymentMode == DeploymentMode::OnlineAUX) {
+  if (DefaultsHelpers::onlineDeploymentMode()) {
     if (loadableServicesStr.empty() == false) {
       loadableServicesStr += ",";
     }

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -307,7 +307,12 @@ void DataRelayer::setOldestPossibleInput(TimesliceId proposed, ChannelIndex chan
       if (element.size() != 0) {
         if (input.lifetime != Lifetime::Condition && mCompletionPolicy.name != "internal-dpl-injected-dummy-sink") {
           didDrop = true;
-          LOGP(error, "Dropping incomplete {} Lifetime::{} data in slot {} with timestamp {} < {} as it can never be completed.", DataSpecUtils::describe(input), input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          auto& state = mContext.get<DeviceState>();
+          if (state.transitionHandling != TransitionHandlingState::NoTransition && DefaultsHelpers::onlineDeploymentMode()) {
+            LOGP(warning, "Stop transition requested. Dropping incomplete {} Lifetime::{} data in slot {} with timestamp {} < {} as it will never be completed.", DataSpecUtils::describe(input), input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          } else {
+            LOGP(error, "Dropping incomplete {} Lifetime::{} data in slot {} with timestamp {} < {} as it can never be completed.", DataSpecUtils::describe(input), input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          }
         } else {
           LOGP(debug,
                "Silently dropping data {} in pipeline slot {} because it has timeslice {} < {} after receiving data from channel {}."
@@ -326,7 +331,12 @@ void DataRelayer::setOldestPossibleInput(TimesliceId proposed, ChannelIndex chan
         }
         auto& element = mCache[si * mInputs.size() + mi];
         if (element.size() == 0) {
-          LOGP(error, "Missing {} (lifetime:{}) while dropping incomplete data in slot {} with timestamp {} < {}.", DataSpecUtils::describe(input), input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          auto& state = mContext.get<DeviceState>();
+          if (state.transitionHandling != TransitionHandlingState::NoTransition && DefaultsHelpers::onlineDeploymentMode()) {
+            LOGP(warning, "Missing {} (lifetime:{}) while dropping incomplete data in slot {} with timestamp {} < {}.", DataSpecUtils::describe(input), input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          } else {
+            LOGP(error, "Missing {} (lifetime:{}) while dropping incomplete data in slot {} with timestamp {} < {}.", DataSpecUtils::describe(input), input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          }
         }
       }
     }

--- a/Framework/Core/src/DefaultsHelpers.cxx
+++ b/Framework/Core/src/DefaultsHelpers.cxx
@@ -64,4 +64,16 @@ DeploymentMode DefaultsHelpers::deploymentMode()
   return retVal;
 }
 
+bool DefaultsHelpers::onlineDeploymentMode()
+{
+  switch (DefaultsHelpers::deploymentMode()) {
+    case DeploymentMode::OnlineAUX:
+    case DeploymentMode::OnlineECS:
+    case DeploymentMode::OnlineDDS:
+      return true;
+    default:
+      return false;
+  }
+}
+
 } // namespace o2::framework


### PR DESCRIPTION
DPL: demote error to warning when dropping on a stop transition

Data might be missing for real here, and dropping the processing of
those timeslices is the unfortunate but correct thing to do.
