### PR TITLE
DPL: add support for decompressing directly to shared memory

### DIFF
--- a/Framework/AnalysisSupport/src/RNTuplePlugin.cxx
+++ b/Framework/AnalysisSupport/src/RNTuplePlugin.cxx
@@ -12,6 +12,7 @@
 #include "Framework/RuntimeError.h"
 #include "Framework/RootArrowFilesystem.h"
 #include "Framework/Plugins.h"
+#include "Framework/FairMQResizableBuffer.h"
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
@@ -852,7 +853,10 @@ struct RNTupleObjectReadingImplementation : public RootArrowFactoryPlugin {
     return new RootArrowFactory{
       .options = [context]() { return context->format->DefaultWriteOptions(); },
       .format = [context]() { return context->format; },
-    };
+      .deferredOutputStreamer = [](std::shared_ptr<arrow::dataset::FileFragment> fragment, const std::shared_ptr<arrow::ResizableBuffer>& buffer) -> std::shared_ptr<arrow::io::OutputStream> {
+        auto treeFragment = std::dynamic_pointer_cast<RNTupleFileFragment>(fragment);
+        return std::make_shared<FairMQOutputStream>(buffer);
+      }};
   }
 };
 

--- a/Framework/Core/include/Framework/RootArrowFilesystem.h
+++ b/Framework/Core/include/Framework/RootArrowFilesystem.h
@@ -12,6 +12,7 @@
 #define O2_FRAMEWORK_ROOT_ARROW_FILESYSTEM_H_
 
 #include <TBufferFile.h>
+#include <arrow/buffer.h>
 #include <arrow/dataset/dataset.h>
 #include <arrow/dataset/type_fwd.h>
 #include <arrow/dataset/file_base.h>
@@ -96,6 +97,9 @@ class VirtualRootFileSystemBase : public arrow::fs::FileSystem
 struct RootArrowFactory final {
   std::function<std::shared_ptr<arrow::dataset::FileWriteOptions>()> options = nullptr;
   std::function<std::shared_ptr<arrow::dataset::FileFormat>()> format = nullptr;
+  // Builds an output streamer which is able to read from the source fragment
+  // in a deferred way.
+  std::function<std::shared_ptr<arrow::io::OutputStream>(std::shared_ptr<arrow::dataset::FileFragment>, const std::shared_ptr<arrow::ResizableBuffer>& buffer)> deferredOutputStreamer = nullptr;
 };
 
 struct RootArrowFactoryPlugin {
@@ -143,6 +147,8 @@ class TFileFileSystem : public VirtualRootFileSystemBase
   arrow::Result<arrow::fs::FileInfo> GetFileInfo(const std::string& path) override;
 
   TFileFileSystem(TDirectoryFile* f, size_t readahead, RootObjectReadingFactory&);
+
+  ~TFileFileSystem() override;
 
   std::string type_name() const override
   {

--- a/Framework/Core/src/RootArrowFilesystem.cxx
+++ b/Framework/Core/src/RootArrowFilesystem.cxx
@@ -42,6 +42,12 @@ TFileFileSystem::TFileFileSystem(TDirectoryFile* f, size_t readahead, RootObject
   ((TFile*)mFile)->SetReadaheadSize(50 * 1024 * 1024);
 }
 
+TFileFileSystem::~TFileFileSystem()
+{
+  mFile->Close();
+  delete mFile;
+}
+
 std::shared_ptr<RootObjectHandler> TFileFileSystem::GetObjectHandler(arrow::dataset::FileSource source)
 {
   // We use a plugin to create the actual objects inside the


### PR DESCRIPTION

This PR postpones the read operations which would usually populate an intermediate
RecordBatch and it performs them directly on its subsequent shared memory
serialization. Doing so avoids having the intermediate representation allocate most
of the memory.

For the moment this is only done for the TTree plugin. RNtuple support will come
in a subsequent PR.
