### PR TITLE
FIT: Geometry alignment macros

### DIFF
--- a/Detectors/FIT/FT0/macros/FT0Misaligner.C
+++ b/Detectors/FIT/FT0/macros/FT0Misaligner.C
@@ -1,15 +1,30 @@
+// Copyright 2021-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  FT0Misaligner.C
+/// \brief ROOT macro for creating an FT0 geometry alignment object. Based on ITSMisaligner.C
+///
+/// \author Andreas Molander andreas.molander@cern.ch, Alla Maevskaya
+
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-//#define ENABLE_UPGRADES
+
+#include "CCDB/CcdbApi.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 #include "DetectorsCommonDataFormats/AlignParam.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "CCDB/CcdbApi.h"
-#include "FT0Base/Geometry.h"
-#include <TRandom.h>
+
 #include <TFile.h>
 #include <vector>
 #include <fmt/format.h>
+
 #endif
 
 using AlgPar = std::array<double, 6>;
@@ -23,19 +38,15 @@ void FT0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
                    const std::string& fileName = "FT0Alignment.root")
 {
   std::vector<o2::detectors::AlignParam> params;
-  o2::base::GeometryManager::loadGeometry("", false);
-  //  auto geom = o2::ft0::Geometry::Instance();
   AlgPar pars;
   bool glo = true;
 
   o2::detectors::DetID detFT0("FT0");
 
-  // FT0 detector
-  //set A side
   std::string symNameA = "FT0A";
   pars = generateMisalignment(xA, yA, zA, psiA, thetaA, phiA);
   params.emplace_back(symNameA.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
-  //set C side
+
   std::string symNameC = "FT0C";
   pars = generateMisalignment(xC, yC, zC, psiC, thetaC, phiC);
   params.emplace_back(symNameC.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
@@ -57,14 +68,15 @@ void FT0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
     algFile.Close();
   }
 }
+
 AlgPar generateMisalignment(double x, double y, double z, double psi, double theta, double phi)
 {
   AlgPar pars;
-  pars[0] = gRandom->Gaus(0, x);
-  pars[1] = gRandom->Gaus(0, y);
-  pars[2] = gRandom->Gaus(0, z);
-  pars[3] = gRandom->Gaus(0, psi);
-  pars[4] = gRandom->Gaus(0, theta);
-  pars[5] = gRandom->Gaus(0, phi);
+  pars[0] = x;
+  pars[1] = y;
+  pars[2] = z;
+  pars[3] = psi;
+  pars[4] = theta;
+  pars[5] = phi;
   return std::move(pars);
 }

--- a/Detectors/FIT/FV0/base/include/FV0Base/Geometry.h
+++ b/Detectors/FIT/FV0/base/include/FV0Base/Geometry.h
@@ -133,6 +133,16 @@ class Geometry
     return o2::base::GeometryManager::getPNEntry(getDetID(), index);
   }
 
