### PR TITLE
CCDB: add getSpecificForRun

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -322,15 +322,9 @@ T* CCDBManagerInstance::getForTimeStamp(std::string const& path, long timestamp)
 template <typename T>
 T* CCDBManagerInstance::getForRun(std::string const& path, int runNumber, bool setRunMetadata)
 {
-  auto [start, stop] = getRunDuration(runNumber);
-  if (start < 0 || stop < 0) {
-    if (mFatalWhenNull) {
-      reportFatal(std::string("Failed to get run duration for run ") + std::to_string(runNumber));
-    }
-    return nullptr;
-  }
-  mMetaData = setRunMetadata ? MD{{"runNumber", std::to_string(runNumber)}} : MD{};
-  return getForTimeStamp<T>(path, start / 2 + stop / 2);
+  auto metaData = setRunMetadata ? MD{{"runNumber", std::to_string(runNumber)}} : MD{};
+  mMetaData = metaData;
+  return getSpecificForRun<T>(path, runNumber, metaData);
 }
 
 template <typename T>


### PR DESCRIPTION
This PR adds a method `getSpecificForRun` to the base CCDB manager class. It is specifically tailored for analysis use in which the reconstruction pass is checked and the run number comes from the BCs `runNumber()` [getter](https://github.com/AliceO2Group/AliceO2/blob/9d39dbc56748f775abc302459aa219f72af94a96/Framework/Core/include/Framework/AnalysisDataModel.h#L39). Typical use cases, just to get started, are [multiplicity](https://github.com/AliceO2Group/O2Physics/blob/ba3f2925735dee0f9a10b273a9975b9fc970f798/Common/TableProducer/multiplicityTable.cxx#L386) and [centrality](https://github.com/AliceO2Group/O2Physics/blob/ba3f2925735dee0f9a10b273a9975b9fc970f798/Common/TableProducer/centralityTable.cxx#L259). Meant as a follow up on #13554 to cover all analysis use cases, tagging also @mpuccio. Thanks! 