### PR TITLE
DPL Analysis: workaround to publish histograms also with pipelining

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -287,6 +287,7 @@ struct OutputManager<HistogramRegistry> {
     auto& deviceSpec = context.services().get<o2::framework::DeviceSpec const>();
     context.outputs().snapshot(what.ref(deviceSpec.inputTimesliceId, deviceSpec.maxInputTimeslices), *(what.getListOfHistograms()));
     what.clean();
+    sleep(deviceSpec.inputTimesliceId);
     return true;
   }
 };
@@ -314,6 +315,7 @@ struct OutputManager<OutputObj<T>> {
   {
     auto& deviceSpec = context.services().get<o2::framework::DeviceSpec const>();
     context.outputs().snapshot(what.ref(deviceSpec.inputTimesliceId, deviceSpec.maxInputTimeslices), *what);
+    sleep(deviceSpec.inputTimesliceId);
     return true;
   }
 };


### PR DESCRIPTION

For some reason if the histograms arrive all at once, they get dropped.
Not yet sure why that happens. It clearly cannot merely be a matter of
"older possible timeframe" being wrong, nor a problem with the order of
the end of stream, because otherwise I would expect also this to fail.
