### PR TITLE
[AFIT-112]: FT0's reco update, 3 new event bits

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
@@ -61,7 +61,7 @@ class RecPoints
   enum ETimeType { kTimeMean,
                    kTimeA,
                    kTimeC,
-                   kVertex };
+                   kTimeVertex };
 
   // Enum for trigger nits specified in rec-points and AOD data
   enum ETriggerBits { kOrA = 0,           // OrA time-trigger signal
@@ -125,8 +125,8 @@ class RecPoints
   bool isValidTime(int side) const { return getCollisionTime(side) < o2::InteractionRecord::DummyTime; }
   void setCollisionTime(short time, int side) { mCollisionTime[side] = time; }
 
-  short getVertex() const { return getCollisionTime(kVertex); }
-  void setVertex(short vertex) { mCollisionTime[kVertex] = vertex; }
+  short getVertex() const { return getCollisionTime(kTimeVertex); }
+  void setVertex(short vertex) { mCollisionTime[kTimeVertex] = vertex; }
 
   o2::fit::Triggers getTrigger() const { return mTriggers; }
   void setTriggers(o2::fit::Triggers trig) { mTriggers = trig; }
@@ -149,9 +149,9 @@ class RecPoints
   void initRecPointTriggers(const o2::fit::Triggers& digitTriggers, uint8_t extraTrgWord = 0)
   {
     const auto digitTriggerWord = digitTriggers.getTriggersignals();
-    const auto trgAndTechWordPair = parseDigitTriggerWord(digitTriggerWord, true);
+    const auto trgAndTechWordPair = o2::fit::Triggers::parseDigitTriggerWord(digitTriggerWord, true);
     mTriggers.setTriggers(trgAndTechWordPair.first | extraTrgWord);
-    mTechWord = trgAndTechWordPair.second;
+    mTechnicalWord = trgAndTechWordPair.second;
   }
 
   std::array<short, 4> mCollisionTime = {sDummyCollissionTime,

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
@@ -24,7 +24,9 @@
 #include "Rtypes.h"
 #include <TObject.h>
 #include <gsl/span>
-
+#include <string>
+#include <utility>
+#include <map>
 namespace o2
 {
 namespace ft0
@@ -32,10 +34,10 @@ namespace ft0
 
 struct ChannelDataFloat {
 
-  int ChId = -1;           //channel Id
-  int ChainQTC = -1;       //QTC chain
-  float CFDTime = -20000;  //time in ps, 0 at the LHC clk center
-  float QTCAmpl = -20000;  // Amplitude mV
+  int ChId = -1;          // channel Id
+  int ChainQTC = -1;      // QTC chain
+  float CFDTime = -20000; // time in ps, 0 at the LHC clk center
+  float QTCAmpl = -20000; // Amplitude mV
 
   ChannelDataFloat() = default;
   ChannelDataFloat(int iPmt, float time, float charge, int chainQTC)
@@ -56,10 +58,39 @@ class RecPoints
 {
 
  public:
-  enum : int { TimeMean,
-               TimeA,
-               TimeC,
-               Vertex };
+  enum ETimeType { kTimeMean,
+                   kTimeA,
+                   kTimeC,
+                   kVertex };
+
+  // Enum for trigger nits specified in rec-points and AOD data
+  enum ETriggerBits { kOrA = 0,           // OrA time-trigger signal
+                      kOrC = 1,           // OrC time-trigger signal
+                      kSemiCentral = 2,   // Semi-central amplitude-trigger signal
+                      kCentral = 3,       // Central amplitude-trigger signal
+                      kVertex = 4,        // Vertex time-trigger signal
+                      kIsActiveSideA = 5, // Side-A has at least one channel active
+                      kIsActiveSideC = 6, // Side-C has at least one channel active
+                      kIsFlangeEvent = 7  // Flange event at Side-C, at least one channel has time which corresponds to -82 cm area
+  };
+  static const inline std::map<unsigned int, std::string> sMapTriggerBits = {
+    {ETriggerBits::kOrA, "OrA"},
+    {ETriggerBits::kOrC, "OrC"},
+    {ETriggerBits::kSemiCentral, "Semicentral"},
+    {ETriggerBits::kCentral, "Central"},
+    {ETriggerBits::kVertex, "Vertex"},
+    {ETriggerBits::kIsActiveSideA, "IsActiveSideA"},
+    {ETriggerBits::kIsActiveSideC, "IsActiveSideC"},
+    {ETriggerBits::kIsFlangeEvent, "IsFlangeEvent"}};
+
+  enum ETechnicalBits { kLaser = 0,             // indicates the laser was triggered in this BC
+                        kOutputsAreBlocked = 1, // indicates that laser-induced pulses should arrive from detector to FEE in this BC (and trigger outputs are blocked)
+                        kDataIsValid = 2,       // data is valid for processing
+  };
+  static const inline std::map<unsigned int, std::string> sMapTechnicalBits = {
+    {ETechnicalBits::kLaser, "Laser"},
+    {ETechnicalBits::kOutputsAreBlocked, "OutputsAreBlocked"},
+    {ETechnicalBits::kDataIsValid, "DataIsValid"}};
 
   o2::dataformats::RangeReference<int, int> ref;
   o2::InteractionRecord mIntRecord; // Interaction record (orbit, bc)
@@ -73,25 +104,41 @@ class RecPoints
     mIntRecord = iRec;
     mTriggers = chTrig;
   }
+  RecPoints(int chDataFirstEntryPos,
+            int chDataNEntries,
+            const o2::InteractionRecord& ir,
+            const std::array<short, 4>& arrTimes,
+            const o2::fit::Triggers& digitTriggers,
+            uint8_t extraTriggerWord) : mIntRecord(ir), mCollisionTime(arrTimes)
+  {
+    ref.setFirstEntry(chDataFirstEntryPos);
+    ref.setEntries(chDataNEntries);
+    initRecPointTriggers(digitTriggers, extraTriggerWord);
+  }
+
   ~RecPoints() = default;
 
   short getCollisionTime(int side) const { return mCollisionTime[side]; }
-  short getCollisionTimeMean() const { return getCollisionTime(TimeMean); }
-  short getCollisionTimeA() const { return getCollisionTime(TimeA); }
-  short getCollisionTimeC() const { return getCollisionTime(TimeC); }
+  short getCollisionTimeMean() const { return getCollisionTime(kTimeMean); }
+  short getCollisionTimeA() const { return getCollisionTime(kTimeA); }
+  short getCollisionTimeC() const { return getCollisionTime(kTimeC); }
   bool isValidTime(int side) const { return getCollisionTime(side) < o2::InteractionRecord::DummyTime; }
   void setCollisionTime(short time, int side) { mCollisionTime[side] = time; }
 
-  short getVertex() const { return getCollisionTime(Vertex); }
-  void setVertex(short vertex) { mCollisionTime[Vertex] = vertex; }
+  short getVertex() const { return getCollisionTime(kVertex); }
+  void setVertex(short vertex) { mCollisionTime[kVertex] = vertex; }
 
   o2::fit::Triggers getTrigger() const { return mTriggers; }
   void setTriggers(o2::fit::Triggers trig) { mTriggers = trig; }
 
+  static constexpr uint8_t makeExtraTrgWord(bool isActiveA = true, bool isActiveC = true, bool isFlangeEvent = true)
+  {
+    return (static_cast<uint8_t>(isActiveA) << kIsActiveSideA) |
+           (static_cast<uint8_t>(isActiveC) << kIsActiveSideC) |
+           (static_cast<uint8_t>(isFlangeEvent) << kIsFlangeEvent);
+  }
+
   o2::InteractionRecord getInteractionRecord() const { return mIntRecord; };
-
-  // void SetMgrEventTime(Double_t time) { mTimeStamp = time; }
-
   gsl::span<const ChannelDataFloat> getBunchChannelData(const gsl::span<const ChannelDataFloat> tfdata) const;
   short static constexpr sDummyCollissionTime = 32767;
 
@@ -99,13 +146,21 @@ class RecPoints
   bool operator==(const RecPoints&) const = default;
 
  private:
+  void initRecPointTriggers(const o2::fit::Triggers& digitTriggers, uint8_t extraTrgWord = 0)
+  {
+    const auto digitTriggerWord = digitTriggers.getTriggersignals();
+    const auto trgAndTechWordPair = parseDigitTriggerWord(digitTriggerWord, true);
+    mTriggers.setTriggers(trgAndTechWordPair.first | extraTrgWord);
+    mTechWord = trgAndTechWordPair.second;
+  }
+
   std::array<short, 4> mCollisionTime = {sDummyCollissionTime,
                                          sDummyCollissionTime,
                                          sDummyCollissionTime,
                                          sDummyCollissionTime};
   o2::fit::Triggers mTriggers; // pattern of triggers  in this BC
-
-  ClassDefNV(RecPoints, 3);
+  uint8_t mTechnicalWord{0};   // field for keeping ETechnicalBits
+  ClassDefNV(RecPoints, 4);
 };
 } // namespace ft0
 } // namespace o2

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
@@ -109,7 +109,7 @@ class RecPoints
             const o2::InteractionRecord& ir,
             const std::array<short, 4>& arrTimes,
             const o2::fit::Triggers& digitTriggers,
-            uint8_t extraTriggerWord) : mIntRecord(ir), mCollisionTime(arrTimes)
+            uint8_t extraTriggerWord) : mIntRecord(ir), mCollisionTime(arrTimes), mTriggers(digitTriggers)
   {
     ref.setFirstEntry(chDataFirstEntryPos);
     ref.setEntries(chDataNEntries);

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/RecPoints.h
@@ -130,7 +130,7 @@ class RecPoints
 
   o2::fit::Triggers getTrigger() const { return mTriggers; }
   void setTriggers(o2::fit::Triggers trig) { mTriggers = trig; }
-
+  uint8_t getTechnicalWord() const { return mTechnicalWord; }
   static constexpr uint8_t makeExtraTrgWord(bool isActiveA = true, bool isActiveC = true, bool isFlangeEvent = true)
   {
     return (static_cast<uint8_t>(isActiveA) << kIsActiveSideA) |

--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
@@ -110,6 +110,10 @@ class Triggers
     timeA = atimeA;
     timeC = atimeC;
   }
+  void setTriggers(uint8_t trgsig)
+  {
+    triggersignals = trgsig;
+  }
 
   void setTriggers(Bool_t isA, Bool_t isC, Bool_t isVrtx, Bool_t isCnt, Bool_t isSCnt, uint8_t chanA, uint8_t chanC, int32_t aamplA,
                    int32_t aamplC, int16_t atimeA, int16_t atimeC, Bool_t isLaser, Bool_t isOutputsAreBlocked, Bool_t isDataValid)

--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
@@ -70,6 +70,12 @@ class Triggers
   {
     return trgWord | (static_cast<uint64_t>(checkMinBiasFT0(trgWord)) << bitMinBias);
   }
+  static constexpr std::pair<uint8_t, uint8_t> parseDigitTriggerWord(uint8_t digitWord, bool shiftTechBitsToBegin = false)
+  {
+    const uint8_t techWordMask = word(bitLaser, bitOutputsAreBlocked, bitDataIsValid);
+    const uint8_t shiftTechWordPos = shiftTechBitsToBegin ? bitLaser : 0;
+    return {(digitWord & (~techWordMask)), (digitWord & techWordMask) >> shiftTechWordPos};
+  }
 
   bool getOrA() const { return (triggersignals & (1 << bitA)) != 0; }
   bool getOrC() const { return (triggersignals & (1 << bitC)) != 0; }               // only used by FT0/FDD (same bit as OrAOut in FV0)

--- a/Detectors/FIT/FT0/reconstruction/src/CollisionTimeRecoTask.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/CollisionTimeRecoTask.cxx
@@ -88,7 +88,7 @@ RP CollisionTimeRecoTask::processDigit(const o2::ft0::Digit& digit,
         ndigitsC++;
       }
       isActiveC = true;
-      isFlangeEvent |= channelData.CFDTime > -450 && channelData.CFDTime < -350;
+      isFlangeEvent |= channelData.CFDTime < -350 && channelData.CFDTime > -450;
     }
   }
   std::array<short, 4> mCollisionTime = {RP::sDummyCollissionTime, RP::sDummyCollissionTime, RP::sDummyCollissionTime, RP::sDummyCollissionTime};

