### PR TITLE
Get column value by column label in Framework Core ASoA

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2172,6 +2172,47 @@ std::tuple<typename Cs::type...> getRowData(T rowIterator, uint64_t globalIndex 
 {
   return std::make_tuple(getSingleRowData<T, Cs>(rowIterator, globalIndex)...);
 }
+
+template <typename R, typename T, typename... Cs>
+std::optional<R> getColumnValueByLabel(o2::framework::pack<Cs...>, const T& rowIterator, const std::string& columnLabel)
+{
+  std::optional<R> value = std::nullopt;
+
+  ([&]() {
+    if (value) {
+      return;
+    }
+
+    if constexpr (std::is_arithmetic_v<typename Cs::type> && std::is_convertible_v<typename Cs::type, R>) {
+      if constexpr (o2::soa::is_dynamic_v<Cs>) {
+        // check if bindings have the same size as lambda parameters (getter do not have additional parameters)
+        if constexpr (o2::framework::pack_size(typename Cs::bindings_t{}) == o2::framework::pack_size(typename Cs::callable_t::args{})) {
+          std::string label = Cs::columnLabel();
+
+          // dynamic columns do not have "f" prefix in columnLabel() return string
+          if (std::strcmp(&columnLabel[1], label.data()) == 0 || columnLabel == label) {
+            value = static_cast<R>(static_cast<Cs>(rowIterator).get());
+          }
+
+        }
+      } else if constexpr (o2::soa::is_persistent_v<Cs> && !o2::soa::is_index_column_v<Cs>) {
+        if (columnLabel == Cs::columnLabel()) {
+          value = static_cast<R>(static_cast<Cs>(rowIterator).get());
+        }
+
+      }
+    }
+  }(),
+   ...);
+
+  return value;
+}
+
+template <typename R, typename T>
+std::optional<R> getColumnValueByLabel(const T& rowIterator, const std::string& columnLabel)
+{
+  return getColumnValueByLabel<R>(typename T::parent_t::table_t::columns{}, rowIterator, columnLabel);
+}
 } // namespace row_helpers
 } // namespace o2::soa
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2187,7 +2187,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, 
 {
   using Col = Column;
 
-  if(found) {
+  if (found) {
     return nullptr;
   }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2173,36 +2173,34 @@ std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, 
   return std::make_tuple(getSingleRowData<T, Cs>(table, rowIterator, ci, ai, globalIndex)...);
 }
 
-template <typename R, typename T, typename Column>
+template <typename R, typename T, typename C>
 R getColumnValue(const T& rowIterator)
 {
-  return static_cast<R>(static_cast<Column>(rowIterator).get());
+  return static_cast<R>(static_cast<C>(rowIterator).get());
 }
 
 template <typename R, typename T>
 using ColumnGetterFunction = R (*)(const T&);
 
-template <typename R, typename T, typename Column>
+template <typename R, typename T, typename C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
 {
-  using Col = Column;
-
   if (found) {
     return nullptr;
   }
 
-  if constexpr (std::is_arithmetic_v<typename Col::type> && std::is_convertible_v<typename Col::type, R>) {
-    if constexpr (o2::soa::is_dynamic_v<Col>) {
-      if constexpr (o2::framework::pack_size(typename Col::bindings_t{}) == o2::framework::pack_size(typename Col::callable_t::args{})) {
-        if (columnLabel == std::string_view(&Col::columnLabel()[1]) || columnLabel == std::string_view(Col::columnLabel())) {
+  if constexpr (std::is_arithmetic_v<typename C::type> && std::is_convertible_v<typename C::type, R>) {
+    if constexpr (o2::soa::is_dynamic_v<C>) {
+      if constexpr (o2::framework::pack_size(typename C::bindings_t{}) == o2::framework::pack_size(typename C::callable_t::args{})) {
+        if (std::string_view(&columnLabel[1]) == std::string_view(C::columnLabel()) || columnLabel == std::string_view(C::columnLabel())) {
           found = true;
-          return &getColumnValue<R, T, Col>;
+          return &getColumnValue<R, T, C>;
         }
       }
-    } else if constexpr (o2::soa::is_persistent_v<Col> && !o2::soa::is_index_column_v<Col>) {
-      if (columnLabel == std::string_view(Col::columnLabel())) {
+    } else if constexpr (o2::soa::is_persistent_v<C> && !o2::soa::is_index_column_v<C>) {
+      if (columnLabel == std::string_view(C::columnLabel())) {
         found = true;
-        return &getColumnValue<R, T, Col>;
+        return &getColumnValue<R, T, C>;
       }
     }
   }
@@ -2211,7 +2209,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, 
 }
 
 template <typename R, typename T, typename... Cs>
-ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const T& rowIterator, const std::string_view& columnLabel)
+ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const std::string_view& columnLabel)
 {
   std::string_view labelView(columnLabel);
   bool found = false;
@@ -2227,9 +2225,9 @@ ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, co
 }
 
 template <typename R, typename T>
-ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const T& table, const std::string_view& columnLabel)
+ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& columnLabel)
 {
-  return getColumnGetterByLabel<R>(typename T::columns{}, table.begin(), columnLabel);
+  return getColumnGetterByLabel<R, typename T::iterator>(typename T::columns{}, columnLabel);
 }
 } // namespace row_helpers
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -30,10 +30,8 @@
 #include <array>
 #include <cassert>
 #include <fmt/format.h>
-#include <functional>
 #include <gsl/span>
 #include <limits>
-#include <stdexcept>
 
 namespace o2::framework
 {
@@ -1215,7 +1213,7 @@ struct TableIterator : IP, C... {
   {
     static_assert(std::same_as<decltype(&(static_cast<B*>(this)->mColumnIterator)), std::decay_t<decltype(B::mColumnIterator)>*>, "foo");
     return &(static_cast<B*>(this)->mColumnIterator);
-    // return static_cast<std::decay_t<decltype(B::mColumnIterator)>*>(nullptr);
+    //return static_cast<std::decay_t<decltype(B::mColumnIterator)>*>(nullptr);
   }
 
   template <typename B>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2200,25 +2200,19 @@ concept persistent_with_common_getter = is_persistent_v<T> && requires(T t) {
 template <typename R, typename T, persistent_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
-  const size_t n = columnLabel.size();
-
-  if (n == 0 || n != strlen(C::columnLabel())) {
-    return nullptr;
-  }
-
-  return (std::strcmp(columnLabel.data(), C::columnLabel())) ? nullptr : &getColumnValue<R, T, C>;
+  return std::strncmp(columnLabel.data(), C::columnLabel(), columnLabel.size()) ? nullptr : &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, dynamic_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
-  const size_t n = columnLabel.size();
+  // allows user to use consistent formatting (with prefix) of all column labels
+  // by default there isn't 'f' prefix for dynamic column labels, strncmp(x,y,0) is always 0
+  bool isPrefixMatch = columnLabel.size() > 1 && !std::strncmp(columnLabel.substr(1).data(), C::columnLabel(), columnLabel.size() - 1);
+  // check also exact match if user is aware of prefix missing
+  bool isExactMatch = !std::strncmp(columnLabel.data(), C::columnLabel(), columnLabel.size());
 
-  if (n == 0 || (n != strlen(C::columnLabel()) && n - 1 != strlen(C::columnLabel()))) {
-    return nullptr;
-  }
-
-  return ((std::strcmp(&columnLabel[1], C::columnLabel()) && std::strcmp(columnLabel.data(), C::columnLabel()))) ? nullptr : &getColumnValue<R, T, C>;
+  return (isPrefixMatch || isExactMatch) ? &getColumnValue<R, T, C> : nullptr;
 }
 
 template <typename R, typename T, typename... Cs>
@@ -2229,7 +2223,7 @@ ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, co
   (void)((func = createGetterPtr<R, T, Cs>(columnLabel), func) || ...);
 
   if (!func) {
-    throw framework::runtime_error("Getter for provided columnLabel not found!");
+    throw framework::runtime_error_f("Getter for \"%s\" not found", columnLabel);
   }
 
   return func;
@@ -2242,6 +2236,10 @@ template <typename R, typename T>
 ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& columnLabel)
 {
   using TypesWithCommonGetter = o2::framework::selected_pack_multicondition<with_common_getter_t, framework::pack<R>, typename T::columns>;
+
+  if (columnLabel.size() == 0) {
+    throw framework::runtime_error("columnLabel: must not be empty");
+  }
 
   return getColumnGetterByLabel<R, typename T::iterator>(TypesWithCommonGetter{}, columnLabel);
 }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <fmt/format.h>
 #include <concepts>
+#include <cstring>
 #include <gsl/span>
 #include <limits>
 
@@ -2200,35 +2201,38 @@ template <typename T, typename R>
 using with_common_getter_t = typename std::conditional<persistent_with_common_getter<T, R> || dynamic_with_common_getter<T, R>, std::true_type, std::false_type>::type;
 
 template <typename R, typename T, persistent_with_common_getter<R> C>
-ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
+ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
-  if (std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
-    found = true;
+  const size_t n = columnLabel.size();
+
+  if(n == 0 || n != strlen(C::columnLabel())) {
+    return nullptr;
   }
 
-  return &getColumnValue<R, T, C>;
+  return (std::strncmp(columnLabel.data(), C::columnLabel(), n)) ? nullptr : &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, dynamic_with_common_getter<R> C>
-ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
+ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
-  if (std::strcmp(&columnLabel[1], C::columnLabel()) == 0 || std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
-    found = true;
+  const size_t n = columnLabel.size();
+
+  if(n == 0 || n != strlen(C::columnLabel())) {
+    return nullptr;
   }
 
-  return &getColumnValue<R, T, C>;
+  return ((std::strncmp(&columnLabel[1], C::columnLabel(), n-1) && std::strncmp(columnLabel.data(), C::columnLabel(), n))) ? nullptr : &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, typename... Cs>
 ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const std::string_view& columnLabel)
 {
-  bool found = false;
   ColumnGetterFunction<R, T> func;
 
-  (void)((func = createGetterPtr<R, T, Cs>(columnLabel, found), found) || ...);
+  (void)((func = createGetterPtr<R, T, Cs>(columnLabel), func) || ...);
 
-  if (!found) {
-    throw std::runtime_error("Getter for provided columnLabel not found!");
+  if (!func) {
+    throw framework::runtime_error("Getter for provided columnLabel not found!");
   }
 
   return func;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -30,8 +30,10 @@
 #include <array>
 #include <cassert>
 #include <fmt/format.h>
+#include <functional>
 #include <gsl/span>
 #include <limits>
+#include <stdexcept>
 
 namespace o2::framework
 {
@@ -2208,6 +2210,67 @@ template <typename R, typename T>
 std::optional<R> getColumnValueByLabel(const T& rowIterator, const std::string& columnLabel)
 {
   return getColumnValueByLabel<R>(typename T::parent_t::table_t::columns{}, rowIterator, columnLabel);
+}
+
+template <typename R, typename T, typename Column>
+R getColumnValue(const T& rowIterator)
+{
+  // This directly calls the column's get() method
+  return static_cast<R>(static_cast<Column>(rowIterator).get());
+}
+
+template <typename R, typename T, typename Column>
+using GetFunctionPointer = R (*)(const T&);
+
+template <typename R, typename T, typename Column>
+GetFunctionPointer<R, T, Column> createGetterPtr(const std::string_view& columnLabel, bool& found)
+{
+  using Col = Column;
+
+  if (found) {
+    return nullptr;
+  }
+
+  if constexpr (std::is_arithmetic_v<typename Col::type> && std::is_convertible_v<typename Col::type, R>) {
+    if constexpr (o2::soa::is_dynamic_v<Col>) {
+      if constexpr (o2::framework::pack_size(typename Col::bindings_t{}) == o2::framework::pack_size(typename Col::callable_t::args{})) {
+        if (columnLabel == std::string_view(&Col::columnLabel()[1]) || columnLabel == std::string_view(Col::columnLabel())) {
+          found = true;
+          return &getColumnValue<R, T, Col>;
+        }
+      }
+    } else if constexpr (o2::soa::is_persistent_v<Col> && !o2::soa::is_index_column_v<Col>) {
+      if (columnLabel == std::string_view(Col::columnLabel())) {
+        found = true;
+        return &getColumnValue<R, T, Col>;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+template <typename R, typename T, typename... Cs>
+std::function<R(const T&)> getColumnGetterByLabel(o2::framework::pack<Cs...>, const T& rowIterator, const std::string_view& columnLabel)
+{
+  std::string_view labelView(columnLabel);
+  bool found = false;
+  std::function<R(const T&)> func = nullptr;
+
+  // Iterate through each column in the pack and create the getter function pointer if a match is found
+  (void)((func = createGetterForColumn<R, T, Cs>(labelView, found), found) || ...);
+
+  if (!found) {
+    throw std::runtime_error("Getter for provided columnLabel not found!");
+  }
+
+  return func;
+}
+
+template <typename R, typename T>
+std::function<R(const typename T::iterator&)> getColumnGetterByLabel(const T& table, const std::string_view& columnLabel)
+{
+  return getColumnGetterByLabel<R>(typename T::columns{}, table.begin(), columnLabel);
 }
 } // namespace row_helpers
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2155,7 +2155,7 @@ typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = s
   if (globalIndex != std::numeric_limits<uint64_t>::max() && globalIndex != *std::get<0>(rowIterator.getIndices())) {
     rowIterator.setCursor(globalIndex);
   }
-  return rowIterator.template getDynamicColumn<C>();
+  return static_cast<C>(rowIterator).get();
 }
 
 template <typename T, soa::is_index_column C>
@@ -2168,9 +2168,9 @@ typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = s
 }
 
 template <typename T, typename... Cs>
-std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, uint64_t ci = std::numeric_limits<uint64_t>::max(), uint64_t ai = std::numeric_limits<uint64_t>::max(), uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
+std::tuple<typename Cs::type...> getRowData(T rowIterator, uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
 {
-  return std::make_tuple(getSingleRowData<T, Cs>(table, rowIterator, ci, ai, globalIndex)...);
+  return std::make_tuple(getSingleRowData<T, Cs>(rowIterator, globalIndex)...);
 }
 } // namespace row_helpers
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2168,9 +2168,9 @@ typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = s
 }
 
 template <typename T, typename... Cs>
-std::tuple<typename Cs::type...> getRowData(T rowIterator, uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
+std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, uint64_t ci = std::numeric_limits<uint64_t>::max(), uint64_t ai = std::numeric_limits<uint64_t>::max(), uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
 {
-  return std::make_tuple(getSingleRowData<T, Cs>(rowIterator, globalIndex)...);
+  return std::make_tuple(getSingleRowData<T, Cs>(table, rowIterator, ci, ai, globalIndex)...);
 }
 
 template <typename R, typename T, typename Column>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2185,7 +2185,7 @@ template <typename R, typename T>
 using ColumnGetterFunction = R (*)(const T&);
 
 template <typename T, typename R>
-concept dynamic_with_common_getter = is_dynamic_v<T> &&
+concept dynamic_with_common_getter = is_dynamic_column<T> &&
                                      // lambda is callable without additional free args
                                      framework::pack_size(typename T::bindings_t{}) == framework::pack_size(typename T::callable_t::args{}) &&
                                      requires(T t) {
@@ -2242,7 +2242,7 @@ using with_common_getter_t = typename std::conditional<persistent_with_common_ge
 template <typename R, typename T>
 ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& targetColumnLabel)
 {
-  using TypesWithCommonGetter = o2::framework::selected_pack_multicondition<with_common_getter_t, framework::pack<R>, typename T::columns>;
+  using TypesWithCommonGetter = o2::framework::selected_pack_multicondition<with_common_getter_t, framework::pack<R>, typename T::columns_t>;
 
   if (targetColumnLabel.size() == 0) {
     throw framework::runtime_error("columnLabel: must not be empty");

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2208,11 +2208,16 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   // allows user to use consistent formatting (with prefix) of all column labels
   // by default there isn't 'f' prefix for dynamic column labels
-  bool isPrefixMatch = columnLabel.size() > 1 && columnLabel.substr(1) == C::columnLabel();
-  // check also exact match if user is aware of prefix missing
-  bool isExactMatch = columnLabel == C::columnLabel();
+  if(columnLabel.size() > 1 && columnLabel.substr(1) == C::columnLabel()) {
+    return &getColumnValue<R, T, C>;
+  }
 
-  return (isPrefixMatch || isExactMatch) ? &getColumnValue<R, T, C> : nullptr;
+  // check also exact match if user is aware of prefix missing
+  if(columnLabel == C::columnLabel()) {
+    return &getColumnValue<R, T, C>;
+  }
+
+  return nullptr;
 }
 
 template <typename R, typename T, typename... Cs>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -30,6 +30,7 @@
 #include <array>
 #include <cassert>
 #include <fmt/format.h>
+#include <concepts>
 #include <gsl/span>
 #include <limits>
 
@@ -2182,40 +2183,51 @@ R getColumnValue(const T& rowIterator)
 template <typename R, typename T>
 using ColumnGetterFunction = R (*)(const T&);
 
-template <typename R, typename T, typename C>
+template <typename T, typename R>
+concept dynamic_with_common_getter = is_dynamic_v<T> && 
+  // lambda is callable without additional free args
+  framework::pack_size(typename T::bindings_t{}) == framework::pack_size(typename T::callable_t::args{}) &&
+  requires (T t)
+{
+  { t.get() } -> std::convertible_to<R>;
+};
+
+template <typename T, typename R>
+concept persistent_with_common_getter = is_persistent_v<T> && requires (T t)
+{
+  { t.get() } -> std::convertible_to<R>;
+};
+
+template <typename T, typename R>
+using with_common_getter_t = typename std::conditional<persistent_with_common_getter<T, R> || dynamic_with_common_getter<T, R>, std::true_type, std::false_type>::type;
+
+template <typename R, typename T, persistent_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
 {
-  if (found) {
-    return nullptr;
-  }
-
-  if constexpr (std::is_arithmetic_v<typename C::type> && std::is_convertible_v<typename C::type, R>) {
-    if constexpr (o2::soa::is_dynamic_v<C>) {
-      if constexpr (o2::framework::pack_size(typename C::bindings_t{}) == o2::framework::pack_size(typename C::callable_t::args{})) {
-        if (std::string_view(&columnLabel[1]) == std::string_view(C::columnLabel()) || columnLabel == std::string_view(C::columnLabel())) {
-          found = true;
-          return &getColumnValue<R, T, C>;
-        }
-      }
-    } else if constexpr (o2::soa::is_persistent_v<C> && !o2::soa::is_index_column_v<C>) {
-      if (columnLabel == std::string_view(C::columnLabel())) {
-        found = true;
-        return &getColumnValue<R, T, C>;
-      }
+    if (std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
+      found = true;
     }
-  }
 
-  return nullptr;
+    return &getColumnValue<R, T, C>;
+}
+
+template <typename R, typename T, dynamic_with_common_getter<R> C>
+ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
+{
+    if (std::strcmp(&columnLabel[1], C::columnLabel()) == 0 || std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
+        found = true;
+    }
+
+    return &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, typename... Cs>
 ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const std::string_view& columnLabel)
 {
-  std::string_view labelView(columnLabel);
   bool found = false;
   ColumnGetterFunction<R, T> func;
 
-  (void)((func = createGetterPtr<R, T, Cs>(labelView, found), found) || ...);
+  (void)((func = createGetterPtr<R, T, Cs>(columnLabel, found), found) || ...);
 
   if (!found) {
     throw std::runtime_error("Getter for provided columnLabel not found!");
@@ -2227,7 +2239,9 @@ ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, co
 template <typename R, typename T>
 ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& columnLabel)
 {
-  return getColumnGetterByLabel<R, typename T::iterator>(typename T::columns{}, columnLabel);
+  using TypesWithCommonGetter = o2::framework::selected_pack_multicondition<with_common_getter_t, framework::pack<R>, typename T::columns>;
+
+  return getColumnGetterByLabel<R, typename T::iterator>(TypesWithCommonGetter{}, columnLabel);
 }
 } // namespace row_helpers
 } // namespace o2::soa
@@ -2990,6 +3004,7 @@ consteval auto getIndexTargets()
     }                                                                                                                      \
                                                                                                                            \
     using bindings_t = typename o2::framework::pack<Bindings...>;                                                          \
+    using bindings_types_t = typename o2::framework::pack<typename Bindings::type...>;                                              \
     std::tuple<o2::soa::ColumnIterator<typename Bindings::type> const*...> boundIterators;                                 \
   }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2197,9 +2197,6 @@ concept persistent_with_common_getter = is_persistent_v<T> && requires(T t) {
   { t.get() } -> std::convertible_to<R>;
 };
 
-template <typename T, typename R>
-using with_common_getter_t = typename std::conditional<persistent_with_common_getter<T, R> || dynamic_with_common_getter<T, R>, std::true_type, std::false_type>::type;
-
 template <typename R, typename T, persistent_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
@@ -2209,7 +2206,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
     return nullptr;
   }
 
-  return (std::strncmp(columnLabel.data(), C::columnLabel(), n)) ? nullptr : &getColumnValue<R, T, C>;
+  return (std::strcmp(columnLabel.data(), C::columnLabel())) ? nullptr : &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, dynamic_with_common_getter<R> C>
@@ -2221,7 +2218,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
     return nullptr;
   }
 
-  return ((std::strncmp(&columnLabel[1], C::columnLabel(), n - 1) && std::strncmp(columnLabel.data(), C::columnLabel(), n))) ? nullptr : &getColumnValue<R, T, C>;
+  return ((std::strcmp(&columnLabel[1], C::columnLabel()) && std::strcmp(columnLabel.data(), C::columnLabel()))) ? nullptr : &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, typename... Cs>
@@ -2237,6 +2234,9 @@ ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, co
 
   return func;
 }
+
+template <typename T, typename R>
+using with_common_getter_t = typename std::conditional<persistent_with_common_getter<T, R> || dynamic_with_common_getter<T, R>, std::true_type, std::false_type>::type;
 
 template <typename R, typename T>
 ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& columnLabel)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2214,7 +2214,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   const size_t n = columnLabel.size();
 
-  if (n == 0 || (n != strlen(C::columnLabel()) && n-1 != strlen(C::columnLabel()))) {
+  if (n == 0 || (n != strlen(C::columnLabel()) && n - 1 != strlen(C::columnLabel()))) {
     return nullptr;
   }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2198,22 +2198,24 @@ concept persistent_with_common_getter = is_persistent_v<T> && requires(T t) {
 };
 
 template <typename R, typename T, persistent_with_common_getter<R> C>
-ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
+ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& targetColumnLabel)
 {
-  return columnLabel == C::columnLabel() ? &getColumnValue<R, T, C> : nullptr;
+  return targetColumnLabel == C::columnLabel() ? &getColumnValue<R, T, C> : nullptr;
 }
 
 template <typename R, typename T, dynamic_with_common_getter<R> C>
-ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
+ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& targetColumnLabel)
 {
+  std::string_view columnLabel(C::columnLabel());
+
   // allows user to use consistent formatting (with prefix) of all column labels
   // by default there isn't 'f' prefix for dynamic column labels
-  if (columnLabel.size() > 1 && columnLabel.substr(1) == C::columnLabel()) {
+  if (targetColumnLabel.starts_with("f") && targetColumnLabel.substr(1) == columnLabel) {
     return &getColumnValue<R, T, C>;
   }
 
   // check also exact match if user is aware of prefix missing
-  if (columnLabel == C::columnLabel()) {
+  if (targetColumnLabel == columnLabel) {
     return &getColumnValue<R, T, C>;
   }
 
@@ -2221,14 +2223,14 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 }
 
 template <typename R, typename T, typename... Cs>
-ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const std::string_view& columnLabel)
+ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const std::string_view& targetColumnLabel)
 {
   ColumnGetterFunction<R, T> func;
 
-  (void)((func = createGetterPtr<R, T, Cs>(columnLabel), func) || ...);
+  (void)((func = createGetterPtr<R, T, Cs>(targetColumnLabel), func) || ...);
 
   if (!func) {
-    throw framework::runtime_error_f("Getter for \"%s\" not found", columnLabel);
+    throw framework::runtime_error_f("Getter for \"%s\" not found", targetColumnLabel);
   }
 
   return func;
@@ -2238,15 +2240,15 @@ template <typename T, typename R>
 using with_common_getter_t = typename std::conditional<persistent_with_common_getter<T, R> || dynamic_with_common_getter<T, R>, std::true_type, std::false_type>::type;
 
 template <typename R, typename T>
-ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& columnLabel)
+ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const std::string_view& targetColumnLabel)
 {
   using TypesWithCommonGetter = o2::framework::selected_pack_multicondition<with_common_getter_t, framework::pack<R>, typename T::columns>;
 
-  if (columnLabel.size() == 0) {
+  if (targetColumnLabel.size() == 0) {
     throw framework::runtime_error("columnLabel: must not be empty");
   }
 
-  return getColumnGetterByLabel<R, typename T::iterator>(TypesWithCommonGetter{}, columnLabel);
+  return getColumnGetterByLabel<R, typename T::iterator>(TypesWithCommonGetter{}, targetColumnLabel);
 }
 } // namespace row_helpers
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2184,17 +2184,15 @@ template <typename R, typename T>
 using ColumnGetterFunction = R (*)(const T&);
 
 template <typename T, typename R>
