### PR TITLE
Fix in TOF-TPC matching for tracks seeing multiple sectors.

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -449,6 +449,7 @@ bool MatchTOF::prepareTPCData()
           mTracksLblWork[sector][trkType::UNCONS].emplace_back(mTracksLblWork[sec][trkType::UNCONS][it]);
         }
         mLTinfos[sector][trkType::UNCONS].emplace_back(mLTinfos[sec][trkType::UNCONS][it]);
+        mVZtpcOnly[sector].push_back(mVZtpcOnly[sec][it]);
         mTracksSectIndexCache[trkType::UNCONS][sector].push_back(itnew);
       }
     }


### PR DESCRIPTION
When TPC track candidate which should be checked in 2 sectors, replicate also its mVZtpcOnly entries.

ping to @pbuehler 