### PR TITLE
DPL: Do not compute metrics if the GUI is not available

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -848,9 +848,7 @@ auto flushMetrics(ServiceRegistryRef registry, DataProcessingStats& stats) -> vo
     }
     monitoring.send(std::move(metric));
   });
-  if (DefaultsHelpers::onlineDeploymentMode() == false) {
-    relayer.sendContextState();
-  }
+  relayer.sendContextState();
   monitoring.flushBuffer();
   O2_SIGNPOST_END(monitoring_service, sid, "flush", "done flushing metrics");
 };

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -1034,6 +1034,9 @@ uint64_t DataRelayer::getCreationTimeForSlot(TimesliceSlot slot)
 
 void DataRelayer::sendContextState()
 {
+  if (!mContext.get<DriverConfig const>().driverHasGUI) {
+    return;
+  }
   std::scoped_lock<O2_LOCKABLE(std::recursive_mutex)> lock(mMutex);
   auto& states = mContext.get<DataProcessingStates>();
   for (size_t ci = 0; ci < mTimesliceIndex.size(); ++ci) {


### PR DESCRIPTION

Also revert the change to drop metrics when running in online mode.
