### PR TITLE
DPL Analysis: remove selected_pack (fixed)

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -213,8 +213,6 @@ template <typename D, typename... Cs>
 struct TableMetadata {
   using columns = framework::pack<Cs...>;
   using persistent_columns_t = framework::selected_pack<soa::is_persistent_column_t, Cs...>;
-  using external_index_columns_t = framework::selected_pack<soa::is_external_index_t, Cs...>;
-  using internal_index_columns_t = framework::selected_pack<soa::is_self_index_t, Cs...>;
 
   template <typename Key, typename... PCs>
   static consteval std::array<bool, sizeof...(PCs)> getMap(framework::pack<PCs...>)
@@ -1033,6 +1031,13 @@ concept can_bind = requires(T&& t) {
 template <typename... C>
 concept has_index = (is_indexing_column<C> || ...);
 
+template <is_index_column C>
+  requires (!is_self_index_column<C>)
+auto getBinding() -> typename C::binding_t {}
+
+template <typename C>
+auto getBinding() -> void {}
+
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
  public:
@@ -1040,9 +1045,9 @@ struct TableIterator : IP, C... {
   using policy_t = IP;
   using all_columns = framework::pack<C...>;
   using persistent_columns_t = framework::selected_pack<soa::is_persistent_column_t, C...>;
-  using external_index_columns_t = framework::selected_pack<soa::is_external_index_t, C...>;
-  using internal_index_columns_t = framework::selected_pack<soa::is_self_index_t, C...>;
-  using bindings_pack_t = decltype([]<typename... Cs>(framework::pack<Cs...>) -> framework::pack<typename Cs::binding_t...> {}(external_index_columns_t{})); // decltype(extractBindings(external_index_columns_t{}));
+  using bindings_pack_t = decltype([]<typename... Cs>(framework::pack<Cs...>) {
+    return framework::pack<decltype(getBinding<Cs>())...>{};
+  }(all_columns{}));
 
   TableIterator(arrow::ChunkedArray* columnData[sizeof...(C)], IP&& policy)
     : IP{policy},
@@ -1135,7 +1140,7 @@ struct TableIterator : IP, C... {
   template <typename... CL, typename TA>
   void doSetCurrentIndex(framework::pack<CL...>, TA* current)
   {
-    (CL::setCurrent(current), ...);
+    ([&current, this](){ if constexpr (is_index_column<CL> && !is_self_index_column<CL>) {CL::setCurrent(current);} }(), ...);
   }
 
   template <typename CL>
@@ -1147,24 +1152,30 @@ struct TableIterator : IP, C... {
   template <typename... Cs>
   auto getIndexBindingsImpl(framework::pack<Cs...>) const
   {
-    return std::vector<o2::soa::Binding>{static_cast<Cs const&>(*this).getCurrentRaw()...};
+    std::vector<o2::soa::Binding> result;
+    ([this, &result](){
+      if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) {
+        result.emplace_back(static_cast<Cs const&>(*this).getCurrentRaw());
+      }
+    }(), ...);
+    return result;
   }
 
   auto getIndexBindings() const
   {
-    return getIndexBindingsImpl(external_index_columns_t{});
+    return getIndexBindingsImpl(all_columns{});
   }
 
   template <typename... TA>
   void bindExternalIndices(TA*... current)
   {
-    (doSetCurrentIndex(external_index_columns_t{}, current), ...);
+    (doSetCurrentIndex(all_columns{}, current), ...);
   }
 
   template <typename... Cs>
   void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& ptrs)
   {
-    (Cs::setCurrentRaw(ptrs[framework::has_type_at_v<Cs>(p)]), ...);
+    ([&ptrs, p, this](){ if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) { Cs::setCurrentRaw(ptrs[framework::has_type_at_v<Cs>(p)]); } }(), ...);
   }
 
   template <typename... Cs, typename I>
@@ -1172,18 +1183,18 @@ struct TableIterator : IP, C... {
   {
     o2::soa::Binding b;
     b.bind(ptr);
-    (Cs::setCurrentRaw(b), ...);
+    ([&ptr, &b, this](){ if constexpr (is_self_index_column<Cs>) { Cs::setCurrentRaw(b); } }(), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)
   {
-    doSetCurrentIndexRaw(external_index_columns_t{}, std::forward<std::vector<o2::soa::Binding>>(ptrs));
+    doSetCurrentIndexRaw(all_columns{}, std::forward<std::vector<o2::soa::Binding>>(ptrs));
   }
 
   template <typename I>
   void bindInternalIndices(I const* table)
   {
-    doSetCurrentInternal(internal_index_columns_t{}, table);
+    doSetCurrentInternal(all_columns{}, table);
   }
 
  private:
@@ -1367,25 +1378,25 @@ static constexpr std::string getLabelFromTypeForKey(std::string const& key)
 template <typename B, typename... C>
 consteval static bool hasIndexTo(framework::pack<C...>&&)
 {
-  return (o2::soa::is_binding_compatible_v<B, typename C::binding_t>() || ...);
+  return ([](){ if constexpr (is_index_column<C> && !is_self_index_column<C>) { return o2::soa::is_binding_compatible_v<B, typename C::binding_t>(); } else { return false; } }() || ...);
 }
 
 template <typename B, typename... C>
 consteval static bool hasSortedIndexTo(framework::pack<C...>&&)
 {
-  return ((C::sorted && o2::soa::is_binding_compatible_v<B, typename C::binding_t>()) || ...);
+  return ([](){if constexpr (is_index_column<C> && !is_self_index_column<C>) { return (C::sorted && o2::soa::is_binding_compatible_v<B, typename C::binding_t>()); } else { return false; }}() || ...);
 }
 
 template <typename B, typename Z>
 consteval static bool relatedByIndex()
 {
-  return hasIndexTo<B>(typename Z::table_t::external_index_columns_t{});
+  return hasIndexTo<B>(typename Z::table_t::columns_t{});
 }
 
 template <typename B, typename Z>
 consteval static bool relatedBySortedIndex()
 {
-  return hasSortedIndexTo<B>(typename Z::table_t::external_index_columns_t{});
+  return hasSortedIndexTo<B>(typename Z::table_t::columns_t{});
 }
 } // namespace o2::soa
 
@@ -1713,16 +1724,13 @@ class Table
   using persistent_columns_t = decltype([]<typename... C>(framework::pack<C...>&&) -> framework::selected_pack<soa::is_persistent_column_t, C...> {}(columns_t{}));
   using column_types = decltype([]<typename... C>(framework::pack<C...>) -> framework::pack<typename C::type...> {}(persistent_columns_t{}));
 
-  using external_index_columns_t = decltype([]<typename... C>(framework::pack<C...>&&) -> framework::selected_pack<soa::is_external_index_t, C...> {}(columns_t{}));
-  using internal_index_columns_t = decltype([]<typename... C>(framework::pack<C...>&&) -> framework::selected_pack<soa::is_self_index_t, C...> {}(columns_t{}));
   template <typename IP>
   using base_iterator = decltype(base_iter<D, O, IP>(columns_t{}));
 
   template <typename IP, typename Parent, typename... T>
   struct TableIteratorBase : base_iterator<IP> {
     using columns_t = typename Parent::columns_t;
-    using external_index_columns_t = typename Parent::external_index_columns_t;
-    using bindings_pack_t = decltype([]<typename... C>(framework::pack<C...>) -> framework::pack<typename C::binding_t...> {}(external_index_columns_t{}));
+    using bindings_pack_t = typename base_iterator<IP>::bindings_pack_t;
     // static constexpr const std::array<TableRef, sizeof...(T)> originals{T::ref...};
     static constexpr auto originals = Parent::originals;
     using policy_t = IP;
@@ -1815,7 +1823,7 @@ class Table
       using decayed = std::decay_t<TI>;
       if constexpr (framework::has_type<decayed>(bindings_pack_t{})) { // index to another table
         constexpr auto idx = framework::has_type_at_v<decayed>(bindings_pack_t{});
-        return framework::pack_element_t<idx, external_index_columns_t>::getId();
+        return framework::pack_element_t<idx, columns_t>::getId();
       } else if constexpr (std::same_as<decayed, Parent>) { // self index
         return this->globalIndex();
       } else if constexpr (is_indexing_column<decayed>) { // soa::Index<>
@@ -2040,13 +2048,13 @@ class Table
 
   void bindInternalIndicesExplicit(o2::soa::Binding binding)
   {
-    doBindInternalIndicesExplicit(internal_index_columns_t{}, binding);
+    doBindInternalIndicesExplicit(columns_t{}, binding);
   }
 
   template <typename... Cs>
   void doBindInternalIndicesExplicit(framework::pack<Cs...>, o2::soa::Binding binding)
   {
-    (static_cast<Cs>(mBegin).setCurrentRaw(binding), ...);
+    ([this, &binding](){ if constexpr (is_self_index_column<Cs>) { static_cast<Cs>(mBegin).setCurrentRaw(binding); } }(), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)
@@ -2063,7 +2071,7 @@ class Table
   template <typename T>
   void copyIndexBindings(T& dest) const
   {
-    doCopyIndexBindings(external_index_columns_t{}, dest);
+    doCopyIndexBindings(columns_t{}, dest);
   }
 
   auto select(framework::expressions::Filter const& f) const
@@ -3282,7 +3290,6 @@ class FilteredBase : public T
   using T::originals;
   using columns_t = typename T::columns_t;
   using persistent_columns_t = typename T::persistent_columns_t;
-  using external_index_columns_t = typename T::external_index_columns_t;
 
   using iterator = T::template iterator_template_o<FilteredIndexPolicy, self_t>;
   using unfiltered_iterator = T::template iterator_template_o<DefaultIndexPolicy, self_t>;
@@ -3428,7 +3435,7 @@ class FilteredBase : public T
   template <typename T1>
   void copyIndexBindings(T1& dest) const
   {
-    doCopyIndexBindings(external_index_columns_t{}, dest);
+    doCopyIndexBindings(columns_t{}, dest);
   }
 
   template <typename T1>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1042,6 +1042,12 @@ consteval auto getBinding() -> void
 {
 }
 
+template <typename T, typename... Cs>
+consteval auto inBindings(framework::pack<Cs...>)
+{
+  return framework::has_type_at_v<T>(framework::pack<decltype(getBinding<Cs>())...>{});
+}
+
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
  public:
@@ -1049,9 +1055,6 @@ struct TableIterator : IP, C... {
   using policy_t = IP;
   using all_columns = framework::pack<C...>;
   using persistent_columns_t = framework::selected_pack<soa::is_persistent_column_t, C...>;
-  using bindings_pack_t = decltype([]<typename... Cs>(framework::pack<Cs...>) {
-    return framework::pack<decltype(getBinding<Cs>())...>{};
-  }(all_columns{}));
 
   TableIterator(arrow::ChunkedArray* columnData[sizeof...(C)], IP&& policy)
     : IP{policy},
@@ -1825,8 +1828,6 @@ class Table
   template <typename IP, typename Parent, typename... T>
   struct TableIteratorBase : base_iterator<IP> {
     using columns_t = typename Parent::columns_t;
-    using bindings_pack_t = typename base_iterator<IP>::bindings_pack_t;
-    // static constexpr const std::array<TableRef, sizeof...(T)> originals{T::ref...};
     static constexpr auto originals = Parent::originals;
     using policy_t = IP;
     using parent_t = Parent;
@@ -1915,17 +1916,21 @@ class Table
     template <typename TI>
     auto getId() const
     {
-      using decayed = std::decay_t<TI>;
-      if constexpr (framework::has_type<decayed>(bindings_pack_t{})) { // index to another table
-        constexpr auto idx = framework::has_type_at_v<decayed>(bindings_pack_t{});
-        return framework::pack_element_t<idx, columns_t>::getId();
-      } else if constexpr (std::same_as<decayed, Parent>) { // self index
-        return this->globalIndex();
-      } else if constexpr (is_indexing_column<decayed>) { // soa::Index<>
-        return this->globalIndex();
-      } else {
-        return static_cast<int32_t>(-1);
-      }
+      return static_cast<int32_t>(-1);
+    }
+
+    template <typename TI>
+      requires(std::same_as<std::decay_t<TI>, Parent> || is_indexing_column<std::decay_t<TI>>)
+    auto getId() const
+    {
+      return this->globalIndex();
+    }
+
+    template <typename TI>
+      requires(inBindings<std::decay_t<TI>>(typename Parent::all_columns{}) < framework::pack_size(typename Parent::all_columns{}))
+    auto getId() const
+    {
+      return inBindings<std::decay_t<TI>>(typename Parent::all_columns{});
     }
 
     template <soa::is_dynamic_column CD, typename... CDArgs>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1145,9 +1145,12 @@ struct TableIterator : IP, C... {
   void doSetCurrentIndex(framework::pack<CL...>, TA* current)
   {
     (framework::overloaded{
-       [&current, this]<is_index_column CI> requires(!is_self_index_column<CI>) () { CI::setCurrent(current); },
-       []<typename CI>(){}
-       }.template operator()<CL>(), ...);
+      [&current, this]<is_index_column CI>
+        requires(!is_self_index_column<CI>)
+      () { CI::setCurrent(current); },
+      []<typename CI>() {}}
+        .template operator()<CL>(),
+      ...);
   }
 
   template <typename CL>
@@ -1161,11 +1164,14 @@ struct TableIterator : IP, C... {
   {
     std::vector<o2::soa::Binding> result;
     (framework::overloaded{
-       [this, &result]<is_index_column CI> requires(!is_self_index_column<CI>) () mutable {
-           result.emplace_back(CI::getCurrentRaw());
-       },
-       []<typename CI>(){}
-      }.template operator()<Cs>(), ...);
+      [this, &result]<is_index_column CI>
+        requires(!is_self_index_column<CI>)
+      () mutable {
+        result.emplace_back(CI::getCurrentRaw());
+      },
+      []<typename CI>() {}}
+        .template operator()<Cs>(),
+      ...);
     return result;
   }
 
@@ -1184,9 +1190,12 @@ struct TableIterator : IP, C... {
   void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& ptrs)
   {
     (framework::overloaded{
-      [&ptrs, p, this]<is_self_index_column CI> requires(!is_self_index_column<CI>) () { CI::setCurrentRaw(ptrs[framework::has_type_at_v<CI>(p)]); },
-      []<typename CI>(){}
-    }.template operator()<Cs>(), ...);
+      [&ptrs, p, this]<is_self_index_column CI>
+        requires(!is_self_index_column<CI>)
+      () { CI::setCurrentRaw(ptrs[framework::has_type_at_v<CI>(p)]); },
+      []<typename CI>() {}}
+        .template operator()<Cs>(),
+      ...);
   }
 
   template <typename... Cs, typename I>
@@ -1195,9 +1204,10 @@ struct TableIterator : IP, C... {
     o2::soa::Binding b;
     b.bind(ptr);
     (framework::overloaded{
-      [&ptr, &b, this]<is_self_index_column CI>() { CI::setCurrentRaw(b); },
-      []<typename CI>(){}
-     }.template operator()<Cs>(), ...);
+       [&ptr, &b, this]<is_self_index_column CI>() { CI::setCurrentRaw(b); },
+       []<typename CI>() {}}
+       .template operator()<Cs>(),
+     ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)
@@ -1393,18 +1403,24 @@ template <typename B, typename... C>
 consteval static bool hasIndexTo(framework::pack<C...>&&)
 {
   return (framework::overloaded{
-            []<is_index_column CI> requires(!is_self_index_column<CI>) () { return o2::soa::is_binding_compatible_v<B, typename CI::binding_t>(); },
-            []<typename CI>(){ return false; }
-          }.template operator()<C>() || ...);
+    []<is_index_column CI>
+      requires(!is_self_index_column<CI>)
+    () { return o2::soa::is_binding_compatible_v<B, typename CI::binding_t>(); },
+    []<typename CI>() { return false; }}
+      .template operator()<C>() ||
+    ...);
 }
 
 template <typename B, typename... C>
 consteval static bool hasSortedIndexTo(framework::pack<C...>&&)
 {
   return (framework::overloaded{
-            []<is_index_column CI> requires(!is_self_index_column<CI>) () {return (CI::sorted && o2::soa::is_binding_compatible_v<B, typename CI::binding_t>()); },
-            []<typename CI>(){}
-          }.template operator()<C>() || ...);
+    []<is_index_column CI>
+      requires(!is_self_index_column<CI>)
+    () { return (CI::sorted && o2::soa::is_binding_compatible_v<B, typename CI::binding_t>()); },
+    []<typename CI>() {}}
+      .template operator()<C>() ||
+    ...);
 }
 
 template <typename B, typename Z>
