### PR TITLE
Propagate ITS UPC mode flag to matching AOD BCs and collisions

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ROFRecord.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ROFRecord.h
@@ -31,6 +31,8 @@ class ROFRecord
 {
 
  public:
+  enum { VtxStdMode = 0,
+         VtxUPCMode = 1 };
   using EvIdx = o2::dataformats::RangeReference<int, int>;
   using BCData = o2::InteractionRecord;
   using ROFtype = unsigned int;

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -124,6 +124,7 @@ class Vertex : public VertexBase
   using ushort = unsigned short;
   enum Flags : ushort {
     TimeValidated = 0x1 << 0, // Flag that the vertex was validated by external time measurement (e.g. FIT)
+    UPCMode = 0x1 << 1,       // vertex is found in the UPC mode ITS ROF
     FlagsMask = 0xffff
   };
 

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -624,6 +624,8 @@ class AODProducerWorkflowDPL : public Task
 
   std::uint64_t fillBCSlice(int (&slice)[2], double tmin, double tmax, const std::map<uint64_t, int>& bcsMap) const;
 
+  std::vector<uint8_t> fillBCFlags(const o2::globaltracking::RecoContainer& data, std::map<uint64_t, int>& bcsMap) const;
+
   // helper for tpc clusters
   void countTPCClusters(const o2::globaltracking::RecoContainer& data);
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1798,6 +1798,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   using namespace o2::aodhelpers;
 
   auto bcCursor = createTableCursor<o2::aod::BCs>(pc);
+  auto bcFlagsCursor = createTableCursor<o2::aod::BCFlags>(pc);
   auto cascadesCursor = createTableCursor<o2::aod::Cascades>(pc);
   auto collisionsCursor = createTableCursor<o2::aod::Collisions>(pc);
   auto decay3BodyCursor = createTableCursor<o2::aod::Decay3Bodys>(pc);
@@ -2234,6 +2235,13 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   }
 
   bcToClassMask.clear();
