### PR TITLE
fix in FT0 digitization (time wrt BC)

### DIFF
--- a/Detectors/FIT/FT0/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Digitizer.cxx
@@ -220,7 +220,7 @@ void Digitizer::process(const std::vector<o2::ft0::HitType>* hits,
     // Subtract time-of-flight from hit time
     const Float_t timeOfFlight = hit.GetPos().R() / o2::constants::physics::LightSpeedCm2NS;
     const Float_t timeOffset = is_A_side ? params.hitTimeOffsetA : params.hitTimeOffsetC;
-    Double_t hit_time = hit.GetTime() - timeOfFlight + timeOffset;
+    Double_t hit_time = hit.GetTime() - timeOfFlight + timeOffset + mIntRecord.getTimeOffsetWrtBC();
 
     if (hit_time > 150) {
       continue; // not collect very slow particles
@@ -285,7 +285,7 @@ void Digitizer::storeBC(BCCache& bc,
     if (mCalibOffset) {
       miscalib = mCalibOffset->mTimeOffsets[ipmt];
     }
-    int smeared_time = 1000. * (*cfd.particle - params.mCfdShift) * params.mChannelWidthInverse + miscalib + int(1000. * mIntRecord.getTimeOffsetWrtBC() * params.mChannelWidthInverse);
+    int smeared_time = 1000. * (*cfd.particle - params.mCfdShift) * params.mChannelWidthInverse + miscalib; // + int(1000. * mIntRecord.getTimeOffsetWrtBC() * params.mChannelWidthInverse);
     bool is_time_in_signal_gate = (smeared_time > -params.mTime_trg_gate && smeared_time < params.mTime_trg_gate);
     float charge = measure_amplitude(channel_times) * params.mCharge2amp;
     float amp = is_time_in_signal_gate ? params.mMV_2_Nchannels * charge : 0;


### PR DESCRIPTION
FT0 digitization: moving mIntRecord.getTimeOffsetWrtBC() when caching digit in order to use the current (and correct) collision time

Two plots from TOF QC after this commit is included... TOF-FT0 correlation recovered

![immagine](https://github.com/user-attachments/assets/d20e904b-735e-40a1-9384-5dc50e823809)


![immagine](https://github.com/user-attachments/assets/e6acd00d-474b-4b3f-bbd5-7cf45165f8c7)