+  static std::string getDetectorRightSymName()
+  {
+    return sDetectorRightName + "_0";
+  }
+
+  static std::string getDetectorLeftSymName()
+  {
+    return sDetectorLeftName + "_1";
+  }
+
   /// Get the density of the PMTs.
   static constexpr float getPmtDensity()
   {
@@ -143,6 +153,8 @@ class Geometry
   explicit Geometry(EGeoType initType);
 
   inline static const std::string sDetectorName = "FV0";
+  inline static const std::string sDetectorRightName = sDetectorName + "RIGHT";
+  inline static const std::string sDetectorLeftName = sDetectorName + "LEFT";
 
   // General geometry constants
   static constexpr float sEpsilon = 0.01;     ///< Used to make one spatial dimension infinitesimally larger than other

--- a/Detectors/FIT/FV0/macros/FV0Misaligner.C
+++ b/Detectors/FIT/FV0/macros/FV0Misaligner.C
@@ -1,13 +1,32 @@
+// Copyright 2021-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  FV0Misaligner.C
+/// \brief ROOT macro for creating an FV0 geometry alignment object. The alignment object will align both
+///        detector halves in the same way. Based on ITSMisaligner.C
+///
+/// \author Andreas Molander andreas.molander@cern.ch, Alla Maevskaya
+
 #if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include "CCDB/CcdbApi.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 #include "DetectorsCommonDataFormats/AlignParam.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "CCDB/CcdbApi.h"
-#include <TRandom.h>
+#include "FV0Base/Geometry.h"
+
 #include <TFile.h>
 #include <vector>
 #include <fmt/format.h>
+
 #endif
 
 using AlgPar = std::array<double, 6>;
@@ -20,16 +39,14 @@ void FV0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
                    const std::string& fileName = "FV0Alignment.root")
 {
   std::vector<o2::detectors::AlignParam> params;
-  o2::base::GeometryManager::loadGeometry("", false);
   AlgPar pars;
   bool glo = true;
 
   o2::detectors::DetID detFV0("FV0");
 
-  // FV0 detector
-  for (int ihalf = 1; ihalf < 3; ihalf++) {
-    std::string symName = Form("FV0half_%i", ihalf);
-    pars = generateMisalignment(x, y, z, psi, theta, phi);
+  pars = generateMisalignment(x, y, z, psi, theta, phi);
+
+  for (auto& symName : {o2::fv0::Geometry::getDetectorRightSymName(), o2::fv0::Geometry::getDetectorLeftSymName()}) {
     params.emplace_back(symName.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
   }
 
@@ -50,14 +67,15 @@ void FV0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
     algFile.Close();
   }
 }
+
 AlgPar generateMisalignment(double x, double y, double z, double psi, double theta, double phi)
 {
   AlgPar pars;
-  pars[0] = gRandom->Gaus(0, x);
-  pars[1] = gRandom->Gaus(0, y);
-  pars[2] = gRandom->Gaus(0, z);
-  pars[3] = gRandom->Gaus(0, psi);
-  pars[4] = gRandom->Gaus(0, theta);
-  pars[5] = gRandom->Gaus(0, phi);
+  pars[0] = x;
+  pars[1] = y;
+  pars[2] = z;
+  pars[3] = psi;
+  pars[4] = theta;
+  pars[5] = phi;
   return std::move(pars);
 }

--- a/Detectors/FIT/FV0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Detector.cxx
@@ -280,6 +280,7 @@ void Detector::ConstructGeometry()
   // mGeometry->enableComponent(Geometry::eAluminiumContainer, false);
   mGeometry->buildGeometry();
 }
