### PR TITLE
DPL: cleanup creation of DataProcessorInfo

### DIFF
--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -73,7 +73,6 @@ DataProcessorSpec getSourceSpec()
 {
   static_assert(enable_root_serialization<o2::test::Polymorphic>::value, "enable_root_serialization<o2::test::Polymorphic> must be true");
   auto processingFct = [](ProcessingContext& pc) {
-    static int counter = 0;
     o2::test::TriviallyCopyable a(42, 23, 0xdead);
     o2::test::Polymorphic b(0xbeef);
     std::vector<o2::test::Polymorphic> c{{0xaffe}, {0xd00f}};

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -16,7 +16,6 @@
 #include "Framework/DriverConfig.h"
 #include "../src/DeviceSpecHelpers.h"
 #include <catch_amalgamated.hpp>
-#include <algorithm>
 #include <sstream>
 #include <cstring>
 #include <vector>
@@ -67,10 +66,10 @@ void check(const std::vector<std::string>& arguments,
   std::vector<DataProcessorInfo> dataProcessorInfos;
   for (auto& [name, _] : matrix) {
     dataProcessorInfos.push_back(DataProcessorInfo{
-      name,
-      "executable-name",
-      arguments,
-      workflowOptions,
+      .name = name,
+      .executable = "executable-name",
+      .cmdLineArgs = arguments,
+      .workflowOptions = workflowOptions,
     });
   }
   DriverConfig driverConfig{};
@@ -184,7 +183,7 @@ TEST_CASE("CheckOptionReworking")
 {
   {
     std::vector<DataProcessorInfo> infos = {
-      {{}, {}, {"--driver-client-backend", "foo"}},
+      {.cmdLineArgs = {"--driver-client-backend", "foo"}},
       {}};
     DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
     REQUIRE(infos[0].cmdLineArgs[1] == "foo");
@@ -192,30 +191,30 @@ TEST_CASE("CheckOptionReworking")
   }
   {
     std::vector<DataProcessorInfo> infos = {
-      {{}, {}, {"--driver-client-backend", "foo"}},
-      {{}, {}, {"--driver-client-backend", "bar"}}};
+      {.cmdLineArgs = {"--driver-client-backend", "foo"}},
+      {.cmdLineArgs = {"--driver-client-backend", "bar"}}};
     REQUIRE_THROWS_AS(DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://"), o2::framework::RuntimeErrorRef);
   }
   {
     std::vector<DataProcessorInfo> infos = {
-      {{}, {}, {"--driver-client-backend", "foo"}},
-      {{}, {}, {"--driver-client-backend", "foo"}}};
+      {.cmdLineArgs = {"--driver-client-backend", "foo"}},
+      {.cmdLineArgs = {"--driver-client-backend", "foo"}}};
     DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
     REQUIRE(infos[0].cmdLineArgs[1] == "foo");
     REQUIRE(infos[1].cmdLineArgs[1] == "foo");
   }
   {
     std::vector<DataProcessorInfo> infos = {
-      {{}, {}, {"foo", "bar"}},
-      {{}, {}, {"fnjcnak", "foo"}}};
+      {.cmdLineArgs = {"foo", "bar"}},
+      {.cmdLineArgs = {"fnjcnak", "foo"}}};
     DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
     REQUIRE(infos[0].cmdLineArgs[3] == "stdout://");
     REQUIRE(infos[1].cmdLineArgs[3] == "stdout://");
   }
   {
     std::vector<DataProcessorInfo> infos = {
-      {{}, {}, {"foo", "bar", "--driver-client-backend", "bar"}},
-      {{}, {}, {"fnjcnak", "foo"}}};
+      {.cmdLineArgs = {"foo", "bar", "--driver-client-backend", "bar"}},
+      {.cmdLineArgs = {"fnjcnak", "foo"}}};
     DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
     REQUIRE(infos[0].cmdLineArgs[3] == "bar");
     REQUIRE(infos[1].cmdLineArgs[3] == "bar");
@@ -277,8 +276,8 @@ TEST_CASE("CheckIntegerReworking")
   }
   {
     std::vector<DataProcessorInfo> infos = {
-      {{}, {}, {"foo", "bar", "--readers", "3"}},
-      {{}, {}, {"--readers", "2"}}};
+      {.cmdLineArgs = {"foo", "bar", "--readers", "3"}},
+      {.cmdLineArgs = {"--readers", "2"}}};
     DeviceSpecHelpers::reworkIntegerOption(
       infos, "--readers", []() { return 1; }, 1, [](long long x, long long y) { return x > y ? x : y; });
     REQUIRE(infos[0].cmdLineArgs.size() == 4);

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -142,10 +142,10 @@ TEST_CASE("TestDDS")
 
   std::vector<DataProcessorInfo> dataProcessorInfos = {
     {
-      {"A", "bcsadc/foo", {}, workflowOptions},
-      {"B", "foo", {}, workflowOptions},
-      {"C", "foo", {}, workflowOptions},
-      {"D", "foo", {}, workflowOptions},
+      {.name = "A", .executable = "bcsadc/foo", .workflowOptions = workflowOptions},
+      {.name = "B", .executable = "foo", .workflowOptions = workflowOptions},
+      {.name = "C", .executable = "foo", .workflowOptions = workflowOptions},
+      {.name = "D", .executable = "foo", .workflowOptions = workflowOptions},
     }};
   DriverConfig driverConfig = {
     .batch = true,
@@ -406,10 +406,10 @@ TEST_CASE("TestDDSExpendable")
 
   std::vector<DataProcessorInfo> dataProcessorInfos = {
     {
-      {"A", "bcsadc/foo", {}, workflowOptions},
-      {"B", "foo", {}, workflowOptions},
-      {"C", "foo", {}, workflowOptions},
-      {"D", "foo", {}, workflowOptions},
+      {.name = "A", .executable = "bcsadc/foo", .workflowOptions = workflowOptions},
+      {.name = "B", .executable = "foo", .workflowOptions = workflowOptions},
+      {.name = "C", .executable = "foo", .workflowOptions = workflowOptions},
+      {.name = "D", .executable = "foo", .workflowOptions = workflowOptions},
     }};
   DriverConfig driverConfig = {
     .batch = true,

--- a/Framework/Core/test/test_FrameworkDataFlowToO2Control.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToO2Control.cxx
@@ -561,10 +561,10 @@ TEST_CASE("TestO2ControlDump")
 
   std::vector<DataProcessorInfo> dataProcessorInfos = {
     {
-      {"A", "bcsadc/foo", {}, workflowOptions},
-      {"B", "foo", {}, workflowOptions},
-      {"C", "foo", {}, workflowOptions},
-      {"D", "foo", {}, workflowOptions},
+      {.name = "A", .executable = "bcsadc/foo", .workflowOptions = workflowOptions},
+      {.name = "B", .executable = "foo", .workflowOptions = workflowOptions},
+      {.name = "C", .executable = "foo", .workflowOptions = workflowOptions},
+      {.name = "D", .executable = "foo", .workflowOptions = workflowOptions},
     }};
 
   DriverConfig driverConfig{

--- a/Framework/Core/test/test_WorkflowSerialization.cxx
+++ b/Framework/Core/test/test_WorkflowSerialization.cxx
@@ -52,10 +52,10 @@ TEST_CASE("TestVerifyWorkflowSerialization")
                                     {{"key1", "v\"al'1"}, {"", "val2"}, {"key3", ""}, {"", ""}}}};
 
   std::vector<DataProcessorInfo> dataProcessorInfoOut{
-    {"A", "test_Framework_test_SerializationWorkflow", {"foo"}, {ConfigParamSpec{"aBool", VariantType::Bool, true, {"A Bool"}}}},
-    {"B", "test_Framework_test_SerializationWorkflow", {"b-bar", "bfoof", "fbdbfaso"}},
-    {"C", "test_Framework_test_SerializationWorkflow", {}},
-    {"D", "test_Framework_test_SerializationWorkflow", {}},
+    {.name = "A", .executable = "test_Framework_test_SerializationWorkflow", .cmdLineArgs = {"foo"}, .workflowOptions = {ConfigParamSpec{"aBool", VariantType::Bool, true, {"A Bool"}}}},
+    {.name = "B", .executable = "test_Framework_test_SerializationWorkflow", .cmdLineArgs = {"b-bar", "bfoof", "fbdbfaso"}},
+    {.name = "C", .executable = "test_Framework_test_SerializationWorkflow"},
+    {.name = "D", .executable = "test_Framework_test_SerializationWorkflow"},
   };
 
   CommandInfo commandInfoOut{"o2-dpl-workflow -b --option 1 --option 2"};
@@ -94,7 +94,7 @@ TEST_CASE("TestVerifyWildcard")
     }};
 
   std::vector<DataProcessorInfo> dataProcessorInfoOut{
-    {"A", "test_Framework_test_SerializationWorkflow", {}},
+    {.name = "A", .executable = "test_Framework_test_SerializationWorkflow"},
   };
 
   CommandInfo commandInfoOut{"o2-dpl-workflow -b --option 1 --option 2"};


### PR DESCRIPTION

- Use aggregate initialisation where possible
- Drop unused bits

Will simplify the plugins PR.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/14096).
* #13976 (9 commits)
* __->__ #14096