### PR TITLE
Add termination for record writer to save record file correctly

### DIFF
--- a/Detectors/MUON/MCH/Align/src/Aligner.cxx
+++ b/Detectors/MUON/MCH/Align/src/Aligner.cxx
@@ -359,13 +359,16 @@ void Aligner::init(TString DataRecFName, TString ConsRecFName)
 void Aligner::terminate()
 {
   fInitialized = kFALSE;
-  LOG(info) << "Closing Evaluation TFile";
   if (fDoEvaluation) {
+    LOG(info) << "Closing Evaluation TFile";
     if (fTFile && fTTree) {
       fTFile->cd();
       fTTree->Write();
       fTFile->Close();
     }
+  }
+  if (!fDisableRecordWriter) {
+    mRecordWriter->terminate();
   }
 }
 


### PR DESCRIPTION
Calling terminate function for RecordWriter when terminating aligner instance, making sure the millerecord file will be written to disk correctly.