### PR TITLE
TPC: Adding option to make timegain calib with gausian fits

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
@@ -91,8 +91,8 @@ class CalibdEdxCorrection
 
   void clear();
 
-  void writeToFile(std::string_view fileName) const;
-  void loadFromFile(std::string_view fileName);
+  void writeToFile(std::string_view fileName, std::string_view objName = "CalibdEdxCorrection") const;
+  void loadFromFile(std::string_view fileName, std::string_view objName = "CalibdEdxCorrection");
 
   /// \param outFileName name of the output file
   void dumpToTree(const char* outFileName = "calib_dedx.root") const;

--- a/DataFormats/Detectors/TPC/src/CalibdEdxCorrection.cxx
+++ b/DataFormats/Detectors/TPC/src/CalibdEdxCorrection.cxx
@@ -36,16 +36,16 @@ void CalibdEdxCorrection::clear()
   mDims = -1;
 }
 
-void CalibdEdxCorrection::writeToFile(std::string_view fileName) const
+void CalibdEdxCorrection::writeToFile(std::string_view fileName, std::string_view objName) const
 {
   std::unique_ptr<TFile> file(TFile::Open(fileName.data(), "recreate"));
-  file->WriteObject(this, "CalibdEdxCorrection");
+  file->WriteObject(this, objName.data());
 }
 
-void CalibdEdxCorrection::loadFromFile(std::string_view fileName)
+void CalibdEdxCorrection::loadFromFile(std::string_view fileName, std::string_view objName)
 {
   std::unique_ptr<TFile> file(TFile::Open(fileName.data()));
-  auto tmp = file->Get<CalibdEdxCorrection>("CalibdEdxCorrection");
+  auto tmp = file->Get<CalibdEdxCorrection>(objName.data());
   if (tmp != nullptr) {
     *this = *tmp;
   }

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalculatedEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalculatedEdx.h
@@ -130,7 +130,7 @@ class CalculatedEdx
   float getMinChargeMaxThreshold() { return mMinChargeMaxThreshold; }
 
   /// fill missing clusters with minimum charge (method=0) or minimum charge/2 (method=1) or Landau (method=2)
-  void fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method);
+  void fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method, std::array<std::vector<float>, 5>& chargeTotROC, std::array<std::vector<float>, 5>& chargeMaxROC);
 
   /// get the truncated mean for the input track with the truncation range, charge type, region and corrections
   /// the cluster charge is normalized by effective length*gain, you can turn off the normalization by setting all corrections to false
@@ -241,9 +241,6 @@ class CalculatedEdx
   bool mDebug{false};                                                  ///< use the debug streamer
   CalibdEdxContainer mCalibCont;                                       ///< calibration container
   std::unique_ptr<o2::utils::TreeStreamRedirector> mStreamer{nullptr}; ///< debug streamer
-
-  std::array<std::vector<float>, 5> mChargeTotROC;
-  std::array<std::vector<float>, 5> mChargeMaxROC;
 
   CorrectdEdxDistortions mSCdEdxCorrection; ///< for space-charge correction of dE/dx
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
@@ -60,6 +60,7 @@ class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc
   void setApplyCuts(bool apply) { mApplyCuts = apply; }
   void setElectronCut(std::tuple<float, int, float> values) { mElectronCut = values; }
   void setMaterialType(o2::base::Propagator::MatCorrType materialType) { mMatType = materialType; }
+  void setMakeGaussianFits(const bool makeGaussianFits) { mMakeGaussianFits = makeGaussianFits; }
 
   /// \brief Check if there are enough data to compute the calibration.
   /// \return false if any of the histograms has less entries than mMinEntries
@@ -117,6 +118,7 @@ class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc
   std::tuple<float, int, float> mElectronCut{}; ///< Values passed to CalibdEdx::setElectronCut
   TrackCuts mCuts;                              ///< Cut object
   o2::base::Propagator::MatCorrType mMatType{}; ///< material type for track propagation
