### PR TITLE
o2-sim: More universal timestamp setup

### DIFF
--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-# A simple chain of algorithms from MC to reco (and analysis)
+# A linearized and simplified chain of algorithms from MC to reco (and analysis) for ALICE Run3.
+# Please note that this script was originally provided as first and quick integration of
+# algorithms in the MC pipeline (mainly for testing purposes).
+# The script does, however, not represent a production setup and it is not maintained actively. 
+# The official MC configs and production system is maintained in O2DPG (https://github.com/AliceO2Group/O2DPG) 
+# and it is advised to use that one. Some documentation can be found here: https://aliceo2group.github.io/simulation/docs/o2dpgworkflow/
 
 # ------------ LOAD UTILITY FUNCTIONS ----------------------------
 . ${O2_ROOT}/share/scripts/jobutils.sh


### PR DESCRIPTION
This matters for workflows using o2sim_grp to pickup timestamps (like sim_challenge) and only changes the behaviour of o2-sim-serial. Does not affect O2DPG-MC.

Fixes https://its.cern.ch/jira/browse/O2-5377

Also adding some notes in sim_challenge.sh