### PR TITLE
FIT: add RecPoint reader and writer workflows for FV0 and FDD

### DIFF
--- a/DataFormats/Detectors/FIT/FDD/CMakeLists.txt
+++ b/DataFormats/Detectors/FIT/FDD/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 o2_add_library(DataFormatsFDD
   SOURCES src/RawEventData.cxx
+          src/RecPoint.cxx
           src/CTF.cxx
           src/LookUpTable.cxx
   PUBLIC_LINK_LIBRARIES O2::FDDBase

--- a/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/RecPoint.h
+++ b/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/RecPoint.h
@@ -9,8 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file RecPoint.h
+/// \file  RecPoint.h
 /// \brief Definition of the FDD RecPoint class
+
 #ifndef ALICEO2_FDD_RECPOINT_H
 #define ALICEO2_FDD_RECPOINT_H
 
@@ -42,6 +43,7 @@ struct ChannelDataFloat {
   }
 
   void print() const;
+  bool operator==(const ChannelDataFloat&) const = default;
 
   ClassDefNV(ChannelDataFloat, 1);
 };
@@ -79,6 +81,9 @@ class RecPoint
   short static constexpr sDummyCollissionTime = 32767;
   int getFirstEntry() const { return mRef.getFirstEntry(); }
   int getEntriesInCurrentBC() const { return mRef.getEntries(); }
+
+  void print() const;
+  bool operator==(const RecPoint&) const = default;
 
  private:
   o2::dataformats::RangeReference<int, int> mRef;

--- a/DataFormats/Detectors/FIT/FDD/src/RecPoint.cxx
+++ b/DataFormats/Detectors/FIT/FDD/src/RecPoint.cxx
@@ -1,0 +1,33 @@
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   RecPoint.cxx
+/// \brief  Implementation of the FDD RecPoint class
+/// \author Andreas Molander andreas.molander@cern.ch
+
+#include "DataFormatsFDD/RecPoint.h"
+#include "Framework/Logger.h"
+
+using namespace o2::fdd;
+
+void ChannelDataFloat::print() const
+{
+  LOG(info) << "ChannelDataFloat data:";
+  LOG(info) << "Channel ID: " << mPMNumber << ", Time (ps): " << mTime << ", Charge (ADC): " << mChargeADC << ", QTC chain: " << adcId;
+}
+
+void RecPoint::print() const
+{
+  LOG(info) << "RecPoint data:";
+  LOG(info) << "Collision times: A: " << getCollisionTimeA() << ", C: " << getCollisionTimeC();
+  LOG(info) << "Ref first: " << mRef.getFirstEntry() << ", Ref entries: " << mRef.getEntries();
+  LOG(info) << "Triggers: " << mTriggers.print();
+}

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
@@ -47,6 +47,7 @@ struct ChannelDataFloat {
   }
 
   void print() const;
+  bool operator==(const ChannelDataFloat&) const = default;
 
   ClassDefNV(ChannelDataFloat, 1);
 };
@@ -74,8 +75,6 @@ class RecPoints
   }
   ~RecPoints() = default;
 
-  void print() const;
-
   short getCollisionTime(int side) const { return mCollisionTime[side]; }
   short getCollisionTimeMean() const { return getCollisionTime(TimeMean); }
   short getCollisionTimeA() const { return getCollisionTime(TimeA); }
@@ -95,6 +94,9 @@ class RecPoints
 
   gsl::span<const ChannelDataFloat> getBunchChannelData(const gsl::span<const ChannelDataFloat> tfdata) const;
   short static constexpr sDummyCollissionTime = 32767;
