### PR TITLE
Str: Silence predicted chi2 calculation

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -100,6 +100,8 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
 
   template <typename T>
   GPUd() value_t getPredictedChi2(const BaseCluster<T>& p) const;
+  template <typename T>
+  GPUd() value_t getPredictedChi2Quiet(const BaseCluster<T>& p) const;
 
   GPUd() void buildCombinedCovMatrix(const TrackParametrizationWithError& rhs, MatrixDSym5& cov) const;
   GPUd() value_t getPredictedChi2(const TrackParametrizationWithError& rhs, MatrixDSym5& covToSet) const;
@@ -313,6 +315,16 @@ GPUdi() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const Base
   const dim2_t pyz = {value_T(p.getY()), value_T(p.getZ())};
   const dim3_t cov = {value_T(p.getSigmaY2()), value_T(p.getSigmaYZ()), value_T(p.getSigmaZ2())};
   return getPredictedChi2(pyz, cov);
+}
+
+//__________________________________________________________________________
+template <typename value_T>
+template <typename T>
+GPUdi() auto TrackParametrizationWithError<value_T>::getPredictedChi2Quiet(const BaseCluster<T>& p) const -> value_t
+{
+  const dim2_t pyz = {value_T(p.getY()), value_T(p.getZ())};
+  const dim3_t cov = {value_T(p.getSigmaY2()), value_T(p.getSigmaYZ()), value_T(p.getSigmaZ2())};
+  return getPredictedChi2Quiet(pyz, cov);
 }
 
 //______________________________________________

--- a/Detectors/Vertexing/StrangenessTracking/src/StrangenessTracker.cxx
+++ b/Detectors/Vertexing/StrangenessTracking/src/StrangenessTracker.cxx
@@ -507,7 +507,7 @@ bool StrangenessTracker::updateTrack(const ITSCluster& clus, o2::track::TrackPar
       return false;
     }
   }
-  auto chi2 = std::abs(track.getPredictedChi2(clus)); // abs to be understood
+  auto chi2 = std::abs(track.getPredictedChi2Quiet(clus)); // abs to be understood
   LOG(debug) << "Chi2: " << chi2;
   if (chi2 > mStrParams->mMaxChi2 || chi2 < 0) {
     return false;


### PR DESCRIPTION
Around 60-70% of the async logs are polluted by the strangeness trackers update step with negative values which is of little help.
Also the abs of the chi2 is taken afterward so the logged message is by definition ignored thus silencing it just follows this logic.