-concept dynamic_with_common_getter = is_dynamic_v<T> && 
-  // lambda is callable without additional free args
-  framework::pack_size(typename T::bindings_t{}) == framework::pack_size(typename T::callable_t::args{}) &&
-  requires (T t)
-{
-  { t.get() } -> std::convertible_to<R>;
-};
+concept dynamic_with_common_getter = is_dynamic_v<T> &&
+                                     // lambda is callable without additional free args
+                                     framework::pack_size(typename T::bindings_t{}) == framework::pack_size(typename T::callable_t::args{}) &&
+                                     requires(T t) {
+                                       { t.get() } -> std::convertible_to<R>;
+                                     };
 
 template <typename T, typename R>
-concept persistent_with_common_getter = is_persistent_v<T> && requires (T t)
-{
+concept persistent_with_common_getter = is_persistent_v<T> && requires(T t) {
   { t.get() } -> std::convertible_to<R>;
 };
 
@@ -2204,21 +2202,21 @@ using with_common_getter_t = typename std::conditional<persistent_with_common_ge
 template <typename R, typename T, persistent_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
 {
-    if (std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
-      found = true;
-    }
+  if (std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
+    found = true;
+  }
 
-    return &getColumnValue<R, T, C>;
+  return &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, dynamic_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
 {
-    if (std::strcmp(&columnLabel[1], C::columnLabel()) == 0 || std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
-        found = true;
-    }
+  if (std::strcmp(&columnLabel[1], C::columnLabel()) == 0 || std::strcmp(columnLabel.data(), C::columnLabel()) == 0) {
+    found = true;
+  }
 
-    return &getColumnValue<R, T, C>;
+  return &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, typename... Cs>
@@ -3004,7 +3002,7 @@ consteval auto getIndexTargets()
     }                                                                                                                      \
                                                                                                                            \
     using bindings_t = typename o2::framework::pack<Bindings...>;                                                          \
-    using bindings_types_t = typename o2::framework::pack<typename Bindings::type...>;                                              \
+    using bindings_types_t = typename o2::framework::pack<typename Bindings::type...>;                                     \
     std::tuple<o2::soa::ColumnIterator<typename Bindings::type> const*...> boundIterators;                                 \
   }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2205,7 +2205,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   const size_t n = columnLabel.size();
 
-  if(n == 0 || n != strlen(C::columnLabel())) {
+  if (n == 0 || n != strlen(C::columnLabel())) {
     return nullptr;
   }
 
@@ -2217,11 +2217,11 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   const size_t n = columnLabel.size();
 
-  if(n == 0 || n != strlen(C::columnLabel())) {
+  if (n == 0 || n != strlen(C::columnLabel())) {
     return nullptr;
   }
 
-  return ((std::strncmp(&columnLabel[1], C::columnLabel(), n-1) && std::strncmp(columnLabel.data(), C::columnLabel(), n))) ? nullptr : &getColumnValue<R, T, C>;
+  return ((std::strncmp(&columnLabel[1], C::columnLabel(), n - 1) && std::strncmp(columnLabel.data(), C::columnLabel(), n))) ? nullptr : &getColumnValue<R, T, C>;
 }
 
 template <typename R, typename T, typename... Cs>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2173,59 +2173,21 @@ std::tuple<typename Cs::type...> getRowData(T rowIterator, uint64_t globalIndex 
   return std::make_tuple(getSingleRowData<T, Cs>(rowIterator, globalIndex)...);
 }
 
-template <typename R, typename T, typename... Cs>
-std::optional<R> getColumnValueByLabel(o2::framework::pack<Cs...>, const T& rowIterator, const std::string& columnLabel)
-{
-  std::optional<R> value = std::nullopt;
-
-  ([&]() {
-    if (value) {
-      return;
-    }
-
-    if constexpr (std::is_arithmetic_v<typename Cs::type> && std::is_convertible_v<typename Cs::type, R>) {
-      if constexpr (o2::soa::is_dynamic_v<Cs>) {
-        // check if bindings have the same size as lambda parameters (getter do not have additional parameters)
-        if constexpr (o2::framework::pack_size(typename Cs::bindings_t{}) == o2::framework::pack_size(typename Cs::callable_t::args{})) {
-          // dynamic columns do not have "f" prefix in columnLabel() return string
-          if (std::strcmp(&columnLabel[1], Cs::columnLabel()) == 0 || std::strcmp(columnLabel.data(), Cs::columnLabel()) == 0) {
-            value = static_cast<R>(static_cast<Cs>(rowIterator).get());
-          }
-        }
-      } else if constexpr (o2::soa::is_persistent_v<Cs> && !o2::soa::is_index_column_v<Cs>) {
-        if (std::strcmp(columnLabel.data(), Cs::columnLabel()) == 0) {
-          value = static_cast<R>(static_cast<Cs>(rowIterator).get());
-        }
-      }
-    }
-  }(),
-   ...);
-
-  return value;
-}
-
-template <typename R, typename T>
-std::optional<R> getColumnValueByLabel(const T& rowIterator, const std::string& columnLabel)
-{
-  return getColumnValueByLabel<R>(typename T::parent_t::table_t::columns{}, rowIterator, columnLabel);
-}
-
 template <typename R, typename T, typename Column>
 R getColumnValue(const T& rowIterator)
 {
-  // This directly calls the column's get() method
   return static_cast<R>(static_cast<Column>(rowIterator).get());
 }
 
-template <typename R, typename T, typename Column>
-using GetFunctionPointer = R (*)(const T&);
+template <typename R, typename T>
+using ColumnGetterFunction = R (*)(const T&);
 
 template <typename R, typename T, typename Column>
-GetFunctionPointer<R, T, Column> createGetterPtr(const std::string_view& columnLabel, bool& found)
+ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel, bool& found)
 {
   using Col = Column;
 
-  if (found) {
+  if(found) {
     return nullptr;
   }
 
@@ -2249,14 +2211,13 @@ GetFunctionPointer<R, T, Column> createGetterPtr(const std::string_view& columnL
 }
 
 template <typename R, typename T, typename... Cs>
-std::function<R(const T&)> getColumnGetterByLabel(o2::framework::pack<Cs...>, const T& rowIterator, const std::string_view& columnLabel)
+ColumnGetterFunction<R, T> getColumnGetterByLabel(o2::framework::pack<Cs...>, const T& rowIterator, const std::string_view& columnLabel)
 {
   std::string_view labelView(columnLabel);
   bool found = false;
-  std::function<R(const T&)> func = nullptr;
+  ColumnGetterFunction<R, T> func;
 
-  // Iterate through each column in the pack and create the getter function pointer if a match is found
-  (void)((func = createGetterForColumn<R, T, Cs>(labelView, found), found) || ...);
+  (void)((func = createGetterPtr<R, T, Cs>(labelView, found), found) || ...);
 
   if (!found) {
     throw std::runtime_error("Getter for provided columnLabel not found!");
@@ -2266,7 +2227,7 @@ std::function<R(const T&)> getColumnGetterByLabel(o2::framework::pack<Cs...>, co
 }
 
 template <typename R, typename T>
-std::function<R(const typename T::iterator&)> getColumnGetterByLabel(const T& table, const std::string_view& columnLabel)
+ColumnGetterFunction<R, typename T::iterator> getColumnGetterByLabel(const T& table, const std::string_view& columnLabel)
 {
   return getColumnGetterByLabel<R>(typename T::columns{}, table.begin(), columnLabel);
 }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2200,17 +2200,17 @@ concept persistent_with_common_getter = is_persistent_v<T> && requires(T t) {
 template <typename R, typename T, persistent_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
-  return std::strncmp(columnLabel.data(), C::columnLabel(), columnLabel.size()) ? nullptr : &getColumnValue<R, T, C>;
+  return columnLabel == C::columnLabel() ? &getColumnValue<R, T, C> : nullptr;
 }
 
 template <typename R, typename T, dynamic_with_common_getter<R> C>
 ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   // allows user to use consistent formatting (with prefix) of all column labels
-  // by default there isn't 'f' prefix for dynamic column labels, strncmp(x,y,0) is always 0
-  bool isPrefixMatch = columnLabel.size() > 1 && !std::strncmp(columnLabel.substr(1).data(), C::columnLabel(), columnLabel.size() - 1);
+  // by default there isn't 'f' prefix for dynamic column labels
+  bool isPrefixMatch = columnLabel.size() > 1 && columnLabel.substr(1) == C::columnLabel();
   // check also exact match if user is aware of prefix missing
-  bool isExactMatch = !std::strncmp(columnLabel.data(), C::columnLabel(), columnLabel.size());
+  bool isExactMatch = columnLabel == C::columnLabel();
 
   return (isPrefixMatch || isExactMatch) ? &getColumnValue<R, T, C> : nullptr;
 }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1215,7 +1215,7 @@ struct TableIterator : IP, C... {
   {
     static_assert(std::same_as<decltype(&(static_cast<B*>(this)->mColumnIterator)), std::decay_t<decltype(B::mColumnIterator)>*>, "foo");
     return &(static_cast<B*>(this)->mColumnIterator);
-    //return static_cast<std::decay_t<decltype(B::mColumnIterator)>*>(nullptr);
+    // return static_cast<std::decay_t<decltype(B::mColumnIterator)>*>(nullptr);
   }
 
   template <typename B>
@@ -2157,7 +2157,7 @@ typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = s
   if (globalIndex != std::numeric_limits<uint64_t>::max() && globalIndex != *std::get<0>(rowIterator.getIndices())) {
     rowIterator.setCursor(globalIndex);
   }
-  return static_cast<C>(rowIterator).get();
+  return rowIterator.template getDynamicColumn<C>();
 }
 
 template <typename T, soa::is_index_column C>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2214,7 +2214,7 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   const size_t n = columnLabel.size();
 
-  if (n == 0 || n != strlen(C::columnLabel())) {
+  if (n == 0 || (n != strlen(C::columnLabel()) && n-1 != strlen(C::columnLabel()))) {
     return nullptr;
   }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -3002,7 +3002,6 @@ consteval auto getIndexTargets()
     }                                                                                                                      \
                                                                                                                            \
     using bindings_t = typename o2::framework::pack<Bindings...>;                                                          \
-    using bindings_types_t = typename o2::framework::pack<typename Bindings::type...>;                                     \
     std::tuple<o2::soa::ColumnIterator<typename Bindings::type> const*...> boundIterators;                                 \
   }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2187,19 +2187,15 @@ std::optional<R> getColumnValueByLabel(o2::framework::pack<Cs...>, const T& rowI
       if constexpr (o2::soa::is_dynamic_v<Cs>) {
         // check if bindings have the same size as lambda parameters (getter do not have additional parameters)
         if constexpr (o2::framework::pack_size(typename Cs::bindings_t{}) == o2::framework::pack_size(typename Cs::callable_t::args{})) {
-          std::string label = Cs::columnLabel();
-
           // dynamic columns do not have "f" prefix in columnLabel() return string
-          if (std::strcmp(&columnLabel[1], label.data()) == 0 || columnLabel == label) {
+          if (std::strcmp(&columnLabel[1], Cs::columnLabel()) == 0 || std::strcmp(columnLabel.data(), Cs::columnLabel()) == 0) {
             value = static_cast<R>(static_cast<Cs>(rowIterator).get());
           }
-
         }
       } else if constexpr (o2::soa::is_persistent_v<Cs> && !o2::soa::is_index_column_v<Cs>) {
-        if (columnLabel == Cs::columnLabel()) {
+        if (std::strcmp(columnLabel.data(), Cs::columnLabel()) == 0) {
           value = static_cast<R>(static_cast<Cs>(rowIterator).get());
         }
-
       }
     }
   }(),

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2208,12 +2208,12 @@ ColumnGetterFunction<R, T> createGetterPtr(const std::string_view& columnLabel)
 {
   // allows user to use consistent formatting (with prefix) of all column labels
   // by default there isn't 'f' prefix for dynamic column labels
-  if(columnLabel.size() > 1 && columnLabel.substr(1) == C::columnLabel()) {
+  if (columnLabel.size() > 1 && columnLabel.substr(1) == C::columnLabel()) {
     return &getColumnValue<R, T, C>;
   }
 
   // check also exact match if user is aware of prefix missing
-  if(columnLabel == C::columnLabel()) {
+  if (columnLabel == C::columnLabel()) {
     return &getColumnValue<R, T, C>;
   }
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -75,12 +75,6 @@ inline bool diffCategory(BinningIndex const& a, BinningIndex const& b)
 template <template <typename... Cs> typename BP, typename T, typename... Cs>
 std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPolicy, int minCatSize, int outsider)
 {
-  arrow::Table* arrowTable = table.asArrowTable().get();
-  auto rowIterator = table.begin();
-
-  uint64_t ind = 0;
-  uint64_t selInd = 0;
-  gsl::span<int64_t const> selectedRows;
   std::vector<BinningIndex> groupedIndices;
 
   // Separate check to account for Filtered size different from arrow table
@@ -127,8 +121,9 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 
       auto values = binningPolicy.getBinningValues(rowIterator, arrowTable, ci, ai, ind);
       auto val = binningPolicy.getBin(values);
+
       if (val != outsider) {
-        groupedIndices.emplace_back(val, ind);
+        groupedIndices.emplace_back(val, *std::get<1>(rowIterator.getIndices()));
       }
       ind++;
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -127,9 +127,8 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 
       auto values = binningPolicy.getBinningValues(rowIterator, arrowTable, ci, ai, ind);
       auto val = binningPolicy.getBin(values);
-
       if (val != outsider) {
-        groupedIndices.emplace_back(val, *std::get<1>(rowIterator.getIndices()));
+        groupedIndices.emplace_back(val, ind);
       }
       ind++;
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -75,6 +75,12 @@ inline bool diffCategory(BinningIndex const& a, BinningIndex const& b)
 template <template <typename... Cs> typename BP, typename T, typename... Cs>
 std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPolicy, int minCatSize, int outsider)
 {
+  arrow::Table* arrowTable = table.asArrowTable().get();
+  auto rowIterator = table.begin();
+
+  uint64_t ind = 0;
+  uint64_t selInd = 0;
+  gsl::span<int64_t const> selectedRows;
   std::vector<BinningIndex> groupedIndices;
 
   // Separate check to account for Filtered size different from arrow table

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -12,7 +12,6 @@
 #ifndef FRAMEWORK_BINNINGPOLICY_H
 #define FRAMEWORK_BINNINGPOLICY_H
 
-#include "Framework/ASoA.h"
 #include "Framework/HistogramSpec.h" // only for VARIABLE_WIDTH
 #include "Framework/Pack.h"
 
@@ -237,7 +236,7 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   }
 
   template <typename T, typename T2>
-  auto getBinningValue(T& rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValue(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
     if constexpr (has_type<T2>(pack<Ls...>{})) {
       if (globalIndex != -1) {
@@ -245,20 +244,20 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
       }
       return std::get<T2>(mBinningFunctions)(rowIterator);
     } else {
-      return soa::row_helpers::getSingleRowData<T, T2>(rowIterator, globalIndex);
+      return soa::row_helpers::getSingleRowData<T, T2>(table, rowIterator, ci, ai, globalIndex);
     }
   }
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(getBinningValue<T, Ts>(rowIterator, globalIndex)...);
+    return std::make_tuple(getBinningValue<T, Ts>(rowIterator, table, ci, ai, globalIndex)...);
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, globalIndex);
+    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
   }
 
   template <typename... T2s>
@@ -280,15 +279,15 @@ struct ColumnBinningPolicy : BinningPolicyBase<sizeof...(Ts)> {
   }
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(rowIterator, globalIndex)...);
+    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(table, rowIterator, ci, ai, globalIndex)...);
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, globalIndex);
+    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
   }
 
   int getBin(std::tuple<typename Ts::type...> const& data) const
@@ -305,15 +304,15 @@ struct NoBinningPolicy {
   NoBinningPolicy() = default;
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(rowIterator, globalIndex));
+    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(table, rowIterator, ci, ai, globalIndex));
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, globalIndex);
+    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
   }
 
   int getBin(std::tuple<typename C::type> const& data) const

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -256,7 +256,7 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
   {
     return getBinningValues(rowIterator, globalIndex);
   }
