### PR TITLE
fix in TOF sim digitization (decalibration), and add MC truth for QC …

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
@@ -53,7 +53,7 @@ class Cluster : public o2::BaseCluster<float>
 
   Cluster() = default;
 
-  Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, double timeRaw, double time, float tot, int L0L1latency, int deltaBC);
+  Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, double timeRaw, double time, float tot, int L0L1latency, int deltaBC, float geanttime = 0.0, double t0 = 0.0);
 
   ~Cluster() = default;
 
@@ -134,6 +134,10 @@ class Cluster : public o2::BaseCluster<float>
   int getDigitInfoCH(int idig) const { return mDigitInfoCh[idig]; }
   double getDigitInfoT(int idig) const { return mDigitInfoT[idig]; }
   float getDigitInfoTOT(int idig) const { return mDigitInfoTOT[idig]; }
+  float getTgeant() const { return mTgeant; }
+  void setTgeant(float val) { mTgeant = val; }
+  double getT0true() const { return mT0true; }
+  void setT0true(double val) { mT0true = val; }
 
  private:
 #if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
@@ -153,8 +157,10 @@ class Cluster : public o2::BaseCluster<float>
   int mDigitInfoCh[6] = {0, 0, 0, 0, 0, 0};
   double mDigitInfoT[6] = {0., 0., 0., 0., 0., 0.};
   float mDigitInfoTOT[6] = {0., 0., 0., 0., 0., 0.};
+  float mTgeant = 0.0;
+  double mT0true = 0.0;
 
-  ClassDefNV(Cluster, 4);
+  ClassDefNV(Cluster, 5);
 };
 
 #ifndef GPUCA_GPUCODE

--- a/DataFormats/Detectors/TOF/src/Cluster.cxx
+++ b/DataFormats/Detectors/TOF/src/Cluster.cxx
@@ -23,7 +23,7 @@ using namespace o2::tof;
 
 ClassImp(o2::tof::Cluster);
 
-Cluster::Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, double timeRaw, double time, float tot, int L0L1Latency, int deltaBC) : o2::BaseCluster<float>(sensid, x, y, z, sy2, sz2, syz), mTimeRaw(timeRaw), mTime(time), mTot(tot), mL0L1Latency(L0L1Latency), mDeltaBC(deltaBC)
+Cluster::Cluster(std::int16_t sensid, float x, float y, float z, float sy2, float sz2, float syz, double timeRaw, double time, float tot, int L0L1Latency, int deltaBC, float geanttime, double t0) : o2::BaseCluster<float>(sensid, x, y, z, sy2, sz2, syz), mTimeRaw(timeRaw), mTime(time), mTot(tot), mL0L1Latency(L0L1Latency), mDeltaBC(deltaBC), mTgeant(geanttime), mT0true(t0)
 {
 
   // caching R and phi

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
@@ -28,7 +28,7 @@ class MatchInfoTOF
   using GTrackID = o2::dataformats::GlobalTrackID;
 
  public:
-  MatchInfoTOF(int idLocal, int idxTOFCl, double time, float chi2, o2::track::TrackLTIntegral trkIntLT, GTrackID idxTrack, float dt = 0, float z = 0, float dx = 0, float dz = 0, float dy = 0) : mIdLocal(idLocal), mIdxTOFCl(idxTOFCl), mSignal(time), mChi2(chi2), mIntLT(trkIntLT), mIdxTrack(idxTrack), mDeltaT(dt), mZatTOF(z), mDXatTOF(dx), mDZatTOF(dz), mDYatTOF(dy){};
+  MatchInfoTOF(int idLocal, int idxTOFCl, double time, float chi2, o2::track::TrackLTIntegral trkIntLT, GTrackID idxTrack, float dt = 0, float z = 0, float dx = 0, float dz = 0, float dy = 0, float geanttime = 0.0, double t0 = 0.0) : mIdLocal(idLocal), mIdxTOFCl(idxTOFCl), mSignal(time), mChi2(chi2), mIntLT(trkIntLT), mIdxTrack(idxTrack), mDeltaT(dt), mZatTOF(z), mDXatTOF(dx), mDZatTOF(dz), mDYatTOF(dy), mTgeant(geanttime), mT0true(t0){};
   MatchInfoTOF() = default;
   void setIdxTOFCl(int index) { mIdxTOFCl = index; }
   void setIdxTrack(GTrackID index) { mIdxTrack = index; }
@@ -70,6 +70,10 @@ class MatchInfoTOF
   void setVz(float val) { mVz = val; }
   int getChannel() const { return mChannel; }
   void setChannel(int val) { mChannel = val; }
+  float getTgeant() const { return mTgeant; }
+  void setTgeant(float val) { mTgeant = val; }
+  double getT0true() const { return mT0true; }
+  void setT0true(double val) { mT0true = val; }
 
  private:
   int mIdLocal;                      // track id in sector of the pair track-TOFcluster
@@ -88,8 +92,10 @@ class MatchInfoTOF
   // Hit pattern information
   bool mHitUpDown = false;    ///< hit pattern in TOF up-down
   bool mHitLeftRight = false; ///< hit pattern in TOF left-right
+  float mTgeant = 0.0;        ///< geant time in MC
+  double mT0true = 0.0;       ///< t0true
 
-  ClassDefNV(MatchInfoTOF, 7);
+  ClassDefNV(MatchInfoTOF, 8);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -32,8 +32,8 @@ class Digit
  public:
   Digit() = default;
 
-  Digit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label = -1, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0);
-  Digit(Int_t channel, Int_t tdc, Int_t tot, uint32_t orbit, uint16_t bc, Int_t label = -1, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0);
+  Digit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label = -1, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0, float geanttime = 0, double t0 = 0);
+  Digit(Int_t channel, Int_t tdc, Int_t tot, uint32_t orbit, uint16_t bc, Int_t label = -1, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0, float geanttime = 0, double t0 = 0);
   ~Digit() = default;
 
   /// Get global ordering key made of
