### PR TITLE
DPL: initialize TimingInfo.timeslice

### DIFF
--- a/Framework/Core/include/Framework/TimingInfo.h
+++ b/Framework/Core/include/Framework/TimingInfo.h
@@ -23,7 +23,11 @@ namespace o2::framework
 
 struct TimingInfo {
   constexpr static ServiceKind service_kind = ServiceKind::Stream;
-  size_t timeslice;           /// the timeslice associated to current processing
+  size_t timeslice = 0;       /// the timeslice associated to current processing. The default
+                              /// is in general overridden unless the end of stream arrives
+                              /// without any previous processing, so we need to 0 it,
+                              /// and not use -1, which would break the oldest possible timeframe
+                              /// in that case.
   uint32_t firstTForbit = -1; /// the orbit the TF begins
   uint32_t tfCounter = -1;    // the counter associated to a TF
   uint32_t runNumber = -1;


### PR DESCRIPTION
DPL: initialize TimingInfo.timeslice

Empty processing will otherwise have it set wrong on End Of Stream
