### PR TITLE
DPL: provide defaults for inputs and outputs

### DIFF
--- a/Framework/Core/include/Framework/DataProcessorSpec.h
+++ b/Framework/Core/include/Framework/DataProcessorSpec.h
@@ -40,8 +40,8 @@ struct DataProcessorMetadata {
 
 struct DataProcessorSpec {
   std::string name;
-  Inputs inputs;
-  Outputs outputs;
+  Inputs inputs = {};
+  Outputs outputs = {};
   AlgorithmSpec algorithm;
 
   Options options = {};


### PR DESCRIPTION

Silence a bunch of warnings when using aggregate initialization.
