### PR TITLE
Geant4: Disable TransportationWithMsc mode

### DIFF
--- a/Detectors/gconfig/g4config.in
+++ b/Detectors/gconfig/g4config.in
@@ -43,6 +43,9 @@
 /mcPhysics/emModel/setRegions  EMC_Lead$ EMC_Scintillator$
 /mcPhysics/emModel/setParticles  e- e+
 
+# combined transportation + Msc mode is currently broken for ALICE (Geant 10.2.0)
+/process/em/transportationWithMsc Disabled
+
 #
 # Adding extra lines for fixing tracking bias
 #


### PR DESCRIPTION
The combined transportation + multiple scattering stepping mode was introduced in Geant4 11.1 and made the default for physics list FTFP_BERT_EMV.

For ALICE, this mode does not work as spotted here: https://its.cern.ch/jira/browse/O2-5212

Disabling this mode fixed the issue and restores
the behaviour from Geant4 11.0.4