### PR TITLE
PrimaryGen: More consistent vertex configuration

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -37,7 +37,8 @@ enum class SimFieldMode {
 enum class VertexMode {
   kNoVertex = 0,     // no vertexing should be applied in the generator
   kDiamondParam = 1, // Diamond param will influence vertexing
-  kCCDB = 2          // vertex should be taken from CCDB (Calib/MeanVertex object)
+  kCCDB = 2,         // vertex should be taken from CCDB (Calib/MeanVertex object)
+  kCollCxt = 3       // vertex should be taken from collision context
 };
 
 enum class TimeStampMode {

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -391,8 +391,11 @@ bool SimConfig::parseVertexModeString(std::string const& vertexstring, VertexMod
   } else if (vertexstring == "kCCDB") {
     mode = VertexMode::kCCDB;
     return true;
+  } else if (vertexstring == "kCollContext") {
+    mode = VertexMode::kCollCxt;
+    return true;
   }
-  LOG(error) << "Vertex mode must be one of kNoVertex, kDiamondParam, kCCDB";
+  LOG(error) << "Vertex mode must be one of kNoVertex, kDiamondParam, kCCDB, kCollContext";
   return false;
 }
 

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -270,6 +270,13 @@ void PrimaryGenerator::setVertexMode(o2::conf::VertexMode const& mode, o2::dataf
     LOG(info) << "The mean vertex is set to :";
     mMeanVertex->print();
   }
+  if (mVertexMode == o2::conf::VertexMode::kNoVertex) {
+    setApplyVertex(false);
+    LOG(info) << "Disabling vertexing";
+    mMeanVertex = std::move(std::unique_ptr<o2::dataformats::MeanVertexObject>(new o2::dataformats::MeanVertexObject(0, 0, 0, 0, 0, 0, 0, 0)));
+    LOG(info) << "The mean vertex is set to :";
+    mMeanVertex->print();
+  }
 }
 
 /*****************************************************************/
@@ -298,7 +305,7 @@ void PrimaryGenerator::fixInteractionVertex()
   SmearGausVertexZ(false);
 
   // we use the mMeanVertexObject if initialized (initialize first)
-  if (!mMeanVertex) {
+  if (mMeanVertex.get() == nullptr) {
     if (mVertexMode == o2::conf::VertexMode::kDiamondParam) {
       auto const& param = InteractionDiamondParam::Instance();
       const auto& xyz = param.position;

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -127,6 +127,8 @@ class O2PrimaryServerDevice final : public fair::mq::Device
       } else if (vtxMode == VertexMode::kCCDB) {
         // we need to fetch the CCDB object
         mPrimGen->setVertexMode(vtxMode, ccdbmgr.getForTimeStamp<o2::dataformats::MeanVertexObject>("GLO/Calib/MeanVertex", conf.getTimestamp()));
+      } else if (vtxMode == VertexMode::kCollCxt) {
+        // The vertex will be injected from the outside via setExternalVertex
       } else {
         LOG(fatal) << "Unsupported vertex mode";
       }
@@ -186,13 +188,14 @@ class O2PrimaryServerDevice final : public fair::mq::Device
       const int MAX_RETRY = 100;
       do {
         mStack->Reset();
+        const auto& conf = mSimConfig;
         // see if we the vertex comes from the collision context
-        if (mCollissionContext) {
+        if (mCollissionContext && conf.getVertexMode() == o2::conf::VertexMode::kCollCxt) {
           const auto& vertices = mCollissionContext->getInteractionVertices();
           if (vertices.size() > 0) {
             auto collisionindex = mEventID_to_CollID.at(mEventCounter);
             auto& vertex = vertices.at(collisionindex);
-            LOG(info) << "Setting vertex " << vertex << " for event " << mEventCounter << " for prefix " << mSimConfig.getOutPrefix();
+            LOG(info) << "Setting vertex " << vertex << " for event " << mEventCounter << " for prefix " << mSimConfig.getOutPrefix() << " from CollContext";
             mPrimGen->setExternalVertexForNextEvent(vertex.X(), vertex.Y(), vertex.Z());
           }
         }


### PR DESCRIPTION
* do not apply a vertex when the mode is kNoVertex (this was buggy)

* introduce a new vertex mode kCollContext to indicate the the vertex is to be taken from a collision context