### PR TITLE
HybridGenerator: Asyncronous + parallel event generation

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -141,6 +141,11 @@ class Generator : public FairGenerator
   /** lorentz boost data members **/
   Double_t mBoost;
 
+  // a unique generator instance counter
+  // this can be used to make sure no two generator instances have the same seed etc.
+  static std::atomic<int> InstanceCounter;
+  int mThisInstanceID = 0;
+
  private:
   void updateSubGeneratorInformation(o2::dataformats::MCEventHeader* header) const;
 

--- a/Generators/include/Generators/GeneratorExternalParam.h
+++ b/Generators/include/Generators/GeneratorExternalParam.h
@@ -37,6 +37,7 @@ struct GeneratorExternalParam : public o2::conf::ConfigurableParamHelper<Generat
 struct ExternalGenConfig {
   std::string fileName = "";
   std::string funcName = "";
+  std::string iniFile = ""; // if ini file is given, the configuration will be taken from this and the other 2 fields neglected
 };
 
 } // end namespace eventgen

--- a/Generators/include/Generators/GeneratorHybridParam.h
+++ b/Generators/include/Generators/GeneratorHybridParam.h
@@ -31,6 +31,7 @@ namespace eventgen
 struct GeneratorHybridParam : public o2::conf::ConfigurableParamHelper<GeneratorHybridParam> {
   std::string configFile = ""; // JSON configuration file for the generators
   bool randomize = false;      // randomize the order of the generators, if not generator using fractions
+  int num_workers = 1;         // number of threads available for asyn/parallel event generation
   O2ParamDef(GeneratorHybridParam, "GeneratorHybrid");
 };
 

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -287,6 +287,9 @@ class GeneratorPythia8 : public Generator
                                // Value of -1 means unitialized; 0 will be time-dependent and values >1 <= MAX_SEED concrete reproducible seeding
   Pythia8GenConfig mGenConfig; // configuration object
 
+  static std::atomic<int> Pythia8InstanceCounter;
+  int mThisPythia8InstanceID = 0;
+
   constexpr static long MAX_SEED = 900000000;
 
   ClassDefOverride(GeneratorPythia8, 1);

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -28,6 +28,8 @@ namespace o2
 namespace eventgen
 {
 
+std::atomic<int> Generator::InstanceCounter{0};
+
 /*****************************************************************/
 /*****************************************************************/
 
@@ -35,6 +37,8 @@ Generator::Generator() : FairGenerator("ALICEo2", "ALICEo2 Generator"),
                          mBoost(0.)
 {
   /** default constructor **/
+  mThisInstanceID = Generator::InstanceCounter;
+  Generator::InstanceCounter++;
 }
 
 /*****************************************************************/
@@ -43,6 +47,8 @@ Generator::Generator(const Char_t* name, const Char_t* title) : FairGenerator(na
                                                                 mBoost(0.)
 {
   /** constructor **/
+  mThisInstanceID = Generator::InstanceCounter;
+  Generator::InstanceCounter++;
 }
 
 /*****************************************************************/

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -285,6 +285,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
       return;
     }
     auto hybrid = new o2::eventgen::GeneratorHybrid(config);
+    hybrid->setNEvents(conf.getNEvents());
     primGen->AddGenerator(hybrid);
 #endif
   } else {

--- a/run/SimExamples/Hybrid_parallel/README.md
+++ b/run/SimExamples/Hybrid_parallel/README.md
@@ -1,0 +1,9 @@
+<!-- doxy
+\page refrunSimExamplesHybrid Example Hybrid_parallel
+/doxy -->
+
+Demonstrating how the Hybrid generator can be setup with multiple clones of the same
+generator to speedup event generation (for a single timeframe).
+
+- **run_parallel.sh** main example shell script
+- **hybridconfig_parallel.json** &rarr; example JSON file for the hybrid generator configuration

--- a/run/SimExamples/Hybrid_parallel/hybridconfig_extern_parallel.json
+++ b/run/SimExamples/Hybrid_parallel/hybridconfig_extern_parallel.json
@@ -1,0 +1,69 @@
+{
+  "mode": "parallel",
+  "generators": [
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_ROOT}/MC/config/PWGHF/ini/GeneratorHF_D2H_ccbar_Mode2_OmegaC.ini"
+      }
+    }
+  ]
+}

