### PR TITLE
ITS - DeadMapBuilder, adding protection for end of stream

### DIFF
--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -102,6 +102,7 @@ class ITSMFTDeadMapBuilder : public Task
 
   std::vector<uint16_t> mDeadMapTF{};
 
+  int mRunNumber = -1;
   unsigned long mFirstOrbitTF = 0x0;
   unsigned long mFirstOrbitRun = 0x0;
 

--- a/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DeadMapBuilderSpec.cxx
@@ -90,7 +90,7 @@ void ITSMFTDeadMapBuilder::init(InitContext& ic)
 }
 
 ///////////////////////////////////////////////////////////////////
-// TODO: can ChipMappingITS help here?
+// TODO:  can ChipMappingITS help here?
 std::vector<uint16_t> ITSMFTDeadMapBuilder::getChipIDsOnSameCable(uint16_t chip)
 {
   if (mRunMFT || chip < N_CHIPS_ITSIB) {


### PR DESCRIPTION
With this PR:

- Protection against processing dummy orbit at the EoS
- Ensure run number is in metadata
- Possible fix for the stop() not being called (happening rarely but preventing to have the object in ccdb)

cc @iravasen @mcoquet642 