### PR TITLE
Fix round-robin reading in DigitizationContext::retrieveHits

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -218,6 +218,10 @@ inline void DigitizationContext::retrieveHits(std::vector<TChain*> const& chains
     return;
   }
   br->SetAddress(&hits);
+  auto maxEntries = br->GetEntries();
+  if (maxEntries) {
+    entryID %= maxEntries;
+  }
   br->GetEntry(entryID);
 }
 


### PR DESCRIPTION
Fixes [problem](https://its.cern.ch/jira/browse/O2-5861) of missing QED hits.

The ITS clusters per chip before and after the fix:

![nclITSQEDFix](https://github.com/user-attachments/assets/4876cbed-80ff-4200-b89f-caefb39308fd)
