### PR TITLE
Optionally always parse trigger word, extra dump options

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -80,7 +80,8 @@ struct GBTLink {
   enum Verbosity : int8_t { Silent = -1,
                             VerboseErrors,
                             VerboseHeaders,
-                            VerboseData };
+                            VerboseData,
+                            VerboseRawDump };
 
   using RDH = o2::header::RDHAny;
   using RDHUtils = o2::raw::RDHUtils;
@@ -108,6 +109,7 @@ struct GBTLink {
 
   // transient data filled from current RDH
   int wordLength = o2::itsmft::GBTPaddedWordLength; // padded (16bytes) vs non-padded (10bytes) words
+  bool alwaysParseTrigger = false;
   bool expectPadding = true;
   bool rofJumpWasSeen = false; // this link had jump in ROF IR
   uint32_t lanesActive = 0;   // lanes declared by the payload header
@@ -141,6 +143,43 @@ struct GBTLink {
   void cacheData(const void* ptr, size_t sz)
   {
     rawData.add(reinterpret_cast<const PayLoadSG::DataType*>(ptr), sz);
+    if (verbosity >= VerboseRawDump) {
+
+      LOGP(info, "Caching new RDH block for {}", describe());
+      const auto* rdh = reinterpret_cast<const RDH*>(ptr);
+      if (!rdh) {
+        return;
+      }
+      RDHUtils::printRDH(rdh);
+      long szd = RDHUtils::getMemorySize(*rdh);
+      long offs = sizeof(RDH);
+      char* ptrR = ((char*)ptr) + sizeof(RDH);
+      while (offs + wordLength <= szd) {
+        const o2::itsmft::GBTWord* w = reinterpret_cast<const o2::itsmft::GBTWord*>(ptrR);
+        std::string com = fmt::format(" | FeeID:{:#06x} offs: {:6} ", feeID, offs);
+        if (w->isData()) {
+          com += "data word";
+        } else if (w->isDataHeader()) {
+          com += "data header";
+        } else if (w->isDataTrailer()) {
+          com += "data trailer";
+        } else if (w->isTriggerWord()) {
+          com += "trigger word";
+        } else if (w->isDiagnosticWord()) {
+          com += "diag word";
+        } else if (w->isCalibrationWord()) {
+          com += "calib word";
+          com += fmt::format(" #{}", ((const GBTCalibration*)w)->calibCounter);
+        } else if (w->isCableDiagnostic()) {
+          com += "cable diag word";
+        } else if (w->isStatus()) {
+          com += "status word";
+        }
+        w->printX(expectPadding, com);
+        offs += wordLength;
+        ptrR += wordLength;
+      }
+    }
   }
 
   bool needToPrintError(uint32_t count) { return verbosity == Silent ? false : (verbosity > VerboseErrors || count == 1); }
@@ -318,13 +357,13 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
         break;
       }
       if (gbtTrg) {
-        if (!gbtTrg->continuation) { // this is a continuation from the previous CRU page
-          statistics.nTriggers++;
-          lanesStop = 0;
-          lanesWithData = 0;
+        if (!gbtTrg->continuation || alwaysParseTrigger) { // this is a continuation from the previous CRU page
+          statistics.nTriggers += gbtTrg->continuation == 0;
           ir.bc = gbtTrg->bc;
           ir.orbit = gbtTrg->orbit;
           trigger = gbtTrg->triggerType;
+          lanesStop = 0;
+          lanesWithData = 0;
         }
         if (gbtTrg->noData) {
           if (verbosity >= VerboseHeaders) {
@@ -351,7 +390,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     expectPacketDone = true;
 
     while (!gbtD->isDataTrailer() && !(cruPageAlignmentPaddingSeen = isAlignmentPadding())) { // start reading real payload
-      if (verbosity >= VerboseData) {
+      if ((verbosity % VerboseData) == 0) {
         gbtD->printX(expectPadding);
       }
       GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsGBTDataID(gbtD));

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
@@ -165,7 +165,7 @@ struct GBTWord {
 
   uint8_t getHeader() const { return id; }
 
-  void printX(bool padded = true) const;
+  void printX(bool padded = true, std::string com = "") const;
   void printB(bool padded = true) const;
 
   ClassDefNV(GBTWord, 1);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -91,6 +91,9 @@ class RawPixelDecoder final : public PixelReader
   void setVerbosity(int v);
   int getVerbosity() const { return mVerbosity; }
 
+  void setAlwaysParseTrigger(bool v) { mAlwaysParseTrigger = v; }
+  bool getAlwaysParseTrigger() const { return mAlwaysParseTrigger; }
+
   void printReport(bool decstat = true, bool skipNoErr = true) const;
   void produceRawDataDumps(int dump, const o2::framework::TimingInfo& tinfo);
 
@@ -164,6 +167,7 @@ class RawPixelDecoder final : public PixelReader
   bool mROFRampUpStage = false;                                                       // are we still in the ROF ramp up stage?
   bool mSkipRampUpData = false;
   bool mVerifyDecoder = false;
+  bool mAlwaysParseTrigger = false;
   int mVerbosity = 0;
   int mNThreads = 1; // number of decoding threads
   // statistics

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTWord.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTWord.cxx
@@ -18,16 +18,16 @@
 
 using namespace o2::itsmft;
 
-void GBTWord::printX(bool padded) const
+void GBTWord::printX(bool padded, std::string com) const
 {
   /// print in right aligned hex format, optionally padding to 128 bits
   if (padded) {
-    LOGF(info, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
+    LOGF(info, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %s",
          data8[15], data8[14], data8[13], data8[12], data8[11], data8[10],
-         data8[9], data8[8], data8[7], data8[6], data8[5], data8[4], data8[3], data8[2], data8[1], data8[0]);
+         data8[9], data8[8], data8[7], data8[6], data8[5], data8[4], data8[3], data8[2], data8[1], data8[0], com.c_str());
   } else {
-    LOGF(info, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
-         data8[9], data8[8], data8[7], data8[6], data8[5], data8[4], data8[3], data8[2], data8[1], data8[0]);
+    LOGF(info, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %s",
+         data8[9], data8[8], data8[7], data8[6], data8[5], data8[4], data8[3], data8[2], data8[1], data8[0], com.c_str());
   }
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -270,6 +270,7 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
       lnk.wordLength = (lnk.expectPadding = (RDHUtils::getDataFormat(rdh) == 0)) ? o2::itsmft::GBTPaddedWordLength : o2::itsmft::GBTWordLength;
       getCreateRUDecode(mMAP.FEEId2RUSW(RDHUtils::getFEEID(rdh))); // make sure there is a RU for this link
       lnk.verbosity = GBTLink::Verbosity(mVerbosity);
+      lnk.alwaysParseTrigger = mAlwaysParseTrigger;
       if (mVerbosity >= GBTLink::Verbosity::VerboseHeaders) {
         LOG(info) << mSelfName << " registered new link " << lnk.describe() << " RUSW=" << int(mMAP.FEEId2RUSW(lnk.feeID));
       }

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -95,6 +95,7 @@ void STFDecoder<Mapping>::init(InitContext& ic)
     if (mDumpOnError != int(GBTLink::RawDataDumps::DUMP_NONE) && (!dumpDir.empty() && !o2::utils::Str::pathIsDirectory(dumpDir))) {
       throw std::runtime_error(fmt::format("directory {} for raw data dumps does not exist", dumpDir));
     }
+    mDecoder->setAlwaysParseTrigger(ic.options().get<bool>("always-parse-trigger"));
     mDecoder->setAllowEmptyROFs(ic.options().get<bool>("allow-empty-rofs"));
     mDecoder->setRawDumpDirectory(dumpDir);
     mDecoder->setFillCalibData(mDoCalibData);
@@ -414,7 +415,8 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
     inp.origin == o2::header::gDataOriginITS ? AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingITS>>(inp, ggRequest)} : AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingMFT>>(inp, ggRequest)},
     Options{
       {"nthreads", VariantType::Int, 1, {"Number of decoding/clustering threads"}},
-      {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data) of 1st lane"}},
+      {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data, 3: raw data dump) of 1st lane"}},
+      {"always-parse-trigger", VariantType::Bool, false, {"parse trigger word even if flags continuation of old trigger"}},
       {"raw-data-dumps", VariantType::Int, int(GBTLink::RawDataDumps::DUMP_NONE), {"Raw data dumps on error (0: none, 1: HBF for link, 2: whole TF for all links"}},
       {"raw-data-dumps-directory", VariantType::String, "", {"Destination directory for the raw data dumps"}},
       {"unmute-extra-lanes", VariantType::Bool, false, {"allow extra lanes to be as verbose as 1st one"}},


### PR DESCRIPTION
With --always-parse-trigger decoder will always parse the GBT trigger word, even if the 1st trigger of the TF has a continuation flag set (this is a corruption in the real data but can be benign in the threshold calibration data.

Extra verbosity option (3) is added to dump annotated cached raw data for every link before actual decoding starts.