### PR TITLE
DPL: improve backtrace handling

### DIFF
--- a/Framework/Foundation/test/test_SignpostLogger.cxx
+++ b/Framework/Foundation/test/test_SignpostLogger.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 
 O2_DECLARE_LOG(test_Signpost2, "my category2");
+O2_DECLARE_DYNAMIC_STACKTRACE_LOG(SignpostStacktrace);
 
 int main(int argc, char** argv)
 {
@@ -57,4 +58,9 @@ int main(int argc, char** argv)
   O2_SIGNPOST_START(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will see, because we turned them on");
   O2_SIGNPOST_END(test_SignpostDynamic, id, "Test category", "This is dynamic signpost which you will see, because we turned them on");
 #endif
+
+  // Test stacktraces
+  O2_SIGNPOST_ID_GENERATE(idStacktrace, SignpostStacktrace);
+  O2_LOG_ENABLE(SignpostStacktrace);
+  O2_SIGNPOST_EVENT_EMIT_ERROR(SignpostStacktrace, idStacktrace, "Test category", "An error with stacktrace %d \n", 1);
 }


### PR DESCRIPTION
DPL: improve backtrace handling

In case demangling does not work, still try with addr2line. In case
that fails as well, print what we have from backtrace.
