### PR TITLE
DPL Analysis: replace SFINAE with overloaded restricted templates

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1416,6 +1416,7 @@ template <typename T, typename Policy, bool OPT = false>
 struct PresliceBase : public Policy {
   constexpr static bool optional = OPT;
   using target_t = T;
+  using policy_t = Policy;
   const std::string binding;
 
   PresliceBase(expressions::BindingNode index_)
@@ -1452,6 +1453,15 @@ template <typename T>
 using Preslice = PresliceBase<T, PreslicePolicySorted, false>;
 template <typename T>
 using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
+
+template <typename T>
+concept is_preslice = requires(T t) {
+  std::same_as<decltype(t.binding), std::string>;
+  std::same_as<decltype(t.bindingKey), StringPair>;
+  &T::isMising;
+  &T::updateSliceInfo;
+  &T::getSliceFor;
+};
 
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1456,8 +1456,8 @@ using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 
 template <typename T>
 concept is_preslice = requires(T t) {
-  std::same_as<decltype(t.binding), std::string>;
-  std::same_as<decltype(t.bindingKey), StringPair>;
+  requires std::same_as<decltype(t.binding), std::string>;
+  requires std::same_as<decltype(t.bindingKey), StringPair>;
   &T::isMising;
   &T::updateSliceInfo;
   &T::getSliceFor;

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -190,6 +190,9 @@ template <is_producable T>
 struct Produces : WritingCursor<T> {
 };
 
+template <typename T>
+concept is_produces = requires (T t) { typename T::cursor_t; typename T::persistent_table_t; &T::cursor; };
+
 /// Use this to group together produces. Useful to separate them logically
 /// or simply to stay within the 100 elements per Task limit.
 /// Use as:
@@ -200,6 +203,9 @@ struct Produces : WritingCursor<T> {
 /// Notice the label MySetOfProduces is just a mnemonic and can be omitted.
 struct ProducesGroup {
 };
+
+template <typename T>
+concept is_produces_group = std::derived_from<T, ProducesGroup>;
 
 /// Helper template for table transformations
 template <soa::is_metadata M, soa::TableRef Ref>
@@ -250,6 +256,7 @@ constexpr auto transformBase()
 
 template <is_spawnable T>
 struct Spawns : decltype(transformBase<T>()) {
+  using spawnable_t = T;
   using metadata = decltype(transformBase<T>())::metadata;
   using extension_t = typename metadata::extension_table_t;
   using base_table_t = typename metadata::base_table_t;
@@ -275,6 +282,12 @@ struct Spawns : decltype(transformBase<T>()) {
   }
   std::shared_ptr<typename T::table_t> table = nullptr;
   std::shared_ptr<extension_t> extension = nullptr;
+};
+
+template <typename T>
+concept is_spawns = requires(T t) {
+  typename T::metadata;
+  std::same_as<decltype(t.pack()), typename T::expression_pack_t>;
 };
 
 /// Policy to control index building
@@ -420,6 +433,7 @@ constexpr auto transformBase()
 
 template <soa::is_index_table T>
 struct Builds : decltype(transformBase<T>()) {
+  using buildable_t = T;
   using metadata = decltype(transformBase<T>())::metadata;
   using IP = std::conditional_t<metadata::exclusive, IndexBuilder<Exclusive>, IndexBuilder<Sparse>>;
   using Key = metadata::Key;
@@ -453,6 +467,13 @@ struct Builds : decltype(transformBase<T>()) {
     this->table = std::make_shared<T>(IP::template indexBuilder<Key, metadata::sources.size(), metadata::sources>(o2::aod::label<T::ref>(), std::forward<std::vector<std::shared_ptr<arrow::Table>>>(tables), framework::pack<Cs...>{}));
     return (this->table != nullptr);
   }
+};
+
+template <typename T>
+concept is_builds = requires(T t) {
+  typename T::metadata;
+  typename T::Key;
+  std::same_as<decltype(t.pack()), typename T::index_pack_t>;
 };
 
 /// This helper class allows you to declare things which will be created by a
@@ -550,11 +571,15 @@ struct OutputObj {
   uint32_t mTaskHash;
 };
 
+template <typename T>
+concept is_outputobj = requires (T t) { &T::setObject; std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>; };
+
 /// This helper allows you to fetch a Sevice from the context or
 /// by using some singleton. This hopefully will hide the Singleton and
 /// We will be able to retrieve it in a more thread safe manner later on.
 template <typename T>
 struct Service {
+  using service_t = T;
   T* service;
 
   decltype(auto) operator->() const
@@ -566,6 +591,9 @@ struct Service {
     }
   }
 };
+
+template <typename T>
+concept is_service = requires (T t) { std::same_as<decltype(t.service), typename T::service_t*>; &T::operator->;};
 
 auto getTableFromFilter(soa::is_filtered_table auto const& table, soa::SelectionVector&& selection)
 {
@@ -581,6 +609,7 @@ void initializePartitionCaches(std::set<uint32_t> const& hashes, std::shared_ptr
 
 template <typename T>
 struct Partition {
+  using content_t = T;
   Partition(expressions::Node&& filter_) : filter{std::forward<expressions::Node>(filter_)}
   {
   }
@@ -690,6 +719,9 @@ struct Partition {
     return mFiltered->size();
   }
 };
+
+template <typename T>
+concept is_partition = requires (T t) {&T::updatePlaceholders; std::same_as<decltype(t.filter), expressions::Filter>; std::same_as<decltype(t.mFiltered), std::unique_ptr<o2::soa::Filtered<typename T::content_t>>>;};
 }  // namespace o2::framework
 
 namespace o2::soa

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -573,7 +573,10 @@ struct OutputObj {
 
 template <typename T>
 concept is_outputobj = requires(T t) {
-  &T::setObject;
+  &T::setHash;
+  &T::spec;
+  &T::ref;
+  requires std::same_as<decltype(t.operator->()), typename T::obj_t*>;
   requires std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>;
 };
 

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -287,7 +287,7 @@ struct Spawns : decltype(transformBase<T>()) {
 template <typename T>
 concept is_spawns = requires(T t) {
   typename T::metadata;
-  std::same_as<decltype(t.pack()), typename T::expression_pack_t>;
+  requires std::same_as<decltype(t.pack()), typename T::expression_pack_t>;
 };
 
 /// Policy to control index building
@@ -473,7 +473,7 @@ template <typename T>
 concept is_builds = requires(T t) {
   typename T::metadata;
   typename T::Key;
-  std::same_as<decltype(t.pack()), typename T::index_pack_t>;
+  requires std::same_as<decltype(t.pack()), typename T::index_pack_t>;
 };
 
 /// This helper class allows you to declare things which will be created by a
@@ -572,7 +572,10 @@ struct OutputObj {
 };
 
 template <typename T>
-concept is_outputobj = requires(T t) { &T::setObject; std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>; };
+concept is_outputobj = requires(T t) {
+  &T::setObject;
+  requires std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>;
+};
 
 /// This helper allows you to fetch a Sevice from the context or
 /// by using some singleton. This hopefully will hide the Singleton and
@@ -593,7 +596,10 @@ struct Service {
 };
 
 template <typename T>
-concept is_service = requires(T t) { std::same_as<decltype(t.service), typename T::service_t*>; &T::operator->; };
+concept is_service = requires(T t) {
+  requires std::same_as<decltype(t.service), typename T::service_t*>;
+  &T::operator->;
+};
 
 auto getTableFromFilter(soa::is_filtered_table auto const& table, soa::SelectionVector&& selection)
 {
@@ -721,7 +727,11 @@ struct Partition {
 };
 
 template <typename T>
-concept is_partition = requires(T t) {&T::updatePlaceholders; std::same_as<decltype(t.filter), expressions::Filter>; std::same_as<decltype(t.mFiltered), std::unique_ptr<o2::soa::Filtered<typename T::content_t>>>; };
+concept is_partition = requires(T t) {
+  &T::updatePlaceholders;
+  requires std::same_as<decltype(t.filter), expressions::Filter>;
+  requires std::same_as<decltype(t.mFiltered), std::unique_ptr<o2::soa::Filtered<typename T::content_t>>>;
+};
 }  // namespace o2::framework
 
 namespace o2::soa

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -191,7 +191,7 @@ struct Produces : WritingCursor<T> {
 };
 
 template <typename T>
-concept is_produces = requires (T t) { typename T::cursor_t; typename T::persistent_table_t; &T::cursor; };
+concept is_produces = requires(T t) { typename T::cursor_t; typename T::persistent_table_t; &T::cursor; };
 
 /// Use this to group together produces. Useful to separate them logically
 /// or simply to stay within the 100 elements per Task limit.
@@ -572,7 +572,7 @@ struct OutputObj {
 };
 
 template <typename T>
-concept is_outputobj = requires (T t) { &T::setObject; std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>; };
+concept is_outputobj = requires(T t) { &T::setObject; std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>; };
 
 /// This helper allows you to fetch a Sevice from the context or
 /// by using some singleton. This hopefully will hide the Singleton and
@@ -593,7 +593,7 @@ struct Service {
 };
 
 template <typename T>
-concept is_service = requires (T t) { std::same_as<decltype(t.service), typename T::service_t*>; &T::operator->;};
+concept is_service = requires(T t) { std::same_as<decltype(t.service), typename T::service_t*>; &T::operator->; };
 
 auto getTableFromFilter(soa::is_filtered_table auto const& table, soa::SelectionVector&& selection)
 {
@@ -721,7 +721,7 @@ struct Partition {
 };
 
 template <typename T>
-concept is_partition = requires (T t) {&T::updatePlaceholders; std::same_as<decltype(t.filter), expressions::Filter>; std::same_as<decltype(t.mFiltered), std::unique_ptr<o2::soa::Filtered<typename T::content_t>>>;};
+concept is_partition = requires(T t) {&T::updatePlaceholders; std::same_as<decltype(t.filter), expressions::Filter>; std::same_as<decltype(t.mFiltered), std::unique_ptr<o2::soa::Filtered<typename T::content_t>>>; };
 }  // namespace o2::framework
 
 namespace o2::soa

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -31,7 +31,8 @@
 namespace o2::framework
 {
 
-namespace {
+namespace
+{
 template <typename O>
 static inline auto extractOriginal(ProcessingContext& pc)
 {
@@ -51,9 +52,10 @@ static inline auto extractOriginals(ProcessingContext& pc)
     return {pc.inputs().get<TableConsumer>(o2::aod::label<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
-}
+} // namespace
 
-namespace analysis_task_parsers {
+namespace analysis_task_parsers
+{
 
 /// Options handling
 template <typename O>
@@ -442,7 +444,7 @@ void setPartition(P&, T&...)
 template <is_partition P, typename... T>
 void setPartition(P& partition, T&... tables)
 {
-  ([&](){ if constexpr (std::same_as<typename P::content_t, T>) {partition.bindTable(tables);} }(), ...);
+  ([&]() { if constexpr (std::same_as<typename P::content_t, T>) {partition.bindTable(tables);} }(), ...);
 }
 
 template <typename P, typename T>
@@ -507,7 +509,7 @@ static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& asso
   }
 }
 
-} // analysis_task_parsers
+} // namespace analysis_task_parsers
 
 template <typename ANY>
 struct UpdateProcessSwitches {

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -509,98 +509,95 @@ static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& asso
   }
 }
 
-} // namespace analysis_task_parsers
+/// Preslice handling
+template <typename T>
+bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>&)
+{
+  return false;
+}
 
-template <typename ANY>
-struct UpdateProcessSwitches {
-  static bool set(std::pair<std::string, bool>, ANY&)
-  {
-    return false;
-  }
-};
-
-template <typename R, typename T, typename... As>
-struct UpdateProcessSwitches<ProcessConfigurable<R, T, As...>> {
-  static bool set(std::pair<std::string, bool> setting, ProcessConfigurable<R, T, As...>& what)
-  {
-    if (what.name == setting.first) {
-      what.value = setting.second;
+template <is_preslice T>
+  requires std::same_as<typename T::policy_t, framework::PreslicePolicySorted>
+bool registerCache(T& preslice, std::vector<StringPair>& bsks, std::vector<StringPair>&)
+{
+  if constexpr (T::optional) {
+    if (preslice.binding == "[MISSING]") {
       return true;
     }
-    return false;
   }
-};
+  auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.first == preslice.bindingKey.first) && (entry.second == preslice.bindingKey.second); });
+  if (locate == bsks.end()) {
+    bsks.emplace_back(preslice.getBindingKey());
+  }
+  return true;
+}
 
-/// Manager template to handle slice caching
+template <is_preslice T>
+  requires std::same_as<typename T::policy_t, framework::PreslicePolicyGeneral>
+bool registerCache(T& preslice, std::vector<StringPair>&, std::vector<StringPair>& bsksU)
+{
+  if constexpr (T::optional) {
+    if (preslice.binding == "[MISSING]") {
+      return true;
+    }
+  }
+  auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.first == preslice.bindingKey.first) && (entry.second == preslice.bindingKey.second); });
+  if (locate == bsksU.end()) {
+    bsksU.emplace_back(preslice.getBindingKey());
+  }
+  return true;
+}
+
 template <typename T>
