### PR TITLE
MCH: enable mapping fixes in ASYNC mode

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -142,6 +142,10 @@ else
   elif [[ $BEAMTYPE == "PbPb" ]]; then
     ITS_CONFIG_KEY+="ITSVertexerParam.lowMultBeamDistCut=0;ITSCATrackerParam.nROFsPerIterations=12;ITSCATrackerParam.perPrimaryVertexProcessing=true;"
   fi
+
+  if [[ $IS_SIMULATED_DATA == 0 && $CTFINPUT == 1 ]]; then # Enable fixes to the MCH readout mapping for async processing of real data
+    MCH_CONFIG_KEY+="MCHDigitModifier.updateST1=true;MCHDigitModifier.updateST2=true;"
+  fi
 fi
 [[ $CTFINPUT == 1 ]] && GPU_CONFIG_KEY+="GPU_proc.tpcInputWithClusterRejection=1;"
 [[ ! -z $NTRDTRKTHREADS ]] && TRD_CONFIG_KEY+="GPU_proc.ompThreads=$NTRDTRKTHREADS;"


### PR DESCRIPTION
The `MCHDigitModifier.updateST1=true` and `MCHDigitModifier.updateST2=true` options are added to the MCH reco workflow for the ASYNC processing of real data.
This enables the code that fixes the readout mapping in existing CTFs for some parts of ST1 and ST2 detectors.

The mapping has also been corrected in the O2 code. Therefore the remapping is disabled for SYNC processing and MC simulations, since they already apply the correct mapping to generate the digits.