### PR TITLE
DPL: enable the plugin for any parent option

### DIFF
--- a/Framework/Core/src/Plugin.cxx
+++ b/Framework/Core/src/Plugin.cxx
@@ -57,7 +57,7 @@ auto lookForCommandLineAODOptions = [](ConfigParamRegistry& registry, int argc, 
       O2_SIGNPOST_EVENT_EMIT(capabilities, sid, "DiscoverAODOptionsInCommandLineCapability", "AOD options found in arguments. Populating from them.");
       return true;
     }
-    if (arg.starts_with("--aod-parent-base-path-replacement")) {
+    if (arg.starts_with("--aod-parent-")) {
       O2_SIGNPOST_EVENT_EMIT(capabilities, sid, "DiscoverAODOptionsInCommandLineCapability", "AOD options found in arguments. Populating from them.");
       return true;
     }


### PR DESCRIPTION

If we read metadata from parents, we might be affecting the workflow generation,
therefore we must consider all the parent affecting options as workflow ones.
