### PR TITLE
TRD add less than operator to Tracklet64 to permit std::merge usage

### DIFF
--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -40,6 +40,16 @@ std::ostream& operator<<(std::ostream& stream, const Tracklet64& trg)
   trg.printStream(stream);
   return stream;
 }
+
+bool operator<(const Tracklet64& lhs, const Tracklet64& rhs)
+{
+  return (lhs.getDetector() < rhs.getDetector()) ||
+         (lhs.getDetector() == rhs.getDetector() && lhs.getROB() < rhs.getROB()) ||
+         (lhs.getDetector() == rhs.getDetector() && lhs.getROB() == rhs.getROB() && lhs.getMCM() < rhs.getMCM()) ||
+         (lhs.getDetector() == rhs.getDetector() && lhs.getROB() == rhs.getROB() && lhs.getMCM() == rhs.getMCM() && lhs.getPadRow() < rhs.getPadRow()) ||
+         (lhs.getDetector() == rhs.getDetector() && lhs.getROB() == rhs.getROB() && lhs.getMCM() == rhs.getMCM() && lhs.getPadRow() == rhs.getPadRow() && lhs.getPadCol() < rhs.getPadCol());
+}
+
 #endif // GPUCA_GPUCODE_DEVICE
 
 } // namespace trd


### PR DESCRIPTION
This permits tracklets to be used in std::merge to sort out the missing tracklets between sim and online.
Once merged, sim tracklets have headers of different formats, so they are trivially discernable.