### PR TITLE
Proper display / filtering of ROOT log messages from stderr in terminal output and InfoLogger

### DIFF
--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -45,6 +45,8 @@ struct DeviceInfo {
   size_t historySize;
   /// The maximum log level ever seen by this device
   LogParsingHelpers::LogLevel maxLogLevel;
+  /// The minimum log level for log messages sent/displayed by this device
+  LogParsingHelpers::LogLevel logLevel{LogParsingHelpers::LogLevel::Info};
 
   /// The minimum level after which the device will exit with 0
   LogParsingHelpers::LogLevel minFailureLevel;

--- a/Framework/Core/src/LogParsingHelpers.cxx
+++ b/Framework/Core/src/LogParsingHelpers.cxx
@@ -30,7 +30,7 @@ LogLevel LogParsingHelpers::parseTokenLevel(std::string_view const s)
   // Example format: [99:99:99][ERROR] (string begins with that, longest is 17 chars)
   constexpr size_t MAXPREFLEN = 17;
   constexpr size_t LABELPOS = 10;
-  if (s.size() < MAXPREFLEN) {
+  if (s.size() < MAXPREFLEN && s.find("*** Break ***") == std::string::npos && !s.starts_with("[INFO]")) {
     return LogLevel::Unknown;
   }
 
@@ -41,7 +41,17 @@ LogLevel LogParsingHelpers::parseTokenLevel(std::string_view const s)
       (unsigned char)s[1] - '0' > 9 || (unsigned char)s[2] - '0' > 9 ||
       (unsigned char)s[4] - '0' > 9 || (unsigned char)s[5] - '0' > 9 ||
       (unsigned char)s[7] - '0' > 9 || (unsigned char)s[8] - '0' > 9) {
-    return LogLevel::Unknown;
+    if (s.starts_with("Info in <") || s.starts_with("Print in <") || s.starts_with("[INFO]")) {
+      return LogLevel::Info;
+    } else if (s.starts_with("Warning in <")) {
+      return LogLevel::Warning;
+    } else if (s.find("Error in <") != std::string::npos) {
+      return LogLevel::Error;
+    } else if (s.starts_with("Fatal in <") || s.find("*** Break ***") != std::string::npos) {
+      return LogLevel::Fatal;
+    } else {
+      return LogLevel::Unknown;
+    }
   }
 
   if (s.compare(LABELPOS, 8, "[DEBUG] ") == 0) {

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -142,24 +142,6 @@ void displayHistory(const DeviceInfo& info, DeviceControl& control)
     auto& line = info.history[ji];
     auto logLevel = info.historyLevel[ji];
 
-    // assign proper loglevel to ROOT log messages from stderr
-    auto getLogLevelUnknown = [&line]() -> LogParsingHelpers::LogLevel {
-      if (line.starts_with("Print in") || line.starts_with("Info in") || line.starts_with("[INFO]")) {
-        return LogParsingHelpers::LogLevel::Info;
-      } else if (line.starts_with("Warning in")) {
-        return LogParsingHelpers::LogLevel::Warning;
-      } else if (line.starts_with("Error in") || line.starts_with("SysError in")) {
-        return LogParsingHelpers::LogLevel::Error;
-      } else if (line.starts_with("Fatal in") || line.starts_with("*** Break ***")) {
-        return LogParsingHelpers::LogLevel::Fatal;
-      } else {
-        return LogParsingHelpers::LogLevel::Unknown;
-      }
-    };
-    if (logLevel == LogParsingHelpers::LogLevel::Unknown) {
-      logLevel = getLogLevelUnknown();
-    }
-
     // Skip empty lines
     if (line.empty()) {
       ji = (ji + 1) % historySize;


### PR DESCRIPTION
Applying the same logic for the terminal/GUI output and the InfoLogger.

For the terminal output, there is a new `logLevel` variable in the `DeviceInfo` which is initialized to the severity level of the device from the command line or to `Info` by default. This variable is independent of the `DeviceControl::logLevel` and it replaces the `DeviceControl::logLevel` to determine which logs are printed in the terminal. Like this, the `DeviceControl::logLevel` only sets the severity of the logs displayed in the GUI itself.