### PR TITLE
Added particle f2(1270) in the O2Database accroding to PDG 2024

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/O2DatabasePDG.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/O2DatabasePDG.h
@@ -490,6 +490,10 @@ inline void O2DatabasePDG::addALICEParticles(TDatabasePDG* db)
   }
 
   // glueball hunting
+  ionCode = 225;
+  if (!db->GetParticle(ionCode)) {
+    db->AddParticle("f2_1270", "f2_1270", 1.2754, kFALSE, 0.1858, 0, "Resonance", ionCode);
+  }
   ionCode = 115;
   if (!db->GetParticle(ionCode)) {
     db->AddParticle("a2_1320", "a2_1320", 1.3182, kFALSE, 0.1078, 0, "Resonance", ionCode);


### PR DESCRIPTION
-- Particle f2(1270) was added for the glueball study in the KsKs mass spectrum.
-- The mass and width are taken from the PDG 2024.
-- BR is set to 100% for the decay mode to KsKs channel, which will be the channel used in the study.