### PR TITLE
Fix for dummy ITS vetrex seeding in cosmice mode

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -143,6 +143,7 @@ class TimeFrame
   {
     deepVectorClear(mPrimaryVertices);
     mROFramesPV.resize(1, 0);
+    mTotVertPerIteration.resize(1);
   };
 
   bool isClusterUsed(int layer, int clusterId) const;


### PR DESCRIPTION
@mconcas This is to fix https://ali-bookkeeping.cern.ch/?page=log-detail&id=107021 in cosmic mode the `TimeFrame::mTotVertPerIteration[0]` was accessed w/o initialization (done via vertexer in the beam mode)