### PR TITLE
AggregatedRunInfo can be requested via GRPGeomHelper + related fixes

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -194,7 +194,7 @@ class CCDBManagerInstance
   /// On error it fatals (if fatal == true) or else returns the pair -1, -1.
   std::pair<int64_t, int64_t> getRunDuration(int runnumber, bool fatal = true);
   static std::pair<int64_t, int64_t> getRunDuration(o2::ccdb::CcdbApi const& api, int runnumber, bool fatal = true);
-
+  static std::pair<int64_t, int64_t> getRunDuration(const MD& headers);
   std::string getSummaryString() const;
 
   size_t getFetchedSize() const { return mFetchedSize; }

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -32,44 +32,47 @@ void CCDBManagerInstance::reportFatal(std::string_view err)
   LOG(fatal) << err;
 }
 
-std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(o2::ccdb::CcdbApi const& api, int runnumber, bool fatal)
+std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(const std::map<std::string, std::string>& headers)
 {
-  auto response = api.retrieveHeaders("RCT/Info/RunInformation", std::map<std::string, std::string>(), runnumber);
-  if (response.size() != 0) {
+  if (headers.size() != 0) {
     std::string report{};
-    auto strt = response.find("STF");
-    auto stop = response.find("ETF");
-    long valStrt = (strt == response.end()) ? -1L : boost::lexical_cast<int64_t>(strt->second);
-    long valStop = (stop == response.end()) ? -1L : boost::lexical_cast<int64_t>(stop->second);
+    auto strt = headers.find("STF");
+    auto stop = headers.find("ETF");
+    long valStrt = (strt == headers.end()) ? -1L : boost::lexical_cast<int64_t>(strt->second);
+    long valStop = (stop == headers.end()) ? -1L : boost::lexical_cast<int64_t>(stop->second);
     if (valStrt < 0 || valStop < 0) {
       report += "Missing STF/EFT -> use SOX/EOX;";
-      strt = response.find("SOX");
-      valStrt = (strt == response.end()) ? -1L : boost::lexical_cast<int64_t>(strt->second);
+      strt = headers.find("SOX");
+      valStrt = (strt == headers.end()) ? -1L : boost::lexical_cast<int64_t>(strt->second);
       if (valStrt < 1) {
         report += fmt::format(" Missing/invalid SOX -> use SOR");
-        strt = response.find("SOR");
-        valStrt = (strt == response.end()) ? -1L : boost::lexical_cast<int64_t>(strt->second);
+        strt = headers.find("SOR");
+        valStrt = (strt == headers.end()) ? -1L : boost::lexical_cast<int64_t>(strt->second);
       }
-      stop = response.find("EOX");
-      valStop = (stop == response.end()) ? -1L : boost::lexical_cast<int64_t>(stop->second);
+      stop = headers.find("EOX");
+      valStop = (stop == headers.end()) ? -1L : boost::lexical_cast<int64_t>(stop->second);
       if (valStop < 1) {
         report += fmt::format(" | Missing/invalid EOX -> use EOR");
-        stop = response.find("EOR");
-        valStop = (stop == response.end()) ? -1L : boost::lexical_cast<int64_t>(stop->second);
+        stop = headers.find("EOR");
+        valStop = (stop == headers.end()) ? -1L : boost::lexical_cast<int64_t>(stop->second);
       }
       if (!report.empty()) {
         LOGP(warn, "{}", report);
       }
     }
-    if (valStrt > 0 && valStop >= valStrt) {
-      return std::make_pair(valStrt, valStop);
-    }
-  }
-  // failure
-  if (fatal) {
-    LOG(fatal) << "Empty, missing or invalid response from query to RCT/Info/RunInformation for run " << runnumber;
+    return std::make_pair(valStrt, valStop);
   }
   return std::make_pair(-1L, -1L);
+}
+
+std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(o2::ccdb::CcdbApi const& api, int runnumber, bool fatal)
+{
+  auto headers = api.retrieveHeaders("RCT/Info/RunInformation", std::map<std::string, std::string>(), runnumber);
+  auto response = getRunDuration(headers);
+  if ((response.first <= 0 || response.second < response.first) && fatal) {
+    LOG(fatal) << "Empty, missing or invalid response from query to RCT/Info/RunInformation for run " << runnumber;
+  }
+  return response;
 }
 
 std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(int runnumber, bool fatal)

--- a/DataFormats/Parameters/include/DataFormatsParameters/AggregatedRunInfo.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/AggregatedRunInfo.h
@@ -29,19 +29,20 @@ class GRPECSObject;
 /// Also offers the authoritative algorithms to collect these information for easy reuse
 /// across various algorithms (anchoredMC, analysis, ...)
 struct AggregatedRunInfo {
-  int runNumber;       // run number
-  int64_t sor;         // best known timestamp for the start of run
-  int64_t eor;         // best known timestamp for end of run
-  int64_t orbitsPerTF; // number of orbits per TF
-  int64_t orbitReset;  // timestamp of orbit reset before run
-  int64_t orbitSOR;    // orbit when run starts after orbit reset
-  int64_t orbitEOR;    // orbit when run ends after orbit reset
+  int runNumber = 0;       // run number
+  int64_t sor = 0;         // best known timestamp for the start of run
+  int64_t eor = 0;         // best known timestamp for end of run
+  int64_t orbitsPerTF = 0; // number of orbits per TF
+  int64_t orbitReset = 0;  // timestamp of orbit reset before run
+  int64_t orbitSOR = 0;    // orbit when run starts after orbit reset
+  int64_t orbitEOR = 0;    // orbit when run ends after orbit reset
 
   // we may have pointers to actual data source objects GRPECS, ...
   const o2::parameters::GRPECSObject* grpECS = nullptr; // pointer to GRPECSobject (fetched during struct building)
 
   // fills and returns AggregatedRunInfo for a given run number.
   static AggregatedRunInfo buildAggregatedRunInfo(o2::ccdb::CCDBManagerInstance& ccdb, int runnumber);
+  static AggregatedRunInfo buildAggregatedRunInfo(int runnumber, long sorMS, long eorMS, long orbitResetMUS, const o2::parameters::GRPECSObject* grpecs, const std::vector<Long64_t>* ctfFirstRunOrbitVec);
 };
 
 } // namespace o2::parameters

