### PR TITLE
ITS tracking: Introduce configurable minimum pt per track length

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -94,7 +94,7 @@ struct TrackingParameters {
   unsigned long MaxMemory = 12000000000UL;
   float MaxChi2ClusterAttachment = 60.f;
   float MaxChi2NDF = 30.f;
-  float MinPt = 0.f;
+  std::vector<float> MinPt = {0.f, 0.f, 0.f, 0.f};
   unsigned char StartLayerMask = 0x7F;
   bool FindShortTracks = false;
   bool PerPrimaryVertexProcessing = false;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -618,7 +618,7 @@ void TrackerTraits::findRoads(const int iteration)
       temporaryTrack.resetCovariance();
       temporaryTrack.setChi2(0);
       fitSuccess = fitTrack(temporaryTrack, mTrkParams[0].NLayers - 1, -1, -1, mTrkParams[0].MaxChi2ClusterAttachment, mTrkParams[0].MaxChi2NDF, 50.f);
-      if (!fitSuccess || temporaryTrack.getPt() < mTrkParams[iteration].MinPt) {
+      if (!fitSuccess || temporaryTrack.getPt() < mTrkParams[iteration].MinPt[mTrkParams[iteration].NLayers - temporaryTrack.getNClusters()]) {
         continue;
       }
       tracks[trackIndex++] = temporaryTrack;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -47,7 +47,7 @@ void ITSTrackingInterface::initialise()
     trackParams[2].TrackletMinPt = 0.1f;
     trackParams[2].CellDeltaTanLambdaSigma *= 4.;
     trackParams[2].MinTrackLength = 4;
-    trackParams[2].MinPt = 0.2f;
+    trackParams[2].MinPt[3] = 0.2f;
     trackParams[2].StartLayerMask = (1 << 6) + (1 << 3);
     if (o2::its::TrackerParamConfig::Instance().doUPCIteration) {
       trackParams[3].TrackletMinPt = 0.1f;


### PR DESCRIPTION
The changes introduce a configurable minimum PT value per track length in the ITS tracking parameters. This allows for more fine-grained control over the minimum PT requirement, which can be useful for different tracking scenarios.

The main changes are:

- Modify the `TrackingParameters` struct to include an array of 4 minimum PT values, one for each track length (7, 6, 5, 4).
- Update the track fitting logic in `TrackerTraits::findRoads()` to use the appropriate minimum PT value based on the track length.
- Update the default minimum PT value in `TrackingInterface::initialise()` to use the new array-based approach.

These changes provide more flexibility in tuning the ITS tracking parameters.