### PR TITLE
TPC QC: Add skeleton for GPUErrorQA task

### DIFF
--- a/Detectors/TPC/qc/CMakeLists.txt
+++ b/Detectors/TPC/qc/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(TPCQC
                        src/SACs.cxx
                        src/IDCsVsSACs.cxx
                        src/TrackClusters.cxx
+		       src/GPUErrorQA.cxx
                PUBLIC_LINK_LIBRARIES O2::TPCBase
                                      O2::DataFormatsTPC
                                      O2::GPUO2Interface
@@ -36,7 +37,8 @@ o2_target_root_dictionary(TPCQC
                                   include/TPCQC/DCSPTemperature.h
                                   include/TPCQC/SACs.h
                                   include/TPCQC/IDCsVsSACs.h
-                                  include/TPCQC/TrackClusters.h)
+                                  include/TPCQC/TrackClusters.h
+				  include/TPCQC/GPUErrorQA.h)
 
 o2_add_test(PID
             COMPONENT_NAME tpc

--- a/Detectors/TPC/qc/include/TPCQC/GPUErrorQA.h
+++ b/Detectors/TPC/qc/include/TPCQC/GPUErrorQA.h
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @file   GPUErrorQA.h
+/// @author Anton Riedel, anton.riedel@cern.ch
+///
+
+#ifndef AliceO2_TPC_QC_GPUERRORQA_H
+#define AliceO2_TPC_QC_GPUERRORQA_H
+
+#include <memory>
+#include <gsl/span>
+
+// root includes
+#include "TH1.h"
+
+// o2 includes
+// #include "DataFormatsTPC/Defs.h"
+
+namespace o2
+{
+namespace tpc
+{
+namespace qc
+{
+
+/// @brief  TPC QC task for errors from GPU reconstruction
+///
+/// This class is used to retrieve and visualize GPU errors
+/// according to corresponding error code and location.
+///
+/// origin: TPC
+/// @author Anton Riedel, anton.riedel@cern.ch
+class GPUErrorQA
+{
+ public:
+  /// \brief Constructor.
+  GPUErrorQA() = default;
+
+  /// process gpu error reported by the reconstruction workflow
+  void processErrors(gsl::span<const std::array<uint32_t, 4>> errors);
+
+  /// Initialize all histograms
+  void initializeHistograms();
+
+  /// Reset all histograms
+  void resetHistograms();
+
+  /// Dump results to a file
+  void dumpToFile(std::string filename);
+
+ private:
+  std::unique_ptr<TH1F> mHist;
+  ClassDefNV(GPUErrorQA, 1)
+};
+} // namespace qc
+} // namespace tpc
+} // namespace o2
+
+#endif // AliceO2_TPC_QC_GPUERRORQA_H

--- a/Detectors/TPC/qc/include/TPCQC/GPUErrorQA.h
+++ b/Detectors/TPC/qc/include/TPCQC/GPUErrorQA.h
@@ -18,6 +18,7 @@
 #define AliceO2_TPC_QC_GPUERRORQA_H
 
 #include <memory>
+#include <unordered_map>
 #include <gsl/span>
 
 // root includes
@@ -55,11 +56,14 @@ class GPUErrorQA
   /// Reset all histograms
   void resetHistograms();
 
+  /// return histograms
+  std::unordered_map<std::string, std::unique_ptr<TH1>>& getMapHist() { return mMapHist; };
+
   /// Dump results to a file
   void dumpToFile(std::string filename);
 
  private:
-  std::unique_ptr<TH1F> mHist;
+  std::unordered_map<std::string, std::unique_ptr<TH1>> mMapHist;
   ClassDefNV(GPUErrorQA, 1)
 };
 } // namespace qc

--- a/Detectors/TPC/qc/src/GPUErrorQA.cxx
+++ b/Detectors/TPC/qc/src/GPUErrorQA.cxx
@@ -1,0 +1,55 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+#include <memory>
+
+// root includes
+#include "TFile.h"
+#include <TH1.h>
+
+// o2 includes
+#include "TPCQC/GPUErrorQA.h"
+#include "GPUErrors.h"
+
+ClassImp(o2::tpc::qc::GPUErrorQA);
+
+using namespace o2::tpc::qc;
+
+//______________________________________________________________________________
+void GPUErrorQA::initializeHistograms()
+{
+  TH1::AddDirectory(false);
+  mHist = std::make_unique<TH1F>("ErrorCounter", "ErrorCounter", o2::gpu::GPUErrors::getMaxErrors(), 0, o2::gpu::GPUErrors::getMaxErrors());
+}
+//______________________________________________________________________________
+void GPUErrorQA::resetHistograms()
+{
+  mHist->Reset();
+}
+//______________________________________________________________________________
+void GPUErrorQA::processErrors(gsl::span<const std::array<uint32_t, 4>> errors)
+{
+  for (const auto& error : errors) {
+    uint32_t errorCode = error[0];
+    mHist->Fill(static_cast<float>(errorCode));
+  }
+}
+
+//______________________________________________________________________________
+void GPUErrorQA::dumpToFile(const std::string filename)
+{
+  auto f = std::unique_ptr<TFile>(TFile::Open(filename.c_str(), "recreate"));
+  mHist->Write();
+  f->Close();
+}

