### PR TITLE
DPL Analysis: fix corner case in index builder algorithm

### DIFF
--- a/Framework/Core/src/IndexBuilderHelpers.cxx
+++ b/Framework/Core/src/IndexBuilderHelpers.cxx
@@ -159,6 +159,10 @@ bool IndexColumnBuilder::findSingle(int idx)
     }
   }
 
+  if (mPosition < mSourceSize && valueAt(mPosition) < idx) {
+    ++mPosition;
+  }
+
   return (mPosition < mSourceSize && valueAt(mPosition) == idx);
 }
 
@@ -174,6 +178,10 @@ bool IndexColumnBuilder::findSlice(int idx)
       mValuePos -= step;
       count = step;
     }
+  }
+
+  if (mValuePos < mValuesArrow->length() && mValuesArrow->Value(mValuePos) <= idx) {
+    ++mPosition;
   }
 
   return (mValuePos < mValuesArrow->length() && mValuesArrow->Value(mValuePos) == idx);


### PR DESCRIPTION
In a specific case where the index would skip exactly one row, the binary search would stop on the skipped row instead of a target one, missing a correct entry. 

@ddobrigk This fixes the specific converted Run 2 data issue we were discussing via email.