### PR TITLE
DPL: Fix endOfStream callback sending old / uninitialized timingInfo values

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1732,6 +1732,12 @@ void DataProcessingDevice::doRun(ServiceRegistryRef ref)
     // We should keep the data generated at end of stream only for those
     // which are not sources.
     timingInfo.keepAtEndOfStream = shouldProcess;
+    // Fill timinginfo with some reasonable values for data sent with endOfStream
+    timingInfo.timeslice = relayer.getOldestPossibleOutput().timeslice.value;
+    timingInfo.tfCounter = 0;
+    timingInfo.firstTForbit = 0;
+    // timingInfo.runNumber = ; // Not sure where to get this if not already set
+    timingInfo.creation = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
     O2_SIGNPOST_EVENT_EMIT(calibration, dpid, "calibration", "TimingInfo.keepAtEndOfStream %d", timingInfo.keepAtEndOfStream);
 
     EndOfStreamContext eosContext{*context.registry, ref.get<DataAllocator>()};


### PR DESCRIPTION
@shahor02 @ktf : So far, we were resending either the timingInfo from the last timeframe with EoS, if we processed a TF before, or just uninitialized data in case a QC task didn't yet receive data. This tries to fill some reasonable values.
I think if we didn't receive any data yet, we cannot know the runNumber, so we just stick to the last one if set, or the default one.

Do you think setting tfCounter and firstTForbit to 0 makes sense? In the end, this data does not belong to a TF, so we should not imply so. I tried this with the FST, and it solved the ERRORS for getting timeslices incompatible to the oldestPossibleTimeslice, and it doesn't trigger new ERRORs at least.