### PR TITLE
HybridGen/EventPool: small fixes, Add missing EventHeader propagation

### DIFF
--- a/Generators/include/Generators/BoxGenerator.h
+++ b/Generators/include/Generators/BoxGenerator.h
@@ -18,6 +18,7 @@
 #include "TParticle.h"
 #include <vector>
 #include <Generators/BoxGunParam.h>
+#include "SimulationDataFormat/MCEventHeader.h"
 
 namespace o2::eventgen
 {
@@ -90,6 +91,14 @@ class BoxGenerator : public Generator
     mParticles.clear();
     std::copy(mEvent.begin(), mEvent.end(), std::back_insert_iterator(mParticles));
     return true;
+  }
+
+  void updateHeader(o2::dataformats::MCEventHeader* eventHeader) override
+  {
+    using Key = o2::dataformats::MCInfoKeys;
+    if (eventHeader) {
+      eventHeader->putInfo<std::string>(Key::generator, "o2::eventgen::BoxGenerator");
+    }
   }
 
  private:

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -73,6 +73,7 @@ class Generator : public FairGenerator
   /** methods to override **/
   virtual Bool_t generateEvent() = 0;   // generates event (in structure internal to generator)
   virtual Bool_t importParticles() = 0; // fills the mParticles vector (transfer from generator state)
+  virtual void updateHeader(o2::dataformats::MCEventHeader* eventHeader) {};
 
   /** setters **/
   void setMomentumUnit(double val) { mMomentumUnit = val; };
@@ -101,9 +102,6 @@ class Generator : public FairGenerator
   Generator(const Generator&);
   /** operator= **/
   Generator& operator=(const Generator&);
-
-  /** methods that can be overridded **/
-  virtual void updateHeader(o2::dataformats::MCEventHeader* eventHeader){};
 
   /** internal methods **/
   Bool_t addTracks(FairPrimaryGenerator* primGen);

--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -135,9 +135,11 @@ class GeneratorFromEventPool : public o2::eventgen::Generator
   }
   bool importParticles() override
   {
+    mO2KineGenerator->clearParticles(); // clear old container before filling with new ones
     auto import_good = mO2KineGenerator->importParticles();
     // transfer the particles (could be avoided)
     mParticles = mO2KineGenerator->getParticles();
+
     return import_good;
   }
 

--- a/Generators/include/Generators/GeneratorHybrid.h
+++ b/Generators/include/Generators/GeneratorHybrid.h
@@ -61,6 +61,7 @@ class GeneratorHybrid : public Generator
   Bool_t Init() override;
   Bool_t generateEvent() override;
   Bool_t importParticles() override;
+  void updateHeader(o2::dataformats::MCEventHeader* eventHeader) override;
 
   void setNEvents(int n) { mNEvents = n; }
 
@@ -106,6 +107,7 @@ class GeneratorHybrid : public Generator
   bool mIsInitialized = false;
 
   int mNEvents = -1; // the number of events to be done, if known (helps initiating cleanup)
+  o2::dataformats::MCEventHeader mMCEventHeader; // to capture event headers
 
   enum class GenMode {
     kSeq,

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -398,10 +398,12 @@ bool GeneratorFromEventPool::Init()
     LOG(error) << "No file found that can be used with EventPool generator";
     return false;
   }
+  LOG(info) << "Found " << mPoolFilesAvailable.size() << " available event pool files";
 
   // now choose the actual file
-  std::uniform_int_distribution<int> distribution(0, mPoolFilesAvailable.size());
-  mFileChosen = mPoolFilesAvailable[distribution(mRandomEngine)];
+  std::uniform_int_distribution<int> distribution(0, mPoolFilesAvailable.size() - 1);
+  auto chosenIndex = distribution(mRandomEngine);
+  mFileChosen = mPoolFilesAvailable[chosenIndex];
   LOG(info) << "EventPool is using file " << mFileChosen;
 
   // we bring up the internal mO2KineGenerator


### PR DESCRIPTION
The HybridGen needs to forward event headers from the underlying
generators.

In order to access these, we need to make a protected function public.
Also adding eventHeader treatment to BoxGenerator.

More fixes:
- clear particle container in EventPool
- do not modify particle statuses in HybridGen (lead to wrong Geant4 simulations)
- fix possible segfault in chosing EventPool file
