### PR TITLE
DPL Analysis: improve handling of tables with sources

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -31,13 +31,14 @@ template <TableRef R>
 constexpr auto tableRef2ConfigParamSpec()
 {
   return o2::framework::ConfigParamSpec{
-                                        std::string{"input:"} + o2::aod::label<R>(),
-                                        framework::VariantType::String,
-                                        aod::sourceSpec<R>(),
-                                        {"\"\""}};
+    std::string{"input:"} + o2::aod::label<R>(),
+    framework::VariantType::String,
+    aod::sourceSpec<R>(),
+    {"\"\""}};
 }
 
-namespace {
+namespace
+{
 template <soa::with_sources T>
 inline constexpr auto getSources()
 {
@@ -66,7 +67,7 @@ constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
 {
   return {};
 }
-}
+}  // namespace
 
 template <TableRef R>
 constexpr auto tableRef2InputSpec()

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -13,7 +13,6 @@
 
 #include "Framework/ASoA.h"
 #include "Framework/DataAllocator.h"
-#include "Framework/ExpressionHelpers.h"
 #include "Framework/IndexBuilderHelpers.h"
 #include "Framework/InputSpec.h"
 #include "Framework/Output.h"
@@ -29,13 +28,56 @@
 namespace o2::soa
 {
 template <TableRef R>
+constexpr auto tableRef2ConfigParamSpec()
+{
+  return o2::framework::ConfigParamSpec{
+                                        std::string{"input:"} + o2::aod::label<R>(),
+                                        framework::VariantType::String,
+                                        aod::sourceSpec<R>(),
+                                        {"\"\""}};
+}
+
+namespace {
+template <soa::with_sources T>
+inline constexpr auto getSources()
+{
+  return []<size_t N, std::array<soa::TableRef, N> refs>() {
+    return []<size_t... Is>(std::index_sequence<Is...>) {
+      return std::vector{soa::tableRef2ConfigParamSpec<refs[Is]>()...};
+    }(std::make_index_sequence<N>());
+  }.template operator()<T::sources.size(), T::sources>();
+}
+
+template <soa::with_sources T>
+constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
+{
+  std::vector<framework::ConfigParamSpec> inputMetadata;
+  auto inputSources = getSources<T>();
+  std::sort(inputSources.begin(), inputSources.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name < b.name; });
+  auto last = std::unique(inputSources.begin(), inputSources.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name == b.name; });
+  inputSources.erase(last, inputSources.end());
+  inputMetadata.insert(inputMetadata.end(), inputSources.begin(), inputSources.end());
+  return inputMetadata;
+}
+
+template <typename T>
+  requires(!soa::with_sources<T>)
+constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
+{
+  return {};
+}
+}
+
+template <TableRef R>
 constexpr auto tableRef2InputSpec()
 {
   return framework::InputSpec{
     o2::aod::label<R>(),
     o2::aod::origin<R>(),
     o2::aod::description(o2::aod::signature<R>()),
-    R.version};
+    R.version,
+    framework::Lifetime::Timeframe,
+    getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>()};
 }
 
 template <TableRef R>
@@ -63,16 +105,6 @@ constexpr auto tableRef2OutputRef()
   return framework::OutputRef{
     o2::aod::label<R>(),
     R.version};
