### PR TITLE
HBFUtils: Optional throw on failed parsing of opt

### DIFF
--- a/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
@@ -64,7 +64,7 @@ struct HBFUtilsInitializer {
   static o2::dataformats::IRFrame IRFrameSel; // IRFrame selected for the current TF
 
   HBFUtilsInitializer(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& wf);
-  static HBFOpt getOptType(const std::string& optString);
+  static HBFOpt getOptType(const std::string& optString, bool throwOnFailure = true);
   static std::vector<o2::dataformats::TFIDInfo> readTFIDInfoVector(const std::string& fname);
   static void readIRFramesVector(const std::string& fname);
   static void assignDataHeaderFromTFIDInfo(const std::vector<o2::dataformats::TFIDInfo>& tfinfoVec, o2::header::DataHeader& dh, o2::framework::DataProcessingHeader& dph);

--- a/Detectors/Raw/src/HBFUtilsInitializer.cxx
+++ b/Detectors/Raw/src/HBFUtilsInitializer.cxx
@@ -65,7 +65,7 @@ HBFUtilsInitializer::HBFUtilsInitializer(const o2f::ConfigContext& configcontext
             upstream = true;
             continue;
           }
-          HBFOpt opt = getOptType(optStr);
+          HBFOpt opt = getOptType(optStr, !helpasked); // do not throw on unknown opt if help-opt was given
           nopts++;
           if ((opt == HBFOpt::INI || opt == HBFOpt::JSON) && !helpasked) {
             o2::conf::ConfigurableParam::updateFromFile(optStr, "HBFUtils", true); // update only those values which were not touched yet (provenance == kCODE)
@@ -78,8 +78,6 @@ HBFUtilsInitializer::HBFUtilsInitializer(const o2f::ConfigContext& configcontext
             hbfuInput = optStr;
           } else if (opt == HBFOpt::ROOT) {
             rootFileInput = optStr;
-          } else if (!helpasked) {
-            LOGP(fatal, "uknown hbfutils-config option {}", optStr);
           }
         }
         if (!nopts && !helpasked) {
@@ -125,7 +123,7 @@ HBFUtilsInitializer::HBFUtilsInitializer(const o2f::ConfigContext& configcontext
 }
 
 //_________________________________________________________
-HBFUtilsInitializer::HBFOpt HBFUtilsInitializer::getOptType(const std::string& optString)
+HBFUtilsInitializer::HBFOpt HBFUtilsInitializer::getOptType(const std::string& optString, bool throwOnFailure)
 {
   // return type of the file provided via HBFConfOpt
   HBFOpt opt = HBFOpt::NONE;
@@ -138,7 +136,7 @@ HBFUtilsInitializer::HBFOpt HBFUtilsInitializer::getOptType(const std::string& o
       opt = HBFOpt::ROOT;
     } else if (optString == HBFUSrc) {
       opt = HBFOpt::HBFUTILS;
-    } else if (optString != "none") {
+    } else if (optString != "none" && throwOnFailure) {
       throw std::runtime_error(fmt::format("invalid option {} for {}", optString, HBFConfOpt));
     }
   }


### PR DESCRIPTION

This moves the logic of throwing (now optionally) on parsing an unknown opt to the getOptType function.
When help-opt was given this, does not throw.
This also fixed the use of ’--hbfutils-config none’.
