### PR TITLE
Possibility to limit raw data dumps from ITS/MFT decoder

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -95,7 +95,7 @@ class RawPixelDecoder final : public PixelReader
   bool getAlwaysParseTrigger() const { return mAlwaysParseTrigger; }
 
   void printReport(bool decstat = true, bool skipNoErr = true) const;
-  void produceRawDataDumps(int dump, const o2::framework::TimingInfo& tinfo);
+  size_t produceRawDataDumps(int dump, const o2::framework::TimingInfo& tinfo);
 
   void clearStat(bool resetRaw = false);
 

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -515,8 +515,9 @@ void RawPixelDecoder<Mapping>::clearStat(bool resetRaw)
 
 ///______________________________________________________________________
 template <class Mapping>
-void RawPixelDecoder<Mapping>::produceRawDataDumps(int dump, const o2::framework::TimingInfo& tinfo)
+size_t RawPixelDecoder<Mapping>::produceRawDataDumps(int dump, const o2::framework::TimingInfo& tinfo)
 {
+  size_t outSize = 0;
   bool dumpFullTF = false;
   for (auto& ru : mRUDecodeVec) {
     if (ru.linkHBFToDump.size()) {
@@ -550,6 +551,7 @@ void RawPixelDecoder<Mapping>::produceRawDataDumps(int dump, const o2::framework
               break;
             }
             ostrm.write(reinterpret_cast<const char*>(piece->data), piece->size);
+            outSize += piece->size;
             entry++;
           }
           LOG(info) << "produced " << std::filesystem::current_path().c_str() << '/' << fnm;
@@ -569,11 +571,13 @@ void RawPixelDecoder<Mapping>::produceRawDataDumps(int dump, const o2::framework
       for (size_t i = 0; i < lnk.rawData.getNPieces(); i++) {
         const auto* piece = lnk.rawData.getPiece(i);
         ostrm.write(reinterpret_cast<const char*>(piece->data), piece->size);
+        outSize += piece->size;
       }
     }
     LOG(info) << "produced " << std::filesystem::current_path().c_str() << '/' << fnm;
     break;
   }
+  return outSize;
 }
 
 ///______________________________________________________________________

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -81,6 +81,7 @@ class STFDecoder : public Task
   bool mApplyNoiseMap = true;
   bool mUseClusterDictionary = true;
   bool mVerifyDecoder = false;
+  bool mDumpFrom1stPipeline = false;
   int mDumpOnError = 0;
   int mNThreads = 1;
   int mVerbosity = 0;
@@ -91,6 +92,8 @@ class STFDecoder : public Task
   size_t mEstNClusPatt = 0;
   size_t mEstNCalib = 0;
   size_t mEstNROF = 0;
+  size_t mMaxRawDumpsSize = 0;
+  size_t mRawDumpedSize = 0;
   std::string mInputSpec;
   std::string mSelfName;
   std::unique_ptr<RawPixelDecoder<Mapping>> mDecoder;


### PR DESCRIPTION
1) If argument of --raw-data-dumps is negative, the dumps will be allowed only from 1st decoded pipeline
   (as before, 1 corresponds to dumping only the links with detected errors, 2 - to whole TF).
2) New option --stop-raw-data-dumps-after-size <size_in_MB> sets max allowed total size in MB for
   dumps (of given pipeline), dumping will be disabled once this size is exceeded.