--- a/Detectors/TPC/qc/src/GPUErrorQA.cxx
+++ b/Detectors/TPC/qc/src/GPUErrorQA.cxx
@@ -13,6 +13,7 @@
 
 #include <cmath>
 #include <memory>
+#include <unordered_map>
 
 // root includes
 #include "TFile.h"
@@ -20,7 +21,7 @@
 
 // o2 includes
 #include "TPCQC/GPUErrorQA.h"
-#include "GPUErrors.h"
+#include "GPUDefMacros.h"
 
 ClassImp(o2::tpc::qc::GPUErrorQA);
 
@@ -30,26 +31,49 @@ using namespace o2::tpc::qc;
 void GPUErrorQA::initializeHistograms()
 {
   TH1::AddDirectory(false);
-  mHist = std::make_unique<TH1F>("ErrorCounter", "ErrorCounter", o2::gpu::GPUErrors::getMaxErrors(), 0, o2::gpu::GPUErrors::getMaxErrors());
+
+  // get gpu error names
+  // copied from GPUErrors.h
+  static std::unordered_map<uint32_t, const char*> errorNames = {
+#define GPUCA_ERROR_CODE(num, name, ...) {num, GPUCA_M_STR(name)},
+#include "GPUErrorCodes.h"
+#undef GPUCA_ERROR_CODE
+  };
+
+  // 1D histogram counting all reported errors
+  mMapHist["ErrorCounter"] = std::make_unique<TH1F>("ErrorCounter", "ErrorCounter", errorNames.size(), 0, errorNames.size());
+  mMapHist["ErrorCounter"]->GetXaxis()->SetTitle("Error Codes");
+  mMapHist["ErrorCounter"]->GetYaxis()->SetTitle("Entries");
+  // for convienence, label each bin with the error name
+  for (size_t bin = 1; bin < mMapHist["ErrorCounter"]->GetNbinsX(); bin++) {
+    auto const& it = errorNames.find(bin);
+    mMapHist["ErrorCounter"]->GetXaxis()->SetBinLabel(bin, it->second);
+  }
 }
 //______________________________________________________________________________
 void GPUErrorQA::resetHistograms()
 {
-  mHist->Reset();
+  for (const auto& pair : mMapHist) {
+    pair.second->Reset();
+  }
 }
 //______________________________________________________________________________
 void GPUErrorQA::processErrors(gsl::span<const std::array<uint32_t, 4>> errors)
 {
   for (const auto& error : errors) {
     uint32_t errorCode = error[0];
-    mHist->Fill(static_cast<float>(errorCode));
+    mMapHist["ErrorCounter"]->Fill(static_cast<float>(errorCode));
   }
 }
 
 //______________________________________________________________________________
 void GPUErrorQA::dumpToFile(const std::string filename)
 {
-  auto f = std::unique_ptr<TFile>(TFile::Open(filename.c_str(), "recreate"));
-  mHist->Write();
-  f->Close();
+  auto f = std::unique_ptr<TFile>(TFile::Open(filename.data(), "recreate"));
+  for (const auto& [name, hist] : mMapHist) {
+    TObjArray arr;
+    arr.SetName(name.data());
+    arr.Add(hist.get());
+    arr.Write(arr.GetName(), TObject::kSingleKey);
+  }
 }

--- a/Detectors/TPC/qc/src/TPCQCLinkDef.h
+++ b/Detectors/TPC/qc/src/TPCQCLinkDef.h
@@ -24,6 +24,7 @@
 #pragma link C++ class o2::tpc::qc::SACs + ;
 #pragma link C++ class o2::tpc::qc::IDCsVsSACs + ;
 #pragma link C++ class o2::tpc::qc::TrackClusters + ;
+#pragma link C++ class o2::tpc::qc::GPUErrorQA + ;
 #pragma link C++ function o2::tpc::qc::helpers::makeLogBinning + ;
 #pragma link C++ function o2::tpc::qc::helpers::setStyleHistogram1D + ;
 #pragma link C++ function o2::tpc::qc::helpers::setStyleHistogram2D + ;


### PR DESCRIPTION
Add skeleton for GPUErrorQA task in O2.

In this draft, only the number of errors for a given error code is counted and put into a 1D histogram.

In principle the error is reporting 4 values, the error code +3 parameters (like SectorRow, Sector, Value, Max ...). However, the meaning of the parameters depends on the error code itself (defined in GPUErrorCodes.h). There was a suggestion in the past to display the errors in a 2D histogram. 

In principle, we could implement 3 2D histograms, putting the error code on the x-axis and the different parameter values on the y-axis.

Tagging @wiechula and @davidrohr for their opinion.