### PR TITLE
Make sure that the string 'using' in a text is NOT interpreted as the using keyword.

### DIFF
--- a/scripts/datamodel-doc/ALICEO2includeFile.py
+++ b/scripts/datamodel-doc/ALICEO2includeFile.py
@@ -1078,15 +1078,15 @@ def extractUsings(nslevel, content):
     if len(iend) == 0:
       print(nslevel)
       sys.exit('Ending ; not found in using declaration! EXIT -->')
-    cont = words[icol:icol+iend[0]+1]
 
-    name = fullDataModelName(nslevel, words[icol+1].txt)
+    # make sure that using is not part of a text, like ".... PID using TPC ..." or similar
     definition = O2DMT.block(words[icol+3:icol+iend[0]], False)
-
-    # namespace, name, cont
-    use = using(nslevel, name, definition, O2DMT.block(cont))
-
-    usings.append(use)
+    if ('"' not in definition and "'" not in definition):
+      # namespace, name, cont
+      name = fullDataModelName(nslevel, words[icol+1].txt)
+      cont = words[icol:icol+iend[0]+1]
+      use = using(nslevel, name, definition, O2DMT.block(cont))
+      usings.append(use)
 
   return usings
 


### PR DESCRIPTION
This is needed to correct some entries in the 'Joins and Iterators' section of the ALICE O2 Analysis framework
DOCUMENTATION web site (https://aliceo2group.github.io/analysis-framework/docs/datamodel/)