### PR TITLE
ITS digi: Ability to process events before the first RO

### DIFF
--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -118,6 +118,7 @@ class Digitizer : public TObject
   uint32_t mROFrameMin = 0; ///< lowest RO frame of current digits
   uint32_t mROFrameMax = 0; ///< highest RO frame of current digits
   uint32_t mNewROFrame = 0; ///< ROFrame corresponding to provided time
+  bool mIsBeforeFirstRO = false;
 
   uint32_t mEventROFrameMin = 0xffffffff; ///< lowest RO frame for processed events (w/o automatic noise ROFs)
   uint32_t mEventROFrameMax = 0;          ///< highest RO frame forfor processed events (w/o automatic noise ROFs)


### PR DESCRIPTION
This commit makes it possible to inject events/hits into the ITS digitizer which happen in time before the "first interaction sampled" (start of the first readout-frame given by HBFUtils).

The commit avoids/fixes a segmenation fault which, so far, occurs in these situations (because of overflow of unsigned int32 newROFrame)

The commit allows to reduce "startup" effects in a timeframe by capturing hits that come from events before data taking starts. This makes MC more realistic.

With these "startup effects" removed, one could now play with short timeframe lengths for skimming studies.