### PR TITLE
Drop unneeded regex

### DIFF
--- a/Detectors/DCS/include/DetectorsDCS/DeliveryType.h
+++ b/Detectors/DCS/include/DetectorsDCS/DeliveryType.h
@@ -20,20 +20,11 @@
 #define O2_DCS_DELIVERY_TYPE
 
 #include <string>
-#include <regex>
 #include <stdexcept>
 #include "DetectorsDCS/GenericFunctions.h"
 
-namespace o2
+namespace o2::dcs
 {
-namespace dcs
-{
-/**
-     * This regular expression matches with strings representing payload types.
-     */
-static const std::regex REGEX_PT(
-  "^(Raw|DPVAL)/(Int|Uint|Float|Double|Bool|Char|String|Time|Binary)$");
-
 /**
      * <p>DeliveryType is a piece of meta-information used for deducing types of
      * DPVAL payloads and DIM service description strings used with services
@@ -406,8 +397,8 @@ inline size_t dim_buffer_size(const DeliveryType type)
       throw std::domain_error("Illegal DeliveryType.");
   }
 }
-} // namespace dcs
+} // namespace o2::dcs
 
-} // namespace o2
+
 
 #endif /* O2_DCS_DELIVERY_TYPE */

--- a/Detectors/DCS/include/DetectorsDCS/DeliveryType.h
+++ b/Detectors/DCS/include/DetectorsDCS/DeliveryType.h
@@ -20,6 +20,7 @@
 #define O2_DCS_DELIVERY_TYPE
 
 #include <string>
+#include <bitset>
 #include <stdexcept>
 #include "DetectorsDCS/GenericFunctions.h"
 


### PR DESCRIPTION

This pollutes a bunch of compile units with unneeded code for creating and handling
the regex.
