### PR TITLE
ITS3: AlpideResponse adjust for APTS

### DIFF
--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/AlpideSimResponse.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/AlpideSimResponse.h
@@ -132,6 +132,8 @@ class AlpideSimResponse
   float getStepCol() const { return mStepInvCol ? 1. / mStepInvCol : 0.f; }
   float getStepRow() const { return mStepInvRow ? 1. / mStepInvRow : 0.f; }
   float getStepDepth() const { return mStepInvDpt ? 1. / mStepInvDpt : 0.f; }
+  void setColMax(float v) noexcept { mColMax = v; }
+  void setRowMax(float v) noexcept { mRowMax = v; }
   void setDataPath(const std::string pth) { mDataPath = pth; }
   void setGridColName(const std::string nm) { mGridColName = nm; }
   void setGridRowName(const std::string nm) { mGridRowName = nm; }
@@ -142,7 +144,7 @@ class AlpideSimResponse
   const std::string& getColRowDataFmt() const { return mColRowDataFmt; }
   void print() const;
 
-  ClassDefNV(AlpideSimResponse, 1);
+  ClassDefNV(AlpideSimResponse, 2);
 };
 
 //-----------------------------------------------------


### PR DESCRIPTION
Updated the code for converting ITSChipResponse files into a format usable by O2, enabling ITS3 digitization with APTS chip response support.
This PR is intended to be used together with #13894 from @f3sch, but be able to compile independently.