### PR TITLE
Fix chaining of expendable devices

### DIFF
--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -97,6 +97,7 @@ struct ForwardChannelInfo {
 
 struct ForwardChannelState {
   TimesliceId oldestForChannel = {0};
+  int64_t droppedMessages = 0;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -174,7 +174,7 @@ std::vector<ForwardingPolicy> ForwardingPolicy::createDefaultPolicies()
             .forward = [](fair::mq::Parts& parts, ChannelIndex channelIndex, ServiceRegistryRef registry) {
               auto &proxy = registry.get<FairMQDeviceProxy>();
               auto *channel = proxy.getForwardChannel(channelIndex);
-              OutputChannelState& state = proxy.getOutputChannelState(channelIndex);
+              ForwardChannelState& state = proxy.getForwardChannelState(channelIndex);
               auto timeout = 1000;
               if (state.droppedMessages > 0) {
                 timeout = 0;


### PR DESCRIPTION
Fix chaining of expendable devices

Obviously for forward channels we need to get the correct channel information.

This probably addresses https://its.cern.ch/jira/browse/O2-5018