+  bool mMakeGaussianFits{};                     ///< fit mean of gaussian fits instead of mean dedx
 
   TFinterval mTFIntervals;     ///< start and end time frame IDs of each calibration time slots
   TimeInterval mTimeIntervals; ///< start and end times of each calibration time slots
@@ -124,7 +126,7 @@ class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc
 
   std::unique_ptr<o2::utils::TreeStreamRedirector> mDebugOutputStreamer; ///< Debug output streamer
 
-  ClassDefOverride(CalibratordEdx, 2);
+  ClassDefOverride(CalibratordEdx, 3);
 };
 
 } // namespace o2::tpc

--- a/Detectors/TPC/calibration/src/CalculatedEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalculatedEdx.cxx
@@ -53,7 +53,7 @@ void CalculatedEdx::setRefit(const unsigned int nHbfPerTf)
   mRefit = std::make_unique<o2::gpu::GPUO2InterfaceRefit>(mClusterIndex, &mTPCCorrMapsHelper, mFieldNominalGPUBz, mTPCTrackClIdxVecInput->data(), nHbfPerTf, mTPCRefitterShMap.data(), mTPCRefitterOccMap.data(), mTPCRefitterOccMap.size());
 }
 
-void CalculatedEdx::fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method)
+void CalculatedEdx::fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method, std::array<std::vector<float>, 5>& chargeMaxROC, std::array<std::vector<float>, 5>& mChargeMaxROC)
 {
   if (method != 0 && method != 1) {
     LOGP(info, "Unrecognized subthreshold cluster treatment. Not adding virtual charges to the track!");
@@ -65,8 +65,8 @@ void CalculatedEdx::fillMissingClusters(int missingClusters[4], float minChargeT
       float chargeTot = (method == 1) ? minChargeTot / 2.f : minChargeTot;
       float chargeMax = (method == 1) ? minChargeMax / 2.f : minChargeMax;
 
-      mChargeTotROC[roc].emplace_back(chargeTot);
-      mChargeTotROC[4].emplace_back(chargeTot);
+      chargeMaxROC[roc].emplace_back(chargeTot);
+      chargeMaxROC[4].emplace_back(chargeTot);
 
       mChargeMaxROC[roc].emplace_back(chargeMax);
       mChargeMaxROC[4].emplace_back(chargeMax);
@@ -82,17 +82,13 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
   int nClsROC[4] = {0, 0, 0, 0};
   int nClsSubThreshROC[4] = {0, 0, 0, 0};
 
-  mChargeTotROC[0].clear();
-  mChargeTotROC[1].clear();
-  mChargeTotROC[2].clear();
-  mChargeTotROC[3].clear();
-  mChargeTotROC[4].clear();
-
-  mChargeMaxROC[0].clear();
-  mChargeMaxROC[1].clear();
-  mChargeMaxROC[2].clear();
-  mChargeMaxROC[3].clear();
-  mChargeMaxROC[4].clear();
+  const int nType = 5;
+  std::array<std::vector<float>, nType> chargeMaxROC;
+  std::array<std::vector<float>, nType> mChargeMaxROC;
+  for (int i = 0; i < nType; ++i) {
+    chargeMaxROC[i].reserve(Mapper::PADROWS);
+    mChargeMaxROC[i].reserve(Mapper::PADROWS);
+  }
 
   // debug vectors
   std::vector<int> excludeClVector;
@@ -356,24 +352,24 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
     }
 
     if (stack == GEMstack::IROCgem) {
-      mChargeTotROC[0].emplace_back(chargeTot);
+      chargeMaxROC[0].emplace_back(chargeTot);
       mChargeMaxROC[0].emplace_back(chargeMax);
       nClsROC[0]++;
     } else if (stack == GEMstack::OROC1gem) {
-      mChargeTotROC[1].emplace_back(chargeTot);
+      chargeMaxROC[1].emplace_back(chargeTot);
       mChargeMaxROC[1].emplace_back(chargeMax);
       nClsROC[1]++;
     } else if (stack == GEMstack::OROC2gem) {
-      mChargeTotROC[2].emplace_back(chargeTot);
+      chargeMaxROC[2].emplace_back(chargeTot);
       mChargeMaxROC[2].emplace_back(chargeMax);
       nClsROC[2]++;
     } else if (stack == GEMstack::OROC3gem) {
-      mChargeTotROC[3].emplace_back(chargeTot);
+      chargeMaxROC[3].emplace_back(chargeTot);
       mChargeMaxROC[3].emplace_back(chargeMax);
       nClsROC[3]++;
     };
 
-    mChargeTotROC[4].emplace_back(chargeTot);
+    chargeMaxROC[4].emplace_back(chargeTot);
     mChargeMaxROC[4].emplace_back(chargeMax);
 
     // for debugging
@@ -418,7 +414,7 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
 
     // fill subthreshold clusters if not excluded
     if (((clusterMask & ClusterFlags::ExcludeSubthresholdCl) == ClusterFlags::None)) {
-      fillMissingClusters(nClsSubThreshROC, minChargeTot, minChargeMax, subthresholdMethod);
+      fillMissingClusters(nClsSubThreshROC, minChargeTot, minChargeMax, subthresholdMethod, chargeMaxROC, mChargeMaxROC);
     }
   } else {
     output.NHitsIROC = nClsROC[0];
@@ -428,15 +424,15 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
   }
 
   // copy corrected cluster charges
-  auto chargeTotVector = mChargeTotROC[4];
-  auto chargeMaxVector = mChargeMaxROC[4];
+  auto chargeTotVector = mDebug ? chargeMaxROC[4] : std::vector<float>();
+  auto chargeMaxVector = mDebug ? mChargeMaxROC[4] : std::vector<float>();
 
   // calculate dEdx
-  output.dEdxTotIROC = getTruncMean(mChargeTotROC[0], low, high);
-  output.dEdxTotOROC1 = getTruncMean(mChargeTotROC[1], low, high);
-  output.dEdxTotOROC2 = getTruncMean(mChargeTotROC[2], low, high);
-  output.dEdxTotOROC3 = getTruncMean(mChargeTotROC[3], low, high);
-  output.dEdxTotTPC = getTruncMean(mChargeTotROC[4], low, high);
+  output.dEdxTotIROC = getTruncMean(chargeMaxROC[0], low, high);
+  output.dEdxTotOROC1 = getTruncMean(chargeMaxROC[1], low, high);
+  output.dEdxTotOROC2 = getTruncMean(chargeMaxROC[2], low, high);
+  output.dEdxTotOROC3 = getTruncMean(chargeMaxROC[3], low, high);
+  output.dEdxTotTPC = getTruncMean(chargeMaxROC[4], low, high);
 
   output.dEdxMaxIROC = getTruncMean(mChargeMaxROC[0], low, high);
   output.dEdxMaxOROC1 = getTruncMean(mChargeMaxROC[1], low, high);

--- a/Detectors/TPC/calibration/src/CalculatedEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalculatedEdx.cxx
@@ -53,7 +53,7 @@ void CalculatedEdx::setRefit(const unsigned int nHbfPerTf)
   mRefit = std::make_unique<o2::gpu::GPUO2InterfaceRefit>(mClusterIndex, &mTPCCorrMapsHelper, mFieldNominalGPUBz, mTPCTrackClIdxVecInput->data(), nHbfPerTf, mTPCRefitterShMap.data(), mTPCRefitterOccMap.data(), mTPCRefitterOccMap.size());
 }
 
