### PR TITLE
TPC: adding check for SACs at endOfStream

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformAggregatorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformAggregatorSpec.h
@@ -201,7 +201,7 @@ class TPCFourierTransformAggregatorSpec : public o2::framework::Task
 
   void endOfStream(o2::framework::EndOfStreamContext& ec) final
   {
-    if (!mDisableScaler) {
+    if (!mDisableScaler && !mProcessSACs) {
       makeTPCScaler(ec.outputs(), true);
     }
     ec.services().get<ControlService>().readyToQuit(QuitRequest::Me);


### PR DESCRIPTION
The function makeTPCScaler should only be called in case the IDCs are processed and not the SACs