### PR TITLE
CcdbDownloader: Improving error handling

### DIFF
--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -485,7 +485,7 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
   bool contentRetrieved = false;
 
   if (curlCode != 0) {
-    LOG(error) << "CCDBDownloader: " << curl_easy_strerror(curlCode) << "\n";
+    LOG(error) << "CCDBDownloader CURL transfer error - " << curl_easy_strerror(curlCode) << "\n";
   }
 
   switch (performData->type) {
@@ -520,15 +520,14 @@ void CCDBDownloader::transferFinished(CURL* easy_handle, CURLcode curlCode)
         } else if (300 <= httpCode && httpCode < 400 && performData->locInd < locations.size()) {
           followRedirect(performData, easy_handle, locations, rescheduled, contentRetrieved);
         } else if (200 <= httpCode && httpCode < 300) {
-          contentRetrieved = true; // Can be overruled by following timeout check
+          contentRetrieved = true; // Can be overruled by following error check
         }
       } else {
         LOG(error) << loggingMessage;
       }
 
-      // Check for timeout
-      if (curlCode == CURLE_OPERATION_TIMEDOUT) {
-        LOG(error) << "Connection timed out.\n";
+      // Check for errors
+      if (curlCode != 0) {
         contentRetrieved = false;
       }
 


### PR DESCRIPTION
Signaling `content not retrieved` on any error detected in `transferFinished`.

Message about timeout (and other errors) will still be provided via:
`LOG(error) << "CCDBDownloader CURL transfer error - " << curl_easy_strerror(curlCode) << "\n";`