### PR TITLE
ITS: CellSeed forced cast to int for chi2

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cell.h
@@ -97,7 +97,7 @@ class CellSeed final : public o2::track::TrackParCovF
   GPUhd() void setFirstTrackletIndex(int trkl) { mTracklets[0] = trkl; };
   GPUhd() int getSecondTrackletIndex() const { return mTracklets[1]; };
   GPUhd() void setSecondTrackletIndex(int trkl) { mTracklets[1] = trkl; };
-  GPUhd() int getChi2() const { return mChi2; };
+  GPUhd() float getChi2() const { return mChi2; };
   GPUhd() void setChi2(float chi2) { mChi2 = chi2; };
   GPUhd() int getLevel() const { return mLevel; };
   GPUhd() void setLevel(int level) { mLevel = level; };


### PR DESCRIPTION
@mconcas @mpuccio is there a reason that I a missing why the `getChi2()` method casts the chi2 to int? Seems to me that this is a bit broken, this affects the update steps the seed at different points in the  algorithm and I saw on a very small test a very very very small change.