### PR TITLE
First iteration to make DCAFitterN GPU-compliant

### DIFF
--- a/Common/DCAFitter/CMakeLists.txt
+++ b/Common/DCAFitter/CMakeLists.txt
@@ -40,3 +40,5 @@ o2_add_test(
   LABELS vertexing
   ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
   VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})
+
+add_subdirectory(GPU)

--- a/Common/DCAFitter/GPU/CMakeLists.txt
+++ b/Common/DCAFitter/GPU/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+if(CUDA_ENABLED)
+# o2_add_library(DCAFitterCUDA
+#                TARGETVARNAME targetName
+#                SOURCES DCAFitterN.cu
+#                # src/FwdDCAFitterN.cxx
+#                PUBLIC_INCLUDE_DIRECTORIES ../include
+#                PUBLIC_LINK_LIBRARIES O2::MathUtils
+#                                      O2::ReconstructionDataFormats
+#                                      O2::DetectorsBase)
+
+# o2_add_test(DCAFitterNCUDA NAME testDCAFitterNCUDA
+#             SOURCES test/testDCAFitterNCUDA.cu
+#             COMPONENT_NAME DCAFitterCUDA
+#             PUBLIC_LINK_LIBRARIES O2::DCAFitter
+#             COMPONENT_NAME GPU
+#             LABELS gpu vertexing)
+endif()
+# if (HIP_ENABLED)
+# o2_add_test(DCAFitterNHIP NAME testDCAFitterNHIP
+#             SOURCES test/testDCAFitterNCUDA.cu
+#             HIPIFIED test
+#             PUBLIC_LINK_LIBRARIES O2::DCAFitterHIP
+#             COMPONENT_NAME GPU
+#             LABELS gpu vertexing)
+# endif()

--- a/Common/DCAFitter/GPU/DCAFitterN.cu
+++ b/Common/DCAFitter/GPU/DCAFitterN.cu
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __HIPCC__
+#include "hip/hip_runtime.h"
+#else
+#include <cuda.h>
+#endif
+
+#include "GPUCommonDef.h"
+#include "DCAFitter/DCAFitterN.h"
+
+namespace o2
+{
+namespace vertexing
+{
+GPUg() void __dummy_instance__()
+{
+#ifdef GPUCA_GPUCODE_DEVICE
+#pragma message "Compiling device code"
+#endif
+  DCAFitter2 ft2;
+  DCAFitter3 ft3;
+  o2::track::TrackParCov tr;
+  ft2.process(tr, tr);
+  ft3.process(tr, tr, tr);
+}
+
+} // namespace vertexing
+} // namespace o2

--- a/Common/DCAFitter/GPU/test/testDCAFitterNCUDA.cu
+++ b/Common/DCAFitter/GPU/test/testDCAFitterNCUDA.cu
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+/// \author matteo.concas@cern.ch
+#define BOOST_TEST_MODULE Test DCAFitterN class on GPU
+
+#ifdef __HIPCC__
+#define GPUPLATFORM "HIP"
+#include "hip/hip_runtime.h"
+#else
+#define GPUPLATFORM "CUDA"
+#include <cuda.h>
+#endif
+
+#include "DCAFitter/DCAFitterN.h"
+#include "GPUCommonDef.h"
+#include <boost/test/unit_test.hpp>
+
+namespace gpu
+{
+GPUg() void testDCAFitterInstanceKernel()
+{
+  o2::vertexing::DCAFitterN<2> ft; // 2 prong fitter
+  ft.setBz(0.f);
+}
+} // namespace gpu
+BOOST_AUTO_TEST_CASE(DCAFitterNProngs)
+{
+}

--- a/Common/MathUtils/include/MathUtils/Cartesian.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian.h
@@ -34,8 +34,8 @@
 #include "GPUCommonMath.h"
 #include "CartesianGPU.h"
 #include "SMatrixGPU.h"
-
 #endif
+
 #include "GPUROOTCartesianFwd.h"
 #include "GPUROOTSMatrixFwd.h"
 
@@ -250,6 +250,22 @@ class Transform3D : public ROOT::Math::Transform3D
   ClassDefNV(Transform3D, 1);
 };
 #endif // Disable for GPU
+
+// Aliasing of the Dot(SVector a, SVector b) operation between SVectors
+#if (!defined(GPUCA_STANDALONE) || !defined(DGPUCA_NO_ROOT)) && !defined(GPUCA_GPUCODE) && !defined(GPUCOMMONRTYPES_H_ACTIVE)
+template <class T, unsigned int D>
+inline T Dot(const SVector<T, D>& lhs, const SVector<T, D>& rhs)
+{
+  return ROOT::Math::Dot(lhs, rhs);
+}
+
+template <class T, unsigned int D1, unsigned int D2, class R>
+inline SMatrix<T, D1, D1, MatRepSym<T, D1>> Similarity(const SMatrix<T, D1, D2, R>& lhs, const SMatrix<T, D2, D2, MatRepSym<T, D2>>& rhs)
+{
+  return ROOT::Math::Similarity(lhs, rhs);
+}
+#endif // Disable for GPU
+
 } // namespace math_utils
 } // namespace o2
 

--- a/Common/MathUtils/include/MathUtils/SMatrixGPU.h
+++ b/Common/MathUtils/include/MathUtils/SMatrixGPU.h
@@ -1468,5 +1468,5 @@ GPUdi() SMatrixGPU<T, D1, D1, MatRepSymGPU<T, D1>> Similarity(const SMatrixGPU<T
   AssignSym::Evaluate(mret, tmp * Transpose(lhs));
   return mret;
 }