--- a/Detectors/FIT/FT0/reconstruction/src/CollisionTimeRecoTask.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/CollisionTimeRecoTask.cxx
@@ -58,6 +58,10 @@ RP CollisionTimeRecoTask::processDigit(const o2::ft0::Digit& digit,
   constexpr int nMCPsA = 4 * Geometry::NCellsA;
 
   int nch{0};
+  bool isActiveA = false;
+  bool isActiveC = false;
+  bool isFlangeEvent = false;
+
   for (const auto& channelData : inChData) {
     if (channelData.ChId >= NCHANNELS) {
       // Reference channels shouldn't participate in reco at all!
@@ -68,15 +72,23 @@ RP CollisionTimeRecoTask::processDigit(const o2::ft0::Digit& digit,
       outChData.emplace_back(channelData.ChId, timeInPS, (float)channelData.QTCAmpl, channelData.ChainQTC);
       nch++;
     }
+    const bool isOkForTimeCalc = TimeFilterParam::Instance().checkAll(channelData);
     //  only signals which satisfy conditions may participate in time calculation
-    if (TimeFilterParam::Instance().checkAll(channelData)) {
-      if (channelData.ChId < nMCPsA) {
+    if (channelData.ChId < nMCPsA) {
+      // A-side
+      if (isOkForTimeCalc) {
         sideAtime += timeInPS;
         ndigitsA++;
-      } else {
+      }
+      isActiveA = true;
+    } else {
+      // C-side
+      if (isOkForTimeCalc) {
         sideCtime += timeInPS;
         ndigitsC++;
       }
+      isActiveC = true;
+      isFlangeEvent |= channelData.CFDTime > -450 && channelData.CFDTime < -350;
     }
   }
   std::array<short, 4> mCollisionTime = {RP::sDummyCollissionTime, RP::sDummyCollissionTime, RP::sDummyCollissionTime, RP::sDummyCollissionTime};
@@ -90,7 +102,8 @@ RP CollisionTimeRecoTask::processDigit(const o2::ft0::Digit& digit,
   } else {
     mCollisionTime[TimeMean] = std::min(mCollisionTime[TimeA], mCollisionTime[TimeC]);
   }
-  return RecPoints{mCollisionTime, firstEntry, nch, digit.mIntRecord, digit.mTriggers};
+  const uint8_t extraTrgWord = RecPoints::makeExtraTrgWord(isActiveA, isActiveC, isFlangeEvent);
+  return RecPoints(firstEntry, nch, digit.mIntRecord, mCollisionTime, digit.mTriggers, extraTrgWord);
 }
 //______________________________________________________
 void CollisionTimeRecoTask::FinishTask()


### PR DESCRIPTION
https://its.cern.ch/jira/browse/AFIT-112
1. Added new three event bits for reco: IsActiveA, IsActiveC, IsFlangeEvent
2. Tech bits moved to dedicated recpoint field(+1 byte), mostly for recoQC