### PR TITLE
Added severity flag to uvErrorCheck in CcdbDownloader.

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -87,6 +87,11 @@ curl_socket_t opensocketCallback(void* clientp, curlsocktype purpose, struct cur
  */
 void onUVClose(uv_handle_t* handle);
 
+enum DownloaderErrorLevel {
+  MINOR,
+  SEVERE
+};
+
 /// A class encapsulating and performing simple CURL requests in terms of a so-called CURL multi-handle.
 /// A multi-handle allows to use a connection pool (connection cache) in the CURL layer even
 /// with short-lived CURL easy-handles. Thereby the overhead of connection to servers can be


### PR DESCRIPTION
While a lot of errors `CCDBDownloader: UV error - bad file descriptor`  show up some of them can be demoted to warnings as they don't have significant impact on the downloader workflow. This PR adds a severity flag which demotes messages regarding socket status to warnings to address this issue.