### PR TITLE
Add GPUTPCClusterFilter class to remove TPC clusters in generic way for cluster studies

### DIFF
--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SRCS_NO_CINT
     Global/GPUErrors.cxx
     Merger/GPUTPCGMMergerGPU.cxx
     Debug/GPUROOTDumpCore.cxx
+    Debug/GPUTPCClusterFilter.cxx
     utils/timer.cxx)
 
 set(SRCS_NO_H SliceTracker/GPUTPCTrackerDump.cxx

--- a/GPU/GPUTracking/Debug/GPUTPCClusterFilter.cxx
+++ b/GPU/GPUTracking/Debug/GPUTPCClusterFilter.cxx
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTPCClusterFilter.cxx
+/// \author David Rohr
+
+#include "GPUTPCClusterFilter.h"
+#include "DataFormatsTPC/ClusterNative.h"
+
+using namespace o2::gpu;
+
+GPUTPCClusterFilter::GPUTPCClusterFilter(const o2::tpc::ClusterNativeAccess& clusters)
+{
+  // Could initialize private variables based on the clusters here
+}
+
+bool GPUTPCClusterFilter::filter(uint32_t sector, uint32_t row, o2::tpc::ClusterNative& cl)
+{
+  // Return true to keep the cluster, false to drop it.
+  // May change cluster properties by modifying the cl reference.
+  // Note that this function might be called multiple times for the same cluster, in which case the final modified cl reference goes into the output clusters.
+  return true;
+}

--- a/GPU/GPUTracking/Debug/GPUTPCClusterFilter.h
+++ b/GPU/GPUTracking/Debug/GPUTPCClusterFilter.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTPCClusterFilter.h
+/// \author David Rohr
+
+#ifndef GPUTPCCLUSTERFILTER_H
+#define GPUTPCCLUSTERFILTER_H
+
+#include <cstdint>
+
+namespace o2::tpc
+{
+struct ClusterNativeAccess;
+struct ClusterNative;
+} // namespace o2::tpc
+
+namespace o2::gpu
+{
+class GPUTPCClusterFilter
+{
+ public:
+  GPUTPCClusterFilter(const o2::tpc::ClusterNativeAccess& clusters);
+  bool filter(uint32_t sector, uint32_t row, o2::tpc::ClusterNative& cl);
+};
+} // namespace o2::gpu
+
+#endif

--- a/GPU/GPUTracking/Definitions/GPULogging.h
+++ b/GPU/GPUTracking/Definitions/GPULogging.h
@@ -34,6 +34,7 @@
   #define GPUError(...)
   #define GPUFatal(...)
 #elif defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE_DEVICE) && !defined(GPUCA_NO_FMT)
+  #include <cstdio>
   #include <fmt/printf.h>
   #define GPUInfo(string, ...)                 \
     {                                          \
@@ -54,6 +55,7 @@
 #elif defined(GPUCA_STANDALONE) || defined(GPUCA_GPUCODE_DEVICE) || (defined(GPUCA_ALIROOT_LIB) && defined(GPUCA_GPUCODE) && defined(__cplusplus) && __cplusplus < 201703L)
   // For standalone / CUDA / HIP, we just use printf, which should be available
   // Temporarily, we also have to handle CUDA on AliRoot with O2 defaults due to ROOT / CUDA incompatibilities
+  #include <cstdio>
   #define GPUInfo(string, ...)            \
     {                                     \
       printf(string "\n", ##__VA_ARGS__); \

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -286,6 +286,7 @@ AddOption(tpcDownscaledEdx, uint8_t, 0, "", 0, "If != 0, downscale dEdx processi
 AddOption(tpcMaxAttachedClustersPerSectorRow, uint32_t, 51000, "", 0, "Maximum number of TPC attached clusters which can be decoded per SectorRow")
 AddOption(tpcUseOldCPUDecoding, bool, false, "", 0, "Enable old CPU-based TPC decoding")
 AddOption(tpcApplyCFCutsAtDecoding, bool, false, "", 0, "Apply cluster cuts from clusterization during decoding of compressed clusters")
+AddOption(tpcApplyDebugClusterFilter, bool, false, "", 0, "Apply custom cluster filter of GPUTPCClusterFilter class")
 AddOption(RTCcacheFolder, std::string, "./rtccache/", "", 0, "Folder in which the cache file is stored")
 AddOption(RTCprependCommand, std::string, "", "", 0, "Prepend RTC compilation commands by this string")
 AddOption(RTCoverrideArchitecture, std::string, "", "", 0, "Override arhcitecture part of RTC compilation command line")

--- a/GPU/GPUTracking/Global/GPUChainTrackingCompression.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingCompression.cxx
@@ -21,6 +21,7 @@
 #ifdef GPUCA_HAVE_O2HEADERS
 #include "GPUTPCCFChainContext.h"
 #include "TPCClusterDecompressor.h"
+#include "GPUTPCClusterFilter.h"
 #endif
 #include "utils/strtag.h"
 
@@ -226,6 +227,7 @@ int32_t GPUChainTracking::RunTPCDecompression()
       return 1;
     }
     if (GetProcessingSettings().tpcApplyCFCutsAtDecoding) {
+      GPUTPCClusterFilter clusterFilter(*mClusterNativeAccess);
       ClusterNative* outputBuffer;
       for (int32_t iPhase = 0; iPhase < 2; iPhase++) {
         uint32_t countTotal = 0;
@@ -233,8 +235,10 @@ int32_t GPUChainTracking::RunTPCDecompression()
           for (uint32_t iRow = 0; iRow < GPUCA_ROW_COUNT; iRow++) {
             uint32_t count = 0;
             for (uint32_t k = 0; k < mClusterNativeAccess->nClusters[iSector][iRow]; k++) {
-              const ClusterNative& cl = mClusterNativeAccess->clusters[iSector][iRow][k];
-              bool keep = cl.qTot > param().rec.tpc.cfQTotCutoff && cl.qMax > param().rec.tpc.cfQMaxCutoff && (cl.sigmaPadPacked || !(cl.getFlags() & ClusterNative::flagSingle) || cl.qMax > param().rec.tpc.cfQMaxCutoffSinglePad) && (cl.sigmaTimePacked || !(cl.getFlags() & ClusterNative::flagSingle) || cl.qMax > param().rec.tpc.cfQMaxCutoffSingleTime);
+              ClusterNative cl = mClusterNativeAccess->clusters[iSector][iRow][k];
+              bool keep = cl.qTot > param().rec.tpc.cfQTotCutoff && cl.qMax > param().rec.tpc.cfQMaxCutoff;
+              keep = keep && (cl.sigmaPadPacked || !(cl.getFlags() & ClusterNative::flagSingle) || cl.qMax > param().rec.tpc.cfQMaxCutoffSinglePad) && (cl.sigmaTimePacked || !(cl.getFlags() & ClusterNative::flagSingle) || cl.qMax > param().rec.tpc.cfQMaxCutoffSingleTime);
+              keep = keep && (!GetProcessingSettings().tpcApplyDebugClusterFilter || clusterFilter.filter(iSector, iRow, cl));
               count += keep;
               countTotal += keep;
               if (iPhase) {

--- a/GPU/GPUTracking/display/GPUDisplayInterface.cxx
+++ b/GPU/GPUTracking/display/GPUDisplayInterface.cxx
@@ -19,6 +19,7 @@
 #include <dlfcn.h>
 #include <mutex>
 #include <tuple>
+#include <stdexcept>
 
 using namespace GPUCA_NAMESPACE::gpu;
 


### PR DESCRIPTION
Adds the `configKeyValue` `tpcApplyDebugClusterFilter` to run a customizable cluster filter at CTF decoding stage from `GPU/GPUTracking/Debug/GPUTPCClusterFilter.cxx`.