+
+  void print() const;
+  bool operator==(const RecPoints&) const = default;
 
  private:
   std::array<short, 4> mCollisionTime = {sDummyCollissionTime,

--- a/DataFormats/Detectors/FIT/FT0/src/RecPoints.cxx
+++ b/DataFormats/Detectors/FIT/FT0/src/RecPoints.cxx
@@ -21,14 +21,22 @@
 
 using namespace o2::ft0;
 
+void ChannelDataFloat::print() const
+{
+  printf("  ChID% d | CFDtime=%f | QTCampl=%f QTC chain %d\n", ChId, CFDTime, QTCAmpl, ChainQTC);
+}
+
 gsl::span<const ChannelDataFloat> RecPoints::getBunchChannelData(const gsl::span<const ChannelDataFloat> tfdata) const
 {
   // extract the span of channel data for this bunch from the whole TF data
   return ref.getEntries() ? gsl::span<const ChannelDataFloat>(tfdata).subspan(ref.getFirstEntry(), ref.getEntries()) : gsl::span<const ChannelDataFloat>();
 }
 
-void ChannelDataFloat::print() const
+void RecPoints::print() const
 {
-
-  printf("  ChID% d | CFDtime=%f | QTCampl=%f QTC chain %d\n", ChId, CFDTime, QTCAmpl, ChainQTC);
+  LOG(info) << "RecPoint data:";
+  LOG(info) << "Collision times: mean: " << getCollisionTimeMean() << ", A: " << getCollisionTimeA() << ", C: " << getCollisionTimeC();
+  LOG(info) << "Vertex: " << getVertex();
+  LOG(info) << "Ref first: " << ref.getFirstEntry() << ", Ref entries: " << ref.getEntries();
+  LOG(info) << "Triggers: " << mTriggers.print();
 }

--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/RecPoints.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/RecPoints.h
@@ -42,6 +42,7 @@ struct ChannelDataFloat {
   }
 
   void print() const;
+  bool operator==(const ChannelDataFloat&) const = default;
 
   ClassDefNV(ChannelDataFloat, 1);
 };
@@ -76,6 +77,9 @@ class RecPoints
   o2::InteractionRecord getInteractionRecord() const { return mIntRecord; };
   gsl::span<const ChannelDataFloat> getBunchChannelData(const gsl::span<const ChannelDataFloat> tfdata) const;
   short static constexpr sDummyCollissionTime = 32767;
+
+  void print() const;
+  bool operator==(const RecPoints&) const = default;
 
  private:
   o2::dataformats::RangeReference<int, int> mRef;

--- a/DataFormats/Detectors/FIT/FV0/src/RecPoints.cxx
+++ b/DataFormats/Detectors/FIT/FV0/src/RecPoints.cxx
@@ -14,13 +14,22 @@
 
 using namespace o2::fv0;
 
+void ChannelDataFloat::print() const
+{
+  printf("  Channel=%d | time=%f | charge=%f | adcId=%d\n", channel, time, charge, adcId);
+}
+
+void RecPoints::print() const
+{
+  printf("RecPoint data:");
+  printf("Collision times: first: %f, global mean: %f, selected mean: %f\n", getCollisionFirstTime(), getCollisionGlobalMeanTime(), getCollisionSelectedMeanTime());
+  printf("Ref first: %d, Ref entries: %d\n", mRef.getFirstEntry(), mRef.getEntries());
+  printf("Triggers: ");
+  mTriggers.print();
+}
+
 gsl::span<const ChannelDataFloat> RecPoints::getBunchChannelData(const gsl::span<const ChannelDataFloat> tfdata) const
 {
   // extract the span of channel data for this bunch from the whole TF data
   return mRef.getEntries() ? gsl::span<const ChannelDataFloat>(tfdata).subspan(mRef.getFirstEntry(), mRef.getEntries()) : gsl::span<const ChannelDataFloat>();
-}
-
-void ChannelDataFloat::print() const
-{
-  printf("  Channel=%d | time=%f | charge=%f | adcId=%d\n", channel, time, charge, adcId);
 }

--- a/Detectors/FIT/FDD/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FDD/workflow/CMakeLists.txt
@@ -52,6 +52,16 @@ o2_add_executable(flp-dpl-workflow
                   PUBLIC_LINK_LIBRARIES O2::FDDWorkflow O2::FDDRaw O2::FITWorkflow
                   TARGETVARNAME fddflpexe)
 
