### PR TITLE
[MCH] skip digits produced before the beginning of the TF

### DIFF
--- a/Detectors/MUON/MCH/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Simulation/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(MCHSimulation
                 PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH
                                       O2::DetectorsBase
                                       O2::DetectorsPassive
+                                      O2::DetectorsRaw
                                       O2::MCHBase
                                       O2::MCHGeometryCreator
                                       O2::MCHMappingInterface


### PR DESCRIPTION
@sawenzel @shahor02 , this should address the JIRA ticket [https://its.cern.ch/jira/browse/O2-5395](https://its.cern.ch/jira/browse/O2-5395).

@sawenzel , I tested it with the provided workflow, without the option `--orbits-early 1` which is not yet available in O2DPG/master. Nonetheless, the MCH time shift + resolution results in some digits produced before the beginning of the TF, and I checked that they are properly discarded with this PR.