-void CalculatedEdx::fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method, std::array<std::vector<float>, 5>& chargeMaxROC, std::array<std::vector<float>, 5>& mChargeMaxROC)
+void CalculatedEdx::fillMissingClusters(int missingClusters[4], float minChargeTot, float minChargeMax, int method, std::array<std::vector<float>, 5>& chargeTotROC, std::array<std::vector<float>, 5>& chargeMaxROC)
 {
   if (method != 0 && method != 1) {
     LOGP(info, "Unrecognized subthreshold cluster treatment. Not adding virtual charges to the track!");
@@ -65,11 +65,11 @@ void CalculatedEdx::fillMissingClusters(int missingClusters[4], float minChargeT
       float chargeTot = (method == 1) ? minChargeTot / 2.f : minChargeTot;
       float chargeMax = (method == 1) ? minChargeMax / 2.f : minChargeMax;
 
-      chargeMaxROC[roc].emplace_back(chargeTot);
-      chargeMaxROC[4].emplace_back(chargeTot);
+      chargeTotROC[roc].emplace_back(chargeTot);
+      chargeTotROC[4].emplace_back(chargeTot);
 
-      mChargeMaxROC[roc].emplace_back(chargeMax);
-      mChargeMaxROC[4].emplace_back(chargeMax);
+      chargeMaxROC[roc].emplace_back(chargeMax);
+      chargeMaxROC[4].emplace_back(chargeMax);
     }
   }
 }
