### PR TITLE
GLO: Revert changes on CMakeLists

### DIFF
--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -22,6 +22,8 @@ o2_add_library(GlobalTracking
                        src/MatchGlobalFwdAssessment.cxx
                        src/MatchGlobalFwdParam.cxx
                        src/MatchTOFParams.cxx
+                       src/MatchITSTPCQC.cxx
+                       src/ITSTPCMatchingQCParams.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::DataFormatsTPC
                                      O2::DataFormatsITSMFT


### PR DESCRIPTION
In #13069 these were mistakenly removed and changes are now reverted.