### PR TITLE
GH Actions: Use proper token for creating datamodel-doc PR

### DIFF
--- a/.github/workflows/datamodel-doc.yml
+++ b/.github/workflows/datamodel-doc.yml
@@ -70,7 +70,7 @@ jobs:
           # Send pull request
           # We need to use "gh" ourselves because alisw/pull-request gets
           # confused when multiple repos are checked out.
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh pr create -B \
+          GH_TOKEN="$GITHUB_TOKEN" gh pr create -B \
           AliceO2Group:master -H alibuild:auto-datamodel-doc \
           --no-maintainer-edit -t 'Automatic data model update' -b "This update \
           to the data model documentation was automatically created from \


### PR DESCRIPTION
Current action is failing because it's not using the token with the correct permissions

I'm using ``ALIBUILD_GITHUB_TOKEN`` to standarize with the other commands, but in theory we could use ``GITHUB_TOKEN`` with some additional permissions too ( [Defining access for the GITHUB_TOKEN permissions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs#defining-access-for-the-github_token-permissions))

Reported by @vkucera, tagging @ktf for review
