### PR TITLE
Use rejectlist in MID reconstruction

### DIFF
--- a/Detectors/MUON/MID/Filtering/include/MIDFiltering/ChannelMasksHandler.h
+++ b/Detectors/MUON/MID/Filtering/include/MIDFiltering/ChannelMasksHandler.h
@@ -71,6 +71,9 @@ class ChannelMasksHandler
   /// Comparison operator
   bool operator==(const ChannelMasksHandler& right) const { return mMasks == right.mMasks; }
 
+  /// Clear masks
+  void clear() { mMasks.clear(); }
+
  private:
   /// Gets the mask
   /// \param deId Detection element ID

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
@@ -55,7 +55,8 @@ class HitMapBuilder
 
   /// Sets the masked channels
   /// \param maskedChannels vector of masked channels
-  void setMaskedChannels(const std::vector<ColumnData>& maskedChannels);
+  /// \param clear clear the current masks
+  void setMaskedChannels(const std::vector<ColumnData>& maskedChannels, bool clear);
 
  private:
   /// Checks if the track crossed the same element

--- a/Detectors/MUON/MID/Tracking/src/HitMapBuilder.cxx
+++ b/Detectors/MUON/MID/Tracking/src/HitMapBuilder.cxx
@@ -23,9 +23,11 @@ namespace mid
 
 HitMapBuilder::HitMapBuilder(const GeometryTransformer& geoTrans) : mMapping(), mHitFinder(geoTrans) {}
 
-void HitMapBuilder::setMaskedChannels(const std::vector<ColumnData>& maskedChannels)
+void HitMapBuilder::setMaskedChannels(const std::vector<ColumnData>& maskedChannels, bool clear)
 {
-  mMaskedChannels.clear();
+  if (clear) {
+    mMaskedChannels.clear();
+  }
   std::array<int, 2> nLines{4, 1};
   for (auto& mask : maskedChannels) {
     for (int icath = 0; icath < 2; ++icath) {

--- a/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
@@ -102,14 +102,24 @@ class TrackerDeviceDPL
 
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
   {
-    if (mCheckMasked && matcher == of::ConcreteDataMatcher(header::gDataOriginMID, "MASKED_CHANNELS", 0)) {
-      LOG(info) << "Update MID_MASKED_CHANNELS";
-      auto* badChannels = static_cast<std::vector<ColumnData>*>(obj);
-      mHitMapBuilder->setMaskedChannels(*badChannels);
-      return;
-    }
     if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
       return;
+    }
+    if (mCheckMasked) {
+      bool rebuildMaskedChannels = false;
+      if (matcher == of::ConcreteDataMatcher(header::gDataOriginMID, "BAD_CH_TRK", 0)) {
+        LOG(info) << "Update MID_BAD_CH_TRK";
+        mBadChannels = *static_cast<std::vector<ColumnData>*>(obj);
+        rebuildMaskedChannels = true;
+      } else if (matcher == of::ConcreteDataMatcher(header::gDataOriginMID, "REJECTLIST_TRK", 0)) {
+        LOG(info) << "Update MID_REJECTLIST_TRK";
+        mRejectList = *static_cast<std::vector<ColumnData>*>(obj);
+        rebuildMaskedChannels = true;
+      }
+      if (rebuildMaskedChannels) {
+        mHitMapBuilder->setMaskedChannels(mBadChannels, true);
+        mHitMapBuilder->setMaskedChannels(mRejectList, false);
+      }
     }
   }
 
@@ -129,6 +139,7 @@ class TrackerDeviceDPL
       mHitMapBuilder = std::make_unique<HitMapBuilder>(geoTrans);
     }
     pc.inputs().get<std::vector<ColumnData>*>("mid_bad_channels_forTracks");
+    pc.inputs().get<std::vector<ColumnData>*>("mid_rejectlist_forTracks");
   }
 
   bool mIsMC = false;
@@ -142,6 +153,8 @@ class TrackerDeviceDPL
   std::chrono::duration<double> mTimerTracker{0}; ///< tracker timer
   std::chrono::duration<double> mTimerBuilder{0}; ///< hit map builder timer
   unsigned int mNROFs{0};                         /// Total number of processed ROFs
+  std::vector<ColumnData> mBadChannels{};         ///< Bad channels
+  std::vector<ColumnData> mRejectList{};          ///< Reject list
 };
 
 framework::DataProcessorSpec getTrackerSpec(bool isMC, bool checkMasked)
@@ -149,7 +162,8 @@ framework::DataProcessorSpec getTrackerSpec(bool isMC, bool checkMasked)
   std::vector<of::InputSpec> inputSpecs;
   inputSpecs.emplace_back("mid_clusters", header::gDataOriginMID, "CLUSTERS");
   inputSpecs.emplace_back("mid_clusters_rof", header::gDataOriginMID, "CLUSTERSROF");
-  inputSpecs.emplace_back("mid_bad_channels_forTracks", header::gDataOriginMID, "MASKED_CHANNELS", 0, of::Lifetime::Condition, of::ccdbParamSpec("MID/Calib/BadChannels"));
+  inputSpecs.emplace_back("mid_bad_channels_forTracks", header::gDataOriginMID, "BAD_CH_TRK", 0, of::Lifetime::Condition, of::ccdbParamSpec("MID/Calib/BadChannels"));
+  inputSpecs.emplace_back("mid_rejectlist_forTracks", header::gDataOriginMID, "REJECTLIST_TRK", 0, of::Lifetime::Condition, of::ccdbParamSpec("MID/Calib/RejectList"));
   auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
                                                               false,                             // GRPECS=true
                                                               false,                             // GRPLHCIF


### PR DESCRIPTION
This PR implements the use of a reject list, i.e. an additional list of bad channels to be masked.
The list is filled manually in the CCDB and allows to account for detector issues occurring during the run.
The first commit applies the reject list when filtering the MID digits. The second take them into account when estimating the RPC efficiency.
The commits are meant to be atomic: please do not squash.