### PR TITLE
Fix for failing dataflow build

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -24,8 +24,6 @@ o2_add_library(Generators
                        src/GeneratorTGenerator.cxx
                        src/GeneratorExternalParam.cxx
                        src/GeneratorFromFile.cxx
-                       src/GeneratorHybrid.cxx
-                       src/GeneratorHybridParam.cxx
                        src/GeneratorFromO2KineParam.cxx
                        src/GeneratorFileOrCmd.cxx
                        src/GeneratorFileOrCmdParam.cxx
@@ -50,6 +48,8 @@ o2_add_library(Generators
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMC.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMCParam.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/AODToHepMC.cxx>
+                       $<$<AND:$<BOOL:${pythia_FOUND}>,$<BOOL:${HepMC3_FOUND}>>:src/GeneratorHybrid.cxx>
+                       $<$<AND:$<BOOL:${pythia_FOUND}>,$<BOOL:${HepMC3_FOUND}>>:src/GeneratorHybridParam.cxx>
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils O2::DetectorsBase O2::ZDCBase
                                      O2::SimulationDataFormat ${pythiaTarget} ${hepmcTarget}
                                      FairRoot::Gen
@@ -70,8 +70,6 @@ set(headers
     include/Generators/GeneratorTGenerator.h
     include/Generators/GeneratorExternalParam.h
     include/Generators/GeneratorFromFile.h
-    include/Generators/GeneratorHybrid.h
-    include/Generators/GeneratorHybridParam.h
     include/Generators/GeneratorFromO2KineParam.h
     include/Generators/GeneratorFileOrCmd.h
     include/Generators/GeneratorFileOrCmdParam.h
@@ -102,6 +100,11 @@ endif()
 if(HepMC3_FOUND)
   list(APPEND headers include/Generators/GeneratorHepMC.h)
   list(APPEND headers include/Generators/GeneratorHepMCParam.h)
+endif()
+
+if(pythia_FOUND AND HepMC3_FOUND)
+  list(APPEND headers include/Generators/GeneratorHybrid.h)
+  list(APPEND headers include/Generators/GeneratorHybridParam.h)
 endif()
 
 o2_target_root_dictionary(Generators HEADERS ${headers})

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -18,7 +18,6 @@
 #include <fairlogger/Logger.h>
 #include <SimConfig/SimConfig.h>
 #include <Generators/GeneratorFromFile.h>
-#include <Generators/GeneratorHybrid.h>
 #include <Generators/GeneratorTParticle.h>
 #include <Generators/GeneratorTParticleParam.h>
 #ifdef GENERATORS_WITH_PYTHIA8
@@ -27,11 +26,14 @@
 #endif
 #include <Generators/GeneratorTGenerator.h>
 #include <Generators/GeneratorExternalParam.h>
-#include <Generators/GeneratorHybridParam.h>
 #include "Generators/GeneratorFromO2KineParam.h"
 #ifdef GENERATORS_WITH_HEPMC3
 #include <Generators/GeneratorHepMC.h>
 #include <Generators/GeneratorHepMCParam.h>
+#endif
+#if defined(GENERATORS_WITH_PYTHIA8) && defined(GENERATORS_WITH_HEPMC3)
+#include <Generators/GeneratorHybrid.h>
+#include <Generators/GeneratorHybridParam.h>
 #endif
 #include <Generators/PrimaryGenerator.h>
 #include <Generators/BoxGunParam.h>
@@ -260,6 +262,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
         primGen->AddGenerator(boxGen);
       }
     }
+#if defined(GENERATORS_WITH_PYTHIA8) && defined(GENERATORS_WITH_HEPMC3)
   } else if (genconfig.compare("hybrid") == 0) { // hybrid using multiple generators
     LOG(info) << "Init hybrid generator";
     auto& hybridparam = GeneratorHybridParam::Instance();
@@ -276,6 +279,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     }
     auto hybrid = new o2::eventgen::GeneratorHybrid(config);
     primGen->AddGenerator(hybrid);
+#endif
   } else {
     LOG(fatal) << "Invalid generator";
   }

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -52,10 +52,12 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::DecayerPythia8Param> + ;
 #pragma link C++ class o2::eventgen::GeneratorFactory + ;
 #endif
-#pragma link C++ class o2::eventgen::GeneratorFromFile + ;
-#pragma link C++ class o2::eventgen::GeneratorFromO2Kine + ;
+#if defined(GENERATORS_WITH_PYTHIA8) && defined(GENERATORS_WITH_HEPMC3)
 #pragma link C++ class o2::eventgen::GeneratorHybrid + ;
 #pragma link C++ class o2::eventgen::GeneratorHybridParam + ;
+#endif
+#pragma link C++ class o2::eventgen::GeneratorFromFile + ;
+#pragma link C++ class o2::eventgen::GeneratorFromO2Kine + ;
 #pragma link C++ class o2::eventgen::GeneratorFromO2KineParam + ;
 #pragma link C++ class o2::eventgen::O2KineGenConfig + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorFromO2KineParam> + ;


### PR DESCRIPTION
Hybrid generator includes Pythia8, so when the dataflow build happens, without this fix, the Pythia8 header is loaded. It's not found due to the nature of the dataflow build. This fix prevents the Hybrid generator loading if Pythia8 is not found and it includes also HepMC3, given that a similar issue might arise with that generator as well in the future.