### PR TITLE
DPL: add missing header on macOS

### DIFF
--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -16,6 +16,7 @@
 #include "Headers/DataHeaderHelpers.h"
 
 #include <fmt/format.h>
+#include <sstream>
 #include <cstring>
 #include <cinttypes>
 #include <regex>


### PR DESCRIPTION

For some reasons this is not included anymore.
