### PR TITLE
DPL Analysis: fix missing connection to the grid

### DIFF
--- a/Framework/AnalysisSupport/src/Plugin.cxx
+++ b/Framework/AnalysisSupport/src/Plugin.cxx
@@ -175,6 +175,10 @@ struct DiscoverMetadataInAOD : o2::framework::ConfigDiscoveryPlugin {
             }
           }
 
+          if (parentFilename.starts_with("alien://")) {
+            TGrid::Connect("alien://");
+          }
+
           std::unique_ptr<TFile> parentFile{TFile::Open(parentFilename.c_str())};
           if (parentFile.get() == nullptr) {
             LOGP(fatal, "Couldn't open derived file \"{}\"!", parentFilename);


### PR DESCRIPTION

It's not a given that parent files and the original data are
on the same support, so we need to connect to the grid if needed.
