### PR TITLE
DPL Analysis: make sure VLAs use only one basket

### DIFF
--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -83,8 +83,9 @@ class ColumnToBranch
   ColumnToBranch(ColumnToBranch const& other) = delete;
   ColumnToBranch(ColumnToBranch&& other) = delete;
   void at(const int64_t* pos);
-  int fieldSize() const { return mFieldSize; }
-  char const* branchName() const { return mBranchName.c_str(); }
+  [[nodiscard]] int fieldSize() const { return mFieldSize; }
+  [[nodiscard]] int columnEntries() const { return mColumn->length(); }
+  [[nodiscard]] char const* branchName() const { return mBranchName.c_str(); }
 
  private:
   void accessChunk();


### PR DESCRIPTION

Otherwise it seems to create issues with ROOT bulk reading if the baskets
are split across multiple clusters.

In particular, each row needs 4 bytes for the size of the elements in the row
and the _size branch needs to also have its size correctly set.
