### PR TITLE
MID: skip digits produced before the beginning of the TF

### DIFF
--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -51,6 +51,7 @@ o2_add_executable(digitizer-workflow
                                         O2::MCHDigitFiltering
                                         O2::MFTSimulation
                                         O2::MIDSimulation
+                                        O2::MIDRaw
                                         O2::PHOSSimulation
                                         O2::CPVSimulation
                                         O2::TOFSimulation


### PR DESCRIPTION
This should address the JIRA ticket: https://its.cern.ch/jira/browse/O2-5395.