### PR TITLE
improve TOF infos in TPCtimeseries

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
@@ -75,6 +75,17 @@ class MatchInfoTOF
   double getT0true() const { return mT0true; }
   void setT0true(double val) { mT0true = val; }
 
+  enum QualityFlags { isMultiHitX = 0x1 << 0,
+                      isMultiHitZ = 0x1 << 1,
+                      badDy = 0x1 << 2,
+                      isMultiStrip = 0x1 << 3,
+                      isNotInPad = 0x1 << 4,
+                      chiGT3 = 0x1 << 5,
+                      chiGT5 = 0x1 << 6,
+                      hasT0sameBC = 0x1 << 7,
+                      hasT0_1BCbefore = 0x1 << 8,
+                      hasT0_2BCbefore = 0x1 << 9 };
+
  private:
   int mIdLocal;                      // track id in sector of the pair track-TOFcluster
   float mChi2;                       // chi2 of the pair track-TOFcluster

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCTimeSeriesSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCTimeSeriesSpec.h
@@ -23,7 +23,7 @@ namespace tpc
 static constexpr header::DataDescription getDataDescriptionTimeSeries() { return header::DataDescription{"TIMESERIES"}; }
 static constexpr header::DataDescription getDataDescriptionTPCTimeSeriesTFId() { return header::DataDescription{"ITPCTSTFID"}; }
 
-o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType, const bool enableUnbinnedWriter, o2::dataformats::GlobalTrackID::mask_t src);
+o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType, const bool enableUnbinnedWriter, o2::dataformats::GlobalTrackID::mask_t src, bool useft0 = false);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/tpc-time-series.cxx
+++ b/Detectors/TPC/workflow/src/tpc-time-series.cxx
@@ -29,6 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", VariantType::Bool, false, {"disable root-files output writers"}},
     {"enable-unbinned-root-output", VariantType::Bool, false, {"writing out unbinned track data"}},
     {"track-sources", VariantType::String, std::string{o2::dataformats::GlobalTrackID::ALL}, {"comma-separated list of sources to use"}},
+    {"use-ft0", VariantType::Bool, false, {"enable FT0 rec-points"}},
     {"material-type", VariantType::Int, 2, {"Type for the material budget during track propagation: 0=None, 1=Geo, 2=LUT"}}};
   std::swap(workflowOptions, options);
 }
@@ -43,7 +44,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const bool enableUnbinnedWriter = config.options().get<bool>("enable-unbinned-root-output");
   auto src = o2::dataformats::GlobalTrackID::getSourcesMask(config.options().get<std::string>("track-sources"));
   auto materialType = static_cast<o2::base::Propagator::MatCorrType>(config.options().get<int>("material-type"));
-  workflow.emplace_back(o2::tpc::getTPCTimeSeriesSpec(disableWriter, materialType, enableUnbinnedWriter, src));
+  const bool useft0 = config.options().get<bool>("use-ft0");
+  workflow.emplace_back(o2::tpc::getTPCTimeSeriesSpec(disableWriter, materialType, enableUnbinnedWriter, src, useft0));
   if (!disableWriter) {
     workflow.emplace_back(o2::tpc::getTPCTimeSeriesWriterSpec());
   }

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -54,7 +54,7 @@ if [[ $CALIB_ASYNC_EXTRACTTPCCURRENTS == 1 ]]; then
   add_W o2-tpc-integrate-cluster-workflow "${CONFIG_CTPTPC}"
 fi
 if [[ $CALIB_ASYNC_EXTRACTTIMESERIES == 1 ]] ; then
-  CONFIG_TPCTIMESERIES=
+  CONFIG_TPCTIMESERIES=" --use-ft0"
   : ${CALIB_ASYNC_SAMPLINGFACTORTIMESERIES:=0.001}
   if [[ ! -z ${CALIB_ASYNC_ENABLEUNBINNEDTIMESERIES:-} ]]; then
     CONFIG_TPCTIMESERIES+=" --enable-unbinned-root-output --sample-unbinned-tsallis --threads ${TPCTIMESERIES_THREADS:-1}"


### PR DESCRIPTION
This is to port additional TOF(FT0 event time) infos in TPC timeseries

@miranov25 @ercolessi 

- applying FT0-AC to TOF times
- quality mask for TOF
   -  single/multiple hits in tof clusters
   -  single/multiple strips matched
   -  chi2 matching