### PR TITLE
Promoting operational errors to critical severity

### DIFF
--- a/Detectors/TPC/workflow/src/IDCToVectorSpec.cxx
+++ b/Detectors/TPC/workflow/src/IDCToVectorSpec.cxx
@@ -405,7 +405,7 @@ class IDCToVectorDevice : public o2::framework::Task
 
       for (const auto& inf : infVec) {
         if (!inf.hasBothEPs()) {
-          LOGP(error, "IDC CRU {:3}: data missing at ({:8}, {:4}) for one or both end points {:02b} in TF {}", cru, inf.heartbeatOrbit, inf.heartbeatBC, inf.epSeen, tfCounter);
+          LOGP(critical, "IDC CRU {:3}: data missing at ({:8}, {:4}) for one or both end points {:02b} in TF {}", cru, inf.heartbeatOrbit, inf.heartbeatBC, inf.epSeen, tfCounter);
           hasErrors = true;
         }
       }
@@ -417,12 +417,12 @@ class IDCToVectorDevice : public o2::framework::Task
       }
 
       if (packetsInTF != infVec.size()) {
-        LOGP(error, "IDC CRU {:3}: number of IDC packets {} does not match max over all CRUs {} in TF {}", cru, packetsInTF, infVec.size(), tfCounter);
+        LOGP(critical, "IDC CRU {:3}: number of IDC packets {} does not match max over all CRUs {} in TF {}", cru, packetsInTF, infVec.size(), tfCounter);
         hasErrors = true;
       }
 
       if (!std::equal(infVecComp->begin(), infVecComp->end(), infVec.begin())) {
-        LOGP(error, "IDC CRU {:3}: mismatch in orbit numbers", cru);
+        LOGP(critical, "IDC CRU {:3}: mismatch in orbit numbers", cru);
         hasErrors = true;
       }
     }

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -579,7 +579,7 @@ auto decongestionCallbackOrdered = [](AsyncTask& task, size_t id) -> void {
     if (state.transitionHandling != TransitionHandlingState::NoTransition && DefaultsHelpers::onlineDeploymentMode()) {
       O2_SIGNPOST_EVENT_EMIT_WARN(async_queue, cid, "oldest_possible_timeslice", "Stop transition requested. Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
     } else {
-      O2_SIGNPOST_EVENT_EMIT_ERROR(async_queue, cid, "oldest_possible_timeslice", "Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
+      O2_SIGNPOST_EVENT_EMIT_CRITICAL(async_queue, cid, "oldest_possible_timeslice", "Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
     }
     timesliceIndex.rescan();
   }
@@ -650,7 +650,7 @@ o2::framework::ServiceSpec
           if (state.transitionHandling != TransitionHandlingState::NoTransition && DefaultsHelpers::onlineDeploymentMode()) {
             O2_SIGNPOST_EVENT_EMIT_WARN(data_processor_context, cid, "oldest_possible_timeslice", "Stop transition requested. Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
           } else {
-            O2_SIGNPOST_EVENT_EMIT_ERROR(data_processor_context, cid, "oldest_possible_timeslice", "Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
+            O2_SIGNPOST_EVENT_EMIT_CRITICAL(data_processor_context, cid, "oldest_possible_timeslice", "Some Lifetime::Timeframe data got dropped starting at %" PRIi64, oldNextTimeslice);
           }
           timesliceIndex.rescan();
         }

--- a/Utilities/EPNMonitoring/src/EPNstderrMonitor.cxx
+++ b/Utilities/EPNMonitoring/src/EPNstderrMonitor.cxx
@@ -77,7 +77,7 @@ class EPNMonitor
   std::unordered_map<std::string, fileMon> mFiles;
   std::string mPath;
   std::vector<std::regex> mFilters;
-  std::unordered_map<std::string, std::pair<InfoLogger::InfoLogger::Severity, int>> mMapRootLogTypes;
+  std::unordered_map<std::string, std::pair<InfoLogger::InfoLogger::Severity, int>> mMapLogTypes;
   volatile unsigned int mRunNumber;
   std::string mPartition;
   unsigned int nLines = 0;
@@ -95,12 +95,11 @@ EPNMonitor::EPNMonitor(std::string path, bool infoLogger, int runNumber, std::st
   mFilters.emplace_back("^Warning in <TGraph");
   mFilters.emplace_back("^Warning in <TInterpreter");
   mFilters.emplace_back("Dividing histograms with different labels");
-  mMapRootLogTypes.emplace("Info in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Info, 13});
-  mMapRootLogTypes.emplace("Print in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Info, 13});
-  mMapRootLogTypes.emplace("Warning in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Warning, 11});
-  mMapRootLogTypes.emplace("Error in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Error, 2});
-  mMapRootLogTypes.emplace("Fatal in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Fatal, 1});
-  mMapRootLogTypes.emplace("*** Break ***", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Fatal, 1});
+  mMapLogTypes.emplace("(core dumped)", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Error, 1});
+  mMapLogTypes.emplace("Warning in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Warning, 11});
+  mMapLogTypes.emplace("Error in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Error, 2});
+  mMapLogTypes.emplace("Fatal in <", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Fatal, 1});
+  mMapLogTypes.emplace("*** Break ***", std::pair<InfoLogger::InfoLogger::Severity, int>{InfoLogger::InfoLogger::Severity::Fatal, 1});
   mInfoLoggerActive = infoLogger;
   mPath = path;
   mRunNumber = runNumber;
@@ -214,7 +213,7 @@ void EPNMonitor::thread()
             // assign proper severity / level for remaining ROOT log messages
             auto severity{InfoLogger::InfoLogger::Severity::Error};
             int level{3};
-            for (const auto& logType : mMapRootLogTypes) {
+            for (const auto& logType : mMapLogTypes) {
               if (line.find(logType.first) != std::string::npos) {
                 severity = std::get<InfoLogger::InfoLogger::Severity>(logType.second);
                 level = std::get<int>(logType.second);


### PR DESCRIPTION
This PR promotes Error messages which require some action from the shifter to the InfoLogger Ops level.

As a first step, "(core dumped)" messages are set to severity=Error and level=1 in the EPNstderrMonitor task. I will also check for other stderr messages which we might want to promote.

Now, in the second step, we should promote known DPL Erros (https://alice-qc-shifter.docs.cern.ch/pdp/infologgerMessages/ and https://alice-operations.docs.cern.ch/ECS/ECS_operational/#known-messages-in-the-guis) for which we ask the shifter to act (create BKE or call an expert) to level=1. 