--- a/DataFormats/Parameters/src/AggregatedRunInfo.cxx
+++ b/DataFormats/Parameters/src/AggregatedRunInfo.cxx
@@ -41,47 +41,43 @@ o2::parameters::AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo(o2::
   std::map<std::string, std::string> metadata;
   metadata["runNumber"] = Form("%d", runnumber);
   auto grpecs = ccdb.getSpecific<o2::parameters::GRPECSObject>("GLO/Config/GRPECS", run_mid_timestamp, metadata);
+  bool oldFatalState = ccdb.getFatalWhenNull();
+  ccdb.setFatalWhenNull(false);
+  auto ctp_first_run_orbit = ccdb.getForTimeStamp<std::vector<Long64_t>>("CTP/Calib/FirstRunOrbit", run_mid_timestamp);
+  ccdb.setFatalWhenNull(oldFatalState);
+  return buildAggregatedRunInfo(runnumber, sor, eor, tsOrbitReset, grpecs, ctp_first_run_orbit);
+}
+
+o2::parameters::AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo(int runnumber, long sorMS, long eorMS, long orbitResetMUS, const o2::parameters::GRPECSObject* grpecs, const std::vector<Long64_t>* ctfFirstRunOrbitVec)
+{
   auto nOrbitsPerTF = grpecs->getNHBFPerTF();
-
-  // calculate SOR orbit
-  int64_t orbitSOR = (sor * 1000 - tsOrbitReset) / o2::constants::lhc::LHCOrbitMUS;
-  int64_t orbitEOR = (eor * 1000 - tsOrbitReset) / o2::constants::lhc::LHCOrbitMUS;
-
+  // calculate SOR/EOR orbits
+  int64_t orbitSOR = (sorMS * 1000 - orbitResetMUS) / o2::constants::lhc::LHCOrbitMUS;
+  int64_t orbitEOR = (eorMS * 1000 - orbitResetMUS) / o2::constants::lhc::LHCOrbitMUS;
   // adjust to the nearest TF edge to satisfy condition (orbitSOR % nOrbitsPerTF == 0)
   orbitSOR = (orbitSOR / nOrbitsPerTF + 1) * nOrbitsPerTF; // +1 to choose the safe boundary ... towards run middle
   orbitEOR = orbitEOR / nOrbitsPerTF * nOrbitsPerTF;
-
-  // fetch SOR directly from CTP entry on CCDB
-  bool oldFatalState = ccdb.getFatalWhenNull();
-  ccdb.setFatalWhenNull(false);
-  auto ctp_first_run_orbit = ccdb.getForTimeStamp<std::vector<int64_t>>("CTP/Calib/FirstRunOrbit", run_mid_timestamp);
-  ccdb.setFatalWhenNull(oldFatalState);
-  if (ctp_first_run_orbit && ctp_first_run_orbit->size() >= 3) {
-    // if we have CTP first run orbit available, we should use it
-
-    // int64_t creation_time = (*ctp_first_run_orbit)[0];
-    int64_t ctp_run_number = (*ctp_first_run_orbit)[1];
-    int64_t ctp_orbitSOR = (*ctp_first_run_orbit)[2];
-
-    if (ctp_run_number == runnumber) {
-      // overwrite orbitSOR
+  if (ctfFirstRunOrbitVec && ctfFirstRunOrbitVec->size() >= 3) { // if we have CTP first run orbit available, we should use it
+    int64_t creation_timeIGNORED = (*ctfFirstRunOrbitVec)[0];    // do not use CTP start of run time!
+    int64_t ctp_run_number = (*ctfFirstRunOrbitVec)[1];
+    int64_t ctp_orbitSOR = (*ctfFirstRunOrbitVec)[2];
+    if (creation_timeIGNORED == -1 && ctp_run_number == -1 && ctp_orbitSOR == -1) {
+      LOGP(warn, "Default dummy CTP/Calib/FirstRunOrbit was provide, ignoring");
+    } else if (ctp_run_number == runnumber) { // overwrite orbitSOR
       if (ctp_orbitSOR != orbitSOR) {
-        LOG(warn) << "The calculated orbitSOR " << orbitSOR << " differs from CTP orbitSOR " << ctp_orbitSOR;
+        LOGP(warn, "The calculated orbitSOR {} differs from CTP orbitSOR {}", orbitSOR, ctp_orbitSOR);
         // reasons for this is different unit of time storage in RunInformation (ms) and orbitReset (us), etc.
-
         // so we need to adjust the SOR timings to be consistent
-        auto sor_new = (int64_t)((tsOrbitReset + ctp_orbitSOR * o2::constants::lhc::LHCOrbitMUS) / 1000.);
-        if (sor_new != sor) {
-          LOG(warn) << "Adjusting SOR from " << sor << " to " << sor_new;
-          sor = sor_new;
+        auto sor_new = (int64_t)((orbitResetMUS + ctp_orbitSOR * o2::constants::lhc::LHCOrbitMUS) / 1000.);
+        if (sor_new != sorMS) {
+          LOGP(warn, "Adjusting SOR from {} to {}", sorMS, sor_new);
+          sorMS = sor_new;
         }
       }
       orbitSOR = ctp_orbitSOR;
     } else {
-      LOG(error) << "AggregatedRunInfo: run number inconsistency found (asked: " << runnumber << " vs CTP found: " << ctp_run_number << ")";
-      LOG(error) << " ... not using CTP info";
+      LOGP(error, "AggregatedRunInfo: run number inconsistency found (asked: {} vs CTP found: {}, ignoring", runnumber, ctp_run_number);
     }
   }
-
-  return AggregatedRunInfo{runnumber, sor, eor, nOrbitsPerTF, tsOrbitReset, orbitSOR, orbitEOR, grpecs};
+  return AggregatedRunInfo{runnumber, sorMS, eorMS, nOrbitsPerTF, orbitResetMUS, orbitSOR, orbitEOR, grpecs};
 }

--- a/Detectors/Base/include/DetectorsBase/GRPGeomHelper.h
+++ b/Detectors/Base/include/DetectorsBase/GRPGeomHelper.h
@@ -22,6 +22,7 @@
 #include "DataFormatsParameters/GRPLHCIFData.h"
 #include "DataFormatsParameters/GRPECSObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/AggregatedRunInfo.h"
 
 namespace o2::framework
 {
@@ -92,6 +93,7 @@ struct GRPGeomRequest {
                      Ideal,
                      Alignments };
 
+  bool askAggregateRunInfo = false;
   bool askGRPECS = false;
   bool askGRPLHCIF = false;
   bool askGRPMagField = false;
@@ -105,6 +107,7 @@ struct GRPGeomRequest {
 
   GRPGeomRequest() = delete;
   GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs, bool askOnce = false, bool needPropD = false, std::string detMaskString = "all");
+  void requireAggregateRunInfo(std::vector<o2::framework::InputSpec>& inputs);
   void addInput(const o2::framework::InputSpec&& isp, std::vector<o2::framework::InputSpec>& inputs);
 };
 
@@ -121,14 +124,16 @@ class GRPGeomHelper
   }
   void setRequest(std::shared_ptr<GRPGeomRequest> req);
   bool finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj);
-  void checkUpdates(o2::framework::ProcessingContext& pc) const;
+  void checkUpdates(o2::framework::ProcessingContext& pc);
 
   auto getAlignment(o2::detectors::DetID det) const { return mAlignments[det]; }
   auto getMatLUT() const { return mMatLUT; }
   auto getGRPECS() const { return mGRPECS; }
   auto getGRPLHCIF() const { return mGRPLHCIF; }
   auto getGRPMagField() const { return mGRPMagField; }
-  auto getOrbitResetTimeMS() const { return mOrbitResetTimeMS; }
+  auto getOrbitResetTimeMS() const { return mOrbitResetTimeMUS / 1000; }
+  auto getOrbitResetTimeMUS() const { return mOrbitResetTimeMUS; }
+  const o2::parameters::AggregatedRunInfo& getAggregatedRunInfo() const { return mAggregatedRunInfo; }
   static int getNHBFPerTF();
 
  private:
@@ -141,7 +146,8 @@ class GRPGeomHelper
   const o2::parameters::GRPECSObject* mGRPECS = nullptr;
   const o2::parameters::GRPLHCIFData* mGRPLHCIF = nullptr;
   const o2::parameters::GRPMagField* mGRPMagField = nullptr;
-  long mOrbitResetTimeMS = 0; // orbit reset time in milliseconds
+  o2::parameters::AggregatedRunInfo mAggregatedRunInfo{};
+  long mOrbitResetTimeMUS = 0; // orbit reset time in microseconds
 };
 
 } // namespace base