@@ -66,7 +66,7 @@ class Digit
 
   void printStream(std::ostream& stream) const;
 
-  void merge(Int_t tdc, Int_t tot);
+  bool merge(Int_t tdc, Int_t tot);
 
   void getPhiAndEtaIndex(int& phi, int& eta) const;
 
@@ -93,6 +93,11 @@ class Digit
   void setTriggerBunch(uint16_t value) { mTriggerBunch = value; }
   uint16_t getTriggerBunch() const { return mTriggerBunch; }
 
+  float getTgeant() const { return mTgeant; }
+  void setTgeant(float val) { mTgeant = val; }
+  double getT0true() const { return mT0true; }
+  void setT0true(double val) { mT0true = val; }
+
  private:
   friend class boost::serialization::access;
 
@@ -107,8 +112,10 @@ class Digit
   uint16_t mTriggerBunch = 0;    //!< bunch id of trigger event
   Bool_t mIsUsedInCluster;       //!/< flag to declare that the digit was used to build a cluster
   Bool_t mIsProblematic = false; //!< flag to tell whether the channel of the digit was problemati; not persistent; default = ok
+  float mTgeant = 0.0;           ///< geant time in MC
+  double mT0true = 0.0;          ///< t0true
 
-  ClassDefNV(Digit, 4);
+  ClassDefNV(Digit, 5);
 };
 
 std::ostream& operator<<(std::ostream& stream, const Digit& dig);

--- a/Detectors/TOF/base/include/TOFBase/Strip.h
+++ b/Detectors/TOF/base/include/TOFBase/Strip.h
@@ -80,7 +80,7 @@ class Strip
   /// reset points container
   o2::tof::Digit* findDigit(ULong64_t key);
 
-  Int_t addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lbl = 0, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0); // returns the MC label
+  Int_t addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lbl = 0, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0, float geanttime = 0, double t0 = 0); // returns the MC label
 
   void fillOutputContainer(std::vector<o2::tof::Digit>& digits);
 

--- a/Detectors/TOF/base/src/Digit.cxx
+++ b/Detectors/TOF/base/src/Digit.cxx
@@ -17,14 +17,14 @@ using namespace o2::tof;
 
 ClassImp(o2::tof::Digit);
 
-Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label, uint32_t triggerorbit, uint16_t triggerbunch)
-  : mChannel(channel), mTDC(tdc), mTOT(tot), mIR(0, 0), mLabel(label), mTriggerOrbit(triggerorbit), mTriggerBunch(triggerbunch), mIsUsedInCluster(kFALSE)
+Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label, uint32_t triggerorbit, uint16_t triggerbunch, float geanttime, double t0)
+  : mChannel(channel), mTDC(tdc), mTOT(tot), mIR(0, 0), mLabel(label), mTriggerOrbit(triggerorbit), mTriggerBunch(triggerbunch), mIsUsedInCluster(kFALSE), mTgeant(geanttime), mT0true(t0)
 {
   mIR.setFromLong(bc);
 }
 //______________________________________________________________________
-Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, uint32_t orbit, uint16_t bc, Int_t label, uint32_t triggerorbit, uint16_t triggerbunch)
-  : mChannel(channel), mTDC(tdc), mTOT(tot), mIR(bc, orbit), mLabel(label), mTriggerOrbit(triggerorbit), mTriggerBunch(triggerbunch), mIsUsedInCluster(kFALSE)
+Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, uint32_t orbit, uint16_t bc, Int_t label, uint32_t triggerorbit, uint16_t triggerbunch, float geanttime, double t0)
+  : mChannel(channel), mTDC(tdc), mTOT(tot), mIR(bc, orbit), mLabel(label), mTriggerOrbit(triggerorbit), mTriggerBunch(triggerbunch), mIsUsedInCluster(kFALSE), mTgeant(geanttime), mT0true(t0)
 {
 }
 //______________________________________________________________________
