### PR TITLE
Fix for cluster sharing map allocating too much memory + related fixes

### DIFF
--- a/Detectors/TPC/qc/src/Tracking.cxx
+++ b/Detectors/TPC/qc/src/Tracking.cxx
@@ -55,7 +55,10 @@ void Tracking::initialize(outputModes outputMode, bool postprocessOnly)
   } else {
     throw std::runtime_error("Failed to initialize run parameters from GRP");
   }
-  mQAConfig->ReadConfigurableParam();
+  auto global = mQAConfig->ReadConfigurableParam();
+  if (grp->isDetReadOut(o2::detectors::DetID::TPC) && global.tpcTriggeredMode ^ !grp->isDetContinuousReadOut(o2::detectors::DetID::TPC)) {
+    throw std::runtime_error("TPC triggered mode (GPU_global.tpcTriggeredMode) not set correctly");
+  }
   mQAConfig->configQA.shipToQCAsCanvas = mOutputMode == outputLayout;
   mQA = std::make_unique<GPUO2InterfaceQA>(mQAConfig.get());
   if (!postprocessOnly) {

--- a/Detectors/TPC/workflow/src/ClusterSharingMapSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterSharingMapSpec.cxx
@@ -41,8 +41,8 @@ void ClusterSharingMapSpec::run(ProcessingContext& pc)
 
   std::shared_ptr<o2::gpu::GPUParam> param = o2::gpu::GPUO2InterfaceUtils::getFullParamShared(0.f, nHBPerTF);
   auto& bufVecSh = pc.outputs().make<std::vector<unsigned char>>(Output{o2::header::gDataOriginTPC, "CLSHAREDMAP", 0}, clustersTPC->clusterIndex.nClustersTotal);
-  size_t occupancyMapSize = o2::gpu::GPUO2InterfaceRefit::fillOccupancyMapGetSize(nHBPerTF, param.get());
-  auto& bufVecOcc = pc.outputs().make<std::vector<unsigned int>>(Output{o2::header::gDataOriginTPC, "TPCOCCUPANCYMAP", 0}, occupancyMapSize);
+  size_t occupancyMapSizeBytes = o2::gpu::GPUO2InterfaceRefit::fillOccupancyMapGetSize(nHBPerTF, param.get());
+  auto& bufVecOcc = pc.outputs().make<std::vector<unsigned int>>(Output{o2::header::gDataOriginTPC, "TPCOCCUPANCYMAP", 0}, occupancyMapSizeBytes / sizeof(int));
   o2::gpu::GPUO2InterfaceRefit::fillSharedClustersAndOccupancyMap(&clustersTPC->clusterIndex, tracksTPC, tracksTPCClRefs.data(), bufVecSh.data(), bufVecOcc.data(), nHBPerTF, param.get());
 
   timer.Stop();

--- a/GPU/GPUTracking/DataTypes/GPUSettings.h
+++ b/GPU/GPUTracking/DataTypes/GPUSettings.h
@@ -53,11 +53,11 @@ class GPUSettings
 #ifdef GPUCA_NOCOMPAT
 // Settings describing the global run parameters
 struct GPUSettingsGRP {
-  // All new members must be sizeof(int) resp. sizeof(float) for alignment reasons!
+  // All new members must be sizeof(int) resp. sizeof(float) for alignment reasons!, default value for newly added members for old data will be 0.
   float solenoidBzNominalGPU = -5.00668f; // solenoid field strength
   int constBz = 0;                        // for test-MC events with constant Bz
   int homemadeEvents = 0;                 // Toy-MC events
-  int continuousMaxTimeBin = 0;           // 0 for triggered events, -1 for default of 23ms
+  int continuousMaxTimeBin = 0;           // 0 for triggered events, -1 for default TF length
   int needsClusterer = 0;                 // Set to true if the data requires the clusterizer
   int doCompClusterDecode = 0;            // Set to true if the data contains compressed TPC clusters
 };

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfigurableParam.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfigurableParam.cxx
@@ -103,10 +103,12 @@ GPUSettingsO2 GPUO2InterfaceConfiguration::ReadConfigurableParam(GPUO2InterfaceC
   obj.configReconstruction = rec;
   obj.configDisplay = display;
   obj.configQA = QA;
-  if (global.continuousMaxTimeBin) {
-    obj.configGRP.continuousMaxTimeBin = global.continuousMaxTimeBin;
-  } else {
-    obj.configGRP.continuousMaxTimeBin = global.tpcTriggeredMode ? 0 : -1;
+  if (obj.configGRP.continuousMaxTimeBin == 0 || obj.configGRP.continuousMaxTimeBin == -1) {
+    if (global.continuousMaxTimeBin) {
+      obj.configGRP.continuousMaxTimeBin = global.continuousMaxTimeBin;
+    } else {
+      obj.configGRP.continuousMaxTimeBin = global.tpcTriggeredMode ? 0 : -1;
+    }
   }
   if (global.solenoidBzNominalGPU > -1e6f) {
     obj.configGRP.solenoidBzNominalGPU = global.solenoidBzNominalGPU;

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceUtils.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceUtils.cxx
@@ -85,8 +85,10 @@ std::unique_ptr<GPUParam> GPUO2InterfaceUtils::getFullParam(float solenoidBz, un
   if (!pConfiguration) {
     tmpConfig = std::make_unique<GPUO2InterfaceConfiguration>();
     pConfiguration = &tmpConfig;
+    (*pConfiguration)->configGRP.continuousMaxTimeBin = -1;
   } else if (!*pConfiguration) {
     *pConfiguration = std::make_unique<GPUO2InterfaceConfiguration>();
+    (*pConfiguration)->configGRP.continuousMaxTimeBin = -1;
   }
   (*pConfiguration)->configGRP.solenoidBzNominalGPU = solenoidBz;
   if (pO2Settings && *pO2Settings) {


### PR DESCRIPTION
Problem was not that nHbfPerTf was 128 instead of 32, as originally assumed, but simply it returned size in bytes, so factor 4 from sizeof(int) was incorrect.

While checking, I saw that the number of time bins was not always correct for triggered data.
Some cases are also fixed here, though not sure if it is always correct now, or if anyone actually uses triggered data.