### PR TITLE
[MCH] change Mathieson K3xy

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/ResponseParam.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/ResponseParam.h
@@ -30,11 +30,11 @@ struct ResponseParam : public o2::conf::ConfigurableParamHelper<ResponseParam> {
   float pitchSt1 = 0.21;    ///< anode-cathode pitch (cm) for station 1
   float pitchSt2345 = 0.25; ///< anode-cathode pitch (cm) for station 2 to 5
 
-  float mathiesonSqrtKx3St1 = 0.7000;    ///< Mathieson parameter sqrt(K3) in x direction for station 1
-  float mathiesonSqrtKx3St2345 = 0.7131; ///< Mathieson parameter sqrt(K3) in x direction for station 2 to 5
+  float mathiesonSqrtKx3St1 = 0.5477;    ///< Mathieson parameter sqrt(K3) in x direction for station 1
+  float mathiesonSqrtKx3St2345 = 0.5477; ///< Mathieson parameter sqrt(K3) in x direction for station 2 to 5
 
-  float mathiesonSqrtKy3St1 = 0.7550;    ///< Mathieson parameter sqrt(K3) in y direction for station 1
-  float mathiesonSqrtKy3St2345 = 0.7642; ///< Mathieson parameter sqrt(K3) in y direction for station 2 to 5
+  float mathiesonSqrtKy3St1 = 0.5477;    ///< Mathieson parameter sqrt(K3) in y direction for station 1
+  float mathiesonSqrtKy3St2345 = 0.5477; ///< Mathieson parameter sqrt(K3) in y direction for station 2 to 5
 
   float chargeSlopeSt1 = 25.;    ///< charge slope used in E to charge conversion for station 1
   float chargeSlopeSt2345 = 10.; ///< charge slope used in E to charge conversion for station 2 to 5


### PR DESCRIPTION
Change the Mathieson K3x and K3y parameters for all chambers to match the cluster shape measured in run3 data.
This applies to both the clustering and the simulation of the chamber response.