### PR TITLE
GPU TPC: Fix TPC clusterizer qMax cut

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.cxx
@@ -27,6 +27,10 @@ GPUd() bool ClusterAccumulator::toNative(const ChargePos& pos, Charge q, tpc::Cl
   if (cn.qTot <= param.rec.tpc.cfQTotCutoff) {
     return false;
   }
+  cn.qMax = q;
+  if (cn.qMax <= param.rec.tpc.cfQMaxCutoff) {
+    return false;
+  }
   if (mTimeMean < param.rec.tpc.clustersShiftTimebinsClusterizer) {
     return false;
   }
@@ -48,7 +52,6 @@ GPUd() bool ClusterAccumulator::toNative(const ChargePos& pos, Charge q, tpc::Cl
   flags |= (wasSplitInPad) ? tpc::ClusterNative::flagSplitPad : 0;
   flags |= (isSingleCluster) ? tpc::ClusterNative::flagSingle : 0;
 
-  cn.qMax = q;
   cn.setTimeFlags(mTimeMean - param.rec.tpc.clustersShiftTimebinsClusterizer, flags);
   cn.setPad(mPadMean);
   cn.setSigmaTime(mTimeSigma);


### PR DESCRIPTION
Checking stored CTFs, I saw that we have clusters with qMax = 3, while we process with `cfQMaxCutoff = 3`, which should cut away `qMax <= 3`. I ran some local tests processing raw data, and I see that indeed the clusterizer produces clusters with `qMax = 3`, while the cut seems to be correct: https://github.com/AliceO2Group/AliceO2/blob/f76f1a70c5664e4f8ed9219a067aaee0a2258378/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx#L45

Perhaps this is related to charge splitting between clusters? In any case, this PR fixes it by having a posterior cut on the qMax when the cluster is stored.

@fweig : Could you have a look and comment what happens in the clusterizer?