### PR TITLE
ITS: Improved memory usage for vresetd scan

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -235,7 +235,6 @@ class ITSThresholdCalibrator : public Task
   short int mRunTypeRUCopy[N_RU] = {0};
   short int mCdwCntRU[N_RU][N_ROW] = {{0}};
   short int mLoopVal[N_RU][N_ROW] = {{0}};
-  short int mRowRU[N_RU] = {0};
   bool mActiveLinks[N_RU][3] = {{false}};
   std::set<short int> mRuSet;
   // Either "T" for threshold, "V" for VCASN, or "I" for ITHR

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -234,6 +234,7 @@ class ITSThresholdCalibrator : public Task
   short int mRunTypeRU[N_RU] = {0};
   short int mRunTypeRUCopy[N_RU] = {0};
   short int mCdwCntRU[N_RU][N_ROW] = {{0}};
+  short int mLoopVal[N_RU][N_ROW] = {{0}};
   short int mRowRU[N_RU] = {0};
   bool mActiveLinks[N_RU][3] = {{false}};
   std::set<short int> mRuSet;

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -744,40 +744,38 @@ void ITSThresholdCalibrator::extractThresholdRow(const short int& chipID, const 
 
   } else { // threshold, vcasn, ithr
 
-    for (int scan_i = 0; scan_i < ((mScanType == 'r') ? N_RANGE : N_RANGE2); scan_i++) {
-
+    short int iRU = getRUID(chipID);
 #ifdef WITH_OPENMP
-      omp_set_num_threads(mNThreads);
+    omp_set_num_threads(mNThreads);
 #pragma omp parallel for schedule(dynamic)
 #endif
-      // Loop over all columns (pixels) in the row
-      for (short int col_i = 0; col_i < this->N_COL; col_i++) {
-
-        // Do the threshold fit
-        float thresh = 0., noise = 0.;
-        bool success = false;
-        int spoints = 0;
-        if (isDumpS) { // already protected for multi-thread in the init
-          mFitHist->SetName(Form("scurve_chip%d_row%d_col%d_scani%d", chipID, row, col_i, scan_i));
-        }
-
-        success = this->findThreshold(chipID, mPixelHits[chipID][row][col_i],
-                                      this->mX, mScanType == 'r' ? N_RANGE2 : N_RANGE, thresh, noise, spoints, scan_i);
-
-        vChipid[col_i] = chipID;
-        vRow[col_i] = row;
-        vThreshold[col_i] = (mScanType == 'T' || mScanType == 'r') ? (short int)(thresh * 10.) : (short int)(thresh);
-        vNoise[col_i] = (float)(noise * 10.); // always factor 10 also for ITHR/VCASN to not have all zeros
-        vSuccess[col_i] = success;
-        vPoints[col_i] = spoints > 0 ? (unsigned char)(spoints) : 0;
-
-        if (mScanType == 'r') {
-          vMixData[col_i] = (scan_i * this->mStep) + mMin;
-        }
+    // Loop over all columns (pixels) in the row
+    for (short int col_i = 0; col_i < this->N_COL; col_i++) {
+      // Do the threshold fit
+      float thresh = 0., noise = 0.;
+      bool success = false;
+      int spoints = 0;
+      int scan_i = mScanType == 'r' ? (mLoopVal[iRU][row] - mMin) / mStep : 0;
+      if (isDumpS) { // already protected for multi-thread in the init
+        mFitHist->SetName(Form("scurve_chip%d_row%d_col%d_scani%d", chipID, row, col_i, scan_i));
       }
+
+      success = this->findThreshold(chipID, mPixelHits[chipID][row][col_i],
+                                    this->mX, mScanType == 'r' ? N_RANGE2 : N_RANGE, thresh, noise, spoints, scan_i);
+
+      vChipid[col_i] = chipID;
+      vRow[col_i] = row;
+      vThreshold[col_i] = (mScanType == 'T' || mScanType == 'r') ? (short int)(thresh * 10.) : (short int)(thresh);
+      vNoise[col_i] = (float)(noise * 10.); // always factor 10 also for ITHR/VCASN to not have all zeros
+      vSuccess[col_i] = success;
+      vPoints[col_i] = spoints > 0 ? (unsigned char)(spoints) : 0;
+
       if (mScanType == 'r') {
-        this->saveThreshold(); // save before moving to the next vresetd
+        vMixData[col_i] = mLoopVal[iRU][row];
       }
+    }
+    if (mScanType == 'r') {
+      this->saveThreshold(); // save before moving to the next vresetd
     }
 
     // Fill the ScTree tree
@@ -1363,9 +1361,10 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         cwcnt = (short int)(calib.calibCounter);
         // count the last N injections
         short int checkVal = (mScanType == 'I') ? mMin : mMax;
-        if (loopval == checkVal && realcharge == mMin2) { // the second condition is relevant only for mScanType=p
+        if ((mScanType != 'r' && loopval == checkVal) || (mScanType == 'r' && realcharge == mMax2)) {
           mCdwCntRU[iRU][row]++;
-          mRowRU[iRU] = row; // keep the row
+          mRowRU[iRU] = row;            // keep the row
+          mLoopVal[iRU][row] = loopval; // keep loop val (relevant for VRESET2D scan only)
         }
         if (this->mVerboseOutput) {
           LOG(info) << "RU: " << iRU << " CDWcounter: " << cwcnt << " row: " << row << " Loopval: " << loopval << " realcharge: " << realcharge << " confDBv: " << mCdwVersion;
@@ -1412,6 +1411,9 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         if ((chipID % mChipModBase) != mChipModSel) {
           continue;
         }
+        if ((loopval == 100 || loopval == 105) && (chipID == 1 || chipID == 8)) {
+          LOG(info) << "Loopval: " << loopval << " Charge: " << realcharge << " Chip: " << chipID << " row: " << d.getRow() << " Col: " << d.getColumn();
+        }
         if (d.getRow() != row && mVerboseOutput) {
           LOG(info) << "iROF: " << iROF << " ChipID " << chipID << ": current row is " << d.getRow() << " (col = " << d.getColumn() << ") but the one in CW is " << row;
         }
@@ -1425,7 +1427,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         short int ru = getRUID(chipID);
         mActiveLinks[ru][getLinkID(chipID, ru)] = true;
         // check rows and allocate memory
-        if (mForbiddenRows.count(chipID)) {
+        if (mScanType != 'r' && mForbiddenRows.count(chipID)) {
           for (int iforb = mForbiddenRows[chipID].size() - 1; iforb >= 0; iforb--) {
             if (mForbiddenRows[chipID][iforb] == row) {
               mChipsForbRows[chipID] = true;
@@ -1490,7 +1492,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
     }
     // Check if scan of a row is finished: only for specific scans!
     bool passCondition = (mCdwCntRU[iRU][mRowRU[iRU]] >= nInjScaled * nL);
-    if (mScanType != 'D' && mScanType != 'A' && mScanType != 'P' && mScanType != 'p' && mScanType != 'R' && mScanType != 'r' && passCondition) {
+    if (mScanType != 'D' && mScanType != 'A' && mScanType != 'P' && mScanType != 'p' && mScanType != 'R' && passCondition) {
       // extract data from the row
       for (short int iChip = 0; iChip < chipEnabled.size(); iChip++) {
         short int chipID = chipEnabled[iChip];
@@ -1871,7 +1873,7 @@ void ITSThresholdCalibrator::finalize()
       this->addDatabaseEntry(it_ineff->first, name, std::vector<float>(), false);
       it_ineff = this->mIneffPixID.erase(it_ineff);
     }
-  } else if (this->mScanType == 'P' || this->mScanType == 'p' || this->mScanType == 'r' || mScanType == 'R') { // pulse length scan 1D and 2D, vresetd scan 1D & 2D
+  } else if (this->mScanType == 'P' || this->mScanType == 'p' || mScanType == 'R') { // pulse length scan 1D and 2D, vresetd scan 1D (2D already extracted in run())
     name = "Pulse";
     // extract hits for the available row(s)
     auto itchip = this->mPixelHits.cbegin();

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -1411,9 +1411,6 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         if ((chipID % mChipModBase) != mChipModSel) {
           continue;
         }
-        if ((loopval == 100 || loopval == 105) && (chipID == 1 || chipID == 8)) {
-          LOG(info) << "Loopval: " << loopval << " Charge: " << realcharge << " Chip: " << chipID << " row: " << d.getRow() << " Col: " << d.getColumn();
-        }
         if (d.getRow() != row && mVerboseOutput) {
           LOG(info) << "iROF: " << iROF << " ChipID " << chipID << ": current row is " << d.getRow() << " (col = " << d.getColumn() << ") but the one in CW is " << row;
         }

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -1309,10 +1309,12 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
     short int row = -1;
     short int cwcnt = -1;
     bool isAllZero = true;
+    short int ruIndex = -1;
     for (short int iRU = 0; iRU < this->N_RU; iRU++) {
       const auto& calib = calibs[iROF * this->N_RU + iRU];
       if (calib.calibUserField != 0) {
         mRuSet.insert(iRU);
+        ruIndex = iRU;
         isAllZero = false;
 
         if (loopval >= 0) {
@@ -1363,7 +1365,6 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         short int checkVal = (mScanType == 'I') ? mMin : mMax;
         if ((mScanType != 'r' && loopval == checkVal) || (mScanType == 'r' && realcharge == mMax2)) {
           mCdwCntRU[iRU][row]++;
-          mRowRU[iRU] = row;            // keep the row
           mLoopVal[iRU][row] = loopval; // keep loop val (relevant for VRESET2D scan only)
         }
         if (this->mVerboseOutput) {
@@ -1466,29 +1467,31 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         }
       }
     } // if (charge)
-  }   // for (ROFs)
 
-  // Prepare the ChipDone object for QC + extract data if the row is completed
-  for (auto& iRU : mRuSet) {
+    ////
+    // Prepare the ChipDone object for QC + extract data if the row is completed
+    if (ruIndex < 0) {
+      continue;
+    }
     short int nL = 0;
     for (int iL = 0; iL < 3; iL++) {
-      if (mActiveLinks[iRU][iL]) {
+      if (mActiveLinks[ruIndex][iL]) {
         nL++; // count active links
       }
     }
-    std::vector<short int> chipEnabled = getChipListFromRu(iRU, mActiveLinks[iRU]); // chip boundaries
+    std::vector<short int> chipEnabled = getChipListFromRu(ruIndex, mActiveLinks[ruIndex]); // chip boundaries
     // Fill the chipDone info string
-    if (mRunTypeRUCopy[iRU] == nInjScaled * nL) {
+    if (mRunTypeRUCopy[ruIndex] == nInjScaled * nL) {
       for (short int iChip = 0; iChip < chipEnabled.size(); iChip++) {
         if ((chipEnabled[iChip] % mChipModBase) != mChipModSel) {
           continue;
         }
         addDatabaseEntry(chipEnabled[iChip], "", std::vector<float>(), true);
       }
-      mRunTypeRUCopy[iRU] = 0; // reset here is safer (the other counter is reset in finalize)
+      mRunTypeRUCopy[ruIndex] = 0; // reset here is safer (the other counter is reset in finalize)
     }
     // Check if scan of a row is finished: only for specific scans!
-    bool passCondition = (mCdwCntRU[iRU][mRowRU[iRU]] >= nInjScaled * nL);
+    bool passCondition = (mCdwCntRU[ruIndex][row] >= nInjScaled * nL);
     if (mScanType != 'D' && mScanType != 'A' && mScanType != 'P' && mScanType != 'p' && mScanType != 'R' && passCondition) {
       // extract data from the row
       for (short int iChip = 0; iChip < chipEnabled.size(); iChip++) {
@@ -1498,17 +1501,19 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         }
         if (!isDumpS || (std::find(chipDumpList.begin(), chipDumpList.end(), chipID) != chipDumpList.end() || !chipDumpList.size())) { // to dump s-curves as histograms
           if (mPixelHits.count(chipID)) {
-            if (mPixelHits[chipID].count(mRowRU[iRU])) { // make sure the row exists
-              extractAndUpdate(chipID, mRowRU[iRU]);
-              mPixelHits[chipID].erase(mRowRU[iRU]);
-              mForbiddenRows[chipID].push_back(mRowRU[iRU]);
+            if (mPixelHits[chipID].count(row)) { // make sure the row exists
+              extractAndUpdate(chipID, row);
+              if (mScanType != 'r' || (mScanType == 'r' && mLoopVal[ruIndex][row] == mMax)) {
+                mPixelHits[chipID].erase(row);
+              }
+              mForbiddenRows[chipID].push_back(row);
             }
           }
         }
       }
-      mCdwCntRU[iRU][mRowRU[iRU]] = 0; // reset
+      mCdwCntRU[ruIndex][row] = 0; // reset
     }
-  } // end loop on RuSet
+  } // for (ROFs)
 
   if (!(this->mRunTypeUp)) {
     finalize();


### PR DESCRIPTION
Before: thresholds for each VRESETD extracted only at the END of the scan
Now: thresholds extracted every time the VRESETD changes, then memory is erased