### PR TITLE
DPL: avoid asserting the workflow is empty

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1118,6 +1118,10 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
 {
   // Always check for validity of the workflow before instanciating it
   DeviceSpecHelpers::validate(workflow);
+  // In case the workflow is empty, we simply do not need to instanciate any device.
+  if (workflow.empty()) {
+    return;
+  }
   std::vector<LogicalForwardInfo> availableForwardsInfo;
   std::vector<DeviceConnectionEdge> logicalEdges;
   std::vector<DeviceConnectionId> connections;

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -756,7 +756,10 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
                                      std::vector<OutputSpec>& outputs,
                                      std::vector<LogicalForwardInfo>& forwardedInputsInfo)
 {
-  assert(!workflow.empty());
+  // In case the workflow is empty, we do not have anything to do.
+  if (workflow.empty()) {
+    return;
+  }
 
   // This is the state. Oif is the iterator I use for the searches.
   std::vector<LogicalOutputInfo> availableOutputsInfo;


### PR DESCRIPTION

This is a property that depends on user input, so an empty workflow is actually
possible and should be handled. This currently breaks if the empty workflow is
provided in debug mode.
