### PR TITLE
Data model: add uint8_t flag to tag upc reco settings

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -40,6 +40,7 @@ DECLARE_SOA_COLUMN(RunNumber, runNumber, int);          //! Run number
 DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);       //! Bunch crossing number (globally unique in this run)
 DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t); //! CTP trigger mask
 DECLARE_SOA_COLUMN(InputMask, inputMask, uint64_t);     //! CTP input mask
+DECLARE_SOA_COLUMN(Flags, flags, uint8_t);     //! BC flags (e.g. tagging of UPC tracking settings, etc)
 } // namespace bc
 
 DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", //! Root of data model for tables pointing to a bunch crossing
@@ -50,6 +51,10 @@ DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1, //! Root of data model for 
                             o2::soa::Index<>,
                             bc::RunNumber, bc::GlobalBC,
                             bc::TriggerMask, bc::InputMask);
+DECLARE_SOA_TABLE_VERSIONED(BCs_002, "AOD", "BC", 2, //! Root of data model for tables pointing to a bunch crossing, version 1
+                            o2::soa::Index<>,
+                            bc::RunNumber, bc::GlobalBC,
+                            bc::TriggerMask, bc::InputMask, bc::Flags);
 
 using BCs = BCs_001; // current version
 using BC = BCs::iterator;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -40,7 +40,7 @@ DECLARE_SOA_COLUMN(RunNumber, runNumber, int);          //! Run number
 DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);       //! Bunch crossing number (globally unique in this run)
 DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t); //! CTP trigger mask
 DECLARE_SOA_COLUMN(InputMask, inputMask, uint64_t);     //! CTP input mask
-DECLARE_SOA_COLUMN(Flags, flags, uint8_t);     //! BC flags (e.g. tagging of UPC tracking settings, etc)
+DECLARE_SOA_COLUMN(Flags, flags, uint8_t);              //! BC flags (e.g. tagging of UPC tracking settings, etc)
 } // namespace bc
 
 DECLARE_SOA_TABLE(BCs_000, "AOD", "BC", //! Root of data model for tables pointing to a bunch crossing

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -51,10 +51,8 @@ DECLARE_SOA_TABLE_VERSIONED(BCs_001, "AOD", "BC", 1, //! Root of data model for 
                             o2::soa::Index<>,
                             bc::RunNumber, bc::GlobalBC,
                             bc::TriggerMask, bc::InputMask);
-DECLARE_SOA_TABLE_VERSIONED(BCs_002, "AOD", "BC", 2, //! Root of data model for tables pointing to a bunch crossing, version 1
-                            o2::soa::Index<>,
-                            bc::RunNumber, bc::GlobalBC,
-                            bc::TriggerMask, bc::InputMask, bc::Flags);
+DECLARE_SOA_TABLE(BCFlags, "AOD", "BCFLAG", //! flag for tagging UPCs, joinable with BCs
+                  bc::Flags);
 
 using BCs = BCs_001; // current version
 using BC = BCs::iterator;


### PR DESCRIPTION
Tagging relevant people: @shahor02, @mconcas

This PR adds a `uint8_t` field named `Flags` to the BC table (now versioned at 002) to allow for proper tagging of the use of UPC settings in recent Pb-Pb reconstruction. 

The addition of a single `uint8_t` should lead to a marginal overhead in the data size. The current BC table occupies 0.1% of the compressed AO2D size, and it consists of a single `int` and three `uint64_t`s; another 8 bits would add 3-4% extra to that 0.1%. 