### PR TITLE
ITS3: Move to ITSTrackingInterface

### DIFF
--- a/Detectors/Upgrades/ITS3/reconstruction/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/reconstruction/CMakeLists.txt
@@ -19,7 +19,6 @@ o2_add_library(ITS3Reconstruction
                        src/BuildTopologyDictionary.cxx
                        src/LookUp.cxx
                        src/IOUtils.cxx
-                #        src/FastMultEst.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
                                      O2::ITSMFTReconstruction
                                      O2::ITS3Base
@@ -40,6 +39,15 @@ o2_target_root_dictionary(
           include/ITS3Reconstruction/LookUp.h
           include/ITS3Reconstruction/IOUtils.h
 )
+
+o2_add_library(ITS3TrackingInterface
+  TARGETVARNAME targetName
+  SOURCES src/TrackingInterface.cxx
+               PRIVATE_LINK_LIBRARIES
+                       O2::ITS3Reconstruction
+                       O2::ITSTrackingInterface
+                       O2::Framework
+                       O2::GPUTracking)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TrackingInterface.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TrackingInterface.h
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_ITS3_TRACKINGINTERFACE
+#define O2_ITS3_TRACKINGINTERFACE
+
+#include "ITStracking/TrackingInterface.h"
+#include "ITS3Reconstruction/TopologyDictionary.h"
+
+namespace o2::its3
+{
+
+class ITS3TrackingInterface final : public its::ITSTrackingInterface
+{
+ public:
+  using its::ITSTrackingInterface::ITSTrackingInterface;
+
+  void setClusterDictionary(const o2::its3::TopologyDictionary* d) { mDict = d; }
+  void updateTimeDependentParams(framework::ProcessingContext& pc) final;
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
+
+ protected:
+  void loadROF(gsl::span<itsmft::ROFRecord>& trackROFspan,
+               gsl::span<const itsmft::CompClusterExt> clusters,
+               gsl::span<const unsigned char>::iterator& pattIt,
+               const dataformats::MCTruthContainer<MCCompLabel>* mcLabels) final;
+
+ private:
+  const o2::its3::TopologyDictionary* mDict{nullptr};
+};
+
+} // namespace o2::its3
+
+#endif

--- a/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
@@ -119,6 +119,9 @@ int loadROFrameDataITS3(its::TimeFrame* tf,
   for (auto& v : tf->mNTrackletsPerCluster) {
     v.resize(tf->getUnsortedClusters()[1].size());
   }
+  for (auto& v : tf->mNTrackletsPerClusterSum) {
+    v.resize(tf->getUnsortedClusters()[1].size() + 1);
+  }
 
   if (mcLabels != nullptr) {
     tf->mClusterLabels = mcLabels;

--- a/Detectors/Upgrades/ITS3/reconstruction/src/TrackingInterface.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/TrackingInterface.cxx
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITS3Reconstruction/TrackingInterface.h"
+#include "ITS3Reconstruction/IOUtils.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+
+namespace o2::its3
+{
+
+void ITS3TrackingInterface::updateTimeDependentParams(framework::ProcessingContext& pc)
+{
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+    pc.inputs().get<o2::its3::TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
+    pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alppar");
+    if (pc.inputs().getPos("itsTGeo") >= 0) {
+      pc.inputs().get<o2::its::GeometryTGeo*>("itsTGeo");
+    }
+    auto geom = its::GeometryTGeo::Instance();
+    geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot, o2::math_utils::TransformType::T2G));
+    getConfiguration(pc);
+  }
+}
+
+void ITS3TrackingInterface::finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+  if (matcher == framework::ConcreteDataMatcher("IT3", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated";
+    setClusterDictionary((const o2::its3::TopologyDictionary*)obj);
+    return;
+  }
+  if (matcher == framework::ConcreteDataMatcher("ITS", "ALPIDEPARAM", 0)) {
+    LOG(info) << "Alpide param updated";
+    const auto& par = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
+    par.printKeyValues();
+    return;
+  }
+  if (matcher == framework::ConcreteDataMatcher("GLO", "MEANVERTEX", 0)) {
+    LOGP(info, "Mean vertex acquired");
+    setMeanVertex((const o2::dataformats::MeanVertexObject*)obj);
+    return;
+  }
+  if (matcher == framework::ConcreteDataMatcher("ITS", "GEOMTGEO", 0)) {
+    LOG(info) << "ITS GeometryTGeo loaded from ccdb";
+    o2::its::GeometryTGeo::adopt((o2::its::GeometryTGeo*)obj);
+    return;
+  }
+}
+
+void ITS3TrackingInterface::loadROF(gsl::span<itsmft::ROFRecord>& trackROFspan,
+                                    gsl::span<const itsmft::CompClusterExt> clusters,
+                                    gsl::span<const unsigned char>::iterator& pattIt,
+                                    const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
+{
+  ioutils::loadROFrameDataITS3(mTimeFrame, trackROFspan, clusters, pattIt, mDict, mcLabels);
+}
+
+} // namespace o2::its3

--- a/Detectors/Upgrades/ITS3/workflow/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/workflow/CMakeLists.txt
@@ -19,7 +19,6 @@ o2_add_library(ITS3Workflow
                        src/ClustererSpec.cxx
                        src/ClusterWriterSpec.cxx
                        src/TrackerSpec.cxx
-                      #  src/CookedTrackerSpec.cxx
                        src/TrackWriterSpec.cxx
                        src/TrackReaderSpec.cxx
                        src/VertexReaderSpec.cxx
@@ -31,6 +30,7 @@ o2_add_library(ITS3Workflow
                                      O2::ITStracking
                                      O2::ITSMFTReconstruction
                                      O2::ITS3Reconstruction
+                                     O2::ITS3TrackingInterface
                                      O2::ITSWorkflow
                                      O2::GPUTracking
                                      O2::ITSBase)

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
@@ -15,23 +15,18 @@
 #define O2_ITS3_TRACKERDPL
 
 #include "DataFormatsParameters/GRPObject.h"
-#include "ITS3Reconstruction/TopologyDictionary.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+#include "DataFormatsCalibration/MeanVertexObject.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 
-#include "ITStracking/TimeFrame.h"
-#include "ITStracking/Tracker.h"
-#include "ITStracking/TrackerTraits.h"
-#include "ITStracking/Vertexer.h"
-#include "ITStracking/VertexerTraits.h"
+#include "ITS3Reconstruction/TrackingInterface.h"
 
-#include "GPUO2Interface.h"
-#include "GPUReconstruction.h"
-#include "GPUChainITS.h"
-#include "CommonUtils/StringUtils.h"
-#include "TStopwatch.h"
+#include "GPUDataTypes.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+
+#include "TStopwatch.h"
 
 namespace o2::its3
 {
@@ -39,33 +34,36 @@ namespace o2::its3
 class TrackerDPL : public framework::Task
 {
  public:
-  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, int trgType, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU);
+  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr,
+             bool isMC,
+             int trgType,
+             const its::TrackingMode& trMode = its::TrackingMode::Unset,
+             const bool overrBeamEst = false,
+             gpu::GPUDataTypes::DeviceType dType = gpu::GPUDataTypes::DeviceType::CPU);
+  ~TrackerDPL() override = default;
+  TrackerDPL(const TrackerDPL&) = delete;
+  TrackerDPL(TrackerDPL&&) = delete;
+  TrackerDPL& operator=(const TrackerDPL&) = delete;
+  TrackerDPL& operator=(TrackerDPL&&) = delete;
+
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
-  void setClusterDictionary(const o2::its3::TopologyDictionary* d) { mDict = d; }
+  void stop() final;
 
  private:
   void updateTimeDependentParams(framework::ProcessingContext& pc);
-
-  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest{};
-  bool mIsMC{false};
-  int mUseTriggers{0};
-  std::string mMode{"sync"};
-  std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain{};
-  bool mRunVertexer{true};
-  bool mCosmicsProcessing{false};
-  const o2::its3::TopologyDictionary* mDict{};
-  std::unique_ptr<o2::gpu::GPUChainITS> mChainITS{};
-  std::unique_ptr<its::Tracker> mTracker{};
-  std::unique_ptr<its::Vertexer> mVertexer{};
-  TStopwatch mTimer{};
+  std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
+  std::unique_ptr<o2::gpu::GPUChainITS> mChainITS = nullptr;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+  ITS3TrackingInterface mITS3TrackingInterface;
+  TStopwatch mTimer;
 };
 
 /// create a processor spec
 /// run ITS CA tracker
-framework::DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, int useTrig, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType);
+framework::DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, int useTrig, const std::string& trMode, const bool overrBeamEst = false, gpu::GPUDataTypes::DeviceType dType = gpu::GPUDataTypes::DeviceType::CPU);
 
 } // namespace o2::its3
 

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -46,346 +46,57 @@ namespace its3
 {
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
-TrackerDPL::TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, int trgType, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType) : mGGCCDBRequest(gr), mIsMC{isMC}, mUseTriggers{trgType}, mMode{trModeS}, mRecChain{o2::gpu::GPUReconstruction::CreateInstance(dType, true)}
+TrackerDPL::TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr,
+                       bool isMC,
+                       int trgType,
+                       const its::TrackingMode& trMode,
+                       const bool overrBeamEst,
+                       o2::gpu::GPUDataTypes::DeviceType dType) : mGGCCDBRequest(gr),
+                                                                  mRecChain{o2::gpu::GPUReconstruction::CreateInstance(dType, true)},
+                                                                  mITS3TrackingInterface{isMC, trgType, overrBeamEst}
 {
-  std::transform(mMode.begin(), mMode.end(), mMode.begin(), [](unsigned char c) { return std::tolower(c); });
+  mITS3TrackingInterface.setTrackingMode(trMode);
 }
 
