### PR TITLE
[MCH] remove duplicates before uploading

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h
@@ -61,5 +61,13 @@ class DsChannelId
 
   ClassDefNV(DsChannelId, 1); // class for MCH readout channel
 };
+
+inline bool operator==(const DsChannelId& a, const DsChannelId& b) { return a.value() == b.value(); }
+inline bool operator!=(const DsChannelId& a, const DsChannelId& b) { return !(a == b); }
+inline bool operator<(const DsChannelId& a, const DsChannelId& b) { return a.value() < b.value(); }
+inline bool operator>(const DsChannelId& a, const DsChannelId& b) { return b < a; }
+inline bool operator<=(const DsChannelId& a, const DsChannelId& b) { return !(a > b); }
+inline bool operator>=(const DsChannelId& a, const DsChannelId& b) { return !(a < b); }
+
 } // namespace o2::mch
 #endif

--- a/Detectors/MUON/MCH/Conditions/src/bad-channels-ccdb.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/bad-channels-ccdb.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include <boost/program_options.hpp>
+#include <algorithm>
 #include <ctime>
 #include <fstream>
 #include <iterator>
@@ -209,9 +210,12 @@ void uploadBadChannels(const std::string ccdbUrl,
                        const std::string badChannelType,
                        uint64_t startTimestamp,
                        uint64_t endTimestamp,
-                       const BadChannelsVector& bv,
+                       BadChannelsVector& bv,
                        bool makeDefault)
 {
+  std::sort(bv.begin(), bv.end());
+  bv.erase(std::unique(bv.begin(), bv.end()), bv.end());
+
   std::cout << std::endl;
   o2::ccdb::CcdbApi api;
   api.init(ccdbUrl);


### PR DESCRIPTION
The RejectList can be filled in different ways (excluding DS, Solar, DE, HV/LV DCS alias) that can be combined, which may result in rejecting several times the same channel. It's not a problem when using it in the digit filtering, but it's a waste of lookup time and storage in the CCDB. This PR ensures each channel appears only once.