+o2_add_executable(recpoints-reader-workflow
+                  SOURCES src/recpoints-reader-workflow.cxx
+                  COMPONENT_NAME fdd
+                  PUBLIC_LINK_LIBRARIES O2::FDDWorkflow)
+
+o2_add_executable(recpoints-writer-workflow
+                  SOURCES src/recpoints-writer-workflow.cxx
+                  COMPONENT_NAME fdd
+                  PUBLIC_LINK_LIBRARIES O2::FDDWorkflow)
+
 o2_add_executable(integrate-cluster-workflow
                   SOURCES src/cluster-integrator.cxx
                   COMPONENT_NAME fdd

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RecPointReaderSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RecPointReaderSpec.h
@@ -31,7 +31,7 @@ namespace fdd
 class RecPointReader : public Task
 {
  public:
-  RecPointReader(bool useMC = true);
+  RecPointReader(bool useMC = false);
   ~RecPointReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -42,7 +42,7 @@ class RecPointReader : public Task
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
 
-  bool mUseMC = true; // use MC truth
+  bool mUseMC = false; // use MC truth
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginFDD;
 
   std::vector<o2::fdd::RecPoint>* mRecPoints = nullptr;

--- a/Detectors/FIT/FDD/workflow/src/RecPointReaderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/RecPointReaderSpec.cxx
@@ -11,15 +11,13 @@
 
 /// @file  RecPointReaderSpec.cxx
 
-#include <vector>
-
-#include "TTree.h"
-
-#include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
 #include "Framework/Logger.h"
 #include "FDDWorkflow/RecPointReaderSpec.h"
 #include "CommonUtils/NameConf.h"
+
+#include <vector>
 
 using namespace o2::framework;
 using namespace o2::fdd;

--- a/Detectors/FIT/FDD/workflow/src/recpoints-reader-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/recpoints-reader-workflow.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -10,17 +10,17 @@
 // or submit itself to any jurisdiction.
 
 /// \file  recpoints-reader-workflow.cxx
-/// \brief FT0 RecPoints reader workflow
+/// \brief FDD RecPoints reader workflow
 ///
-/// \author ruben.shahoyan@cern.ch, Andreas Molander andreas.molander@cern.ch
+/// \author Andreas Molander andreas.molander@cern.ch
+
+#include "FDDWorkflow/RecPointReaderSpec.h"
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/Variant.h"
-
-#include "FT0Workflow/RecPointReaderSpec.h"
 
 #include <vector>
 
@@ -47,9 +47,8 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
 {
   o2::conf::ConfigurableParam::updateFromString(ctx.options().get<std::string>("configKeyValues"));
   bool disableMC = ctx.options().get<bool>("disable-mc");
-
   WorkflowSpec specs;
-  DataProcessorSpec producer = o2::ft0::getRecPointReaderSpec(!disableMC);
+  DataProcessorSpec producer = o2::fdd::getFDDRecPointReaderSpec(!disableMC);
   specs.push_back(producer);
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit

--- a/Detectors/FIT/FDD/workflow/src/recpoints-writer-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/recpoints-writer-workflow.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -9,27 +9,20 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file  recpoints-reader-workflow.cxx
-/// \brief FT0 RecPoints reader workflow
+/// \file  recpoints-writer-workflow.cxx
+/// \brief FDD RecPoints writer workflow
 ///
-/// \author ruben.shahoyan@cern.ch, Andreas Molander andreas.molander@cern.ch
+/// \author Andreas Molander andreas.molander@cern.ch
+
+#include "FDDWorkflow/RecPointWriterSpec.h"
 
 #include "CommonUtils/ConfigurableParam.h"
-#include "DetectorsRaw/HBFUtilsInitializer.h"
-#include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/Variant.h"
-
-#include "FT0Workflow/RecPointReaderSpec.h"
 
 #include <vector>
 
 using namespace o2::framework;
-
-void customize(std::vector<CallbacksPolicy>& policies)
-{
-  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
-}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -37,8 +30,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"disable-mc", VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
-  o2::raw::HBFUtilsInitializer::addConfigOption(options);
-  std::swap(workflowOptions, options);
+  workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
 
 #include "Framework/runDataProcessing.h"
@@ -49,10 +41,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   bool disableMC = ctx.options().get<bool>("disable-mc");
 
   WorkflowSpec specs;
-  DataProcessorSpec producer = o2::ft0::getRecPointReaderSpec(!disableMC);
+  DataProcessorSpec producer = o2::fdd::getFDDRecPointWriterSpec(!disableMC);
   specs.push_back(producer);
-
-  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
-  o2::raw::HBFUtilsInitializer hbfIni(ctx, specs);
   return specs;
 }

--- a/Detectors/FIT/FT0/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FT0/workflow/CMakeLists.txt
@@ -98,6 +98,11 @@ o2_add_executable(recpoints-reader-workflow
                   COMPONENT_NAME ft0
                   PUBLIC_LINK_LIBRARIES O2::FT0Workflow)
 
+o2_add_executable(recpoints-writer-workflow
+                  SOURCES src/recpoints-writer-workflow.cxx
+                  COMPONENT_NAME ft0
+                  PUBLIC_LINK_LIBRARIES O2::FT0Workflow)
+
 o2_add_executable(integrate-cluster-workflow
                   SOURCES src/cluster-integrator.cxx
                   COMPONENT_NAME ft0

--- a/Detectors/FIT/FT0/workflow/src/recpoints-writer-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/recpoints-writer-workflow.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -9,27 +9,20 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file  recpoints-reader-workflow.cxx
-/// \brief FT0 RecPoints reader workflow
+/// \file  recpoints-writer-workflow.cxx
+/// \brief FT0 RecPoints writer workflow
 ///
-/// \author ruben.shahoyan@cern.ch, Andreas Molander andreas.molander@cern.ch
+/// \author Andreas Molander andreas.molander@cern.ch
 
 #include "CommonUtils/ConfigurableParam.h"
-#include "DetectorsRaw/HBFUtilsInitializer.h"
-#include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/Variant.h"
 
-#include "FT0Workflow/RecPointReaderSpec.h"
+#include "FT0Workflow/RecPointWriterSpec.h"
 
 #include <vector>
 
 using namespace o2::framework;
-
-void customize(std::vector<CallbacksPolicy>& policies)
-{
-  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
-}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -37,8 +30,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"disable-mc", VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
-  o2::raw::HBFUtilsInitializer::addConfigOption(options);
-  std::swap(workflowOptions, options);
+  workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
 
 #include "Framework/runDataProcessing.h"
@@ -49,10 +41,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   bool disableMC = ctx.options().get<bool>("disable-mc");
 
   WorkflowSpec specs;
-  DataProcessorSpec producer = o2::ft0::getRecPointReaderSpec(!disableMC);
+  DataProcessorSpec producer = o2::ft0::getRecPointWriterSpec(!disableMC);
   specs.push_back(producer);
-
-  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
-  o2::raw::HBFUtilsInitializer hbfIni(ctx, specs);
   return specs;
 }

--- a/Detectors/FIT/FV0/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FV0/workflow/CMakeLists.txt
@@ -53,6 +53,16 @@ o2_add_executable(flp-dpl-workflow
                   PUBLIC_LINK_LIBRARIES O2::FV0Workflow O2::FITWorkflow O2::FV0Raw
                   TARGETVARNAME fv0flpexe)
 
+o2_add_executable(recpoints-reader-workflow
+                  SOURCES src/recpoints-reader-workflow.cxx
+                  COMPONENT_NAME fv0
+                  PUBLIC_LINK_LIBRARIES O2::FV0Workflow)
+
+o2_add_executable(recpoints-writer-workflow
+                  SOURCES src/recpoints-writer-workflow.cxx
+                  COMPONENT_NAME fv0
+                  PUBLIC_LINK_LIBRARIES O2::FV0Workflow)
+
 o2_add_executable(integrate-cluster-workflow
                   SOURCES src/cluster-integrator.cxx
                   COMPONENT_NAME fv0

--- a/Detectors/FIT/FV0/workflow/src/recpoints-reader-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/recpoints-reader-workflow.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -10,9 +10,9 @@
 // or submit itself to any jurisdiction.
 
 /// \file  recpoints-reader-workflow.cxx
-/// \brief FT0 RecPoints reader workflow
+/// \brief FV0 RecPoints reader workflow
 ///
-/// \author ruben.shahoyan@cern.ch, Andreas Molander andreas.molander@cern.ch
+/// \author Andreas Molander andreas.molander@cern.ch
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
@@ -20,7 +20,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/Variant.h"
 
-#include "FT0Workflow/RecPointReaderSpec.h"
+#include "FV0Workflow/RecPointReaderSpec.h"
 
 #include <vector>
 
@@ -49,7 +49,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   bool disableMC = ctx.options().get<bool>("disable-mc");
 
   WorkflowSpec specs;
-  DataProcessorSpec producer = o2::ft0::getRecPointReaderSpec(!disableMC);
+  DataProcessorSpec producer = o2::fv0::getRecPointReaderSpec(!disableMC);
   specs.push_back(producer);
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit

--- a/Detectors/FIT/FV0/workflow/src/recpoints-writer-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/recpoints-writer-workflow.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -9,27 +9,20 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file  recpoints-reader-workflow.cxx
-/// \brief FT0 RecPoints reader workflow
+/// \file  recpoints-writer-workflow.cxx
+/// \brief FV0 RecPoints writer workflow
 ///
-/// \author ruben.shahoyan@cern.ch, Andreas Molander andreas.molander@cern.ch
+/// \author Andreas Molander andreas.molander@cern.ch
+
+#include "FV0Workflow/RecPointWriterSpec.h"
 
 #include "CommonUtils/ConfigurableParam.h"
-#include "DetectorsRaw/HBFUtilsInitializer.h"
-#include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/Variant.h"
-
-#include "FT0Workflow/RecPointReaderSpec.h"
 
 #include <vector>
 
 using namespace o2::framework;
-
-void customize(std::vector<CallbacksPolicy>& policies)
-{
-  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
-}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -37,8 +30,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"disable-mc", VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
-  o2::raw::HBFUtilsInitializer::addConfigOption(options);
-  std::swap(workflowOptions, options);
+  workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
 
 #include "Framework/runDataProcessing.h"
@@ -49,10 +41,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   bool disableMC = ctx.options().get<bool>("disable-mc");
 
   WorkflowSpec specs;
-  DataProcessorSpec producer = o2::ft0::getRecPointReaderSpec(!disableMC);
+  DataProcessorSpec producer = o2::fv0::getRecPointWriterSpec(!disableMC);
   specs.push_back(producer);
-
-  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
-  o2::raw::HBFUtilsInitializer hbfIni(ctx, specs);
   return specs;
 }

--- a/Detectors/FIT/macros/CMakeLists.txt
+++ b/Detectors/FIT/macros/CMakeLists.txt
@@ -40,5 +40,10 @@ o2_add_test_root_macro(readFITDCSdata.C
                                              O2::CCDB
                        LABELS fit)
 
+o2_add_test_root_macro(compareRecPoints.C
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
+                                             O2::DataFormatsFIT
+                       LABELS fit)
+
 o2_data_file(COPY readFITDCSdata.C DESTINATION Detectors/FIT/macros/)
 o2_data_file(COPY readFITDeadChannelMap.C DESTINATION Detectors/FIT/macros/)

--- a/Detectors/FIT/macros/compareRecPoints.C
+++ b/Detectors/FIT/macros/compareRecPoints.C
@@ -1,0 +1,110 @@
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file compareRecPoints.C
+/// \brief ROOT macro to compare two trees with RecPoints
+///
+/// \author Artur Furs artur.furs@cern.ch, Andreas Molander andreas.molander@cern.ch
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "DataFormatsFT0/RecPoints.h"
+#include "DataFormatsFV0/RecPoints.h"
+#include "DataFormatsFDD/RecPoint.h"
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <iostream>
+#endif
+
+void compareRecPoints(std::string filename1, std::string filename2)
+{
+  std::unique_ptr<TFile> file1(TFile::Open(filename1.c_str(), "READ"));
+  TTree* tree1 = (TTree*)file1->Get("o2sim");
+
+  std::unique_ptr<TFile> file2(TFile::Open(filename2.c_str(), "READ"));
+  TTree* tree2 = (TTree*)file2->Get("o2sim");
+
+  if (tree1->GetEntries() != tree2->GetEntries()) {
+    std::cout << "Non equal number of entries in trees!" << std::endl;
+    return;
+  }
+
+  typedef typename o2::ft0::RecPoints RecPoint;
+  typedef typename o2::ft0::ChannelDataFloat ChannelDataFloat;
+
+  std::vector<RecPoint> vecRecPoints1;
+  std::vector<RecPoint>* ptrVecRecPoints1 = &vecRecPoints1;
+
+  std::vector<ChannelDataFloat> vecChannelDataFloat1;
+  std::vector<ChannelDataFloat>* ptrVecChannelDataFloat1 = &vecChannelDataFloat1;
+
+  tree1->SetBranchAddress("FT0Cluster", &ptrVecRecPoints1);
+  tree1->SetBranchAddress("FT0RecChData", &ptrVecChannelDataFloat1);
+
+  std::vector<RecPoint> vecRecPoints2;
+  std::vector<RecPoint>* ptrVecRecPoints2 = &vecRecPoints2;
+
+  std::vector<ChannelDataFloat> vecChannelDataFloat2;
+  std::vector<ChannelDataFloat>* ptrVecChannelDataFloat2 = &vecChannelDataFloat2;
+
+  tree2->SetBranchAddress("FT0Cluster", &ptrVecRecPoints2);
+  tree2->SetBranchAddress("FT0RecChData", &ptrVecChannelDataFloat2);
+
+  for (int iEntry = 0; iEntry < tree1->GetEntries(); iEntry++) {
+    tree1->GetEntry(iEntry);
+    tree2->GetEntry(iEntry);
+
+    if (vecRecPoints1 != vecRecPoints2) {
+      std::cout << "Non equal RecPoints vector!" << std::endl;
+
+      if (vecRecPoints1.size() == vecRecPoints2.size()) {
+        for (int iEvent = 0; iEvent < vecRecPoints1.size(); iEvent++) {
+          const auto& recPoint1 = vecRecPoints1[iEvent];
+          const auto& recPoint2 = vecRecPoints2[iEvent];
+
+          if (!(recPoint1 == recPoint2)) {
+            std::cout << "First RecPoint" << std::endl;
+            recPoint1.print();
+            std::cout << "Second RecPoint" << std::endl;
+            recPoint2.print();
+          }
+        }
+      } else {
+        std::cout << "Non equal number of RecPoints!" << std::endl;
+      }
+    }
+    if (vecChannelDataFloat1 != vecChannelDataFloat2) {
+      std::cout << "Non equal ChannelDataFloat vector!" << std::endl;
+
+      if (vecChannelDataFloat1.size() == vecChannelDataFloat2.size()) {
+        for (int iEvent = 0; iEvent < vecChannelDataFloat1.size(); iEvent++) {
+          const auto& channelDataFloat1 = vecChannelDataFloat1[iEvent];
+          const auto& channelDataFloat2 = vecChannelDataFloat2[iEvent];
+
+          if (!(channelDataFloat1 == channelDataFloat2)) {
+            std::cout << "First ChannelDataFloat" << std::endl;
+            channelDataFloat1.print();
+            std::cout << "Second ChannelDataFloat" << std::endl;
+            channelDataFloat2.print();
+          }
+        }
+      } else {
+        std::cout << "Non equal number of ChannelDataFloat!" << std::endl;
+      }
+    }
+  }
+
+  return;
+}


### PR DESCRIPTION
The main purpose of the commit:
- Adding workflows for reading RecPoints for FV0 and FDD, these are needed for MC aQC

Secondary purposes that arose during development:
- ROOT macro for comparing two RecPoint files
- Workflows for writing RecPoints added for FT0, FV0 and FDD (i.e. simply standalone RecPoint writers, not related to reconstrucion)
- The two items above were needed to verify the new RecPoint reader workflows, namely by: reconstructing CTFs -> writing RecPoints to file -> Reading RecPoints from file -> Writing RecPoints to new file -> Comparing the two files
- Minor cosmetics (e.g. reordering of includes) and utility functions (print and == operator functions)