### PR TITLE
[MCH] fix wire position on station 1

### DIFF
--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
@@ -70,6 +70,7 @@ class Response
   float inclandbfield(float thetawire, float betagamma, float bx) const;
 
  private:
+  Station mStation{};             ///< Station type
   MathiesonOriginal mMathieson{}; ///< Mathieson function
   float mPitch = 0.f;             ///< anode-cathode pitch (cm)
   float mChargeSlope = 0.f;       ///< charge slope used in E to charge conversion

--- a/Detectors/MUON/MCH/Simulation/src/Response.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Response.cxx
@@ -26,7 +26,7 @@
 using namespace o2::mch;
 
 //_____________________________________________________________________
-Response::Response(Station station)
+Response::Response(Station station) : mStation(station)
 {
   if (station == Station::Type1) {
     mMathieson.setPitch(ResponseParam::Instance().pitchSt1);
@@ -68,9 +68,9 @@ float Response::etocharge(float edepos) const
 //_____________________________________________________________________
 float Response::getAnod(float x) const
 {
-  int n = int(x / mPitch);
-  float wire = (x > 0) ? n + 0.5 : n - 0.5;
-  return wire * mPitch;
+  return (mStation == Station::Type1)
+           ? std::round(x / mPitch) * mPitch
+           : (std::floor(x / mPitch) + 0.5f) * mPitch;
 }
 
 //_____________________________________________________________________


### PR DESCRIPTION
The position of the anode wires in the local coordinate system of the quadrants of station 1 is different w.r.t. the other stations. For station 1, the origin of the system is on top of a wire, while it is shifted by half the pitch for the other stations.

I observed that by looking at the cluster charge asymmetry between the 2 cathodes as a function of the cluster position w.r.t. the closest wire. The pattern was inverted for station 1 w.r.t. other stations and w.r.t. the expected pattern.

I also checked with Christophe on a picture of an open quadrant of station 1. The position of the wires w.r.t. the center of the pads on the non-bending cathode was shifted by half the pitch in MC.

I checked that the effect is negligible on the efficiency and resolution in MC, although it has some effect on the number of pads fired, mostly on the non-bending cathode.
