### PR TITLE
ITS/MFT decoder sends vector with certain errors details

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -290,6 +290,14 @@ struct GBTLinkDecodingStat {
   ClassDefNV(GBTLinkDecodingStat, 3);
 };
 
+struct ErrorMessage {
+  uint16_t id = -1;
+  uint16_t errType = 0;
+  uint16_t errInfo0 = 0;
+  uint16_t errInfo1 = 0;
+  ClassDefNV(ErrorMessage, 1)
+};
+
 } // namespace itsmft
 } // namespace o2
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -54,6 +54,8 @@ struct RUDecodeData {
   bool ROFRampUpStage = false;                                                // flag that the data come from the ROF rate ramp-up stage
   GBTCalibData calibData{};                                                   // calibration info from GBT calibration word
   std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> chipErrorsTF{}; // vector of chip decoding errors seen in the given TF
+  std::vector<ErrorMessage> errMsgVecTF;                                      // Specific errors info collected for sending for the whole TF
+
   const RUInfo* ruInfo = nullptr;
 
   RUDecodeData()

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -55,4 +55,7 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::ClustererParam < o2::detectors::DetID::ITS>> + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::ClustererParam < o2::detectors::DetID::MFT>> + ;
 
+#pragma link C++ class o2::itsmft::ErrorMessage + ;
+#pragma link C++ class std::vector < o2::itsmft::ErrorMessage> + ;
+
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
@@ -62,6 +62,14 @@ void RUDecodeData::fillChipStatistics(int icab, const ChipPixelData* chipData)
     auto& chErr = chipErrorsTF[compid];
     chErr.first++;
     chErr.second |= chipData->getErrorFlags();
+
+    if (chipData->isErrorSet(ChipStat::RepeatingPixel)) {
+      auto& errMsg = errMsgVecTF.emplace_back();
+      errMsg.id = chipData->getChipID();
+      errMsg.errType = ChipStat::RepeatingPixel;
+      errMsg.errInfo0 = chipData->getErrorInfo() & 0xffff;         // row
+      errMsg.errInfo1 = (chipData->getErrorInfo() >> 16) & 0xffff; // row
+    }
   }
   if (action & ChipStat::ErrActDump) {
     linkHBFToDump[(uint64_t(cableLinkPtr[icab]->subSpec) << 32) + cableLinkPtr[icab]->hbfEntry] = cableLinkPtr[icab]->irHBF.orbit;

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -247,7 +247,8 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
   }
   auto& linkErrors = pc.outputs().make<std::vector<GBTLinkDecodingStat>>(Output{orig, "LinkErrors", 0});
   auto& decErrors = pc.outputs().make<std::vector<ChipError>>(Output{orig, "ChipErrors", 0});
-  mDecoder->collectDecodingErrors(linkErrors, decErrors);
+  auto& errMessages = pc.outputs().make<std::vector<ErrorMessage>>(Output{orig, "ErrorInfo", 0});
+  mDecoder->collectDecodingErrors(linkErrors, decErrors, errMessages);
 
   pc.outputs().snapshot(Output{orig, "PHYSTRIG", 0}, mDecoder->getExternalTriggers());
 
@@ -398,6 +399,7 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
 
   outputs.emplace_back(inp.origin, "LinkErrors", 0, Lifetime::Timeframe);
   outputs.emplace_back(inp.origin, "ChipErrors", 0, Lifetime::Timeframe);
+  outputs.emplace_back(inp.origin, "ErrorInfo", 0, Lifetime::Timeframe);
   outputs.emplace_back(inp.origin, "CHIPSSTATUS", 0, Lifetime::Timeframe);
 
   if (inp.askSTFDist) {


### PR DESCRIPTION
An output vector<o2::itsmft::ErrorMessage> is added with information about ChipStat::RepeatingPixel error details (at the moment, other errors may be added). Each element of ErrorMessage is assigned as:
errMsg.id = chipID
errMsg.errType = ChipStat::RepeatingPixel (at the moment) errMsg.errInfo0 = row
errMsg.errInfo1 = col