### PR TITLE
[EMCAL-1135] Throw exception in case starttime is to large or small

### DIFF
--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -63,6 +63,7 @@ o2_target_root_dictionary(
         include/EMCALReconstruction/RecoParam.h
         include/EMCALReconstruction/StuDecoder.h
         include/EMCALReconstruction/TRUDataHandler.h
+        include/EMCALReconstruction/TRUDecodingErrors.h
 )
 
 o2_add_executable(rawreader-file

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoContainer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoContainer.h
@@ -30,6 +30,9 @@
 #include <EMCALReconstruction/FastORTimeSeries.h>
 #include <EMCALReconstruction/TRUDataHandler.h>
 
+#ifndef ALICEO2_EMCAL_RECOCONTAINER_H
+#define ALICEO2_EMCAL_RECOCONTAINER_H
+
 namespace o2::emcal
 {
 /// \struct RecCellInfo
@@ -372,3 +375,5 @@ class RecoContainerReader
 };
 
 } // namespace o2::emcal
+
+#endif

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ReconstructionErrors.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ReconstructionErrors.h
@@ -222,10 +222,11 @@ const char* getGainErrorDescription(unsigned int errorcode);
 /// FastOR index or TRU index is called, or by the TRU data handler if
 /// the patch index is outside range.
 enum class TRUDecodingError_t {
-  TRU_INDEX_INVALID,    ///< TRU index invalid
-  PATCH_INDEX_INVALID,  ///< Patch index outside range
-  FASTOR_INDEX_INVALID, ///< FastOR index unknown
-  UNKNOWN_ERROR         ///< Unknown error type
+  TRU_INDEX_INVALID,        ///< TRU index invalid
+  PATCH_INDEX_INVALID,      ///< Patch index outside range
+  FASTOR_INDEX_INVALID,     ///< FastOR index unknown
+  FASTOR_STARTTIME_INVALID, ///< FastOr stattime is larger than 14
+  UNKNOWN_ERROR             ///< Unknown error type
 };
 
 /// \brief Get the number of TRU error codes
@@ -253,6 +254,8 @@ constexpr int getErrorCodeFromTRUDecodingError(TRUDecodingError_t error)
       return 1;
     case TRUDecodingError_t::FASTOR_INDEX_INVALID:
       return 2;
+    case TRUDecodingError_t::FASTOR_STARTTIME_INVALID:
+      return 3;
     case TRUDecodingError_t::UNKNOWN_ERROR:
       return -1;
   }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/TRUDecodingErrors.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/TRUDecodingErrors.h
@@ -29,7 +29,7 @@ class FastOrStartTimeInvalidException : public std::exception
  public:
   /// \brief Constructor
   /// \param l0size Size of the L0 patch
-  FastOrStartTimeInvalidException(unsigned int time) : std::exception(), mErrorMessage(), mStartTime(time)
+  FastOrStartTimeInvalidException(int time) : std::exception(), mErrorMessage(), mStartTime(time)
   {
     mErrorMessage = "FastOr starttime invalid: " + std::to_string(time);
   }
@@ -46,7 +46,7 @@ class FastOrStartTimeInvalidException : public std::exception
 
   /// \brief Get the size of the L0 patch
   /// \return Size of the L0 patch
-  unsigned int getStartTime() const noexcept { return mStartTime; }
+  int getStartTime() const noexcept { return mStartTime; }
 
  private:
   std::string mErrorMessage; ///< Buffer for error message

--- a/Detectors/EMCAL/reconstruction/src/FastORTimeSeries.cxx
+++ b/Detectors/EMCAL/reconstruction/src/FastORTimeSeries.cxx
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <iostream>
 #include "EMCALReconstruction/FastORTimeSeries.h"
-#include "EMCALBase/TRUDecodingErrors.h"
+#include "EMCALReconstruction/TRUDecodingErrors.h"
 
 using namespace o2::emcal;
 
