### PR TITLE
Semaphore distinction in CCDB

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1461,7 +1461,7 @@ std::map<std::string, std::string> CcdbApi::retrieveHeaders(std::string const& p
 
   if (!mSnapshotCachePath.empty()) {
     // protect this sensitive section by a multi-process named semaphore
-    auto semaphore_barrier = std::make_unique<CCDBSemaphore>(mSnapshotCachePath, path);
+    auto semaphore_barrier = std::make_unique<CCDBSemaphore>(mSnapshotCachePath + std::string("_headers"), path);
 
     std::string logfile = mSnapshotCachePath + "/log";
     std::fstream out(logfile, ios_base::out | ios_base::app);


### PR DESCRIPTION
Use different semaphores when retrieving headers vs snapshotting the blob.

Otherwise there seems to be a funny overlap in actions and snapshotting was not really protected.

Fixes: https://its.cern.ch/jira/browse/O2-5834