@@ -2075,9 +2091,10 @@ class Table
   void doBindInternalIndicesExplicit(framework::pack<Cs...>, o2::soa::Binding binding)
   {
     (framework::overloaded{
-      [this, &binding]<is_self_index_column CI>() { static_cast<CI>(mBegin).setCurrentRaw(binding); },
-      []<typename CI>(){}
-     }.template operator()<Cs>(), ...);
+       [this, &binding]<is_self_index_column CI>() { static_cast<CI>(mBegin).setCurrentRaw(binding); },
+       []<typename CI>() {}}
+       .template operator()<Cs>(),
+     ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1144,7 +1144,10 @@ struct TableIterator : IP, C... {
   template <typename... CL, typename TA>
   void doSetCurrentIndex(framework::pack<CL...>, TA* current)
   {
-    ([&current, this]() { if constexpr (is_index_column<CL> && !is_self_index_column<CL>) {CL::setCurrent(current);} }(), ...);
+    (framework::overloaded{
+       [&current, this]<is_index_column CI> requires(!is_self_index_column<CI>) () { CI::setCurrent(current); },
+       []<typename CI>(){}
+       }.template operator()<CL>(), ...);
   }
 
   template <typename CL>
@@ -1157,12 +1160,12 @@ struct TableIterator : IP, C... {
   auto getIndexBindingsImpl(framework::pack<Cs...>) const
   {
     std::vector<o2::soa::Binding> result;
-    ([this, &result]() {
-      if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) {
-        result.emplace_back(static_cast<Cs const&>(*this).getCurrentRaw());
-      }
-    }(),
-     ...);
+    (framework::overloaded{
+       [this, &result]<is_index_column CI> requires(!is_self_index_column<CI>) () mutable {
+           result.emplace_back(CI::getCurrentRaw());
+       },
+       []<typename CI>(){}
+      }.template operator()<Cs>(), ...);
     return result;
   }
 
@@ -1180,7 +1183,10 @@ struct TableIterator : IP, C... {
   template <typename... Cs>
   void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& ptrs)
   {
-    ([&ptrs, p, this]() { if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) { Cs::setCurrentRaw(ptrs[framework::has_type_at_v<Cs>(p)]); } }(), ...);
+    (framework::overloaded{
+      [&ptrs, p, this]<is_self_index_column CI> requires(!is_self_index_column<CI>) () { CI::setCurrentRaw(ptrs[framework::has_type_at_v<CI>(p)]); },
+      []<typename CI>(){}
+    }.template operator()<Cs>(), ...);
   }
 
   template <typename... Cs, typename I>
