### PR TITLE
[EMCal-688] ClusterLabel: Fix bug in label sorting condition

### DIFF
--- a/DataFormats/Detectors/EMCAL/src/ClusterLabel.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ClusterLabel.cxx
@@ -71,5 +71,5 @@ void ClusterLabel::orderLabels()
 {
   // Sort the pairs based on values in descending order
   std::sort(mClusterLabels.begin(), mClusterLabels.end(),
-            [](const labelWithE& a, const labelWithE& b) { return a.energyFraction >= b.energyFraction; });
+            [](const labelWithE& a, const labelWithE& b) { return a.energyFraction > b.energyFraction; });
 }


### PR DESCRIPTION
Changed >= to > to prevent infinite loops when comparing equal energy fractions