### PR TITLE
Modify CA async opts, possible set from config.param

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -63,6 +63,7 @@ struct TrackingParameters {
   int CellMinimumLevel();
   int CellsPerRoad() const { return NLayers - 2; }
   int TrackletsPerRoad() const { return NLayers - 1; }
+  std::string asString() const;
 
   int NLayers = 7;
   int DeltaROF = 0;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -55,9 +55,14 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
 
 struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerParamConfig> {
   // Use TGeo for mat. budget
+  static const int MaxIter = 4;
+  static const int MinTrackLenght = 4;
+  static const int MaxTrackLenght = 7;
   bool useMatCorrTGeo = false;  // use full geometry to corect for material budget accounting in the fits. Default is to use the material budget LUT.
   bool useFastMaterial = false; // use faster material approximation for material budget accounting in the fits.
   int deltaRof = 0;             // configure the width of the window in ROFs to be considered for the tracking.
+  int minTrackLgtIter[MaxIter] = {};                                        // minimum track length at each iteration, used only if >0, otherwise use code defaults
+  float minPtIterLgt[MaxIter * (MaxTrackLenght - MinTrackLenght + 1)] = {}; // min.pT for given track length at this iteration, used only if >0, otherwise use code defaults
   float sysErrY2[7] = {0};      // systematic error^2 in Y per layer
   float sysErrZ2[7] = {0};      // systematic error^2 in Z per layer
   float maxChi2ClusterAttachment = -1.f;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingInterface.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingInterface.h
@@ -70,6 +70,9 @@ class ITSTrackingInterface
     mMode = mode;
   }
 
+  auto getTracker() const { return mTracker.get(); }
+  auto getVertexer() const { return mVertexer.get(); }
+
   TimeFrame* mTimeFrame = nullptr;
 
  protected:

--- a/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
@@ -28,6 +28,28 @@ std::string asString(TrackingMode mode)
   return "unknown";
 }
 
+std::string TrackingParameters::asString() const
+{
+  std::string str = fmt::format("NZb:{} NPhB:{} NROFIt:{} PerVtx:{} DropFail:{} ClSh:{} TtklMinPt:{:.2f} MinCl:{}",
+                                ZBins, PhiBins, nROFsPerIterations, PerPrimaryVertexProcessing, DropTFUponFailure, ClusterSharing, TrackletMinPt, MinTrackLength);
+  bool first = true;
+  for (int il = NLayers; il >= MinTrackLength; il--) {
+    int slot = NLayers - il;
+    if (slot < (int)MinPt.size() && MinPt[slot] > 0) {
+      if (first) {
+        first = false;
+        str += " MinPt: ";
+      }
+      str += fmt::format("L{}:{:.2f} ", il, MinPt[slot]);
+    }
+  }
+  str += " SystErrY/Z:";
+  for (size_t i = 0; i < SystErrorY2.size(); i++) {
+    str += fmt::format("{:.2e}/{:.2e} ", SystErrorY2[i], SystErrorZ2[i]);
+  }
+  return str;
+}
+
 std::ostream& operator<<(std::ostream& os, TrackingMode v)
 {
   os << asString(v);

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -481,7 +481,6 @@ void Tracker::rectifyClusterIndices()
 void Tracker::getGlobalConfiguration()
 {
   auto& tc = o2::its::TrackerParamConfig::Instance();
-  tc.printKeyValues(true, true);
   if (tc.useMatCorrTGeo) {
     mTraits->setCorrType(o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrTGeo);
   } else if (tc.useFastMaterial) {

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -103,7 +103,6 @@ float Vertexer::clustersToVerticesHybrid(std::function<void(std::string s)> logg
 void Vertexer::getGlobalConfiguration()
 {
   auto& vc = o2::its::VertexerParamConfig::Instance();
-  vc.printKeyValues(true, true);
   auto& grc = o2::its::ITSGpuTrackingParamConfig::Instance();
 
   // This is odd: we override only the parameters for the first iteration.

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -44,7 +44,7 @@ void TrackerDPL::init(InitContext& ic)
   mITSTrackingInterface.setTraitsFromProvider(mChainITS->GetITSVertexerTraits(),
                                               mChainITS->GetITSTrackerTraits(),
                                               mChainITS->GetITSTimeframe());
-  mITSTrackingInterface.initialise();
+  //  mITSTrackingInterface.initialise() will be called from the ITSTrackingInterface::updateTimeDependentParams at 1st initialization since it needs some run conditions
 }
 
 void TrackerDPL::stop()


### PR DESCRIPTION
Print selected settigs only once from the 1st pipeline. Rescale pT cutoffs by actual/nominal B-field. For this reason, CA ITSTrackingInterface::initialise is moved inside ITSTrackingInterface::updateTimeDependentParams 1st call (during 1st TF processing).

@mpuccio here I set defaults to the best I could get so far for 37kHz pbpb, see ITSV2 in https://its.cern.ch/jira/browse/O2-5763?focusedId=6680013&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6680013 and add a possibility to modify the minTrackLenght and corresponding pt cut-offs from the config.param (taken only if non-0). I assume for pp we may want different settings, so should be flexible. E.g. this default settings correspond to:
```
 --configKeyValues "ITSCATrackerParam.minTrackLgtIter[2]=4;ITSCATrackerParam.minTrackLgtIter[3]=4;ITSCATrackerParam.minPtIterLgt[0]=0.08;ITSCATrackerParam.minPtIterLgt[0]=0.08;ITSCATrackerParam.minPtIterLgt[4]=0.08;ITSCATrackerParam.minPtIterLgt[8]=0.08;ITSCATrackerParam.minPtIterLgt[9]=0.2;ITSCATrackerParam.minPtIterLgt[10]=1.;ITSCATrackerParam.minPtIterLgt[11]=0.16;"
```