@@ -83,11 +83,11 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
   int nClsSubThreshROC[4] = {0, 0, 0, 0};
 
   const int nType = 5;
+  std::array<std::vector<float>, nType> chargeTotROC;
   std::array<std::vector<float>, nType> chargeMaxROC;
-  std::array<std::vector<float>, nType> mChargeMaxROC;
   for (int i = 0; i < nType; ++i) {
+    chargeTotROC[i].reserve(Mapper::PADROWS);
     chargeMaxROC[i].reserve(Mapper::PADROWS);
-    mChargeMaxROC[i].reserve(Mapper::PADROWS);
   }
 
   // debug vectors
@@ -352,25 +352,25 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
     }
 
     if (stack == GEMstack::IROCgem) {
-      chargeMaxROC[0].emplace_back(chargeTot);
-      mChargeMaxROC[0].emplace_back(chargeMax);
+      chargeTotROC[0].emplace_back(chargeTot);
+      chargeMaxROC[0].emplace_back(chargeMax);
       nClsROC[0]++;
     } else if (stack == GEMstack::OROC1gem) {
-      chargeMaxROC[1].emplace_back(chargeTot);
-      mChargeMaxROC[1].emplace_back(chargeMax);
+      chargeTotROC[1].emplace_back(chargeTot);
+      chargeMaxROC[1].emplace_back(chargeMax);
       nClsROC[1]++;
     } else if (stack == GEMstack::OROC2gem) {
-      chargeMaxROC[2].emplace_back(chargeTot);
-      mChargeMaxROC[2].emplace_back(chargeMax);
+      chargeTotROC[2].emplace_back(chargeTot);
+      chargeMaxROC[2].emplace_back(chargeMax);
       nClsROC[2]++;
     } else if (stack == GEMstack::OROC3gem) {
-      chargeMaxROC[3].emplace_back(chargeTot);
-      mChargeMaxROC[3].emplace_back(chargeMax);
+      chargeTotROC[3].emplace_back(chargeTot);
+      chargeMaxROC[3].emplace_back(chargeMax);
       nClsROC[3]++;
     };
 
