### PR TITLE
TPC MC: Move hit exlusion after Track Ref creation

### DIFF
--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -153,6 +153,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
   if (fMC->IsTrackEntering() || fMC->IsTrackExiting()) {
     stack->addTrackReference(o2::TrackReference(position.X(), position.Y(), position.Z(), momentum.X(), momentum.Y(),
                                                 momentum.Z(), fMC->TrackLength(), time, trackID, GetDetId()));
+    lastReferenceR = fMC->TrackLength();
   }
   if (TMath::Abs(lastReferenceR - fMC->TrackLength()) > kMaxDistRef) { /// we can speedup
     stack->addTrackReference(o2::TrackReference(position.X(), position.Y(), position.Z(), momentum.X(), momentum.Y(),


### PR DESCRIPTION
It can happen that after including the exclusion of hits between the field cage vessel and strips that no track refs are created.
Move the exclusion of hist after the track refs creation.