### PR TITLE
ITS - Dead Map Workflow allows for saving single chips

### DIFF
--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DeadMapBuilderSpec.h
@@ -83,6 +83,7 @@ class ITSMFTDeadMapBuilder : public Task
   bool mRunMFT = false;
   bool mDoLocalOutput = false;
   bool mSkipStaticMap = false;
+  bool mNoGroupITSLanes = false;
   uint16_t N_CHIPS;
   uint16_t N_CHIPS_ITSIB = o2::itsmft::ChipMappingITS::getNChips(0);
   int mTFLength = 32; // TODO find utility for proper value -- o2::base::GRPGeomHelper::getNHBFPerTF() returns 128 see https://github.com/AliceO2Group/AliceO2/blob/051b56f9f136e7977e83f5d26d922db9bd6ecef5/Detectors/Base/src/GRPGeomHelper.cxx#L233 and correct also default option is getSpec


### PR DESCRIPTION
An option of the `o2-itsmft-deadmap-builder-workflow` is added to save single chip addresses in the time-evolving part of the ITS maps, without grouping the chips into lanes.

@iravasen  , Jiyoung,   I propose to test it with beam before setting the parameter as new default. 

To test:
`--no-group-its-lanes` 

At that point the static map is not necessary anymore:

`--no-group-its-lanes --skip-static-map`