### PR TITLE
Common/Constants: Add hyperhelium5 mass

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -73,7 +73,8 @@ enum Pdg {
   kAlpha = 1000020040,
   kHyperTriton = 1010010030,
   kHyperHydrogen4 = 1010010040,
-  kHyperHelium4 = 1010020040
+  kHyperHelium4 = 1010020040,
+  kHyperHelium5 = 1010020050
 };
 
 /// \brief Declarations of masses for additional particles
@@ -120,6 +121,7 @@ constexpr double MassAlpha = 3.7273794066;
 constexpr double MassHyperTriton = 2.99131;
 constexpr double MassHyperHydrogen4 = 3.9226;
 constexpr double MassHyperHelium4 = 3.9217;
+constexpr double MassHyperHelium5 = 4.841;
 
 /// \brief Declarations of masses for particles in ROOT PDG_t
 constexpr double MassDown = 0.00467;

--- a/Common/Constants/include/CommonConstants/make_pdg_header.py
+++ b/Common/Constants/include/CommonConstants/make_pdg_header.py
@@ -129,6 +129,7 @@ class Pdg(Enum):
     kHyperTriton = 1010010030
     kHyperHydrogen4 = 1010010040
     kHyperHelium4 = 1010020040
+    kHyperHelium5 = 1010020050
 
 
 dbPdg = ROOT.o2.O2DatabasePDG


### PR DESCRIPTION
This PR is to add the hyperhelium5 mass for further reconstruction of decay3bodys. Since the files of physics constants always have individual changes, I submitted this PR separately.