### PR TITLE
Logging error and clearing output upon timeout

### DIFF
--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -523,10 +523,8 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
       }
 
       // Check for timeout
-      curl_off_t transferTime = 0;
-      curl_easy_getinfo(easy_handle, CURLINFO_TOTAL_TIME_T, &transferTime);
-      if (transferTime / 1000 >= mRequestTimeoutMS) {
-        LOG(error) << "Connection timeout\n";
+      if (curlCode == CURLE_OPERATION_TIMEDOUT) {
+        log(error) << "Connection timed out.\n";
         contentRetrieved = false;
       }
 

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -484,6 +484,10 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
   bool rescheduled = false;
   bool contentRetrieved = false;
 
+  if (curlCode != 0) {
+    LOG(error) << "CCDBDownloader: " << curl_easy_strerror(curlCode) << "\n";
+  }
+
   switch (performData->type) {
     case BLOCKING: {
       --(*performData->requestsLeft);
@@ -524,7 +528,7 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
 
       // Check for timeout
       if (curlCode == CURLE_OPERATION_TIMEDOUT) {
-        log(error) << "Connection timed out.\n";
+        LOG(error) << "Connection timed out.\n";
         contentRetrieved = false;
       }
 


### PR DESCRIPTION
When a timeout happens due to a connection exceeding `mRequestTimeoutMS` an error will be logged and the partially written content of destination vector will be purged.