### PR TITLE
ITS - (and MFT), better TF sampling in the deadmap builder

### DIFF
--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -104,11 +104,16 @@ class ITSMFTDeadMapBuilder : public Task
 
   unsigned long mFirstOrbitTF = 0x0;
   unsigned long mFirstOrbitRun = 0x0;
-  long mLastSampledOrbit = 0x0;
 
   std::string mDataSource = "chipsstatus";
 
   int mTFSampling = 350;
+
+  // utils for an improved sampling algorithm
+  std::unordered_set<long> mSampledTFs{};
+  std::deque<long> mSampledHistory{};
+  int mTFSamplingTolerance = 20;
+  int mSampledSlidingWindowSize = 1000; // units: mTFSampling
 
   o2::itsmft::TimeDeadMap mMapObject;
 
@@ -118,6 +123,7 @@ class ITSMFTDeadMapBuilder : public Task
   // Utils
 
   std::vector<uint16_t> getChipIDsOnSameCable(uint16_t);
+  bool acceptTF(long);
 
   o2::framework::DataTakingContext mDataTakingContext{};
   o2::framework::TimingInfo mTimingInfo{};

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -104,11 +104,11 @@ class ITSMFTDeadMapBuilder : public Task
 
   unsigned long mFirstOrbitTF = 0x0;
   unsigned long mFirstOrbitRun = 0x0;
+  long mLastSampledOrbit = 0x0;
 
   std::string mDataSource = "chipsstatus";
 
   int mTFSampling = 350;
-  std::string mSamplingMode = "first-orbit-run"; // Use this default to ensure process of first TF. At the moment, use any other option to sample on absolute orbit value.
 
   o2::itsmft::TimeDeadMap mMapObject;
 

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -47,6 +47,12 @@ void ITSMFTDeadMapBuilder::init(InitContext& ic)
   LOG(info) << "ITSMFTDeadMapBuilder init... " << mSelfName;
 
   mTFSampling = ic.options().get<int>("tf-sampling");
+  mTFSamplingTolerance = ic.options().get<int>("tf-sampling-tolerance");
+  if (mTFSamplingTolerance > mTFSampling) {
+    LOG(warning) << "Invalid request tf-sampling-tolerance larger or equal than tf-sampling. Setting tolerance to " << mTFSampling - 1;
+    mTFSamplingTolerance = mTFSampling - 1;
+  }
+  mSampledSlidingWindowSize = ic.options().get<int>("tf-sampling-history-size");
   mTFLength = ic.options().get<int>("tf-length");
   mDoLocalOutput = ic.options().get<bool>("local-output");
   mObjectName = ic.options().get<std::string>("outfile");
@@ -66,6 +72,8 @@ void ITSMFTDeadMapBuilder::init(InitContext& ic)
     N_CHIPS = o2::itsmft::ChipMappingITS::getNChips();
   }
 
+  mSampledTFs.clear();
+  mSampledHistory.clear();
   mDeadMapTF.clear();
   mStaticChipStatus.clear();
   mMapObject.clear();
@@ -75,7 +83,7 @@ void ITSMFTDeadMapBuilder::init(InitContext& ic)
     mStaticChipStatus.resize(N_CHIPS, false);
   }
 
-  LOG(info) << "Sampling one TF every " << mTFSampling;
+  LOG(info) << "Sampling one TF every " << mTFSampling << " with " << mTFSamplingTolerance << " TF tolerance";
 
   return;
 }
@@ -92,6 +100,39 @@ std::vector<uint16_t> ITSMFTDeadMapBuilder::getChipIDsOnSameCable(uint16_t chip)
     std::generate(chipList.begin(), chipList.end(), [&firstchipcable]() { return firstchipcable++; });
     return chipList;
   }
+}
+
+bool ITSMFTDeadMapBuilder::acceptTF(long orbit)
+{
+
+  // Description of the algorithm:
+  // Return true if the TF index (calculated as orbit/TF_length) falls within any interval [k * tf_sampling, k * tf_sampling + tolerance) for some integer k, provided no other TFs have been found in the same interval.
+
+  if (mTFSamplingTolerance < 1) {
+    return ((orbit / mTFLength) % mTFSampling == 0);
+  }
+
+  if ((orbit / mTFLength) % mTFSampling > mTFSamplingTolerance) {
+    return false;
+  }
+
+  long sampling_index = orbit / mTFLength / mTFSampling;
+
+  if (mSampledTFs.find(sampling_index) == mSampledTFs.end()) {
+
+    mSampledTFs.insert(sampling_index);
+    mSampledHistory.push_back(sampling_index);
+
+    if (mSampledHistory.size() > mSampledSlidingWindowSize) {
+      long oldIndex = mSampledHistory.front();
+      mSampledHistory.pop_front();
+      mSampledTFs.erase(oldIndex);
+    }
+
+    return true;
+  }
+
+  return false;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -152,12 +193,11 @@ void ITSMFTDeadMapBuilder::run(ProcessingContext& pc)
 
   long sampled_orbit = mFirstOrbitTF - mFirstOrbitRun;
 
-  if ((sampled_orbit / mTFLength) % mTFSampling != 0 && sampled_orbit <= mLastSampledOrbit + mTFLength * mTFSampling) {
+  if (!acceptTF(sampled_orbit)) {
     return;
   }
 
   mStepCounter++;
-  mLastSampledOrbit = sampled_orbit;
   LOG(info) << "Processing step #" << mStepCounter << " out of " << mTFCounter << " TF received. First orbit " << mFirstOrbitTF;
 
   mDeadMapTF.clear();
@@ -376,6 +416,8 @@ DataProcessorSpec getITSMFTDeadMapBuilderSpec(std::string datasource, bool doMFT
     outputs,
     AlgorithmSpec{adaptFromTask<ITSMFTDeadMapBuilder>(datasource, doMFT)},
     Options{{"tf-sampling", VariantType::Int, 350, {"Process every Nth TF. Selection according to first TF orbit."}},
+            {"tf-sampling-tolerance", VariantType::Int, 20, {"Tolerance on the tf-sampling value (sliding window size)."}},
+            {"tf-sampling-history-size", VariantType::Int, 1000, {"Do not check if new TF is contained in a window that is older than N steps."}},
             {"tf-length", VariantType::Int, 32, {"Orbits per TF."}},
             {"skip-static-map", VariantType::Bool, false, {"Do not fill static part of the map."}},
             {"ccdb-url", VariantType::String, "", {"CCDB url. Ignored if endOfStream is processed."}},


### PR DESCRIPTION
@iravasen , @jovankaas, @IsakovAD, below the details of the fine tuning in this PR:


**outdated (see conversation below): **

The dead map builder is currently sampling online 1 TF every 350 using the condition "CurrentTF % 350 == 0".
I've noticed that few hiccups may occur resulting in gaps of 2x, 3x or 4x 350 TFs.

This PR tries to workaround this, by modifying the sampling condition as follows: "CurrentTF % 350 == 0 OR CurrentTF - LastProcessedTF > 350".

caveat: depending on the order of arrival of the TFs to the aggregator node, this may result in oversampling, good from the physics point of view but increasing the size of the object handled by the workflow.

** New implementation in the second commit **, commented below