-struct PresliceManager {
-  static bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>&)
-  {
-    return false;
-  }
+bool updateSliceInfo(T&, ArrowTableSlicingCache&)
+{
+  return false;
+}
 
-  static bool updateSliceInfo(T&, ArrowTableSlicingCache&)
-  {
-    return false;
+template <is_preslice T>
+static bool updateSliceInfo(T& preslice, ArrowTableSlicingCache& cache)
+  requires std::same_as<typename T::policy_t, framework::PreslicePolicySorted>
+{
+  if constexpr (T::optional) {
+    if (preslice.binding == "[MISSING]") {
+      return true;
+    }
   }
-};
+  preslice.updateSliceInfo(cache.getCacheFor(preslice.getBindingKey()));
+  return true;
+}
 
-template <typename T, typename Policy, bool OPT>
-struct PresliceManager<PresliceBase<T, Policy, OPT>> {
-  static bool registerCache(PresliceBase<T, Policy, OPT>& container, std::vector<StringPair>& bsks, std::vector<StringPair>&)
-    requires std::same_as<Policy, framework::PreslicePolicySorted>
-  {
-    if constexpr (OPT) {
-      if (container.binding == "[MISSING]") {
-        return true;
-      }
+template <is_preslice T>
+static bool updateSliceInfo(T& preslice, ArrowTableSlicingCache& cache)
+  requires std::same_as<typename T::policy_t, framework::PreslicePolicyGeneral>
+{
+  if constexpr (T::optional) {
+    if (preslice.binding == "[MISSING]") {
+      return true;
     }
-    auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.first == container.bindingKey.first) && (entry.second == container.bindingKey.second); });
-    if (locate == bsks.end()) {
-      bsks.emplace_back(container.getBindingKey());
-    }
+  }
+  preslice.updateSliceInfo(cache.getCacheUnsortedFor(preslice.getBindingKey()));
+  return true;
+}
+
+/// Process switches handling
+template <typename T>
+static bool setProcessSwitch(std::pair<std::string, bool>, T&)
+{
+  return false;
+}
+
+template <is_process_configurable T>
+static bool setProcessSwitch(std::pair<std::string, bool> setting, T& pc)
+{
+  if (pc.name == setting.first) {
+    pc.value = setting.second;
     return true;
   }
+  return false;
+}
 
