### PR TITLE
Apply encoding to boxgen particles

### DIFF
--- a/Generators/include/Generators/BoxGenerator.h
+++ b/Generators/include/Generators/BoxGenerator.h
@@ -19,6 +19,8 @@
 #include <vector>
 #include <Generators/BoxGunParam.h>
 #include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/ParticleStatus.h"
+#include <SimulationDataFormat/MCGenProperties.h>
 
 namespace o2::eventgen
 {
@@ -90,6 +92,14 @@ class BoxGenerator : public Generator
   {
     mParticles.clear();
     std::copy(mEvent.begin(), mEvent.end(), std::back_insert_iterator(mParticles));
+    for (auto& particle : mParticles) {
+      auto statusCode = particle.GetStatusCode();
+      if (!mcgenstatus::isEncoded(statusCode)) {
+        particle.SetStatusCode(mcgenstatus::MCGenStatusEncoding(statusCode, 0).fullEncoding);
+      }
+      // Set the transport bit according to the HepMC status code
+      particle.SetBit(ParticleStatus::kToBeDone, mcgenstatus::getHepMCStatusCode(particle.GetStatusCode()) == 1);
+    }
     return true;
   }
 


### PR DESCRIPTION
This is a mandatory fix when using BoxGen with the hybrid generator, which takes the status directly from the underlying generators and does not apply it. 