### PR TITLE
O2-4592 - adding TOF dX and dZ to the track QA table with int8 precision

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -433,6 +433,8 @@ class AODProducerWorkflowDPL : public Task
     int8_t dRefGloSnp{std::numeric_limits<int8_t>::min()};
     int8_t dRefGloTgl{std::numeric_limits<int8_t>::min()};
     int8_t dRefGloQ2Pt{std::numeric_limits<int8_t>::min()};
+    int8_t dTofdX{std::numeric_limits<int8_t>::min()};
+    int8_t dTofdZ{std::numeric_limits<int8_t>::min()};
   };
 
   // helper struct for addToFwdTracksTable()

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2697,7 +2697,7 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
                        << "trackQAHolder.dRefGloSnp=" << trackQAHolder.dRefGloSnp
                        << "trackQAHolder.dRefGloTgl=" << trackQAHolder.dRefGloTgl
                        << "trackQAHolder.dRefGloQ2Pt=" << trackQAHolder.dRefGloQ2Pt
-                       << "trackQAHolder.dTofdY=" << trackQAHolder.dTofdY
+                       << "trackQAHolder.dTofdX=" << trackQAHolder.dTofdX
                        << "trackQAHolder.dTofdZ=" << trackQAHolder.dTofdZ
                        << "scaleTOF=" << scaleTOF
                        << "\n";

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -383,8 +383,7 @@ void AODProducerWorkflowDPL::addToTracksQATable(TracksQACursorType& tracksQACurs
     trackQAInfoHolder.dRefGloTgl,
     trackQAInfoHolder.dRefGloQ2Pt,
     trackQAInfoHolder.dTofdY,
-    trackQAInfoHolder.dTofdZ
-    );
+    trackQAInfoHolder.dTofdZ);
 }
 
 template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>
@@ -2601,13 +2600,13 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
     trackQAHolder.tpcdEdxTot2R = uint8_t(tpcOrig.getdEdx().dEdxTotOROC2 * dEdxNorm);
     trackQAHolder.tpcdEdxTot3R = uint8_t(tpcOrig.getdEdx().dEdxTotOROC3 * dEdxNorm);
     ///
-    float_t scaleTOF=0;
+    float_t scaleTOF = 0;
     if (contributorsGID[GIndex::Source::TOF].isIndexSet()) { // ITS-TPC-TRD-TOF, ITS-TPC-TOF, TPC-TRD-TOF, TPC-TOF
       const auto& tofMatch = data.getTOFMatch(trackIndex);
       const float qpt = gloCopy.getQ2Pt();
-      scaleTOF=std::sqrt(o2::aod::track::trackQAScaledTOF[0]*o2::aod::track::trackQAScaledTOF[0]+qpt*qpt*o2::aod::track::trackQAScaledTOF[1]*o2::aod::track::trackQAScaledTOF[1])/(2.*o2::aod::track::trackQAScaleBins);
-      trackQAHolder.dTofdX = safeInt8Clamp(tofMatch.getDXatTOF()/scaleTOF);
-      trackQAHolder.dTofdZ = safeInt8Clamp(tofMatch.getDZatTOF()/scaleTOF);
+      scaleTOF = std::sqrt(o2::aod::track::trackQAScaledTOF[0] * o2::aod::track::trackQAScaledTOF[0] + qpt * qpt * o2::aod::track::trackQAScaledTOF[1] * o2::aod::track::trackQAScaledTOF[1]) / (2. * o2::aod::track::trackQAScaleBins);
+      trackQAHolder.dTofdX = safeInt8Clamp(tofMatch.getDXatTOF() / scaleTOF);
+      trackQAHolder.dTofdZ = safeInt8Clamp(tofMatch.getDZatTOF() / scaleTOF);
     }
 
     // Add matching information at a reference point (defined by

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -383,7 +383,7 @@ void AODProducerWorkflowDPL::addToTracksQATable(TracksQACursorType& tracksQACurs
     trackQAInfoHolder.dRefGloTgl,
     trackQAInfoHolder.dRefGloQ2Pt,
     trackQAInfoHolder.dTofdX,
-    trackQAInfoHolder.dTofdZ)
+    trackQAInfoHolder.dTofdZ);
 }
 
 template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -381,7 +381,9 @@ void AODProducerWorkflowDPL::addToTracksQATable(TracksQACursorType& tracksQACurs
     trackQAInfoHolder.dRefGloZ,
     trackQAInfoHolder.dRefGloSnp,
     trackQAInfoHolder.dRefGloTgl,
-    trackQAInfoHolder.dRefGloQ2Pt)
+    trackQAInfoHolder.dRefGloQ2Pt,
+    trackQAInfoHolder.dTofdX,
+    trackQAInfoHolder.dTofdZ)
 }
 
 template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -381,9 +381,7 @@ void AODProducerWorkflowDPL::addToTracksQATable(TracksQACursorType& tracksQACurs
     trackQAInfoHolder.dRefGloZ,
     trackQAInfoHolder.dRefGloSnp,
     trackQAInfoHolder.dRefGloTgl,
-    trackQAInfoHolder.dRefGloQ2Pt,
-    trackQAInfoHolder.dTofdY,
-    trackQAInfoHolder.dTofdZ);
+    trackQAInfoHolder.dRefGloQ2Pt)
 }
 
 template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>
