### PR TITLE
MFT: read track covariances from AO2Ds

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -192,6 +192,8 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& reque
           } else if (version == 1U) {
             outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACK/1"_h>>(input, pc));
           }
+        } else if (description == header::DataDescription{"EXMFTTRACKCOV"}) {
+          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACKCOV/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXFWDTRACK"}) {
           outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXFWDTRACK/0"_h>>(input, pc));
         } else if (description == header::DataDescription{"EXFWDTRACKCOV"}) {


### PR DESCRIPTION
The `"EXMFTTRACKCOV"` table is added to the `aodSpawnerCallback()` in order to load the MFT tracks covariances from the AO2Ds.