### PR TITLE
Improve AggregatedRunInfo: prioritize use of CTP/Calib/FirstRunOrbit

### DIFF
--- a/DataFormats/Parameters/src/AggregatedRunInfo.cxx
+++ b/DataFormats/Parameters/src/AggregatedRunInfo.cxx
@@ -48,7 +48,39 @@ o2::parameters::AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo(o2::
   int64_t orbitEOR = (eor * 1000 - tsOrbitReset) / o2::constants::lhc::LHCOrbitMUS;
 
   // adjust to the nearest TF edge to satisfy condition (orbitSOR % nOrbitsPerTF == 0)
-  orbitSOR = orbitSOR / nOrbitsPerTF * nOrbitsPerTF;
+  orbitSOR = (orbitSOR / nOrbitsPerTF + 1) * nOrbitsPerTF; // +1 to choose the safe boundary ... towards run middle
+  orbitEOR = orbitEOR / nOrbitsPerTF * nOrbitsPerTF;
+
+  // fetch SOR directly from CTP entry on CCDB
+  bool oldFatalState = ccdb.getFatalWhenNull();
+  ccdb.setFatalWhenNull(false);
+  auto ctp_first_run_orbit = ccdb.getForTimeStamp<std::vector<int64_t>>("CTP/Calib/FirstRunOrbit", run_mid_timestamp);
+  ccdb.setFatalWhenNull(oldFatalState);
+  if (ctp_first_run_orbit && ctp_first_run_orbit->size() >= 3) {
+    // if we have CTP first run orbit available, we should use it
+
+    // int64_t creation_time = (*ctp_first_run_orbit)[0];
+    int64_t ctp_run_number = (*ctp_first_run_orbit)[1];
+    int64_t ctp_orbitSOR = (*ctp_first_run_orbit)[2];
+
+    if (ctp_run_number != runnumber) {
+      LOG(error) << "AggregatedRunInfo: run number inconsistency found (asked: " << runnumber << " vs CTP found: " << ctp_run_number << ")";
+    }
+
+    // overwrite orbitSOR
+    if (ctp_orbitSOR != orbitSOR) {
+      LOG(warn) << "The calculated orbitSOR " << orbitSOR << " differs from CTP orbitSOR " << ctp_orbitSOR;
+      // reasons for this is different unit of time storage in RunInformation (ms) and orbitReset (us), etc.
+
+      // so we need to adjust the SOR timings to be consistent
+      auto sor_new = (int64_t)((tsOrbitReset + ctp_orbitSOR * o2::constants::lhc::LHCOrbitMUS) / 1000.);
+      if (sor_new != sor) {
+        LOG(warn) << "Adjusting SOR from " << sor << " to " << sor_new;
+        sor = sor_new;
+      }
+    }
+    orbitSOR = ctp_orbitSOR;
+  }
 
   return AggregatedRunInfo{runnumber, sor, eor, nOrbitsPerTF, tsOrbitReset, orbitSOR, orbitEOR};
 }


### PR DESCRIPTION
use CTP/Calib/FirstRunOrbit when available. Otherwise fallback to RunInformation.