### PR TITLE
Remove unused mLabels containers

### DIFF
--- a/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
@@ -72,7 +72,6 @@ class MCTruthSourceTask : public o2::framework::Task
   bool mFinished = false;
   int mSize = 0;
   bool mNew = false;
-  o2::dataformats::MCTruthContainer<long> mLabels; // labels which get filled
 };
 
 o2::framework::DataProcessorSpec getMCTruthSourceSpec(bool newmctruth)

--- a/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
@@ -97,7 +97,6 @@ class MCTruthWriterTask : public o2::framework::Task
   bool mNew = false;
   bool mIO = false;
   int mID = 0;
-  o2::dataformats::MCTruthContainer<long> mLabels; // labels which get filled
 };
 
 o2::framework::DataProcessorSpec getMCTruthWriterSpec(int id, bool doio, bool newmctruth)


### PR DESCRIPTION
Saw by chance that these members are never used, so we can remove them