### PR TITLE
DPL Analysis: add configurable expression columns

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -426,7 +426,7 @@ template <typename T>
 concept has_extension = is_metadata<T> && not_void<typename T::extension_table_t>;
 
 template <typename T>
-concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; std::same_as<std::true_type, typename T::configurable_t>; };
+concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; requires std::same_as<std::true_type, typename T::configurable_t>; };
 
 template <typename T>
 concept is_spawnable_column = std::same_as<typename T::spawnable_t, std::true_type>;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -3162,7 +3162,7 @@ consteval auto getIndexTargets()
   using _Name_ = _Name_##From<o2::aod::Hash<_Origin_ ""_h>>;
 
 #define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE(_Name_, _Table_, _Description_, ...) \
-  O2HASH(#_Name_ "CfgExtension");                                                   \
+  O2HASH(#_Name_ "CfgExtension");                                                    \
   DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_FULL(_Name_, #_Name_ "CfgExtension", _Table_, "AOD", "EX" _Description_, 0, __VA_ARGS__)
 
 #define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Version_, _Desc_, _Exclusive_, ...)                                         \

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -426,6 +426,9 @@ template <typename T>
 concept has_extension = is_metadata<T> && not_void<typename T::extension_table_t>;
 
 template <typename T>
+concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; std::same_as<std::true_type, typename T::configurable_t>; };
+
+template <typename T>
 concept is_spawnable_column = std::same_as<typename T::spawnable_t, std::true_type>;
 
 template <typename B, typename E>
@@ -2355,7 +2358,7 @@ O2HASH("TEST/0");
   DECLARE_SOA_BITMAP_COLUMN_FULL(_Name_, _Getter_, _Size_, "f" #_Name_)
 
 /// An 'expression' column. i.e. a column that can be calculated from other
-/// columns with gandiva based on supplied C++ expression.
+/// columns with gandiva based on static C++ expression.
 #define DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_, _Expression_)                                                       \
   struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                                                                               \
     static constexpr const char* mLabel = _Label_;                                                                                                \
@@ -2392,6 +2395,38 @@ O2HASH("TEST/0");
 
 #define DECLARE_SOA_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Expression_) \
   DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_, _Expression_);
+
+/// A configurable 'expression' column. i.e. a column that can be calculated from other
+/// columns with gandiva based on dynamically supplied C++ expression or a string definition.
+#define DECLARE_SOA_CONFIGURABLE_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Label_)                                                             \
+  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                                                                               \
+    static constexpr const char* mLabel = _Label_;                                                                                                \
+    static constexpr const int32_t mHash = _Label_ ""_h;                                                                                          \
+    using base = o2::soa::Column<_Type_, _Name_>;                                                                                                 \
+    using type = _Type_;                                                                                                                          \
+    using column_t = _Name_;                                                                                                                      \
+    using spawnable_t = std::true_type;                                                                                                           \
+    _Name_(arrow::ChunkedArray const* column)                                                                                                     \
+      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))                                                                    \
+    {                                                                                                                                             \
+    }                                                                                                                                             \
+                                                                                                                                                  \
+    _Name_() = default;                                                                                                                           \
+    _Name_(_Name_ const& other) = default;                                                                                                        \
+    _Name_& operator=(_Name_ const& other) = default;                                                                                             \
+                                                                                                                                                  \
+    decltype(auto) _Getter_() const                                                                                                               \
+    {                                                                                                                                             \
+      return *mColumnIterator;                                                                                                                    \
+    }                                                                                                                                             \
+                                                                                                                                                  \
+    decltype(auto) get() const                                                                                                                    \
+    {                                                                                                                                             \
+      return _Getter_();                                                                                                                          \
+    }                                                                                                                                             \
+  };                                                                                                                                              \
+  [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_ { _Label_, o2::framework::TypeIdHelpers::uniqueId<_Name_>(), \
+                                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
 
 /// An index column is a column of indices to elements / of another table named
 /// _Name_##s. The column name will be _Name_##Id and will always be stored in
@@ -3103,6 +3138,32 @@ consteval auto getIndexTargets()
 #define DECLARE_SOA_EXTENDED_TABLE_USER(_Name_, _Table_, _Description_, ...) \
   O2HASH(#_Name_ "Extension");                                               \
   DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, #_Name_ "Extension", _Table_, "AOD", "EX" _Description_, 0, __VA_ARGS__)
+
+#define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_FULL(_Name_, _Label_, _OriginalTable_, _Origin_, _Desc_, _Version_, ...)           \
+  O2HASH(_Desc_ "/" #_Version_);                                                                                                   \
+  template <typename O>                                                                                                            \
+  using _Name_##CfgExtensionFrom = soa::Table<o2::aod::Hash<_Label_ ""_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O>;          \
+  using _Name_##CfgExtension = _Name_##CfgExtensionFrom<o2::aod::Hash<_Origin_ ""_h>>;                                             \
+  template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                             \
+  struct _Name_##CfgExtensionMetadataFrom : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                \
+    using base_table_t = _OriginalTable_;                                                                                          \
+    using extension_table_t = _Name_##CfgExtensionFrom<O>;                                                                         \
+    using placeholders_pack_t = framework::pack<__VA_ARGS__>;                                                                      \
+    using configurable_t = std::true_type;                                                                                         \
+    static constexpr auto sources = _OriginalTable_::originals;                                                                    \
+  };                                                                                                                               \
+  using _Name_##CfgExtensionMetadata = _Name_##CfgExtensionMetadataFrom<o2::aod::Hash<_Origin_ ""_h>>;                             \
+  template <>                                                                                                                      \
+  struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                \
+    using metadata = _Name_##CfgExtensionMetadata;                                                                                 \
+  };                                                                                                                               \
+  template <typename O>                                                                                                            \
+  using _Name_##From = o2::soa::JoinFull<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, _OriginalTable_, _Name_##CfgExtensionFrom<O>>; \
+  using _Name_ = _Name_##From<o2::aod::Hash<_Origin_ ""_h>>;
+
+#define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE(_Name_, _Table_, _Description_, ...) \
+  O2HASH(#_Name_ "CfgExtension");                                                   \
+  DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_FULL(_Name_, #_Name_ "CfgExtension", _Table_, "AOD", "EX" _Description_, 0, __VA_ARGS__)
 
 #define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Version_, _Desc_, _Exclusive_, ...)                                         \
   O2HASH(#_Name_);                                                                                                                         \

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -247,6 +247,9 @@ struct TableTransform {
 template <typename T>
 concept is_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> && soa::has_extension<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata>;
 
+template <typename T>
+concept is_dynamically_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> && soa::has_configurable_extension<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata>;
+
 template <is_spawnable T>
 constexpr auto transformBase()
 {
@@ -282,12 +285,60 @@ struct Spawns : decltype(transformBase<T>()) {
   }
   std::shared_ptr<typename T::table_t> table = nullptr;
   std::shared_ptr<extension_t> extension = nullptr;
+  std::shared_ptr<gandiva::Projector> projector = nullptr;
 };
 
 template <typename T>
 concept is_spawns = requires(T t) {
   typename T::metadata;
   requires std::same_as<decltype(t.pack()), typename T::expression_pack_t>;
+  requires std::same_as<decltype(t.projector), std::shared_ptr<gandiva::Projector>>;
+};
+
+/// This helper struct allows you to declare extended tables with dynamically-supplied
+/// expressions to be created by the task
+/// The actual expressions have to be set in init() for the configurable expression
+/// columns, used to define the table
+
+template <is_dynamically_spawnable T>
+struct Defines : decltype(transformBase<T>()) {
+  using spawnable_t = T;
+  using metadata = decltype(transformBase<T>())::metadata;
+  using extension_t = typename metadata::extension_table_t;
+  using base_table_t = typename metadata::base_table_t;
+  using placeholders_pack_t = typename metadata::placeholders_pack_t;
+  static constexpr size_t N = framework::pack_size(placeholders_pack_t{});
+
+  constexpr auto pack()
+  {
+    return placeholders_pack_t{};
+  }
+
+  typename T::table_t* operator->()
+  {
+    return table.get();
+  }
+  typename T::table_t const& operator*() const
+  {
+    return *table;
+  }
+
+  auto asArrowTable()
+  {
+    return extension->asArrowTable();
+  }
+  std::shared_ptr<typename T::table_t> table = nullptr;
+  std::shared_ptr<extension_t> extension = nullptr;
+
+  std::array<o2::framework::expressions::Projector, N> projectors;
+  std::shared_ptr<gandiva::Projector> projector = nullptr;
+};
+
+template <typename T>
+concept is_defines = requires(T t) {
+  typename T::metadata;
+  requires std::same_as<decltype(t.pack()), typename T::placeholders_pack_t>;
+  requires std::same_as<decltype(t.projector), std::shared_ptr<gandiva::Projector>>;
 };
 
 /// Policy to control index building

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -795,7 +795,8 @@ template <soa::is_table T, soa::is_spawnable_column... Cs>
 auto Extend(T const& table)
 {
   using output_t = Join<T, soa::Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Cs...>>;
-  return output_t{{o2::framework::spawner(framework::pack<Cs...>{}, {table.asArrowTable()}, "dynamicExtension"), table.asArrowTable()}, 0};
+  static std::shared_ptr<gandiva::Projector> projector = nullptr;
+  return output_t{{o2::framework::spawner(framework::pack<Cs...>{}, {table.asArrowTable()}, "dynamicExtension", projector), table.asArrowTable()}, 0};
 }
 
 /// Template function to attach dynamic columns on-the-fly (e.g. inside

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -141,22 +141,27 @@ bool requestInputs(std::vector<InputSpec>&, T const&)
 }
 
 template <is_spawns T>
-bool requestInputs(std::vector<InputSpec>& inputs, T const& spawns)
-{
-  auto base_specs = spawns.base_specs();
-  for (auto base_spec : base_specs) {
-    base_spec.metadata.push_back(ConfigParamSpec{std::string{"control:spawn"}, VariantType::Bool, true, {"\"\""}});
-    DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
-  }
-  return true;
+const char* controlOption() {
+  return "control:spawn";
 }
 
 template <is_builds T>
-bool requestInputs(std::vector<InputSpec>& inputs, T const& builds)
+const char* controlOption() {
+  return "control:build";
+}
+
+template <is_defines T>
+const char* controlOption() {
+  return "control:define";
+}
+
+template <typename T>
+  requires(is_spawns<T> || is_builds<T> || is_defines<T>)
+bool requestInputs(std::vector<InputSpec>& inputs, T const& entity)
 {
-  auto base_specs = builds.base_specs();
+  auto base_specs = entity.base_specs();
   for (auto base_spec : base_specs) {
-    base_spec.metadata.push_back(ConfigParamSpec{std::string{"control:build"}, VariantType::Bool, true, {"\"\""}});
+    base_spec.metadata.push_back(ConfigParamSpec{std::string{controlOption<T>()}, VariantType::Bool, true, {"\"\""}});
     DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
   }
   return true;
@@ -219,17 +224,11 @@ bool appendOutput(std::vector<OutputSpec>& outputs, T& obj, uint32_t hash)
   return true;
 }
 
-template <is_spawns T>
-bool appendOutput(std::vector<OutputSpec>& outputs, T& spawns, uint32_t)
+template <typename T>
+  requires(is_spawns<T> || is_builds<T> || is_defines<T>)
+bool appendOutput(std::vector<OutputSpec>& outputs, T& entity, uint32_t)
 {
-  outputs.emplace_back(spawns.spec());
-  return true;
-}
-
-template <is_builds T>
-bool appendOutput(std::vector<OutputSpec>& outputs, T& builds, uint32_t)
-{
-  outputs.emplace_back(builds.spec());
+  outputs.emplace_back(entity.spec());
   return true;
 }
 
@@ -286,7 +285,7 @@ bool prepareOutput(ProcessingContext& context, T& spawns)
     originalTable = makeEmptyTable<base_table_t>(o2::aod::label<metadata::extension_table_t::ref>());
   }
 
-  spawns.extension = std::make_shared<typename T::extension_t>(o2::framework::spawner<o2::aod::Hash<metadata::extension_table_t::ref.desc_hash>>(originalTable, o2::aod::label<metadata::extension_table_t::ref>()));
+  spawns.extension = std::make_shared<typename T::extension_t>(o2::framework::spawner<o2::aod::Hash<metadata::extension_table_t::ref.desc_hash>>(originalTable, o2::aod::label<metadata::extension_table_t::ref>(), spawns.projector));
   spawns.table = std::make_shared<typename T::spawnable_t::table_t>(soa::ArrowHelpers::joinTables({spawns.extension->asArrowTable(), originalTable}));
   return true;
 }
@@ -296,6 +295,21 @@ bool prepareOuput(ProcessingContext& context, T& builds)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::buildable_t::ref.desc_hash>>::metadata;
   return builds.template build<typename T::buildable_t::indexing_t>(builds.pack(), extractOriginals<metadata::sources.size(), metadata::sources>(context));
+}
+
+template <is_defines T>
+bool prepareOutput(ProcessingContext& context, T& defines)
+{
+  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::ref.desc_hash>>::metadata;
+  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::sources.size(), metadata::sources>(context));
+  if (originalTable->schema()->fields().empty() == true) {
+    using base_table_t = typename T::base_table_t::table_t;
+    originalTable = makeEmptyTable<base_table_t>(o2::aod::label<metadata::extension_table_t::ref>());
+  }
+
+  defines.extension = std::make_shared<typename T::extension_t>(o2::framework::spawner<o2::aod::Hash<metadata::extension_table_t::ref.desc_hash>>(originalTable, o2::aod::label<metadata::extension_table_t::ref>(), defines.projectors.data(), defines.projector));
+  defines.table = std::make_shared<typename T::spawnable_t::table_t>(soa::ArrowHelpers::joinTables({defines.extension->asArrowTable(), originalTable}));
+  return true;
 }
 
 template <typename T>
@@ -330,6 +344,13 @@ template <is_builds T>
 bool finalizeOutput(ProcessingContext& context, T& builds)
 {
   context.outputs().adopt(builds.output(), builds.asArrowTable());
+  return true;
+}
+
+template <is_defines T>
+bool finalizeOutput(ProcessingContext& context, T& defines)
+{
+  context.outputs().adopt(defines.output(), defines.asArrowTable());
   return true;
 }
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -141,17 +141,20 @@ bool requestInputs(std::vector<InputSpec>&, T const&)
 }
 
 template <is_spawns T>
-const char* controlOption() {
+const char* controlOption()
+{
   return "control:spawn";
 }
 
 template <is_builds T>
-const char* controlOption() {
+const char* controlOption()
+{
   return "control:build";
 }
 
 template <is_defines T>
-const char* controlOption() {
+const char* controlOption()
+{
   return "control:define";
 }
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -576,7 +576,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     homogeneous_apply_refs([&ic](auto&& element) { return analysis_task_parsers::prepareService(ic, element); }, *task.get());
 
     auto& callbacks = ic.services().get<CallbackService>();
-    auto endofdatacb = [task](EndOfStreamContext& eosContext) {
+    auto eoscb = [task](EndOfStreamContext& eosContext) {
       homogeneous_apply_refs([&eosContext](auto& element) {
           analysis_task_parsers::postRunService(eosContext, element);
           analysis_task_parsers::postRunOutput(eosContext, element);
@@ -585,13 +585,13 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       eosContext.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     };
 
-    callbacks.set<CallbackService::Id::EndOfStream>(endofdatacb);
+    callbacks.set<CallbackService::Id::EndOfStream>(eoscb);
 
     /// update configurables in filters and partitions
     homogeneous_apply_refs(
       [&ic](auto& element) -> bool { return analysis_task_parsers::updatePlaceholders(ic, element); },
       *task.get());
-    /// create for filters gandiva trees matched to schemas and store the pointers into expressionInfos
+    /// create expression trees for filters gandiva trees matched to schemas and store the pointers into expressionInfos
     homogeneous_apply_refs([&expressionInfos](auto& element) {
       return analysis_task_parsers::createExpressionTrees(expressionInfos, element);
     },

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -404,6 +404,8 @@ inline Node ifnode(Node&& condition_, Configurable<L1> const& then_, Configurabl
 
 /// A struct, containing the root of the expression tree
 struct Filter {
+  Filter() = default;
+
   Filter(Node&& node_) : node{std::make_unique<Node>(std::forward<Node>(node_))}
   {
     (void)designateSubtrees(node.get());
@@ -413,7 +415,14 @@ struct Filter {
   {
     (void)designateSubtrees(node.get());
   }
-  std::unique_ptr<Node> node;
+
+  Filter& operator= (Filter&& other) noexcept
+  {
+    node = std::move(other.node);
+    return *this;
+  }
+
+  std::unique_ptr<Node> node = nullptr;
 
   size_t designateSubtrees(Node* node, size_t index = 0);
 };

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -416,7 +416,7 @@ struct Filter {
     (void)designateSubtrees(node.get());
   }
 
-  Filter& operator= (Filter&& other) noexcept
+  Filter& operator=(Filter&& other) noexcept
   {
     node = std::move(other.node);
     return *this;

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -855,12 +855,12 @@ auto makeEmptyTable(const char* name, framework::pack<Cs...> p)
 }
 
 std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema, size_t nColumns,
-                                            expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name, std::shared_ptr<gandiva::Projector> projector = nullptr);
+                                            expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name, std::shared_ptr<gandiva::Projector>& projector);
 
 /// Expression-based column generator to materialize columns
 template <aod::is_aod_hash D>
   requires(soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
-auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, o2::framework::expressions::Projector* projectors, std::shared_ptr<gandiva::Projector> projector)
+auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, o2::framework::expressions::Projector* projectors, std::shared_ptr<gandiva::Projector>& projector)
 {
   using placeholders_pack_t = typename o2::aod::MetadataTrait<D>::metadata::placeholders_pack_t;
   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
@@ -875,7 +875,7 @@ auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* na
 
 template <aod::is_aod_hash D>
   requires(soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
-auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, o2::framework::expressions::Projector* projectors, std::shared_ptr<gandiva::Projector> projector)
+auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, o2::framework::expressions::Projector* projectors, std::shared_ptr<gandiva::Projector>& projector)
 {
   using placeholders_pack_t = typename o2::aod::MetadataTrait<D>::metadata::placeholders_pack_t;
   if (fullTable->num_rows() == 0) {
@@ -889,7 +889,7 @@ auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, o
 
 template <aod::is_aod_hash D>
   requires(soa::has_extension<typename o2::aod::MetadataTrait<D>::metadata> && !soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
-auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, std::shared_ptr<gandiva::Projector> projector = nullptr)
+auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, std::shared_ptr<gandiva::Projector>& projector)
 {
   using expression_pack_t = typename o2::aod::MetadataTrait<D>::metadata::expression_pack_t;
   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
@@ -909,7 +909,7 @@ auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* na
 
 template <aod::is_aod_hash D>
   requires(soa::has_extension<typename o2::aod::MetadataTrait<D>::metadata> && !soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
-auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, std::shared_ptr<gandiva::Projector> projector = nullptr)
+auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, std::shared_ptr<gandiva::Projector>& projector)
 {
   using expression_pack_t = typename o2::aod::MetadataTrait<D>::metadata::expression_pack_t;
   if (fullTable->num_rows() == 0) {
@@ -927,7 +927,7 @@ auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, s
 }
 
 template <typename... C>
-auto spawner(framework::pack<C...> columns, std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name)
+auto spawner(framework::pack<C...> columns, std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, std::shared_ptr<gandiva::Projector>& projector)
 {
   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
   if (fullTable->num_rows() == 0) {
@@ -936,7 +936,7 @@ auto spawner(framework::pack<C...> columns, std::vector<std::shared_ptr<arrow::T
   static auto fields = o2::soa::createFieldsFromColumns(columns);
   static auto new_schema = std::make_shared<arrow::Schema>(fields);
   std::array<expressions::Projector, sizeof...(C)> projectors{{std::move(C::Projector())...}};
-  return spawnerHelper(fullTable, new_schema, sizeof...(C), projectors.data(), fields, name);
+  return spawnerHelper(fullTable, new_schema, sizeof...(C), projectors.data(), fields, name, projector);
 }
 
 template <typename... T>

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -855,11 +855,41 @@ auto makeEmptyTable(const char* name, framework::pack<Cs...> p)
 }
 
 std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema, size_t nColumns,
-                                            expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name);
+                                            expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name, std::shared_ptr<gandiva::Projector> projector = nullptr);
 
 /// Expression-based column generator to materialize columns
 template <aod::is_aod_hash D>
-auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name)
+  requires(soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
+auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, o2::framework::expressions::Projector* projectors, std::shared_ptr<gandiva::Projector> projector)
+{
+  using placeholders_pack_t = typename o2::aod::MetadataTrait<D>::metadata::placeholders_pack_t;
+  auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
+  if (fullTable->num_rows() == 0) {
+    return makeEmptyTable(name, placeholders_pack_t{});
+  }
+  static auto fields = o2::soa::createFieldsFromColumns(placeholders_pack_t{});
+  static auto new_schema = std::make_shared<arrow::Schema>(fields);
+
+  return spawnerHelper(fullTable, new_schema, framework::pack_size(placeholders_pack_t{}), projectors, fields, name, projector);
+}
+
+template <aod::is_aod_hash D>
+  requires(soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
+auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, o2::framework::expressions::Projector* projectors, std::shared_ptr<gandiva::Projector> projector)
+{
+  using placeholders_pack_t = typename o2::aod::MetadataTrait<D>::metadata::placeholders_pack_t;
+  if (fullTable->num_rows() == 0) {
+    return makeEmptyTable(name, placeholders_pack_t{});
+  }
+  static auto fields = o2::soa::createFieldsFromColumns(placeholders_pack_t{});
+  static auto new_schema = std::make_shared<arrow::Schema>(fields);
+
+  return spawnerHelper(fullTable, new_schema, framework::pack_size(placeholders_pack_t{}), projectors, fields, name, projector);
+}
+
+template <aod::is_aod_hash D>
+  requires(soa::has_extension<typename o2::aod::MetadataTrait<D>::metadata> && !soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
+auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name, std::shared_ptr<gandiva::Projector> projector = nullptr)
 {
   using expression_pack_t = typename o2::aod::MetadataTrait<D>::metadata::expression_pack_t;
   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
@@ -874,11 +904,12 @@ auto spawner(std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* na
   }
   (expression_pack_t{});
 
-  return spawnerHelper(fullTable, new_schema, framework::pack_size(expression_pack_t{}), projectors.data(), fields, name);
+  return spawnerHelper(fullTable, new_schema, framework::pack_size(expression_pack_t{}), projectors.data(), fields, name, projector);
 }
 
 template <aod::is_aod_hash D>
-auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name)
+  requires(soa::has_extension<typename o2::aod::MetadataTrait<D>::metadata> && !soa::has_configurable_extension<typename o2::aod::MetadataTrait<D>::metadata>)
+auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name, std::shared_ptr<gandiva::Projector> projector = nullptr)
 {
   using expression_pack_t = typename o2::aod::MetadataTrait<D>::metadata::expression_pack_t;
   if (fullTable->num_rows() == 0) {
@@ -892,21 +923,8 @@ auto spawner(std::shared_ptr<arrow::Table> const& fullTable, const char* name)
   }
   (expression_pack_t{});
 
-  return spawnerHelper(fullTable, new_schema, framework::pack_size(expression_pack_t{}), projectors.data(), fields, name);
+  return spawnerHelper(fullTable, new_schema, framework::pack_size(expression_pack_t{}), projectors.data(), fields, name, projector);
 }
-
-// template <soa::OriginEnc ORIGIN, typename... C>
-// auto spawner(framework::pack<C...> columns, std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name)
-// {
-//   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables));
-//   if (fullTable->num_rows() == 0) {
-//     return makeEmptyTable<soa::Table<ORIGIN, C...>>(name);
-//   }
-//   static auto fields = o2::soa::createFieldsFromColumns(columns);
-//   static auto new_schema = std::make_shared<arrow::Schema>(fields);
-//   std::array<expressions::Projector, sizeof...(C)> projectors{{std::move(C::Projector())...}};
-//   return spawnerHelper(fullTable, new_schema, sizeof...(C), projectors.data(), fields, name);
-// }
 
 template <typename... C>
 auto spawner(framework::pack<C...> columns, std::vector<std::shared_ptr<arrow::Table>>&& tables, const char* name)

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -83,7 +83,8 @@ static inline auto extractOriginals(ProcessingContext& pc)
     return {pc.inputs().get<TableConsumer>(o2::aod::label<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
-namespace {
+namespace
+{
 template <typename D>
   requires(D::exclusive)
 auto make_build(D metadata, InputSpec const& input, ProcessingContext& pc)
@@ -109,7 +110,7 @@ auto make_build(D metadata, InputSpec const& input, ProcessingContext& pc)
                                                                                                         extractOriginals<sources.size(), sources>(pc),
                                                                                                         index_pack_t{});
 }
-}
+} // namespace
 
 AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec>& requested)
 {
@@ -149,7 +150,8 @@ AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec>& req
   }};
 }
 
-namespace{
+namespace
+{
 template <o2::aod::is_aod_hash D>
 auto make_spawn(InputSpec const& input, ProcessingContext& pc)
 {
@@ -158,7 +160,7 @@ auto make_spawn(InputSpec const& input, ProcessingContext& pc)
   static std::shared_ptr<gandiva::Projector> projector = nullptr;
   return o2::framework::spawner<D>(extractOriginals<sources.size(), sources>(pc), input.binding.c_str(), projector);
 }
-}
+} // namespace
 
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& requested)
 {

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -83,59 +83,81 @@ static inline auto extractOriginals(ProcessingContext& pc)
     return {pc.inputs().get<TableConsumer>(o2::aod::label<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
+namespace {
+template <typename D>
+  requires(D::exclusive)
+auto make_build(D metadata, InputSpec const& input, ProcessingContext& pc)
+{
+  using metadata_t = decltype(metadata);
+  using Key = typename metadata_t::Key;
+  using index_pack_t = typename metadata_t::index_pack_t;
+  constexpr auto sources = metadata_t::sources;
+  return o2::framework::IndexBuilder<o2::framework::Exclusive>::indexBuilder<Key, sources.size(), sources>(input.binding.c_str(),
+                                                                                                           extractOriginals<sources.size(), sources>(pc),
+                                                                                                           index_pack_t{});
+}
+
+template <typename D>
+  requires(!D::exclusive)
+auto make_build(D metadata, InputSpec const& input, ProcessingContext& pc)
+{
+  using metadata_t = decltype(metadata);
+  using Key = typename metadata_t::Key;
+  using index_pack_t = typename metadata_t::index_pack_t;
+  constexpr auto sources = metadata_t::sources;
+  return o2::framework::IndexBuilder<o2::framework::Sparse>::indexBuilder<Key, sources.size(), sources>(input.binding.c_str(),
+                                                                                                        extractOriginals<sources.size(), sources>(pc),
+                                                                                                        index_pack_t{});
+}
+}
 
 AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec>& requested)
 {
-  return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
+  return AlgorithmSpec::InitCallback{[requested](InitContext& /*ic*/) {
     return [requested](ProcessingContext& pc) {
       auto outputs = pc.outputs();
       // spawn tables
       for (auto& input : requested) {
         auto&& [origin, description, version] = DataSpecUtils::asConcreteDataMatcher(input);
-        auto maker = [&](auto metadata) {
-          using metadata_t = decltype(metadata);
-          using Key = typename metadata_t::Key;
-          using index_pack_t = typename metadata_t::index_pack_t;
-          constexpr auto sources = metadata_t::sources;
-          if constexpr (metadata_t::exclusive == true) {
-            return o2::framework::IndexBuilder<o2::framework::Exclusive>::indexBuilder<Key, sources.size(), sources>(input.binding.c_str(),
-                                                                                                                     extractOriginals<sources.size(), sources>(pc),
-                                                                                                                     index_pack_t{});
-          } else {
-            return o2::framework::IndexBuilder<o2::framework::Sparse>::indexBuilder<Key, sources.size(), sources>(input.binding.c_str(),
-                                                                                                                  extractOriginals<sources.size(), sources>(pc),
-                                                                                                                  index_pack_t{});
-          }
-        };
-
         if (description == header::DataDescription{"MA_RN2_EX"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run2MatchedExclusiveMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run2MatchedExclusiveMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_RN2_SP"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run2MatchedSparseMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run2MatchedSparseMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_RN3_EX"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run3MatchedExclusiveMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run3MatchedExclusiveMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_RN3_SP"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run3MatchedSparseMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run3MatchedSparseMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_BCCOL_EX"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsExclusiveMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::MatchedBCCollisionsExclusiveMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_BCCOL_SP"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsSparseMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::MatchedBCCollisionsSparseMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_BCCOLS_EX"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsExclusiveMultiMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::MatchedBCCollisionsExclusiveMultiMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_BCCOLS_SP"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsSparseMultiMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::MatchedBCCollisionsSparseMultiMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_RN3_BC_SP"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run3MatchedToBCSparseMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run3MatchedToBCSparseMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_RN3_BC_EX"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run3MatchedToBCExclusiveMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run3MatchedToBCExclusiveMetadata{}, input, pc));
         } else if (description == header::DataDescription{"MA_RN2_BC_SP"}) {
-          outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run2MatchedToBCSparseMetadata{}));
+          outputs.adopt(Output{origin, description, version}, make_build(o2::aod::Run2MatchedToBCSparseMetadata{}, input, pc));
         } else {
           throw std::runtime_error("Not an index table");
         }
       }
     };
   }};
+}
+
+namespace{
+template <o2::aod::is_aod_hash D>
+auto make_spawn(InputSpec const& input, ProcessingContext& pc)
+{
+  using metadata_t = o2::aod::MetadataTrait<D>::metadata;
+  constexpr auto sources = metadata_t::sources;
+  static std::shared_ptr<gandiva::Projector> projector = nullptr;
+  return o2::framework::spawner<D>(extractOriginals<sources.size(), sources>(pc), input.binding.c_str(), projector);
+}
 }
 
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& requested)
@@ -146,43 +168,37 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& reque
       // spawn tables
       for (auto& input : requested) {
         auto&& [origin, description, version] = DataSpecUtils::asConcreteDataMatcher(input);
-        auto maker = [&]<o2::aod::is_aod_hash D>() {
-          using metadata_t = o2::aod::MetadataTrait<D>::metadata;
-          constexpr auto sources = metadata_t::sources;
-          return o2::framework::spawner<D>(extractOriginals<sources.size(), sources>(pc), input.binding.c_str());
-        };
-
         if (description == header::DataDescription{"EXTRACK"}) {
-          outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACK/0"_h>>());
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACK/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXTRACK_IU"}) {
-          outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACK_IU/0"_h>>());
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACK_IU/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXTRACKCOV"}) {
-          outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACKCOV/0"_h>>());
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKCOV/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXTRACKCOV_IU"}) {
-          outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACKCOV_IU/0"_h>>());
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKCOV_IU/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXTRACKEXTRA"}) {
           if (version == 0U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACKEXTRA/0"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKEXTRA/0"_h>>(input, pc));
           } else if (version == 1U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACKEXTRA/1"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKEXTRA/1"_h>>(input, pc));
           } else if (version == 2U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXTRACKEXTRA/2"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKEXTRA/2"_h>>(input, pc));
           }
         } else if (description == header::DataDescription{"EXMFTTRACK"}) {
           if (version == 0U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXMFTTRACK/0"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACK/0"_h>>(input, pc));
           } else if (version == 1U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXMFTTRACK/1"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACK/1"_h>>(input, pc));
           }
         } else if (description == header::DataDescription{"EXFWDTRACK"}) {
-          outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXFWDTRACK/0"_h>>());
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXFWDTRACK/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXFWDTRACKCOV"}) {
-          outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXFWDTRACKCOV/0"_h>>());
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXFWDTRACKCOV/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXMCPARTICLE"}) {
           if (version == 0U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXMCPARTICLE/0"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMCPARTICLE/0"_h>>(input, pc));
           } else if (version == 1U) {
-            outputs.adopt(Output{origin, description, version}, maker.template operator()<o2::aod::Hash<"EXMCPARTICLE/1"_h>>());
+            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMCPARTICLE/1"_h>>(input, pc));
           }
         } else {
           throw runtime_error("Not an extended table");

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -86,7 +86,7 @@ void TableBuilder::setLabel(const char* label)
 
 std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema, size_t nColumns,
                                             expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name,
-                                            std::shared_ptr<gandiva::Projector> projector)
+                                            std::shared_ptr<gandiva::Projector>& projector)
 {
   if (projector == nullptr) {
     projector = framework::expressions::createProjectorHelper(nColumns, projectors, fullTable->schema(), fields);

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -85,9 +85,12 @@ void TableBuilder::setLabel(const char* label)
 }
 
 std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema, size_t nColumns,
-                                            expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name)
+                                            expressions::Projector* projectors, std::vector<std::shared_ptr<arrow::Field>> const& fields, const char* name,
+                                            std::shared_ptr<gandiva::Projector> projector)
 {
-  auto mergedProjectors = framework::expressions::createProjectorHelper(nColumns, projectors, fullTable->schema(), fields);
+  if (projector == nullptr) {
+    projector = framework::expressions::createProjectorHelper(nColumns, projectors, fullTable->schema(), fields);
+  }
 
   arrow::TableBatchReader reader(*fullTable);
   std::shared_ptr<arrow::RecordBatch> batch;
@@ -105,7 +108,7 @@ std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const&
       break;
     }
     try {
-      s = mergedProjectors->Evaluate(*batch, arrow::default_memory_pool(), &v);
+      s = projector->Evaluate(*batch, arrow::default_memory_pool(), &v);
       if (!s.ok()) {
         throw runtime_error_f("Cannot apply projector to source table of %s: %s", name, s.ToString().c_str());
       }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1684,7 +1684,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
               for (auto& input : device.inputs) {
                 for (auto& param : input.metadata) {
                   if (param.type == VariantType::Bool && param.name.find("control:") != std::string::npos) {
-                    if (param.name != "control:default" && param.name != "control:spawn" && param.name != "control:build") {
+                    if (param.name != "control:default" && param.name != "control:spawn" && param.name != "control:build" && param.name != "control:define") {
                       auto confName = confNameFromParam(param.name).second;
                       param.defaultValue = reg->get<bool>(confName.c_str());
                     }

--- a/Framework/Core/test/test_TableSpawner.cxx
+++ b/Framework/Core/test/test_TableSpawner.cxx
@@ -77,7 +77,7 @@ TEST_CASE("TestTableSpawner")
   }
 
   Defines<ExcPoints> excpts;
-  excpts.projectors[0] = test::x* test::x + test::y * test::y + test::z * test::z;
+  excpts.projectors[0] = test::x * test::x + test::y * test::y + test::z * test::z;
 
   auto extension_2 = ExcPointsCfgExtension{o2::framework::spawner<o2::aod::Hash<"EXCFGPTS/0"_h>>({t1}, o2::aod::Hash<"ExcPoints"_h>::str, excpts.projectors.data(), excpts.projector)};
   auto excpoints = ExcPoints{{t1, extension_2.asArrowTable()}, 0};

--- a/Framework/Core/test/test_TableSpawner.cxx
+++ b/Framework/Core/test/test_TableSpawner.cxx
@@ -50,8 +50,10 @@ TEST_CASE("TestTableSpawner")
   auto t1 = b1.finalize();
   Points st1{t1};
 
+  std::shared_ptr<gandiva::Projector> projector = nullptr;
+
   auto expoints_a = o2::soa::Extend<o2::aod::Points, test::Rsq, test::Sin>(st1);
-  auto extension = ExPointsExtension{o2::framework::spawner<o2::aod::Hash<"EXPTSNG/0"_h>>(t1, o2::aod::Hash<"ExPoints"_h>::str)};
+  auto extension = ExPointsExtension{o2::framework::spawner<o2::aod::Hash<"EXPTSNG/0"_h>>(t1, o2::aod::Hash<"ExPoints"_h>::str, projector)};
   auto expoints = ExPoints{{t1, extension.asArrowTable()}, 0};
 
   REQUIRE(expoints_a.size() == 9);

--- a/Framework/Core/test/test_TableSpawner.cxx
+++ b/Framework/Core/test/test_TableSpawner.cxx
@@ -28,10 +28,14 @@ DECLARE_SOA_COLUMN(Y, y, float);
 DECLARE_SOA_COLUMN(Z, z, float);
 DECLARE_SOA_EXPRESSION_COLUMN(Rsq, rsq, float, test::x* test::x + test::y * test::y + test::z * test::z);
 DECLARE_SOA_EXPRESSION_COLUMN(Sin, sin, float, test::x / nsqrt(test::x * test::x + test::y * test::y));
+
+DECLARE_SOA_CONFIGURABLE_EXPRESSION_COLUMN(Cfg, cfg, float, "configurable");
 } // namespace test
 
 DECLARE_SOA_TABLE(Points, "AOD", "PTSNG", test::X, test::Y, test::Z);
 DECLARE_SOA_EXTENDED_TABLE(ExPoints, Points, "EXPTSNG", 0, test::Rsq, test::Sin);
+
+DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE(ExcPoints, Points, "CFGPTS", test::Cfg);
 } // namespace o2::aod
 
 TEST_CASE("TestTableSpawner")
@@ -70,5 +74,25 @@ TEST_CASE("TestTableSpawner")
     ++rex;
     ++rexp;
     ++rexp_a;
+  }
+
+  Defines<ExcPoints> excpts;
+  excpts.projectors[0] = test::x* test::x + test::y * test::y + test::z * test::z;
+
+  auto extension_2 = ExcPointsCfgExtension{o2::framework::spawner<o2::aod::Hash<"EXCFGPTS/0"_h>>({t1}, o2::aod::Hash<"ExcPoints"_h>::str, excpts.projectors.data(), excpts.projector)};
+  auto excpoints = ExcPoints{{t1, extension_2.asArrowTable()}, 0};
+
+  rex = extension.begin();
+  auto rex_2 = extension_2.begin();
+  auto rexcp = excpoints.begin();
+
+  for (auto i = 1; i < 10; ++i) {
+    float rsq = i * i * 4 + i * i * 9 + i * i * 16;
+    REQUIRE(rex.rsq() == rsq);
+    REQUIRE(rex_2.cfg() == rsq);
+    REQUIRE(rexcp.cfg() == rsq);
+    ++rex;
+    ++rex_2;
+    ++rexcp;
   }
 }


### PR DESCRIPTION
Introducing configurable expression columns. 

* A special expression column defined with `DECLARE_SOA_CONFIGURABLE_EXPRESSION_COLUMN(Name, getter, type, "label")`
* A special extended table defined with `DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE(Name, BaseTable, "DESC", ext::column2, ext::column2, ...)` that can only contain configurable expression columns
* `Defines<Name> d;` template that can be added to an analysis task, indicating that it will define and produce this special extended table
* The actual expressions can be set inside `init()` function of the analysis task, using `d.projectors` array using the same order of columns as in the table declaration
* The expressions can use configurables from the task, as they are already set before `init()` is called
The aim is to be able to set the expressions from external sources, i.e. CCDB, task configuration JSON, etc.

* Improved Gandiva projector caching behavior for `Spawns` and `Defines`
* Added a test for the new functionality

The corresponding example in O2Physics will be updated after this is merged.