-    chargeMaxROC[4].emplace_back(chargeTot);
-    mChargeMaxROC[4].emplace_back(chargeMax);
+    chargeTotROC[4].emplace_back(chargeTot);
+    chargeMaxROC[4].emplace_back(chargeMax);
 
     // for debugging
     if (mDebug) {
@@ -414,7 +414,7 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
 
     // fill subthreshold clusters if not excluded
     if (((clusterMask & ClusterFlags::ExcludeSubthresholdCl) == ClusterFlags::None)) {
-      fillMissingClusters(nClsSubThreshROC, minChargeTot, minChargeMax, subthresholdMethod, chargeMaxROC, mChargeMaxROC);
+      fillMissingClusters(nClsSubThreshROC, minChargeTot, minChargeMax, subthresholdMethod, chargeTotROC, chargeMaxROC);
     }
   } else {
     output.NHitsIROC = nClsROC[0];
@@ -424,21 +424,21 @@ void CalculatedEdx::calculatedEdx(o2::tpc::TrackTPC& track, dEdxInfo& output, fl
   }
 
   // copy corrected cluster charges
-  auto chargeTotVector = mDebug ? chargeMaxROC[4] : std::vector<float>();
-  auto chargeMaxVector = mDebug ? mChargeMaxROC[4] : std::vector<float>();
+  auto chargeTotVector = mDebug ? chargeTotROC[4] : std::vector<float>();
+  auto chargeMaxVector = mDebug ? chargeMaxROC[4] : std::vector<float>();
 
   // calculate dEdx
-  output.dEdxTotIROC = getTruncMean(chargeMaxROC[0], low, high);
-  output.dEdxTotOROC1 = getTruncMean(chargeMaxROC[1], low, high);
-  output.dEdxTotOROC2 = getTruncMean(chargeMaxROC[2], low, high);
-  output.dEdxTotOROC3 = getTruncMean(chargeMaxROC[3], low, high);
-  output.dEdxTotTPC = getTruncMean(chargeMaxROC[4], low, high);
+  output.dEdxTotIROC = getTruncMean(chargeTotROC[0], low, high);
+  output.dEdxTotOROC1 = getTruncMean(chargeTotROC[1], low, high);
+  output.dEdxTotOROC2 = getTruncMean(chargeTotROC[2], low, high);
+  output.dEdxTotOROC3 = getTruncMean(chargeTotROC[3], low, high);
+  output.dEdxTotTPC = getTruncMean(chargeTotROC[4], low, high);
 
-  output.dEdxMaxIROC = getTruncMean(mChargeMaxROC[0], low, high);
-  output.dEdxMaxOROC1 = getTruncMean(mChargeMaxROC[1], low, high);
-  output.dEdxMaxOROC2 = getTruncMean(mChargeMaxROC[2], low, high);
-  output.dEdxMaxOROC3 = getTruncMean(mChargeMaxROC[3], low, high);
-  output.dEdxMaxTPC = getTruncMean(mChargeMaxROC[4], low, high);
+  output.dEdxMaxIROC = getTruncMean(chargeMaxROC[0], low, high);
+  output.dEdxMaxOROC1 = getTruncMean(chargeMaxROC[1], low, high);
+  output.dEdxMaxOROC2 = getTruncMean(chargeMaxROC[2], low, high);
+  output.dEdxMaxOROC3 = getTruncMean(chargeMaxROC[3], low, high);
+  output.dEdxMaxTPC = getTruncMean(chargeMaxROC[4], low, high);
 
   // for debugging
   if (mDebug) {

--- a/Detectors/TPC/calibration/src/CalibratordEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalibratordEdx.cxx
@@ -40,7 +40,7 @@ void CalibratordEdx::finalizeSlot(Slot& slot)
 
   // compute calibration values from histograms
   CalibdEdx* container = slot.getContainer();
-  container->finalize();
+  container->finalize(mMakeGaussianFits);
   container->finalizeDebugOutput();
   mCalibs.push_back(container->getCalib());
 

--- a/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
@@ -69,6 +69,7 @@ class CalibratordEdxDevice : public Task
     const auto dumpData = ic.options().get<bool>("file-dump");
     const auto dumpHistograms = ic.options().get<uint32_t>("dump-histograms");
     const auto trackDebug = ic.options().get<bool>("track-debug");
+    const bool makeGaussianFits = !ic.options().get<bool>("disable-gaussian-fits");
 
     mCalibrator = std::make_unique<tpc::CalibratordEdx>();
     mCalibrator->setHistParams(dEdxBins, mindEdx, maxdEdx, angularBins, fitSnp);
@@ -82,6 +83,7 @@ class CalibratordEdxDevice : public Task
     mCalibrator->setMaterialType(mMatType);
     mCalibrator->setDumpHistograms(dumpHistograms);
     mCalibrator->setTrackDebug(trackDebug);
+    mCalibrator->setMakeGaussianFits(makeGaussianFits);
 
     if (dumpData) {
       const auto dumpDataName = ic.options().get<std::string>("file-dump-name");
@@ -218,8 +220,8 @@ DataProcessorSpec getCalibratordEdxSpec(const o2::base::Propagator::MatCorrType 
       {"fit-threshold", VariantType::Float, 0.2f, {"dEdx width around the MIP peak used in the fit"}},
       {"fit-threshold-low-factor", VariantType::Float, 1.5f, {"factor for low dEdx width around the MIP peak used in the fit"}},
 
-      {"dedxbins", VariantType::Int, 60, {"number of dEdx bins"}},
-      {"min-dedx", VariantType::Float, 20.0f, {"minimum value for dEdx histograms"}},
+      {"dedxbins", VariantType::Int, 70, {"number of dEdx bins"}},
+      {"min-dedx", VariantType::Float, 10.0f, {"minimum value for dEdx histograms"}},
       {"max-dedx", VariantType::Float, 90.0f, {"maximum value for dEdx histograms"}},
       {"angularbins", VariantType::Int, 36, {"number of angular bins: Tgl and Snp"}},
       {"fit-snp", VariantType::Bool, false, {"enable Snp correction"}},
@@ -228,6 +230,7 @@ DataProcessorSpec getCalibratordEdxSpec(const o2::base::Propagator::MatCorrType 
       {"file-dump", VariantType::Bool, false, {"directly dump calibration to file"}},
       {"file-dump-name", VariantType::String, "calibratordEdx.root", {"name of the file dump output file"}},
       {"track-debug", VariantType::Bool, false, {"track dEdx debugging"}},
+      {"disable-gaussian-fits", VariantType::Bool, false, {"disable calibration with gaussian fits and use mean instead"}},
     }};
 }
 

--- a/Detectors/TPC/workflow/src/MIPTrackFilterSpec.cxx
+++ b/Detectors/TPC/workflow/src/MIPTrackFilterSpec.cxx
@@ -163,9 +163,9 @@ DataProcessorSpec getMIPTrackFilterSpec()
     outputs,
     adaptFromTask<MIPTrackFilterDevice>(),
     Options{
-      {"min-momentum", VariantType::Double, 0.3, {"minimum momentum cut"}},
-      {"max-momentum", VariantType::Double, 0.7, {"maximum momentum cut"}},
-      {"min-dedx", VariantType::Double, 20., {"minimum dEdx cut"}},
+      {"min-momentum", VariantType::Double, 0.35, {"minimum momentum cut"}},
+      {"max-momentum", VariantType::Double, 0.55, {"maximum momentum cut"}},
+      {"min-dedx", VariantType::Double, 10., {"minimum dEdx cut"}},
       {"max-dedx", VariantType::Double, 200., {"maximum dEdx cut"}},
       {"min-clusters", VariantType::Int, 60, {"minimum number of clusters in a track"}},
       {"processEveryNthTF", VariantType::Int, 1, {"Using only a fraction of the data: 1: Use every TF, 10: Process only every tenth TF."}},


### PR DESCRIPTION
- setting tighter default momentum range for filtering MIPs to reject kaons and electrons

- adding option to write CalibdEdx to local file by converting the boost histogram to a ROOT histogram

- lowering minimum dEdx to 10 for better stabillity in A16

other changes:
- TPC: make calculation of dedx parallelisable