### PR TITLE
Workaround ROOT serialization bug affecting CalDet<PadFlags>

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Defs.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Defs.h
@@ -97,7 +97,7 @@ enum class StatisticsType {
   MeanStdDev   ///< Use mean and standard deviation
 };
 
-enum class PadFlags : unsigned short {
+enum class PadFlags : unsigned int {
   flagGoodPad = 1 << 0,      ///< flag for a good pad binary 0001
   flagDeadPad = 1 << 1,      ///< flag for a dead pad binary 0010
   flagUnknownPad = 1 << 2,   ///< flag for unknown status binary 0100

--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -169,6 +169,7 @@ class CalArray
 
   /// initialize the data array depending on what is set as PadSubset
   void initData();
+  ClassDefNV(CalArray, 1)
 };
 
 #ifndef GPUCA_ALIGPUCODE

--- a/Detectors/TPC/base/src/TPCBaseLinkDef.h
+++ b/Detectors/TPC/base/src/TPCBaseLinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ class o2::tpc::CalArray < unsigned> + ;
 #pragma link C++ class o2::tpc::CalArray < short> + ;
 #pragma link C++ class o2::tpc::CalArray < bool> + ;
+#pragma link C++ class o2::tpc::CalArray < o2::tpc::PadFlags> + ;
 #pragma link C++ class o2::tpc::CalDet < float> + ;
 #pragma link C++ class o2::tpc::CalDet < double> + ;
 #pragma link C++ class o2::tpc::CalDet < int> + ;
@@ -60,6 +61,8 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::ParameterGas> + ;
 #pragma link C++ enum o2::tpc::AmplificationMode;
 #pragma link C++ enum o2::tpc::DigitzationMode;
+#pragma link C++ enum o2::tpc::PadFlags;
+#pragma link C++ enum o2::tpc::PadSubset;
 #pragma link C++ struct o2::tpc::ParameterGEM;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::ParameterGEM> + ;
 #pragma link C++ class o2::tpc::IonTailSettings + ;

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCCCDBHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCCCDBHelper.h
@@ -32,7 +32,7 @@ struct IDCOne;
 struct FourierCoeff;
 template <typename DataT>
 struct IDCDelta;
-enum class PadFlags : unsigned short;
+enum class PadFlags : unsigned int;
 
 template <class T>
 class CalDet;

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 
-enum class PadFlags : unsigned short;
+enum class PadFlags : unsigned int;
 
 template <class T>
 class CalDet;


### PR DESCRIPTION
ROOT has an issue when serializing std::vector<T> where T is a scoped enum backed by something which has size different from int one.

This is true for any architecture, it just happens to be more lethal on ARM. For more details https://github.com/root-project/root/issues/16312.

Add explicitly types to the linkdef while at it.