+
 void Detector::addAlignableVolumes() const
 {
   //
@@ -292,19 +293,19 @@ void Detector::addAlignableVolumes() const
   LOG(info) << "FV0: Add alignable volumes";
 
   if (!gGeoManager) {
-    LOG(fatal) << "TGeoManager doesn't exist !";
+    LOG(fatal) << "TGeoManager doesn't exist!";
     return;
   }
 
-  TString volPath, symName;
-  for (auto& half : {"RIGHT_0", "LEFT_1"}) {
-    volPath = Form("/cave_1/barrel_1/FV0_1/FV0%s", half);
-    symName = Form("FV0%s", half);
-    LOG(info) << "FV0: Add alignable volume: " << symName << ": " << volPath;
-    if (!gGeoManager->SetAlignableEntry(symName.Data(), volPath.Data())) {
-      LOG(fatal) << "FV0: Unable to set alignable entry! " << symName << ": " << volPath;
+  auto addAlignabelVolume = [](const std::string& volPath, const std::string& symName) -> void {
+    LOG(info) << "FV0: Add alignable volume: " << symName << " <-> " << volPath;
+    if (!gGeoManager->SetAlignableEntry(symName.c_str(), volPath.c_str())) {
+      LOG(fatal) << "FV0: Unable to set alignable entry! " << symName << " <-> " << volPath;
     }
-  }
+  };
+
+  addAlignabelVolume("/cave_1/barrel_1/FV0_1/FV0RIGHT_0", Geometry::getDetectorRightSymName());
+  addAlignabelVolume("/cave_1/barrel_1/FV0_1/FV0LEFT_1", Geometry::getDetectorLeftSymName());
 }
 
 o2::fv0::Hit* Detector::addHit(Int_t trackId, Int_t cellId,

--- a/Detectors/FIT/macros/CMakeLists.txt
+++ b/Detectors/FIT/macros/CMakeLists.txt
@@ -45,5 +45,9 @@ o2_add_test_root_macro(compareRecPoints.C
                                              O2::DataFormatsFIT
                        LABELS fit)
 
+o2_add_test_root_macro(readAlignParam.C
+                       PUBLIC_LINK_LIBRARIES O2::CCDB
+                       LABELS fit)
+
 o2_data_file(COPY readFITDCSdata.C DESTINATION Detectors/FIT/macros/)
 o2_data_file(COPY readFITDeadChannelMap.C DESTINATION Detectors/FIT/macros/)

--- a/Detectors/FIT/macros/readAlignParam.C
+++ b/Detectors/FIT/macros/readAlignParam.C
@@ -1,0 +1,51 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  readAlignParam.C
+/// \brief ROOT macro for reading geometry alignment parameters
+///
+/// \author Andreas Molander <andreas.molander@cern.ch>
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include "CCDB/BasicCCDBManager.h"
+#include "DetectorsCommonDataFormats/AlignParam.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsCommonDataFormats/DetectorNameConf.h"
+
+#include <string>
+#include <vector>
+
+#endif
+
+int readAlignParam(const std::string& detectorName = "FT0",
+                   long timestamp = -1,
+                   const std::string& ccdbUrl = "https://alice-ccdb.cern.ch")
+{
+  o2::ccdb::BasicCCDBManager& ccdbManager = o2::ccdb::BasicCCDBManager::instance();
+  ccdbManager.setURL(ccdbUrl);
+  ccdbManager.setTimestamp(timestamp);
+
+  const o2::detectors::DetID detID(detectorName.c_str());
+  const std::string alignmentPath = o2::base::DetectorNameConf::getAlignmentPath(detID);
+  const auto alignments = ccdbManager.get<std::vector<o2::detectors::AlignParam>>(alignmentPath);
+
+  if (!alignments) {
+    std::cerr << "No alignment parameters found at " << alignmentPath << std::endl;
+    return 1;
+  }
+
+  for (auto alignment : *alignments) {
+    alignment.print();
+  }
+
+  return 0;
+}

--- a/Detectors/FIT/macros/readFT0hits.C
+++ b/Detectors/FIT/macros/readFT0hits.C
@@ -1,12 +1,28 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include "DataFormatsFIT/Triggers.h"
 #include "DataFormatsFT0/Digit.h"
 #include "DataFormatsFT0/HitType.h"
 #include "SimulationDataFormat/MCEventHeader.h"
 #include <TFile.h>
+#include <TH1F.h>
 #include <TH2F.h>
 #include <TTree.h>
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
+
+#endif
 
 void readFT0hits()
 {
@@ -24,6 +40,8 @@ void readFT0hits()
   TH2F* hPel = new TH2F("hPelDig", "N p.e. ", 220, 0, 220, 500, 0, 10000);
   TH2F* hXYA = new TH2F("hXYA", "X vs Y A side", 400, -20, 20, 400, -20, 20);
   TH2F* hXYC = new TH2F("hXYC", "X vs Y C side", 400, -20, 20, 400, -20, 20);
+  TH1F* hZA = new TH1F("hZA", "Z A side", 200, 330, 340);
+  TH1F* hZC = new TH1F("hZC", "Z C side", 200, -90, -80);
 
   gDirectory = cwd;
 
@@ -59,10 +77,13 @@ void readFT0hits()
       hTimeHitA->Fill(detID, hit_time[detID] - 11.04);
       hTimeHitC->Fill(detID, hit_time[detID] - 2.91);
       countE[detID]++;
-      if (detID < 96)
+      if (detID < 96) {
         hXYA->Fill(hit.GetX(), hit.GetY());
-      if (detID > 95)
+        hZA->Fill(hit.GetZ());
+      } else {
         hXYC->Fill(hit.GetX(), hit.GetY());
+        hZC->Fill(hit.GetZ());
+      }
     }
     for (int ii = 0; ii < 220; ii++) {
       if (countE[ii] > 100) {
@@ -82,6 +103,6 @@ void readFT0hits()
   hMultHit->Write();
   hXYA->Write();
   hXYC->Write();
-
+  hZA->Write();
+  hZC->Write();
 } // end of macro
-#endif

--- a/Detectors/FIT/macros/readFV0hits.C
+++ b/Detectors/FIT/macros/readFV0hits.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 
 #include <TFile.h>
@@ -21,6 +32,8 @@
 #include <fairlogger/Logger.h>
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 #include "DetectorsCommonDataFormats/DetID.h"
+
+#endif
 
 void AdjustStatBox(TH1* h, float x1ndc, float x2ndc, float y1ndc, float y2ndc)
 {
@@ -54,6 +67,9 @@ void InitHistoNames(std::vector<std::string>& vhName, std::vector<int>& vPdg)
   vhName.push_back("hElossDet");
   vhName.push_back("hEtotVsR");
   vhName.push_back("hEtotVsEloss");
+  vhName.push_back("hXY");
+  vhName.push_back("hXYzoom");
+  vhName.push_back("hZ");
 
   for (UInt_t ipdg = 0; ipdg < vPdg.size(); ipdg++) {
     std::stringstream ss;
@@ -63,7 +79,7 @@ void InitHistoNames(std::vector<std::string>& vhName, std::vector<int>& vPdg)
   }
 }
 
-void readFV0Hits(std::string simPrefix = "o2sim", UInt_t rebin = 1)
+void readFV0hits(std::string simPrefix = "o2sim", UInt_t rebin = 1)
 {
   using namespace o2::detectors;
   std::string simFName(o2::base::DetectorNameConf::getHitsFileName(DetID::FV0, simPrefix));
@@ -85,6 +101,9 @@ void readFV0Hits(std::string simPrefix = "o2sim", UInt_t rebin = 1)
   TH2F* hElossDet = new TH2F(vHistoNames.at(8).c_str(), "", nEl, 0, el1, nCells, 0, nCells);
   TH2F* hEtotVsR = new TH2F(vHistoNames.at(9).c_str(), "", 30000, 0, 300, 80, 0, 80);
   TH2F* hEtotVsEloss = new TH2F(vHistoNames.at(10).c_str(), "", 30000, 0, 300, nEl, 0, el1);
+  TH2F* hXY = new TH2F(vHistoNames.at(11).c_str(), "", 200, -100, 100, 200, -100, 100);
+  TH2F* hXYzoom = new TH2F(vHistoNames.at(12).c_str(), "", 200, -20, 20, 200, -20, 20);
+  TH1F* hZ = new TH1F(vHistoNames.at(13).c_str(), "", 200, 315, 325);
 
   // Setup histo properties
   hElossDet->SetXTitle("Energy loss [MeV]");
@@ -96,6 +115,14 @@ void readFV0Hits(std::string simPrefix = "o2sim", UInt_t rebin = 1)
   hEtotVsEloss->SetXTitle("Total energy at entrance [MeV]");
   hEtotVsEloss->SetYTitle("Energy loss [MeV]");
   hEtotVsEloss->SetZTitle("Counts");
+  hXY->SetXTitle("X [cm]");
+  hXY->SetYTitle("Y [cm]");
+  hXY->SetZTitle("Counts");
+  hXYzoom->SetXTitle("X [cm]");
+  hXYzoom->SetYTitle("Y [cm]");
+  hXYzoom->SetZTitle("Counts");
+  hZ->SetXTitle("Hit Z-coordinate [cm]");
+  hZ->SetYTitle("Counts");
   for (UInt_t ih = 0; ih < vhElossVsDistance.size(); ih++) {
     TH2F* h = vhElossVsDistance.at(ih);
     std::stringstream ss;
@@ -124,6 +151,9 @@ void readFV0Hits(std::string simPrefix = "o2sim", UInt_t rebin = 1)
   vh.push_back(hEtotVsEloss);
   vh.insert(vh.end(), vhElossVsDistance.begin(), vhElossVsDistance.end());
   vh.insert(vh.end(), vhElossVsEtot.begin(), vhElossVsEtot.end());
+  vh.push_back(hXY);
+  vh.push_back(hXYzoom);
+  vh.push_back(hZ);
   for (UInt_t ih = 0; ih < vh.size(); ih++) {
     vh[ih]->SetDirectory(0);
     vh[ih]->GetXaxis()->SetTitleSize(fontsize);
@@ -177,6 +207,9 @@ void readFV0Hits(std::string simPrefix = "o2sim", UInt_t rebin = 1)
         vhElossVsDistance.at(vhElossVsDistance.size() - 1)->Fill(hit->GetEnergyLoss() * 1e3, distance);
         vhElossVsEtot.at(vhElossVsEtot.size() - 1)->Fill(hit->GetEnergyLoss() * 1e3, hit->GetTotalEnergyAtEntrance() * 1e3);
       }
+      hXY->Fill(hit->GetX(), hit->GetY());
+      hXYzoom->Fill(hit->GetX(), hit->GetY());
+      hZ->Fill(hit->GetZ());
     }
   }
 
@@ -323,5 +356,3 @@ int compareFV0Hits(std::string simFName1 = "fv0hit-rawhistos.root", std::string 
   }
   return 0;
 }
-
-#endif


### PR DESCRIPTION
- Make misalignment macros usable for creating exact misalignments
- Add macro for reading misalignments from CCDB
- Add a couple of plots to hit reading marcos (needed to verify misalignments)
- Minor change to FV0 geometry to provoding symbolic names of alignable volumes