### PR TITLE
ITSMFT: add asString() for clusters

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CompCluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CompCluster.h
@@ -88,6 +88,7 @@ class CompCluster
   }
 
   void print() const;
+  std::string asString() const;
 
   ClassDefNV(CompCluster, 2);
 };
@@ -97,7 +98,7 @@ class CompCluster
 class CompClusterExt : public CompCluster
 {
  private:
-  UShort_t mChipID;  ///< chip id
+  UShort_t mChipID; ///< chip id
 
  public:
   CompClusterExt(UShort_t row = 0, UShort_t col = 0, UShort_t patt = 0, UShort_t chipID = 0) : CompCluster(row, col, patt), mChipID(chipID)
@@ -116,6 +117,7 @@ class CompClusterExt : public CompCluster
   void setChipID(UShort_t c) { mChipID = c; }
 
   void print() const;
+  std::string asString() const;
 
   ClassDefNV(CompClusterExt, 1);
 };

--- a/DataFormats/Detectors/ITSMFT/common/src/CompCluster.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/CompCluster.cxx
@@ -15,20 +15,30 @@
 #include "DataFormatsITSMFT/CompCluster.h"
 #include <cassert>
 #include <iostream>
+#include <format>
 
 using namespace o2::itsmft;
 
 std::ostream& operator<<(std::ostream& stream, const CompCluster& cl)
 {
-  stream << " row: " << cl.getRow() << " col: " << cl.getCol()
-         << " pattID " << cl.getPatternID() << " [flag: " << cl.getFlag() << "] ";
+  stream << cl.asString();
   return stream;
 }
 
 std::ostream& operator<<(std::ostream& stream, const CompClusterExt& cl)
 {
-  stream << " chip: " << cl.getChipID() << ((const CompCluster&)cl);
+  stream << cl.asString();
   return stream;
+}
+
+std::string CompCluster::asString() const
+{
+  return std::format(" row: {:4d} col: {:4d} pattID: {:4d} [flag: {:1d}]", getRow(), getCol(), getPatternID(), getFlag());
+}
+
+std::string CompClusterExt::asString() const
+{
+  return std::format(" chip: {:5d} row: {:4d} col: {:4d} pattID: {:4d} [flag: {:1d}]", getChipID(), getRow(), getCol(), getPatternID(), getFlag());
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
Allows to get (nicely) formatted string of clusters.