### PR TITLE
Protect its/mft decoder agains decreasing row in the same column

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -68,6 +68,7 @@ struct ChipStat {
     FlushedIncomplete,                // ALPIDE MEB was flushed by the busy handling
     StrobeExtended,                   // ALPIDE received a second trigger while the strobe was still open
     WrongAlpideChipID,                // Impossible for given cable ALPIDE ChipOnModule ID
+    DecreasingRow,                    // Decreasing row in the same column
     NErrorsDefined
   };
 
@@ -106,6 +107,7 @@ struct ChipStat {
     "FlushedIncomplete",                            // ALPIDE MEB was flushed by the busy handling
     "StrobeExtended",                               // ALPIDE received a second trigger while the strobe was still open
     "Wrong Alpide ChipID",                          // Impossible for given cable ALPIDE ChipOnModule ID
+    "Decreasing row",                               // Decreasing row in the same column
   };
 
   static constexpr std::array<uint32_t, NErrorsDefined> ErrActions = {
@@ -143,6 +145,7 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // ALPIDE MEB was flushed by the busy handling
     ErrActPropagate | ErrActDump, // ALPIDE received a second trigger while the strobe was still open
     ErrActPropagate | ErrActDump, // Impossible for given cable ALPIDE ChipOnModule ID
+    ErrActPropagate | ErrActDump, // Decreasing row in the same column
   };
   uint16_t feeID = -1;
   size_t nHits = 0;


### PR DESCRIPTION
Discard cable data if this happens. A new error ChipPixelData::DecreasingRow is added.
This PR supersedes https://github.com/AliceO2Group/AliceO2/pull/13715.