### PR TITLE
Fix GeneratorPythia8 construction

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -90,7 +90,7 @@ class GeneratorPythia8 : public Generator
   /** default constructor **/
   GeneratorPythia8();
   /** constructor **/
-  GeneratorPythia8(Pythia8GenConfig const& pars);
+  GeneratorPythia8(Pythia8GenConfig const&);
   /** constructor **/
   GeneratorPythia8(const Char_t* name, const Char_t* title = "ALICEo2 Pythia8 Generator");
   /** destructor **/
@@ -285,7 +285,7 @@ class GeneratorPythia8 : public Generator
   long mInitialRNGSeed = -1;   // initial seed for Pythia random number state;
                                // will be transported to Pythia in the Init function through the Pythia::readString("Random:seed") mechanism.
                                // Value of -1 means unitialized; 0 will be time-dependent and values >1 <= MAX_SEED concrete reproducible seeding
-  std::unique_ptr<Pythia8GenConfig> mGenConfig; // configuration object
+  Pythia8GenConfig mGenConfig; // configuration object
 
   constexpr static long MAX_SEED = 900000000;
 


### PR DESCRIPTION
Fixes smaller issues introduced with the hybrid generator refactoring:

- Make sure that internal configuration object is never null; In fact, it does not need to be a pointer.

- Make sure the internal configuration struct is initialized from the GeneratorPythia8Param configurable when using the default constructor.

This commit fixes an issue/segfault when running the following command

o2-sim-dpl-eventgen --generator external --nEvents 200 --aggregate-timeframe 10000 --configFile ${O2DPG_ROOT}/MC/config/ALICE3/ini/pythia8_pp_136tev.ini -b

(which defaults constructs a Pythia8 generator)