### PR TITLE
DPL: account for aod-parent-access-level == 0

### DIFF
--- a/Framework/AnalysisSupport/src/Plugin.cxx
+++ b/Framework/AnalysisSupport/src/Plugin.cxx
@@ -150,13 +150,20 @@ struct DiscoverMetadataInAOD : o2::framework::ConfigDiscoveryPlugin {
           return results;
         }
 
-        // Lets try in parent files
+        if (!registry.isSet("aod-parent-access-level") || registry.get<int>("aod-parent-access-level") == 0) {
+          LOGP(info, "No metadata found in file \"{}\" and parent level 0 prevents further lookup.", filename);
+          results.push_back(ConfigParamSpec{"aod-metadata-disable", VariantType::String, "1", {"Metadata not found in AOD"}});
+          return results;
+        }
+
+        // Lets try in parent file.
         auto parentFiles = (TMap*)currentFile->Get("parentFiles");
         if (!parentFiles) {
           LOGP(info, "No metadata found in file \"{}\"", filename);
           results.push_back(ConfigParamSpec{"aod-metadata-disable", VariantType::String, "1", {"Metadata not found in AOD"}});
           return results;
         }
+        LOGP(info, "No metadata found in file \"{}\", checking in its parents.", filename);
         for (auto* p : *parentFiles) {
           std::string parentFilename = ((TPair*)p)->Value()->GetName();
           // Do the replacement. Notice this will require changing aod-parent-base-path-replacement to be

--- a/Framework/Core/src/Plugin.cxx
+++ b/Framework/Core/src/Plugin.cxx
@@ -141,7 +141,7 @@ struct DiscoverAODOptionsInCommandLine : o2::framework::ConfigDiscoveryPlugin {
         bool injectOption = true;
         for (size_t i = 0; i < argc; i++) {
           std::string_view arg = argv[i];
-          if (!arg.starts_with("--aod-writer-") && arg != "--aod-parent-base-path-replacement") {
+          if (!arg.starts_with("--aod-writer-") && !arg.starts_with("--aod-parent-")) {
             continue;
           }
           std::string key = arg.data() + 2;
@@ -155,6 +155,9 @@ struct DiscoverAODOptionsInCommandLine : o2::framework::ConfigDiscoveryPlugin {
           }
           if (key == "aod-parent-base-path-replacement") {
             results.push_back(ConfigParamSpec{"aod-parent-base-path-replacement", VariantType::String, value, {R"(Replace base path of parent files. Syntax: FROM;TO. E.g. "alien:///path/in/alien;/local/path". Enclose in "" on the command line.)"}});
+          }
+          if (key == "aod-parent-access-level") {
+            results.push_back(ConfigParamSpec{"aod-parent-access-level", VariantType::String, value, {"Allow parent file access up to specified level. Default: no (0)"}});
           }
         }
         if (injectOption) {

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -216,7 +216,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     .options = {ConfigParamSpec{"aod-file-private", VariantType::String, ctx.options().get<std::string>("aod-file"), {"AOD file"}},
                 ConfigParamSpec{"aod-max-io-rate", VariantType::Float, 0.f, {"Maximum I/O rate in MB/s"}},
                 ConfigParamSpec{"aod-reader-json", VariantType::String, {"json configuration file"}},
-                ConfigParamSpec{"aod-parent-access-level", VariantType::String, {"Allow parent file access up to specified level. Default: no (0)"}},
                 ConfigParamSpec{"time-limit", VariantType::Int64, 0ll, {"Maximum run time limit in seconds"}},
                 ConfigParamSpec{"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
                 ConfigParamSpec{"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},


### PR DESCRIPTION

In the case of self contained derived data, it is ok not to look in the parents
for missing metadata.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/13670).
* #13671
* __->__ #13670