### PR TITLE
MC: Fix alignment of entries in MCTruthContainer, Header size must be a multiple of the alignment - DO NOT MERGE, STILL BROKEN

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
@@ -24,8 +24,9 @@ namespace emcal
 /// \class MCLabel
 /// \brief Monte-Carlo label for EMCAL clusters / digits
 /// \ingroup EMCALDataFormat
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   Double_t mAmplitudeFraction;
 

--- a/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/MCLabel.h
+++ b/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/MCLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 namespace fdd
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   Int_t mDetID = -1;
 

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/MCLabel.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/MCLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 namespace ft0
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   Int_t mDetID = -1;
 

--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/MCLabel.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/MCLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 namespace fv0
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   Int_t mChannel = -1;
 

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/MCLabel.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/MCLabel.h
@@ -23,8 +23,9 @@ namespace o2
 {
 namespace mid
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   uint32_t mStripsInfo = 0; /// Strip information
 

--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/MCLabel.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/MCLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 namespace phos
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   float mEdep = 0; // deposited energy
 

--- a/DataFormats/Detectors/ZDC/include/DataFormatsZDC/MCLabel.h
+++ b/DataFormats/Detectors/ZDC/include/DataFormatsZDC/MCLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 namespace zdc
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   Int_t mChannel = -1;
 

--- a/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
@@ -110,7 +110,7 @@ class ConstMCTruthContainer : public std::vector<char>
 } // namespace o2
 
 // This is done so that DPL treats this container as a vector.
-// In particular in enables
+// In particular it enables
 // a) --> snapshot without ROOT dictionary (as a flat buffer)
 // b) --> requesting the resource in shared mem using make<T>
 #ifndef GPUCA_STANDALONE

--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 // Composed Label to encode MC track id, event it comes from and the source (file)
 
-class MCCompLabel
+class __attribute__((packed)) MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   static constexpr uint64_t ul0x1 = 0x1;
   static constexpr uint64_t NotSet = 0xffffffffffffffff;

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -133,6 +133,9 @@ class MCTruthContainer
     uint32_t nofHeaderElements;
     uint32_t nofTruthElements;
   };
+#ifndef __CLING__
+  static_assert(alignof(FlatHeader) <= sizeof(uint32_t), "Invalid alignment");
+#endif
 
   // access
   MCTruthHeaderElement const& getMCTruthHeader(uint32_t dataindex) const { return mHeaderArray[dataindex]; }

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -25,6 +25,7 @@
 #include <cstring> // memmove, memcpy
 #include <memory>
 #include <vector>
+#include <algorithm>
 
 // type traits are needed for the compile time consistency check
 // maybe to be moved out of Framework first
@@ -124,7 +125,7 @@ class MCTruthContainer
   MCTruthContainer& operator=(MCTruthContainer&& other) = default;
 
   using self_type = MCTruthContainer<TruthElement>;
-  struct FlatHeader {
+  struct alignas(std::max(alignof(TruthElement), sizeof(uint32_t))) FlatHeader {
     uint8_t version = 1;
     uint8_t sizeofHeaderElement = sizeof(MCTruthHeaderElement);
     uint8_t sizeofTruthElement = sizeof(TruthElement);

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -45,7 +45,6 @@
 #pragma link C++ class o2::BasicXYZQHit < float, float, int> + ;
 #pragma link C++ class o2::BasicXYZQHit < double, double, int> + ;
 #pragma link C++ struct o2::dataformats::MCTruthHeaderElement + ;
-#pragma link C++ class o2::dataformats::MCTruthContainer < long> + ;
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::MCCompLabel> - ;
 #pragma link C++ class o2::dataformats::ConstMCTruthContainer < o2::MCCompLabel> - ;
 #pragma link C++ class std::vector < o2::dataformats::MCTruthContainer < o2::MCCompLabel>> + ;

--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -26,7 +26,7 @@ namespace o2
 {
 BOOST_AUTO_TEST_CASE(MCTruth)
 {
-  using TruthElement = long;
+  using TruthElement = int;
   dataformats::MCTruthContainer<TruthElement> container;
   container.addElement(0, TruthElement(1));
   container.addElement(0, TruthElement(2));
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(MCTruth)
 
 BOOST_AUTO_TEST_CASE(MCTruth_RandomAccess)
 {
-  using TruthElement = long;
+  using TruthElement = int;
   dataformats::MCTruthContainer<TruthElement> container;
   container.addElementRandomAccess(0, TruthElement(1));
   container.addElementRandomAccess(0, TruthElement(2));
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(MCTruth_RandomAccess)
 
 BOOST_AUTO_TEST_CASE(MCTruthContainer_flatten)
 {
-  using TruthElement = long;
+  using TruthElement = int;
   using TruthContainer = dataformats::MCTruthContainer<TruthElement>;
   TruthContainer container;
   container.addElement(0, TruthElement(1));
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(MCTruthContainer_flatten)
 
 BOOST_AUTO_TEST_CASE(LabelContainer_noncont)
 {
-  using TruthElement = long;
+  using TruthElement = int;
   // creates a container where labels might not be contiguous
   dataformats::LabelContainer<TruthElement, false> container;
   container.addLabel(0, TruthElement(1));
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(LabelContainer_noncont)
 
 BOOST_AUTO_TEST_CASE(MCTruthContainer_move)
 {
-  using TruthElement = long;
+  using TruthElement = int;
   using Container = dataformats::MCTruthContainer<TruthElement>;
   Container container;
   container.addElement(0, TruthElement(1));

--- a/Detectors/TOF/simulation/include/TOFSimulation/MCLabel.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/MCLabel.h
@@ -20,8 +20,9 @@ namespace o2
 {
 namespace tof
 {
-class MCLabel : public o2::MCCompLabel
+class __attribute__((packed)) MCLabel : public o2::MCCompLabel
 {
+  // We use __attribute__((packed)), since we have unaligned stored data of MCCompLabel
  private:
   Int_t mTDC = -1;
 


### PR DESCRIPTION
This fixes a bug in the alignment of our MC Labels, I think...
The header is 12 bytes, the elements are 8 bytes. This makes the elements aligned to 4 bytes since we place them manually, if I understand correctly.
This can crash during the access if the compiler uses an aligned 8 byte load, which he is allowed to do.
Problem with this fix is that I believe it makes all written ConstMCTruthContainers unreadable....

To be discussed.

@sawenzel  @ktf @shahor02 @pzhristov 