### PR TITLE
Fix for PV contributor being AB track

### DIFF
--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1288,7 +1288,7 @@ class TPCTimeSeries : public Task
           // make cut around DCA to vertex due to gammas
           if ((std::abs(dcaITSTPCTmp[0]) < maxITSTPCDCAr_comb) && (std::abs(dcaITSTPCTmp[1]) < maxITSTPCDCAz_comb)) {
             // propagate TPC track to ITS track and store delta track parameters
-            if (track.rotate(tracksITS[idxITSTrack].getAlpha()) && propagator->propagateTo(track, trackITSTPCTmp.getX(), false, mMaxSnp, mFineStep, mMatType)) {
+            if (idxITSTrack >= 0 && track.rotate(tracksITS[idxITSTrack].getAlpha()) && propagator->propagateTo(track, trackITSTPCTmp.getX(), false, mMaxSnp, mFineStep, mMatType)) {
               o2::track::TrackPar trackITS(tracksITS[idxITSTrack]);
               const bool propITSOk = propagator->propagateTo(trackITS, trackITSTPCTmp.getX(), false, mMaxSnp, mFineStep, mMatType);
               if (propITSOk) {


### PR DESCRIPTION
@miranov25 @matthias-kleiner the TPCTimeSeriesSpec was crashing on the reconstruction with AB tracks allowed to use ITS IB layers (thus contributing to the PV). This trivial fix will treat them as regular PV contributors for what concerns DCA to PV but the difference between TPC and ITS tracks will be dummy.