### PR TITLE
Optionally select CTFs in timestamps or orbits range

### DIFF
--- a/Common/Utils/include/CommonUtils/IRFrameSelector.h
+++ b/Common/Utils/include/CommonUtils/IRFrameSelector.h
@@ -46,6 +46,8 @@ class IRFrameSelector
   auto getIRFrames() const { return mFrames; }
   bool isSet() const { return mIsSet; }
 
+  void setOwnList(const std::vector<o2::dataformats::IRFrame>& lst, bool toBeSorted);
+
  private:
   gsl::span<const o2::dataformats::IRFrame> mFrames{}; // externally provided span of IRFrames, must be sorted in IRFrame.getMin()
   o2::dataformats::IRFrame mLastIRFrameChecked{};      // last frame which was checked

--- a/Common/Utils/src/IRFrameSelector.cxx
+++ b/Common/Utils/src/IRFrameSelector.cxx
@@ -167,6 +167,16 @@ size_t IRFrameSelector::loadIRFrames(const std::string& fname)
   return mOwnList.size();
 }
 
+void IRFrameSelector::setOwnList(const std::vector<o2::dataformats::IRFrame>& lst, bool toBeSorted)
+{
+  clear();
+  mOwnList.insert(mOwnList.end(), lst.begin(), lst.end());
+  if (toBeSorted) {
+    std::sort(mOwnList.begin(), mOwnList.end(), [](const auto& a, const auto& b) { return a.getMin() < b.getMin(); });
+  }
+  setSelectedIRFrames(mOwnList, 0, 0, 0, false);
+}
+
 void IRFrameSelector::print(bool lst) const
 {
   LOGP(info, "Last query stopped at entry {} for IRFrame {}:{}", mLastBoundID,
@@ -183,6 +193,8 @@ void IRFrameSelector::clear()
 {
   mIsSet = false;
   mOwnList.clear();
+  mLastIRFrameChecked.getMin().clear(); // invalidate
+  mLastBoundID = -1;
   mFrames = {};
 }
 

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -31,8 +31,10 @@ struct CTFReaderInp {
   std::string remoteRegex{};
   std::string metricChannel{};
   std::string fileIRFrames{};
+  std::string fileRunTimeSpans{};
   std::vector<int> ctfIDs{};
   bool skipSkimmedOutTF = false;
+  bool invertIRFramesSelection = false;
   bool allowMissingDetectors = false;
   bool checkTFLimitBeforeReading = false;
   bool sup0xccdb = false;


### PR DESCRIPTION
```
--run-time-span-file <text file with run range_min range_max entries>
```
This option allows to push to DPL only those TFs which overlap with the `<runnumber> <range-min> <range-max>` (separators can be any whitespace, comma or semicolon) records provided via text file (assuming that there are some entries for a given run, otherwise the option is ignored).
Multiple ranges per run and multiple runs can be mentioned in a single input file. The range limits can be indicated either as a UNIX timestamp in `ms` or as an orbit number (in the fill the run belongs to).

In case an option
```
--invert-irframe-selection
```
is provided, the selections above are inverted: TFs matching some of the provided ranges will be discarded, while the rest will be pushed to the DPL

At the end of the processing the `ctf-writer` will create a local file `ctf_read_ntf.txt` containing only the number of TFs pushed to the DPL.
If no TF passes the selections above, this file will contain 0.
