### PR TITLE
DPL: move TableConsumer support out of line in general

### DIFF
--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -12,6 +12,7 @@
 #ifndef FRAMEWORK_ANALYSIS_TASK_H_
 #define FRAMEWORK_ANALYSIS_TASK_H_
 
+#include "Framework/TableConsumer.h"
 #include "Framework/AnalysisManagers.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/CallbackService.h"

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -15,7 +15,6 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/InputRoute.h"
 #include "Framework/TypeTraits.h"
-#include "Framework/TableConsumer.h"
 #include "Framework/Traits.h"
 #include "Framework/RuntimeError.h"
 #include "Framework/Logger.h"
@@ -39,6 +38,9 @@
 
 namespace o2::framework
 {
+
+template <typename A>
+concept TableConsumerLike = requires (A a) { a. asArrowTable(); };
 
 // Wrapper class to get CCDB metadata
 struct CCDBMetadataExtractor {
@@ -233,6 +235,16 @@ class InputRecord
     return ref;
   }
 
+  template <TableConsumerLike T, typename R>
+  decltype(auto) get(R binding, int part = 0) const
+  {
+    DataRef ref = getRef(binding, part);
+    // substitution for TableConsumer
+    // For the moment this is dummy, as it requires proper support to
+    // create the RDataSource from the arrow buffer.
+    auto data = reinterpret_cast<uint8_t const*>(ref.payload);
+    return std::make_unique<T>(data, DataRefUtils::getPayloadSize(ref));
+  }
   /// Get the object of specified type T for the binding R.
   /// If R is a string like object, we look up by name the InputSpec and
   /// return the data associated to the given label.
@@ -272,14 +284,6 @@ class InputRecord
       return reinterpret_cast<char const*>(ref.payload);
 
       // implementation (d)
-    } else if constexpr (std::is_same<T, TableConsumer>::value) {
-      // substitution for TableConsumer
-      // For the moment this is dummy, as it requires proper support to
-      // create the RDataSource from the arrow buffer.
-      auto data = reinterpret_cast<uint8_t const*>(ref.payload);
-      return std::make_unique<TableConsumer>(data, DataRefUtils::getPayloadSize(ref));
-
-      // implementation (f)
     } else if constexpr (is_span<T>::value) {
       // substitution for span of messageable objects
       // FIXME: there will be std::span in C++20

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -25,6 +25,7 @@
 #include "Framework/RawDeviceService.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/SourceInfoHeader.h"
+#include "Framework/TableConsumer.h"
 #include "Framework/ChannelInfo.h"
 #include "Framework/Logger.h"
 

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -28,6 +28,7 @@
 #include "Framework/DevicesManager.h"
 #include "Framework/DeviceConfig.h"
 #include "Framework/ServiceMetricsInfo.h"
+#include "Framework/TableConsumer.h"
 #include "WorkflowHelpers.h"
 #include "Framework/WorkflowSpecNode.h"
 #include "Framework/AnalysisSupportHelpers.h"

--- a/Framework/GUISupport/test/test_SimpleTracksED.cxx
+++ b/Framework/GUISupport/test/test_SimpleTracksED.cxx
@@ -14,6 +14,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ParallelContext.h"
 #include "Framework/runDataProcessing.h"
+#include "Framework/TableConsumer.h"
 #include "Framework/InputRecord.h"
 #include "Framework/Logger.h"
 #include "Framework/AnalysisDataModel.h"


### PR DESCRIPTION

This is now only included if one uses the Analysis framework.