-}
-
-template <TableRef R>
-constexpr auto tableRef2ConfigParamSpec()
-{
-  return o2::framework::ConfigParamSpec{
-    std::string{"input:"} + o2::aod::label<R>(),
-    framework::VariantType::String,
-    aod::sourceSpec<R>(),
-    {"\"\""}};
 }
 }  // namespace o2::soa
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -65,46 +65,6 @@ concept is_enumeration = is_enumeration_v<std::decay_t<T>>;
 // the contents of an AnalysisTask...
 namespace {
 struct AnalysisDataProcessorBuilder {
-  template <typename T>
-  static ConfigParamSpec getSpec()
-  {
-    if constexpr (soa::has_metadata<aod::MetadataTrait<T>>) {
-      return ConfigParamSpec{std::string{"input:"} + aod::MetadataTrait<T>::metadata::tableLabel(), VariantType::String, aod::MetadataTrait<T>::metadata::sourceSpec(), {"\"\""}};
-    } else {
-      using O1 = framework::pack_element_t<0, typename T::originals>;
-      return ConfigParamSpec{std::string{"input:"} + aod::MetadataTrait<T>::metadata::tableLabel(), VariantType::String, aod::MetadataTrait<O1>::metadata::sourceSpec(), {"\"\""}};
-    }
-  }
-
-  template <soa::TableRef R>
-  static ConfigParamSpec getSpec()
-  {
-    return soa::tableRef2ConfigParamSpec<R>();
-  }
-
-  template <soa::with_sources T>
-  static inline auto getSources()
-  {
-    return []<size_t N, std::array<soa::TableRef, N> refs>() {
-      return []<size_t... Is>(std::index_sequence<Is...>) {
-        return std::vector{soa::tableRef2ConfigParamSpec<refs[Is]>()...};
-      }(std::make_index_sequence<N>());
-    }.template operator()<T::sources.size(), T::sources>();
-  }
-
-  template <soa::with_sources T>
-
-  static auto getInputMetadata()
-  {
-    std::vector<ConfigParamSpec> inputMetadata;
-    auto inputSources = getSources<T>();
-    std::sort(inputSources.begin(), inputSources.end(), [](ConfigParamSpec const& a, ConfigParamSpec const& b) { return a.name < b.name; });
-    auto last = std::unique(inputSources.begin(), inputSources.end(), [](ConfigParamSpec const& a, ConfigParamSpec const& b) { return a.name == b.name; });
-    inputSources.erase(last, inputSources.end());
-    inputMetadata.insert(inputMetadata.end(), inputSources.begin(), inputSources.end());
-    return inputMetadata;
-  }
-
   template <typename G, typename... Args>
   static void addGroupingCandidates(std::vector<StringPair>& bk, std::vector<StringPair>& bku)
   {
@@ -130,14 +90,9 @@ struct AnalysisDataProcessorBuilder {
   template <soa::TableRef R>
   static void addOriginalRef(const char* name, bool value, std::vector<InputSpec>& inputs)
   {
-    using metadata = typename aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata;
-    std::vector<ConfigParamSpec> inputMetadata;
-    inputMetadata.emplace_back(ConfigParamSpec{std::string{"control:"} + name, VariantType::Bool, value, {"\"\""}});
-    if constexpr (soa::with_sources<metadata>) {
-      auto inputSources = getInputMetadata<metadata>();
-      inputMetadata.insert(inputMetadata.end(), inputSources.begin(), inputSources.end());
-    }
-    DataSpecUtils::updateInputList(inputs, InputSpec{o2::aod::label<R>(), o2::aod::origin<R>(), aod::description(o2::aod::signature<R>()), R.version, Lifetime::Timeframe, inputMetadata});
+    auto spec = soa::tableRef2InputSpec<R>();
+    spec.metadata.emplace_back(ConfigParamSpec{std::string{"control:"} + name, VariantType::Bool, value, {"\"\""}});
+    DataSpecUtils::updateInputList(inputs, std::move(spec));
   }
 
   /// helpers to append expression information for a single argument

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -385,6 +385,15 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   auto outputSpecLessThan = [](OutputSpec const& lhs, OutputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
   std::sort(ac.requestedDYNs.begin(), ac.requestedDYNs.end(), inputSpecLessThan);
   std::sort(ac.providedDYNs.begin(), ac.providedDYNs.end(), outputSpecLessThan);
+
+  DataProcessorSpec indexBuilder{
+                                 "internal-dpl-aod-index-builder",
+                                 {},
+                                 {},
+                                 readers::AODReaderHelpers::indexBuilderCallback(ac.requestedIDXs),
+                                 {}};
+  AnalysisSupportHelpers::addMissingOutputsToBuilder(ac.requestedIDXs, ac.requestedAODs, ac.requestedDYNs, indexBuilder);
+
   for (auto& input : ac.requestedDYNs) {
     if (std::none_of(ac.providedDYNs.begin(), ac.providedDYNs.end(), [&input](auto const& x) { return DataSpecUtils::match(input, x); })) {
       ac.spawnerInputs.emplace_back(input);
@@ -397,15 +406,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {},
     readers::AODReaderHelpers::aodSpawnerCallback(ac.spawnerInputs),
     {}};
-
-  DataProcessorSpec indexBuilder{
-    "internal-dpl-aod-index-builder",
-    {},
-    {},
-    readers::AODReaderHelpers::indexBuilderCallback(ac.requestedIDXs),
-    {}};
-
-  AnalysisSupportHelpers::addMissingOutputsToBuilder(ac.requestedIDXs, ac.requestedAODs, ac.requestedDYNs, indexBuilder);
   AnalysisSupportHelpers::addMissingOutputsToSpawner({}, ac.spawnerInputs, ac.requestedAODs, aodSpawner);
 
   AnalysisSupportHelpers::addMissingOutputsToReader(ac.providedAODs, ac.requestedAODs, aodReader);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -387,11 +387,11 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   std::sort(ac.providedDYNs.begin(), ac.providedDYNs.end(), outputSpecLessThan);
 
   DataProcessorSpec indexBuilder{
-                                 "internal-dpl-aod-index-builder",
-                                 {},
-                                 {},
-                                 readers::AODReaderHelpers::indexBuilderCallback(ac.requestedIDXs),
-                                 {}};
+    "internal-dpl-aod-index-builder",
+    {},
+    {},
+    readers::AODReaderHelpers::indexBuilderCallback(ac.requestedIDXs),
+    {}};
   AnalysisSupportHelpers::addMissingOutputsToBuilder(ac.requestedIDXs, ac.requestedAODs, ac.requestedDYNs, indexBuilder);
 
   for (auto& input : ac.requestedDYNs) {


### PR DESCRIPTION
* When an `InputSpec` is created for a given `TableRef`, add the metadata unconditionally - this simplifies handling of inputs, that themselves depend on other input, such as index and extended tables.
* Reorder creation of aod-spawner and aod-builder on service device injection so that index tables can be created using the auto-spawned tables as well