### PR TITLE
Add fraction of TPC clusters used for PID to AO2D

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2487,6 +2487,9 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     extraInfoHolder.tpcNClsFindableMinusFound = tpcOrig.getNClusters() - tpcClData.found;
     extraInfoHolder.tpcNClsFindableMinusCrossedRows = tpcOrig.getNClusters() - tpcClData.crossed;
     extraInfoHolder.tpcNClsShared = tpcClData.shared;
+    uint8_t clsFractionUsedForPID = (tpcOrig.getdEdx().NHitsIROC + tpcOrig.getdEdx().NHitsOROC1 + tpcOrig.getdEdx().NHitsOROC2 + tpcOrig.getdEdx().NHitsOROC3) * 8 / tpcClData.found;
+    clsFractionUsedForPID = clsFractionUsedForPID > 7u ? 7u : clsFractionUsedForPID; // 7 is the maximum value
+    extraInfoHolder.flags |= clsFractionUsedForPID << 25;
     if (src == GIndex::TPC) { // standalone TPC track should set its time from their timebins range
       if (needBCSlice) {
         double t = (tpcOrig.getTime0() + 0.5 * (tpcOrig.getDeltaTFwd() - tpcOrig.getDeltaTBwd())) * mTPCBinNS; // central value

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2487,7 +2487,7 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
     extraInfoHolder.tpcNClsFindableMinusFound = tpcOrig.getNClusters() - tpcClData.found;
     extraInfoHolder.tpcNClsFindableMinusCrossedRows = tpcOrig.getNClusters() - tpcClData.crossed;
     extraInfoHolder.tpcNClsShared = tpcClData.shared;
-    uint8_t clsFractionUsedForPID = (tpcOrig.getdEdx().NHitsIROC + tpcOrig.getdEdx().NHitsOROC1 + tpcOrig.getdEdx().NHitsOROC2 + tpcOrig.getdEdx().NHitsOROC3) * 8 / tpcClData.found;
+    uint32_t clsFractionUsedForPID = (tpcOrig.getdEdx().NHitsIROC + tpcOrig.getdEdx().NHitsOROC1 + tpcOrig.getdEdx().NHitsOROC2 + tpcOrig.getdEdx().NHitsOROC3) * 8 / tpcClData.found;
     clsFractionUsedForPID = clsFractionUsedForPID > 7u ? 7u : clsFractionUsedForPID; // 7 is the maximum value
     extraInfoHolder.flags |= clsFractionUsedForPID << 25;
     if (src == GIndex::TPC) { // standalone TPC track should set its time from their timebins range

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -343,6 +343,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(IsPVContributor, isPVContributor, //! Run 3: Has this
                            [](uint8_t flags) -> bool { return (flags & o2::aod::track::PVContributor) == o2::aod::track::PVContributor; });
 DECLARE_SOA_DYNAMIC_COLUMN(PIDForTracking, pidForTracking, //! PID hypothesis used during tracking. See the constants in the class PID in PID.h
                            [](uint32_t flags) -> uint32_t { return flags >> 28; });
+DECLARE_SOA_DYNAMIC_COLUMN(MinFractionOfTPCclustersForPID, minFractionOfTPCclustersForPID, //! Minimum fraction of TPC clusters used for PID in bins of 0.125
+                           [](uint32_t flags) -> float { return ((flags >> 25) & 0x7) * 0.125; });
 DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsFound, tpcNClsFound, //! Number of found TPC clusters
                            [](uint8_t tpcNClsFindable, int8_t tpcNClsFindableMinusFound) -> int16_t { return (int16_t)tpcNClsFindable - tpcNClsFindableMinusFound; });
 DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, //! Number of crossed TPC Rows
@@ -487,6 +489,7 @@ DECLARE_SOA_TABLE_FULL(StoredTracksExtra_000, "TracksExtra", "AOD", "TRACKEXTRA"
                        track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
                        track::PIDForTracking<track::Flags>,
                        track::IsPVContributor<track::Flags>,
+                       track::MinFractionOfTPCclustersForPID<track::Flags>,
                        track::HasITS<track::DetectorMap>, track::HasTPC<track::DetectorMap>,
                        track::HasTRD<track::DetectorMap>, track::HasTOF<track::DetectorMap>,
                        track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
@@ -505,6 +508,7 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredTracksExtra_001, "TracksExtra", "AOD", "T
                                  track::TPCSignal, track::TRDSignal, track::Length, track::TOFExpMom,
                                  track::PIDForTracking<track::Flags>,
                                  track::IsPVContributor<track::Flags>,
+                                 track::MinFractionOfTPCclustersForPID<track::Flags>,
                                  track::HasITS<track::v001::DetectorMap>, track::HasTPC<track::v001::DetectorMap>,
                                  track::HasTRD<track::v001::DetectorMap>, track::HasTOF<track::v001::DetectorMap>,
                                  track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -42,6 +42,7 @@ enum TrackFlags : uint32_t {
   PVContributor = 0x2,       // This track has contributed to the collision vertex fit
   OrphanTrack = 0x4,         // Track has no association with any collision vertex
   TrackTimeAsym = 0x8,       // track with an asymmetric time range
+  // NOTE bits 26..28 reserved for the fraction of TPC clusters used for PID
   // NOTE Highest 4 (29..32) bits reserved for PID hypothesis
 };
 enum TrackFlagsRun2Enum {


### PR DESCRIPTION
We add this fraction as a binned variable contained in the track flags (like the PID in tracking).
@shahor02 this is how I would implement the change we discuss before.
@ddobrigk @pzhristov  @jgrosseo  please have a look: we need this information to clean up the dE/dx signal following the change of dE/dx calculation in the reconstruction that exclude the clusters close to the sector boundaries. A few open points:
- this is far from elegant, but it avoids changing the data model
- My naive guess is that 12.5% is a good enough binning, but maybe @wiechula can tell us if this is indeed the case

I am still testing so I open in draft.