@@ -20,6 +20,9 @@ void FastORTimeSeries::fillReversed(const gsl::span<const uint16_t> samples, uin
 {
   if (starttime >= 14) {
     throw FastOrStartTimeInvalidException(starttime);
+  }
+  if (starttime + 1 < samples.size()) {
+    throw FastOrStartTimeInvalidException(static_cast<int>(starttime) - static_cast<int>(samples.size()) + 1);
   }
   for (std::size_t isample = 0; isample < samples.size(); isample++) {
     mTimeSamples[starttime - isample] = samples[isample];

--- a/Detectors/EMCAL/reconstruction/src/ReconstructionErrors.cxx
+++ b/Detectors/EMCAL/reconstruction/src/ReconstructionErrors.cxx
@@ -156,6 +156,8 @@ TRUDecodingError_t getTRUDecodingErrorFromErrorCode(unsigned int errorcode)
       return TRUDecodingError_t::PATCH_INDEX_INVALID;
     case 2:
       return TRUDecodingError_t::FASTOR_INDEX_INVALID;
+    case 3:
+      return TRUDecodingError_t::FASTOR_STARTTIME_INVALID;
     default:
       return TRUDecodingError_t::UNKNOWN_ERROR;
   }
@@ -170,6 +172,8 @@ const char* getTRUDecodingErrorName(TRUDecodingError_t errortype)
       return "PatchIndexInvalid";
     case TRUDecodingError_t::FASTOR_INDEX_INVALID:
       return "FastORIndexInvalid";
+    case TRUDecodingError_t::FASTOR_STARTTIME_INVALID:
+      return "FastORStartTimeInvalid";
     default:
       return "UnknownError";
   }
@@ -189,6 +193,8 @@ const char* getTRUDecodingErrorTitle(TRUDecodingError_t errortype)
       return "Patch index invalid";
     case TRUDecodingError_t::FASTOR_INDEX_INVALID:
       return "FastOR index invalid";
+    case TRUDecodingError_t::FASTOR_STARTTIME_INVALID:
+      return "FastOR starttime invalid";
     default:
       return "Unknown error";
   }
@@ -208,6 +214,8 @@ const char* getTRUDecodingErrorErrorDescription(TRUDecodingError_t errortype)
       return "Patch index is invalid";
     case TRUDecodingError_t::FASTOR_INDEX_INVALID:
       return "FastOR index is invalid";
+    case TRUDecodingError_t::FASTOR_STARTTIME_INVALID:
+      return "FastOR starttime is invalid";
     default:
       return "Unknown error";
   }

--- a/Detectors/EMCAL/reconstruction/test/testFastORTimeSeries.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testFastORTimeSeries.cxx
@@ -16,7 +16,7 @@
 #include <tuple>
 #include <TRandom.h>
 #include <EMCALReconstruction/FastORTimeSeries.h>
-#include "EMCALBase/TRUDecodingErrors.h"
+#include "EMCALReconstruction/TRUDecodingErrors.h"
 
 namespace o2
 {

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -30,6 +30,7 @@
 #include "EMCALReconstruction/RawReaderMemory.h"
 #include "EMCALReconstruction/RecoContainer.h"
 #include "EMCALReconstruction/ReconstructionErrors.h"
+#include "EMCALReconstruction/TRUDecodingErrors.h"
 #include "EMCALWorkflow/CalibLoader.h"
 
 namespace o2
@@ -44,6 +45,7 @@ class MinorAltroDecodingError;
 class RawDecodingError;
 class FastORIndexException;
 class TRUIndexException;
+class FastOrStartTimeInvalidException;
 
 namespace reco_workflow
 {
@@ -465,6 +467,17 @@ class RawToCellConverterSpec : public framework::Task
   /// is activated an error object with additional information is
   /// produced.
   void handleFastORErrors(const FastORIndexException& error, unsigned int linkID, unsigned int indexTRU);
+
+  /// \brief Handler function for FastOR start time errors
+  /// \param error FastOR index error
+  /// \param linkID DDL raising the exception
+  /// \param indexTRU TRU raising the exception
+  ///
+  /// Errors are printed to the infoLogger until a user-defiened
+  /// threshold is reached. In case the export of decoder errors
+  /// is activated an error object with additional information is
+  /// produced.
+  void handleFastORStartTimeErrors(const FastOrStartTimeInvalidException& e, unsigned int linkID, unsigned int indexTRU);
 
   /// \brief Handler function patch index exception
   /// \param error Patch index error


### PR DESCRIPTION
- This commit is an extension for PR: https://github.com/AliceO2Group/AliceO2/pull/13326
- Move error class from base to reconstruction
- added handling of error RawToCell converter: handleFastORStartTimeErrors
- add error type to TRUDecodingError to indicate invalid starttime