### PR TITLE
Fix int8/uint8 type in LinPad2Y for GPUTPCCompressionTrackModel

### DIFF
--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionTrackModel.h
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionTrackModel.h
@@ -100,13 +100,13 @@ class GPUTPCCompressionTrackModel
   GPUd() void getClusterErrors2(int32_t iRow, float z, float sinPhi, float DzDs, float& ErrY2, float& ErrZ2) const;
   GPUd() void resetCovariance();
 
-  GPUd() float LinearPad2Y(int32_t slice, float pad, float padWidth, int8_t npads) const
+  GPUd() float LinearPad2Y(int32_t slice, float pad, float padWidth, uint8_t npads) const
   {
     const float u = (pad - 0.5f * npads) * padWidth;
     return (slice >= GPUCA_NSLICES / 2) ? -u : u;
   }
 
-  GPUd() float LinearY2Pad(int32_t slice, float y, float padWidth, int8_t npads) const
+  GPUd() float LinearY2Pad(int32_t slice, float y, float padWidth, uint8_t npads) const
   {
     const float u = (slice >= GPUCA_NSLICES / 2) ? -y : y;
     return u / padWidth + 0.5f * npads;


### PR DESCRIPTION
Fixes a bug in https://github.com/AliceO2Group/AliceO2/pull/13874.
Trivial, merging