### PR TITLE
Digicontext: Several improvements

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -83,6 +83,7 @@ struct SimConfigData {
   bool mNoGeant = false;                              // if Geant transport should be turned off (when one is only interested in the generated events)
   bool mIsUpgrade = false;                            // true if the simulation is for Run 5
   std::string mFromCollisionContext = "";             // string denoting a collision context file; If given, this file will be used to determine number of events
+                                                      //
   bool mForwardKine = false;                          // true if tracks and event headers are to be published on a FairMQ channel (for reading by other consumers)
   bool mWriteToDisc = true;                           // whether we write simulation products (kine, hits) to disc
   VertexMode mVertexMode = VertexMode::kDiamondParam; // by default we should use die InteractionDiamond parameter
@@ -176,6 +177,10 @@ class SimConfig
   bool forwardKine() const { return mConfigData.mForwardKine; }
   bool writeToDisc() const { return mConfigData.mWriteToDisc; }
   VertexMode getVertexMode() const { return mConfigData.mVertexMode; }
+
+  // returns the pair of collision context filename as well as event prefix encoded
+  // in the mFromCollisionContext string. Returns empty string if information is not available or set.
+  std::pair<std::string, std::string> getCollContextFilenameAndEventPrefix() const;
 
  private:
   SimConfigData mConfigData; //!

--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -578,5 +578,7 @@ DigitizationContext DigitizationContext::extractSingleTimeframe(int timeframeid,
   } catch (std::exception) {
     LOG(warn) << "No such timeframe id in collision context. Returing empty object";
   }
+  // fix number of collisions
+  r.setNCollisions(r.mEventRecords.size());
   return r;
 }

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -138,7 +138,8 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     mPrimGen->SetEvent(&mEventHeader);
 
     // A good moment to couple to collision context
-    auto collContextFileName = mSimConfig.getConfigData().mFromCollisionContext;
+    auto collContextFileName_PrefixPair = mSimConfig.getCollContextFilenameAndEventPrefix();
+    auto collContextFileName = collContextFileName_PrefixPair.first;
     if (collContextFileName.size() > 0) {
       LOG(info) << "Simulation has collission context";
       mCollissionContext = o2::steer::DigitizationContext::loadFromFile(collContextFileName);
@@ -147,7 +148,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
         LOG(info) << "We found " << vertices.size() << " vertices included ";
 
         // initialize the eventID to collID mapping
-        const auto source = mCollissionContext->findSimPrefix(mSimConfig.getOutPrefix());
+        const auto source = mCollissionContext->findSimPrefix(collContextFileName_PrefixPair.second);
         if (source == -1) {
           LOG(fatal) << "Wrong simulation prefix";
         }


### PR DESCRIPTION
Work needed for restructuring O2DPG MC workflows towards the use of a globally pre-generated collision context.

* fixes for picking up vertices from collision contexts
* possibility to generate vertices in CollContextTool from CCDB entry
* smaller cleanup

relates to https://its.cern.ch/jira/browse/O2-3622