--- a/Framework/Core/include/Framework/CCDBParamSpec.h
+++ b/Framework/Core/include/Framework/CCDBParamSpec.h
@@ -23,9 +23,9 @@ struct CCDBMetadata {
 };
 
 ConfigParamSpec ccdbPathSpec(std::string const& path);
-ConfigParamSpec ccdbRunDependent(bool defaultValue = true);
+ConfigParamSpec ccdbRunDependent(int defaultValue = 1); // <1: not run-dependent, 1: run-dependent object with usual timestamp, 2: run-dependent object with runNumber used instead of timestamp
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {}, int qrate = 0);
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, int runDependent, std::vector<CCDBMetadata> metadata = {}, int qrate = 0);
 /// Helper to create an InputSpec which will read from a CCDB
 /// Notice that those input specs have some convetions for their metadata:
 ///

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -493,7 +493,7 @@ class InputRecord
     auto cacheEntry = cache.matcherToMetadataId.find(path);
     if (cacheEntry == cache.matcherToMetadataId.end()) {
       cache.matcherToMetadataId.insert(std::make_pair(path, id));
-      cache.idToMetadata[id] = extractCCDBHeaders(ref);
+      cache.idToMetadata[id] = DataRefUtils::extractCCDBHeaders(ref);
       LOGP(info, "Caching CCDB metadata {}: {}", id.value, path);
       return cache.idToMetadata[id];
     }
