### PR TITLE
DPL: trigger runtime error in case of duplicate processor names

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -2933,8 +2933,9 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
     workflowHashA += hash_fn(dp.name);
   }
 
-  for (auto& dp : workflow) {
+  for (auto& dp : physicalWorkflow) {
     rankIndex.insert(std::make_pair(dp.name, workflowHashA));
+    dp.metadata.emplace(dp.metadata.begin(), std::string{"executable"}, currentWorkflow.executable);
   }
 
   std::vector<DataProcessorInfo> dataProcessorInfos;
@@ -2956,11 +2957,10 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
     // We remove the duplicates because for the moment child get themself twice:
     // once from the actual definition in the child, a second time from the
     // configuration they get passed by their parents.
-    std::regex pipe_pattern{"_t[0-9][0-9]*$"};
     for (auto& dp : importedWorkflow) {
-      auto found = std::find_if(dataProcessorInfos.begin(), dataProcessorInfos.end(),
-                                [&name = dp.name, &pipe_pattern, &exec = currentWorkflow.executable](DataProcessorInfo const& info) { return (std::regex_replace(info.name, pipe_pattern, "") == name && info.executable == exec); });
-      if (found == dataProcessorInfos.end()) {
+      auto found = std::find_if(physicalWorkflow.begin(), physicalWorkflow.end(),
+                                [&name = dp.name](DataProcessorSpec const& spec) { return spec.name == name; });
+      if (found == physicalWorkflow.end() || (*dp.metadata.begin()).value != currentWorkflow.executable) {
         physicalWorkflow.push_back(dp);
         rankIndex.insert(std::make_pair(dp.name, workflowHashB));
       }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -2956,14 +2956,11 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
     // We remove the duplicates because for the moment child get themself twice:
     // once from the actual definition in the child, a second time from the
     // configuration they get passed by their parents.
+    std::regex pipe_pattern{"_t[0-9][0-9]*$"};
     for (auto& dp : importedWorkflow) {
-      auto found = std::find_if(physicalWorkflow.begin(), physicalWorkflow.end(),
-                                [&name = dp.name](DataProcessorSpec const& spec) { return spec.name == name; });
-      // also checking the workflow for processors with the same name but from a different executable,
-      // adding them to the workflow to trigger the check for duplicate names in the MATERIALISE_WORKFLOW state
-      auto duplicate_name = std::find_if(dataProcessorInfos.begin(), dataProcessorInfos.end(),
-                                         [&name = dp.name, &exec = currentWorkflow.executable](DataProcessorInfo const& info) { return (info.name == name && info.executable != exec); });
-      if (found == physicalWorkflow.end() || duplicate_name != dataProcessorInfos.end()) {
+      auto found = std::find_if(dataProcessorInfos.begin(), dataProcessorInfos.end(),
+                                [&name = dp.name, &pipe_pattern, &exec = currentWorkflow.executable](DataProcessorInfo const& info) { return (std::regex_replace(info.name, pipe_pattern, "") == name && info.executable == exec); });
+      if (found == dataProcessorInfos.end()) {
         physicalWorkflow.push_back(dp);
         rankIndex.insert(std::make_pair(dp.name, workflowHashB));
       }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -2959,7 +2959,11 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
     for (auto& dp : importedWorkflow) {
       auto found = std::find_if(physicalWorkflow.begin(), physicalWorkflow.end(),
                                 [&name = dp.name](DataProcessorSpec const& spec) { return spec.name == name; });
-      if (found == physicalWorkflow.end()) {
+      // also checking the workflow for processors with the same name but from a different executable,
+      // adding them to the workflow to trigger the check for duplicate names in the MATERIALISE_WORKFLOW state
+      auto duplicate_name = std::find_if(dataProcessorInfos.begin(), dataProcessorInfos.end(),
+                                         [&name = dp.name, &exec = currentWorkflow.executable](DataProcessorInfo const& info) { return (info.name == name && info.executable != exec); });
+      if (found == physicalWorkflow.end() || duplicate_name != dataProcessorInfos.end()) {
         physicalWorkflow.push_back(dp);
         rankIndex.insert(std::make_pair(dp.name, workflowHashB));
       }


### PR DESCRIPTION
Adding processors to the workflow if they have the same name as an already added processor but come from a different executable. This will trigger a runtime error in the `MATERIALISE_WORKFLOW` state in https://github.com/AliceO2Group/AliceO2/blob/28d9c7622ec3429fb306df2499fa2c21363c28b6/Framework/Core/src/WorkflowHelpers.cxx#L935 