### PR TITLE
[EMCAL-1135] Throw exception in case of to large starttime for TRU channel

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/TRUDecodingErrors.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/TRUDecodingErrors.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_TRUDECODINGERRORS_H
+#define ALICEO2_EMCAL_TRUDECODINGERRORS_H
+
+#include <exception>
+#include <string>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class FastOrStartTimeInvalidException
+/// \brief Handling of error if starttime is to large (>=14). This is most likely caused by a corrupted channel header where a FEC channel is identified as a TRU channel
+/// \ingroup EMCALbase
+class FastOrStartTimeInvalidException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param l0size Size of the L0 patch
+  FastOrStartTimeInvalidException(unsigned int time) : std::exception(), mErrorMessage(), mStartTime(time)
+  {
+    mErrorMessage = "FastOr starttime invalid: " + std::to_string(time);
+  }
+
+  /// \brief Destructor
+  ~FastOrStartTimeInvalidException() noexcept final = default;
+
+  /// \brief Access to error message
+  /// \return Error message
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the size of the L0 patch
+  /// \return Size of the L0 patch
+  unsigned int getStartTime() const noexcept { return mStartTime; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for error message
+  int mStartTime;            ///< Size of the L0 patch
+};
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif //  ALICEO2_EMCAL_TRUDECODINGERRORS_H

--- a/Detectors/EMCAL/reconstruction/src/FastORTimeSeries.cxx
+++ b/Detectors/EMCAL/reconstruction/src/FastORTimeSeries.cxx
@@ -12,12 +12,15 @@
 #include <algorithm>
 #include <iostream>
 #include "EMCALReconstruction/FastORTimeSeries.h"
+#include "EMCALBase/TRUDecodingErrors.h"
 
 using namespace o2::emcal;
 
 void FastORTimeSeries::fillReversed(const gsl::span<const uint16_t> samples, uint8_t starttime)
 {
-
+  if (starttime >= 14) {
+    throw FastOrStartTimeInvalidException(starttime);
+  }
   for (std::size_t isample = 0; isample < samples.size(); isample++) {
     mTimeSamples[starttime - isample] = samples[isample];
   }

--- a/Detectors/EMCAL/reconstruction/test/testFastORTimeSeries.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testFastORTimeSeries.cxx
@@ -16,6 +16,7 @@
 #include <tuple>
 #include <TRandom.h>
 #include <EMCALReconstruction/FastORTimeSeries.h>
+#include "EMCALBase/TRUDecodingErrors.h"
 
 namespace o2
 {
@@ -139,6 +140,12 @@ BOOST_AUTO_TEST_CASE(FastORTimeSeries_test)
     BOOST_CHECK_EQUAL_COLLECTIONS(adcs.begin(), adcs.end(), reference.begin(), reference.end());
     BOOST_CHECK_EQUAL(testcase.calculateL1TimeSum(8), calculateTimesum(reference, 8));
   }
+
+  // test case where a normal FEC channel is identified as TRU channel. FEC channel can have lenght of 15 and would therefore cause an overflow in the FEC channel (max lenght 14)
+  auto starttime = 14;
+  auto bunch = generateSmallBunch(14);
+  BOOST_CHECK_EXCEPTION(FastORTimeSeries(14, bunch, starttime), FastOrStartTimeInvalidException, [starttime](const FastOrStartTimeInvalidException& e) { return e.getStartTime() == starttime; });
+
   return;
 
   // test adding 2 bunches


### PR DESCRIPTION


- A case was found where the starttime was larger than the maximum possible bunch length of a TRU channel
- For REC channel, the maximum length is 15, while for TRU channel, it is 14.
- A possible bit-flip could cause a FEC channel to be flagged as TRU channel, however if that channel than has a starttime of 14, it will write into unallocated memory as it exceeds the length of the vector
- Added an exception and implemented a unit test for the exception