### PR TITLE
GPU: WORKAROUND for CUDA bug exposing device code via host symbols

### DIFF
--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -956,8 +956,10 @@ GPUd() typename TrackParametrization<value_T>::value_t TrackParametrization<valu
 
 namespace o2::track
 {
+#if !defined(GPUCA_GPUCODE) || defined(GPUCA_GPUCODE_DEVICE) // FIXME: DR: WORKAROUND to avoid CUDA bug creating host symbols for device code.
 template class TrackParametrization<float>;
-#ifndef GPUCA_GPUCODE_DEVICE
+#endif
+#ifndef GPUCA_GPUCODE
 template class TrackParametrization<double>;
 #endif
 } // namespace o2::track

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -1245,8 +1245,10 @@ GPUd() void TrackParametrizationWithError<value_T>::printHexadecimal()
 
 namespace o2::track
 {
+#if !defined(GPUCA_GPUCODE) || defined(GPUCA_GPUCODE_DEVICE) // FIXME: DR: WORKAROUND to avoid CUDA bug creating host symbols for device code.
 template class TrackParametrizationWithError<float>;
-#ifndef GPUCA_GPUCODE_DEVICE
+#endif
+#ifndef GPUCA_GPUCODE
 template class TrackParametrizationWithError<double>;
 #endif
 } // namespace o2::track

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -786,8 +786,10 @@ GPUd() void PropagatorImpl<value_T>::getFieldXYZ(const math_utils::Point3D<doubl
 
 namespace o2::base
 {
+#if !defined(GPUCA_GPUCODE) || defined(GPUCA_GPUCODE_DEVICE) // FIXME: DR: WORKAROUND to avoid CUDA bug creating host symbols for device code.
 template class PropagatorImpl<float>;
-#ifndef GPUCA_GPUCODE_DEVICE
+#endif
+#ifndef GPUCA_GPUCODE
 template class PropagatorImpl<double>;
 #endif
 #ifndef __HIPCC__ // TODO: Fixme: must prevent HIP from compiling this, should file bug report


### PR DESCRIPTION
Workaround for the CUDA bug reported here: https://forums.developer.nvidia.com/t/nvcc-creates-host-symbols-for-device-functions-after-explicit-class-template-instantiation/305817

Apparently this has affected us since a while, but was never spotted since the bogus symbols were never linked as the CU libraries were linked first. But it failed in @mconcas DCAFitter tests.

This workaround is also not complete, since we have more cases of such bogus symbols, also for non template code. Will need to find a reproducer and also report to NVIDIA.

Meanwhile this stops @mconcas reproducer from crashing and should unblock him