### PR TITLE
DPL: avoid expensive find_if for check of AVAILABLE_MANAGED_SHM metric when sending metrics

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingStats.h
+++ b/Framework/Core/include/Framework/DataProcessingStats.h
@@ -189,6 +189,8 @@ struct DataProcessingStats {
   std::array<MetricSpec, MAX_METRICS> metricSpecs = {};
   std::array<int64_t, MAX_METRICS> lastPublishedMetrics = {};
   std::vector<int> availableMetrics;
+  // for fast check for AVAILABLE_MANAGED_SHM metric which is only provided for readout-proxy
+  bool hasAvailSHMMetric = false;
   // How many commands have been committed to the queue.
   std::atomic<int> insertedCmds = 0;
   // The insertion point for the next command.

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -764,11 +764,8 @@ auto sendRelayerMetrics(ServiceRegistryRef registry, DataProcessingStats& stats)
   using namespace fair::mq::shmem;
   auto& spec = registry.get<DeviceSpec const>();
 
-  auto hasMetric = [&runningWorkflow](const DataProcessingStats::MetricSpec& metric) -> bool {
-    return metric.metricId == static_cast<int>(ProcessingStatsId::AVAILABLE_MANAGED_SHM_BASE) + (runningWorkflow.shmSegmentId % 512);
-  };
   // FIXME: Ugly, but we do it only every 5 seconds...
-  if (std::find_if(stats.metricSpecs.begin(), stats.metricSpecs.end(), hasMetric) != stats.metricSpecs.end()) {
+  if (stats.hasAvailSHMMetric) {
     auto device = registry.get<RawDeviceService>().device();
     long freeMemory = -1;
     try {
@@ -1104,8 +1101,12 @@ o2::framework::ServiceSpec CommonServices::dataProcessingStats()
                    .sendInitialValue = true}};
 
       for (auto& metric : metrics) {
-        if (metric.metricId == (int)ProcessingStatsId::AVAILABLE_MANAGED_SHM_BASE + (runningWorkflow.shmSegmentId % 512) && spec.name.compare("readout-proxy") != 0) {
-          continue;
+        if (metric.metricId == (int)ProcessingStatsId::AVAILABLE_MANAGED_SHM_BASE + (runningWorkflow.shmSegmentId % 512)) {
+          if (spec.name.compare("readout-proxy") == 0) {
+            stats->hasAvailSHMMetric = true;
+          } else {
+            continue;
+          }
         }
         stats->registerMetric(metric);
       }


### PR DESCRIPTION
### CPU usage tests on my laptop
`O2_DPL_DEPLOYMENT_MODE=Local o2-qc-run-producer -b --monitoring-backend infologger://debug --message-rate 1000 --min-size 10 --max-size 10`
before:          dummy-sink at 41%, producer-0 at 18%
with this PR: dummy-sink at 18%, producer-0 at 13%

`O2_DPL_DEPLOYMENT_MODE=OnlineECS o2-qc-run-producer -b --monitoring-backend infologger://debug --message-rate 1000 --min-size 10 --max-size 10`
before:          dummy-sink at 53%, producer-0 at 20%
with this PR: dummy-sink at 35%, producer-0 at 18%