### PR TITLE
DPL: fix setting of run number

### DIFF
--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -423,7 +423,7 @@ ExpirationHandler::Handler LifetimeHelpers::enumerate(ConcreteDataMatcher const&
     dh.payloadSerializationMethod = gSerializationMethodNone;
     dh.tfCounter = timestamp;
     try {
-      dh.runNumber = atoi(services.get<DataTakingContext>().runNumber.c_str());
+      dh.runNumber = strtoull(services.get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("runNumber", "0").c_str(), nullptr, 10);
     } catch (...) {
       dh.runNumber = 0;
     }

--- a/Framework/Core/test/test_SimpleTimer.cxx
+++ b/Framework/Core/test/test_SimpleTimer.cxx
@@ -40,7 +40,6 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{
         adaptStateless([](ControlService& control, InputRecord& inputs) {
           DataRef ref = inputs.get("atimer");
-          assert(header);
           auto* header = o2::header::get<o2::header::DataHeader*>(ref.header);
           LOG(info) << "Run number: " << header->runNumber;
           // This is invoked autonomously by the timer.

--- a/Framework/Core/test/test_SimpleTimer.cxx
+++ b/Framework/Core/test/test_SimpleTimer.cxx
@@ -38,7 +38,11 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
         InputSpec{"atimer", "TST", "TIMER", 0, Lifetime::Timer}},
       {},
       AlgorithmSpec{
-        adaptStateless([](ControlService& control) {
+        adaptStateless([](ControlService& control, InputRecord& inputs) {
+          DataRef ref = inputs.get("atimer");
+          assert(header);
+          auto* header = o2::header::get<o2::header::DataHeader*>(ref.header);
+          LOG(info) << "Run number: " << header->runNumber;
           // This is invoked autonomously by the timer.
           control.readyToQuit(QuitRequest::Me);
         })}},


### PR DESCRIPTION

This is actually a workaround. The real issue is that timer at the moment are
completely outside of the data streaming and therefore do not have access to
the DataTakingService, where the proper calculation for the run number happens
and it's cached.

OK for now.

In the future we should make sure that the LifetimeHelpers::enumerate
gets a "Streaming" context, not the global one.