@@ -1188,7 +1194,10 @@ struct TableIterator : IP, C... {
   {
     o2::soa::Binding b;
     b.bind(ptr);
-    ([&ptr, &b, this]() { if constexpr (is_self_index_column<Cs>) { Cs::setCurrentRaw(b); } }(), ...);
+    (framework::overloaded{
+      [&ptr, &b, this]<is_self_index_column CI>() { CI::setCurrentRaw(b); },
+      []<typename CI>(){}
+     }.template operator()<Cs>(), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)
@@ -1383,13 +1392,19 @@ static constexpr std::string getLabelFromTypeForKey(std::string const& key)
 template <typename B, typename... C>
 consteval static bool hasIndexTo(framework::pack<C...>&&)
 {
-  return ([]() { if constexpr (is_index_column<C> && !is_self_index_column<C>) { return o2::soa::is_binding_compatible_v<B, typename C::binding_t>(); } else { return false; } }() || ...);
+  return (framework::overloaded{
+            []<is_index_column CI> requires(!is_self_index_column<CI>) () { return o2::soa::is_binding_compatible_v<B, typename CI::binding_t>(); },
+            []<typename CI>(){ return false; }
+          }.template operator()<C>() || ...);
 }
 
 template <typename B, typename... C>
 consteval static bool hasSortedIndexTo(framework::pack<C...>&&)
 {
-  return ([]() {if constexpr (is_index_column<C> && !is_self_index_column<C>) { return (C::sorted && o2::soa::is_binding_compatible_v<B, typename C::binding_t>()); } else { return false; } }() || ...);
+  return (framework::overloaded{
+            []<is_index_column CI> requires(!is_self_index_column<CI>) () {return (CI::sorted && o2::soa::is_binding_compatible_v<B, typename CI::binding_t>()); },
+            []<typename CI>(){}
+          }.template operator()<C>() || ...);
 }
 
 template <typename B, typename Z>
@@ -2059,7 +2074,10 @@ class Table
   template <typename... Cs>
   void doBindInternalIndicesExplicit(framework::pack<Cs...>, o2::soa::Binding binding)
   {
-    ([this, &binding]() { if constexpr (is_self_index_column<Cs>) { static_cast<Cs>(mBegin).setCurrentRaw(binding); } }(), ...);
+    (framework::overloaded{
+      [this, &binding]<is_self_index_column CI>() { static_cast<CI>(mBegin).setCurrentRaw(binding); },
+      []<typename CI>(){}
+     }.template operator()<Cs>(), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1032,11 +1032,15 @@ template <typename... C>
 concept has_index = (is_indexing_column<C> || ...);
 
 template <is_index_column C>
-  requires (!is_self_index_column<C>)
-auto getBinding() -> typename C::binding_t {}
+  requires(!is_self_index_column<C>)
+auto getBinding() -> typename C::binding_t
+{
+}
 
 template <typename C>
-auto getBinding() -> void {}
+auto getBinding() -> void
+{
+}
 
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
@@ -1140,7 +1144,7 @@ struct TableIterator : IP, C... {
   template <typename... CL, typename TA>
   void doSetCurrentIndex(framework::pack<CL...>, TA* current)
   {
-    ([&current, this](){ if constexpr (is_index_column<CL> && !is_self_index_column<CL>) {CL::setCurrent(current);} }(), ...);
+    ([&current, this]() { if constexpr (is_index_column<CL> && !is_self_index_column<CL>) {CL::setCurrent(current);} }(), ...);
   }
 
   template <typename CL>
@@ -1153,11 +1157,12 @@ struct TableIterator : IP, C... {
   auto getIndexBindingsImpl(framework::pack<Cs...>) const
   {
     std::vector<o2::soa::Binding> result;
-    ([this, &result](){
+    ([this, &result]() {
       if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) {
         result.emplace_back(static_cast<Cs const&>(*this).getCurrentRaw());
       }
-    }(), ...);
+    }(),
+     ...);
     return result;
   }
 
@@ -1175,7 +1180,7 @@ struct TableIterator : IP, C... {
   template <typename... Cs>
   void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& ptrs)
   {
-    ([&ptrs, p, this](){ if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) { Cs::setCurrentRaw(ptrs[framework::has_type_at_v<Cs>(p)]); } }(), ...);
+    ([&ptrs, p, this]() { if constexpr (is_index_column<Cs> && !is_self_index_column<Cs>) { Cs::setCurrentRaw(ptrs[framework::has_type_at_v<Cs>(p)]); } }(), ...);
   }
 
   template <typename... Cs, typename I>
@@ -1183,7 +1188,7 @@ struct TableIterator : IP, C... {
   {
     o2::soa::Binding b;
     b.bind(ptr);
-    ([&ptr, &b, this](){ if constexpr (is_self_index_column<Cs>) { Cs::setCurrentRaw(b); } }(), ...);
+    ([&ptr, &b, this]() { if constexpr (is_self_index_column<Cs>) { Cs::setCurrentRaw(b); } }(), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)
@@ -1378,13 +1383,13 @@ static constexpr std::string getLabelFromTypeForKey(std::string const& key)
 template <typename B, typename... C>
 consteval static bool hasIndexTo(framework::pack<C...>&&)
 {
-  return ([](){ if constexpr (is_index_column<C> && !is_self_index_column<C>) { return o2::soa::is_binding_compatible_v<B, typename C::binding_t>(); } else { return false; } }() || ...);
+  return ([]() { if constexpr (is_index_column<C> && !is_self_index_column<C>) { return o2::soa::is_binding_compatible_v<B, typename C::binding_t>(); } else { return false; } }() || ...);
 }
 
 template <typename B, typename... C>
 consteval static bool hasSortedIndexTo(framework::pack<C...>&&)
 {
-  return ([](){if constexpr (is_index_column<C> && !is_self_index_column<C>) { return (C::sorted && o2::soa::is_binding_compatible_v<B, typename C::binding_t>()); } else { return false; }}() || ...);
+  return ([]() {if constexpr (is_index_column<C> && !is_self_index_column<C>) { return (C::sorted && o2::soa::is_binding_compatible_v<B, typename C::binding_t>()); } else { return false; } }() || ...);
 }
 
 template <typename B, typename Z>
@@ -2054,7 +2059,7 @@ class Table
   template <typename... Cs>
   void doBindInternalIndicesExplicit(framework::pack<Cs...>, o2::soa::Binding binding)
   {
-    ([this, &binding](){ if constexpr (is_self_index_column<Cs>) { static_cast<Cs>(mBegin).setCurrentRaw(binding); } }(), ...);
+    ([this, &binding]() { if constexpr (is_self_index_column<Cs>) { static_cast<Cs>(mBegin).setCurrentRaw(binding); } }(), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1033,12 +1033,12 @@ concept has_index = (is_indexing_column<C> || ...);
 
 template <is_index_column C>
   requires(!is_self_index_column<C>)
-constexpr auto getBinding() -> typename C::binding_t
+consteval auto getBinding() -> typename C::binding_t
 {
 }
 
 template <typename C>
-constexpr auto getBinding() -> void
+consteval auto getBinding() -> void
 {
 }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1251,7 +1251,7 @@ struct TableIterator : IP, C... {
   {
   }
 
-  ///Overloaded helpers for column binding
+  /// Overloaded helpers for column binding
   template <soa::is_persistent_column CL>
   void doBind()
   {

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1033,12 +1033,12 @@ concept has_index = (is_indexing_column<C> || ...);
 
 template <is_index_column C>
   requires(!is_self_index_column<C>)
-auto getBinding() -> typename C::binding_t
+constexpr auto getBinding() -> typename C::binding_t
 {
 }
 
 template <typename C>
-auto getBinding() -> void
+constexpr auto getBinding() -> void
 {
 }
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1058,7 +1058,7 @@ struct TableIterator : IP, C... {
 
   TableIterator(arrow::ChunkedArray* columnData[sizeof...(C)], IP&& policy)
     : IP{policy},
-      C(columnData[framework::has_type_at_v<C>(all_columns{})])...
+      C(columnData[framework::has_type_at_v<C>(framework::pack<C...>{})])...
   {
     bind();
   }
@@ -1066,7 +1066,7 @@ struct TableIterator : IP, C... {
   TableIterator(arrow::ChunkedArray* columnData[sizeof...(C)], IP&& policy)
     requires(has_index<C...>)
     : IP{policy},
-      C(columnData[framework::has_type_at_v<C>(all_columns{})])...
+      C(columnData[framework::has_type_at_v<C>(framework::pack<C...>{})])...
   {
     bind();
     // In case we have an index column might need to constrain the actual
@@ -1144,60 +1144,38 @@ struct TableIterator : IP, C... {
     return *this;
   }
 
-  template <typename... CL, typename TA>
-  void doSetCurrentIndex(framework::pack<CL...>, TA* current)
-  {
-    (doSetCurrentIndexImpl<CL>(current), ...);
-  }
-
   template <typename CL>
   auto getCurrent() const
   {
     return CL::getCurrentRaw();
   }
 
-  template <typename... Cs>
-  auto getIndexBindingsImpl(framework::pack<Cs...>) const
-  {
-    std::vector<o2::soa::Binding> result;
-    (doGetIndexBindingImpl<Cs>(result), ...);
-    return result;
-  }
-
   auto getIndexBindings() const
   {
-    return getIndexBindingsImpl(all_columns{});
+    std::vector<o2::soa::Binding> result;
+    (doGetIndexBindingImpl<C>(result), ...);
+    return result;
   }
 
   template <typename... TA>
   void bindExternalIndices(TA*... current)
   {
-    (doSetCurrentIndex(all_columns{}, current), ...);
-  }
-
-  template <typename... Cs>
-  void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& bindings)
-  {
-    (doSetCurrentIndexRawImpl<Cs>(bindings[framework::has_type_at_v<Cs>(p)]), ...);
-  }
-
-  template <typename... Cs, typename I>
-  void doSetCurrentInternal(framework::pack<Cs...>, I const* ptr)
-  {
-    o2::soa::Binding b;
-    b.bind(ptr);
-    (doSetCurrentInternalImpl<Cs>(b), ...);
+    ([this]<typename... Cs, typename TT>(framework::pack<Cs...>, TT* t){
+      (doSetCurrentIndexImpl<Cs>(t), ...);
+    }(framework::pack<C...>{}, current), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& bindings)
   {
-    doSetCurrentIndexRaw(all_columns{}, std::forward<std::vector<o2::soa::Binding>>(bindings));
+    (doSetCurrentIndexRawImpl<C>(bindings[framework::has_type_at_v<C>(framework::pack<C...>{})]), ...);
   }
 
   template <typename I>
   void bindInternalIndices(I const* table)
   {
-    doSetCurrentInternal(all_columns{}, table);
+    o2::soa::Binding b;
+    b.bind(table);
+    (doSetCurrentInternalImpl<C>(b), ...);
   }
 
  private:

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1160,9 +1160,10 @@ struct TableIterator : IP, C... {
   template <typename... TA>
   void bindExternalIndices(TA*... current)
   {
-    ([this]<typename... Cs, typename TT>(framework::pack<Cs...>, TT* t){
+    ([this]<typename... Cs, typename TT>(framework::pack<Cs...>, TT* t) {
       (doSetCurrentIndexImpl<Cs>(t), ...);
-    }(framework::pack<C...>{}, current), ...);
+    }(framework::pack<C...>{}, current),
+     ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& bindings)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1144,13 +1144,7 @@ struct TableIterator : IP, C... {
   template <typename... CL, typename TA>
   void doSetCurrentIndex(framework::pack<CL...>, TA* current)
   {
-    (framework::overloaded{
-      [&current, this]<is_index_column CI>
-        requires(!is_self_index_column<CI>)
-      () { CI::setCurrent(current); },
-      []<typename CI>() {}}
-        .template operator()<CL>(),
-      ...);
+    (doSetCurrentIndexImpl<CL>(current), ...);
   }
 
   template <typename CL>
@@ -1163,15 +1157,7 @@ struct TableIterator : IP, C... {
   auto getIndexBindingsImpl(framework::pack<Cs...>) const
   {
     std::vector<o2::soa::Binding> result;
-    (framework::overloaded{
-      [this, &result]<is_index_column CI>
-        requires(!is_self_index_column<CI>)
-      () mutable {
-        result.emplace_back(CI::getCurrentRaw());
-      },
-      []<typename CI>() {}}
-        .template operator()<Cs>(),
-      ...);
+    (doGetIndexBindingImpl<Cs>(result), ...);
     return result;
   }
 
@@ -1187,15 +1173,9 @@ struct TableIterator : IP, C... {
   }
 
   template <typename... Cs>
-  void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& ptrs)
+  void doSetCurrentIndexRaw(framework::pack<Cs...> p, std::vector<o2::soa::Binding>&& bindings)
   {
-    (framework::overloaded{
-      [&ptrs, p, this]<is_self_index_column CI>
-        requires(!is_self_index_column<CI>)
-      () { CI::setCurrentRaw(ptrs[framework::has_type_at_v<CI>(p)]); },
-      []<typename CI>() {}}
-        .template operator()<Cs>(),
-      ...);
+    (doSetCurrentIndexRawImpl<Cs>(bindings[framework::has_type_at_v<Cs>(p)]), ...);
   }
 
   template <typename... Cs, typename I>
@@ -1203,16 +1183,12 @@ struct TableIterator : IP, C... {
   {
     o2::soa::Binding b;
     b.bind(ptr);
-    (framework::overloaded{
-       [&ptr, &b, this]<is_self_index_column CI>() { CI::setCurrentRaw(b); },
-       []<typename CI>() {}}
-       .template operator()<Cs>(),
-     ...);
+    (doSetCurrentInternalImpl<Cs>(b), ...);
   }
 
-  void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)
+  void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& bindings)
   {
-    doSetCurrentIndexRaw(all_columns{}, std::forward<std::vector<o2::soa::Binding>>(ptrs));
+    doSetCurrentIndexRaw(all_columns{}, std::forward<std::vector<o2::soa::Binding>>(bindings));
   }
 
   template <typename I>
@@ -1222,6 +1198,78 @@ struct TableIterator : IP, C... {
   }
 
  private:
+  /// Overloaded helpers for index manipulations
+  template <soa::is_index_column CL, typename TA>
+    requires(!soa::is_self_index_column<CL>)
+  void doSetCurrentIndexImpl(TA* current)
+  {
+    CL::setCurrent(current);
+  }
+
+  template <soa::is_column CL, typename TA>
+    requires(!soa::is_index_column<CL>)
+  void doSetCurrentIndexImpl(TA*)
+  {
+  }
+
+  template <soa::is_index_column CL>
+    requires(!soa::is_self_index_column<CL>)
+  auto doGetIndexBindingImpl(std::vector<o2::soa::Binding>& bindings) const
+  {
+    bindings.emplace_back(CL::getCurrentRaw());
+  }
+
+  template <soa::is_column CL>
+    requires(!soa::is_index_column<CL>)
+  auto doGetIndexBindingImpl(std::vector<o2::soa::Binding>& bindings) const
+  {
+    bindings.emplace_back();
+  }
+
+  template <soa::is_index_column CL>
+    requires(!soa::is_self_index_column<CL>)
+  void doSetCurrentIndexRawImpl(o2::soa::Binding const& b)
+  {
+    CL::setCurrentRaw(b);
+  }
+
+  template <soa::is_column CL>
+    requires(!soa::is_index_column<CL>)
+  void doSetCurrentIndexRawImpl(o2::soa::Binding const&)
+  {
+  }
+
+  template <soa::is_self_index_column CL>
+  void doSetCurrentInternalImpl(o2::soa::Binding const& b)
+  {
+    CL::setCurrentRaw(b);
+  }
+
+  template <soa::is_column CL>
+    requires(!soa::is_self_index_column<CL>)
+  void doSetCurrentInternalImpl(o2::soa::Binding const&)
+  {
+  }
+
+  ///Overloaded helpers for column binding
+  template <soa::is_persistent_column CL>
+  void doBind()
+  {
+    CL::mColumnIterator.mCurrentPos = &this->mRowIndex;
+  }
+
+  template <soa::is_dynamic_column CL>
+  void doBind()
+  {
+    bindDynamicColumn<CL>(typename CL::bindings_t{});
+  }
+
+  template <soa::is_column CL>
+    requires(!soa::is_persistent_column<CL> && !soa::is_dynamic_column<CL>)
+  void doBind()
+  {
+  }
+
   /// Helper to move at the end of columns which actually have an iterator.
   template <typename... PC>
   void doMoveToEnd(framework::pack<PC...>)
@@ -1234,12 +1282,7 @@ struct TableIterator : IP, C... {
   void bind()
   {
     using namespace o2::soa;
-    auto f = framework::overloaded{
-      [this]<soa::is_persistent_column T>(T*) -> void { T::mColumnIterator.mCurrentPos = &this->mRowIndex; },
-      [this]<soa::is_dynamic_column T>(T*) -> void { bindDynamicColumn<T>(typename T::bindings_t{}); },
-      [this]<typename T>(T*) -> void {},
-    };
-    (f(static_cast<C*>(nullptr)), ...);
+    (doBind<C>(), ...);
     if constexpr (has_index<C...>) {
       this->setIndices(this->getIndices());
       this->setOffsets(this->getOffsets());
@@ -1399,28 +1442,44 @@ static constexpr std::string getLabelFromTypeForKey(std::string const& key)
   O2_BUILTIN_UNREACHABLE();
 }
 
+template <soa::is_index_column CL, typename B>
+  requires(!soa::is_self_index_column<CL>)
+consteval static bool hasIndexToImpl()
+{
+  return o2::soa::is_binding_compatible_v<B, typename CL::binding_t>();
+}
+
+template <soa::is_column CL, typename B>
+  requires(!soa::is_index_column<CL>)
+consteval static bool hasIndexToImpl()
+{
+  return false;
+}
+
 template <typename B, typename... C>
 consteval static bool hasIndexTo(framework::pack<C...>&&)
 {
-  return (framework::overloaded{
-    []<is_index_column CI>
-      requires(!is_self_index_column<CI>)
-    () { return o2::soa::is_binding_compatible_v<B, typename CI::binding_t>(); },
-    []<typename CI>() { return false; }}
-      .template operator()<C>() ||
-    ...);
+  return (hasIndexToImpl<C, B>() || ...);
+}
+
+template <soa::is_index_column CL, typename B>
+  requires(!soa::is_self_index_column<CL>)
+consteval static bool hasSortedIndexToImpl()
+{
+  return CL::sorted && o2::soa::is_binding_compatible_v<B, typename CL::binding_t>();
+}
+
+template <soa::is_column CL, typename B>
+  requires(!soa::is_index_column<CL>)
+consteval static bool hasSortedIndexToImpl()
+{
+  return false;
 }
 
 template <typename B, typename... C>
 consteval static bool hasSortedIndexTo(framework::pack<C...>&&)
 {
-  return (framework::overloaded{
-    []<is_index_column CI>
-      requires(!is_self_index_column<CI>)
-    () { return (CI::sorted && o2::soa::is_binding_compatible_v<B, typename CI::binding_t>()); },
-    []<typename CI>() {}}
-      .template operator()<C>() ||
-    ...);
+  return (hasSortedIndexToImpl<C, B>() || ...);
 }
 
 template <typename B, typename Z>
@@ -2087,14 +2146,22 @@ class Table
     doBindInternalIndicesExplicit(columns_t{}, binding);
   }
 
+  template <soa::is_self_index_column CL>
+  void doBindInternalIndicesExplicitImpl(o2::soa::Binding binding)
+  {
+    static_cast<CL>(mBegin).setCurrentRaw(binding);
+  }
+
+  template <soa::is_column CL>
+    requires(!soa::is_self_index_column<CL>)
+  void doBindInternalIndicesExplicitImpl(o2::soa::Binding)
+  {
+  }
+
   template <typename... Cs>
   void doBindInternalIndicesExplicit(framework::pack<Cs...>, o2::soa::Binding binding)
   {
-    (framework::overloaded{
-       [this, &binding]<is_self_index_column CI>() { static_cast<CI>(mBegin).setCurrentRaw(binding); },
-       []<typename CI>() {}}
-       .template operator()<Cs>(),
-     ...);
+    (doBindInternalIndicesExplicitImpl<Cs>(binding), ...);
   }
 
   void bindExternalIndicesRaw(std::vector<o2::soa::Binding>&& ptrs)

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -812,9 +812,6 @@ template <typename C>
 concept is_marker_column = requires { &C::mark; };
 
 template <typename T>
-using is_dynamic_t = std::conditional_t<is_dynamic_column<T>, std::true_type, std::false_type>;
-
-template <typename T>
 concept is_column = is_persistent_column<T> || is_dynamic_column<T> || is_indexing_column<T> || is_marker_column<T>;
 
 template <typename T>
@@ -1828,20 +1825,17 @@ class Table
       }
     }
 
-    template <typename CD, typename... CDArgs>
+    template <soa::is_dynamic_column CD, typename... CDArgs>
     auto getDynamicColumn() const
     {
-      using decayed = std::decay_t<CD>;
-      static_assert(is_dynamic_t<decayed>(), "Requested column is not a dynamic column");
-      return static_cast<decayed>(*this).template getDynamicValue<CDArgs...>();
+      return static_cast<std::decay_t<CD>>(*this).template getDynamicValue<CDArgs...>();
     }
 
     template <typename B, typename CC>
+      requires(is_dynamic_column<CC> || is_persistent_column<CC>)
     auto getValue() const
     {
-      using COL = std::decay_t<CC>;
-      static_assert(is_dynamic_t<COL>() || soa::is_persistent_column<COL>, "Should be persistent or dynamic column with no argument that has a return type convertable to float");
-      return static_cast<B>(static_cast<COL>(*this).get());
+      return static_cast<B>(static_cast<std::decay_t<CC>>(*this).get());
     }
 
     template <typename B, typename... CCs>

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -46,8 +46,9 @@ auto isIndexTo()
 }
 
 template <typename T, typename G>
-auto isIndexTo() -> std::false_type
+auto isIndexTo()
 {
+  return std::false_type{};
 }
 
 template <typename T, typename G>

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -34,18 +34,22 @@ auto interleaveTuples(std::tuple<T1s...>& t1, std::tuple<T2s...>& t2)
   return interleaveTuplesImpl(t1, t2, std::index_sequence_for<T1s...>());
 }
 
-template <soa::is_index_column T, typename G>
-  requires(!soa::is_self_index_column<T>)
+template <soa::is_index_column T, soa::is_table G>
+  requires(!soa::is_self_index_column<T> && o2::soa::is_binding_compatible_v<std::decay_t<G>, typename std::decay_t<T>::binding_t>())
 consteval auto isIndexTo()
 {
-  if constexpr (o2::soa::is_binding_compatible_v<G, typename T::binding_t>()) {
-    return std::true_type{};
-  } else {
-    return std::false_type{};
-  }
+  return std::true_type{};
 }
 
-template <typename T, typename G>
+template <soa::is_index_column T, soa::is_table G>
+  requires(!soa::is_self_index_column<T> && !o2::soa::is_binding_compatible_v<std::decay_t<G>, typename std::decay_t<T>::binding_t>())
+consteval auto isIndexTo()
+{
+  return std::false_type{};
+}
+
+template <soa::is_column T, soa::is_table G>
+  requires(!soa::is_index_column<T>)
 consteval auto isIndexTo()
 {
   return std::false_type{};

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -34,14 +34,27 @@ auto interleaveTuples(std::tuple<T1s...>& t1, std::tuple<T2s...>& t2)
   return interleaveTuplesImpl(t1, t2, std::index_sequence_for<T1s...>());
 }
 
+template <soa::is_index_column T, typename G>
+  requires(!soa::is_self_index_column<T>)
+auto isIndexTo()
+{
+  if constexpr (o2::soa::is_binding_compatible_v<G, typename T::binding_t>()) {
+    return std::true_type{};
+  } else {
+    return std::false_type{};
+  }
+}
+
 template <typename T, typename G>
-using is_index_to_g_t = typename std::conditional<o2::soa::is_binding_compatible_v<G, typename T::binding_t>(), std::true_type, std::false_type>::type;
+auto isIndexTo() ->std::false_type {}
+
+template <typename T, typename G>
+using is_index_to_g_t = decltype(isIndexTo<T, G>());
 
 template <typename G, typename A>
 expressions::BindingNode getMatchingIndexNode()
 {
-  using external_index_columns_pack = typename A::external_index_columns_t;
-  using selected_indices_t = selected_pack_multicondition<is_index_to_g_t, pack<G>, external_index_columns_pack>;
+  using selected_indices_t = selected_pack_multicondition<is_index_to_g_t, pack<G>, typename A::columns_t>;
   static_assert(pack_size(selected_indices_t{}) == 1, "No matching index column from associated to grouping");
   using index_column_t = pack_head_t<selected_indices_t>;
   return expressions::BindingNode{index_column_t::mLabel, o2::framework::TypeIdHelpers::uniqueId<typename index_column_t::column_t>(), expressions::selectArrowType<typename index_column_t::type>()};

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -36,7 +36,7 @@ auto interleaveTuples(std::tuple<T1s...>& t1, std::tuple<T2s...>& t2)
 
 template <soa::is_index_column T, typename G>
   requires(!soa::is_self_index_column<T>)
-constexpr auto isIndexTo()
+consteval auto isIndexTo()
 {
   if constexpr (o2::soa::is_binding_compatible_v<G, typename T::binding_t>()) {
     return std::true_type{};
@@ -46,7 +46,7 @@ constexpr auto isIndexTo()
 }
 
 template <typename T, typename G>
-constexpr auto isIndexTo()
+consteval auto isIndexTo()
 {
   return std::false_type{};
 }

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -46,7 +46,9 @@ auto isIndexTo()
 }
 
 template <typename T, typename G>
-auto isIndexTo() ->std::false_type {}
+auto isIndexTo() -> std::false_type
+{
+}
 
 template <typename T, typename G>
 using is_index_to_g_t = decltype(isIndexTo<T, G>());

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -36,7 +36,7 @@ auto interleaveTuples(std::tuple<T1s...>& t1, std::tuple<T2s...>& t2)
 
 template <soa::is_index_column T, typename G>
   requires(!soa::is_self_index_column<T>)
-auto isIndexTo()
+constexpr auto isIndexTo()
 {
   if constexpr (o2::soa::is_binding_compatible_v<G, typename T::binding_t>()) {
     return std::true_type{};
@@ -46,7 +46,7 @@ auto isIndexTo()
 }
 
 template <typename T, typename G>
-auto isIndexTo()
+constexpr auto isIndexTo()
 {
   return std::false_type{};
 }


### PR DESCRIPTION
* Avoid using `overloaded{}` in templates
* Fix index binding not happening due to typo (`is_self_index_column` used in place if `is_index_column`)