### PR TITLE
Fix GPUTPCGeometry LinearY2PadC and LinearPad2YC, define biased ones in GPUTPCCompressionTrackModel

### DIFF
--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -69,7 +69,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
       }
       const ClusterNative& GPUrestrict() orgCl = clusters->clusters[hit.slice][hit.row][hit.num - clusters->clusterOffset[hit.slice][hit.row]];
       float x = param.tpcGeometry.Row2X(hit.row);
-      float y = param.tpcGeometry.LinearPad2Y(hit.slice, hit.row, orgCl.getPad());
+      float y = track.LinearPad2Y(hit.slice, orgCl.getPad(), param.tpcGeometry.PadWidth(hit.row), param.tpcGeometry.NPads(hit.row));
       float z = param.tpcGeometry.LinearTime2Z(hit.slice, orgCl.getTime());
       if (nClustersStored) {
         if ((hit.slice < GPUCA_NSLICES) ^ (lastSlice < GPUCA_NSLICES)) {
@@ -115,7 +115,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
         }
         c.rowDiffA[cidx] = row;
         c.sliceLegDiffA[cidx] = (hit.leg == lastLeg ? 0 : compressor.NSLICES) + slice;
-        float pad = CAMath::Max(0.f, CAMath::Min((float)param.tpcGeometry.NPads(GPUCA_ROW_COUNT - 1), param.tpcGeometry.LinearY2Pad(hit.slice, hit.row, track.Y())));
+        float pad = CAMath::Max(0.f, CAMath::Min((float)param.tpcGeometry.NPads(GPUCA_ROW_COUNT - 1), track.LinearY2Pad(hit.slice, track.Y(), param.tpcGeometry.PadWidth(hit.row), param.tpcGeometry.NPads(hit.row))));
         c.padResA[cidx] = orgCl.padPacked - orgCl.packPad(pad);
         float time = CAMath::Max(0.f, param.tpcGeometry.LinearZ2Time(hit.slice, track.Z() + zOffset));
         c.timeResA[cidx] = (orgCl.getTimePacked() - orgCl.packTime(time)) & 0xFFFFFF;

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionTrackModel.h
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionTrackModel.h
@@ -100,6 +100,18 @@ class GPUTPCCompressionTrackModel
   GPUd() void getClusterErrors2(int32_t iRow, float z, float sinPhi, float DzDs, float& ErrY2, float& ErrZ2) const;
   GPUd() void resetCovariance();
 
+  GPUd() float LinearPad2Y(int32_t slice, float pad, float padWidth, int8_t npads) const
+  {
+    const float u = (pad - 0.5f * npads) * padWidth;
+    return (slice >= GPUCA_NSLICES / 2) ? -u : u;
+  }
+
+  GPUd() float LinearY2Pad(int32_t slice, float y, float padWidth, int8_t npads) const
+  {
+    const float u = (slice >= GPUCA_NSLICES / 2) ? -y : y;
+    return u / padWidth + 0.5f * npads;
+  }
+
 #endif
 
  protected:

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressionCore.inc
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressionCore.inc
@@ -113,7 +113,7 @@ class TPCClusterDecompressionCore
           timeTmp |= 0xFF000000;
         }
         time = timeTmp + ClusterNative::packTime(CAMath::Max(0.f, param.tpcGeometry.LinearZ2Time(slice, track.Z() + zOffset)));
-        float tmpPad = CAMath::Max(0.f, CAMath::Min((float)param.tpcGeometry.NPads(GPUCA_ROW_COUNT - 1), param.tpcGeometry.LinearY2Pad(slice, row, track.Y())));
+        float tmpPad = CAMath::Max(0.f, CAMath::Min((float)param.tpcGeometry.NPads(GPUCA_ROW_COUNT - 1), track.LinearY2Pad(slice, track.Y(), param.tpcGeometry.PadWidth(row), param.tpcGeometry.NPads(row))));
         pad = cmprClusters.padResA[clusterOffset - trackIndex - 1] + ClusterNative::packPad(tmpPad);
         time = time & 0xFFFFFF;
         pad = (uint16_t)pad;
