### PR TITLE
MRRTF-227: added ERRORS and HBPACKETS dummy messages

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -189,9 +189,13 @@ class DataDecoderTask
     std::vector<Digit> digits;
     std::vector<ROFRecord> rofs;
     std::vector<OrbitInfo> orbits;
+    std::vector<DecoderError> errors;
+    std::vector<HeartBeatPacket> hbpackets;
     output.snapshot(Output{header::gDataOriginMCH, "DIGITS", 0}, digits);
     output.snapshot(Output{header::gDataOriginMCH, "DIGITROFS", 0}, rofs);
     output.snapshot(Output{header::gDataOriginMCH, "ORBITS", 0}, orbits);
+    output.snapshot(Output{header::gDataOriginMCH, "ERRORS", 0}, errors);
+    output.snapshot(Output{header::gDataOriginMCH, "HBPACKETS", 0}, hbpackets);
   }
 
   bool isDroppedTF(framework::ProcessingContext& pc)


### PR DESCRIPTION
DPL messages for ERRORS and HBPACKETS were incorrectly not injected in the `DEADBEEF` case, leading to dropped TFs.
The symptom are messages like this in the EPN ILG:
```
Expected Lifetime::Timeframe data MCH/HBPACKETS/0 was not created for timeslice 47383 and might result in dropped timeframes
Expected Lifetime::Timeframe data MCH/ERRORS/0 was not created for timeslice 20 and might result in dropped timeframes
```