### PR TITLE
Fix fake/correct status for barrel tracks

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -1447,7 +1447,7 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
     table[GTrackID::MCH] = parent0.getMCHRef();
     table[GTrackID::MID] = parent0.getMIDRef();
   }
-  return std::move(table);
+  return table;
 }
 
 //________________________________________________________

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -482,8 +482,6 @@ class AODProducerWorkflowDPL : public Task
   // using -1 as dummies for AOD
   struct MCLabels {
     uint32_t labelID = -1;
-    uint32_t labelITS = -1;
-    uint32_t labelTPC = -1;
     uint16_t labelMask = 0;
     uint8_t fwdLabelMask = 0;
   };


### PR DESCRIPTION
The fMcMask bit 15 (fake global track label or TOF_label != TPC_lable) was wrong since original TOF cluster label (set in the reconstruction) was compared with TPC remapped label prepared for AOD storage.
In fact, we don't need to consider separately the global_label.isFake and TOF-TPC mismach: TOF is the last detector in the matching process and the global track label is determined by the TPC track label. Hence, if the TOF match is present but its cluster is not contributed by the TPC track, the global label isFake will be necessarilly true, and vice versa.

Also, the status of bit 13 (flagging ITS-TPC mismatch) was covering only track-to-track matches but not those from the afterburner.

Now settings of fakeness relies on the isFake status from the reconstruction.