### PR TITLE
Add mass hypothesis for H4L, He4L, He5L and charge hypothesis for dec…

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Decay3Body.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Decay3Body.h
@@ -29,7 +29,7 @@ class Decay3Body : public o2::track::TrackParCov /// TO BE DONE: extend to gener
   using PID = o2::track::PID;
 
   Decay3Body() = default;
-  Decay3Body(PID pid, const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2);
+  Decay3Body(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2, o2::track::PID pid = o2::track::PID::HyperTriton);
 
   const Track& getProng(int i) const { return mProngs[i]; }
   Track& getProng(int i) { return mProngs[i]; }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
@@ -33,19 +33,19 @@ namespace o2cp = o2::constants::physics;
 namespace pid_constants // GPUs currently cannot have static constexpr array members
 {
 typedef uint8_t ID;
-static constexpr ID NIDsTot = 17;
+static constexpr ID NIDsTot = 19;
 
 #if !defined(GPUCA_GPUCODE_DEVICE) || defined(GPUCA_GPU_DEBUG_PRINT)
 GPUconstexpr() const char* sNames[NIDsTot + 1] = ///< defined particle names
   {"Electron", "Muon", "Pion", "Kaon", "Proton", "Deuteron", "Triton", "He3", "Alpha",
-   "Pion0", "Photon", "K0", "Lambda", "HyperTriton", "Hyperhydrog4", "XiMinus", "OmegaMinus", nullptr};
+   "Pion0", "Photon", "K0", "Lambda", "HyperTriton", "Hyperhydrog4", "XiMinus", "OmegaMinus", "HyperHelium4", "HyperHelium5", nullptr};
 #endif
 
 GPUconstexpr() const float sMasses[NIDsTot] = ///< defined particle masses
   {o2cp::MassElectron, o2cp::MassMuon, o2cp::MassPionCharged, o2cp::MassKaonCharged,
    o2cp::MassProton, o2cp::MassDeuteron, o2cp::MassTriton, o2cp::MassHelium3,
    o2cp::MassAlpha, o2cp::MassPionNeutral, o2cp::MassPhoton,
-   o2cp::MassKaonNeutral, o2cp::MassLambda, o2cp::MassHyperTriton, o2cp::MassHyperhydrog4, o2cp::MassXiMinus, o2cp::MassOmegaMinus};
+   o2cp::MassKaonNeutral, o2cp::MassLambda, o2cp::MassHyperTriton, o2cp::MassHyperhydrog4, o2cp::MassXiMinus, o2cp::MassOmegaMinus, o2cp::MassHyperHelium4, o2cp::MassHyperHelium5};
 
 GPUconstexpr() const float sMasses2[NIDsTot] = ///< defined particle masses^2
   {o2cp::MassElectron * o2cp::MassElectron,
@@ -64,7 +64,9 @@ GPUconstexpr() const float sMasses2[NIDsTot] = ///< defined particle masses^2
    o2cp::MassHyperTriton* o2cp::MassHyperTriton,
    o2cp::MassHyperhydrog4* o2cp::MassHyperhydrog4,
    o2cp::MassXiMinus* o2cp::MassXiMinus,
-   o2cp::MassOmegaMinus* o2cp::MassOmegaMinus};
+   o2cp::MassOmegaMinus* o2cp::MassOmegaMinus,
+   o2cp::MassHyperHelium4* o2cp::MassHyperHelium4,
+   o2cp::MassHyperHelium5* o2cp::MassHyperHelium5};
 
 GPUconstexpr() const float sMasses2Z[NIDsTot] = ///< defined particle masses / Z
   {o2cp::MassElectron, o2cp::MassMuon,
@@ -73,12 +75,14 @@ GPUconstexpr() const float sMasses2Z[NIDsTot] = ///< defined particle masses / Z
    o2cp::MassTriton, o2cp::MassHelium3 / 2.,
    o2cp::MassAlpha / 2.,
    0, 0, 0, 0, o2cp::MassHyperTriton, o2cp::MassHyperhydrog4,
-   o2cp::MassXiMinus, o2cp::MassOmegaMinus};
+   o2cp::MassXiMinus, o2cp::MassOmegaMinus,
+   o2cp::MassHyperHelium4 / 2., o2cp::MassHyperHelium5 / 2.};
 
 GPUconstexpr() const int sCharges[NIDsTot] = ///< defined particle charges
   {1, 1, 1, 1, 1, 1, 1, 2, 2,
    0, 0, 0, 0, 1, 1,
-   1, 1};
+   1, 1,
+   2, 2};
 } // namespace pid_constants
 
 class PID
