### PR TITLE
GPU: ITS fix MC label output

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -63,6 +63,7 @@ framework::WorkflowSpec getWorkflow(bool useMC,
         cfg.runITSTracking = true;
         cfg.itsTriggerType = useTrig;
         cfg.itsOverrBeamEst = overrideBeamPosition;
+        cfg.processITSMC = useMC;
 
         Inputs ggInputs;
         auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false, true, false, true, true,

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -128,6 +128,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
     int32_t lumiScaleType = 0; // 0=off, 1=CTP, 2=TPC scalers
     bool outputErrorQA = false;
     bool runITSTracking = false;
+    bool processITSMC = false;
     bool itsOverrBeamEst = false;
     bool tpcTriggerHandling = false;
   };

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -1180,7 +1180,7 @@ Inputs GPURecoWorkflowSpec::inputs()
     if (mSpecConfig.itsOverrBeamEst) {
       inputs.emplace_back("meanvtx", "GLO", "MEANVERTEX", 0, Lifetime::Condition, ccdbParamSpec("GLO/Calib/MeanVertex", {}, 1));
     }
-    if (mSpecConfig.processMC) {
+    if (mSpecConfig.processITSMC) {
       inputs.emplace_back("itsmclabels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
       inputs.emplace_back("ITSMC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
     }
@@ -1254,8 +1254,9 @@ Outputs GPURecoWorkflowSpec::outputs()
     outputSpecs.emplace_back(gDataOriginITS, "VERTICESROF", 0, Lifetime::Timeframe);
     outputSpecs.emplace_back(gDataOriginITS, "IRFRAMES", 0, Lifetime::Timeframe);
 
-    if (mSpecConfig.processMC) {
+    if (mSpecConfig.processITSMC) {
       outputSpecs.emplace_back(gDataOriginITS, "VERTICESMCTR", 0, Lifetime::Timeframe);
+      outputSpecs.emplace_back(gDataOriginITS, "VERTICESMCPUR", 0, Lifetime::Timeframe);
       outputSpecs.emplace_back(gDataOriginITS, "TRACKSMCTR", 0, Lifetime::Timeframe);
       outputSpecs.emplace_back(gDataOriginITS, "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
     }

--- a/GPU/Workflow/src/gpu-reco-workflow.cxx
+++ b/GPU/Workflow/src/gpu-reco-workflow.cxx
@@ -179,6 +179,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   cfg.outputErrorQA = isEnabled(outputTypes, ioType::ErrorQA);
   cfg.outputSharedClusterMap = (cfg.outputCAClusters || cfg.caClusterer || isEnabled(inputTypes, ioType::Clusters)) && cfg.outputTracks && !isEnabled(outputTypes, ioType::NoSharedMap);
   cfg.processMC = doMC;
+  cfg.processITSMC = doMC;
   cfg.sendClustersPerSector = isEnabled(outputTypes, ioType::SendClustersPerSector);
   cfg.askDISTSTF = !cfgc.options().get<bool>("ignore-dist-stf");
   cfg.readTRDtracklets = isEnabled(inputTypes, ioType::TRDTracklets);


### PR DESCRIPTION
Allow MC labels to be calculated using ITS gpu tracking.
Note I had to separate the label processing using an additional flag `processITSMC` and not using the normal `--disable-mc` since this flag implicitly requires TPC things and not to disturb the code too much, I opted for this though it is ugly (better suggestions?).