### PR TITLE
DPL Analysis: enable cache without prefetching

### DIFF
--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -550,9 +550,17 @@ void TreeToTable::addAllColumns(TTree* tree, std::vector<std::string>&& names)
   // Was affected by https://github.com/root-project/root/issues/8962
   // Re-enabling this seems to cut the number of IOPS in half
   tree->SetCacheSize(25000000);
-  tree->SetClusterPrefetch(true);
+  // tree->SetClusterPrefetch(true);
   for (auto& reader : mBranchReaders) {
     tree->AddBranchToCache(reader->branch());
+    if (strncmp(reader->branch()->GetName(), "fIndexArray", strlen("fIndexArray")) == 0) {
+      std::string sizeBranchName = reader->branch()->GetName();
+      sizeBranchName += "_size";
+      TBranch* sizeBranch = (TBranch*)tree->GetBranch(sizeBranchName.c_str());
+      if (sizeBranch) {
+        tree->AddBranchToCache(sizeBranch);
+      }
+    }
   }
   tree->StopCacheLearningPhase();
 }


### PR DESCRIPTION
DPL Analysis: enable cache without prefetching

This give the same results in terms of reduced IOPs, without
the problems with the multiple basket branches.

It also adds explicitly to the cache all the _size branches.

Not yet clear if we need to have ROOT v6.32.06-alice2 as well for
this to work correctly.
