### PR TITLE
Use O2LongInt aliased to long int instead of int64_t in persistent ob…

### DIFF
--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/DCSDPValues.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/DCSDPValues.h
@@ -14,22 +14,23 @@
 
 #include <Rtypes.h>
 #include "Framework/Logger.h"
+#include "Framework/O2LongInt.h"
 
 namespace o2
 {
 namespace fit
 {
 struct DCSDPValues {
-  std::vector<std::pair<uint64_t, int64_t>> values;
+  std::vector<std::pair<O2LongUInt, O2LongInt>> values;
 
   DCSDPValues()
   {
-    values = std::vector<std::pair<uint64_t, int64_t>>();
+    values = std::vector<std::pair<O2LongUInt, O2LongInt>>();
   }
 
   void add(uint64_t timestamp, int64_t value)
   {
-    values.push_back(std::pair<uint64_t, int64_t>(timestamp, value));
+    values.push_back(std::pair<O2LongUInt, O2LongInt>(timestamp, value));
   }
 
   bool empty()

--- a/Detectors/GRP/calibration/include/GRPCalibration/GRPDCSDPsProcessor.h
+++ b/Detectors/GRP/calibration/include/GRPCalibration/GRPDCSDPsProcessor.h
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <deque>
 #include "Framework/Logger.h"
+#include "Framework/O2LongInt.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
@@ -37,11 +38,11 @@ using DPID = o2::dcs::DataPointIdentifier;
 using DPVAL = o2::dcs::DataPointValue;
 using DPCOM = o2::dcs::DataPointCompositeObject;
 
-inline unsigned long llu2lu(std::uint64_t v) { return (unsigned long)v; }
+inline O2LongUInt llu2lu(std::uint64_t v) { return (O2LongUInt)v; }
 
 struct GRPEnvVariables {
 
-  std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>> mEnvVars;
+  std::unordered_map<std::string, std::vector<std::pair<O2LongUInt, double>>> mEnvVars;
   size_t totalEntries() const
   {
     size_t s = 0;
@@ -60,7 +61,7 @@ struct GRPEnvVariables {
     }
   }
 
-  ClassDefNV(GRPEnvVariables, 1);
+  ClassDefNV(GRPEnvVariables, 2);
 };
 
 struct MagFieldHelper {
@@ -122,7 +123,7 @@ struct MagFieldHelper {
 
 struct GRPCollimators {
 
-  std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>> mCollimators;
+  std::unordered_map<std::string, std::vector<std::pair<O2LongUInt, double>>> mCollimators;
   size_t totalEntries() const
   {
     size_t s = 0;
@@ -141,7 +142,7 @@ struct GRPCollimators {
     }
   }
 
-  ClassDefNV(GRPCollimators, 1);
+  ClassDefNV(GRPCollimators, 2);
 };
 
 struct GRPLHCInfo {
@@ -191,19 +192,19 @@ struct GRPLHCInfo {
   static constexpr std::string_view lhcStringAliases[NLHCStringAliases] = {"ALI_Lumi_Source_Name", "BEAM_MODE", "MACHINE_MODE"};
   static constexpr int nAliasesLHC = (int)NCollimatorAliases + (int)NBeamAliases + (int)NBkgAliases + (int)NBPTXAliases + (int)NBPTXPhaseAliases + (int)NBPTXPhaseRMSAliases + (int)NBPTXPhaseShiftAliases + (int)NLumiAliases + (int)NLHCStringAliases;
 
-  std::array<std::vector<std::pair<uint64_t, double>>, 2> mIntensityBeam;
-  std::array<std::vector<std::pair<uint64_t, double>>, 3> mBackground;
-  std::vector<std::pair<uint64_t, double>> mInstLumi;
-  std::vector<std::pair<uint64_t, double>> mBPTXdeltaT;
-  std::vector<std::pair<uint64_t, double>> mBPTXdeltaTRMS;
-  std::array<std::vector<std::pair<uint64_t, double>>, 2> mBPTXPhase;
-  std::array<std::vector<std::pair<uint64_t, double>>, 2> mBPTXPhaseRMS;
-  std::array<std::vector<std::pair<uint64_t, double>>, 2> mBPTXPhaseShift;
-  std::pair<uint64_t, std::string> mLumiSource;  // only one value per object: when there is a change, a new object is stored
-  std::pair<uint64_t, std::string> mMachineMode; // only one value per object: when there is a change, a new object is stored
-  std::pair<uint64_t, std::string> mBeamMode;    // only one value per object: when there is a change, a new object is stored
+  std::array<std::vector<std::pair<O2LongUInt, double>>, 2> mIntensityBeam;
+  std::array<std::vector<std::pair<O2LongUInt, double>>, 3> mBackground;
+  std::vector<std::pair<O2LongUInt, double>> mInstLumi;
+  std::vector<std::pair<O2LongUInt, double>> mBPTXdeltaT;
+  std::vector<std::pair<O2LongUInt, double>> mBPTXdeltaTRMS;
+  std::array<std::vector<std::pair<O2LongUInt, double>>, 2> mBPTXPhase;
+  std::array<std::vector<std::pair<O2LongUInt, double>>, 2> mBPTXPhaseRMS;
+  std::array<std::vector<std::pair<O2LongUInt, double>>, 2> mBPTXPhaseShift;
+  std::pair<O2LongUInt, std::string> mLumiSource;  // only one value per object: when there is a change, a new object is stored
+  std::pair<O2LongUInt, std::string> mMachineMode; // only one value per object: when there is a change, a new object is stored
+  std::pair<O2LongUInt, std::string> mBeamMode;    // only one value per object: when there is a change, a new object is stored
 
-  void resetAndKeepLastVector(std::vector<std::pair<uint64_t, double>>& vect)
+  void resetAndKeepLastVector(std::vector<std::pair<O2LongUInt, double>>& vect)
   {
     // always check that the size is > 0 (--> begin != end) for all vectors
     if (vect.begin() != vect.end()) {
@@ -291,16 +292,16 @@ class GRPDCSDPsProcessor
   void init(const std::vector<DPID>& pids);
   int process(const gsl::span<const DPCOM> dps);
   int processDP(const DPCOM& dpcom);
-  uint64_t processFlags(uint64_t flag, const char* pid) { return 0; } // for now it is not really implemented
+  O2LongUInt processFlags(O2LongUInt flag, const char* pid) { return 0; } // for now it is not really implemented
   bool processCollimators(const DPCOM& dpcom);
   bool processEnvVar(const DPCOM& dpcom);
-  bool processPairD(const DPCOM& dpcom, const std::string& alias, std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>>& mapToUpdate);
-  bool processPairS(const DPCOM& dpcom, const std::string& alias, std::pair<uint64_t, std::string>& p, bool& flag);
-  bool compareToLatest(std::pair<uint64_t, double>& p, double val);
+  bool processPairD(const DPCOM& dpcom, const std::string& alias, std::unordered_map<std::string, std::vector<std::pair<O2LongUInt, double>>>& mapToUpdate);
+  bool processPairS(const DPCOM& dpcom, const std::string& alias, std::pair<O2LongUInt, std::string>& p, bool& flag);
+  bool compareToLatest(std::pair<O2LongUInt, double>& p, double val);
   bool processLHCIFDPs(const DPCOM& dpcom);
 
   void resetAndKeepLastLHCIFDPs() { mLHCInfo.resetAndKeepLast(); }
-  void resetAndKeepLast(std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>>& mapToReset)
+  void resetAndKeepLast(std::unordered_map<std::string, std::vector<std::pair<O2LongUInt, double>>>& mapToReset)
   {
     // keep only the latest measurement
     for (auto& el : mapToReset) {
@@ -366,8 +367,8 @@ class GRPDCSDPsProcessor
   void useVerboseMode() { mVerbose = true; }
   void clearVectors() { mClearVectors = true; }
 
-  void printVectorInfo(const std::vector<std::pair<uint64_t, double>>& vect, bool afterUpdate);
-  void updateVector(const DPID& dpid, std::vector<std::pair<uint64_t, double>>& vect, std::string alias, uint64_t timestamp, double val);
+  void printVectorInfo(const std::vector<std::pair<O2LongUInt, double>>& vect, bool afterUpdate);
+  void updateVector(const DPID& dpid, std::vector<std::pair<O2LongUInt, double>>& vect, std::string alias, O2LongUInt timestamp, double val);
 
  private:
   std::unordered_map<DPID, bool> mPids; // contains all PIDs for the processor, the bool

--- a/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
+++ b/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
@@ -185,7 +185,7 @@ bool GRPDCSDPsProcessor::processEnvVar(const DPCOM& dpcom)
 }
 
 //______________________________________________________________________
-bool GRPDCSDPsProcessor::processPairD(const DPCOM& dpcom, const std::string& alias, std::unordered_map<std::string, std::vector<std::pair<uint64_t, double>>>& mapToUpdate)
+bool GRPDCSDPsProcessor::processPairD(const DPCOM& dpcom, const std::string& alias, std::unordered_map<std::string, std::vector<std::pair<O2LongUInt, double>>>& mapToUpdate)
 {
 
   // function to process Data Points that is stored in a pair
@@ -207,7 +207,7 @@ bool GRPDCSDPsProcessor::processPairD(const DPCOM& dpcom, const std::string& ali
 }
 
 //______________________________________________________________________
-bool GRPDCSDPsProcessor::processPairS(const DPCOM& dpcom, const std::string& alias, std::pair<uint64_t, std::string>& p, bool& flag)
+bool GRPDCSDPsProcessor::processPairS(const DPCOM& dpcom, const std::string& alias, std::pair<O2LongUInt, std::string>& p, bool& flag)
 {
 
   // function to process string Data Points that is stored in a pair
@@ -237,7 +237,7 @@ bool GRPDCSDPsProcessor::processPairS(const DPCOM& dpcom, const std::string& ali
 
 //______________________________________________________________________
 
-bool GRPDCSDPsProcessor::compareToLatest(std::pair<uint64_t, double>& p, double val)
+bool GRPDCSDPsProcessor::compareToLatest(std::pair<O2LongUInt, double>& p, double val)
 {
 
   // check if the content of the pair should be updated
@@ -408,7 +408,7 @@ void GRPDCSDPsProcessor::updateCollimatorsCCDB()
 
 //______________________________________________________________________
 
-void GRPDCSDPsProcessor::printVectorInfo(const std::vector<std::pair<uint64_t, double>>& vect, bool afterUpdate)
+void GRPDCSDPsProcessor::printVectorInfo(const std::vector<std::pair<O2LongUInt, double>>& vect, bool afterUpdate)
 {
 
   std::string stage = afterUpdate ? "after update" : "before update";
@@ -422,7 +422,7 @@ void GRPDCSDPsProcessor::printVectorInfo(const std::vector<std::pair<uint64_t, d
 
 //______________________________________________________________________
 
-void GRPDCSDPsProcessor::updateVector(const DPID& dpid, std::vector<std::pair<uint64_t, double>>& vect, std::string alias, uint64_t timestamp, double val)
+void GRPDCSDPsProcessor::updateVector(const DPID& dpid, std::vector<std::pair<O2LongUInt, double>>& vect, std::string alias, O2LongUInt timestamp, double val)
 {
   printVectorInfo(vect, 0);
   bool updateFlag = false;

--- a/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
+++ b/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
@@ -22,6 +22,7 @@
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DeliveryType.h"
+#include "Framework/O2LongInt.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "CommonUtils/MemFileHelper.h"
 #include "CCDB/CcdbApi.h"
@@ -40,13 +41,13 @@ using DPCOM = o2::dcs::DataPointCompositeObject;
 
 struct MFTDCSinfo {
 
-  std::pair<uint64_t, double> firstValue; // first value seen by the MFT DCS processor
-  std::pair<uint64_t, double> lastValue;  // last value seen by the MFT DCS processor
-  std::pair<uint64_t, double> meanValue;  // mean value seen by the MFT DCS processor
-  std::pair<uint64_t, double> stddevValue; // standard deviation value seen by the MFT DCS processor
-  std::pair<uint64_t, double> midValue;   // mid value seen by the MFT DCS processor
-  std::pair<uint64_t, double> maxChange;  // maximum variation seen by the MFT DCS processor
-  std::pair<uint64_t, double> summary;    // number of entries by the MFT DCS processor
+  std::pair<O2LongUInt, double> firstValue;  // first value seen by the MFT DCS processor
+  std::pair<O2LongUInt, double> lastValue;   // last value seen by the MFT DCS processor
+  std::pair<O2LongUInt, double> meanValue;   // mean value seen by the MFT DCS processor
+  std::pair<O2LongUInt, double> stddevValue; // standard deviation value seen by the MFT DCS processor
+  std::pair<O2LongUInt, double> midValue;    // mid value seen by the MFT DCS processor
+  std::pair<O2LongUInt, double> maxChange;   // maximum variation seen by the MFT DCS processor
+  std::pair<O2LongUInt, double> summary;     // number of entries by the MFT DCS processor
 
   MFTDCSinfo()
   {

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFDCSProcessor.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFDCSProcessor.h
@@ -18,6 +18,7 @@
 #include <deque>
 #include <numeric>
 #include "Framework/Logger.h"
+#include "Framework/O2LongInt.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
@@ -40,19 +41,19 @@ using DPVAL = o2::dcs::DataPointValue;
 using DPCOM = o2::dcs::DataPointCompositeObject;
 
 struct TOFDCSinfo {
-  std::pair<uint64_t, double> firstValue; // first value seen by the TOF DCS processor
-  std::pair<uint64_t, double> lastValue;  // last value seen by the TOF DCS processor
-  std::pair<uint64_t, double> midValue;   // mid value seen by the TOF DCS processor
-  std::pair<std::array<uint64_t, 2>, double> maxChange; // maximum variation seen by the TOF DCS processor (previous - subsequent value)
-  std::pair<uint64_t, double> minValue;                 // smallest measurement seen by the TOF DCS processor
-  std::pair<uint64_t, double> maxValue;                 // largest measurement seen by the TOF DCS processor
+  std::pair<O2LongUInt, double> firstValue;               // first value seen by the TOF DCS processor
+  std::pair<O2LongUInt, double> lastValue;                // last value seen by the TOF DCS processor
+  std::pair<O2LongUInt, double> midValue;                 // mid value seen by the TOF DCS processor
+  std::pair<std::array<O2LongUInt, 2>, double> maxChange; // maximum variation seen by the TOF DCS processor (previous - subsequent value)
+  std::pair<O2LongUInt, double> minValue;                 // smallest measurement seen by the TOF DCS processor
+  std::pair<O2LongUInt, double> maxValue;                 // largest measurement seen by the TOF DCS processor
   bool updated = false;
   TOFDCSinfo()
   {
     firstValue = std::make_pair(0, -999999999);
     lastValue = std::make_pair(0, -999999999);
     midValue = std::make_pair(0, -999999999);
-    std::array<uint64_t, 2> atmp = {0, 0};
+    std::array<O2LongUInt, 2> atmp = {0, 0};
     maxChange = std::make_pair(atmp, 0);
     minValue = std::make_pair(0, 99999999999);
     maxValue = std::make_pair(0, -99999999999);

--- a/Detectors/ZDC/calib/include/ZDCCalib/ZDCDCSProcessor.h
+++ b/Detectors/ZDC/calib/include/ZDCCalib/ZDCDCSProcessor.h
@@ -15,6 +15,7 @@
 #include <deque>
 #include <numeric>
 #include "Framework/Logger.h"
+#include "Framework/O2LongInt.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
@@ -39,10 +40,10 @@ using DPVAL = o2::dcs::DataPointValue;
 using DPCOM = o2::dcs::DataPointCompositeObject;
 
 struct ZDCDCSinfo {
-  std::pair<uint64_t, double> firstValue; // first value seen by the ZDC DCS processor
-  std::pair<uint64_t, double> lastValue;  // last value seen by the ZDC DCS processor
-  std::pair<uint64_t, double> midValue;   // mid value seen by the ZDC DCS processor
-  std::pair<uint64_t, double> maxChange;  // maximum variation seen by the ZDC DCS processor
+  std::pair<O2LongUInt, double> firstValue; // first value seen by the ZDC DCS processor
+  std::pair<O2LongUInt, double> lastValue;  // last value seen by the ZDC DCS processor
+  std::pair<O2LongUInt, double> midValue;   // mid value seen by the ZDC DCS processor
+  std::pair<O2LongUInt, double> maxChange;  // maximum variation seen by the ZDC DCS processor
 
   ZDCDCSinfo()
   {

--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(FrameworkFoundation
                SOURCES src/RuntimeError.cxx
                src/Signpost.cxx
                src/BacktraceHelpers.cxx
+               src/O2LongInt.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation3rdparty
               )

--- a/Framework/Foundation/include/Framework/O2LongInt.h
+++ b/Framework/Foundation/include/Framework/O2LongInt.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ Due to the root bug https://github.com/root-project/root/issues/17216
+ we cannot safely use std::pair<std::int64_t,...> since it is saved in the
+ root file as long int, on the MacOS considered to be different from int64_t or
+ UInt64_t. Thererefor, we define out own O2LongInt and make sure that it is at
+ least 8 bytes long.
+*/
+
+#ifndef O2_FRAMEWORK_O2LONGINT_H_
+#define O2_FRAMEWORK_O2LONGINT_H_
+
+namespace o2
+{
+
+static_assert(sizeof(long int) >= 8, "long int on this machine is < 8 bytes.");
+
+using O2LongInt = long int;
+using O2LongUInt = unsigned long int;
+
+} // namespace o2
+#endif // O2_FRAMEWORK_O2LONGINT_H_

--- a/Framework/Foundation/src/O2LongInt.cxx
+++ b/Framework/Foundation/src/O2LongInt.cxx
@@ -1,0 +1,12 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/O2LongInt.h"


### PR DESCRIPTION
…jects with pair<...>

This is to make readable on the MacOS the CCDB objects with pair<std::int64_t,...> (stored as pair<long int, ...>). A static_assert is added to ensure that the long int is at least 8 bytes long.