### PR TITLE
DPL: thread safe activity detection

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingContext.h
+++ b/Framework/Core/include/Framework/DataProcessingContext.h
@@ -26,9 +26,7 @@ struct DataProcessorSpec;
 struct DataProcessorContext {
   DataProcessorContext(DataProcessorContext const&) = delete;
   DataProcessorContext() = default;
-  // These are specific of a given context and therefore
-  // not shared by threads.
-  bool* wasActive = nullptr;
+
   bool allDone = false;
   /// Latest run number we processed globally for this DataProcessor.
   int64_t lastRunNumberProcessed = -1;

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -113,7 +113,6 @@ class DataProcessingDevice : public fair::mq::Device
   std::vector<fair::mq::RegionInfo> mPendingRegionInfos; /// A list of the region infos not yet notified.
   std::mutex mRegionInfoMutex;
   ProcessingPolicies mProcessingPolicies; /// User policies related to data processing
-  bool mWasActive = false;                /// Whether or not the device was active at last iteration.
   std::vector<uv_work_t> mHandles;        /// Handles to use to schedule work.
   std::vector<TaskStreamInfo> mStreams;   /// Information about the task running in the associated mHandle.
   /// Handle to wake up the main loop from other threads

--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -30,6 +30,8 @@ typedef struct uv_async_s uv_async_t;
 namespace o2::framework
 {
 
+struct DataProcessorContext;
+
 /// Running state information of a given device
 struct DeviceState {
   /// Motivation for the loop being triggered.
@@ -108,6 +110,11 @@ struct DeviceState {
   /// the bits we are interested in.
   std::vector<int> severityStack;
   TransitionHandlingState transitionHandling = TransitionHandlingState::NoTransition;
+
+  // The DataProcessorContext which was most recently active.
+  // We use this to determine if we should trigger the loop without
+  // waiting for some events.
+  std::atomic<DataProcessorContext*> lastActiveDataProcessor = nullptr;
 };
 
 } // namespace o2::framework


### PR DESCRIPTION

This makes sure that the detection of active data processors in
a device is threadsafe by recording the last active one.

The main loop will then short circuit libuv in case the last active
dataprocessor was reported and it will reset the last active pointer
to nullptr if it has not changed in the meanwhile (meaning that another
data processor was actually able to process something).
