### PR TITLE
TPC digi: Cut digits arriving before timeframe/readout start

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
@@ -258,6 +258,10 @@ inline float SAMPAProcessing::getZfromTimeBin(float timeBin, Side s) const
 
 inline TimeBin SAMPAProcessing::getTimeBinFromTime(float time) const
 {
+  if (time < 0.f) {
+    // protection and convention for negative times (otherwise overflow)
+    return 0;
+  }
   return static_cast<TimeBin>(time / mEleParam->ZbinWidth);
 }
 


### PR DESCRIPTION
Relates to
https://its.cern.ch/jira/browse/O2-5395

and should allow to treat correctly events coming before the timeframe start to reduce the startup effect in MC.