### PR TITLE
SVectorGPU and SMatrixGPU implementation should be in detail namespace

### DIFF
--- a/Common/MathUtils/include/MathUtils/SMatrixGPU.h
+++ b/Common/MathUtils/include/MathUtils/SMatrixGPU.h
@@ -34,7 +34,7 @@
 #include "GPUCommonAlgorithm.h"
 #include "GPUCommonLogger.h"
 
-namespace o2::math_utils
+namespace o2::math_utils::detail
 {
 template <bool>
 struct Check {
@@ -1468,5 +1468,5 @@ GPUdi() SMatrixGPU<T, D1, D1, MatRepSymGPU<T, D1>> Similarity(const SMatrixGPU<T
   AssignSym::Evaluate(mret, tmp * Transpose(lhs));
   return mret;
 }
-} // namespace o2::math_utils
+} // namespace o2::math_utils::detail
 #endif

--- a/GPU/Common/test/testSMatrixImp.cu
+++ b/GPU/Common/test/testSMatrixImp.cu
@@ -27,9 +27,9 @@
 #include <Math/SMatrix.h>
 #include <random>
 
-using MatSym3DGPU = o2::math_utils::SMatrixGPU<double, 3, 3, o2::math_utils::MatRepSymGPU<double, 3>>;
+using MatSym3DGPU = o2::math_utils::detail::SMatrixGPU<double, 3, 3, o2::math_utils::detail::MatRepSymGPU<double, 3>>;
 using MatSym3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>>;
-using Mat3DGPU = o2::math_utils::SMatrixGPU<double, 3, 3, o2::math_utils::MatRepStdGPU<double, 3, 3>>;
+using Mat3DGPU = o2::math_utils::detail::SMatrixGPU<double, 3, 3, o2::math_utils::detail::MatRepStdGPU<double, 3, 3>>;
 using Mat3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepStd<double, 3, 3>>;
 
 static constexpr double tolerance = 1e-8;


### PR DESCRIPTION
@mconcas : This should fix the problem.
Actually not sure how it ever worked...
With the patch it is still failing since some functions like Dot are not implemented for the GPU, but I think you can take it from here.