@@ -136,7 +136,7 @@ class TPCClusterDecompressionCore
         pad = cmprClusters.padA[trackIndex];
       }
       const auto cluster = decompressTrackStore(cmprClusters, clusterOffset, slice, row, pad, time, args...);
-      float y = param.tpcGeometry.LinearPad2Y(slice, row, cluster.getPad());
+      float y = track.LinearPad2Y(slice, cluster.getPad(), param.tpcGeometry.PadWidth(row), param.tpcGeometry.NPads(row));
       float z = param.tpcGeometry.LinearTime2Z(slice, cluster.getTime());
       if (clusterIndex == 0) {
         zOffset = z;

--- a/GPU/GPUTracking/DataTypes/GPUTPCGeometry.h
+++ b/GPU/GPUTracking/DataTypes/GPUTPCGeometry.h
@@ -114,7 +114,11 @@ class GPUTPCGeometry // TODO: Make values constexpr
 
   GPUd() float LinearPad2Y(int32_t slice, int32_t row, float pad) const
   {
+#ifdef GPUCA_TPC_GEOMETRY_O2
+    const float u = (pad - 0.5f * (mNPads[row] - 1)) * PadWidth(row);
+#else
     const float u = (pad - 0.5f * mNPads[row]) * PadWidth(row);
+#endif
     return (slice >= GPUCA_NSLICES / 2) ? -u : u;
   }
 
@@ -127,7 +131,11 @@ class GPUTPCGeometry // TODO: Make values constexpr
   GPUd() float LinearY2Pad(int32_t slice, int32_t row, float y) const
   {
     const float u = (slice >= GPUCA_NSLICES / 2) ? -y : y;
+#ifdef GPUCA_TPC_GEOMETRY_O2
+    return u / PadWidth(row) + 0.5f * (mNPads[row] - 1);
+#else
     return u / PadWidth(row) + 0.5f * mNPads[row];
+#endif
   }
 
   GPUd() static float LinearZ2Time(int32_t slice, float z)


### PR DESCRIPTION
@davidrohr @wiechula we had a discussion with Alex about `pad<->coordinate` conversion, looks like biased cluster coordinates are used only for track-based compression, where the bias is irrelevant (though, in the absence of other distortions, potentially may increase the entropy). Otherwise, the conversion with TPCFastTransform is used, which is fine.
But the inverse, cluster coordinate to pad conversion `tpcGeometry.LinearY2Pad`, biases the pad value by 0.5, and since it is always rounded to int using  `GPUCommonMath::Float2UIntRn(float x) { return (uint32_t)(int32_t)(x + 0.5f); }`, it effectively shifts the cluster central padID by 1.
This method is used in the tracking only to check if the pad is dead, in the 
(1) in the GPUTracking/Merger/GPUTPCGMTrackParam.cxx to decide if the dedx should be calculated
(2) in the GPUTracking/SliceTracker/GPUTPCTrackletConstructor.cxx to decide if in case of not finding a cluster at the probed padrow the tracklet should be penalized for the hole.

This PR adds an extra unbiased method `LinearY2PadC` and `LinearPad2YC`, and uses it (1) and (2).
Reprocessing ~60 TFs of LHC24ar_559781 with this PR I don't see any effect on tracking (see the plot below). Cannot judge about the dedx change, if needed, can provide `tpctracks.root` trees.
Let me know if you still want to merge this.

@wiechula , the LinearPad2Y is also used in the https://github.com/AliceO2Group/AliceO2/blob/98dc52125d7e9badca2b8f1fd8c0603c020966e8/Detectors/TPC/calibration/src/CorrectdEdxDistortions.cxx#L79-L87, used to account for the corrections in dEdX calculations, do you want to change it to LinearY2PadC also there?

@davidrohr in the https://github.com/AliceO2Group/AliceO2/blob/98dc52125d7e9badca2b8f1fd8c0603c020966e8/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx#L235-L237 the LinearPad2Y as a marginal correction in the check of cluster timebin coung outside of the allowed range, should we change it also there?


![diffLinearY2PadC](https://github.com/user-attachments/assets/01be9acf-caf4-48f8-a3ca-4cc81d6db32c)