@@ -110,8 +114,10 @@ class PID
   static constexpr ID Hyperhydrog4 = 14;
   static constexpr ID XiMinus = 15;
   static constexpr ID OmegaMinus = 16;
+  static constexpr ID HyperHelium4 = 17;
+  static constexpr ID HyperHelium5 = 18;
   static constexpr ID FirstExt = PI0;
-  static constexpr ID LastExt = OmegaMinus;
+  static constexpr ID LastExt = HyperHelium5;
   static constexpr ID NIDsTot = pid_constants::NIDsTot; ///< total number of defined IDs
   static_assert(NIDsTot == LastExt + 1, "Incorrect NIDsTot, please update!");
 

--- a/DataFormats/Reconstruction/src/Decay3Body.cxx
+++ b/DataFormats/Reconstruction/src/Decay3Body.cxx
@@ -13,7 +13,7 @@
 
 using namespace o2::dataformats;
 
-Decay3Body::Decay3Body(PID pid, const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2)
+Decay3Body::Decay3Body(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz, const Track& tr0, const Track& tr1, const Track& tr2, o2::track::PID pid)
   : mProngs{tr0, tr1, tr2}
 {
   std::array<float, 21> cov{}, cov1{}, cov2{};

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexHypothesis.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexHypothesis.h
@@ -131,10 +131,14 @@ class SVertex3Hypothesis
   void set(PID v0, PID ppos, PID pneg, PID pbach, float sig, float nSig, float margin, float cpt, float bz = 0.f);
   void set(PID v0, PID ppos, PID pneg, PID pbach, const float pars[NPIDParams], float bz = 0.f);
 
+  PID getPIDHyp() const { return mPIDV0; }
   float getMassV0Hyp() const { return PID::getMass(mPIDV0); }
   float getMassPosProng() const { return PID::getMass(mPIDPosProng); }
   float getMassNegProng() const { return PID::getMass(mPIDNegProng); }
   float getMassBachProng() const { return PID::getMass(mPIDBachProng); }
+  float getChargePosProng() const { return PID::getCharge(mPIDPosProng); }
+  float getChargeNegProng() const { return PID::getCharge(mPIDNegProng); }
+  float getChargeBachProng() const { return PID::getCharge(mPIDBachProng); }
 
   float calcMass2(float p2Pos, float p2Neg, float p2Bach, float p2Tot) const
   {

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -87,6 +87,8 @@ class SVertexer
   enum Hyp3body {
     H3L3body,
     AntiH3L3body,
+    H4L3body,
+    AntiH4L3body,
     He4L3body,
     AntiHe4L3body,
     He5L3body,

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -138,7 +138,9 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   // cuts on different 3 body PID params
   bool check3bodyHypothesis = true;
   float pidCutsH3L3body[SVertex3Hypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5};  // H3L -> d p pi-
+  float pidCutsH4L3body[SVertex3Hypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5};  // H4L -> t p pi-
   float pidCutsHe4L3body[SVertex3Hypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5}; // He4L -> He3 p pi-
+  float pidCutsHe5L3body[SVertex3Hypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5}; // He5L -> He4 p pi-
 
   O2ParamDef(SVertexerParams, "svertexer");
 };

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1437,7 +1437,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Track2, track2, int, Tracks, "_2"); //! Track 2 in
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                   //! Collision index
 } // namespace decay3body
 
-DECLARE_SOA_TABLE(Decay3Bodys, "AOD", "DECAY3BODY", //! Run 2 cascade table
+DECLARE_SOA_TABLE(Decay3Bodys, "AOD", "DECAY3BODY", //! 3-body decay table
                   o2::soa::Index<>, decay3body::CollisionId, decay3body::Track0Id, decay3body::Track1Id, decay3body::Track2Id);
 
 using Decay3Bodys = Decay3Bodys; //! this defines the current default version


### PR DESCRIPTION
This pull request is the same as https://github.com/AliceO2Group/AliceO2/pull/13435. The former pull request was closed by mistake during a force push to rerun the checks. 
---------------------------------------------------------------------------------------------------------------------------
Add hyperhelium4 and hyperhelium5 in PID.h
Add mass hypothesis for hyperhydrogen4 ( -> proton + pion + triton(bach) ), hyperhelium4 ( -> proton + pion + helium3(bach) ), and hyperhelium5 ( -> proton + pion + alpha(bach) ) for Decay3Bodys
Fix the description of Decays3Bodys
In invariant mass check of the 3-body decay particle, set the charge of bachelor according the 3-body vertex hypothesis instead of PID