### PR TITLE
Base: allow to create alignment for individual detectors other than ITS

### DIFF
--- a/Detectors/Base/src/GRPGeomHelper.cxx
+++ b/Detectors/Base/src/GRPGeomHelper.cxx
@@ -235,7 +235,7 @@ void GRPGeomHelper::checkUpdates(ProcessingContext& pc)
       for (auto id = DetID::First; id <= DetID::Last; id++) {
         std::string binding = fmt::format("align{}", DetID::getName(id));
         if (pc.inputs().getPos(binding.c_str()) < 0) {
-          return;
+          continue;
         } else {
           pc.inputs().get<std::vector<o2::detectors::AlignParam>*>(binding);
         }


### PR DESCRIPTION
Previously the matcher would stop at the first not found binding, e.g. ITS.
Meaning one could request alignment only for lower provenance detectors like TPC&TRD&TOF, which does not really make sense generally, but for IT3 it does. 