### PR TITLE
TPC: improving simulation of distortions in MC

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -138,6 +138,9 @@ class Digitizer
   void setMeanLumiDistortions(float meanLumi);
   void setMeanLumiDistortionsDerivative(float meanLumi);
 
+  /// in case of scaled distortions, the distortions can be recalculated to ensure consistent distortions and corrections
+  void recalculateDistortions();
+
  private:
   DigitContainer mDigitContainer;      ///< Container for the Digits
   std::unique_ptr<SC> mSpaceCharge;    ///< Handler of full distortions (static + IR dependant)
@@ -151,7 +154,8 @@ class Digitizer
   bool mUseSCDistortions = false;      ///< Flag to switch on the use of space-charge distortions
   int mDistortionScaleType = 0;        ///< type=0: no scaling of distortions, type=1 distortions without any scaling, type=2 distortions scaling with lumi
   float mLumiScaleFactor = 0;          ///< value used to scale the derivative map
-  ClassDefNV(Digitizer, 2);
+  bool mUseScaledDistortions = false;  ///< whether the distortions are already scaled
+  ClassDefNV(Digitizer, 3);
 };
 } // namespace tpc
 } // namespace o2

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -240,7 +240,7 @@ void Digitizer::setMeanLumiDistortionsDerivative(float meanLumi)
 
 void Digitizer::recalculateDistortions()
 {
-  if (!mSpaceCharge || !mSpaceCharge) {
+  if (!mSpaceCharge || !mSpaceChargeDer) {
     LOGP(info, "Average or derivative distortions not set");
     return;
   }

--- a/Detectors/TPC/spacecharge/include/TPCSpaceCharge/SpaceCharge.h
+++ b/Detectors/TPC/spacecharge/include/TPCSpaceCharge/SpaceCharge.h
@@ -354,7 +354,20 @@ class SpaceCharge
   /// \param approachR when the difference between the desired r coordinate and the position of the global correction is deltaR, approach the desired r coordinate by deltaR * \p approachR.
   /// \param approachPhi when the difference between the desired phi coordinate and the position of the global correction is deltaPhi, approach the desired phi coordinate by deltaPhi * \p approachPhi.
   /// \param diffCorr if the absolute differences from the interpolated values for the global corrections from the last iteration compared to the current iteration is smaller than this value, set converged to true for current global distortion
-  void calcGlobalDistWithGlobalCorrIterative(const DistCorrInterpolator<DataT>& globCorr, const int maxIter = 100, const DataT approachZ = 0.5, const DataT approachR = 0.5, const DataT approachPhi = 0.5, const DataT diffCorr = 1e-6);
+  /// \param type whether to calculate distortions or corrections
+  void calcGlobalDistWithGlobalCorrIterative(const DistCorrInterpolator<DataT>& globCorr, const int maxIter = 100, const DataT approachZ = 1, const DataT approachR = 1, const DataT approachPhi = 1, const DataT diffCorr = 50e-6, const SpaceCharge<DataT>* scSCale = nullptr, float scale = 0);
+
+  /// step 5: calculate global distortions using the global corrections (FAST)
+  /// \param scSCale possible second sc object
+  /// \param scale scaling for second sc object
+  void calcGlobalDistWithGlobalCorrIterative(const Side side, const SpaceCharge<DataT>* scSCale = nullptr, float scale = 0, const int maxIter = 100, const DataT approachZ = 1, const DataT approachR = 1, const DataT approachPhi = 1, const DataT diffCorr = 50e-6);
+  void calcGlobalDistWithGlobalCorrIterative(const SpaceCharge<DataT>* scSCale = nullptr, float scale = 0, const int maxIter = 100, const DataT approachZ = 1, const DataT approachR = 1, const DataT approachPhi = 1, const DataT diffCorr = 50e-6);
+
+  /// calculate global corrections from global distortions
+  /// \param scSCale possible second sc object
+  /// \param scale scaling for second sc object
+  void calcGlobalCorrWithGlobalDistIterative(const Side side, const SpaceCharge<DataT>* scSCale = nullptr, float scale = 0, const int maxIter = 100, const DataT approachZ = 1, const DataT approachR = 1, const DataT approachPhi = 1, const DataT diffCorr = 50e-6);
+  void calcGlobalCorrWithGlobalDistIterative(const SpaceCharge<DataT>* scSCale = nullptr, float scale = 0, const int maxIter = 100, const DataT approachZ = 1, const DataT approachR = 1, const DataT approachPhi = 1, const DataT diffCorr = 50e-6);
 
   /// \return returns number of vertices in z direction
   unsigned short getNZVertices() const { return mParamGrid.NZVertices; }
@@ -1358,6 +1371,8 @@ class SpaceCharge
 
   /// set potentialsdue to ROD misalignment
   void initRodAlignmentVoltages(const MisalignmentType misalignmentType, const FCType fcType, const int sector, const Side side, const float deltaPot);
+
+  void calcGlobalDistCorrIterative(const DistCorrInterpolator<DataT>& globCorr, const int maxIter, const DataT approachZ, const DataT approachR, const DataT approachPhi, const DataT diffCorr, const SpaceCharge<DataT>* scSCale, float scale, const Type type);
 
   ClassDefNV(SpaceCharge, 6);
 };

--- a/Detectors/TPC/spacecharge/src/SpaceCharge.cxx
+++ b/Detectors/TPC/spacecharge/src/SpaceCharge.cxx
@@ -748,7 +748,7 @@ void SpaceCharge<DataT>::calcGlobalDistCorrIterative(const DistCorrInterpolator<
     initContainer(mGlobalCorrdRPhi[side], true);
   }
 
-  const auto& scScale = (type == Type::Distortions) ? scSCale->mInterpolatorGlobalCorr[side] : scSCale->mInterpolatorGlobalDist[side];
+  const auto& scSCaleInterpolator = (type == Type::Distortions) ? scSCale->mInterpolatorGlobalCorr[side] : scSCale->mInterpolatorGlobalDist[side];
 
 #pragma omp parallel for num_threads(sNThreads)
   for (unsigned int iPhi = 0; iPhi < mParamGrid.NPhiVertices; ++iPhi) {
@@ -802,13 +802,13 @@ void SpaceCharge<DataT>::calcGlobalDistCorrIterative(const DistCorrInterpolator<
           // interpolate global correction at new point and calculate position of global correction
           corrdR = globCorr.evaldR(zCurrPos, rCurrPos, phiCurrPos);
           if (scSCale && scale != 0) {
-            corrdR += scale * scScale.evaldR(zCurrPos, rCurrPos, phiCurrPos);
+            corrdR += scale * scSCaleInterpolator.evaldR(zCurrPos, rCurrPos, phiCurrPos);
           }
           const DataT rNewPos = rCurrPos + corrdR;
 
           DataT corrPhi = 0;
           if (scSCale && scale != 0) {
-            corrPhi = scale * scScale.evaldRPhi(zCurrPos, rCurrPos, phiCurrPos);
+            corrPhi = scale * scSCaleInterpolator.evaldRPhi(zCurrPos, rCurrPos, phiCurrPos);
           }
           corrPhi += globCorr.evaldRPhi(zCurrPos, rCurrPos, phiCurrPos);
           corrPhi /= rCurrPos;
@@ -818,7 +818,7 @@ void SpaceCharge<DataT>::calcGlobalDistCorrIterative(const DistCorrInterpolator<
 
           corrdZ = globCorr.evaldZ(zCurrPos, rCurrPos, phiCurrPos);
           if (scSCale && scale != 0) {
-            corrdZ += scale * scScale.evaldZ(zCurrPos, rCurrPos, phiCurrPos);
+            corrdZ += scale * scSCaleInterpolator.evaldZ(zCurrPos, rCurrPos, phiCurrPos);
           }
           const DataT zNewPos = zCurrPos + corrdZ;
 


### PR DESCRIPTION
- adding option to recalculate (merging) the distortions in case of large scaling
- accessing the distortions of the derivative map at the distorted position for better consistency with corrections
- optimizing default parameters for calculating distortions/corrections