### PR TITLE
Fix scaling ITS CA tracker params for low Bfield

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -120,17 +120,15 @@ void ITSTrackingInterface::initialise()
   for (auto& params : trackParams) {
     params.CorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT;
   }
-
   // adjust pT settings to actual mag. field
   for (size_t ip = 0; ip < trackParams.size(); ip++) {
     auto& param = trackParams[ip];
+    param.TrackletMinPt *= bFactor;
     for (int ilg = trackConf.MaxTrackLenght; ilg >= trackConf.MinTrackLenght; ilg--) {
       int lslot = trackConf.MaxTrackLenght - ilg;
       param.MinPt[lslot] *= bFactor;
-      param.TrackletMinPt *= bFactor;
     }
   }
-
   mTracker->setParameters(trackParams);
   mVertexer->setParameters(vertParams);
 }

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -22,7 +22,7 @@
 #include "ITStracking/Cell.h"
 #include "CommonConstants/MathConstants.h"
 
-#ifdef CA_DEBUG
+#if defined(CA_DEBUG) && !defined(GPUCA_GPUCODE_DEVICE)
 #include <cstdio>
 #endif
 


### PR DESCRIPTION
The [problem](https://its.cern.ch/jira/browse/O2-5777?focusedId=6707228&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6707228) of missing ITS tracks in the low B-field run was due to the excessive application (in the unrelated loop) of the scaling factor `<1` (real_field/5kG) to `param.TrackletMinPt`, leading to `param.TrackletMinPt~0`. 
This PR fixes it by applying the factor only once, leading to improved reconstruction (compared to no scaling, red and blue on the plot below).

![ITSlowField](https://github.com/user-attachments/assets/c48500e3-cd9e-4520-a202-71965eec2733)

@mpuccio still, it is not clear why setting the `param.TrackletMinPt` close to 0 leads to the loss of tracks. I guess it is related to lines https://github.com/AliceO2Group/AliceO2/blob/a8f75744fd7d4078a834ff71891cf306937c8c86/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx#L419-L421, but not sure why.