-void TrackerDPL::init(InitContext& /*ic*/)
+void TrackerDPL::init(InitContext& ic)
 {
   mTimer.Stop();
   mTimer.Reset();
-
   o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
-
   mChainITS.reset(mRecChain->AddChain<o2::gpu::GPUChainITS>());
-  mVertexer = std::make_unique<Vertexer>(mChainITS->GetITSVertexerTraits());
-  mTracker = std::make_unique<Tracker>(mChainITS->GetITSTrackerTraits());
-  mRunVertexer = true;
-  mCosmicsProcessing = false;
-  std::vector<TrackingParameters> trackParams;
+  mITS3TrackingInterface.setTraitsFromProvider(mChainITS->GetITSVertexerTraits(),
+                                               mChainITS->GetITSTrackerTraits(),
+                                               mChainITS->GetITSTimeframe());
+  mITS3TrackingInterface.initialise();
+}
 
-  if (mMode == "async") {
-
-    trackParams.resize(3);
-    trackParams[1].TrackletMinPt = 0.2f;
-    trackParams[1].CellDeltaTanLambdaSigma *= 2.;
-    trackParams[2].TrackletMinPt = 0.1f;
-    trackParams[2].CellDeltaTanLambdaSigma *= 4.;
-    trackParams[2].MinTrackLength = 4;
-
-    LOG(info) << "Initializing tracker in async. phase reconstruction with " << trackParams.size() << " passes";
-
-  } else if (mMode == "async_misaligned") {
-
-    trackParams.resize(3);
-    trackParams[0].PhiBins = 32;
-    trackParams[0].ZBins = 64;
-    trackParams[0].CellDeltaTanLambdaSigma *= 3.;
-    trackParams[0].SystErrorZ2[0] = 1.e-4;
-    trackParams[0].SystErrorZ2[1] = 1.e-4;
-    trackParams[0].SystErrorZ2[2] = 1.e-4;
-    std::copy(trackParams[0].SystErrorZ2.begin(), trackParams[0].SystErrorZ2.end(), trackParams[0].SystErrorY2.begin());
-    trackParams[0].MaxChi2ClusterAttachment = 60.;
-    trackParams[0].MaxChi2NDF = 40.;
-    trackParams[1] = trackParams[0];
-    trackParams[2] = trackParams[0];
-    trackParams[1].MinTrackLength = 6;
-    trackParams[2].MinTrackLength = 4;
-    LOG(info) << "Initializing tracker in misaligned async. phase reconstruction with " << trackParams.size() << " passes";
-
-  } else if (mMode == "sync_misaligned") {
-
-    trackParams.resize(3);
-    trackParams[0].PhiBins = 32;
-    trackParams[0].ZBins = 64;
-    trackParams[0].CellDeltaTanLambdaSigma *= 3.;
-    trackParams[0].SystErrorZ2[0] = 1.e-4;
-    trackParams[0].SystErrorZ2[1] = 1.e-4;
-    trackParams[0].SystErrorZ2[2] = 1.e-4;
-    trackParams[0].SystErrorZ2[3] = 9.e-4;
-    trackParams[0].SystErrorZ2[4] = 9.e-4;
-    trackParams[0].SystErrorZ2[5] = 9.e-4;
-    trackParams[0].SystErrorZ2[6] = 9.e-4;
-    std::copy(trackParams[0].SystErrorZ2.begin(), trackParams[0].SystErrorZ2.end(), trackParams[0].SystErrorY2.begin());
-    trackParams[0].MaxChi2ClusterAttachment = 60.;
-    trackParams[0].MaxChi2NDF = 40.;
-    trackParams[1] = trackParams[0];
-    trackParams[2] = trackParams[0];
-    trackParams[1].MinTrackLength = 6;
-    trackParams[2].MinTrackLength = 4;
-    LOG(info) << "Initializing tracker in misaligned sync. phase reconstruction with " << trackParams.size() << " passes";
-
-  } else if (mMode == "sync") {
-    trackParams.resize(1);
-    LOG(info) << "Initializing tracker in sync. phase reconstruction with " << trackParams.size() << " passes";
-  } else if (mMode == "cosmics") {
-    mCosmicsProcessing = true;
-    mRunVertexer = false;
-    trackParams.resize(1);
-    trackParams[0].MinTrackLength = 4;
-    trackParams[0].CellDeltaTanLambdaSigma *= 10;
-    trackParams[0].PhiBins = 4;
-    trackParams[0].ZBins = 16;
-    trackParams[0].PVres = 1.e5f;
-    trackParams[0].MaxChi2ClusterAttachment = 60.;
-    trackParams[0].MaxChi2NDF = 40.;
-    trackParams[0].TrackletsPerClusterLimit = 100.;
-    trackParams[0].CellsPerClusterLimit = 100.;
-    LOG(info) << "Initializing tracker in reconstruction for cosmics with " << trackParams.size() << " passes";
-
-  } else {
-    throw std::runtime_error(fmt::format("Unsupported ITS tracking mode {:s} ", mMode));
-  }
-
-  for (auto& params : trackParams) {
-    params.CorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT;
-    for (int iLayer{0}; iLayer < params.NLayers - 4; ++iLayer) { // initialise ITS3 radii and lengths
-      params.LayerZ[iLayer] = constants::segment::lengthSensitive;
-      params.LayerRadii[iLayer] = constants::radii[iLayer];
-    }
-  }
-
-  mTracker->setParameters(trackParams);
+void TrackerDPL::stop()
+{
+  LOGF(info, "CPU Reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots", mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
 void TrackerDPL::run(ProcessingContext& pc)
 {
+  auto cput = mTimer.CpuTime();
+  auto realt = mTimer.RealTime();
   mTimer.Start(false);
-  updateTimeDependentParams(pc);
-  auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
-  gsl::span<const unsigned char> patterns = pc.inputs().get<gsl::span<unsigned char>>("patterns");
-  gsl::span<const o2::itsmft::PhysTrigger> physTriggers;
-  std::vector<o2::itsmft::PhysTrigger> fromTRD;
-  if (mUseTriggers == 2) { // use TRD triggers
-    o2::InteractionRecord ir{0, pc.services().get<o2::framework::TimingInfo>().firstTForbit};
-    auto trdTriggers = pc.inputs().get<gsl::span<o2::trd::TriggerRecord>>("phystrig");
-    for (const auto& trig : trdTriggers) {
-      if (trig.getBCData() >= ir && trig.getNumberOfTracklets()) {
-        ir = trig.getBCData();
-        fromTRD.emplace_back(o2::itsmft::PhysTrigger{ir, 0});
-      }
-    }
-    physTriggers = gsl::span<const o2::itsmft::PhysTrigger>(fromTRD.data(), fromTRD.size());
-  } else if (mUseTriggers == 1) { // use Phys triggers from ITS stream
-    physTriggers = pc.inputs().get<gsl::span<o2::itsmft::PhysTrigger>>("phystrig");
-  }
-
-  // code further down does assignment to the rofs and the altered object is used for output
-  // we therefore need a copy of the vector rather than an object created directly on the input data,
-  // the output vector however is created directly inside the message memory thus avoiding copy by
-  // snapshot
-  auto orig = o2::header::gDataOriginITS;
-  auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{orig, "ITSTrackROF", 0}, rofsinput.begin(), rofsinput.end());
-
-  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{orig, "IRFRAMES", 0});
-
-  const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
-  int nBCPerTF = alpParams.roFrameLengthInBC;
-
-  LOG(info) << "ITS3Tracker pulled " << compClusters.size() << " clusters, " << rofs.size() << " RO frames";
-
-  const dataformats::MCTruthContainer<MCCompLabel>* labels = nullptr;
-  gsl::span<itsmft::MC2ROFRecord const> mc2rofs;
-  if (mIsMC) {
-    labels = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("labels").release();
-    // get the array as read-only span, a snapshot is send forward
-    mc2rofs = pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("MC2ROframes");
-    LOG(info) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
-  }
-
-  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{orig, "TRACKCLSID", 0});
-  std::vector<o2::MCCompLabel> trackLabels;
-  std::vector<MCCompLabel> verticesLabels;
-  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{orig, "TRACKS", 0});
-  std::vector<o2::MCCompLabel> allTrackLabels;
-  std::vector<o2::MCCompLabel> allVerticesLabels;
-  std::vector<float> allVerticesPurities;
-
-  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{orig, "VERTICESROF", 0});
-  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{orig, "VERTICES", 0});
-
-  TimeFrame* timeFrame = mChainITS->GetITSTimeframe();
-  timeFrame->resizeVectors(7);
-  mTracker->adoptTimeFrame(*timeFrame);
-
-  mTracker->setBz(o2::base::Propagator::Instance()->getNominalBz());
-  mVertexer->adoptTimeFrame(*timeFrame);
-  auto pattIt = patterns.begin();
-
-  const gsl::span<itsmft::ROFRecord> rofspan(rofs);
-  ioutils::loadROFrameDataITS3(timeFrame, rofspan, compClusters, pattIt, mDict, labels);
-  std::vector<int> savedROF;
-  auto logger = [&](const std::string& s) { LOG(info) << s; };
-  auto errorLogger = [&](const std::string& s) { LOG(error) << s; };
-
-  // o2::its3::FastMultEst multEst;                        // mult estimator
-  std::vector<bool> processingMask(rofs.size(), true); // Override mult estimator
-  int cutVertexMult{0};
-  // int cutRandomMult = int(rofs.size()) - multEst.selectROFs(rofs, compClusters, physTriggers, processingMask);
-  timeFrame->setMultiplicityCutMask(processingMask);
-  float vertexerElapsedTime{0.f};
-  if (mRunVertexer) {
-    // Run seeding vertexer
-    vertexerElapsedTime = mVertexer->clustersToVertices(logger);
-  }
-  const auto& multEstConf = FastMultEstConfig::Instance(); // parameters for mult estimation and cuts
-  gsl::span<const std::pair<MCCompLabel, float>> vMCRecInfo;
-  for (size_t iRof{0}; iRof < rofspan.size(); ++iRof) {
-    std::vector<Vertex> vtxVecLoc;
-    auto& vtxROF = vertROFvec.emplace_back(rofspan[iRof]);
-    vtxROF.setFirstEntry(vertices.size());
-    if (mRunVertexer) {
-      auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
-      if (mIsMC) {
-        vMCRecInfo = timeFrame->getPrimaryVerticesMCRecInfo(iRof);
-      }
-      vtxROF.setNEntries(vtxSpan.size());
-      bool selROF = vtxSpan.size() == 0;
-      for (size_t iV{0}; iV < vtxSpan.size(); ++iV) {
-        auto& v = vtxSpan[iV];
-        if (multEstConf.isVtxMultCutRequested() && !multEstConf.isPassingVtxMultCut(v.getNContributors())) {
-          continue; // skip vertex of unwanted multiplicity
-        }
-        selROF = true;
-        vertices.push_back(v);
-        if (mIsMC) {
-          allVerticesLabels.push_back(vMCRecInfo[iV].first);
-          allVerticesPurities.push_back(vMCRecInfo[iV].second);
-        }
-      }
-      if (processingMask[iRof] && !selROF) { // passed selection in clusters and not in vertex multiplicity
-                                             //         LOG(debug) << fmt::format("ROF {} rejected by the vertex multiplicity selection [{},{}]",
-                                             //                                   iRof,
-                                             //                                   multEstConf.cutMultVtxLow,
-                                             //                                   multEstConf.cutMultVtxHigh);
-        processingMask[iRof] = selROF;
-        cutVertexMult++;
-      }
-    } else { // cosmics
-      vtxVecLoc.emplace_back(Vertex());
-      vtxVecLoc.back().setNContributors(1);
-      vtxROF.setNEntries(vtxVecLoc.size());
-      for (auto& v : vtxVecLoc) {
-        vertices.push_back(v);
-      }
-      timeFrame->addPrimaryVertices(vtxVecLoc, iRof, 0);
-    }
-  }
-  // LOG(info) << fmt::format(" - rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, rofspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);
-  LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} vertices found in {} ROFs", vertexerElapsedTime, timeFrame->getPrimaryVerticesNum(), rofspan.size());
-  LOG(info) << fmt::format(" - Beam position computed for the TF: {}, {}", timeFrame->getBeamX(), timeFrame->getBeamY());
-
-  if (mCosmicsProcessing && compClusters.size() > 1500 * rofspan.size()) {
-    LOG(error) << "Cosmics processing was requested with an average detector occupancy exceeding 1.e-7, skipping TF processing.";
-  } else {
-
-    timeFrame->setMultiplicityCutMask(processingMask);
-    // Run CA tracker
-    mTracker->clustersToTracks(logger, errorLogger);
-    if (timeFrame->hasBogusClusters() != 0) {
-      LOG(warning) << fmt::format(" - The processed timeframe had {} clusters with wild z coordinates, check the dictionaries", timeFrame->hasBogusClusters());
-    }
-
-    for (unsigned int iROF{0}; iROF < rofs.size(); ++iROF) {
-      auto& rof{rofs[iROF]};
-      auto& tracks = timeFrame->getTracks(iROF);
-      trackLabels = timeFrame->getTracksLabel(iROF);
-      auto number{tracks.size()};
-      auto first{allTracks.size()};
-      rof.setFirstEntry(first);
-      rof.setNEntries(number);
-      if (processingMask[iROF]) {
-        irFrames.emplace_back(rof.getBCData(), rof.getBCData() + nBCPerTF - 1).info = tracks.size();
-      }
-
-      std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
-      // Some conversions that needs to be moved in the tracker internals
-      for (unsigned int iTrk{0}; iTrk < tracks.size(); ++iTrk) {
-        auto& trc{tracks[iTrk]};
-        trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
-        int nclf = 0, ncl = (int)allClusIdx.size();
-        for (int ic = TrackITSExt::MaxClusters; (ic--) != 0;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
-          auto clid = trc.getClusterIndex(ic);
-          if (clid >= 0) {
-            trc.setClusterSize(ic, timeFrame->getClusterSize(clid));
-            allClusIdx.push_back(clid);
-            nclf++;
-          }
-        }
-        assert(ncl == nclf);
-        allTracks.emplace_back(trc);
-      }
-    }
-
-    LOGP(info, "ITS3Tracker pushed {} tracks and {} vertices", allTracks.size(), vertices.size());
-    if (mIsMC) {
-      LOGP(info, "ITS3Tracker pushed {} track labels", allTrackLabels.size());
-      LOGP(info, "ITS3Tracker pushed {} vertex labels", allVerticesLabels.size());
-
-      pc.outputs().snapshot(Output{orig, "TRACKSMCTR", 0}, allTrackLabels);
-      pc.outputs().snapshot(Output{orig, "VERTICESMCTR", 0}, allVerticesLabels);
-      pc.outputs().snapshot(Output{orig, "VERTICESMCPUR", 0}, allVerticesPurities);
-      pc.outputs().snapshot(Output{orig, "ITSTrackMC2ROF", 0}, mc2rofs);
-    }
-  }
+  mITS3TrackingInterface.updateTimeDependentParams(pc);
+  mITS3TrackingInterface.run(pc);
   mTimer.Stop();