@@ -311,7 +311,7 @@ struct NoBinningPolicy {
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
   {
     return getBinningValues(rowIterator, globalIndex);
   }

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -237,7 +237,7 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   }
 
   template <typename T, typename T2>
-  auto getBinningValue(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValue(T& rowIterator, uint64_t globalIndex = -1) const
   {
     if constexpr (has_type<T2>(pack<Ls...>{})) {
       if (globalIndex != -1) {
@@ -245,20 +245,20 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
       }
       return std::get<T2>(mBinningFunctions)(rowIterator);
     } else {
-      return soa::row_helpers::getSingleRowData<T, T2>(table, rowIterator, ci, ai, globalIndex);
+      return soa::row_helpers::getSingleRowData<T, T2>(rowIterator, globalIndex);
     }
   }
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(getBinningValue<T, Ts>(rowIterator, table, ci, ai, globalIndex)...);
+    return std::make_tuple(getBinningValue<T, Ts>(rowIterator, globalIndex)...);
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
+    return getBinningValues(rowIterator, globalIndex);
   }
 
   template <typename... T2s>
@@ -280,15 +280,15 @@ struct ColumnBinningPolicy : BinningPolicyBase<sizeof...(Ts)> {
   }
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(table, rowIterator, ci, ai, globalIndex)...);
+    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(rowIterator, globalIndex)...);
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
+    return getBinningValues(rowIterator, globalIndex);
   }
 
   int getBin(std::tuple<typename Ts::type...> const& data) const
