### PR TITLE
MUON: use track time in global muon matching

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -339,6 +339,7 @@ class MatchGlobalFwd
   o2::itsmft::ChipMappingMFT mMFTMapping;
   bool mMCTruthON = false;      ///< Flag availability of MC truth
   bool mUseMIDMCHMatch = false; ///< Flag for using MCHMID matches (TrackMCHMID)
+  bool mUseTrackTime = false;   ///< Flag for using the MCH or MCHMID track time information to select the MFT ROF(s)
   int mSaveMode = 0;            ///< Output mode [0 = SaveBestMatch; 1 = SaveAllMatches; 2 = SaveTrainingData; 3 = SaveNCandidates]
   int mNCandidates = 5;         ///< Numbers of matching candidates to save in savemode=3
   MatchingType mMatchingType = MATCHINGUNDEFINED;

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdParam.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdParam.h
@@ -39,6 +39,7 @@ struct GlobalFwdMatchingParam : public o2::conf::ConfigurableParamHelper<GlobalF
   bool MCMatching = false;                                ///< MFT-MCH matching computed from MCLabels
   double matchPlaneZ = -77.5;                             ///< MFT-MCH matching plane z coordinate
   bool useMIDMatch = false;                               ///< Use input from MCH-MID matching
+  bool useTrackTime = false;                              ///< Use the MCH or MCHMID track time information to select the MFT ROF(s)
   Int_t saveMode = kBestMatch;                            ///< Global Forward Tracks save mode
   float MFTRadLength = 0.042;                             ///< MFT thickness in radiation length
   float alignResidual = 1.;                               ///< Alignment residual for cluster position uncertainty


### PR DESCRIPTION
Added option for using the track time when selecting the MFT candidates to be matched with a given MCH track.
This helps to reduce the number of candidates when the MCH track is already matched with MID and therefore has a precise timing. In this case the number of MCH tracks that need to be combined with MFT tracks from two adjacent ROFs is strongly reduced.