### PR TITLE
Fix for TPC edge clusters in CTF decoding

### DIFF
--- a/GPU/GPUTracking/DataCompression/GPUTPCDecompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCDecompressionKernels.cxx
@@ -57,6 +57,19 @@ GPUdii() void GPUTPCDecompressionKernels::Thread<GPUTPCDecompressionKernels::ste
     ClusterNative* clout = buffer + decompressor.mNativeClustersIndex[linearIndex];
     uint32_t end = offsets[linearIndex] + ((linearIndex >= decompressor.mInputGPU.nSliceRows) ? 0 : decompressor.mInputGPU.nSliceRowClusters[linearIndex]);
     TPCClusterDecompressionCore::decompressHits(cmprClusters, offsets[linearIndex], end, clout);
+    if (processors.param.rec.tpc.clustersEdgeFixDistance > 0.f) {
+      constexpr GPUTPCGeometry geo;
+      for (uint32_t k = 0; k < outputAccess->nClusters[iSector][iRow]; k++) {
+        auto& cluster = buffer[k];
+        if (cluster.getFlags() & ClusterNative::flagEdge) {
+          auto padF = cluster.getPad();
+          float distEdge = padF < geo.NPads(iRow) / 2 ? padF : geo.NPads(iRow) - 1 - padF;
+          if (distEdge > processors.param.rec.tpc.clustersEdgeFixDistance) {
+            cluster.setFlags(cluster.getFlags() ^ ClusterNative::flagEdge);
+          }
+        }
+      }
+    }
     if (processors.param.rec.tpc.clustersShiftTimebins != 0.f) {
       for (uint32_t k = 0; k < outputAccess->nClusters[iSector][iRow]; k++) {
         auto& cl = buffer[k];

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
@@ -94,6 +94,19 @@ int32_t TPCClusterDecompressor::decompress(const CompressedClusters* clustersCom
       ClusterNative* clout = buffer + clusters[i][j].size();
       uint32_t end = offsets[i][j] + ((i * GPUCA_ROW_COUNT + j >= clustersCompressed->nSliceRows) ? 0 : clustersCompressed->nSliceRowClusters[i * GPUCA_ROW_COUNT + j]);
       TPCClusterDecompressionCore::decompressHits(*clustersCompressed, offsets[i][j], end, clout);
+      if (param.rec.tpc.clustersEdgeFixDistance > 0.f) {
+        constexpr GPUTPCGeometry geo;
+        for (uint32_t k = 0; k < clustersNative.nClusters[i][j]; k++) {
+          auto& cluster = buffer[k];
+          if (cluster.getFlags() & ClusterNative::flagEdge) {
+            auto padF = cluster.getPad();
+            float distEdge = padF < geo.NPads(j) / 2 ? padF : geo.NPads(j) - 1 - padF;
+            if (distEdge > param.rec.tpc.clustersEdgeFixDistance) {
+              cluster.setFlags(cluster.getFlags() ^ ClusterNative::flagEdge);
+            }
+          }
+        }
+      }
       if (param.rec.tpc.clustersShiftTimebins != 0.f) {
         for (uint32_t k = 0; k < clustersNative.nClusters[i][j]; k++) {
           auto& cl = buffer[k];

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -72,6 +72,7 @@ AddOptionRTC(tubeChi2, float, 5.f * 5.f, "", 0, "Max chi2 to mark cluster adjace
 AddOptionRTC(tubeMaxSize2, float, 2.5f * 2.5f, "", 0, "Square of max tube size (normally derrived from tpcTubeChi2)")
 AddOptionRTC(clustersShiftTimebins, float, 0, "", 0, "Shift of TPC clusters (applied during CTF cluster decoding)")
 AddOptionRTC(clustersShiftTimebinsClusterizer, float, 0, "", 0, "Shift of TPC clusters (applied during CTF clusterization)")
+AddOptionRTC(clustersEdgeFixDistance, float, 0.f, "", 0, "If >0, revert cluster.flag edge bit distance to edge exceeds this parameter (fixed during CTF decoding)")
 AddOptionRTC(defaultZOffsetOverR, float, 0.5210953f, "", 0, "Shift of TPC clusters (applied during CTF cluster decoding)")
 AddOptionRTC(PID_EKrangeMin, float, 0.47f, "", 0, "min P of electron/K BB bands crossing")
 AddOptionRTC(PID_EKrangeMax, float, 0.57f, "", 0, "max P of electron/K BB bands crossing")


### PR DESCRIPTION
Edge clusters before and after the fix with `GPU_rec_tpc.clustersEdgeFixDistance=0.5`
Default `GPU_rec_tpc.clustersEdgeFixDistance` is 0 (no fix).

![clfix](https://github.com/user-attachments/assets/51733e6f-a17d-40df-8502-2ea6989ed437)
