### PR TITLE
CollisionContextTool: different QED printing

### DIFF
--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -49,6 +49,27 @@ void DigitizationContext::printCollisionSummary(bool withQED, int truncateOutput
     }
   } else {
     std::cout << "Number of Collisions " << mEventRecords.size() << "\n";
+    if (mEventPartsWithQED.size() > 0) {
+      auto num_qed_events = mEventPartsWithQED.size() - mEventRecords.size();
+      if (num_qed_events > 0) {
+        std::cout << "Number of QED events (but not shown) " << num_qed_events << "\n";
+        // find first and last QED collision so that we can give the range in orbits where these
+        // things are included
+        auto firstQEDcoll_iter = std::find_if(mEventPartsWithQED.begin(), mEventPartsWithQED.end(),
+                                              [](const std::vector<EventPart>& vec) {
+                                                return std::find_if(vec.begin(), vec.end(), [](EventPart const& p) { return p.sourceID == 99; }) != vec.end();
+                                              });
+
+        auto lastColl_iter = std::find_if(mEventPartsWithQED.rbegin(), mEventPartsWithQED.rend(),
+                                          [](const std::vector<EventPart>& vec) {
+                                            return std::find_if(vec.begin(), vec.end(), [](EventPart const& p) { return p.sourceID == 99; }) != vec.end();
+                                          });
+
+        auto firstindex = std::distance(mEventPartsWithQED.begin(), firstQEDcoll_iter);
+        auto lastindex = std::distance(mEventPartsWithQED.begin(), lastColl_iter.base()) - 1;
+        std::cout << "QED from: " << mEventRecordsWithQED[firstindex] << " ---> " << mEventRecordsWithQED[lastindex] << "\n";
+      }
+    }
     for (int i = 0; i < mEventRecords.size(); ++i) {
       if (truncateOutputTo >= 0 && i > truncateOutputTo) {
         std::cout << "--- Output truncated to " << truncateOutputTo << " ---\n";

--- a/Steer/src/CollisionContextTool.cxx
+++ b/Steer/src/CollisionContextTool.cxx
@@ -456,7 +456,7 @@ int main(int argc, char* argv[])
   // <---- at this moment we have a dense collision context (not representing the final output we want)
   LOG(info) << "<<------ DENSE CONTEXT ---------";
   if (options.printContext) {
-    digicontext.printCollisionSummary(options.qedInteraction.size() > 0);
+    digicontext.printCollisionSummary();
   }
   LOG(info) << "-------- DENSE CONTEXT ------->>";
 
@@ -467,7 +467,7 @@ int main(int argc, char* argv[])
   // <---- at this moment we have a dense collision context (not representing the final output we want)
   LOG(info) << "<<------ FILTERED CONTEXT ---------";
   if (options.printContext) {
-    digicontext.printCollisionSummary(options.qedInteraction.size() > 0);
+    digicontext.printCollisionSummary();
   }
   LOG(info) << "-------- FILTERED CONTEXT ------->>";
 
@@ -510,7 +510,7 @@ int main(int argc, char* argv[])
   }
 
   if (options.printContext) {
-    digicontext.printCollisionSummary(options.qedInteraction.size() > 0);
+    digicontext.printCollisionSummary();
   }
   digicontext.saveToFile(options.outfilename);
 
@@ -578,7 +578,7 @@ int main(int argc, char* argv[])
         str << path_prefix << tf_output_counter++ << "/collisioncontext.root";
         copy.saveToFile(str.str());
         LOG(info) << "----";
-        copy.printCollisionSummary(options.qedInteraction.size() > 0);
+        copy.printCollisionSummary();
       }
     }
   }


### PR DESCRIPTION
No longer print all QED interactions (may be too long). Rather, give a short summary of QED stats.