### PR TITLE
Disable trackref assert

### DIFF
--- a/run/checkStack.cxx
+++ b/run/checkStack.cxx
@@ -142,10 +142,10 @@ int main(int argc, char** argv)
     bool havereferences = trackrefs->size();
     if (havereferences) {
       for (auto& trackID : trackidsinTPC) {
-        auto trackrefs = mcreader.getTrackRefs(eventID, trackID);
-        LOG(debug) << " Track " << trackID << " has " << trackrefs.size() << " TrackRefs";
-        assert(trackrefs.size() > 0);
-        for (auto& ref : trackrefs) {
+        auto tpc_trackrefs = mcreader.getTrackRefs(eventID, trackID);
+        LOG(debug) << " Track " << trackID << " has " << tpc_trackrefs.size() << " TrackRefs";
+        // assert(tpc_trackrefs.size() > 0);
+        for (auto& ref : tpc_trackrefs) {
           assert(ref.getTrackID() == trackID);
         }
       }


### PR DESCRIPTION
This test is currently failing and disrupting the CI in Geant3 kinematics checks. Disabling the assert on trackrefs for now. Will investigate the cause offline.

Also renaming the variable to avoid shadowing an outer-scope variable.