### PR TITLE
GeneratorHybrid: improve unit treatment

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -78,9 +78,13 @@ class Generator : public FairGenerator
 
   /** setters **/
   void setMomentumUnit(double val) { mMomentumUnit = val; };
+  double getMomentumUnit() const { return mMomentumUnit; }
   void setEnergyUnit(double val) { mEnergyUnit = val; };
+  double getEnergyUnit() const { return mEnergyUnit; }
   void setPositionUnit(double val) { mPositionUnit = val; };
+  double getPositionUnit() const { return mPositionUnit; }
   void setTimeUnit(double val) { mTimeUnit = val; };
+  double getTimeUnit() const { return mTimeUnit; }
   void setBoost(Double_t val) { mBoost = val; };
   void setTriggerMode(ETriggerMode_t val) { mTriggerMode = val; };
   void addTrigger(Trigger trigger) { mTriggers.push_back(trigger); };

--- a/Generators/include/Generators/GeneratorHybrid.h
+++ b/Generators/include/Generators/GeneratorHybrid.h
@@ -54,7 +54,6 @@ class GeneratorHybrid : public Generator
 {
 
  public:
-  GeneratorHybrid() = default;
   GeneratorHybrid(const std::string& inputgens);
   ~GeneratorHybrid();
 


### PR DESCRIPTION
So far, units are treated solely in the Generator::addTrack function. This works well for fundamental generators.

However, the hybrid generator is a meta generator potentially consisting of a collection of underlying generators that may have completely different units. This may currently lead to wrong generator output, in certain cases.

This commit fixes these bugs and introduces unit handling within GeneratorHybrid.