### PR TITLE
DPL: improve HistogramRegistry.h

### DIFF
--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -409,4 +409,9 @@ void HistogramRegistry::registerName(const std::string& name)
   mRegisteredNames.push_back(name);
 }
 
+void HistFiller::badHistogramFill(char const* name)
+{
+  LOGF(fatal, "The number of arguments in fill function called for histogram %s is incompatible with histogram dimensions.", name);
+}
+
 } // namespace o2::framework


### PR DESCRIPTION

- Use concepts to determine which fill operation applies to a given
  kind of histograms.
- Make sure we out of line invalid filling operations.