@@ -2569,6 +2567,12 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
       trackQAHolder.tpcdcaR = 100. * dcaInfo[0] / sqrt(1. + trackPar.getQ2Pt() * trackPar.getQ2Pt());
       trackQAHolder.tpcdcaZ = 100. * dcaInfo[1] / sqrt(1. + trackPar.getQ2Pt() * trackPar.getQ2Pt());
     }
+    // This allows to safely clamp any float to one byte, using the
+    // minmal/maximum values as under-/overflow borders and rounding to the nearest integer
+    auto safeInt8Clamp = [](auto value) -> int8_t {
+      using ValType = decltype(value);
+      return static_cast<int8_t>(TMath::Nint(std::clamp(value, static_cast<ValType>(std::numeric_limits<int8_t>::min()), static_cast<ValType>(std::numeric_limits<int8_t>::max()))));
+    };
     /// get tracklet byteMask
     uint8_t clusterCounters[8] = {0};
     {
@@ -2600,10 +2604,10 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
     trackQAHolder.tpcdEdxTot2R = uint8_t(tpcOrig.getdEdx().dEdxTotOROC2 * dEdxNorm);
     trackQAHolder.tpcdEdxTot3R = uint8_t(tpcOrig.getdEdx().dEdxTotOROC3 * dEdxNorm);
     ///
-    float_t scaleTOF = 0;
+    float scaleTOF{0};
     if (contributorsGID[GIndex::Source::TOF].isIndexSet()) { // ITS-TPC-TRD-TOF, ITS-TPC-TOF, TPC-TRD-TOF, TPC-TOF
       const auto& tofMatch = data.getTOFMatch(trackIndex);
-      const float qpt = gloCopy.getQ2Pt();
+      const float qpt = trackPar.getQ2Pt();
       scaleTOF = std::sqrt(o2::aod::track::trackQAScaledTOF[0] * o2::aod::track::trackQAScaledTOF[0] + qpt * qpt * o2::aod::track::trackQAScaledTOF[1] * o2::aod::track::trackQAScaledTOF[1]) / (2. * o2::aod::track::trackQAScaleBins);
       trackQAHolder.dTofdX = safeInt8Clamp(tofMatch.getDXatTOF() / scaleTOF);
       trackQAHolder.dTofdZ = safeInt8Clamp(tofMatch.getDZatTOF() / scaleTOF);
@@ -2631,13 +2635,6 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
         };
         auto scaleGlo = [&x](int i) -> float {
           return o2::aod::track::trackQAScaleBins / std::sqrt(o2::aod::track::trackQAScaleGloP0[i] * o2::aod::track::trackQAScaleGloP0[i] + (o2::aod::track::trackQAScaleGloP1[i] * x) * (o2::aod::track::trackQAScaleGloP1[i] * x));
-        };
-
-        // This allows to safely clamp any float to one byte, using the
-        // minmal/maximum values as under-/overflow borders and rounding to the nearest integer
-        auto safeInt8Clamp = [](auto value) -> int8_t {
-          using ValType = decltype(value);
-          return static_cast<int8_t>(TMath::Nint(std::clamp(value, static_cast<ValType>(std::numeric_limits<int8_t>::min()), static_cast<ValType>(std::numeric_limits<int8_t>::max()))));
         };
 
         // Calculate deltas for contributors

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2607,7 +2607,8 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
     trackQAHolder.tpcdEdxTot3R = uint8_t(tpcOrig.getdEdx().dEdxTotOROC3 * dEdxNorm);
     ///
     float scaleTOF{0};
-    if (contributorsGID[GIndex::Source::TOF].isIndexSet()) { // ITS-TPC-TRD-TOF, ITS-TPC-TOF, TPC-TRD-TOF, TPC-TOF
+    auto contributorsGIDA = data.getSingleDetectorRefs(trackIndex);
+    if (contributorsGIDA[GIndex::Source::TOF].isIndexSet()) { // ITS-TPC-TRD-TOF, ITS-TPC-TOF, TPC-TRD-TOF, TPC-TOF
       const auto& tofMatch = data.getTOFMatch(trackIndex);
       const float qpt = trackPar.getQ2Pt();
       scaleTOF = std::sqrt(o2::aod::track::trackQAScaledTOF[0] * o2::aod::track::trackQAScaledTOF[0] + qpt * qpt * o2::aod::track::trackQAScaledTOF[1] * o2::aod::track::trackQAScaledTOF[1]) / (2. * o2::aod::track::trackQAScaleBins);

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -721,7 +721,7 @@ DECLARE_SOA_TABLE_VERSIONED(TracksQA_002, "AOD", "TRACKQA", 2, //! trackQA infor
                             trackqa::IsDummy<trackqa::DeltaRefContParamY, trackqa::DeltaRefContParamZ, trackqa::DeltaRefContParamSnp, trackqa::DeltaRefContParamTgl, trackqa::DeltaRefContParamQ2Pt,
                                              trackqa::DeltaRefGloParamY, trackqa::DeltaRefGloParamZ, trackqa::DeltaRefGloParamSnp, trackqa::DeltaRefGloParamTgl, trackqa::DeltaRefGloParamQ2Pt>);
 
-using TracksQAVersion = TracksQA_001;
+using TracksQAVersion = TracksQA_002;
 using TracksQA = TracksQAVersion::iterator;
 
 namespace fwdtrack

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -686,6 +686,8 @@ DECLARE_SOA_COLUMN(DeltaRefGloParamZ, deltaRefGloParamZ, int8_t);         //! No
 DECLARE_SOA_COLUMN(DeltaRefGloParamSnp, deltaRefGloParamSnp, int8_t);     //! Normalized delta of global track to average contributors matched tracks at reference point in the same frame Snp
 DECLARE_SOA_COLUMN(DeltaRefGloParamTgl, deltaRefGloParamTgl, int8_t);     //! Normalized delta of global track to average contributors matched tracks at reference point in the same frame Tgl
 DECLARE_SOA_COLUMN(DeltaRefGloParamQ2Pt, deltaRefGloParamQ2Pt, int8_t);   //! Normalized delta of global track to average contributors matched tracks at reference point in the same frame Q2Pt
+DECLARE_SOA_COLUMN(DeltaTOFdX, deltaTOFdX, int8_t);                       //!
+DECLARE_SOA_COLUMN(DeltaTOFdZ, deltaTOFdZ, int8_t);                       //!
 
 DECLARE_SOA_DYNAMIC_COLUMN(IsDummy, isDummy, //! indicates if the propagation of the contrib. tracks was successful and residuals are available
                            [](int8_t cY, int8_t cZ, int8_t cSnp, int8_t cTgl, int8_t cQ2Pt, int8_t gY, int8_t gZ, int8_t gSnp, int8_t gTgl, int8_t gQ2Pt) -> bool {
@@ -706,6 +708,16 @@ DECLARE_SOA_TABLE_VERSIONED(TracksQA_001, "AOD", "TRACKQA", 1, //! trackQA infor
                             trackqa::TPCdEdxTot0R, trackqa::TPCdEdxTot1R, trackqa::TPCdEdxTot2R, trackqa::TPCdEdxTot3R,
                             trackqa::DeltaRefContParamY, trackqa::DeltaRefContParamZ, trackqa::DeltaRefContParamSnp, trackqa::DeltaRefContParamTgl, trackqa::DeltaRefContParamQ2Pt,
                             trackqa::DeltaRefGloParamY, trackqa::DeltaRefGloParamZ, trackqa::DeltaRefGloParamSnp, trackqa::DeltaRefGloParamTgl, trackqa::DeltaRefGloParamQ2Pt,
+                            trackqa::IsDummy<trackqa::DeltaRefContParamY, trackqa::DeltaRefContParamZ, trackqa::DeltaRefContParamSnp, trackqa::DeltaRefContParamTgl, trackqa::DeltaRefContParamQ2Pt,
+                                             trackqa::DeltaRefGloParamY, trackqa::DeltaRefGloParamZ, trackqa::DeltaRefGloParamSnp, trackqa::DeltaRefGloParamTgl, trackqa::DeltaRefGloParamQ2Pt>);
+
+DECLARE_SOA_TABLE_VERSIONED(TracksQA_002, "AOD", "TRACKQA", 2, //! trackQA information - version 2 - including contributor residuals of matched tracks at reference radius + TOF delta information
+                            o2::soa::Index<>, trackqa::TrackId, trackqa::TPCTime0, trackqa::TPCDCAR, trackqa::TPCDCAZ, trackqa::TPCClusterByteMask,
+                            trackqa::TPCdEdxMax0R, trackqa::TPCdEdxMax1R, trackqa::TPCdEdxMax2R, trackqa::TPCdEdxMax3R,
+                            trackqa::TPCdEdxTot0R, trackqa::TPCdEdxTot1R, trackqa::TPCdEdxTot2R, trackqa::TPCdEdxTot3R,
+                            trackqa::DeltaRefContParamY, trackqa::DeltaRefContParamZ, trackqa::DeltaRefContParamSnp, trackqa::DeltaRefContParamTgl, trackqa::DeltaRefContParamQ2Pt,
+                            trackqa::DeltaRefGloParamY, trackqa::DeltaRefGloParamZ, trackqa::DeltaRefGloParamSnp, trackqa::DeltaRefGloParamTgl, trackqa::DeltaRefGloParamQ2Pt,
+                            trackqa::DeltaTOFdX, trackqa::DeltaTOFdZ,
                             trackqa::IsDummy<trackqa::DeltaRefContParamY, trackqa::DeltaRefContParamZ, trackqa::DeltaRefContParamSnp, trackqa::DeltaRefContParamTgl, trackqa::DeltaRefContParamQ2Pt,
                                              trackqa::DeltaRefGloParamY, trackqa::DeltaRefGloParamZ, trackqa::DeltaRefGloParamSnp, trackqa::DeltaRefGloParamTgl, trackqa::DeltaRefGloParamQ2Pt>);
 
@@ -1651,7 +1663,7 @@ using Tracked3body = Tracked3Bodys::iterator;
 namespace origins
 {
 DECLARE_SOA_COLUMN(DataframeID, dataframeID, uint64_t); //! Data frame ID (what is usually found in directory name in the AO2D.root, i.e. DF_XXX)
-} // namespace origin
+} // namespace origins
 
 DECLARE_SOA_TABLE(Origins, "AOD", "ORIGIN", //! Table which contains the IDs of all dataframes merged into this dataframe
                   o2::soa::Index<>, origins::DataframeID);

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -130,7 +130,7 @@ constexpr std::array<float, 5> trackQAScaleContP0{0.257192, 0.0775375, 0.0042428
 constexpr std::array<float, 5> trackQAScaleContP1{0.189371, 0.409071, 0.00694444, 0.00720038, 0.0806902};
 constexpr std::array<float, 5> trackQAScaleGloP0{0.130985, 0.0775375, 0.00194703, 0.000405458, 0.0160007};
 constexpr std::array<float, 5> trackQAScaleGloP1{0.183731, 0.409071, 0.00621802, 0.00624881, 0.0418957};
-constexpr std::array<float, 2> trackQAScaledTOF{1.1,0.33};
+constexpr std::array<float, 2> trackQAScaledTOF{1.1, 0.33};
 } // namespace o2::aod::track
 
 namespace o2::aod::fwdtrack

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -130,6 +130,7 @@ constexpr std::array<float, 5> trackQAScaleContP0{0.257192, 0.0775375, 0.0042428
 constexpr std::array<float, 5> trackQAScaleContP1{0.189371, 0.409071, 0.00694444, 0.00720038, 0.0806902};
 constexpr std::array<float, 5> trackQAScaleGloP0{0.130985, 0.0775375, 0.00194703, 0.000405458, 0.0160007};
 constexpr std::array<float, 5> trackQAScaleGloP1{0.183731, 0.409071, 0.00621802, 0.00624881, 0.0418957};
+constexpr std::array<float, 2> trackQAScaledTOF{1.1,0.33};
 } // namespace o2::aod::track
 
 namespace o2::aod::fwdtrack


### PR DESCRIPTION
### **O2-4592 - adding TOF dX and dZ to the track QA table with int8 precision**

### **Description**

This update adds key TOF information, such as **dX** and **dZ**, to the trackQA table in AO2D. These additions are critical for machine learning applications and conditional tracking post-corrections. 

#### **Information for Machine Learning**
- **ΔX and ΔZ**:  + Expanding the search road - in this pull request
- **Integral Time**: For hypotheses and Length (Δ).  
- **Integral Material Budget**: After the TPC.  
- **Flags Information**: To handle cases where more than one cluster is assigned to the track (e.g., pad overlap).  

#### **Usage of Information - Conditional Tracking as Post-Correction**
1. **ΔY and ΔZ**:
   - Correction for wrong mass hypotheses (tracking mass and TOF PID), improving matching efficiency and reducing fakes (primarily to recover TPC crossing points).  
   - Adjustment for electron bremsstrahlung.  
   - Compensation for imperfect drift velocity and distortion calibration.  
2. **Conditional Correction for Deep Secondaries**:
   - Based on decay radius and mother particle mass.  
3. **Background Probability Evaluation**:
   - Estimation of the probability of absorption or decay.  

People involved:
@noferini, @ercolessi, @f3sch 
