### PR TITLE
Reset mParticles before filled with new set of particles

### DIFF
--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -159,7 +159,7 @@ Bool_t GeneratorHepMC::generateEvent()
     tries++;
   } while (tries < max_tries);
 
-  LOG(fatal) << "HepMC event gen failed (Does the file/stream have enough events)?";
+  LOG(error) << "HepMC event gen failed (Does the file/stream have enough events)?";
 
   /** failure **/
   return false;

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -286,6 +286,7 @@ Bool_t GeneratorHepMC::importParticles()
   }
 
   /** loop over particles **/
+  mParticles.clear();
   auto particles = mEvent->particles();
   for (int i = 0; i < particles.size(); ++i) {
 


### PR DESCRIPTION
Without this the particle buffer mParticles is continuously growing.