-  static bool registerCache(PresliceBase<T, Policy, OPT>& container, std::vector<StringPair>&, std::vector<StringPair>& bsksU)
-    requires std::same_as<Policy, framework::PreslicePolicyGeneral>
-  {
-    if constexpr (OPT) {
-      if (container.binding == "[MISSING]") {
-        return true;
-      }
-    }
-    auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.first == container.bindingKey.first) && (entry.second == container.bindingKey.second); });
-    if (locate == bsksU.end()) {
-      bsksU.emplace_back(container.getBindingKey());
-    }
-    return true;
-  }
-
-  static bool updateSliceInfo(PresliceBase<T, Policy, OPT>& container, ArrowTableSlicingCache& cache)
-    requires std::same_as<Policy, framework::PreslicePolicySorted>
-  {
-    if constexpr (OPT) {
-      if (container.binding == "[MISSING]") {
-        return true;
-      }
-    }
-    container.updateSliceInfo(cache.getCacheFor(container.getBindingKey()));
-    return true;
-  }
-
-  static bool updateSliceInfo(PresliceBase<T, Policy, OPT>& container, ArrowTableSlicingCache& cache)
-    requires std::same_as<Policy, framework::PreslicePolicyGeneral>
-  {
-    if constexpr (OPT) {
-      if (container.binding == "[MISSING]") {
-        return true;
-      }
-    }
-    container.updateSliceInfo(cache.getCacheUnsortedFor(container.getBindingKey()));
-    return true;
-  }
-};
+} // namespace analysis_task_parsers
 } // namespace o2::framework
 
 #endif // ANALYSISMANAGERS_H

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -31,294 +31,7 @@
 namespace o2::framework
 {
 
-template <typename ANY>
-struct GroupedCombinationManager {
-  template <typename TG, typename... T2s>
-  static void setGroupedCombination(ANY&, TG&, T2s&...)
-  {
-  }
-};
-
-template <typename T1, typename GroupingPolicy, typename BP, typename G, typename... As>
-struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy, BP, G, As...>> {
-  template <typename TG, typename... T2s>
-  static void setGroupedCombination(GroupedCombinationsGenerator<T1, GroupingPolicy, BP, G, As...>& comb, TG& grouping, std::tuple<T2s...>& associated)
-  {
-    static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
-    if constexpr (std::same_as<G, TG>) {
-      static_assert((framework::has_type<As>(pack<T2s...>{}) && ...), "You didn't subscribed to all tables requested for mixing");
-      comb.setTables(grouping, associated);
-    }
-  }
-};
-
-template <typename ANY>
-struct PartitionManager {
-  template <typename... T2s>
-  static void setPartition(ANY&, T2s&...)
-  {
-  }
-
-  template <typename... Ts>
-  static void bindExternalIndices(ANY&, Ts*...)
-  {
-  }
-
-  template <typename E>
-  static void bindInternalIndices(ANY&, E*)
-  {
-  }
-
-  template <typename... Ts>
-  static void getBoundToExternalIndices(ANY&, Ts&...)
-  {
-  }
-
-  static void updatePlaceholders(ANY&, InitContext&)
-  {
-  }
-
-  static bool newDataframe(ANY&)
-  {
-    return false;
-  }
-};
-
-template <typename T>
-struct PartitionManager<Partition<T>> {
-  template <typename T2>
-  static void doSetPartition(Partition<T>& partition, T2& table)
-  {
-    if constexpr (std::same_as<T, T2>) {
-      partition.bindTable(table);
-    }
-  }
-
-  template <typename... T2s>
-  static void setPartition(Partition<T>& partition, T2s&... tables)
-  {
-    (doSetPartition(partition, tables), ...);
-  }
-
-  template <typename... Ts>
-  static void bindExternalIndices(Partition<T>& partition, Ts*... tables)
-  {
-    partition.bindExternalIndices(tables...);
-  }
-
-  template <typename E>
-  static void bindInternalIndices(Partition<T>& partition, E* table)
-  {
-    if constexpr (o2::soa::is_binding_compatible_v<T, std::decay_t<E>>()) {
-      partition.bindInternalIndicesTo(table);
-    }
-  }
-
-  static void updatePlaceholders(Partition<T>& partition, InitContext& context)
-  {
-    partition.updatePlaceholders(context);
-  }
-
-  static bool newDataframe(Partition<T>& partition)
-  {
-    partition.dataframeChanged = true;
-    return true;
-  }
-};
-
-template <typename ANY>
-struct FilterManager {
-  static bool createExpressionTrees(ANY&, std::vector<ExpressionInfo>&)
-  {
-    return false;
-  }
-
-  static bool updatePlaceholders(ANY&, InitContext&)
-  {
-    return false;
-  }
-};
-
-template <>
-struct FilterManager<expressions::Filter> {
-  static bool createExpressionTrees(expressions::Filter const& filter, std::vector<ExpressionInfo>& expressionInfos)
-  {
-    expressions::updateExpressionInfos(filter, expressionInfos);
-    return true;
-  }
-
-  static bool updatePlaceholders(expressions::Filter& filter, InitContext& ctx)
-  {
-    expressions::updatePlaceholders(filter, ctx);
-    return true;
-  }
-};
-
-/// A manager which takes care of condition objects
-template <typename T>
-struct ConditionManager {
-  template <typename ANY>
-  static bool appendCondition(std::vector<InputSpec>& inputs, ANY& x)
-  {
-    if constexpr (std::derived_from<ANY, ConditionGroup>) {
-      homogeneous_apply_refs<true>([&inputs](auto& y) { return ConditionManager<std::decay_t<decltype(y)>>::appendCondition(inputs, y); }, x);
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  template <typename ANY>
-  static bool newDataframe(InputRecord& record, ANY& x)
-  {
-    if constexpr (std::derived_from<ANY, ConfigurableGroup>) {
-      homogeneous_apply_refs<true>([&record](auto&& y) { return ConditionManager<std::decay_t<decltype(y)>>::newDataframe(record, y); }, x);
-      return true;
-    } else {
-      return false;
-    }
-  }
-};
-
-template <typename OBJ>
-struct ConditionManager<Condition<OBJ>> {
-  static bool appendCondition(std::vector<InputSpec>& inputs, Condition<OBJ>& what)
-  {
-    inputs.emplace_back(InputSpec{what.path, "AODC", runtime_hash(what.path.c_str()), Lifetime::Condition, ccdbParamSpec(what.path)});
-    return true;
-  }
-  static bool newDataframe(InputRecord& inputs, Condition<OBJ>& what)
-  {
-    what.instance = (OBJ*)inputs.get<OBJ*>(what.path).get();
-    return true;
-  }
-};
-
-/// SFINAE placeholder, also handles recursion in ProcessGroup
-template <typename T>
-struct OutputManager {
-  template <typename ANY>
-  static bool appendOutput(std::vector<OutputSpec>& outputs, ANY& what, uint32_t v)
-  {
-    if constexpr (std::derived_from<ANY, ProducesGroup>) {
-      homogeneous_apply_refs<true>([&outputs, v](auto& p) { return OutputManager<std::decay_t<decltype(p)>>::appendOutput(outputs, p, v); }, what);
-      return true;
-    }
-    return false;
-  }
-
-  template <typename ANY>
-  static bool prepare(ProcessingContext& context, ANY& what)
-  {
-    if constexpr (std::derived_from<ANY, ProducesGroup>) {
-      homogeneous_apply_refs<true>([&context](auto& p) { return OutputManager<std::decay_t<decltype(p)>>::prepare(context, p); }, what);
-      return true;
-    }
-    return false;
-  }
-
-  template <typename ANY>
-  static bool postRun(EndOfStreamContext& context, ANY& what)
-  {
-    if constexpr (std::derived_from<ANY, ProducesGroup>) {
-      homogeneous_apply_refs<true>([&context](auto& p) { return OutputManager<std::decay_t<decltype(p)>>::postRun(context, p); }, what);
-      return true;
-    }
-    return true;
-  }
-
-  template <typename ANY>
-  static bool finalize(ProcessingContext& context, ANY& what)
-  {
-    if constexpr (std::derived_from<ANY, ProducesGroup>) {
-      homogeneous_apply_refs<true>([&context](auto& p) { return OutputManager<std::decay_t<decltype(p)>>::finalize(context, p); }, what);
-      return true;
-    }
-    return true;
-  }
-};
-
-/// Produces specialization
-template <is_producable T>
-struct OutputManager<Produces<T>> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, Produces<T>& /*what*/, uint32_t)
-  {
-    outputs.emplace_back(OutputForTable<typename Produces<T>::persistent_table_t>::spec());
-    return true;
-  }
-  static bool prepare(ProcessingContext& context, Produces<T>& what)
-  {
-    what.resetCursor(std::move(context.outputs().make<TableBuilder>(OutputForTable<typename Produces<T>::persistent_table_t>::ref())));
-    return true;
-  }
-  static bool finalize(ProcessingContext&, Produces<T>& what)
-  {
-    what.setLabel(o2::aod::label<Produces<T>::persistent_table_t::ref>());
-    what.release();
-    return true;
-  }
-  static bool postRun(EndOfStreamContext&, Produces<T>&)
-  {
-    return true;
-  }
-};
-
-/// HistogramRegistry specialization
-template <>
-struct OutputManager<HistogramRegistry> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, HistogramRegistry& what, uint32_t hash)
-  {
-    what.setHash(hash);
-    outputs.emplace_back(what.spec());
-    return true;
-  }
-  static bool prepare(ProcessingContext&, HistogramRegistry&)
-  {
-    return true;
-  }
-
-  static bool finalize(ProcessingContext&, HistogramRegistry&)
-  {
-    return true;
-  }
-
-  static bool postRun(EndOfStreamContext& context, HistogramRegistry& what)
-  {
-    auto& deviceSpec = context.services().get<o2::framework::DeviceSpec const>();
-    context.outputs().snapshot(what.ref(deviceSpec.inputTimesliceId, deviceSpec.maxInputTimeslices), *(what.getListOfHistograms()));
-    what.clean();
-    return true;
-  }
-};
-
-/// OutputObj specialization
-template <typename T>
-struct OutputManager<OutputObj<T>> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, OutputObj<T>& what, uint32_t hash)
-  {
-    what.setHash(hash);
-    outputs.emplace_back(what.spec());
-    return true;
-  }
-  static bool prepare(ProcessingContext&, OutputObj<T>&)
-  {
-    return true;
-  }
-
-  static bool finalize(ProcessingContext&, OutputObj<T>&)
-  {
-    return true;
-  }
-
-  static bool postRun(EndOfStreamContext& context, OutputObj<T>& what)
-  {
-    auto& deviceSpec = context.services().get<o2::framework::DeviceSpec const>();
-    context.outputs().snapshot(what.ref(deviceSpec.inputTimesliceId, deviceSpec.maxInputTimeslices), *what);
-    return true;
-  }
-};
-
-/// Spawns specializations
+namespace {
 template <typename O>
 static inline auto extractOriginal(ProcessingContext& pc)
 {
@@ -338,240 +51,463 @@ static inline auto extractOriginals(ProcessingContext& pc)
     return {pc.inputs().get<TableConsumer>(o2::aod::label<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
-
-template <is_spawnable T>
-struct OutputManager<Spawns<T>> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, Spawns<T>& what, uint32_t)
-  {
-    outputs.emplace_back(what.spec());
-    return true;
-  }
-
-  static bool prepare(ProcessingContext& pc, Spawns<T>& what)
-  {
-    using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata;
-    auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::sources.size(), metadata::sources>(pc));
-    if (originalTable->schema()->fields().empty() == true) {
-      using base_table_t = typename Spawns<T>::base_table_t::table_t;
-      originalTable = makeEmptyTable<base_table_t>(o2::aod::label<metadata::extension_table_t::ref>());
-    }
-
-    what.extension = std::make_shared<typename Spawns<T>::extension_t>(o2::framework::spawner<o2::aod::Hash<metadata::extension_table_t::ref.desc_hash>>(originalTable, o2::aod::label<metadata::extension_table_t::ref>()));
-    what.table = std::make_shared<typename T::table_t>(soa::ArrowHelpers::joinTables({what.extension->asArrowTable(), originalTable}));
-    return true;
-  }
-
-  static bool finalize(ProcessingContext& pc, Spawns<T>& what)
-  {
-    pc.outputs().adopt(what.output(), what.asArrowTable());
-    return true;
-  }
-
-  static bool postRun(EndOfStreamContext&, Spawns<T>&)
-  {
-    return true;
-  }
-};
-
-/// Builds specialization
-template <typename... Ts>
-static inline auto doExtractOriginal(framework::pack<Ts...>, ProcessingContext& pc)
-{
-  if constexpr (sizeof...(Ts) == 1) {
-    return pc.inputs().get<TableConsumer>(aod::MetadataTrait<framework::pack_element_t<0, framework::pack<Ts...>>>::metadata::tableLabel())->asArrowTable();
-  } else {
-    return std::vector{pc.inputs().get<TableConsumer>(aod::MetadataTrait<Ts>::metadata::tableLabel())->asArrowTable()...};
-  }
 }
 
-template <typename... Os>
-static inline auto extractOriginalsVector(framework::pack<Os...>, ProcessingContext& pc)
+namespace analysis_task_parsers {
+
+/// Options handling
+template <typename O>
+bool appendOption(std::vector<ConfigParamSpec>&, O&)
 {
-  return std::vector{extractOriginalJoined<Os>(pc)...};
+  return false;
 }
 
-template <soa::is_index_table T>
-struct OutputManager<Builds<T>> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, Builds<T>& what, uint32_t)
-  {
-    outputs.emplace_back(what.spec());
-    return true;
-  }
+template <is_configurable O>
+bool appendOption(std::vector<ConfigParamSpec>& options, O& option)
+{
+  return ConfigurableHelpers::appendOption(options, option);
+}
 
-  static bool prepare(ProcessingContext& pc, Builds<T>& what)
-  {
-    using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata;
-    return what.template build<typename T::indexing_t>(what.pack(), extractOriginals<metadata::sources.size(), metadata::sources>(pc));
-  }
-
-  static bool finalize(ProcessingContext& pc, Builds<T>& what)
-  {
-    pc.outputs().adopt(what.output(), what.asArrowTable());
-    return true;
-  }
-
-  static bool postRun(EndOfStreamContext&, Builds<T>&)
-  {
-    return true;
-  }
-};
-
-template <typename T>
-struct ServiceManager {
-  template <typename ANY>
-  static bool add(std::vector<ServiceSpec>& /*specs*/, ANY& /*any*/)
-  {
-    return false;
-  }
-
-  template <typename ANY>
-  static bool prepare(InitContext&, ANY&)
-  {
-    return false;
-  }
-
-  template <typename ANY>
-  static bool postRun(EndOfStreamContext&, ANY&)
-  {
-    return false;
-  }
-};
-
-template <typename T>
-struct ServiceManager<Service<T>> {
-  static bool add(std::vector<ServiceSpec>& specs, Service<T>& /*service*/)
-  {
-    if constexpr (o2::framework::base_of_template<LoadableServicePlugin, T>) {
-      T p = T{};
-      auto loadableServices = PluginManager::parsePluginSpecString(p.loadSpec.c_str());
-      PluginManager::loadFromPlugin<ServiceSpec, ServicePlugin>(loadableServices, specs);
-    }
-    return true;
-  }
-
-  static bool prepare(InitContext& context, Service<T>& service)
-  {
-    if constexpr (requires { &T::instance; }) {
-      service.service = &(T::instance()); // Sigh...
-      return true;
-    } else {
-      service.service = &(context.services().get<T>());
-      return true;
-    }
-    return false;
-  }
-
-  /// If a service has a method endOfStream, it is called at the end of the stream.
-  static bool postRun(EndOfStreamContext& /*context*/, Service<T>& service)
-  {
-    // FIXME: for the moment we only need endOfStream to be
-    // stateless. In the future we might want to pass it EndOfStreamContext
-    if constexpr (requires { &T::endOfStream; }) {
-      service.service->endOfStream();
-      return true;
-    }
-    return false;
-  }
-};
-
-template <typename T>
-struct CacheManager {
-  template <typename ANY>
-  static bool initialize(InitContext&, ANY&)
-  {
-    return false;
-  }
-  template <typename ANY>
-  static bool initialize(ProcessingContext&, ANY&)
-  {
-    return false;
-  }
-};
-
-template <>
-struct CacheManager<SliceCache> {
-  static bool initialize(InitContext&, SliceCache&)
-  {
-    return false;
-  }
-  static bool initialize(ProcessingContext& pc, SliceCache& cache)
-  {
-    if (cache.ptr == nullptr) {
-      cache.ptr = &pc.services().get<ArrowTableSlicingCache>();
-    }
-    return true;
-  }
-};
-
-template <typename T>
-struct OptionManager {
-  template <typename ANY>
-  static bool appendOption(std::vector<ConfigParamSpec>& options, ANY& x)
-  {
-    /// Recurse, in case we are brace constructible
-    if constexpr (std::derived_from<ANY, ConfigurableGroup>) {
-      if constexpr (requires { x.prefix; }) {
-        homogeneous_apply_refs<true>([prefix = x.prefix]<typename C>(C& y) { // apend group prefix if set
-          if constexpr (requires { y.name; }) {
-            y.name.insert(0, 1, '.');
-            y.name.insert(0, prefix);
-          }
-          return true;
-        },
-                                     x);
+template <is_configurable_group O>
+bool appendOption(std::vector<ConfigParamSpec>& options, O& optionGroup)
+{
+  if constexpr (requires { optionGroup.prefix; }) {
+    homogeneous_apply_refs<true>([prefix = optionGroup.prefix]<typename C>(C& option) { // apend group prefix if set
+      if constexpr (requires { option.name; }) {
+        option.name.insert(0, 1, '.');
+        option.name.insert(0, prefix);
       }
-      homogeneous_apply_refs<true>([&options](auto& y) { return OptionManager<std::decay_t<decltype(y)>>::appendOption(options, y); }, x);
       return true;
-    } else {
-      return false;
-    }
+    },
+                                 optionGroup);
+  }
+  homogeneous_apply_refs<true>([&options](auto& option) { return appendOption(options, option); }, optionGroup);
+  return true;
+}
+
+template <typename O>
+bool prepareOption(InitContext&, O&)
+{
+  return false;
+}
+
+template <is_configurable O>
+bool prepareOption(InitContext& context, O& configurable)
+{
+  if constexpr (variant_trait_v<typename O::type> != VariantType::Unknown) {
+    configurable.value = context.options().get<typename O::type>(configurable.name.c_str());
+  } else {
+    auto pt = context.options().get<boost::property_tree::ptree>(configurable.name.c_str());
+    configurable.value = RootConfigParamHelpers::as<typename O::type>(pt);
+  }
+  return true;
+}
+
+template <is_configurable_group O>
+bool prepareOption(InitContext& context, O& configurableGroup)
+{
+  homogeneous_apply_refs<true>([&context](auto&& configurable) { return prepareOption(context, configurable); }, configurableGroup);
+  return true;
+}
+
+/// Conditions handling
+template <typename C>
+bool appendCondition(std::vector<InputSpec>&, C&)
+{
+  return false;
+}
+
+template <is_condition C>
+bool appendCondition(std::vector<InputSpec>& inputs, C& condition)
+{
+  inputs.emplace_back(InputSpec{condition.path, "AODC", runtime_hash(condition.path.c_str()), Lifetime::Condition, ccdbParamSpec(condition.path)});
+  return true;
+}
+
+template <is_condition_group C>
+bool appendCondition(std::vector<InputSpec>& inputs, C& conditionGroup)
+{
+  homogeneous_apply_refs<true>([&inputs](auto& condition) { return appendCondition(inputs, condition); }, conditionGroup);
+  return true;
+}
+
+/// Table auto-creation handling
+template <typename T>
+bool requestInputs(std::vector<InputSpec>&, T const&)
+{
+  return false;
+}
+
+template <is_spawns T>
+bool requestInputs(std::vector<InputSpec>& inputs, T const& spawns)
+{
+  auto base_specs = spawns.base_specs();
+  for (auto base_spec : base_specs) {
+    base_spec.metadata.push_back(ConfigParamSpec{std::string{"control:spawn"}, VariantType::Bool, true, {"\"\""}});
+    DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
+  }
+  return true;
+}
+
+template <is_builds T>
+bool requestInputs(std::vector<InputSpec>& inputs, T const& builds)
+{
+  auto base_specs = builds.base_specs();
+  for (auto base_spec : base_specs) {
+    base_spec.metadata.push_back(ConfigParamSpec{std::string{"control:build"}, VariantType::Bool, true, {"\"\""}});
+    DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
+  }
+  return true;
+}
+
+template <typename C>
+bool newDataframeCondition(InputRecord&, C&)
+{
+  return false;
+}
+
+template <is_condition C>
+bool newDataframeCondition(InputRecord& record, C& condition)
+{
+  condition.instance = (typename C::type*)record.get<typename C::type*>(condition.path).get();
+  return true;
+}
+
+template <is_condition_group C>
+bool newDataframeCondition(InputRecord& record, C& conditionGroup)
+{
+  homogeneous_apply_refs<true>([&record](auto&& condition) { return newDataframeCondition(record, condition); }, conditionGroup);
+  return true;
+}
+
+/// Outputs handling
+template <typename T>
+bool appendOutput(std::vector<OutputSpec>&, T&, uint32_t)
+{
+  return false;
+}
+
+template <is_produces T>
+bool appendOutput(std::vector<OutputSpec>& outputs, T&, uint32_t)
+{
+  outputs.emplace_back(OutputForTable<typename T::persistent_table_t>::spec());
+  return true;
+}
+
+template <is_produces_group T>
+bool appendOutput(std::vector<OutputSpec>& outputs, T& producesGroup, uint32_t hash)
+{
+  homogeneous_apply_refs<true>([&outputs, hash](auto& produces) { return appendOutput(outputs, produces, hash); }, producesGroup);
+  return true;
+}
+
+template <is_histogram_registry T>
+bool appendOutput(std::vector<OutputSpec>& outputs, T& hr, uint32_t hash)
+{
+  hr.setHash(hash);
+  outputs.emplace_back(hr.spec());
+  return true;
+}
+
+template <is_outputobj T>
+bool appendOutput(std::vector<OutputSpec>& outputs, T& obj, uint32_t hash)
+{
+  obj.setHash(hash);
+  outputs.emplace_back(obj.spec());
+  return true;
+}
+
+template <is_spawns T>
+bool appendOutput(std::vector<OutputSpec>& outputs, T& spawns, uint32_t)
+{
+  outputs.emplace_back(spawns.spec());
+  return true;
+}
+
+template <is_builds T>
+bool appendOutput(std::vector<OutputSpec>& outputs, T& builds, uint32_t)
+{
+  outputs.emplace_back(builds.spec());
+  return true;
+}
+
+template <typename T>
+bool postRunOutput(EndOfStreamContext&, T&)
+{
+  return false;
+}
+
+template <is_histogram_registry T>
+bool postRunOutput(EndOfStreamContext& context, T& hr)
+{
+  auto& deviceSpec = context.services().get<o2::framework::DeviceSpec const>();
+  context.outputs().snapshot(hr.ref(deviceSpec.inputTimesliceId, deviceSpec.maxInputTimeslices), *(hr.getListOfHistograms()));
+  hr.clean();
+  return true;
+}
+
+template <is_outputobj T>
+bool postRunOutput(EndOfStreamContext& context, T& obj)
+{
+  auto& deviceSpec = context.services().get<o2::framework::DeviceSpec const>();
+  context.outputs().snapshot(obj.ref(deviceSpec.inputTimesliceId, deviceSpec.maxInputTimeslices), *obj);
+  return true;
+}
+
+template <typename T>
+bool prepareOutput(ProcessingContext&, T&)
+{
+  return false;
+}
+
+template <is_produces T>
+bool prepareOutput(ProcessingContext& context, T& produces)
+{
+  produces.resetCursor(std::move(context.outputs().make<TableBuilder>(OutputForTable<typename T::persistent_table_t>::ref())));
+  return true;
+}
+
+template <is_produces_group T>
+bool prepareOutput(ProcessingContext& context, T& producesGroup)
+{
+  homogeneous_apply_refs<true>([&context](auto& produces) { return prepareOutput(context, produces); }, producesGroup);
+  return true;
+}
+
+template <is_spawns T>
+bool prepareOutput(ProcessingContext& context, T& spawns)
+{
+  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::ref.desc_hash>>::metadata;
+  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::sources.size(), metadata::sources>(context));
+  if (originalTable->schema()->fields().empty() == true) {
+    using base_table_t = typename T::base_table_t::table_t;
+    originalTable = makeEmptyTable<base_table_t>(o2::aod::label<metadata::extension_table_t::ref>());
   }
 
-  template <typename ANY>
-  static bool prepare(InitContext& ic, ANY& x)
-  {
-    if constexpr (std::derived_from<ANY, ConfigurableGroup>) {
-      homogeneous_apply_refs<true>([&ic](auto&& y) { return OptionManager<std::decay_t<decltype(y)>>::prepare(ic, y); }, x);
-      return true;
-    } else {
-      return false;
-    }
-  }
-};
+  spawns.extension = std::make_shared<typename T::extension_t>(o2::framework::spawner<o2::aod::Hash<metadata::extension_table_t::ref.desc_hash>>(originalTable, o2::aod::label<metadata::extension_table_t::ref>()));
+  spawns.table = std::make_shared<typename T::spawnable_t::table_t>(soa::ArrowHelpers::joinTables({spawns.extension->asArrowTable(), originalTable}));
+  return true;
+}
 
-template <typename T, ConfigParamKind K, typename IP>
-struct OptionManager<Configurable<T, K, IP>> {
-  static bool appendOption(std::vector<ConfigParamSpec>& options, Configurable<T, K, IP>& what)
-  {
-    return ConfigurableHelpers::appendOption(options, what);
-  }
+template <is_builds T>
+bool prepareOuput(ProcessingContext& context, T& builds)
+{
+  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::buildable_t::ref.desc_hash>>::metadata;
+  return builds.template build<typename T::buildable_t::indexing_t>(builds.pack(), extractOriginals<metadata::sources.size(), metadata::sources>(context));
+}
 
-  static bool prepare(InitContext& context, Configurable<T, K, IP>& what)
-  {
-    if constexpr (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown) {
-      what.value = context.options().get<T>(what.name.c_str());
-    } else {
-      auto pt = context.options().get<boost::property_tree::ptree>(what.name.c_str());
-      what.value = RootConfigParamHelpers::as<T>(pt);
-    }
+template <typename T>
+bool finalizeOutput(ProcessingContext&, T&)
+{
+  return false;
+}
+
+template <is_produces T>
+bool finalizeOutput(ProcessingContext&, T& produces)
+{
+  produces.setLabel(o2::aod::label<T::persistent_table_t::ref>());
+  produces.release();
+  return true;
+}
+
+template <is_produces_group T>
+bool finalizeOutput(ProcessingContext& context, T& producesGroup)
+{
+  homogeneous_apply_refs<true>([&context](auto& produces) { return finalizeOutput(context, produces); }, producesGroup);
+  return true;
+}
+
+template <is_spawns T>
+bool finalizeOutput(ProcessingContext& context, T& spawns)
+{
+  context.outputs().adopt(spawns.output(), spawns.asArrowTable());
+  return true;
+}
+
+template <is_builds T>
+bool finalizeOutput(ProcessingContext& context, T& builds)
+{
+  context.outputs().adopt(builds.output(), builds.asArrowTable());
+  return true;
+}
+
+/// Service handling
+template <typename T>
+bool addService(std::vector<ServiceSpec>&, T&)
+{
+  return false;
+}
+
+template <is_service T>
+bool addService(std::vector<ServiceSpec>& specs, T&)
+{
+  if constexpr (o2::framework::base_of_template<LoadableServicePlugin, typename T::service_t>) {
+    auto p = typename T::service_t{};
+    auto loadableServices = PluginManager::parsePluginSpecString(p.loadSpec.c_str());
+    PluginManager::loadFromPlugin<ServiceSpec, ServicePlugin>(loadableServices, specs);
+  }
+  return true;
+}
+
+template <typename T>
+bool prepareService(InitContext&, T&)
+{
+  return false;
+}
+
+template <is_service T>
+bool prepareService(InitContext& context, T& service)
+{
+  using S = typename T::service_t;
+  if constexpr (requires { &S::instance; }) {
+    service.service = &(S::instance()); // Sigh...
+    return true;
+  } else {
+    service.service = &(context.services().get<S>());
     return true;
   }
-};
+  return false;
+}
 
-template <typename R, typename T, typename... As>
-struct OptionManager<ProcessConfigurable<R, T, As...>> {
-  static bool appendOption(std::vector<ConfigParamSpec>& options, ProcessConfigurable<R, T, As...>& what)
-  {
-    options.emplace_back(ConfigParamSpec{what.name, variant_trait_v<std::decay_t<bool>>, what.value, {what.help}, what.kind});
+template <typename T>
+bool postRunService(EndOfStreamContext&, T&)
+{
+  return false;
+}
+
+template <is_service T>
+bool postRunService(EndOfStreamContext&, T& service)
+{
+  // FIXME: for the moment we only need endOfStream to be
+  // stateless. In the future we might want to pass it EndOfStreamContext
+  if constexpr (requires { &T::service_t::endOfStream; }) {
+    service.service->endOfStream();
     return true;
   }
+  return false;
+}
 
-  static bool prepare(InitContext& context, ProcessConfigurable<R, T, As...>& what)
-  {
-    what.value = context.options().get<bool>(what.name.c_str());
-    return true;
+/// Filter handling
+template <typename T>
+bool updatePlaceholders(InitContext&, T&)
+{
+  return false;
+}
+
+template <expressions::is_filter T>
+bool updatePlaceholders(InitContext& context, T& filter)
+{
+  expressions::updatePlaceholders(filter, context);
+  return true;
+}
+
+template <is_partition T>
+bool updatePlaceholders(InitContext& context, T& partition)
+{
+  partition.updatePlaceholders(context);
+  return true;
+}
+
+template <typename T>
+bool createExpressionTrees(std::vector<ExpressionInfo>&, T&)
+{
+  return false;
+}
+
+template <expressions::is_filter T>
+bool createExpressionTrees(std::vector<ExpressionInfo>& expressionInfos, T& filter)
+{
+  expressions::updateExpressionInfos(filter, expressionInfos);
+  return true;
+}
+
+template <typename T>
+bool newDataframePartition(T&)
+{
+  return false;
+}
+
+template <is_partition T>
+bool newDataframePartition(T& partition)
+{
+  partition.dataframeChanged = true;
+  return true;
+}
+
+template <typename P, typename... T>
+void setPartition(P&, T&...)
+{
+}
+
+template <is_partition P, typename... T>
+void setPartition(P& partition, T&... tables)
+{
+  ([&](){ if constexpr (std::same_as<typename P::content_t, T>) {partition.bindTable(tables);} }(), ...);
+}
+
+template <typename P, typename T>
+void bindInternalIndicesPartition(P&, T*)
+{
+}
+
+template <is_partition P, typename T>
+void bindInternalIndicesPartition(P& partition, T* table)
+{
+  if constexpr (o2::soa::is_binding_compatible_v<typename P::content_t, std::decay_t<T>>()) {
+    partition.bindInternalIndicesTo(table);
   }
-};
+}
+
+template <typename P, typename... T>
+void bindExternalIndicesPartition(P&, T*...)
+{
+}
+
+template <is_partition P, typename... T>
+void bindExternalIndicesPartition(P& partition, T*... tables)
+{
+  partition.bindExternalIndices(tables...);
+}
+
+/// Cache handling
+template <typename T>
+bool preInitializeCache(InitContext&, T&)
+{
+  return false;
+}
+
+template <typename T>
+bool initializeCache(ProcessingContext&, T&)
+{
+  return false;
+}
+
+template <is_slice_cache T>
+bool initializeCache(ProcessingContext& context, T& cache)
+{
+  if (cache.ptr == nullptr) {
+    cache.ptr = &context.services().get<ArrowTableSlicingCache>();
+  }
+  return true;
+}
+
+/// Combinations handling
+template <typename C, typename TG, typename... Ts>
+  requires(!is_combinations_generator<C>)
+void setGroupedCombination(C&, TG&, Ts&...)
+{
+}
+
+template <is_combinations_generator C, typename TG, typename... Ts>
+  requires((sizeof...(Ts) > 0) && (C::compatible(framework::pack<Ts...>{})))
+static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& associated)
+{
+  if constexpr (std::same_as<typename C::g_t, TG>) {
+    comb.setTables(grouping, associated);
+  }
+}
+
+} // analysis_task_parsers
 
 template <typename ANY>
 struct UpdateProcessSwitches {
@@ -590,44 +526,6 @@ struct UpdateProcessSwitches<ProcessConfigurable<R, T, As...>> {
       return true;
     }
     return false;
-  }
-};
-
-/// Manager template to facilitate extended tables spawning
-template <typename T>
-struct SpawnManager {
-  static bool requestInputs(std::vector<InputSpec>&, T const&) { return false; }
-};
-
-template <soa::is_table TABLE>
-struct SpawnManager<Spawns<TABLE>> {
-  static bool requestInputs(std::vector<InputSpec>& inputs, Spawns<TABLE>& spawns)
-  {
-    auto base_specs = spawns.base_specs();
-    for (auto base_spec : base_specs) {
-      base_spec.metadata.push_back(ConfigParamSpec{std::string{"control:spawn"}, VariantType::Bool, true, {"\"\""}});
-      DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
-    }
-    return true;
-  }
-};
-
-/// Manager template for building index tables
-template <typename T>
-struct IndexManager {
-  static bool requestInputs(std::vector<InputSpec>&, T const&) { return false; };
-};
-
-template <soa::is_index_table IDX>
-struct IndexManager<Builds<IDX>> {
-  static bool requestInputs(std::vector<InputSpec>& inputs, Builds<IDX>& builds)
-  {
-    auto base_specs = builds.base_specs();
-    for (auto base_spec : base_specs) {
-      base_spec.metadata.push_back(ConfigParamSpec{std::string{"control:build"}, VariantType::Bool, true, {"\"\""}});
-      DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
-    }
-    return true;
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -319,18 +319,18 @@ struct AnalysisDataProcessorBuilder {
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, processingFunction, infos);
 
     // set filtered tables for partitions with grouping
-    homogeneous_apply_refs([&groupingTable](auto& x) {
-      PartitionManager<std::decay_t<decltype(x)>>::setPartition(x, groupingTable);
-      PartitionManager<std::decay_t<decltype(x)>>::bindInternalIndices(x, &groupingTable);
+    homogeneous_apply_refs([&groupingTable](auto& element) {
+      analysis_task_parsers::setPartition(element, groupingTable);
+      analysis_task_parsers::bindInternalIndicesPartition(element, &groupingTable);
       return true;
     },
                            task);
 
     if constexpr (sizeof...(Associated) == 0) {
       // single argument to process
-      homogeneous_apply_refs([&groupingTable](auto& x) {
-        PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);
-        GroupedCombinationManager<std::decay_t<decltype(x)>>::setGroupedCombination(x, groupingTable);
+      homogeneous_apply_refs([&groupingTable](auto& element) {
+        analysis_task_parsers::bindExternalIndicesPartition(element, &groupingTable);
+        analysis_task_parsers::setGroupedCombination(element, groupingTable);
         return true;
       },
                              task);
@@ -353,7 +353,7 @@ struct AnalysisDataProcessorBuilder {
         [&task](auto&... t) mutable {
           (homogeneous_apply_refs(
              [&t](auto& p) {
-               PartitionManager<std::decay_t<decltype(p)>>::bindInternalIndices(p, &t);
+               analysis_task_parsers::bindInternalIndicesPartition(p, &t);
                return true;
              },
              task),
@@ -364,8 +364,8 @@ struct AnalysisDataProcessorBuilder {
       auto binder = [&task, &groupingTable, &associatedTables](auto& x) mutable {
         x.bindExternalIndices(&groupingTable, &std::get<std::decay_t<Associated>>(associatedTables)...);
         homogeneous_apply_refs([&x](auto& t) mutable {
-          PartitionManager<std::decay_t<decltype(t)>>::setPartition(t, x);
-          PartitionManager<std::decay_t<decltype(t)>>::bindExternalIndices(t, &x);
+          analysis_task_parsers::setPartition(t, x);
+          analysis_task_parsers::bindExternalIndicesPartition(t, &x);
           return true;
         },
                                task);
@@ -381,7 +381,7 @@ struct AnalysisDataProcessorBuilder {
 
       // GroupedCombinations bound separately, as they should be set once for all associated tables
       homogeneous_apply_refs([&groupingTable, &associatedTables](auto& t) {
-        GroupedCombinationManager<std::decay_t<decltype(t)>>::setGroupedCombination(t, groupingTable, associatedTables);
+        analysis_task_parsers::setGroupedCombination(t, groupingTable, associatedTables);
         return true;
       },
                              task);
@@ -399,7 +399,7 @@ struct AnalysisDataProcessorBuilder {
 
           // bind partitions and grouping table
           homogeneous_apply_refs([&groupingTable](auto& x) {
-            PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);
+            analysis_task_parsers::bindExternalIndicesPartition(x, &groupingTable);
             return true;
           },
                                  task);
@@ -409,7 +409,7 @@ struct AnalysisDataProcessorBuilder {
       } else {
         // bind partitions and grouping table
         homogeneous_apply_refs([&groupingTable](auto& x) {
-          PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);
+          analysis_task_parsers::bindExternalIndicesPartition(x, &groupingTable);
           return true;
         },
                                task);
@@ -529,9 +529,9 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<StringPair> bindingsKeysUnsorted;
 
   /// make sure options and configurables are set before expression infos are created
-  homogeneous_apply_refs([&options, &hash](auto& x) { return OptionManager<std::decay_t<decltype(x)>>::appendOption(options, x); }, *task.get());
+  homogeneous_apply_refs([&options, &hash](auto& element) { return analysis_task_parsers::appendOption(options, element); }, *task.get());
   /// extract conditions and append them as inputs
-  homogeneous_apply_refs([&inputs](auto& x) { return ConditionManager<std::decay_t<decltype(x)>>::appendCondition(inputs, x); }, *task.get());
+  homogeneous_apply_refs([&inputs](auto& element) { return analysis_task_parsers::appendCondition(inputs, element); }, *task.get());
 
   /// parse process functions defined by corresponding configurables
   if constexpr (requires { &T::process; }) {
@@ -552,16 +552,10 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   // add preslice declarations to slicing cache definition
   homogeneous_apply_refs([&bindingsKeys, &bindingsKeysUnsorted](auto& x) { return PresliceManager<std::decay_t<decltype(x)>>::registerCache(x, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
 
-  // request base tables for spawnable extended tables
+  // request base tables for spawnable extended tables and indices to be built
   // this checks for duplications
-  homogeneous_apply_refs([&inputs](auto& x) {
-    return SpawnManager<std::decay_t<decltype(x)>>::requestInputs(inputs, x);
-  },
-                         *task.get());
-
-  // request base tables for indices to be built
-  homogeneous_apply_refs([&inputs](auto& x) {
-    return IndexManager<std::decay_t<decltype(x)>>::requestInputs(inputs, x);
+  homogeneous_apply_refs([&inputs](auto& element) {
+    return analysis_task_parsers::requestInputs(inputs, element);
   },
                          *task.get());
 
@@ -570,40 +564,36 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     LOG(warn) << "Task " << name_str << " has no inputs";
   }
 
-  homogeneous_apply_refs([&outputs, &hash](auto& x) { return OutputManager<std::decay_t<decltype(x)>>::appendOutput(outputs, x, hash); }, *task.get());
+  homogeneous_apply_refs([&outputs, &hash](auto& element) { return analysis_task_parsers::appendOutput(outputs, element, hash); }, *task.get());
 
   auto requiredServices = CommonServices::defaultServices();
   auto arrowServices = CommonServices::arrowServices();
   requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());
-  homogeneous_apply_refs([&requiredServices](auto& x) { return ServiceManager<std::decay_t<decltype(x)>>::add(requiredServices, x); }, *task.get());
+  homogeneous_apply_refs([&requiredServices](auto& element) { return analysis_task_parsers::addService(requiredServices, element); }, *task.get());
 
   auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, bindingsKeys, bindingsKeysUnsorted](InitContext& ic) mutable {
-    homogeneous_apply_refs([&ic](auto&& x) { return OptionManager<std::decay_t<decltype(x)>>::prepare(ic, x); }, *task.get());
-    homogeneous_apply_refs([&ic](auto&& x) { return ServiceManager<std::decay_t<decltype(x)>>::prepare(ic, x); }, *task.get());
+    homogeneous_apply_refs([&ic](auto&& element) { return analysis_task_parsers::prepareOption(ic, element); }, *task.get());
+    homogeneous_apply_refs([&ic](auto&& element) { return analysis_task_parsers::prepareService(ic, element); }, *task.get());
 
     auto& callbacks = ic.services().get<CallbackService>();
     auto endofdatacb = [task](EndOfStreamContext& eosContext) {
-      homogeneous_apply_refs([&eosContext](auto&& x) {
-          using X = std::decay_t<decltype(x)>;
-          ServiceManager<X>::postRun(eosContext, x);
-          return OutputManager<X>::postRun(eosContext, x); },
+      homogeneous_apply_refs([&eosContext](auto& element) {
+          analysis_task_parsers::postRunService(eosContext, element);
+          analysis_task_parsers::postRunOutput(eosContext, element);
+          return true;},
                              *task.get());
       eosContext.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     };
 
     callbacks.set<CallbackService::Id::EndOfStream>(endofdatacb);
 
-    /// update configurables in filters
+    /// update configurables in filters and partitions
     homogeneous_apply_refs(
-      [&ic](auto& x) -> bool { return FilterManager<std::decay_t<decltype(x)>>::updatePlaceholders(x, ic); },
-      *task.get());
-    /// update configurables in partitions
-    homogeneous_apply_refs(
-      [&ic](auto& x) -> bool { PartitionManager<std::decay_t<decltype(x)>>::updatePlaceholders(x, ic); return true; },
+      [&ic](auto& element) -> bool { return analysis_task_parsers::updatePlaceholders(ic, element); },
       *task.get());
     /// create for filters gandiva trees matched to schemas and store the pointers into expressionInfos
-    homogeneous_apply_refs([&expressionInfos](auto& x) {
-      return FilterManager<std::decay_t<decltype(x)>>::createExpressionTrees(x, expressionInfos);
+    homogeneous_apply_refs([&expressionInfos](auto& element) {
+      return analysis_task_parsers::createExpressionTrees(expressionInfos, element);
     },
                            *task.get());
 
@@ -614,16 +604,16 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
     ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));
     // initialize global caches
-    homogeneous_apply_refs([&ic](auto& x) {
-      return CacheManager<std::decay_t<decltype(x)>>::initialize(ic, x);
+    homogeneous_apply_refs([&ic](auto& element) {
+      return analysis_task_parsers::preInitializeCache(ic, element);
     },
                            *(task.get()));
 
     return [task, expressionInfos](ProcessingContext& pc) mutable {
       // load the ccdb object from their cache
-      homogeneous_apply_refs([&pc](auto&& x) { return ConditionManager<std::decay_t<decltype(x)>>::newDataframe(pc.inputs(), x); }, *task.get());
+      homogeneous_apply_refs([&pc](auto& element) { return analysis_task_parsers::newDataframeCondition(pc.inputs(), element); }, *task.get());
       // reset partitions once per dataframe
-      homogeneous_apply_refs([](auto&& x) { return PartitionManager<std::decay_t<decltype(x)>>::newDataframe(x); }, *task.get());
+      homogeneous_apply_refs([](auto& element) { return analysis_task_parsers::newDataframePartition(element); }, *task.get());
       // reset selections for the next dataframe
       for (auto& info : expressionInfos) {
         info.resetSelection = true;
@@ -635,12 +625,9 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       },
                              *(task.get()));
       // initialize local caches
-      homogeneous_apply_refs([&pc](auto& x) {
-        return CacheManager<std::decay_t<decltype(x)>>::initialize(pc, x);
-      },
-                             *(task.get()));
+      homogeneous_apply_refs([&pc](auto& element) { return analysis_task_parsers::initializeCache(pc, element); }, *(task.get()));
       // prepare outputs
-      homogeneous_apply_refs([&pc](auto&& x) { return OutputManager<std::decay_t<decltype(x)>>::prepare(pc, x); }, *task.get());
+      homogeneous_apply_refs([&pc](auto& element) { return analysis_task_parsers::prepareOutput(pc, element); }, *task.get());
       // execute run()
       if constexpr (requires { task->run(pc); }) {
         task->run(pc);
@@ -662,7 +649,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
         },
         *task.get());
       // finalize outputs
-      homogeneous_apply_refs([&pc](auto&& x) { return OutputManager<std::decay_t<decltype(x)>>::finalize(pc, x); }, *task.get());
+      homogeneous_apply_refs([&pc](auto& element) { return analysis_task_parsers::finalizeOutput(pc, element); }, *task.get());
     };
   }};
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -444,8 +444,8 @@ auto getTaskNameSetProcesses(std::string& outputName, TaskName first, SetDefault
   auto task = std::make_shared<T>(std::forward<A>(args)...);
   for (auto& setting : second.map) {
     homogeneous_apply_refs(
-      [&](auto& x) {
-        return UpdateProcessSwitches<std::decay_t<decltype(x)>>::set(setting, x);
+      [&](auto& element) {
+        return analysis_task_parsers::setProcessSwitch(setting, element);
       },
       *task.get());
   }
@@ -459,8 +459,8 @@ auto getTaskNameSetProcesses(std::string& outputName, SetDefaultProcesses first,
   auto task = std::make_shared<T>(std::forward<A>(args)...);
   for (auto& setting : first.map) {
     homogeneous_apply_refs(
-      [&](auto& x) {
-        return UpdateProcessSwitches<std::decay_t<decltype(x)>>::set(setting, x);
+      [&](auto& element) {
+        return analysis_task_parsers::setProcessSwitch(setting, element);
       },
       *task.get());
   }
@@ -474,8 +474,8 @@ auto getTaskNameSetProcesses(std::string& outputName, SetDefaultProcesses first,
   auto task = std::make_shared<T>(std::forward<A>(args)...);
   for (auto& setting : first.map) {
     homogeneous_apply_refs(
-      [&](auto& x) {
-        return UpdateProcessSwitches<std::decay_t<decltype(x)>>::set(setting, x);
+      [&](auto& element) {
+        return analysis_task_parsers::setProcessSwitch(setting, element);
       },
       *task.get());
   }
@@ -550,7 +550,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     *task.get());
 
   // add preslice declarations to slicing cache definition
-  homogeneous_apply_refs([&bindingsKeys, &bindingsKeysUnsorted](auto& x) { return PresliceManager<std::decay_t<decltype(x)>>::registerCache(x, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
+  homogeneous_apply_refs([&bindingsKeys, &bindingsKeysUnsorted](auto& element) { return analysis_task_parsers::registerCache(element, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
 
   // request base tables for spawnable extended tables and indices to be built
   // this checks for duplications
@@ -620,8 +620,8 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       }
       // reset pre-slice for the next dataframe
       auto slices = pc.services().get<ArrowTableSlicingCache>();
-      homogeneous_apply_refs([&pc, &slices](auto& x) {
-        return PresliceManager<std::decay_t<decltype(x)>>::updateSliceInfo(x, slices);
+      homogeneous_apply_refs([&pc, &slices](auto& element) {
+        return analysis_task_parsers::updateSliceInfo(element, slices);
       },
                              *(task.get()));
       // initialize local caches

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -580,7 +580,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       homogeneous_apply_refs([&eosContext](auto& element) {
           analysis_task_parsers::postRunService(eosContext, element);
           analysis_task_parsers::postRunOutput(eosContext, element);
-          return true;},
+          return true; },
                              *task.get());
       eosContext.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     };

--- a/Framework/Core/include/Framework/Condition.h
+++ b/Framework/Core/include/Framework/Condition.h
@@ -43,7 +43,7 @@ struct Condition {
 };
 
 template <typename T>
-concept is_condition = requires (T t) {
+concept is_condition = requires(T t) {
   typename T::type;
   std::same_as<T*, decltype(t.instance)>;
   std::same_as<std::string, decltype(t.path)>;

--- a/Framework/Core/include/Framework/Condition.h
+++ b/Framework/Core/include/Framework/Condition.h
@@ -42,6 +42,13 @@ struct Condition {
   }
 };
 
+template <typename T>
+concept is_condition = requires (T t) {
+  typename T::type;
+  std::same_as<T*, decltype(t.instance)>;
+  std::same_as<std::string, decltype(t.path)>;
+};
+
 /// Can be used to group together a number of Configurables
 /// to overcome the limit of 100 Configurables per task.
 /// In order to do so you can do:
@@ -57,6 +64,9 @@ struct Condition {
 /// group.aCut;
 struct ConditionGroup {
 };
+
+template <typename T>
+concept is_condition_group = std::derived_from<T, ConditionGroup>;
 
 } // namespace o2::framework
 #endif // O2_FRAMEWORK_CONDITION_H_

--- a/Framework/Core/include/Framework/Condition.h
+++ b/Framework/Core/include/Framework/Condition.h
@@ -45,7 +45,7 @@ struct Condition {
 template <typename T>
 concept is_condition = requires(T t) {
   typename T::type;
-  requires std::same_as<T*, decltype(t.instance)>;
+  requires std::same_as<typename T::type*, decltype(t.instance)>;
   requires std::same_as<std::string, decltype(t.path)>;
 };
 

--- a/Framework/Core/include/Framework/Condition.h
+++ b/Framework/Core/include/Framework/Condition.h
@@ -45,8 +45,8 @@ struct Condition {
 template <typename T>
 concept is_condition = requires(T t) {
   typename T::type;
-  std::same_as<T*, decltype(t.instance)>;
-  std::same_as<std::string, decltype(t.path)>;
+  requires std::same_as<T*, decltype(t.instance)>;
+  requires std::same_as<std::string, decltype(t.path)>;
 };
 
 /// Can be used to group together a number of Configurables

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -83,7 +83,13 @@ struct Configurable : IP {
 template <typename T, ConfigParamKind K = ConfigParamKind::kGeneric>
 using MutableConfigurable = Configurable<T, K, ConfigurablePolicyMutable<T, K>>;
 
+template <typename T>
+concept is_configurable = requires(T& t) { typename T::type; std::same_as<std::string, decltype(t.name)>; &T::operator typename T::type; };
+
 using ConfigurableAxis = Configurable<std::vector<double>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<double>, ConfigParamKind::kAxisSpec>>;
+
+template <typename T>
+concept is_configurable_axis = is_configurable<T> && requires() {T::kind == ConfigParamKind::kAxisSpec;};
 
 template <typename R, typename T, typename... As>
 struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
@@ -97,7 +103,7 @@ struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
 };
 
 template <typename T>
-concept is_process_configurable = base_of_template<ProcessConfigurable, T>;
+concept is_process_configurable = is_configurable<T> && requires(T& t) { t.process; };
 
 #define PROCESS_SWITCH(_Class_, _Name_, _Help_, _Default_) \
   decltype(ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_}) do##_Name_ = ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_};
@@ -127,6 +133,9 @@ std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)
 /// group.aCut;
 struct ConfigurableGroup {
 };
+
+template <typename T>
+concept is_configurable_group = std::derived_from<T, ConfigurableGroup>;
 
 } // namespace o2::framework
 #endif // O2_FRAMEWORK_CONFIGURABLE_H_

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -89,7 +89,11 @@ concept is_configurable = requires(T& t) { typename T::type; std::same_as<std::s
 using ConfigurableAxis = Configurable<std::vector<double>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<double>, ConfigParamKind::kAxisSpec>>;
 
 template <typename T>
-concept is_configurable_axis = is_configurable<T> && requires() {T::kind == ConfigParamKind::kAxisSpec;};
+concept is_configurable_axis = is_configurable<T>&&
+  requires()
+{
+  T::kind == ConfigParamKind::kAxisSpec;
+};
 
 template <typename R, typename T, typename... As>
 struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -84,7 +84,11 @@ template <typename T, ConfigParamKind K = ConfigParamKind::kGeneric>
 using MutableConfigurable = Configurable<T, K, ConfigurablePolicyMutable<T, K>>;
 
 template <typename T>
-concept is_configurable = requires(T& t) { typename T::type; std::same_as<std::string, decltype(t.name)>; &T::operator typename T::type; };
+concept is_configurable = requires(T& t) {
+  typename T::type;
+  requires std::same_as<std::string, decltype(t.name)>;
+  &T::operator typename T::type;
+};
 
 using ConfigurableAxis = Configurable<std::vector<double>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<double>, ConfigParamKind::kAxisSpec>>;
 

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -418,6 +418,9 @@ struct Filter {
   size_t designateSubtrees(Node* node, size_t index = 0);
 };
 
+template <typename T>
+concept is_filter = std::same_as<T, Filter>;
+
 using Projector = Filter;
 
 /// Function for creating gandiva selection from our internal filter tree

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -49,6 +49,16 @@ expressions::BindingNode getMatchingIndexNode()
 
 template <typename T1, typename GroupingPolicy, typename BP, typename G, typename... As>
 struct GroupedCombinationsGenerator {
+  using grouping_policy_t = GroupingPolicy;
+  using g_t = G;
+  using associated_pack_t = framework::pack<As...>;
+
+  template <typename... Ts>
+  static consteval bool compatible(framework::pack<Ts...> p)
+  {
+    return (framework::has_type<As>(p) && ...);
+  }
+
   using GroupedIteratorType = pack_to_tuple_t<interleaved_pack_t<repeated_type_pack_t<typename G::iterator, sizeof...(As)>, pack<As...>>>;
 
   struct GroupedIterator : public GroupingPolicy {
@@ -228,6 +238,13 @@ struct GroupedCombinationsGenerator {
  private:
   iterator mBegin;
   iterator mEnd;
+};
+
+template <typename T>
+concept is_combinations_generator = requires (T t) {
+  typename T::GroupedIterator;
+  &T::begin;
+  &T::end;
 };
 
 // Aliases for 2-particle correlations

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -241,7 +241,7 @@ struct GroupedCombinationsGenerator {
 };
 
 template <typename T>
-concept is_combinations_generator = requires (T t) {
+concept is_combinations_generator = requires(T t) {
   typename T::GroupedIterator;
   &T::begin;
   &T::end;

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -252,6 +252,9 @@ class HistogramRegistry
   std::array<HistPtr, MAX_REGISTRY_SIZE> mRegistryValue{};
 };
 
+template <typename T>
+concept is_histogram_registry = std::same_as<T, HistogramRegistry>;
+
 //--------------------------------------------------------------------------------------------------
 //--------------------------------------------------------------------------------------------------
 // Implementation of HistFiller template functions.

--- a/Framework/Core/include/Framework/SliceCache.h
+++ b/Framework/Core/include/Framework/SliceCache.h
@@ -12,10 +12,8 @@
 #ifndef SLICECACHE_H
 #define SLICECACHE_H
 
-#include "Framework/ServiceHandle.h"
 #include "Framework/ArrowTableSlicingCache.h"
 #include <arrow/array.h>
-#include <string_view>
 #include <gsl/span>
 
 namespace o2::framework
@@ -23,6 +21,9 @@ namespace o2::framework
 struct SliceCache {
   ArrowTableSlicingCache* ptr = nullptr;
 };
+
+template <typename T>
+concept is_slice_cache = std::same_as<T, SliceCache>;
 } // namespace o2::framework
 
 #endif // SLICECACHE_H


### PR DESCRIPTION
Replaces analysis manager structs with restricted templates. This should improve compilation time of `adaptAnalysisTask`. 
