### PR TITLE
Revert "DPL Analysis: make table origin a dynamic property in preparation to handle multiple sources (#13358)"

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerHelpers.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerHelpers.h
@@ -50,7 +50,7 @@ struct TripletEqualTo {
 typedef boost::unordered_map<Triplet_t, int, TripletHash, TripletEqualTo> TripletsMap_t;
 
 template <typename T>
-auto createTableCursor(framework::ProcessingContext& pc)
+framework::Produces<T> createTableCursor(framework::ProcessingContext& pc)
 {
   framework::Produces<T> c;
   c.resetCursor(pc.outputs()

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1814,7 +1814,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   auto tracksCursor = createTableCursor<o2::aod::StoredTracksIU>(pc);
   auto tracksCovCursor = createTableCursor<o2::aod::StoredTracksCovIU>(pc);
   auto tracksExtraCursor = createTableCursor<o2::aod::StoredTracksExtra>(pc);
-  auto tracksQACursor = createTableCursor<o2::aod::TracksQA>(pc);
+  auto tracksQACursor = createTableCursor<o2::aod::TrackQA>(pc);
   auto ambigTracksCursor = createTableCursor<o2::aod::AmbiguousTracks>(pc);
   auto ambigMFTTracksCursor = createTableCursor<o2::aod::AmbiguousMFTTracks>(pc);
   auto ambigFwdTracksCursor = createTableCursor<o2::aod::AmbiguousFwdTracks>(pc);
@@ -2986,7 +2986,7 @@ DataProcessorSpec getAODProducerWorkflowSpec(GID::mask_t src, bool enableSV, boo
     OutputForTable<Calos>::spec(),
     OutputForTable<CaloTriggers>::spec(),
     OutputForTable<CPVClusters>::spec(),
-    OutputForTable<Origins>::spec(),
+    OutputForTable<Origin>::spec(),
     OutputSpec{"TFN", "TFNumber"},
     OutputSpec{"TFF", "TFFilename"},
     OutputSpec{"AMD", "AODMetadataKeys"},

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -15,7 +15,6 @@
 #include "Framework/Pack.h"
 #include "Framework/FunctionalHelpers.h"
 #include "Headers/DataHeader.h"
-#include "Headers/DataHeaderHelpers.h"
 #include "Framework/CompilerBuiltins.h"
 #include "Framework/Traits.h"
 #include "Framework/Expressions.h"
@@ -36,12 +35,6 @@
   template <typename T>              \
   struct MetadataTrait {             \
     using metadata = std::void_t<T>; \
-  };
-
-#define DECLARE_SOA_ITERATOR_METADATA()                                       \
-  template <typename IT>                                                      \
-  requires(o2::soa::is_soa_iterator_v<IT>) struct MetadataTrait<IT> {         \
-    using metadata = typename MetadataTrait<typename IT::parent_t>::metadata; \
   };
 
 namespace o2::aod
@@ -170,7 +163,7 @@ void call_if_has_not_originals(TLambda&& lambda)
 }
 
 template <typename H, typename... T>
-consteval decltype(auto) make_originals_from_type()
+constexpr auto make_originals_from_type()
 {
   using decayed = std::decay_t<H>;
   if constexpr (sizeof...(T) == 0) {
@@ -193,15 +186,9 @@ consteval decltype(auto) make_originals_from_type()
 }
 
 template <typename... T>
-consteval decltype(auto) make_originals_from_type(framework::pack<T...> p)
+constexpr auto make_originals_from_type(framework::pack<T...>)
 {
-  if constexpr (sizeof...(T) == 0) {
-    return framework::pack<>{};
-  } else {
-    return []<typename H, typename... Ta>(framework::pack<H, Ta...>) {
-      return make_originals_from_type<H, Ta...>();
-    }(p);
-  }
+  return make_originals_from_type<T...>();
 }
 
 /// Policy class for columns which are chunked. This
@@ -783,7 +770,7 @@ struct DefaultIndexPolicy : IndexPolicyBase {
   int64_t mMaxRow = 0;
 };
 
-template <o2::header::DataOrigin ORIGIN, typename... C>
+template <typename... C>
 class Table;
 
 /// Similar to a pair but not a pair, to avoid
@@ -799,11 +786,11 @@ concept CanBind = requires(T&& t) {
   { t.B::mColumnIterator };
 };
 
-template <o2::header::DataOrigin ORIGIN, typename IP, typename... C>
+template <typename IP, typename... C>
 struct RowViewCore : public IP, C... {
  public:
   using policy_t = IP;
-  using table_t = o2::soa::Table<ORIGIN, C...>;
+  using table_t = o2::soa::Table<C...>;
   using all_columns = framework::pack<C...>;
   using persistent_columns_t = framework::selected_pack<is_persistent_t, C...>;
   using index_columns_t = framework::selected_pack<is_index_t, C...>;
@@ -826,7 +813,7 @@ struct RowViewCore : public IP, C... {
   }
 
   RowViewCore() = default;
-  RowViewCore(RowViewCore<ORIGIN, IP, C...> const& other)
+  RowViewCore(RowViewCore<IP, C...> const& other)
     : IP{static_cast<IP const&>(other)},
       C(static_cast<C const&>(other))...
   {
@@ -841,7 +828,7 @@ struct RowViewCore : public IP, C... {
     return *this;
   }
 
-  RowViewCore(RowViewCore<ORIGIN, FilteredIndexPolicy, C...> const& other) requires std::is_same_v<IP, DefaultIndexPolicy>
+  RowViewCore(RowViewCore<FilteredIndexPolicy, C...> const& other) requires std::is_same_v<IP, DefaultIndexPolicy>
     : IP{static_cast<IP const&>(other)},
       C(static_cast<C const&>(other))...
   {
@@ -856,7 +843,7 @@ struct RowViewCore : public IP, C... {
 
   RowViewCore operator++(int)
   {
-    RowViewCore<ORIGIN, IP, C...> copy = *this;
+    RowViewCore<IP, C...> copy = *this;
     this->operator++();
     return copy;
   }
@@ -869,7 +856,7 @@ struct RowViewCore : public IP, C... {
 
   RowViewCore operator--(int)
   {
-    RowViewCore<ORIGIN, IP, C...> copy = *this;
+    RowViewCore<IP, C...> copy = *this;
     this->operator--();
     return copy;
   }
@@ -971,7 +958,7 @@ struct RowViewCore : public IP, C... {
       [this]<typename T>(T*) -> void requires is_persistent_v<T> { T::mColumnIterator.mCurrentPos = &this->mRowIndex; },
       [this]<typename T>(T*) -> void requires is_dynamic_v<T> { bindDynamicColumn<T>(typename T::bindings_t{});},
       [this]<typename T>(T*) -> void {},
-};
+    };
     (f(static_cast<C*>(nullptr)), ...);
     if constexpr (has_index_v) {
       this->setIndices(this->getIndices());
@@ -1018,7 +1005,7 @@ struct ArrowHelpers {
 };
 
 template <typename... T>
-using originals_pack_t = decltype(make_originals_from_type(framework::pack<T...>{}));
+using originals_pack_t = decltype(make_originals_from_type<T...>());
 
 template <typename T, typename... Os>
 constexpr bool are_bindings_compatible_v(framework::pack<Os...>&&)
@@ -1220,35 +1207,9 @@ using PresliceOptional = PresliceBase<T, true, true>;
 
 namespace o2::soa
 {
-/// special case for the template with origin
-template <typename T, template <o2::header::DataOrigin, typename...> class Ref>
-struct is_specialization_origin : std::false_type {
-};
-
-template <template <o2::header::DataOrigin, typename...> class Ref, o2::header::DataOrigin ORIGIN, typename... Args>
-struct is_specialization_origin<Ref<ORIGIN, Args...>, Ref> : std::true_type {
-};
-
-template <typename T, template <o2::header::DataOrigin, typename...> class Ref>
-inline constexpr bool is_specialization_origin_v = is_specialization_origin<T, Ref>::value;
-
-template <template <o2::header::DataOrigin, typename...> class base, typename derived>
-struct is_base_of_template_origin_impl {
-  template <o2::header::DataOrigin ORIGIN, typename... Ts>
-  static constexpr std::true_type test(const base<ORIGIN, Ts...>*);
-  static constexpr std::false_type test(...);
-  using type = decltype(test(std::declval<derived*>()));
-};
-
-template <template <o2::header::DataOrigin, typename...> class base, typename derived>
-using is_base_of_template_origin = typename is_base_of_template_origin_impl<base, derived>::type;
-
-template <template <o2::header::DataOrigin, typename...> class base, typename derived>
-inline constexpr bool is_base_of_template_origin_v = is_base_of_template_origin<base, derived>::value;
-
 //! Helper to check if a type T is an iterator
 template <typename T>
-inline constexpr bool is_soa_iterator_v = soa::is_base_of_template_origin_v<RowViewCore, T> || soa::is_specialization_origin_v<T, RowViewCore>;
+inline constexpr bool is_soa_iterator_v = framework::is_base_of_template_v<RowViewCore, T> || framework::is_specialization_v<T, RowViewCore>;
 
 template <typename T>
 inline consteval bool is_soa_filtered_iterator_v()
@@ -1265,10 +1226,10 @@ inline consteval bool is_soa_filtered_iterator_v()
 }
 
 template <typename T>
-using is_soa_table_t = typename soa::is_specialization_origin<T, soa::Table>;
+using is_soa_table_t = typename framework::is_specialization<T, soa::Table>;
 
 template <typename T>
-inline constexpr bool is_soa_table_like_v = soa::is_base_of_template_origin_v<soa::Table, T>;
+inline constexpr bool is_soa_table_like_v = framework::is_base_of_template_v<soa::Table, T>;
 
 template <typename T>
 class FilteredBase;
@@ -1424,13 +1385,12 @@ arrow::ChunkedArray* getIndexFromLabel(arrow::Table* table, const char* label);
 
 /// A Table class which observes an arrow::Table and provides
 /// It is templated on a set of Column / DynamicColumn types.
-template <o2::header::DataOrigin ORIGIN, typename... C>
+template <typename... C>
 class Table
 {
  public:
-  static constexpr o2::header::DataOrigin mOrigin{ORIGIN};
-  using self_t = Table<ORIGIN, C...>;
-  using table_t = Table<ORIGIN, C...>;
+  using self_t = Table<C...>;
+  using table_t = Table<C...>;
   using columns = framework::pack<C...>;
   using column_types = framework::pack<typename C::type...>;
   using persistent_columns_t = framework::selected_pack<is_persistent_t, C...>;
@@ -1443,7 +1403,7 @@ class Table
   }
 
   template <typename IP, typename Parent, typename... T>
-  struct RowViewBase : public RowViewCore<ORIGIN, IP, C...> {
+  struct RowViewBase : public RowViewCore<IP, C...> {
 
     using external_index_columns_t = framework::selected_pack<is_external_index_t, C...>;
     using bindings_pack_t = decltype(extractBindings(external_index_columns_t{}));
@@ -1454,28 +1414,28 @@ class Table
     RowViewBase() = default;
 
     RowViewBase(arrow::ChunkedArray* columnData[sizeof...(C)], IP&& policy)
-      : RowViewCore<ORIGIN, IP, C...>(columnData, std::forward<decltype(policy)>(policy))
+      : RowViewCore<IP, C...>(columnData, std::forward<decltype(policy)>(policy))
     {
     }
 
     template <typename P, typename... O>
     RowViewBase& operator=(RowViewBase<IP, P, O...> other) requires std::is_same_v<typename P::table_t, typename Parent::table_t>
     {
-      static_cast<RowViewCore<ORIGIN, IP, C...>&>(*this) = static_cast<RowViewCore<ORIGIN, IP, C...>>(other);
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...>>(other);
       return *this;
     }
 
     template <typename P>
     RowViewBase& operator=(RowViewBase<IP, P, T...> other)
     {
-      static_cast<RowViewCore<ORIGIN, IP, C...>&>(*this) = static_cast<RowViewCore<ORIGIN, IP, C...>>(other);
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<IP, C...>>(other);
       return *this;
     }
 
     template <typename P>
     RowViewBase& operator=(RowViewBase<FilteredIndexPolicy, P, T...> other) requires std::is_same_v<IP, DefaultIndexPolicy>
     {
-      static_cast<RowViewCore<ORIGIN, IP, C...>&>(*this) = static_cast<RowViewCore<ORIGIN, FilteredIndexPolicy, C...>>(other);
+      static_cast<RowViewCore<IP, C...>&>(*this) = static_cast<RowViewCore<FilteredIndexPolicy, C...>>(other);
       return *this;
     }
 
@@ -1568,7 +1528,7 @@ class Table
 
     using IP::size;
 
-    using RowViewCore<ORIGIN, IP, C...>::operator++;
+    using RowViewCore<IP, C...>::operator++;
 
     /// Allow incrementing by more than one the iterator
     RowViewBase operator+(int64_t inc) const
@@ -1813,26 +1773,26 @@ class Table
   RowViewSentinel mEnd;
 };
 
-template <o2::header::DataOrigin, typename T>
+template <typename T>
 struct PackToTable {
   static_assert(framework::always_static_assert_v<T>, "Not a pack");
 };
 
-template <o2::header::DataOrigin ORIGIN, typename... C>
-struct PackToTable<ORIGIN, framework::pack<C...>> {
-  using table = o2::soa::Table<ORIGIN, C...>;
+template <typename... C>
+struct PackToTable<framework::pack<C...>> {
+  using table = o2::soa::Table<C...>;
 };
 
-template <o2::header::DataOrigin ORIGIN, typename... T>
+template <typename... T>
 struct TableWrap {
   using all_columns = framework::concatenated_pack_unique_t<typename T::columns...>;
-  using table_t = typename PackToTable<ORIGIN, all_columns>::table;
+  using table_t = typename PackToTable<all_columns>::table;
 };
 
-template <o2::header::DataOrigin ORIGIN, typename... T>
+template <typename... T>
 struct TableIntersect {
   using all_columns = framework::full_intersected_pack_t<typename T::columns...>;
-  using table_t = typename PackToTable<ORIGIN, all_columns>::table;
+  using table_t = typename PackToTable<all_columns>::table;
 };
 
 /// Template trait which allows to map a given
@@ -1842,28 +1802,27 @@ class TableMetadata
 {
  public:
   static constexpr char const* tableLabel() { return INHERIT::mLabel; }
-  // static constexpr char const (&origin())[5] { return INHERIT::table_t::mOrigin; }
-  static consteval auto origin() { return INHERIT::table_t::mOrigin; }
+  static constexpr char const (&origin())[5] { return INHERIT::mOrigin; }
   static constexpr char const (&description())[16] { return INHERIT::mDescription; }
   static constexpr o2::header::DataHeader::SubSpecificationType version() { return INHERIT::mVersion; }
-  static std::string sourceSpec() { return fmt::format("{}/{:s}/{}/{}", INHERIT::mLabel, INHERIT::table_t::mOrigin, INHERIT::mDescription, INHERIT::mVersion); };
+  static std::string sourceSpec() { return fmt::format("{}/{}/{}/{}", INHERIT::mLabel, INHERIT::mOrigin, INHERIT::mDescription, INHERIT::mVersion); };
 };
 
 /// Helper templates to define universal join and concat
-template <o2::header::DataOrigin ORIGIN, typename... T>
+template <typename... T>
 constexpr auto join(T const&... t)
 {
-  return typename o2::soa::TableWrap<ORIGIN, T...>::table_t(ArrowHelpers::joinTables({t.asArrowTable()...}));
+  return typename o2::soa::TableWrap<T...>::table_t(ArrowHelpers::joinTables({t.asArrowTable()...}));
 }
 
-template <o2::header::DataOrigin ORIGIN, typename... T>
+template <typename... T>
 constexpr auto concat(T const&... t)
 {
-  return typename o2::soa::TableIntersect<ORIGIN, T...>::table_t(ArrowHelpers::concatTables({t.asArrowTable()...}));
+  return typename o2::soa::TableIntersect<T...>::table_t(ArrowHelpers::concatTables({t.asArrowTable()...}));
 }
 
 template <typename T1, typename T2>
-using ConcatBase = decltype(concat<o2::header::DataOrigin{"CONC"}>(std::declval<T1>(), std::declval<T2>()));
+using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
 
 void notBoundTable(const char* tableName);
 
@@ -1935,14 +1894,9 @@ std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, 
 } // namespace row_helpers
 } // namespace o2::soa
 
-namespace o2::aod
-{
-DECLARE_SOA_ITERATOR_METADATA();
-}
-
 #define DECLARE_SOA_VERSIONING()                                                                    \
   template <typename T>                                                                             \
-  consteval int getVersion()                                                                        \
+  constexpr int getVersion()                                                                        \
   {                                                                                                 \
     if constexpr (o2::soa::is_type_with_metadata_v<MetadataTrait<T>>) {                             \
       return MetadataTrait<T>::metadata::version();                                                 \
@@ -2672,26 +2626,24 @@ DECLARE_SOA_ITERATOR_METADATA();
   }
 
 #define DECLARE_SOA_TABLE_FULL_VERSIONED(_Name_, _Label_, _Origin_, _Description_, _Version_, ...) \
-  template <o2::header::DataOrigin ORIGIN = o2::header::DataOrigin{_Origin_}>                      \
-  using _Name_##From = o2::soa::Table<ORIGIN, __VA_ARGS__>;                                        \
-  using _Name_ = _Name_##From<o2::header::DataOrigin{_Origin_}>;                                   \
+  using _Name_ = o2::soa::Table<__VA_ARGS__>;                                                      \
                                                                                                    \
-  template <o2::header::DataOrigin ORIGIN = o2::header::DataOrigin{_Origin_}>                      \
-  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata<ORIGIN>> {                     \
-    using table_t = _Name_##From<ORIGIN>;                                                          \
+  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata> {                             \
+    using table_t = _Name_;                                                                        \
     static constexpr o2::header::DataHeader::SubSpecificationType mVersion = _Version_;            \
     static constexpr char const* mLabel = _Label_;                                                 \
+    static constexpr char const mOrigin[5] = _Origin_;                                             \
     static constexpr char const mDescription[16] = _Description_;                                  \
-  };                                                                                               \
-                                                                                                   \
-  template <o2::header::DataOrigin ORIGIN>                                                         \
-  struct MetadataTrait<_Name_##From<ORIGIN>> {                                                     \
-    using metadata = _Name_##Metadata<ORIGIN>;                                                     \
   };                                                                                               \
                                                                                                    \
   template <>                                                                                      \
   struct MetadataTrait<_Name_> {                                                                   \
-    using metadata = _Name_##Metadata<o2::header::DataOrigin{_Origin_}>;                           \
+    using metadata = _Name_##Metadata;                                                             \
+  };                                                                                               \
+                                                                                                   \
+  template <>                                                                                      \
+  struct MetadataTrait<_Name_::unfiltered_iterator> {                                              \
+    using metadata = _Name_##Metadata;                                                             \
   };
 
 #define DECLARE_SOA_TABLE_FULL(_Name_, _Label_, _Origin_, _Description_, ...) \
@@ -2701,37 +2653,33 @@ DECLARE_SOA_ITERATOR_METADATA();
 #define DECLARE_SOA_TABLE_VERSIONED(_Name_, _Origin_, _Description_, _Version_, ...) \
   DECLARE_SOA_TABLE_FULL_VERSIONED(_Name_, #_Name_, _Origin_, _Description_, _Version_, __VA_ARGS__);
 
-#define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)                                                      \
-  template <o2::header::DataOrigin ORIGIN = o2::header::DataOrigin{_Origin_}>                                                               \
-  struct _Name_##ExtensionFrom : o2::soa::Table<ORIGIN, __VA_ARGS__> {                                                                      \
-    using base_t = o2::soa::Table<ORIGIN, __VA_ARGS__>;                                                                                     \
-    _Name_##ExtensionFrom(std::shared_ptr<arrow::Table> table, uint64_t offset = 0) : o2::soa::Table<ORIGIN, __VA_ARGS__>(table, offset){}; \
-    _Name_##ExtensionFrom(_Name_##ExtensionFrom const&) = default;                                                                          \
-    _Name_##ExtensionFrom(_Name_##ExtensionFrom&&) = default;                                                                               \
-    using expression_pack_t = framework::pack<__VA_ARGS__>;                                                                                 \
-    using iterator = typename base_t::template RowView<_Name_##ExtensionFrom<ORIGIN>, _Name_##ExtensionFrom<ORIGIN>>;                       \
-    using const_iterator = iterator;                                                                                                        \
-  };                                                                                                                                        \
-  using _Name_##Extension = _Name_##ExtensionFrom<o2::header::DataOrigin{_Origin_}>;                                                        \
-  template <o2::header::DataOrigin ORIGIN>                                                                                                  \
-  using _Name_##From = o2::soa::Join<_Name_##ExtensionFrom<ORIGIN>, _Table_>;                                                               \
-  using _Name_ = _Name_##From<o2::header::DataOrigin{_Origin_}>;                                                                            \
-                                                                                                                                            \
-  template <o2::header::DataOrigin ORIGIN = o2::header::DataOrigin{_Origin_}>                                                               \
-  struct _Name_##ExtensionMetadata : o2::soa::TableMetadata<_Name_##ExtensionMetadata<ORIGIN>> {                                            \
-    using table_t = _Name_##ExtensionFrom<ORIGIN>;                                                                                          \
-    using base_table_t = _Table_;                                                                                                           \
-    using expression_pack_t = typename _Name_##ExtensionFrom<ORIGIN>::expression_pack_t;                                                    \
-    using originals = soa::originals_pack_t<_Table_>;                                                                                       \
-    using sources = originals;                                                                                                              \
-    static constexpr o2::header::DataHeader::SubSpecificationType mVersion = getVersion<_Table_>();                                         \
-    static constexpr char const* mLabel = #_Name_ "Extension";                                                                              \
-    static constexpr char const mDescription[16] = _Description_;                                                                           \
-  };                                                                                                                                        \
-                                                                                                                                            \
-  template <>                                                                                                                               \
-  struct MetadataTrait<_Name_##Extension> {                                                                                                 \
-    using metadata = _Name_##ExtensionMetadata<o2::header::DataOrigin{"DYN"}>;                                                              \
+#define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)                                          \
+  struct _Name_##Extension : o2::soa::Table<__VA_ARGS__> {                                                                      \
+    using base_t = o2::soa::Table<__VA_ARGS__>;                                                                                 \
+    _Name_##Extension(std::shared_ptr<arrow::Table> table, uint64_t offset = 0) : o2::soa::Table<__VA_ARGS__>(table, offset){}; \
+    _Name_##Extension(_Name_##Extension const&) = default;                                                                      \
+    _Name_##Extension(_Name_##Extension&&) = default;                                                                           \
+    using expression_pack_t = framework::pack<__VA_ARGS__>;                                                                     \
+    using iterator = typename base_t::template RowView<_Name_##Extension, _Name_##Extension>;                                   \
+    using const_iterator = iterator;                                                                                            \
+  };                                                                                                                            \
+  using _Name_ = o2::soa::Join<_Name_##Extension, _Table_>;                                                                     \
+                                                                                                                                \
+  struct _Name_##ExtensionMetadata : o2::soa::TableMetadata<_Name_##ExtensionMetadata> {                                        \
+    using table_t = _Name_##Extension;                                                                                          \
+    using base_table_t = _Table_;                                                                                               \
+    using expression_pack_t = typename _Name_##Extension::expression_pack_t;                                                    \
+    using originals = soa::originals_pack_t<_Table_>;                                                                           \
+    using sources = originals;                                                                                                  \
+    static constexpr o2::header::DataHeader::SubSpecificationType mVersion = getVersion<_Table_>();                             \
+    static constexpr char const* mLabel = #_Name_ "Extension";                                                                  \
+    static constexpr char const mOrigin[5] = _Origin_;                                                                          \
+    static constexpr char const mDescription[16] = _Description_;                                                               \
+  };                                                                                                                            \
+                                                                                                                                \
+  template <>                                                                                                                   \
+  struct MetadataTrait<_Name_##Extension> {                                                                                     \
+    using metadata = _Name_##ExtensionMetadata;                                                                                 \
   };
 
 #define DECLARE_SOA_EXTENDED_TABLE(_Name_, _Table_, _Description_, ...) \
@@ -2740,34 +2688,35 @@ DECLARE_SOA_ITERATOR_METADATA();
 #define DECLARE_SOA_EXTENDED_TABLE_USER(_Name_, _Table_, _Description_, ...) \
   DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, "AOD", _Description_, __VA_ARGS__)
 
-#define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Description_, _Exclusive_, ...)                                                 \
-  template <o2::header::DataOrigin ORIGIN = o2::header::DataOrigin{_Origin_}>                                                                  \
-  struct _Name_##From : o2::soa::IndexTable<ORIGIN, _Key_, __VA_ARGS__> {                                                                      \
-    using base_t = o2::soa::IndexTable<ORIGIN, _Key_, __VA_ARGS__>;                                                                            \
-    _Name_##From(std::shared_ptr<arrow::Table> table, uint64_t offset = 0) : o2::soa::IndexTable<ORIGIN, _Key_, __VA_ARGS__>(table, offset){}; \
-    _Name_##From(_Name_##From const&) = default;                                                                                               \
-    _Name_##From(_Name_##From&&) = default;                                                                                                    \
-    using iterator = typename base_t::template RowView<_Name_##From<ORIGIN>, _Name_##From<ORIGIN>>;                                            \
-    using const_iterator = iterator;                                                                                                           \
-  };                                                                                                                                           \
-  using _Name_ = _Name_##From<o2::header::DataOrigin{_Origin_}>;                                                                               \
-                                                                                                                                               \
-  template <o2::header::DataOrigin ORIGIN = o2::header::DataOrigin{_Origin_}>                                                                  \
-  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata<ORIGIN>> {                                                                 \
-    using table_t = _Name_##From<ORIGIN>;                                                                                                      \
-    using Key = _Key_;                                                                                                                         \
-    using index_pack_t = framework::pack<__VA_ARGS__>;                                                                                         \
-    using originals = decltype(soa::extractBindings(index_pack_t{}));                                                                          \
-    using sources = typename _Name_##From<ORIGIN>::sources_t;                                                                                  \
-    static constexpr o2::header::DataHeader::SubSpecificationType mVersion = 0;                                                                \
-    static constexpr char const* mLabel = #_Name_;                                                                                             \
-    static constexpr char const mDescription[16] = _Description_;                                                                              \
-    static constexpr bool exclusive = _Exclusive_;                                                                                             \
-  };                                                                                                                                           \
-                                                                                                                                               \
-  template <o2::header::DataOrigin ORIGIN>                                                                                                     \
-  struct MetadataTrait<_Name_##From<ORIGIN>> {                                                                                                 \
-    using metadata = _Name_##Metadata<ORIGIN>;                                                                                                 \
+#define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Description_, _Exclusive_, ...)                                   \
+  struct _Name_ : o2::soa::IndexTable<_Key_, __VA_ARGS__> {                                                                      \
+    _Name_(std::shared_ptr<arrow::Table> table, uint64_t offset = 0) : o2::soa::IndexTable<_Key_, __VA_ARGS__>(table, offset){}; \
+    _Name_(_Name_ const&) = default;                                                                                             \
+    _Name_(_Name_&&) = default;                                                                                                  \
+    using iterator = typename base_t::template RowView<_Name_, _Name_>;                                                          \
+    using const_iterator = iterator;                                                                                             \
+  };                                                                                                                             \
+                                                                                                                                 \
+  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata> {                                                           \
+    using Key = _Key_;                                                                                                           \
+    using index_pack_t = framework::pack<__VA_ARGS__>;                                                                           \
+    using originals = decltype(soa::extractBindings(index_pack_t{}));                                                            \
+    using sources = typename _Name_::sources_t;                                                                                  \
+    static constexpr o2::header::DataHeader::SubSpecificationType mVersion = 0;                                                  \
+    static constexpr char const* mLabel = #_Name_;                                                                               \
+    static constexpr char const mOrigin[5] = _Origin_;                                                                           \
+    static constexpr char const mDescription[16] = _Description_;                                                                \
+    static constexpr bool exclusive = _Exclusive_;                                                                               \
+  };                                                                                                                             \
+                                                                                                                                 \
+  template <>                                                                                                                    \
+  struct MetadataTrait<_Name_> {                                                                                                 \
+    using metadata = _Name_##Metadata;                                                                                           \
+  };                                                                                                                             \
+                                                                                                                                 \
+  template <>                                                                                                                    \
+  struct MetadataTrait<_Name_::iterator> {                                                                                       \
+    using metadata = _Name_##Metadata;                                                                                           \
   };
 
 #define DECLARE_SOA_INDEX_TABLE(_Name_, _Key_, _Description_, ...) \
@@ -2788,8 +2737,8 @@ template <typename T>
 class FilteredBase;
 
 template <typename... Ts>
-struct Join : TableWrap<o2::header::DataOrigin{"JOIN"}, Ts...>::table_t {
-  using base = typename TableWrap<o2::header::DataOrigin{"JOIN"}, Ts...>::table_t;
+struct Join : TableWrap<Ts...>::table_t {
+  using base = typename TableWrap<Ts...>::table_t;
   using originals = originals_pack_t<Ts...>;
 
   Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
@@ -3515,11 +3464,11 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
 /// First argument is the key table (BCs for the Collisions+ZDCs case), the rest
 /// are index columns defined for the required tables.
 /// First index will be used by process() as the grouping
-template <o2::header::DataOrigin ORIGIN, typename Key, typename H, typename... Ts>
-struct IndexTable : Table<ORIGIN, soa::Index<>, H, Ts...> {
-  using base_t = Table<ORIGIN, soa::Index<>, H, Ts...>;
+template <typename Key, typename H, typename... Ts>
+struct IndexTable : Table<soa::Index<>, H, Ts...> {
+  using base_t = Table<soa::Index<>, H, Ts...>;
   using table_t = base_t;
-  using safe_base_t = Table<ORIGIN, H, Ts...>;
+  using safe_base_t = Table<H, Ts...>;
   using indexing_t = Key;
   using first_t = typename H::binding_t;
   using rest_t = framework::pack<typename Ts::binding_t...>;
@@ -3535,12 +3484,12 @@ struct IndexTable : Table<ORIGIN, soa::Index<>, H, Ts...> {
   IndexTable& operator=(IndexTable const&) = default;
   IndexTable& operator=(IndexTable&&) = default;
 
-  using iterator = typename base_t::template RowView<IndexTable<ORIGIN, Key, H, Ts...>, IndexTable<ORIGIN, Key, H, Ts...>>;
+  using iterator = typename base_t::template RowView<IndexTable<Key, H, Ts...>, IndexTable<Key, H, Ts...>>;
   using const_iterator = iterator;
 };
 
 template <typename T>
-inline constexpr bool is_soa_index_table_v = soa::is_base_of_template_origin_v<soa::IndexTable, T>;
+inline constexpr bool is_soa_index_table_v = framework::is_base_of_template_v<soa::IndexTable, T>;
 
 template <typename T, bool APPLY>
 struct SmallGroupsBase : public Filtered<T> {

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -562,9 +562,9 @@ DECLARE_SOA_COLUMN(TPCdEdxTot3R, tpcdEdxTot3R, uint8_t);             //! TPC dEd
 
 DECLARE_SOA_TABLE(TracksQA, "AOD", "TRACKQA", //! trackQA information - sampled QA information currently for the TPC
                   o2::soa::Index<>, trackqa::TrackId, trackqa::TPCTime0, trackqa::TPCDCAR, trackqa::TPCDCAZ, trackqa::TPCClusterByteMask,
+                  //                  o2::soa::Index<>, trackqa::TrackId, trackqa::TPCDCAR, trackqa::TPCDCAZ, trackqa::TPCClusterByteMask,
                   trackqa::TPCdEdxMax0R, trackqa::TPCdEdxMax1R, trackqa::TPCdEdxMax2R, trackqa::TPCdEdxMax3R,
                   trackqa::TPCdEdxTot0R, trackqa::TPCdEdxTot1R, trackqa::TPCdEdxTot2R, trackqa::TPCdEdxTot3R);
-//                  o2::soa::Index<>, trackqa::TrackId, trackqa::TPCDCAR, trackqa::TPCDCAZ, trackqa::TPCClusterByteMask,
 
 using TrackQA = TracksQA::iterator;
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -351,7 +351,7 @@ struct OutputManager<Spawns<T>> {
       originalTable = makeEmptyTable<base_table_t>(aod::MetadataTrait<typename Spawns<T>::extension_t>::metadata::tableLabel());
     }
 
-    what.extension = std::make_shared<typename Spawns<T>::extension_t>(o2::framework::spawner<aod::MetadataTrait<typename Spawns<T>::extension_t>::metadata::origin()>(what.pack(), extractOriginals(what.sources_pack(), pc), aod::MetadataTrait<typename Spawns<T>::extension_t>::metadata::tableLabel()));
+    what.extension = std::make_shared<typename Spawns<T>::extension_t>(o2::framework::spawner(what.pack(), extractOriginals(what.sources_pack(), pc), aod::MetadataTrait<typename Spawns<T>::extension_t>::metadata::tableLabel()));
     what.table = std::make_shared<typename T::table_t>(soa::ArrowHelpers::joinTables({what.extension->asArrowTable(), originalTable}));
     return true;
   }

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -843,12 +843,12 @@ std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table>& fullT
                                             expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name);
 
 /// Expression-based column generator to materialize columns
-template <o2::header::DataOrigin ORIGIN, typename... C>
+template <typename... C>
 auto spawner(framework::pack<C...> columns, std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name)
 {
   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
   if (fullTable->num_rows() == 0) {
-    return makeEmptyTable<soa::Table<ORIGIN, C...>>(name);
+    return makeEmptyTable<soa::Table<C...>>(name);
   }
   static auto fields = o2::soa::createFieldsFromColumns(columns);
   static auto new_schema = std::make_shared<arrow::Schema>(fields);

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -164,7 +164,7 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& reque
               originalTables.push_back(pc.inputs().get<TableConsumer>(spec.binding)->asArrowTable());
             }
           }
-          return o2::framework::spawner<metadata_t::origin()>(expressions{}, std::move(originalTables), input.binding.c_str());
+          return o2::framework::spawner(expressions{}, std::move(originalTables), input.binding.c_str());
         };
 
         if (description == header::DataDescription{"TRACK"}) {

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -217,7 +217,7 @@ static void BM_ASoASimpleForLoop(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
 
   for (auto _ : state) {
     float sum = 0;
@@ -245,7 +245,7 @@ static void BM_ASoASimpleForLoopWithOp(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X, test::Y>;
+  using Test = o2::soa::Table<test::X, test::Y>;
 
   for (auto _ : state) {
     Test tests{table};
@@ -273,7 +273,7 @@ static void BM_ASoADynamicColumnPresent(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
+  using Test = o2::soa::Table<test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
 
   for (auto _ : state) {
     Test tests{table};
@@ -301,7 +301,7 @@ static void BM_ASoADynamicColumnCall(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>>;
+  using Test = o2::soa::Table<test::X, test::Y, test::Sum<test::X, test::Y>>;
 
   Test tests{table};
   for (auto _ : state) {

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -97,7 +97,7 @@ static void BM_ASoAHelpersNaiveSimplePairs(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
   int64_t count = 0;
 
@@ -131,7 +131,7 @@ static void BM_ASoAHelpersNaiveSimpleFives(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
   int64_t count = 0;
 
@@ -323,7 +323,7 @@ static void BM_ASoAHelpersCombGenSimplePairs(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
 
   int64_t count = 0;
@@ -354,7 +354,7 @@ static void BM_ASoAHelpersCombGenSimpleFives(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
 
   int64_t count = 0;
@@ -520,8 +520,8 @@ static void BM_ASoAHelpersCombGenSimpleFivesMultipleChunks(benchmark::State& sta
   }
   auto tableB = builderB.finalize();
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
-  using TestB = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, test::X>;
   using ConcatTest = Concat<TestA, TestB>;
 
   ConcatTest tests{tableA, tableB};
@@ -596,7 +596,7 @@ static void BM_ASoAHelpersCombGenSimplePairsSameCategories(benchmark::State& sta
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
   NoBinningPolicy<test::X> noBinning;
 
@@ -629,7 +629,7 @@ static void BM_ASoAHelpersCombGenSimpleFivesSameCategories(benchmark::State& sta
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
   NoBinningPolicy<test::X> noBinning;
 
@@ -662,7 +662,7 @@ static void BM_ASoAHelpersCombGenSimplePairsCategories(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
   NoBinningPolicy<test::X> noBinning;
 
@@ -695,7 +695,7 @@ static void BM_ASoAHelpersCombGenSimpleFivesCategories(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X>;
+  using Test = o2::soa::Table<test::X>;
   Test tests{table};
   NoBinningPolicy<test::X> noBinning;
 

--- a/Framework/Core/test/benchmark_TableBuilder.cxx
+++ b/Framework/Core/test/benchmark_TableBuilder.cxx
@@ -132,7 +132,7 @@ DECLARE_SOA_COLUMN(Y, y, float);
 DECLARE_SOA_COLUMN(Z, z, float);
 } // namespace test
 
-using TestVectors = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test::X, test::Y, test::Z>;
+using TestVectors = o2::soa::Table<test::X, test::Y, test::Z>;
 
 static void BM_TableBuilderSoA(benchmark::State& state)
 {

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -130,7 +130,7 @@ TEST_CASE("TestTableIteration")
   ++tests;
   REQUIRE(tests.x() == 0);
   REQUIRE(tests.y() == 1);
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::X, o2::aod::test::Y>;
+  using Test = o2::soa::Table<o2::aod::test::X, o2::aod::test::Y>;
   Test tests2{table};
   size_t value = 0;
   auto b = tests2.begin();
@@ -180,14 +180,14 @@ TEST_CASE("TestDynamicColumns")
   rowWriter(0, 1, 7);
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::X, o2::aod::test::Y, o2::aod::test::Sum<o2::aod::test::X, o2::aod::test::Y>>;
+  using Test = o2::soa::Table<o2::aod::test::X, o2::aod::test::Y, o2::aod::test::Sum<o2::aod::test::X, o2::aod::test::Y>>;
 
   Test tests{table};
   for (auto& test : tests) {
     REQUIRE(test.sum() == test.x() + test.y());
   }
 
-  using Test2 = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::X, o2::aod::test::Y, o2::aod::test::Sum<o2::aod::test::Y, o2::aod::test::Y>>;
+  using Test2 = o2::soa::Table<o2::aod::test::X, o2::aod::test::Y, o2::aod::test::Sum<o2::aod::test::Y, o2::aod::test::Y>>;
 
   Test2 tests2{table};
   for (auto& test : tests2) {
@@ -267,9 +267,9 @@ TEST_CASE("TestJoinedTables")
   rowWriterZ(0, 8);
   auto tableZ = builderZ.finalize();
 
-  using TestX = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::X>;
-  using TestY = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::Y>;
-  using TestZ = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::Z>;
+  using TestX = o2::soa::Table<o2::aod::test::X>;
+  using TestY = o2::soa::Table<o2::aod::test::Y>;
+  using TestZ = o2::soa::Table<o2::aod::test::Z>;
   using Test = Join<TestX, TestY>;
 
   REQUIRE(Test::contains<TestX>());
@@ -286,14 +286,14 @@ TEST_CASE("TestJoinedTables")
     REQUIRE(7 == test.x() + test.y());
   }
 
-  auto tests2 = join<o2::header::DataOrigin{"JOIN"}>(TestX{tableX}, TestY{tableY});
+  auto tests2 = join(TestX{tableX}, TestY{tableY});
   static_assert(std::is_same_v<Test::table_t, decltype(tests2)>,
                 "Joined tables should have the same type, regardless how we construct them");
   for (auto& test : tests2) {
     REQUIRE(7 == test.x() + test.y());
   }
 
-  auto tests3 = join<o2::header::DataOrigin{"JOIN"}>(TestX{tableX}, TestY{tableY}, TestZ{tableZ});
+  auto tests3 = join(TestX{tableX}, TestY{tableY}, TestZ{tableZ});
 
   for (auto& test : tests3) {
     REQUIRE(15 == test.x() + test.y() + test.z());
@@ -356,25 +356,25 @@ TEST_CASE("TestConcatTables")
   rowWriterD(0, 23, 15);
   auto tableD = builderD.finalize();
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
-  using TestB = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, o2::aod::test::X>;
-  using TestC = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::Z>;
-  using TestD = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::aod::test::X, o2::aod::test::Z>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X>;
+  using TestC = o2::soa::Table<o2::aod::test::Z>;
+  using TestD = o2::soa::Table<o2::aod::test::X, o2::aod::test::Z>;
   using ConcatTest = Concat<TestA, TestB>;
   using JoinedTest = Join<TestA, TestC>;
   using NestedJoinTest = Join<JoinedTest, TestD>;
   using NestedConcatTest = Concat<Join<TestA, TestB>, TestD>;
 
-  static_assert(std::is_same_v<NestedJoinTest::table_t, o2::soa::Table<o2::header::DataOrigin{"JOIN"}, o2::soa::Index<>, o2::aod::test::Y, o2::aod::test::X, o2::aod::test::Z>>, "Bad nested join");
+  static_assert(std::is_same_v<NestedJoinTest::table_t, o2::soa::Table<o2::soa::Index<>, o2::aod::test::Y, o2::aod::test::X, o2::aod::test::Z>>, "Bad nested join");
 
-  static_assert(std::is_same_v<ConcatTest::table_t, o2::soa::Table<o2::header::DataOrigin{"CONC"}, o2::soa::Index<>, o2::aod::test::X>>, "Bad intersection of columns");
+  static_assert(std::is_same_v<ConcatTest::table_t, o2::soa::Table<o2::soa::Index<>, o2::aod::test::X>>, "Bad intersection of columns");
   ConcatTest tests{tableA, tableB};
   REQUIRE(16 == tests.size());
   for (auto& test : tests) {
     REQUIRE(test.index() == test.x());
   }
 
-  static_assert(std::is_same_v<NestedConcatTest::table_t, o2::soa::Table<o2::header::DataOrigin{"CONC"}, o2::aod::test::X>>, "Bad nested concat");
+  static_assert(std::is_same_v<NestedConcatTest::table_t, o2::soa::Table<o2::aod::test::X>>, "Bad nested concat");
 
   // Hardcode a selection for the first 5 odd numbers
   using FilteredTest = Filtered<TestA>;
@@ -539,7 +539,7 @@ TEST_CASE("TestDereference")
   REQUIRE(j.pointB().x() == 3);
   REQUIRE(j.pointB().y() == 4);
 
-  auto joined = join<o2::header::DataOrigin{"JOIN"}>(segments, segmentsExtras);
+  auto joined = join(segments, segmentsExtras);
   joined.bindExternalIndices(&points, &infos);
   auto se = joined.begin();
   REQUIRE(se.n() == 10);
@@ -574,7 +574,7 @@ TEST_CASE("TestFilteredOperators")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
   using FilteredTest = Filtered<TestA>;
   using NestedFilteredTest = Filtered<Filtered<TestA>>;
   using namespace o2::framework;
@@ -611,7 +611,7 @@ TEST_CASE("TestFilteredOperators")
   REQUIRE(0 == filteredIntersection.size());
 
   i = 0;
-  for (auto const& _ : filteredIntersection) {
+  for (auto& f : filteredIntersection) {
     i++;
   }
   REQUIRE(i == 0);
@@ -650,7 +650,7 @@ TEST_CASE("TestNestedFiltering")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
   using FilteredTest = Filtered<TestA>;
   using NestedFilteredTest = Filtered<Filtered<TestA>>;
   using TripleNestedFilteredTest = Filtered<Filtered<Filtered<TestA>>>;

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -42,7 +42,7 @@ TEST_CASE("IteratorTuple")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
 
   TestA tests{tableA};
 
@@ -113,8 +113,8 @@ TEST_CASE("CombinationsGeneratorConstruction")
   auto tableB = builderB.finalize();
   REQUIRE(tableB->num_rows() == 4);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
-  using TestB = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, test::X>;
   using ConcatTest = Concat<TestA, TestB>;
 
   TestA testsA{tableA};
@@ -344,9 +344,9 @@ TEST_CASE("Combinations")
   auto tableC = builderC.finalize();
   REQUIRE(tableC->num_rows() == 4);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
-  using TestB = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X>;
-  using TestC = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y, test::Z>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, test::X>;
+  using TestC = o2::soa::Table<o2::soa::Index<>, test::X, test::Y, test::Z>;
   using ConcatTest = Concat<TestA, TestB>;
 
   TestA testsA{tableA};
@@ -799,7 +799,7 @@ TEST_CASE("BreakingCombinations")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
 
   TestA testsA{tableA};
 
@@ -864,8 +864,8 @@ TEST_CASE("SmallTableCombinations")
   auto tableB = builderB.finalize();
   REQUIRE(tableB->num_rows() == 3);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
-  using TestB = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, test::X>;
 
   TestA testsA{tableA};
   TestB testsB{tableB};
@@ -921,7 +921,7 @@ TEST_CASE("BlockCombinations")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 10);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
   TestA testA{tableA};
   REQUIRE(10 == testA.size());
 
@@ -1204,7 +1204,7 @@ TEST_CASE("CombinationsHelpers")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
 
   TestA testsA{tableA};
 
@@ -1262,7 +1262,7 @@ TEST_CASE("CombinationsHelpers")
   auto tableB = builderB.finalize();
   REQUIRE(tableB->num_rows() == 10);
 
-  using TestB = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
   TestB testB{tableB};
   REQUIRE(10 == testB.size());
 
@@ -1298,7 +1298,7 @@ TEST_CASE("CombinationsHelpers")
 
 TEST_CASE("ConstructorsWithoutTables")
 {
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
   NoBinningPolicy<test::Y> noBinning;
 
   int count = 0;
@@ -1343,7 +1343,7 @@ TEST_CASE("BlockCombinationsCounters")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 10);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y, test::FloatZ>;
   TestA testA{tableA};
   REQUIRE(10 == testA.size());
 

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -51,7 +51,7 @@ TEST_CASE("TestJoinedTablesContains")
   REQUIRE(tests.asArrowTable()->num_columns() != 0);
   REQUIRE(tests.asArrowTable()->num_columns() ==
           tXY->num_columns() + tZD->num_columns());
-  auto tests2 = join<o2::header::DataOrigin{"JOIN"}>(XY{tXY}, ZD{tZD});
+  auto tests2 = join(XY{tXY}, ZD{tZD});
   static_assert(std::is_same_v<Test::table_t, decltype(tests2)>,
                 "Joined tables should have the same type, regardless how we construct them");
 

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -233,7 +233,7 @@ TEST_CASE("TestPartitionIteration")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, aod::test::X, aod::test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, aod::test::X, aod::test::Y>;
   using FilteredTest = o2::soa::Filtered<TestA>;
   using PartitionTest = Partition<TestA>;
   using PartitionFilteredTest = Partition<o2::soa::Filtered<TestA>>;

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -84,7 +84,7 @@ TEST_CASE("HistogramRegistryExpressionFill")
   rowWriterA(0, 7.0f, -4.0f);
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
-  using TestA = o2::soa::Table<o2::header::DataOrigin{"AOD"}, o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
   TestA tests{tableA};
   REQUIRE(8 == tests.size());
 

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -34,8 +34,8 @@ DECLARE_SOA_COLUMN_FULL(Y, y, uint64_t, "y");
 DECLARE_SOA_COLUMN_FULL(Pos, pos, int[4], "pos");
 } // namespace test2
 
-using TestTable = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test2::X, test2::Y>;
-using ArrayTable = o2::soa::Table<o2::header::DataOrigin{"AOD"}, test2::Pos>;
+using TestTable = o2::soa::Table<test2::X, test2::Y>;
+using ArrayTable = o2::soa::Table<test2::Pos>;
 
 TEST_CASE("TestTableBuilder")
 {


### PR DESCRIPTION
This reverts commit ed7a61b91ea12779674dd953fa7fea7c3047078a.

Breaks performance profiling on hyperloop.