### PR TITLE
TOF digitizer: Ability to process events happening before timeframe s…

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -104,8 +104,8 @@ class WindowFiller
 
  protected:
   // info TOF timewindow
-  uint64_t mReadoutWindowCurrent = 0;
-  InteractionRecord mFirstIR{0, 0}; // reference IR (1st IR of the timeframe)
+  uint64_t mReadoutWindowCurrent = 0; // keeps track of current readout window
+  InteractionRecord mFirstIR{0, 0};   // reference IR (1st IR of the timeframe)
   InteractionTimeRecord mEventTime;
 
   bool mContinuous = true;

--- a/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
@@ -82,6 +82,14 @@ class Digitizer : public WindowFiller
   void setEffBoundary2(float val) { mEffBoundary2 = val; }
   void setEffBoundary3(float val) { mEffBoundary3 = val; }
 
+  // determines the readout window id, given a time in nanoseconds (relative
+  // to orbit-reset)
+  uint64_t getReadoutWindow(double timeNS) const
+  {
+    // event time shifted by 2 BC as safe margin before to change current readout window to account for decalibration
+    return uint64_t((timeNS - Geo::BC_TIME * (Geo::OVERLAP_IN_BC + 2)) * Geo::READOUTWINDOW_INV);
+  }
+
  private:
   // parameters
   Int_t mMode;

--- a/Detectors/TOF/simulation/include/TOFSimulation/TOFSimParams.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/TOFSimParams.h
@@ -33,6 +33,8 @@ struct TOFSimParams : public o2::conf::ConfigurableParamHelper<TOFSimParams> {
   float eff_boundary2 = 0.833; // efficiency in the pad border
   float eff_boundary3 = 0.1;   // efficiency in mBound3
 
+  float max_hit_time = 1000.; // time cutoff for hits (time of flight); default 1us
+
   O2ParamDef(TOFSimParams, "TOFSimParams");
 };
 


### PR DESCRIPTION
…tart

Relates to https://its.cern.ch/jira/browse/O2-5395

This commit makes sure that TOF digitization treats correctly events happening before timeframe start:

- cut away hits from events much before first readout frame
- allow to pickup hits from events happening just before the first readout frame (due to time of flight)

some slight code reorganization:

- introduce a getReadoutWindow function for reuse
- introduce a constant for maximal time of flight of hits