### PR TITLE
ALIGN: request only selected alignment objects

### DIFF
--- a/Detectors/GRP/workflows/src/create-aligned-geometry.cxx
+++ b/Detectors/GRP/workflows/src/create-aligned-geometry.cxx
@@ -150,7 +150,10 @@ DataProcessorSpec getAlignerSpec(DetID::mask_t dets)
                                                               false,                                // GRPMagField
                                                               false,                                // askMatLUT
                                                               o2::base::GRPGeomRequest::Alignments, // geometry
-                                                              inputs);
+                                                              inputs,                               // inputs
+                                                              false,                                // ask-once
+                                                              false,                                // dprop
+                                                              DetID::getNames(dets));               // only selected detectors
 
   return DataProcessorSpec{
     "geometry-aligned-producer",


### PR DESCRIPTION
Hi @shahor02, when running with `--onlyDet` the workflow still request the alignment objects of all detectors from the ccdb which is not necessary and confused me when looking at the output. This would request them only for the selected detectors iff the option is used.