### PR TITLE
DPL: use concepts rather than SFINAE

### DIFF
--- a/Framework/Core/include/Framework/Task.h
+++ b/Framework/Core/include/Framework/Task.h
@@ -14,65 +14,10 @@
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/CallbackService.h"
 #include "Framework/EndOfStreamContext.h"
-#include <utility>
 #include <memory>
 
 namespace o2::framework
 {
-
-/// Check if the class task has EndOfStream
-template <typename T>
-class has_endOfStream
-{
-  typedef char one;
-  struct two {
-    char x[2];
-  };
-
-  template <typename C>
-  static one test(decltype(&C::endOfStream));
-  template <typename C>
-  static two test(...);
-
- public:
-  enum { value = sizeof(test<T>(nullptr)) == sizeof(char) };
-};
-
-/// Check if the class task has EndOfStream
-template <typename T>
-class has_finaliseCCDB
-{
-  typedef char one;
-  struct two {
-    char x[2];
-  };
-
-  template <typename C>
-  static one test(decltype(&C::finaliseCCDB));
-  template <typename C>
-  static two test(...);
-
- public:
-  enum { value = sizeof(test<T>(nullptr)) == sizeof(char) };
-};
-
-/// Check if the class task has Stop
-template <typename T>
-class has_stop
-{
-  typedef char one;
-  struct two {
-    char x[2];
-  };
-
-  template <typename C>
-  static one test(decltype(&C::stop));
-  template <typename C>
-  static two test(...);
-
- public:
-  enum { value = sizeof(test<T>(nullptr)) == sizeof(char) };
-};
 
 /// A more familiar task API for the DPL.
 /// This allows you to define your own tasks as subclasses
@@ -115,19 +60,19 @@ AlgorithmSpec adaptFromTask(Args&&... args)
 {
   return AlgorithmSpec::InitCallback{[=](InitContext& ic) {
     auto task = std::make_shared<T>(args...);
-    if constexpr (has_endOfStream<T>::value) {
+    if constexpr (requires { &T::endOfStream; }) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set<CallbackService::Id::EndOfStream>([task](EndOfStreamContext& eosContext) {
         task->endOfStream(eosContext);
       });
     }
-    if constexpr (has_finaliseCCDB<T>::value) {
+    if constexpr (requires { &T::finaliseCCDB; }) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set<CallbackService::Id::CCDBDeserialised>([task](ConcreteDataMatcher& matcher, void* obj) {
         task->finaliseCCDB(matcher, obj);
       });
     }
-    if constexpr (has_stop<T>::value) {
+    if constexpr (requires { &T::stop; }) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set<CallbackService::Id::Stop>([task]() {
         task->stop();
@@ -144,19 +89,19 @@ template <typename T>
 AlgorithmSpec adoptTask(std::shared_ptr<T> task)
 {
   return AlgorithmSpec::InitCallback{[task](InitContext& ic) {
-    if constexpr (has_endOfStream<T>::value) {
+    if constexpr (requires { &T::endOfStream; }) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set<CallbackService::Id::EndOfStream>([task](EndOfStreamContext& eosContext) {
         task->endOfStream(eosContext);
       });
     }
-    if constexpr (has_finaliseCCDB<T>::value) {
+    if constexpr (requires { &T::finaliseCCDB; }) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set<CallbackService::Id::CCDBDeserialised>([task](ConcreteDataMatcher& matcher, void* obj) {
         task->finaliseCCDB(matcher, obj);
       });
     }
-    if constexpr (has_stop<T>::value) {
+    if constexpr (requires { &T::stop; }) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set<CallbackService::Id::Stop>([task]() {
         task->stop();


### PR DESCRIPTION

Notice that we do not impose the arguments, so that we still get a
compilation error if they are wrong.
