### PR TITLE
Fix verbosity parsing in ITS decoder

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -266,6 +266,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
   currRawPiece = rawData.currentPiece();
   uint8_t errRes = uint8_t(GBTLink::NoError);
   bool expectPacketDone = false;
+  bool verboseRawData = verbosity > 0 && ((verbosity % VerboseData) == 0);
   ir.clear();
   while (currRawPiece) { // we may loop over multiple CRU page
     if (dataOffset >= currRawPiece->size) {
@@ -390,7 +391,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     expectPacketDone = true;
 
     while (!gbtD->isDataTrailer() && !(cruPageAlignmentPaddingSeen = isAlignmentPadding())) { // start reading real payload
-      if ((verbosity % VerboseData) == 0) {
+      if (verboseRawData) {
         gbtD->printX(expectPadding);
       }
       GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsGBTDataID(gbtD));


### PR DESCRIPTION
`o2-itsmft-stf-decoder-workflow ... --decoder-verbosity N` 
with `N>0` and `N%2==0` will trigger logging of every raw data word being decoded, with `N>2` the dumping of annotated raw data before decoding starts is activated. The difference is that during decoding some raw data might be suppressed in case of detected errors while the dump with `N>2` is done on the immediate input. To have both use e.g. `N=4`.