### PR TITLE
DPL Analysis: move ownership of payloads to the fragment

### DIFF
--- a/Framework/Core/include/Framework/RootArrowFilesystem.h
+++ b/Framework/Core/include/Framework/RootArrowFilesystem.h
@@ -12,11 +12,13 @@
 #define O2_FRAMEWORK_ROOT_ARROW_FILESYSTEM_H_
 
 #include <TBufferFile.h>
+#include <arrow/dataset/dataset.h>
 #include <arrow/dataset/type_fwd.h>
 #include <arrow/dataset/file_base.h>
 #include <arrow/filesystem/type_fwd.h>
 #include <arrow/type_fwd.h>
 #include <memory>
+#include <utility>
 
 class TFile;
 class TBufferFile;
@@ -24,6 +26,27 @@ class TDirectoryFile;
 
 namespace o2::framework
 {
+
+struct RootObjectHandler {
+  RootObjectHandler(void* p, std::shared_ptr<arrow::dataset::FileFormat> f)
+    : payload(p), format(std::move(f))
+  {
+  }
+
+  ~RootObjectHandler() noexcept(false);
+
+  template <typename T>
+  std::unique_ptr<T> GetObjectAsOwner()
+  {
+    auto* p = payload;
+    payload = nullptr;
+    return std::unique_ptr<T>((T*)p);
+  }
+  std::shared_ptr<arrow::dataset::FileFormat> format;
+
+ private:
+  void* payload = nullptr;
+};
 
 // This is to avoid having to implement a bunch of unimplemented methods
 // for all the possible virtual filesystem we can invent on top of ROOT
@@ -40,7 +63,8 @@ class VirtualRootFileSystemBase : public arrow::fs::FileSystem
     return this->type_name() == other.type_name();
   }
 
-  virtual std::shared_ptr<VirtualRootFileSystemBase> GetSubFilesystem(arrow::dataset::FileSource source) = 0;
+  virtual std::shared_ptr<RootObjectHandler> GetObjectHandler(arrow::dataset::FileSource source) = 0;
+  virtual bool CheckSupport(arrow::dataset::FileSource source) = 0;
 
   arrow::Status CreateDir(const std::string& path, bool recursive) override;
 
@@ -72,7 +96,6 @@ class VirtualRootFileSystemBase : public arrow::fs::FileSystem
 struct RootArrowFactory final {
   std::function<std::shared_ptr<arrow::dataset::FileWriteOptions>()> options = nullptr;
   std::function<std::shared_ptr<arrow::dataset::FileFormat>()> format = nullptr;
-  std::function<std::shared_ptr<VirtualRootFileSystemBase>(void*)> getSubFilesystem = nullptr;
 };
 
 struct RootArrowFactoryPlugin {
@@ -92,9 +115,10 @@ struct RootObjectReadingCapability {
   // Use a void * in order not to expose the kind of object to the
   // generic reading code. This is also where we load the plugin
   // which will be used for the actual creation.
-  std::function<void*(TDirectoryFile* file, std::string const& path)> getHandle;
-  // Same as the above, but uses a TBufferFile as storage
-  std::function<void*(TBufferFile*, std::string const&)> getBufferHandle;
+  std::function<void*(std::shared_ptr<arrow::fs::FileSystem> fs, std::string const& path)> getHandle;
+  // Wether or not this actually supports reading an object of the following class
+  std::function<bool(char const*)> checkSupport;
+
   // This must be implemented to load the actual RootArrowFactory plugin which
   // implements this capability. This way the detection of the file format
   // (via get handle) does not need to know about the actual code which performs
@@ -125,7 +149,9 @@ class TFileFileSystem : public VirtualRootFileSystemBase
     return "TDirectoryFile";
   }
 
-  std::shared_ptr<VirtualRootFileSystemBase> GetSubFilesystem(arrow::dataset::FileSource source) override;
+  std::shared_ptr<RootObjectHandler> GetObjectHandler(arrow::dataset::FileSource source) override;
+  bool CheckSupport(arrow::dataset::FileSource source) override;
+  virtual std::shared_ptr<VirtualRootFileSystemBase> GetSubFilesystem(arrow::dataset::FileSource source);
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
     const std::string& path,
@@ -153,7 +179,12 @@ class TBufferFileFS : public VirtualRootFileSystemBase
     return "tbufferfile";
   }
 
