### PR TITLE
Update deep trigger example

### DIFF
--- a/run/SimExamples/Trigger_ImpactB_Pythia8/trigger_impactb_pythia8.macro
+++ b/run/SimExamples/Trigger_ImpactB_Pythia8/trigger_impactb_pythia8.macro
@@ -2,7 +2,7 @@
 
 #include "Generators/Trigger.h"
 #include "Pythia8/Pythia.h"
-#include "Pythia8/HIUserHooks.h"
+#include "Pythia8/HIInfo.h"
 #include <fairlogger/Logger.h>
 
 o2::eventgen::DeepTrigger


### PR DESCRIPTION
Newer Pythia8 does no longer ship the `HIUserHooks.h` header. Replace by `HIInfo.h`.