### PR TITLE
Improve MID reject list building

### DIFF
--- a/Detectors/MUON/MID/Calibration/macros/README.md
+++ b/Detectors/MUON/MID/Calibration/macros/README.md
@@ -60,6 +60,53 @@ root -l
 .x build_rejectlist.C+(1716436103391,1721272208000,"localhost:8083")
 ```
 
+### Add custom bad channels
+
+The macro `build_rejectlist.C` scans the QCDB and the CCDB in search of issues.
+However, the QCDB flag is based on local boards with empty signals.
+It can happen that a local board is problematic, but not completely dead and, therefore, it is not correctly spotted by the macro.
+It is therefore important to have a way to add the issues by hand.
+This can be done with a json file in the form:
+
+```json
+{
+    "startRun": 557251,
+    "endRun": 557926,
+    "rejectList": [
+        {
+            "deId": 4,
+            "columnId": 2,
+            "patterns": [
+                "0x0",
+                "0xFFFF",
+                "0x0",
+                "0x0",
+                "0x0"
+            ]
+        },
+        {
+            "deId": 13,
+            "columnId": 2,
+            "patterns": [
+                "0x0",
+                "0xFFFF",
+                "0x0",
+                "0x0",
+                "0x0"
+            ]
+        }
+    ]
+}
+```
+
+The path to the file is then given to the macro with:
+
+```shell
+.x build_rejectlist.C+(1726299038000,1727386238000,"http://localhost:8083","http://alice-ccdb.cern.ch","http://localhost:8080","rejectlist.json")
+```
+
+The macro will then merge the manual reject list from the file with the reject list that it finds by scanning the QCDB and CCDB.
+
 ## Running the local CCDB
 
 The local CCDB server can be easily built through alibuild.

--- a/Detectors/MUON/MID/Calibration/macros/build_rejectlist.C
+++ b/Detectors/MUON/MID/Calibration/macros/build_rejectlist.C
@@ -109,6 +109,12 @@ std::vector<long> findObjectsTSInPeriod(long start, long end, const o2::ccdb::Cc
 /// @return Pair with first and last time
 std::pair<uint64_t, uint64_t> findTSRange(TCanvas* qcQuality, bool selectBad = true)
 {
+  // Gets the plot with the quality flags
+  // The flag values are:
+  // Good: 3.5
+  // Medium: 2.5
+  // Bad: 1.5
+  // Null: 0.5
   auto* gr = static_cast<TGraph*>(qcQuality->GetListOfPrimitives()->FindObject("Graph"));
   double xp, yp;
   std::pair<uint64_t, uint64_t> range{std::numeric_limits<uint64_t>::max(), 0};
@@ -276,7 +282,7 @@ std::vector<o2::mid::ColumnData> build_rejectlist(long timestamp, const char* qc
   return build_rejectlist(timestamp, qcdbApi, ccdbApi, outCCDBApi);
 }
 
-/// @brief Builds the reject list iin a time range
+/// @brief Builds the reject list in a time range
 /// @param start Start time for query
 /// @param end End time for query
 /// @param qcdbUrl QCDB URL


### PR DESCRIPTION
The reject list is built from the info available on the QC.
However, sometimes not all issues can be spotted in an automatic way. We thereofore introduced the possibility to manually specify problematic channels to be masked.
This PR also include some minor fix of typos and further explanation comments.
The commits are meant to be atomic: please do not merge.