### PR TITLE
GPU ITS: Fix broken initialisation + cleanup

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -56,13 +56,13 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
 struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerParamConfig> {
   // Use TGeo for mat. budget
   static const int MaxIter = 4;
-  static const int MinTrackLenght = 4;
-  static const int MaxTrackLenght = 7;
+  static const int MinTrackLength = 4;
+  static const int MaxTrackLength = 7;
   bool useMatCorrTGeo = false;  // use full geometry to corect for material budget accounting in the fits. Default is to use the material budget LUT.
   bool useFastMaterial = false; // use faster material approximation for material budget accounting in the fits.
   int deltaRof = 0;             // configure the width of the window in ROFs to be considered for the tracking.
   int minTrackLgtIter[MaxIter] = {};                                        // minimum track length at each iteration, used only if >0, otherwise use code defaults
-  float minPtIterLgt[MaxIter * (MaxTrackLenght - MinTrackLenght + 1)] = {}; // min.pT for given track length at this iteration, used only if >0, otherwise use code defaults
+  float minPtIterLgt[MaxIter * (MaxTrackLength - MinTrackLength + 1)] = {}; // min.pT for given track length at this iteration, used only if >0, otherwise use code defaults
   float sysErrY2[7] = {0};      // systematic error^2 in Y per layer
   float sysErrZ2[7] = {0};      // systematic error^2 in Z per layer
   float maxChi2ClusterAttachment = -1.f;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -81,8 +81,8 @@ void ITSTrackingInterface::initialise()
         if (trackConf.minTrackLgtIter[ip] > 0) {
           param.MinTrackLength = trackConf.minTrackLgtIter[ip];
         }
-        for (int ilg = trackConf.MaxTrackLenght; ilg >= trackConf.MinTrackLenght; ilg--) {
-          int lslot0 = (trackConf.MaxTrackLenght - ilg), lslot = lslot0 + ip * (trackConf.MaxTrackLenght - trackConf.MinTrackLenght + 1);
+        for (int ilg = trackConf.MaxTrackLength; ilg >= trackConf.MinTrackLength; ilg--) {
+          int lslot0 = (trackConf.MaxTrackLength - ilg), lslot = lslot0 + ip * (trackConf.MaxTrackLength - trackConf.MinTrackLength + 1);
           if (trackConf.minPtIterLgt[lslot] > 0.) {
             param.MinPt[lslot0] = trackConf.minPtIterLgt[lslot];
           }
@@ -127,8 +127,8 @@ void ITSTrackingInterface::initialise()
   for (size_t ip = 0; ip < trackParams.size(); ip++) {
     auto& param = trackParams[ip];
     param.TrackletMinPt *= bFactor;
-    for (int ilg = trackConf.MaxTrackLenght; ilg >= trackConf.MinTrackLenght; ilg--) {
-      int lslot = trackConf.MaxTrackLenght - ilg;
+    for (int ilg = trackConf.MaxTrackLength; ilg >= trackConf.MinTrackLength; ilg--) {
+      int lslot = trackConf.MaxTrackLength - ilg;
       param.MinPt[lslot] *= bFactor;
     }
   }
@@ -384,7 +384,7 @@ void ITSTrackingInterface::updateTimeDependentParams(framework::ProcessingContex
     geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot, o2::math_utils::TransformType::T2G));
     initialise();
     getConfiguration(pc);
-    //
+
     if (pc.services().get<const o2::framework::DeviceSpec>().inputTimesliceId == 0) { // print settings only for the 1st pipeling
       o2::its::VertexerParamConfig::Instance().printKeyValues();
       o2::its::TrackerParamConfig::Instance().printKeyValues();

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -44,7 +44,6 @@ void TrackerDPL::init(InitContext& ic)
   mITSTrackingInterface.setTraitsFromProvider(mChainITS->GetITSVertexerTraits(),
                                               mChainITS->GetITSTrackerTraits(),
                                               mChainITS->GetITSTimeframe());
-  //  mITSTrackingInterface.initialise() will be called from the ITSTrackingInterface::updateTimeDependentParams at 1st initialization since it needs some run conditions
 }
 
 void TrackerDPL::stop()

--- a/GPU/Workflow/src/GPUWorkflowITS.cxx
+++ b/GPU/Workflow/src/GPUWorkflowITS.cxx
@@ -40,7 +40,6 @@ void GPURecoWorkflowSpec::initFunctionITS(o2::framework::InitContext& ic)
                                                                           mSpecConfig.itsOverrBeamEst);
   mGPUReco->GetITSTraits(trkTraits, vtxTraits, mITSTimeFrame);
   mITSTrackingInterface->setTraitsFromProvider(vtxTraits, trkTraits, mITSTimeFrame);
-  mITSTrackingInterface->initialise();
 }
 
 void GPURecoWorkflowSpec::finaliseCCDBITS(o2::framework::ConcreteDataMatcher& matcher, void* obj)


### PR DESCRIPTION
Fix ITS GPU, broken since: https://github.com/AliceO2Group/AliceO2/pull/13968

@shahor02: I fixed a typo in the naming of the new configurable params.
I checked in O2DPG they are unused, as the defaults values are also the production one.
Let me know if this is not trivial to merge.