-}; // namespace o2::math_utils
+} // namespace o2::math_utils
 #endif

--- a/GPU/Common/GPUCommonArray.h
+++ b/GPU/Common/GPUCommonArray.h
@@ -38,5 +38,4 @@ template <typename T, size_t N>
 using array = std::array<T, N>;
 #endif
 } // namespace o2::gpu::gpustd
-
 #endif

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -87,6 +87,9 @@ class GPUCommonMath
   GPUhdni() static float Hypot(float x, float y, float z);
   GPUhdni() static float Hypot(float x, float y, float z, float w);
 
+  template <typename T>
+  GPUhd() static void Swap(T& a, T& b);
+
   template <class T>
   GPUdi() static T AtomicExch(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T val)
   {
@@ -173,7 +176,7 @@ class GPUCommonMath
 
 typedef GPUCommonMath CAMath;
 
-// CHOICE Syntax: CHOISE(Host, CUDA&HIP, OpenCL)
+// CHOICE Syntax: CHOICE(Host, CUDA&HIP, OpenCL)
 #if defined(GPUCA_GPUCODE_DEVICE) && (defined(__CUDACC__) || defined(__HIPCC__)) // clang-format off
     #define CHOICE(c1, c2, c3) (c2) // Select second option for CUDA and HIP
 #elif defined(GPUCA_GPUCODE_DEVICE) && defined (__OPENCL__)
@@ -319,6 +322,20 @@ GPUhdi() float GPUCommonMath::Hypot(float x, float y, float z)
 GPUhdi() float GPUCommonMath::Hypot(float x, float y, float z, float w)
 {
   return Sqrt(x * x + y * y + z * z + w * w);
+}
+
+template <typename T>
+void _swap(T& a, T& b)
+{
+  T tmp = a;
+  a = b;
+  b = tmp;
+}
+
+template <typename T>
+GPUhdi() void GPUCommonMath::Swap(T& a, T& b)
+{
+  CHOICE(std::swap(a, b), _swap<T>(a, b), _swap<T>(a, b));
 }
 
 template <class T>

--- a/GPU/Common/GPUROOTSMatrixFwd.h
+++ b/GPU/Common/GPUROOTSMatrixFwd.h
@@ -44,12 +44,12 @@ namespace detail
 {
 template <typename T, unsigned int N>
 class SVectorGPU;
+template <class T, unsigned int D1, unsigned int D2, class R>
+class SMatrixGPU;
 template <class T, unsigned int D>
 class MatRepSymGPU;
 template <class T, unsigned int D1, unsigned int D2>
 class MatRepStdGPU;
-template <class T, unsigned int D1, unsigned int D2, class R>
-class SMatrixGPU;
 } // namespace detail
 
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
@@ -59,17 +59,18 @@ template <class T, unsigned int D1, unsigned int D2, class R>
 using SMatrix = ROOT::Math::SMatrix<T, D1, D2, R>;
 template <class T, unsigned int D>
 using MatRepSym = ROOT::Math::MatRepSym<T, D>;
-template <class T, unsigned int D1, unsigned int D2>
+template <class T, unsigned int D1, unsigned int D2 = D1>
 using MatRepStd = ROOT::Math::MatRepStd<T, D1, D2>;
 #else
 template <typename T, unsigned int N>
 using SVector = detail::SVectorGPU<T, N>;
+template <class T, unsigned int D1, unsigned int D2 = D1, class R = detail::MatRepStdGPU<T, D1, D2>>
+using SMatrix = detail::SMatrixGPU<T, D1, D2, R>;
 template <class T, unsigned int D>
 using MatRepSym = detail::MatRepSymGPU<T, D>;
 template <class T, unsigned int D1, unsigned int D2 = D1>
 using MatRepStd = detail::MatRepStdGPU<T, D1, D2>;
-template <class T, unsigned int D1, unsigned int D2 = D1, class R = detail::MatRepStdGPU<T, D1, D2>>
-using SMatrix = detail::SMatrixGPU<T, D1, D2, R>;
+
 #endif
 
 } // namespace math_utils


### PR DESCRIPTION
Hi @shahor02 , 
I've tried making the DCAFitterN class usable on some GPU code.
I applied some of the usual messages we need to make the `DCAFitterN.h` code ROOT and STD library agnostic.
Nothing should have changed in practice compared to the previous version, as the correct ROOT and STDLib implementations are picked up later in the translation.
I removed two `std::move` in the `return` clause of two methods that would be RVO-ed anyway; this was necessary since it is STDLib.

Hi @davidrohr , it would be nice if you could look at the few changes in GPU-related things.

Note:
This is not yet functional on GPU. Notably, there are currently three main issues:
- When I try to create a library with e.g. nvcc it does not realise `GPUCA_GPUCODE_DEVICE` should be defined in the device code (see DCAFitterN.cu)
- Equivalent GPU-portable versions of `ROOT::Math::Dot` and  `ROOT::Math::Similarity` functions are already present in the SMatrixGPU.h file but are not yet connected to the aliasing in Cartesian.h.
- I am probably missing some detail in the usage of the forward-declared classes in `GPUROOTSMatrixFwd.h` since I end up in having `incomplete types` when I try to compile any  `o2::GPU::gpustd::array<SVectorGPU<float, 3>>`.