### PR TITLE
Add TRD Tracklets to Skimmed Data

### DIFF
--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -42,6 +42,8 @@
 #include <chrono>
 #include "DataFormatsTPC/PIDResponse.h"
 #include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "DataFormatsTRD/Tracklet64.h"
 #include "TROOT.h"
 #include "ReconstructionDataFormats/MatchInfoTOF.h"
 #include "DataFormatsTOF/Cluster.h"
@@ -177,6 +179,7 @@ class TPCTimeSeries : public Task
     auto tracksITSTPC = mTPCOnly ? gsl::span<o2::dataformats::TrackTPCITS>() : recoData.getTPCITSTracks();
     auto tracksITS = mTPCOnly ? gsl::span<o2::its::TrackITS>() : recoData.getITSTracks();
 
+
     // getting the vertices
     auto vertices = mTPCOnly ? gsl::span<o2::dataformats::PrimaryVertex>() : recoData.getPrimaryVertices();
     auto primMatchedTracks = mTPCOnly ? gsl::span<o2::dataformats::VtxTrackIndex>() : recoData.getPrimaryVertexMatchedTracks();     // Global ID's for associated tracks
@@ -186,6 +189,15 @@ class TPCTimeSeries : public Task
     mBufferDCA.mOccupancyMapTPC = std::vector<unsigned int>(recoData.occupancyMapTPC.begin(), recoData.occupancyMapTPC.end());
     if (mBufferDCA.mOccupancyMapTPC.size() > mMaxOccupancyHistBins) {
       mBufferDCA.mOccupancyMapTPC.resize(mMaxOccupancyHistBins);
+    }
+    /// TRD tracklets
+    const auto & tracksTRD = mTPCOnly ? gsl::span<o2::trd::TrackTRD>() : recoData.getITSTPCTRDTracks<o2::trd::TrackTRD>();
+    const auto& trklets = mTPCOnly ? gsl::span<const o2::trd::Tracklet64>():recoData.getTRDTracklets();
+    std::unordered_map<unsigned int, unsigned int> indicesTRDTPC; // TPC track index -> TRD-TPC track index.
+    // loop over all TRD tracks and map them to TPC tracks
+    for (int i = 0; i < tracksTRD.size(); ++i) {
+      //auto trackTPC = tracksTRD[i].getRefTPC().getIndex();
+      //if (trackTPC >= 0) indicesTRDTPC[trackTPC] = i;
     }
 
     // TOF clusters
@@ -464,7 +476,7 @@ class TPCTimeSeries : public Task
       auto myThread = [&](int iThread) {
         for (size_t i = iThread; i < loopEnd; i += mNThreads) {
           if (acceptTrack(tracksTPC[i])) {
-            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC, tracksITS, idxTPCTrackToTOFCluster, tofClusters);
+            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC, tracksITS, idxTPCTrackToTOFCluster, tofClusters, indicesTRDTPC, tracksTRD, trklets);
           }
         }
       };
@@ -481,7 +493,7 @@ class TPCTimeSeries : public Task
       auto myThread = [&](int iThread) {
         for (size_t i = iThread; i < loopEnd; i += mNThreads) {
           if (acceptTrack(tracksTPC[i])) {
-            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC, tracksITS, idxTPCTrackToTOFCluster, tofClusters);
+            fillDCA(tracksTPC, tracksITSTPC, vertices, i, iThread, indicesITSTPC, tracksITS, idxTPCTrackToTOFCluster, tofClusters, indicesTRDTPC,tracksTRD, trklets);
           }
         }
       };
@@ -1117,7 +1129,8 @@ class TPCTimeSeries : public Task
     return isGoodTrack;
   }
 
-  void fillDCA(const gsl::span<const TrackTPC> tracksTPC, const gsl::span<const o2::dataformats::TrackTPCITS> tracksITSTPC, const gsl::span<const o2::dataformats::PrimaryVertex> vertices, const int iTrk, const int iThread, const std::unordered_map<unsigned int, std::array<int, 2>>& indicesITSTPC, const gsl::span<const o2::its::TrackITS> tracksITS, const std::vector<std::tuple<int, float, float, o2::track::TrackLTIntegral, double, float, unsigned int>>& idxTPCTrackToTOFCluster, const gsl::span<const o2::tof::Cluster> tofClusters)
+  void fillDCA(const gsl::span<const TrackTPC> tracksTPC, const gsl::span<const o2::dataformats::TrackTPCITS> tracksITSTPC, const gsl::span<const o2::dataformats::PrimaryVertex> vertices, const int iTrk, const int iThread, const std::unordered_map<unsigned int, std::array<int, 2>>& indicesITSTPC, const gsl::span<const o2::its::TrackITS> tracksITS, const std::vector<std::tuple<int, float, float, o2::track::TrackLTIntegral, double, float, unsigned int>>& idxTPCTrackToTOFCluster, const gsl::span<const o2::tof::Cluster> tofClusters,
+               const std::unordered_map<unsigned int,unsigned int> indicesTRDTPC,const gsl::span<const o2::trd::TrackTRD> tracksTRD,gsl::span<const o2::trd::Tracklet64> trackletsTRD)
   {
     const auto& trackFull = tracksTPC[iTrk];
     const bool isGoodTrack = checkTrack(trackFull);
@@ -1353,6 +1366,9 @@ class TPCTimeSeries : public Task
             tpcZDeltaAtTOF = signSide * (o2::tpc::ParameterElectronics::Instance().ZbinWidth * trackFull.getTime0() - vertex.getTimeStamp().getTimeStamp()) * mVDrift - trackTmpOut.getZ() + tofCl.getZ();
           }
         }
+        // get TRD tracklet
+        std::vector<o2::trd::Tracklet64> trdTracklets;
+        int nTRDTracklets = 0;
 
         // get delta parameter between inner and outer
         float deltaTPCParamInOutTgl = trackFull.getTgl() - trackFull.getParamOut().getTgl();


### PR DESCRIPTION
### **[WIP] Add TRD Tracklets to Skimmed Data**
This PR introduces TRD tracklet support in the time series skimming workflow.
#### ✅ Changes:
- Added 6 TRD tracklets (8 bytes each) per track to skimmed data output.
#### ⚠️ Notes:
- Currently marked as **draft**: filling the `std::vector` of tracklets is not yet implemented.
- Once the data filling is in place, this will enable TRD PID validation and calibration via skimmed time series.
---
Tagging:  
@f3sch — draft for now, pending data filling logic.
