### PR TITLE
[MCH] new option to print the status map content

### DIFF
--- a/Detectors/MUON/MCH/Status/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Status/CMakeLists.txt
@@ -47,6 +47,7 @@ o2_add_executable(
     O2::DataFormatsMCH
     O2::Framework
     O2::MCHGlobalMapping
+    O2::MCHMappingImpl4
     O2::MCHStatus
     )
 


### PR DESCRIPTION
This option allows to print the full list of channels (`ChannelCode`) contained in the status map for a given TF with the associated status.

The index of the TF (= entry in the root file) to be processed is set with option `-i`.

It is possible to apply a status mask (with option -m) to select the status of the channels to be printed.

The output format is:
[INFO] status map content for TF 0 with statusMask=0x7:
[INFO] deid  101 dsid 1127 ch 46 depadindex 20095 solarid  130 elink 14 status 1
[INFO] deid  200 dsid 1084 ch 59 depadindex 17440 solarid  297 elink  0 status 1
...