@@ -44,16 +44,18 @@ std::ostream& operator<<(std::ostream& stream, const Digit& digi)
 
 //______________________________________________________________________
 
-void Digit::merge(Int_t tdc, Int_t tot)
+bool Digit::merge(Int_t tdc, Int_t tot)
 {
 
   // merging two digits
 
   if (tdc < mTDC) {
     mTDC = tdc;
+    return 1; // new came first
     // TODO: adjust TOT
   } else {
     // TODO: adjust TOT
+    return 0;
   }
 }
 

--- a/Detectors/TOF/base/src/Strip.cxx
+++ b/Detectors/TOF/base/src/Strip.cxx
@@ -34,7 +34,7 @@ Strip::Strip(Int_t index)
 {
 }
 //_______________________________________________________________________
-Int_t Strip::addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lbl, uint32_t triggerorbit, uint16_t triggerbunch)
+Int_t Strip::addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lbl, uint32_t triggerorbit, uint16_t triggerbunch, float geanttime, double t0)
 {
 
   // return the MC label. We pass it also as argument, but it can change in
@@ -44,10 +44,13 @@ Int_t Strip::addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lb
   auto dig = findDigit(key);
   if (dig) {
     lbl = dig->getLabel(); // getting the label from the already existing digit
-    dig->merge(tdc, tot);  // merging to the existing digit
+    if (dig->merge(tdc, tot)) { // merging to the existing digit (if new came first upload also MC truth)
+      dig->setTgeant(geanttime);
+      dig->setT0true(t0);
+    }
     mDigitMerged++;
   } else {
-    mDigits.emplace(std::make_pair(key, Digit(channel, tdc, tot, bc, lbl, triggerorbit, triggerbunch)));
+    mDigits.emplace(std::make_pair(key, Digit(channel, tdc, tot, bc, lbl, triggerorbit, triggerbunch, geanttime, t0)));
   }
 
   return lbl;

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -173,6 +173,8 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
   }
 
   c.setMainContributingChannel(mContributingDigit[0]->getChannel());
+  c.setTgeant(mContributingDigit[0]->getTgeant());
+  c.setT0true(mContributingDigit[0]->getT0true());
   c.setTime(mContributingDigit[0]->getCalibratedTime());                                                                                      // time in ps (for now we assume it calibrated)
   c.setTimeRaw(mContributingDigit[0]->getTDC() * Geo::TDCBIN + mContributingDigit[0]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3); // time in ps (for now we assume it calibrated)
 

--- a/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
@@ -135,11 +135,11 @@ class Digitizer : public WindowFiller
 
   CalibApi* mCalibApi = nullptr; //! calib api to handle the TOF calibration
 
-  void fillDigitsInStrip(std::vector<Strip>* strips, o2::dataformats::MCTruthContainer<o2::tof::MCLabel>* mcTruthContainer, int channel, int tdc, int tot, uint64_t nbc, UInt_t istrip, Int_t trackID, Int_t eventID, Int_t sourceID);
+  void fillDigitsInStrip(std::vector<Strip>* strips, o2::dataformats::MCTruthContainer<o2::tof::MCLabel>* mcTruthContainer, int channel, int tdc, int tot, uint64_t nbc, UInt_t istrip, Int_t trackID, Int_t eventID, Int_t sourceID, float geanttime = 0, double t0 = 0.0);
 
   Int_t processHit(const HitType& hit, Double_t event_time);
   void addDigit(Int_t channel, UInt_t istrip, Double_t time, Float_t x, Float_t z, Float_t charge, Int_t iX, Int_t iZ, Int_t padZfired,
-                Int_t trackID);
+                Int_t trackID, float geanttime = 0, double t0 = 0.0);
 
   void checkIfReuseFutureDigits();
 


### PR DESCRIPTION
This is an additional fix for TOF digitization.
After a deep debut I realized that de-calibration was done with the T.o.T. value before of the truncation to T.o.T. channel width.
This  implied to slightly different T.o.T.-values used in de-calibration and calibration stages -> 50-60 ps shift and TOF sigma degradation.
After the fix simulations look consistent we expectations both in mean (0) and sigma (injected 60 ps).
 
Fix is related to the changes in Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h (how tot is managed)


Additional changes are useful (they were when debugging) in order to trace MC truth for timing up to matching.
I did keep it since I would like to add some QC plots to constantly monitor deviation from expectation: both for TOF digitization and tracking (now I am able to disentangle the two effects in MC) 

Once this is merged we will prepare also a PR for QC
