### PR TITLE
ITSMFT::Clusterer: Optionally drop huge clusters

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -121,8 +121,9 @@ void ClustererDPL::updateTimeDependentParams(ProcessingContext& pc)
     // settings for the fired pixel overflow masking
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     const auto& clParams = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance();
+    mClusterer->setDropHugeClusters(clParams.dropHugeClusters);
     if (clParams.maxBCDiffToMaskBias > 0 && clParams.maxBCDiffToSquashBias > 0) {
-      LOGP(fatal, "maxBCDiffToMaskBias = {} and maxBCDiffToMaskBias = {} cannot be set at the same time. Either set masking or squashing with a BCDiff > 0", clParams.maxBCDiffToMaskBias, clParams.maxBCDiffToSquashBias);
+      LOGP(fatal, "maxBCDiffToMaskBias = {} and maxBCDiffToSquashBias = {} cannot be set at the same time. Either set masking or squashing with a BCDiff > 0", clParams.maxBCDiffToMaskBias, clParams.maxBCDiffToSquashBias);
     }
     auto nbc = clParams.maxBCDiffToMaskBias;
     nbc += mClusterer->isContinuousReadOut() ? alpParams.roFrameLengthInBC : (alpParams.roFrameLengthTrig / o2::constants::lhc::LHCBunchSpacingNS);

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -122,8 +122,9 @@ void ClustererDPL::updateTimeDependentParams(ProcessingContext& pc)
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
     const auto& clParams = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance();
     if (clParams.maxBCDiffToMaskBias > 0 && clParams.maxBCDiffToSquashBias > 0) {
-      LOGP(fatal, "maxBCDiffToMaskBias = {} and maxBCDiffToMaskBias = {} cannot be set at the same time. Either set masking or squashing with a BCDiff > 0", clParams.maxBCDiffToMaskBias, clParams.maxBCDiffToSquashBias);
+      LOGP(fatal, "maxBCDiffToMaskBias = {} and maxBCDiffToSquashBias = {} cannot be set at the same time. Either set masking or squashing with a BCDiff > 0", clParams.maxBCDiffToMaskBias, clParams.maxBCDiffToSquashBias);
     }
+    mClusterer->setDropHugeClusters(clParams.dropHugeClusters);
     auto nbc = clParams.maxBCDiffToMaskBias;
     nbc += mClusterer->isContinuousReadOut() ? alpParams.roFrameLengthInBC : (alpParams.roFrameLengthTrig / o2::constants::lhc::LHCBunchSpacingNS);
     mClusterer->setMaxBCSeparationToMask(nbc);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -204,6 +204,9 @@ class Clusterer
   bool isContinuousReadOut() const { return mContinuousReadout; }
   void setContinuousReadOut(bool v) { mContinuousReadout = v; }
 
+  bool isDropHugeClusters() const { return mDropHugeClusters; }
+  void setDropHugeClusters(bool v) { mDropHugeClusters = v; }
+
   int getMaxBCSeparationToMask() const { return mMaxBCSeparationToMask; }
   void setMaxBCSeparationToMask(int n) { mMaxBCSeparationToMask = n; }
 
@@ -238,6 +241,7 @@ class Clusterer
 
   // clusterization options
   bool mContinuousReadout = true; ///< flag continuous readout
+  bool mDropHugeClusters = false; ///< don't include clusters that would be split in more than one
 
   ///< mask continuosly fired pixels in frames separated by less than this amount of BCs (fired from hit in prev. ROF)
   int mMaxBCSeparationToMask = 6000. / o2::constants::lhc::LHCBunchSpacingNS + 10;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClustererParam.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClustererParam.h
@@ -38,6 +38,7 @@ struct ClustererParam : public o2::conf::ConfigurableParamHelper<ClustererParam<
   int maxBCDiffToMaskBias = 10;                    ///< mask if 2 ROFs differ by <= StrobeLength + Bias BCs, use value <0 to disable masking
   int maxBCDiffToSquashBias = -10;                 ///< squash if 2 ROFs differ by <= StrobeLength + Bias BCs, use value <0 to disable squashing
   float maxSOTMUS = 8.;                            ///< max expected signal over threshold in \mus
+  bool dropHugeClusters = false;                   ///< option to drop huge clusters (mitigate beam background)
 
   O2ParamDef(ClustererParam, getParamName().data());
 


### PR DESCRIPTION
@shahor02 
The implementation is obvious.
Taking as example Layer0, stave 5, the difference is visible.
Before:
![stave5_withHuge](https://github.com/user-attachments/assets/2d4df009-b22b-41a6-a3f7-b95f03700591)
After:
![stave5_noHuge](https://github.com/user-attachments/assets/f9bd7702-de36-4488-bca0-f79cbfd62afc)

There are of course much worse scenarios.
See the print of the full layer.
Before:
![withhuge_layer0](https://github.com/user-attachments/assets/54a88510-5d9b-4fd3-a377-ee10d41664f3)
After:
![no_huge_layer0](https://github.com/user-attachments/assets/86fa174b-a01c-4b4f-b615-2c581ad77b57)

Unfortunately this does not really improve much the situation with the reconstruction, as the total number of clusters does changes of orders of ~1%.

Some of the very large clusters will do the dashed clusters effect, as I was mentioning earlier (will look for an example), and there is no way of not saving them with this.

Maybe there is still good reason to keep the "development".