+  LOGP(info, "CPU Reconstruction time for this TF {} s (cpu), {} s (wall)", mTimer.CpuTime() - cput, mTimer.RealTime() - realt);
 }
 
-///_______________________________________
-void TrackerDPL::updateTimeDependentParams(ProcessingContext& pc)
-{
-  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  static bool initOnceDone = false;
-  if (!initOnceDone) { // this params need to be queried only once
-    initOnceDone = true;
-    pc.inputs().get<o2::its3::TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
-    pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alppar");
-
-    // Check if lightweight geometry was requested, otherwise full geometry is loaded
-    if (pc.inputs().getPos("itsTGeo") >= 0) {
-      pc.inputs().get<o2::its::GeometryTGeo*>("itsTGeo");
-    }
-    o2::its::GeometryTGeo* geom = o2::its::GeometryTGeo::Instance();
-    geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot, o2::math_utils::TransformType::T2G));
-    mVertexer->getGlobalConfiguration();
-    mTracker->getGlobalConfiguration();
-  }
-}
-
-///_______________________________________
 void TrackerDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
-  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
-    return;
-  }
-  if (matcher == ConcreteDataMatcher("IT3", "CLUSDICT", 0)) {
-    LOG(info) << "cluster dictionary updated";
-    setClusterDictionary((o2::its3::TopologyDictionary*)obj);
-    return;
-  }
-  if (matcher == ConcreteDataMatcher("ITS", "GEOMTGEO", 0)) {
-    LOG(info) << "IT3 GeometryTGeo loaded from ccdb";
-    o2::its::GeometryTGeo::adopt((o2::its::GeometryTGeo*)obj);
-    return;
-  }
-  // Note: strictly speaking, for Configurable params we don't need finaliseCCDB check, the singletons are updated at the CCDB fetcher level
-  if (matcher == ConcreteDataMatcher("ITS", "ALPIDEPARAM", 0)) {
-    LOG(info) << "Alpide param updated";
-    const auto& par = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-    par.printKeyValues();
-    return;
-  }
+  mITS3TrackingInterface.finaliseCCDB(matcher, obj);
 }
 
 void TrackerDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(info, "ITS3 CA-Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots",
-       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+  LOGF(info, "ITS3 CA-Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots", mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType)
+DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, int trgType, const std::string& trModeS, const bool overrBeamEst, o2::gpu::GPUDataTypes::DeviceType dType)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
@@ -399,7 +110,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, co
   inputs.emplace_back("cldict", "IT3", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("IT3/Calib/ClusterDictionary"));
   inputs.emplace_back("alppar", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam"));
   auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                                                                        // orbitResetTime
-                                                              false,                                                                        // GRPECS
+                                                              true,                                                                         // GRPECS
                                                               false,                                                                        // GRPLHCIF
                                                               true,                                                                         // GRPMagField
                                                               true,                                                                         // askMatLUT
@@ -409,6 +120,9 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, co
 
   if (!useGeom) { // load light-weight geometry
     inputs.emplace_back("itsTGeo", "ITS", "GEOMTGEO", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/Geometry"));
+  }
+  if (overrBeamEst) {
+    inputs.emplace_back("meanvtx", "GLO", "MEANVERTEX", 0, Lifetime::Condition, ccdbParamSpec("GLO/Calib/MeanVertex", {}, 1));
   }
 
   std::vector<OutputSpec> outputs;
@@ -420,8 +134,8 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, co
   outputs.emplace_back("ITS", "IRFRAMES", 0, Lifetime::Timeframe);
 
   if (useMC) {
-    inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("itsmclabels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
+    inputs.emplace_back("ITSMC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "VERTICESMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "VERTICESMCPUR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
@@ -432,7 +146,10 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, const int trgType, co
     "its3-tracker",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TrackerDPL>(ggRequest, useMC, trgType, trModeS, dType)},
+    AlgorithmSpec{adaptFromTask<TrackerDPL>(ggRequest, useMC, trgType,
+                                            trModeS == "sync" ? o2::its::TrackingMode::Sync : trModeS == "async" ? o2::its::TrackingMode::Async
+                                                                                                                 : o2::its::TrackingMode::Cosmics,
+                                            overrBeamEst, dType)},
     Options{}};
 }
 


### PR DESCRIPTION
It runs and efficiency etc. also looks the same :)
vs pt
![image](https://github.com/user-attachments/assets/1a8de173-ad1b-4c8d-9ee9-55f4e556ab62)
vs eta
![image](https://github.com/user-attachments/assets/41545518-68b6-47ad-86d6-5cd124930a0e)
One problem right now is that for the simulation part under the run numbers for ITS3
pp collisions:
303901—303999 1547978230 1547991990
Pb-Pb collisions:
311901—311999 1551418230 1551431990
There is no GLO/Config/GRPECS object so the workflow will crash unless one creates the object themselves.