@@ -506,9 +506,9 @@ class InputRecord
     // The id in the cache is different. Let's destroy the old cached entry
     // and create a new one.
     LOGP(info, "Replacing cached entry {} with {} for {}", oldId.value, id.value, path);
-    cache.idToObject[id] = extracCCDBMetadata(ref);
+    cache.idToMetadata[id] = DataRefUtils::extractCCDBHeaders(ref);
     oldId.value = id.value;
-    return cache.idToObject[id];
+    return cache.idToMetadata[id];
   }
 
   /// Helper method to be used to check if a given part of the InputRecord is present.

--- a/Framework/Core/src/CCDBParamSpec.cxx
+++ b/Framework/Core/src/CCDBParamSpec.cxx
@@ -21,9 +21,9 @@ ConfigParamSpec ccdbPathSpec(std::string const& path)
   return ConfigParamSpec{"ccdb-path", VariantType::String, path, {fmt::format("Path in CCDB ({})", path)}, ConfigParamKind::kGeneric};
 }
 
-ConfigParamSpec ccdbRunDependent(bool defaultValue)
+ConfigParamSpec ccdbRunDependent(int defaultValue)
 {
-  return ConfigParamSpec{"ccdb-run-dependent", VariantType::Bool, defaultValue, {"Give object for specific run number"}, ConfigParamKind::kGeneric};
+  return ConfigParamSpec{"ccdb-run-dependent", VariantType::Int, defaultValue, {"Give object for specific run number"}, ConfigParamKind::kGeneric};
 }
 
 ConfigParamSpec ccdbQueryRateSpec(int r)