--- a/run/SimExamples/Hybrid_parallel/hybridconfig_parallel.json
+++ b/run/SimExamples/Hybrid_parallel/hybridconfig_parallel.json
@@ -1,0 +1,53 @@
+{
+  "mode": "parallel",
+  "generators": [
+    {
+      "name": "pythia8",
+      "config": {
+        "config": "$O2_ROOT/share/Generators/egconfig/pythia8_inel.cfg",
+        "hooksFileName": "",
+        "hooksFuncName": "",
+        "includePartonEvent": false,
+        "particleFilter": "",
+        "verbose": 0
+      }
+    },
+    {
+      "name": "pythia8",
+      "config": {
+        "config": "$O2_ROOT/share/Generators/egconfig/pythia8_inel.cfg",
+        "hooksFileName": "",
+        "hooksFuncName": "",
+        "includePartonEvent": false,
+        "particleFilter": "",
+        "verbose": 0
+      }
+    },
+    {
+      "name": "pythia8",
+      "config": {
+        "config": "$O2_ROOT/share/Generators/egconfig/pythia8_inel.cfg",
+        "hooksFileName": "",
+        "hooksFuncName": "",
+        "includePartonEvent": false,
+        "particleFilter": "",
+        "verbose": 0
+      }
+    },
+    {
+      "name": "pythia8",
+      "config": {
+        "config": "$O2_ROOT/share/Generators/egconfig/pythia8_inel.cfg",
+        "hooksFileName": "",
+        "hooksFuncName": "",
+        "includePartonEvent": false,
+        "particleFilter": "",
+        "verbose": 0
+      }
+    }
+  ],
+  "fractions": [
+    1,
+    1
+  ]
+}

--- a/run/SimExamples/Hybrid_parallel/run_extgen_parallel.sh
+++ b/run/SimExamples/Hybrid_parallel/run_extgen_parallel.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Hybrid generator simulation example in which multiple clones of the same generator
+# are listed in a JSON file (hybridconfig_extern_parallel.json in this folder). These multiple
+# clones are running in parallel to produce a targeted number of events faster.
+
+NEV=10
+WORKERS=8
+
+# Starting simulation with Hybrid generator in parallel mode
+${O2_ROOT}/bin/o2-sim --noGeant -j 1 --field ccdb --vertexMode kCCDB --run 300000 --configKeyValues "GeneratorHybrid.configFile=$PWD/hybridconfig_extern_parallel.json;GeneratorHybrid.randomize=false;GeneratorHybrid.num_workers=${WORKERS}" -g hybrid -o genevents_extern_parallel --timestamp 1546300800000 --seed 836302859 -n $NEV

--- a/run/SimExamples/Hybrid_parallel/run_parallel.sh
+++ b/run/SimExamples/Hybrid_parallel/run_parallel.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Hybrid generator simulation example in which multiple clones of the same generator
+# are listed in a JSON file (hybridconfig_parallel.json in this folder). These multiple
+# clones are running in parallel to produce events faster.
+
+NEV=100
+WORKERS=8
+
+# Starting simulation with Hybrid generator in parallel mode
+${O2_ROOT}/bin/o2-sim --noGeant -j 1 --field ccdb --vertexMode kCCDB --run 300000 --configKeyValues "GeneratorHybrid.configFile=$PWD/hybridconfig_parallel.json;GeneratorHybrid.randomize=false;GeneratorHybrid.num_workers=${WORKERS}" -g hybrid -o genevents_parallel --timestamp 1546300800000 --seed 836302859 -n $NEV

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -16,6 +16,7 @@
 * \subpage refrunSimExamplesHepMC_STARlight
 * \subpage refrunSimExamplesHepMC_EPOS4
 * \subpage refrunSimExamplesHybrid
+* \subpage refrunSimExamplesHybrid_parallel
 * \subpage refrunSimExamplesJet_Embedding_Pythia8
 * \subpage refrunSimExamplesMcTracksToAOD
 * \subpage refrunSimExamplesMcTracksToAOD


### PR DESCRIPTION
This introduces:
* asyncronous event generation
* possibility for parallel event generation

This is useful for:
* hiding latency (IO) of certain generators
* decoupling the actual work from the call sequence into HybridGenerator
* collaboration from multiple clones of the same generator to generate a certain number of events

The implementation relies on tbb::task_arena and input/output queues for decoupling the task_arena from the HybridGenerator thread.

Small adjustments to seeding of Pythia8 in order
to avoid same seeds in multiple parallel Pythia instances.