-  std::shared_ptr<VirtualRootFileSystemBase> GetSubFilesystem(arrow::dataset::FileSource source) override;
+  bool CheckSupport(arrow::dataset::FileSource source) override;
+  std::shared_ptr<RootObjectHandler> GetObjectHandler(arrow::dataset::FileSource source) override;
+  TBufferFile* GetBuffer()
+  {
+    return mBuffer;
+  }
 
  private:
   TBufferFile* mBuffer;

--- a/Framework/Core/test/test_Root2ArrowTable.cxx
+++ b/Framework/Core/test/test_Root2ArrowTable.cxx
@@ -565,12 +565,23 @@ TEST_CASE("RootTree2Dataset")
   {
     REQUIRE(success.ok());
     // Let's read it back...
+    auto tfileFs = std::dynamic_pointer_cast<TFileFileSystem>(outFs);
+    REQUIRE(tfileFs.get());
+    REQUIRE(tfileFs->GetFile());
+    REQUIRE(tfileFs->GetFile()->GetObjectChecked("/DF_3", TClass::GetClass("TTree")));
     arrow::dataset::FileSource source2("/DF_3", outFs);
-    auto newTreeFS = outFs->GetSubFilesystem(source2);
 
-    REQUIRE(format->IsSupported(source) == true);
+    REQUIRE(format->IsSupported(source2) == true);
+    tfileFs = std::dynamic_pointer_cast<TFileFileSystem>(source2.filesystem());
+    REQUIRE(tfileFs.get());
+    REQUIRE(tfileFs->GetFile());
+    REQUIRE(tfileFs->GetFile()->GetObjectChecked("/DF_3", TClass::GetClass("TTree")));
 
-    auto schemaOptWritten = format->Inspect(source);
+    auto schemaOptWritten = format->Inspect(source2);
+    tfileFs = std::dynamic_pointer_cast<TFileFileSystem>(source2.filesystem());
+    REQUIRE(tfileFs.get());
+    REQUIRE(tfileFs->GetFile());
+    REQUIRE(tfileFs->GetFile()->GetObjectChecked("/DF_3", TClass::GetClass("TTree")));
     REQUIRE(schemaOptWritten.ok());
     auto schemaWritten = *schemaOptWritten;
 
@@ -585,7 +596,7 @@ TEST_CASE("RootTree2Dataset")
     std::shared_ptr<arrow::Schema> schema = std::make_shared<arrow::Schema>(fields);
     REQUIRE(validateSchema(schema));
 
-    auto fragmentWritten = format->MakeFragment(source, {}, *physicalSchema);
+    auto fragmentWritten = format->MakeFragment(source2, {}, *physicalSchema);
     REQUIRE(fragmentWritten.ok());
     auto optionsWritten = std::make_shared<arrow::dataset::ScanOptions>();
     options->dataset_schema = schema;
@@ -610,7 +621,6 @@ TEST_CASE("RootTree2Dataset")
 
   // And now we can read back the RNTuple into a RecordBatch
   arrow::dataset::FileSource writtenRntupleSource("/rntuple", outFs);
-  auto newRNTupleFS = outFs->GetSubFilesystem(writtenRntupleSource);
 
   REQUIRE(rNtupleFormat->IsSupported(writtenRntupleSource) == true);
 


### PR DESCRIPTION

This makes sure the FileFragment is the entity which owns the
TTree / RNtuple, so that its caching and memory management have the
correct life-cycle and we do not end up with memory churn or having
to reconfigure the caches.