+
+  // filling BC flags table:
+  auto bcFlags = fillBCFlags(recoData, bcsMap);
+  bcFlagsCursor.reserve(bcFlags.size());
+  for (auto f : bcFlags) {
+    bcFlagsCursor(f);
+  }
 
   // fill cpvcluster table
   if (mInputSources[GIndex::CPV]) {
@@ -2899,6 +2907,36 @@ std::uint64_t AODProducerWorkflowDPL::fillBCSlice(int (&slice)[2], double tmin, 
   return bcOfTimeRef;
 }
 
+std::vector<uint8_t> AODProducerWorkflowDPL::fillBCFlags(const o2::globaltracking::RecoContainer& data, std::map<uint64_t, int>& bcsMap) const
+{
+  std::vector<uint8_t> flags(bcsMap.size());
+
+  // flag BCs belonging to UPC mode ITS ROFs
+  auto bcIt = bcsMap.begin();
+  auto itsrofs = data.getITSTracksROFRecords();
+  auto lROF = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance().roFrameLengthInBC;
+  auto bROF = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance().roFrameBiasInBC;
+  for (auto& rof : itsrofs) {
+    if (!rof.getFlag(o2::itsmft::ROFRecord::VtxUPCMode)) {
+      continue;
+    }
+    uint64_t globalBC0 = rof.getBCData().toLong() + bROF, globalBC1 = globalBC0 + lROF - 1;
+    // BCs are sorted, iterate until the start of ROF
+    while (bcIt != bcsMap.end()) {
+      if (bcIt->first < globalBC0) {
+        ++bcIt;
+        continue;
+      }
+      if (bcIt->first > globalBC1) {
+        break;
+      }
+      flags[bcIt->second] |= o2::aod::bc::ITSUPCMode;
+      ++bcIt;
+    }
+  }
+  return flags;
+}
+
 void AODProducerWorkflowDPL::endOfStream(EndOfStreamContext& /*ec*/)
 {
   LOGF(info, "aod producer dpl total timing: Cpu: %.3e Real: %.3e s in %d slots",
@@ -2960,6 +2998,7 @@ DataProcessorSpec getAODProducerWorkflowSpec(GID::mask_t src, bool enableSV, boo
 
   std::vector<OutputSpec> outputs{
     OutputForTable<BCs>::spec(),
+    OutputForTable<BCFlags>::spec(),
     OutputForTable<Cascades>::spec(),
     OutputForTable<Collisions>::spec(),
     OutputForTable<Decay3Bodys>::spec(),

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -219,10 +219,10 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
           allVerticesLabels.push_back(vMCRecInfo[iV].first);
           allVerticesPurities.push_back(vMCRecInfo[iV].second);
         }
-        if (v.isFlagSet(2)) { // Vertex is reconstructed in a second iteration
-          vtxROF.setFlag(2);  // flag that at least one vertex is from the second iteration
+        if (v.isFlagSet(Vertex::UPCMode)) {              // Vertex is reconstructed in a second iteration
+          vtxROF.setFlag(itsmft::ROFRecord::VtxUPCMode); // flag that at least one vertex is from the second iteration
         } else {
-          vtxROF.setFlag(1); // flag that at least one vertex is from the first iteration
+          vtxROF.setFlag(itsmft::ROFRecord::VtxStdMode); // flag that at least one vertex is from the first iteration
         }
       }
       if (processingMask[iRof] && !selROF) { // passed selection in clusters and not in vertex multiplicity
@@ -292,7 +292,7 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
       int offset = -tracksROF.getFirstEntry(); // cluster entry!!!
       tracksROF.setFirstEntry(first);
       tracksROF.setNEntries(number);
-      tracksROF.setFlags(number ? vtxROF.getFlags() : 0); // copies 0xffffffff if cosmics
+      tracksROF.setFlags(vtxROF.getFlags()); // copies 0xffffffff if cosmics
       if (processingMask[iROF]) {
         irFrames.emplace_back(tracksROF.getBCData(), tracksROF.getBCData() + nBCPerTF - 1).info = tracks.size();
       }

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -201,10 +201,21 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
       if (mIsMC) {
         vMCRecInfo = mTimeFrame->getPrimaryVerticesMCRecInfo(iRof);
       }
-      if (o2::its::TrackerParamConfig::Instance().doUPCIteration && (vtxSpan.size() && vtxSpan[0].getFlags() == 1)) { // at least one vertex in this ROF and it is from second vertex iteration
-        LOGP(debug, "ROF {} rejected as vertices are from the UPC iteration", iRof);
-        processUPCMask[iRof] = true;
-        cutUPCVertex++;
+      if (o2::its::TrackerParamConfig::Instance().doUPCIteration) {
+        if (vtxSpan.size()) {
+          if (vtxSpan[0].isFlagSet(Vertex::UPCMode) == 1) { // at least one vertex in this ROF and it is from second vertex iteration
+            LOGP(debug, "ROF {} rejected as vertices are from the UPC iteration", iRof);
+            processUPCMask[iRof] = true;
+            cutUPCVertex++;
+            vtxROF.setFlag(o2::itsmft::ROFRecord::VtxUPCMode);
+          } else { // in all cases except if as standard mode vertex was found, the ROF was processed with UPC settings
+            vtxROF.setFlag(o2::itsmft::ROFRecord::VtxStdMode);
+          }
+        } else {
+          vtxROF.setFlag(o2::itsmft::ROFRecord::VtxUPCMode);
+        }
+      } else {
+        vtxROF.setFlag(o2::itsmft::ROFRecord::VtxStdMode);
       }
       vtxROF.setNEntries(vtxSpan.size());
       bool selROF = vtxSpan.size() == 0;
@@ -218,11 +229,6 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
         if (mIsMC) {
           allVerticesLabels.push_back(vMCRecInfo[iV].first);
           allVerticesPurities.push_back(vMCRecInfo[iV].second);
-        }
-        if (v.isFlagSet(Vertex::UPCMode)) {              // Vertex is reconstructed in a second iteration
-          vtxROF.setFlag(itsmft::ROFRecord::VtxUPCMode); // flag that at least one vertex is from the second iteration
-        } else {
-          vtxROF.setFlag(itsmft::ROFRecord::VtxStdMode); // flag that at least one vertex is from the first iteration
         }
       }
       if (processingMask[iRof] && !selROF) { // passed selection in clusters and not in vertex multiplicity

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -517,7 +517,9 @@ void VertexerTraits::computeVertices(const int iteration)
                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize(),          // Contributors
                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getAvgDistance2()); // In place of chi2
 
-        vertices.back().setFlags(iteration + 1);
+        if (iteration) {
+          vertices.back().setFlags(Vertex::UPCMode);
+        }
         vertices.back().setTimeStamp(mTimeFrame->getTrackletClusters(rofId)[iCluster].getROF());
         if (mTimeFrame->hasMCinformation()) {
           std::vector<o2::MCCompLabel> labels;

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -16,6 +16,13 @@
 #include <cstdint>
 #include <limits>
 
+namespace o2::aod::bc
+{
+enum BCFlags : uint8_t {
+  ITSUPCMode = 0x1
+};
+}
+
 namespace o2::aod::collision
 {
 enum CollisionFlagsRun2 : uint16_t {


### PR DESCRIPTION
includes https://github.com/AliceO2Group/AliceO2/pull/13415 and depends on https://github.com/AliceO2Group/AliceO2/pull/13411.
@ddobrigk At the moment compilation fails with errors below, I assume I need to wait for the converter, could you please check?

```
In file included from /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h:24,
                 from /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/AOD/src/AODProducerWorkflowSpec.cxx:14:
/home/shahoian/alice/sw/SOURCES/O2/dev/0/Framework/Core/include/Framework/AnalysisHelpers.h: In instantiation of 'void o2::framework::WritingCursor<o2::soa::Table<C ...> >::operator()(T ...) [with T = {int, long unsigned int, long unsigned int, long unsigned int, unsigned char}; PC = {o2::aod::bc::RunNumber, o2::aod::bc::GlobalBC, o2::aod::bc::TriggerMask, o2::aod::bc::InputMask}]':
/home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/AOD/src/AODProducerWorkflowSpec.cxx:2231:13:   required from here
/home/shahoian/alice/sw/SOURCES/O2/dev/0/Framework/Core/include/Framework/AnalysisHelpers.h:48:33: error: static assertion failed: Argument number mismatch
   48 |     static_assert(sizeof...(PC) == sizeof...(T), "Argument number mismatch");
      |                   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/home/shahoian/alice/sw/SOURCES/O2/dev/0/Framework/Core/include/Framework/AnalysisHelpers.h:48:33: note: the comparison reduces to '(4 == 5)'
/home/shahoian/alice/sw/SOURCES/O2/dev/0/Framework/Core/include/Framework/AnalysisHelpers.h:50:11: error: no match for call to '(o2::framework::{anonymous}::memfun_type<void (o2::framework::TableBuilder::persist<int, long unsigned int, long unsigned int, long unsigned int>(const std::array<const char*, 4>&)::<lambda(unsigned int, o2::framework::BuilderMaker<int>::FillType, o2::framework::BuilderMaker<long unsigned int>::FillType, o2::framework::BuilderMaker<long unsigned int>::FillType, o2::framework::BuilderMaker<long unsigned int>::FillType)>::*)(unsigned int, int, long unsigned int, long unsigned int, long unsigned int) const>::type {aka std::function<void(unsigned int, int, long unsigned int, long unsigned int, long unsigned int)>}) (int, const int&, const long unsigned int&, const long unsigned int&, const long unsigned int&, const unsigned char&)'
   50 |     cursor(0, extract(args)...);
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~
In file included from /home/shahoian/alice/sw/ubuntu2204_x86-64/GCC-Toolchain/v12.2.0-alice1-5/include/c++/12.2.0/functional:59,
                 from /home/shahoian/alice/sw/ubuntu2204_x86-64/ROOT/v6-30-01-alice5-16/include/TError.h:37,
                 from /home/shahoian/alice/sw/ubuntu2204_x86-64/ROOT/v6-30-01-alice5-16/include/TVector3.h:14,
                 from /home/shahoian/alice/sw/ubuntu2204_x86-64/FairRoot/v18.4.9-alice3-38/include/FairMCEventHeader.h:19,
                 from /home/shahoian/alice/sw/SOURCES/O2/dev/0/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h:17,
                 from /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/AOD/include/AODProducerWorkflow/AODMcProducerHelpers.h:18,
                 from /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h:17:
/home/shahoian/alice/sw/ubuntu2204_x86-64/GCC-Toolchain/v12.2.0-alice1-5/include/c++/12.2.0/bits/std_function.h:587:7: note: candidate: '_Res std::function<_Res(_ArgTypes ...)>::operator()(_ArgTypes ...) const [with _Res = void; _ArgTypes = {unsigned int, int, long unsigned int, long unsigned int, long unsigned int}]'
  587 |       operator()(_ArgTypes... __args) const
      |       ^~~~~~~~
/home/shahoian/alice/sw/ubuntu2204_x86-64/GCC-Toolchain/v12.2.0-alice1-5/include/c++/12.2.0/bits/std_function.h:587:7: note:   candidate expects 5 arguments, 6 provided
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics

```