### PR TITLE
disable HV-based digit filtering in MUON_SYNC_RECO

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -342,6 +342,7 @@ if has_processing_step MUON_SYNC_RECO; then
     fi
     has_detector_reco ITS && [[ $RUNTYPE != "COSMICS" ]] && CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+="MCHTimeClusterizer.irFramesOnly=true;"
     [[ ! -z ${CUT_RANDOM_FRACTION_MCH:-} ]] && CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+="MCHTimeClusterizer.rofRejectionFraction=$CUT_RANDOM_FRACTION_MCH;"
+    CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+="MCHStatusMap.useHV=false;MCHDigitFilter.statusMask=3;"
   fi
   [[ $RUNTYPE == "COSMICS" ]] && [[ -z ${CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow:-} ]] && CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.FullClusterScan=true"
 fi


### PR DESCRIPTION
The DCS data points of the MCH HV channels used in the digit filtering are stored in the CCDB every 30 minutes. Therefore, they are not available in time for the synchronous reconstruction and the set of data points stored previously are used instead. This results in decisions based on old HV values, which can be as bad as discarding every digits at the beginning of the run.

This PR disables the recording of the HV status in the status map and the corresponding filtering of the digits for the synchronous reconstruction.
