### PR TITLE
Make sure PrimaryGenerator is destructed

### DIFF
--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -40,7 +40,7 @@ namespace eventgen
 PrimaryGenerator::~PrimaryGenerator()
 {
   /** destructor **/
-
+  LOG(info) << "Destructing PrimaryGenerator";
   if (mEmbedFile && mEmbedFile->IsOpen()) {
     mEmbedFile->Close();
     delete mEmbedFile;


### PR DESCRIPTION
Makes sure that PrimaryGenerators are destructed in o2-sim.

Note that all FairGenerator pointers registered in the PrimaryGenerator are automatically destructed as well.