### PR TITLE
Tracking (+ITS): Add quiet function to get predicted chi2

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -93,9 +93,9 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   GPUd() bool propagateToDCA(const o2::dataformats::VertexBase& vtx, value_t b, o2::dataformats::DCA* dca = nullptr, value_t maxD = 999.f);
   GPUd() void invert();
   GPUd() value_t getPredictedChi2(const dim2_t& p, const dim3_t& cov) const;
-  GPUd() value_t getPredictedChi2Unchecked(const dim2_t& p, const dim3_t& cov) const;
+  GPUd() value_t getPredictedChi2Quiet(const dim2_t& p, const dim3_t& cov) const;
   GPUd() value_t getPredictedChi2(const value_t* p, const value_t* cov) const;
-  GPUd() value_t getPredictedChi2Unchecked(const value_t* p, const value_t* cov) const;
+  GPUd() value_t getPredictedChi2Quiet(const value_t* p, const value_t* cov) const;
 
   template <typename T>
   GPUd() value_t getPredictedChi2(const BaseCluster<T>& p) const;
@@ -103,6 +103,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   void buildCombinedCovMatrix(const TrackParametrizationWithError& rhs, MatrixDSym5& cov) const;
   value_t getPredictedChi2(const TrackParametrizationWithError& rhs, MatrixDSym5& covToSet) const;
   GPUd() value_t getPredictedChi2(const TrackParametrizationWithError& rhs) const;
+  GPUd() value_t getPredictedChi2Quiet(const TrackParametrizationWithError& rhs) const;
   bool update(const TrackParametrizationWithError& rhs, const MatrixDSym5& covInv);
   bool update(const TrackParametrizationWithError& rhs);
 
@@ -322,9 +323,9 @@ GPUdi() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const dim2
 
 //______________________________________________
 template <typename value_T>
-GPUdi() auto TrackParametrizationWithError<value_T>::getPredictedChi2Unchecked(const dim2_t& p, const dim3_t& cov) const -> value_t
+GPUdi() auto TrackParametrizationWithError<value_T>::getPredictedChi2Quiet(const dim2_t& p, const dim3_t& cov) const -> value_t
 {
-  return getPredictedChi2Unchecked(p.data(), cov.data());
+  return getPredictedChi2Quiet(p.data(), cov.data());
 }
 
 //______________________________________________

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -736,7 +736,7 @@ GPUd() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const value
 
 //______________________________________________
 template <typename value_T>
-GPUd() auto TrackParametrizationWithError<value_T>::getPredictedChi2Unchecked(const value_t* p, const value_t* cov) const -> value_t
+GPUd() auto TrackParametrizationWithError<value_T>::getPredictedChi2Quiet(const value_t* p, const value_t* cov) const -> value_t
 {
   // Estimate the chi2 of the space point "p" with the cov. matrix "cov"
   auto sdd = static_cast<double>(getSigmaY2()) + static_cast<double>(cov[0]);

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -355,7 +355,7 @@ void TrackerTraits::computeLayerCells(const int iteration)
               break;
             }
 
-            auto predChi2{track.getPredictedChi2(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
+            auto predChi2{track.getPredictedChi2Quiet(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
             if (!track.o2::track::TrackParCov::update(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)) {
               break;
             }
@@ -536,7 +536,7 @@ void TrackerTraits::processNeighbours(int iLayer, int iLevel, const std::vector<
         }
       }
 
-      auto predChi2{seed.getPredictedChi2(trHit.positionTrackingFrame, trHit.covarianceTrackingFrame)};
+      auto predChi2{seed.getPredictedChi2Quiet(trHit.positionTrackingFrame, trHit.covarianceTrackingFrame)};
       if ((predChi2 > mTrkParams[0].MaxChi2ClusterAttachment) || predChi2 < 0.f) {
         CA_DEBUGGER(failed[3]++);
         continue;
@@ -781,7 +781,7 @@ void TrackerTraits::findShortPrimaries()
       float pvRes{mTrkParams[0].PVres / o2::gpu::CAMath::Sqrt(float(pvs[iV].getNContributors()))};
       const float posVtx[2]{0.f, pvs[iV].getZ()};
       const float covVtx[3]{pvRes, 0.f, pvRes};
-      float chi2 = temporaryTrack.getPredictedChi2(posVtx, covVtx);
+      float chi2 = temporaryTrack.getPredictedChi2Quiet(posVtx, covVtx);
       if (chi2 < bestChi2) {
         if (!temporaryTrack.track::TrackParCov::update(posVtx, covVtx)) {
           continue;
@@ -837,7 +837,7 @@ bool TrackerTraits::fitTrack(TrackITSExt& track, int start, int end, int step, f
       }
     }
 
-    auto predChi2{track.getPredictedChi2(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
+    auto predChi2{track.getPredictedChi2Quiet(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
     if ((nCl >= 3 && predChi2 > chi2clcut) || predChi2 < 0.f) {
       return false;
     }
@@ -932,7 +932,7 @@ bool TrackerTraits::trackFollowing(TrackITSExt* track, int rof, bool outward, co
             continue;
           }
 
-          auto predChi2{tbuParams.getPredictedChi2(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
+          auto predChi2{tbuParams.getPredictedChi2Quiet(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)};
           if (predChi2 >= track->getChi2() * mTrkParams[iteration].NSigmaCut) {
             continue;
           }


### PR DESCRIPTION
In PbPb, async 41% of the logfiles are due to negative chi2s in the ITS kalman filtering trials.
While in general the warning/error on a negative chi2 can be important, it is just annoying to log all the failed tests in ITS.
Negative chi2 are anyways excluded by selections and there is no chance they end up in data.

More elegant implementation such as passing the log level to the normal getPredictedChi2 funciton can be envised, will change upon request.
