### PR TITLE
Consistency fix in G4 physics model - fix EMCAL sampling factor

### DIFF
--- a/Common/SimConfig/include/SimConfig/G4Params.h
+++ b/Common/SimConfig/include/SimConfig/G4Params.h
@@ -22,17 +22,24 @@ namespace conf
 
 // enumerating the possible G4 physics settings
 enum class EG4Physics {
-  kFTFP_BERT_optical = 0,         /* just ordinary */
-  kFTFP_BERT_optical_biasing = 1, /* with biasing enabled */
-  kFTFP_INCLXX_optical = 2,       /* special INCL++ version */
-  kFTFP_BERT_HP_optical = 3       /* enable low energy neutron transport */
+  kFTFP_BERT_optical = 0,             /* just ordinary */
+  kFTFP_BERT_optical_biasing = 1,     /* with biasing enabled */
+  kFTFP_INCLXX_optical = 2,           /* special INCL++ version */
+  kFTFP_BERT_HP_optical = 3,          /* enable low energy neutron transport */
+  kFTFP_BERT_EMV_optical = 4,         /* just ordinary with faster electromagnetic physics */
+  kFTFP_BERT_EMV_optical_biasing = 5, /* with biasing enabled with faster electromagnetic physics */
+  kFTFP_INCLXX_EMV_optical = 6,       /* special INCL++ version */
+  kFTFP_BERT_EMV_HP_optical = 7,      /* enable low energy neutron transport */
+  kUSER = 8                           /* allows to give own string combination */
 };
 
 // parameters to influence the G4 engine
 struct G4Params : public o2::conf::ConfigurableParamHelper<G4Params> {
-  EG4Physics physicsmode = EG4Physics::kFTFP_BERT_optical; // physics mode with which to configure G4
+  EG4Physics physicsmode = EG4Physics::kFTFP_BERT_EMV_optical; // default physics mode with which to configure G4
 
   std::string configMacroFile = ""; // a user provided g4Config.in file (otherwise standard one fill be taken)
+  std::string userPhysicsList = ""; // possibility to directly give physics list as string
+
   std::string const& getPhysicsConfigString() const;
 
   O2ParamDef(G4Params, "G4");

--- a/Common/SimConfig/src/G4Params.cxx
+++ b/Common/SimConfig/src/G4Params.cxx
@@ -19,12 +19,21 @@ namespace conf
 
 namespace
 {
-static const std::string confstrings[4] = {"FTFP_BERT_EMV+optical", "FTFP_BERT_EMV+optical+biasing", "FTFP_INCLXX_EMV+optical",
+static const std::string confstrings[8] = {"FTFP_BERT+optical",
+                                           "FTFP_BERT+optical+biasing",
+                                           "FTFP_INCLXX+optical",
+                                           "FTFP_BERT_HP+optical",
+                                           "FTFP_BERT_EMV+optical",
+                                           "FTFP_BERT_EMV+optical+biasing",
+                                           "FTFP_INCLXX_EMV+optical",
                                            "FTFP_BERT_HP_EMV+optical"};
 }
 
 std::string const& G4Params::getPhysicsConfigString() const
 {
+  if (physicsmode == o2::conf::EG4Physics::kUSER) {
+    return userPhysicsList;
+  }
   return confstrings[(int)physicsmode];
 }
 

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -309,6 +309,9 @@ void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::
   }
 
   Float_t samplingFactorTranportModel = 1.;
+  // Note: The sampling factors are chosen so that results from the simulation
+  // engines correspond well with testbeam data
+
   if (contains(mcname, "Geant3")) {
     samplingFactorTranportModel = 1.; // 0.988 // Do nothing
   } else if (contains(mcname, "Fluka")) {
@@ -318,6 +321,9 @@ void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::
     LOG(info) << "Selected physics list: " << physicslist;
     // sampling factors for different Geant4 physics list
     // GEANT4 10.7 -> EMCAL-784
+
+    // set a default (there may be many physics list strings)
+    samplingFactorTranportModel = 0.81;
     if (physicslist == "FTFP_BERT_EMV+optical") {
       samplingFactorTranportModel = 0.821;
     } else if (physicslist == "FTFP_BERT_EMV+optical+biasing") {


### PR DESCRIPTION
improvement for G4 physics model (options):

- offer all physics lists with and without EMV (fast em physics) mode
- better consistency between enum name and actual physics string
- possibility that user gives own string for physics list

EMCAL detector:

- provide a reasonable sampling factor also for Geant4 physics lists not mentioned so far (fixing a problem when we switch from FTFP_BERT_EMV to FTFP_BERT for instance)