@@ -45,11 +45,11 @@ std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<
   return ccdbParamSpec(path, false, metadata, qrate);
 }
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata, int qrate)
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, int runDependent, std::vector<CCDBMetadata> metadata, int qrate)
 {
   // Add here CCDB objecs which should be considered run dependent
   std::vector<ConfigParamSpec> result{ccdbPathSpec(path)};
-  if (runDependent) {
+  if (runDependent > 0) {
     result.push_back(ccdbRunDependent(runDependent));
   }
   if (qrate != 0) {


### PR DESCRIPTION
* Fix fetching CCDB metadata, extend ccdbRunDependent behaviour
ccdbParamSpec run-dependence flag changed from bool to int. The new convension is:
ccdbParamSpec(path) : not run-depndent
ccdbParamSpec(path, 1) : run-dependent object with usual timestamp and runNumber requested via metadata
ccdbParamSpec(path, 2) : run-dependent object with runNumber used instead of timestamp.
So, the entry like `"RCT/Info/RunInformation"` should be requested by passing requesting input e.g. 
`{"RCTRunInfo", "RCT", "RunInfo", 0, Lifetime::Condition, ccdbParamSpec("RCT/Info/RunInformation", 2)}`

* Add a separate method to extract run-duration from RCT info headers

* AggregatedRunInfo can be requested via GRPGeomHelper
To do this, request it after creating `auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(...)` as 
`ggRequest->requireAggregateRunInfo(inputs)`;
Then, in the task, once the `GRPGeomHelper::checkUpdates` was called, one can access the `AggregatedRunInfo`  as 
`const auto& rInfo = GGCCDBRequest.getAggregatedRunInfo()`

TODO: filling of AggregatedRunInfo requires CTP/Calib/FirstRunOrbit which is populated only starting from 15 Aug 2023. 
Need to retrofit it for all real runs and also for the special non-anchored MC range.