@@ -305,15 +305,15 @@ struct NoBinningPolicy {
   NoBinningPolicy() = default;
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(table, rowIterator, ci, ai, globalIndex));
+    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(rowIterator, globalIndex));
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
+    return getBinningValues(rowIterator, globalIndex);
   }
 
   int getBin(std::tuple<typename C::type> const& data) const

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -29,6 +29,7 @@ DECLARE_SOA_COLUMN_FULL(X, x, float, "x");
 DECLARE_SOA_COLUMN_FULL(Y, y, float, "y");
 DECLARE_SOA_COLUMN_FULL(Z, z, float, "z");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
+DECLARE_SOA_DYNAMIC_COLUMN(SumFreeArgs, sumFreeArgs, [](float x, float y, float freeArg) { return x + y + freeArg; });
 } // namespace test
 
 DECLARE_SOA_TABLE(TestTable, "AOD", "TESTTBL", test::X, test::Y, test::Z, test::Sum<test::X, test::Y>);
@@ -360,7 +361,8 @@ static void BM_ASoADynamicColumnCallGetGetterByLabel(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>>;
+  // SumFreeArgs presence checks if dynamic columns get() is handled correctly during compilation
+  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>, test::SumFreeArgs<test::X, test::Y>>;
 
   Test tests{table};
   for (auto _ : state) {

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -308,8 +308,8 @@ static void BM_ASoADynamicColumnPresentGetGetterByLabel(benchmark::State& state)
   for (auto _ : state) {
     Test tests{table};
     float sum = 0;
-    auto xGetter = o2::soa::row_helpers::getColumnGetterByLabel<float>(tests, "x");
-    auto yGetter = o2::soa::row_helpers::getColumnGetterByLabel<float>(tests, "y");
+    auto xGetter = o2::soa::row_helpers::getColumnGetterByLabel<float, Test>("x");
+    auto yGetter = o2::soa::row_helpers::getColumnGetterByLabel<float, Test>("y");
     for (auto& test : tests) {
       sum += xGetter(test) + yGetter(test);
     }
@@ -365,7 +365,7 @@ static void BM_ASoADynamicColumnCallGetGetterByLabel(benchmark::State& state)
   Test tests{table};
   for (auto _ : state) {
     float sum = 0;
-    auto sumGetter = o2::soa::row_helpers::getColumnGetterByLabel<float>(tests, "Sum");
+    auto sumGetter = o2::soa::row_helpers::getColumnGetterByLabel<float, Test>("Sum");
     for (auto& test : tests) {
       sum += sumGetter(test);
     }

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -304,7 +304,7 @@ static void BM_ASoADynamicColumnPresentGetGetterByLabel(benchmark::State& state)
   }
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
+  using Test = o2::soa::InPlaceTable<"A/0"_h, test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
 
   for (auto _ : state) {
     Test tests{table};
@@ -362,7 +362,7 @@ static void BM_ASoADynamicColumnCallGetGetterByLabel(benchmark::State& state)
   auto table = builder.finalize();
 
   // SumFreeArgs presence checks if dynamic columns get() is handled correctly during compilation
-  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>, test::SumFreeArgs<test::X, test::Y>>;
+  using Test = o2::soa::InPlaceTable<"A/0"_h, test::X, test::Y, test::Sum<test::X, test::Y>, test::SumFreeArgs<test::X, test::Y>>;
 
   Test tests{table};
   for (auto _ : state) {

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -290,6 +290,36 @@ static void BM_ASoADynamicColumnPresent(benchmark::State& state)
 
 BENCHMARK(BM_ASoADynamicColumnPresent)->Range(8, 8 << maxrange);
 
+static void BM_ASoADynamicColumnPresentGetGetterByLabel(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
+
+  for (auto _ : state) {
+    Test tests{table};
+    float sum = 0;
+    auto xGetter = o2::soa::row_helpers::getColumnGetterByLabel<float>(tests, "x");
+    auto yGetter = o2::soa::row_helpers::getColumnGetterByLabel<float>(tests, "y");
+    for (auto& test : tests) {
+      sum += xGetter(test) + yGetter(test);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
+}
+
+BENCHMARK(BM_ASoADynamicColumnPresentGetGetterByLabel)->Range(8, 8 << maxrange);
+
 static void BM_ASoADynamicColumnPresentGetValueByLabel(benchmark::State& state)
 {
   // Seed with a real random value, if available
@@ -349,6 +379,34 @@ static void BM_ASoADynamicColumnCall(benchmark::State& state)
   state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
 }
 BENCHMARK(BM_ASoADynamicColumnCall)->Range(8, 8 << maxrange);
+
+static void BM_ASoADynamicColumnCallGetGetterByLabel(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>>;
+
+  Test tests{table};
+  for (auto _ : state) {
+    float sum = 0;
+    auto sumGetter = o2::soa::row_helpers::getColumnGetterByLabel<float>(tests, "Sum");
+    for (auto& test : tests) {
+      sum += sumGetter(test);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
+}
+BENCHMARK(BM_ASoADynamicColumnCallGetGetterByLabel)->Range(8, 8 << maxrange);
 
 static void BM_ASoADynamicColumnCallGetValueByLabel(benchmark::State& state)
 {

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -323,8 +323,6 @@ static void BM_ASoADynamicColumnPresentGetValueByLabel(benchmark::State& state)
 
 BENCHMARK(BM_ASoADynamicColumnPresentGetValueByLabel)->Range(8, 8 << maxrange);
 
-
-
 static void BM_ASoADynamicColumnCall(benchmark::State& state)
 {
   // Seed with a real random value, if available
@@ -381,6 +379,5 @@ static void BM_ASoADynamicColumnCallGetValueByLabel(benchmark::State& state)
   state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
 }
 BENCHMARK(BM_ASoADynamicColumnCallGetValueByLabel)->Range(8, 8 << maxrange);
-
 
 BENCHMARK_MAIN();

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -290,6 +290,41 @@ static void BM_ASoADynamicColumnPresent(benchmark::State& state)
 
 BENCHMARK(BM_ASoADynamicColumnPresent)->Range(8, 8 << maxrange);
 
+static void BM_ASoADynamicColumnPresentGetValueByLabel(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
+
+  std::optional<float> valX, valY;
+  for (auto _ : state) {
+    Test tests{table};
+    float sum = 0;
+    for (auto& test : tests) {
+      valX = o2::soa::row_helpers::getColumnValueByLabel<float>(test, "x");
+      valY = o2::soa::row_helpers::getColumnValueByLabel<float>(test, "y");
+      assert(valX);
+      assert(valY);
+      sum += valX.value() + valY.value();
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
+}
+
+BENCHMARK(BM_ASoADynamicColumnPresentGetValueByLabel)->Range(8, 8 << maxrange);
+
+
+
 static void BM_ASoADynamicColumnCall(benchmark::State& state)
 {
   // Seed with a real random value, if available
@@ -316,5 +351,36 @@ static void BM_ASoADynamicColumnCall(benchmark::State& state)
   state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
 }
 BENCHMARK(BM_ASoADynamicColumnCall)->Range(8, 8 << maxrange);
+
+static void BM_ASoADynamicColumnCallGetValueByLabel(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>>;
+
+  std::optional<float> val;
+  Test tests{table};
+  for (auto _ : state) {
+    float sum = 0;
+    for (auto& test : tests) {
+      val = o2::soa::row_helpers::getColumnValueByLabel<float>(test, "Sum");
+      assert(val);
+      sum += val.value();
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
+}
+BENCHMARK(BM_ASoADynamicColumnCallGetValueByLabel)->Range(8, 8 << maxrange);
+
 
 BENCHMARK_MAIN();

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -320,39 +320,6 @@ static void BM_ASoADynamicColumnPresentGetGetterByLabel(benchmark::State& state)
 
 BENCHMARK(BM_ASoADynamicColumnPresentGetGetterByLabel)->Range(8, 8 << maxrange);
 
-static void BM_ASoADynamicColumnPresentGetValueByLabel(benchmark::State& state)
-{
-  // Seed with a real random value, if available
-  std::default_random_engine e1(1234567891);
-  std::uniform_real_distribution<float> uniform_dist(0, 1);
-
-  TableBuilder builder;
-  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
-  for (auto i = 0; i < state.range(0); ++i) {
-    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
-  }
-  auto table = builder.finalize();
-
-  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Z, test::Sum<test::X, test::Y>>;
-
-  std::optional<float> valX, valY;
-  for (auto _ : state) {
-    Test tests{table};
-    float sum = 0;
-    for (auto& test : tests) {
-      valX = o2::soa::row_helpers::getColumnValueByLabel<float>(test, "x");
-      valY = o2::soa::row_helpers::getColumnValueByLabel<float>(test, "y");
-      assert(valX);
-      assert(valY);
-      sum += valX.value() + valY.value();
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-  state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
-}
-
-BENCHMARK(BM_ASoADynamicColumnPresentGetValueByLabel)->Range(8, 8 << maxrange);
-
 static void BM_ASoADynamicColumnCall(benchmark::State& state)
 {
   // Seed with a real random value, if available
@@ -407,35 +374,5 @@ static void BM_ASoADynamicColumnCallGetGetterByLabel(benchmark::State& state)
   state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
 }
 BENCHMARK(BM_ASoADynamicColumnCallGetGetterByLabel)->Range(8, 8 << maxrange);
-
-static void BM_ASoADynamicColumnCallGetValueByLabel(benchmark::State& state)
-{
-  // Seed with a real random value, if available
-  std::default_random_engine e1(1234567891);
-  std::uniform_real_distribution<float> uniform_dist(0, 1);
-
-  TableBuilder builder;
-  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
-  for (auto i = 0; i < state.range(0); ++i) {
-    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
-  }
-  auto table = builder.finalize();
-
-  using Test = o2::soa::Table<o2::framework::OriginEnc{"AOD"}, test::X, test::Y, test::Sum<test::X, test::Y>>;
-
-  std::optional<float> val;
-  Test tests{table};
-  for (auto _ : state) {
-    float sum = 0;
-    for (auto& test : tests) {
-      val = o2::soa::row_helpers::getColumnValueByLabel<float>(test, "Sum");
-      assert(val);
-      sum += val.value();
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-  state.SetBytesProcessed(state.iterations() * state.range(0) * sizeof(float) * 2);
-}
-BENCHMARK(BM_ASoADynamicColumnCallGetValueByLabel)->Range(8, 8 << maxrange);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
I will continue our discussion here @ktf, @jgrosseo, @saganatt.

@jgrosseo was correct; this solution shouldn't be implemented as it is. It was slower in this benchmark by 3-10 times for simple examples. I will leave this draft PR here and try to implement this alternative solution I was writing about in https://github.com/AliceO2Group/O2Physics/pull/7371.  That 20% I was speaking of during the presentation was the whole task performance difference locally on my laptop. These are my local benchmark results:
```bash
------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------
BM_ASoADynamicColumnPresent/8                            237 ns          236 ns      2983783 bytes_per_second=258.465M/s
BM_ASoADynamicColumnPresent/64                           395 ns          395 ns      1717027 bytes_per_second=1.20857G/s
BM_ASoADynamicColumnPresent/512                         1559 ns         1555 ns       448023 bytes_per_second=2.45328G/s
BM_ASoADynamicColumnPresent/4096                       10961 ns        10933 ns        62651 bytes_per_second=2.79137G/s
BM_ASoADynamicColumnPresent/32768                      85382 ns        85164 ns         8024 bytes_per_second=2.86673G/s
BM_ASoADynamicColumnPresent/262144                    679514 ns       677289 ns          998 bytes_per_second=2.88374G/s
BM_ASoADynamicColumnPresentGetValueByLabel/8             419 ns          418 ns      1622625 bytes_per_second=145.876M/s
BM_ASoADynamicColumnPresentGetValueByLabel/64           1772 ns         1768 ns       392634 bytes_per_second=276.255M/s
BM_ASoADynamicColumnPresentGetValueByLabel/512         12671 ns        12641 ns        54994 bytes_per_second=309.019M/s
BM_ASoADynamicColumnPresentGetValueByLabel/4096        99301 ns        99056 ns         6893 bytes_per_second=315.478M/s
BM_ASoADynamicColumnPresentGetValueByLabel/32768      805034 ns       802857 ns          858 bytes_per_second=311.388M/s
BM_ASoADynamicColumnPresentGetValueByLabel/262144    6319410 ns      6301477 ns          107 bytes_per_second=317.386M/s
BM_ASoADynamicColumnCall/8                              25.3 ns         25.2 ns     28377608 bytes_per_second=2.36521G/s
BM_ASoADynamicColumnCall/64                              183 ns          182 ns      3722494 bytes_per_second=2.61903G/s
BM_ASoADynamicColumnCall/512                            1378 ns         1375 ns       478496 bytes_per_second=2.7751G/s
BM_ASoADynamicColumnCall/4096                          11039 ns        11012 ns        62893 bytes_per_second=2.77126G/s
BM_ASoADynamicColumnCall/32768                         88298 ns        88067 ns         7847 bytes_per_second=2.77221G/s
BM_ASoADynamicColumnCall/262144                       706708 ns       704322 ns          996 bytes_pelementaryer_second=2.77306G/s
BM_ASoADynamicColumnCallGetValueByLabel/8               67.6 ns         67.4 ns     10002511 bytes_per_second=905.098M/s
BM_ASoADynamicColumnCallGetValueByLabel/64               500 ns          498 ns      1345915 bytes_per_second=979.614M/s
BM_ASoADynamicColumnCallGetValueByLabel/512             3981 ns         3972 ns       175994 bytes_per_second=983.554M/s
BM_ASoADynamicColumnCallGetValueByLabel/4096           31831 ns        31757 ns        22014 bytes_per_second=984.025M/s
BM_ASoADynamicColumnCallGetValueByLabel/32768         255368 ns       254706 ns         2722 bytes_per_second=981.526M/s
BM_ASoADynamicColumnCallGetValueByLabel/262144       2029059 ns      2022533 ns          340 bytes_per_second=988.859M/s
```