### PR TITLE
Data model: add extra information for run 2 evsel

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1730,7 +1730,8 @@ DECLARE_SOA_TABLE(Run2BCInfos_000, "AOD", "RUN2BCINFO", run2::EventCuts, //! Leg
                   run2::SPDFiredFastOrL0, run2::SPDFiredFastOrL1,
                   run2::V0TriggerChargeA, run2::V0TriggerChargeC);
 
-DECLARE_SOA_TABLE_VERSIONED(Run2BCInfos_001, "AOD", "RUN2BCINFO", run2::EventCuts, //! Legacy information for Run 2 event selection
+DECLARE_SOA_TABLE_VERSIONED(Run2BCInfos_001, "AOD", "RUN2BCINFO", 1,
+                            run2::EventCuts, //! Legacy information for Run 2 event selection
                             run2::TriggerMaskNext50, run2::L0TriggerInputMask,
                             run2::SPDClustersL0, run2::SPDClustersL1,
                             run2::SPDFiredChipsL0, run2::SPDFiredChipsL1,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1699,6 +1699,8 @@ DECLARE_SOA_COLUMN(SPDFiredFastOrL0, spdFiredFastOrL0, uint16_t);     //! Fired 
 DECLARE_SOA_COLUMN(SPDFiredFastOrL1, spdFiredFastOrL1, uint16_t);     //! Fired FASTOR signals in the first layer of the SPD (online)
 DECLARE_SOA_COLUMN(V0TriggerChargeA, v0TriggerChargeA, uint16_t);     //! V0A trigger charge
 DECLARE_SOA_COLUMN(V0TriggerChargeC, v0TriggerChargeC, uint16_t);     //! V0C trigger charge
+DECLARE_SOA_COLUMN(NTPCClusters, nTPCClusters, uint32_t);             //! total number of TPC clusters (for ev sel)
+DECLARE_SOA_COLUMN(NSDDSSDClusters, nSDDSSDClusters, uint32_t);       //! total number of SSD + SDD clusters (for ev sel)
 namespace oftv0
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                         //! Collision index
@@ -1721,12 +1723,22 @@ DECLARE_SOA_COLUMN(Mass, mass, float);                                  //! mass
 } // namespace oftv0
 } // namespace run2
 
-DECLARE_SOA_TABLE(Run2BCInfos, "AOD", "RUN2BCINFO", run2::EventCuts, //! Legacy information for Run 2 event selection
+DECLARE_SOA_TABLE(Run2BCInfos_000, "AOD", "RUN2BCINFO", run2::EventCuts, //! Legacy information for Run 2 event selection
                   run2::TriggerMaskNext50, run2::L0TriggerInputMask,
                   run2::SPDClustersL0, run2::SPDClustersL1,
                   run2::SPDFiredChipsL0, run2::SPDFiredChipsL1,
                   run2::SPDFiredFastOrL0, run2::SPDFiredFastOrL1,
                   run2::V0TriggerChargeA, run2::V0TriggerChargeC);
+
+DECLARE_SOA_TABLE_VERSIONED(Run2BCInfos_001, "AOD", "RUN2BCINFO", run2::EventCuts, //! Legacy information for Run 2 event selection
+                  run2::TriggerMaskNext50, run2::L0TriggerInputMask,
+                  run2::SPDClustersL0, run2::SPDClustersL1,
+                  run2::SPDFiredChipsL0, run2::SPDFiredChipsL1,
+                  run2::SPDFiredFastOrL0, run2::SPDFiredFastOrL1,
+                  run2::V0TriggerChargeA, run2::V0TriggerChargeC,
+                  run2::NTPCClusters, run2::NSDDSSDClusters);
+
+using Run2BCInfos = Run2BCInfos_000;
 using Run2BCInfo = Run2BCInfos::iterator;
 
 DECLARE_SOA_TABLE(Run2OTFV0s, "AOD", "Run2OTFV0", //! Run 2 V0 on the fly table

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1731,12 +1731,12 @@ DECLARE_SOA_TABLE(Run2BCInfos_000, "AOD", "RUN2BCINFO", run2::EventCuts, //! Leg
                   run2::V0TriggerChargeA, run2::V0TriggerChargeC);
 
 DECLARE_SOA_TABLE_VERSIONED(Run2BCInfos_001, "AOD", "RUN2BCINFO", run2::EventCuts, //! Legacy information for Run 2 event selection
-                  run2::TriggerMaskNext50, run2::L0TriggerInputMask,
-                  run2::SPDClustersL0, run2::SPDClustersL1,
-                  run2::SPDFiredChipsL0, run2::SPDFiredChipsL1,
-                  run2::SPDFiredFastOrL0, run2::SPDFiredFastOrL1,
-                  run2::V0TriggerChargeA, run2::V0TriggerChargeC,
-                  run2::NTPCClusters, run2::NSDDSSDClusters);
+                            run2::TriggerMaskNext50, run2::L0TriggerInputMask,
+                            run2::SPDClustersL0, run2::SPDClustersL1,
+                            run2::SPDFiredChipsL0, run2::SPDFiredChipsL1,
+                            run2::SPDFiredFastOrL0, run2::SPDFiredFastOrL1,
+                            run2::V0TriggerChargeA, run2::V0TriggerChargeC,
+                            run2::NTPCClusters, run2::NSDDSSDClusters);
 
 using Run2BCInfos = Run2BCInfos_000;
 using Run2BCInfo = Run2BCInfos::iterator;

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -57,6 +57,7 @@ enum TrackFlagsRun2Enum {
   FreeClsSPDTracklet = 0x1, // for SPD tracklets, tracklet from cluster not used in tracking
   TPCrefit = 0x2,
   GoldenChi2 = 0x4,
+  TPCout = 0x8
   // NOTE Highest 4 (29..32) bits reserved for PID hypothesis
 };
 enum DetectorMapEnum : uint8_t {


### PR DESCRIPTION
Goes hand-in-hand with: https://github.com/alisw/AliPhysics/pull/23817

* adds extra event selection information to the run 2 converted data by adding:
   * TPCout flag in track flags 
   * total number of tpc clusters as part of run2bcinfos
   * total number of SSD+SDD clusters as part of run2bcinfos

Run2BCInfos now becomes versioned, Run 2 converter in AliPhysics will immediately generate version `001`. An O2Physics converter will be added tomorrow. 

For reference, data size increase is negligible (`Run2BCInfos` currently occupies, with this change, 0.2% of the data size even in pp, where it's smallest).