### PR TITLE
DPL Analysis: Staged declaration macro

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2763,6 +2763,10 @@ DECLARE_SOA_ITERATOR_METADATA();
 #define DECLARE_SOA_TABLE_VERSIONED(_Name_, _Origin_, _Description_, _Version_, ...) \
   DECLARE_SOA_TABLE_FULL_VERSIONED(_Name_, #_Name_, _Origin_, _Description_, _Version_, __VA_ARGS__);
 
+#define DECLARE_SOA_TABLE_STAGED(_BaseName_, _Description_, ...)                                   \
+  DECLARE_SOA_TABLE_FULL_VERSIONED(_BaseName_, #_BaseName_, "AOD", _Description_, 0, __VA_ARGS__); \
+  DECLARE_SOA_TABLE_FULL_VERSIONED(Stored##_BaseName_, "Stored" #_BaseName_, "AOD1", _Description_, 0, __VA_ARGS__);
+
 #define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)                                                      \
   template <o2::framework::OriginEnc ORIGIN = o2::framework::OriginEnc{_Origin_}>                                                           \
   struct _Name_##ExtensionFrom : o2::soa::Table<ORIGIN, __VA_ARGS__> {                                                                      \

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2765,7 +2765,7 @@ DECLARE_SOA_ITERATOR_METADATA();
 
 #define DECLARE_SOA_TABLE_STAGED(_BaseName_, _Description_, ...)                                   \
   DECLARE_SOA_TABLE_FULL_VERSIONED(_BaseName_, #_BaseName_, "AOD", _Description_, 0, __VA_ARGS__); \
-  DECLARE_SOA_TABLE_FULL_VERSIONED(Stored##_BaseName_, "Stored" #_BaseName_, "AOD1", _Description_, 0, __VA_ARGS__);
+  DECLARE_SOA_TABLE_FULL_VERSIONED(Stored##_BaseName_, "Stored" #_BaseName_, "AOD1", _Description_, 0, __VA_ARGS__, soa::Marker<1>);
 
 #define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)                                                      \
   template <o2::framework::OriginEnc ORIGIN = o2::framework::OriginEnc{_Origin_}>                                                           \

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2763,9 +2763,12 @@ DECLARE_SOA_ITERATOR_METADATA();
 #define DECLARE_SOA_TABLE_VERSIONED(_Name_, _Origin_, _Description_, _Version_, ...) \
   DECLARE_SOA_TABLE_FULL_VERSIONED(_Name_, #_Name_, _Origin_, _Description_, _Version_, __VA_ARGS__);
 
-#define DECLARE_SOA_TABLE_STAGED(_BaseName_, _Description_, ...)                                   \
-  DECLARE_SOA_TABLE_FULL_VERSIONED(_BaseName_, #_BaseName_, "AOD", _Description_, 0, __VA_ARGS__); \
-  DECLARE_SOA_TABLE_FULL_VERSIONED(Stored##_BaseName_, "Stored" #_BaseName_, "AOD1", _Description_, 0, __VA_ARGS__, soa::Marker<1>);
+#define DECLARE_SOA_TABLE_STAGED_VERSIONED(_BaseName_, _Description_, _Version_, ...)                      \
+  DECLARE_SOA_TABLE_FULL_VERSIONED(_BaseName_, #_BaseName_, "AOD", _Description_, _Version_, __VA_ARGS__); \
+  DECLARE_SOA_TABLE_FULL_VERSIONED(Stored##_BaseName_, "Stored" #_BaseName_, "AOD1", _Description_, _Version_, __VA_ARGS__, soa::Marker<1>);
+
+#define DECLARE_SOA_TABLE_STAGED(_BaseName_, _Description_, ...) \
+  DECLARE_SOA_TABLE_STAGED_VERSIONED(_BaseName_, _Description_, 0, __VA_ARGS__);
 
 #define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)                                                      \
   template <o2::framework::OriginEnc ORIGIN = o2::framework::OriginEnc{_Origin_}>                                                           \


### PR DESCRIPTION
This is to cover the cases similar to
```cpp
DECLARE_SOA_TABLE(V0Extras, "AOD", "V0EXTRA", //! optional table to refer to custom track extras
                  o2::soa::Index<>, v0data::PosTrackExtraId, v0data::NegTrackExtraId);

DECLARE_SOA_TABLE(StoredV0Extras, "AOD1", "V0EXTRA", //! optional table to refer to custom track extras
                  o2::soa::Index<>, v0data::PosTrackExtraId, v0data::NegTrackExtraId, soa::Marker<1>);
```
that are used extensively throughout O2Physics. 
It can be replaced with
```cpp
DECLARE_SOA_TABLE_STAGED(V0Extras, "V0EXTRA", //! optional table to refer to custom track extras
                         o2::soa::Index<>, v0data::PosTrackExtraId, v0data::NegTrackExtraId)
```

@ktf this is a first step for non-breaking migration to the new table type system.