### PR TITLE
TPC timeseries requiring ft0 info as mandatory

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCTimeSeriesSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCTimeSeriesSpec.h
@@ -23,7 +23,7 @@ namespace tpc
 static constexpr header::DataDescription getDataDescriptionTimeSeries() { return header::DataDescription{"TIMESERIES"}; }
 static constexpr header::DataDescription getDataDescriptionTPCTimeSeriesTFId() { return header::DataDescription{"ITPCTSTFID"}; }
 
-o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType, const bool enableUnbinnedWriter, o2::dataformats::GlobalTrackID::mask_t src, bool useft0 = false);
+o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType, const bool enableUnbinnedWriter, o2::dataformats::GlobalTrackID::mask_t src);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1814,7 +1814,7 @@ class TPCTimeSeries : public Task
   }
 };
 
-o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType, const bool enableUnbinnedWriter, GTrackID::mask_t src, bool useft0)
+o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, const o2::base::Propagator::MatCorrType matType, const bool enableUnbinnedWriter, GTrackID::mask_t src)
 {
   auto dataRequest = std::make_shared<DataRequest>();
   bool useMC = false;
@@ -1823,9 +1823,7 @@ o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, 
   dataRequest->requestTracks(srcTracks, useMC);
   dataRequest->requestClusters(GTrackID::getSourcesMask("TPC"), useMC);
 
-  if (useft0) {
-    dataRequest->requestFT0RecPoints(false);
-  }
+  dataRequest->requestFT0RecPoints(false);
 
   bool tpcOnly = srcTracks == GTrackID::getSourcesMask("TPC");
   if (!tpcOnly) {

--- a/Detectors/TPC/workflow/src/tpc-time-series.cxx
+++ b/Detectors/TPC/workflow/src/tpc-time-series.cxx
@@ -29,7 +29,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", VariantType::Bool, false, {"disable root-files output writers"}},
     {"enable-unbinned-root-output", VariantType::Bool, false, {"writing out unbinned track data"}},
     {"track-sources", VariantType::String, std::string{o2::dataformats::GlobalTrackID::ALL}, {"comma-separated list of sources to use"}},
-    {"use-ft0", VariantType::Bool, false, {"enable FT0 rec-points"}},
     {"material-type", VariantType::Int, 2, {"Type for the material budget during track propagation: 0=None, 1=Geo, 2=LUT"}}};
   std::swap(workflowOptions, options);
 }
@@ -44,8 +43,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const bool enableUnbinnedWriter = config.options().get<bool>("enable-unbinned-root-output");
   auto src = o2::dataformats::GlobalTrackID::getSourcesMask(config.options().get<std::string>("track-sources"));
   auto materialType = static_cast<o2::base::Propagator::MatCorrType>(config.options().get<int>("material-type"));
-  const bool useft0 = config.options().get<bool>("use-ft0");
-  workflow.emplace_back(o2::tpc::getTPCTimeSeriesSpec(disableWriter, materialType, enableUnbinnedWriter, src, useft0));
+  workflow.emplace_back(o2::tpc::getTPCTimeSeriesSpec(disableWriter, materialType, enableUnbinnedWriter, src));
   if (!disableWriter) {
     workflow.emplace_back(o2::tpc::getTPCTimeSeriesWriterSpec());
   }

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -54,7 +54,6 @@ if [[ $CALIB_ASYNC_EXTRACTTPCCURRENTS == 1 ]]; then
   add_W o2-tpc-integrate-cluster-workflow "${CONFIG_CTPTPC}"
 fi
 if [[ $CALIB_ASYNC_EXTRACTTIMESERIES == 1 ]] ; then
-  CONFIG_TPCTIMESERIES=" --use-ft0"
   : ${CALIB_ASYNC_SAMPLINGFACTORTIMESERIES:=0.001}
   if [[ ! -z ${CALIB_ASYNC_ENABLEUNBINNEDTIMESERIES:-} ]]; then
     CONFIG_TPCTIMESERIES+=" --enable-unbinned-root-output --sample-unbinned-tsallis --threads ${TPCTIMESERIES_THREADS:-1}"


### PR DESCRIPTION
Since now also O2DPG package requires FT0 infos for TPC  timeseries in MC workflow I set it as mandatory and I removed the option-flag

@miranov25 