### PR TITLE
[MCH] improve track extrapolation to vtx wo MCS correction

### DIFF
--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackExtrap.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackExtrap.h
@@ -18,6 +18,7 @@
 #define O2_MCH_TRACKEXTRAP_H_
 
 #include <cstddef>
+#include <optional>
 
 #include <TMatrixD.h>
 
@@ -70,17 +71,21 @@ class TrackExtrap
     /// Add branson correction resolution to parameter covariances
     return extrapToVertex(trackParam, xVtx, yVtx, zVtx, errXVtx, errYVtx, true, false);
   }
-  static bool extrapToVertexWithoutBranson(TrackParam& trackParam, double zVtx)
+  static bool extrapToVertexWithoutBranson(TrackParam& trackParam, double zVtx,
+                                           double xUpstream = 0., double yUpstream = 0.,
+                                           std::optional<double> zUpstream = std::nullopt)
   {
     /// Extrapolate track parameters to vertex, corrected for energy loss effects only
     /// Add dispersion due to multiple scattering and energy loss fluctuation to parameter covariances
-    return extrapToVertex(trackParam, 0., 0., zVtx, 0., 0., false, true);
+    return extrapToVertex(trackParam, 0., 0., zVtx, 0., 0., false, true, xUpstream, yUpstream, zUpstream);
   }
-  static bool extrapToVertexUncorrected(TrackParam& trackParam, double zVtx)
+  static bool extrapToVertexUncorrected(TrackParam& trackParam, double zVtx,
+                                        double xUpstream = 0., double yUpstream = 0.,
+                                        std::optional<double> zUpstream = std::nullopt)
   {
     /// Extrapolate track parameters to vertex without multiple scattering and energy loss corrections
     /// Add dispersion due to multiple scattering to parameter covariances
-    return extrapToVertex(trackParam, 0., 0., zVtx, 0., 0., false, false);
+    return extrapToVertex(trackParam, 0., 0., zVtx, 0., 0., false, false, xUpstream, yUpstream, zUpstream);
   }
 
   static bool extrapToMID(TrackParam& trackParam);
@@ -92,7 +97,8 @@ class TrackExtrap
 
  private:
   static bool extrapToVertex(TrackParam& trackParam, double xVtx, double yVtx, double zVtx,
-                             double errXVtx, double errYVtx, bool correctForMCS, bool correctForEnergyLoss);
+                             double errXVtx, double errYVtx, bool correctForMCS, bool correctForEnergyLoss,
+                             double xUpstream = 0., double yUpstream = 0., std::optional<double> zUpstream = std::nullopt);
 
   static bool getAbsorberCorrectionParam(double trackXYZIn[3], double trackXYZOut[3], double pTotal,
                                          double& pathLength, double& f0, double& f1, double& f2,

--- a/Detectors/MUON/MCH/Tracking/src/TrackExtrap.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackExtrap.cxx
@@ -276,7 +276,8 @@ bool TrackExtrap::extrapToMID(TrackParam& trackParam)
 
 //__________________________________________________________________________
 bool TrackExtrap::extrapToVertex(TrackParam& trackParam, double xVtx, double yVtx, double zVtx,
-                                 double errXVtx, double errYVtx, bool correctForMCS, bool correctForEnergyLoss)
+                                 double errXVtx, double errYVtx, bool correctForMCS, bool correctForEnergyLoss,
+                                 double xUpstream, double yUpstream, std::optional<double> zUpstream)
 {
   /// Main method for extrapolation to the vertex:
   /// Returns the track parameters and covariances resulting from the extrapolation of the current trackParam
@@ -285,6 +286,8 @@ bool TrackExtrap::extrapToVertex(TrackParam& trackParam, double xVtx, double yVt
   /// if correctForMCS=false: add parameter dispersion due to MCS in parameter covariances
   /// if correctForEnergyLoss=true:  correct parameters for energy loss and add energy loss fluctuation to covariances
   /// if correctForEnergyLoss=false: do nothing about energy loss
+  /// In case correctForMCS=false and the position of the track upstream the absorber is provided, it is used
+  /// to compute the absorber correction parameters, instead of the extrapolated track position from downstream
 
   if (trackParam.getZ() == zVtx) {
     return true; // nothing to be done if already at vertex
@@ -297,6 +300,18 @@ bool TrackExtrap::extrapToVertex(TrackParam& trackParam, double xVtx, double yVt
       return false;
     } else {
       LOG(warning) << "Ending Z (" << zVtx << ") inside the front absorber (" << SAbsZBeg << ", " << SAbsZEnd << ")";
+      return false;
+    }
+  }
+
+  // check the upstream track position with respect to the absorber if provided and used (spectro z<0)
+  // zUpstream must be >= SAbsZBeg with 100 µm tolerance to account for numerical precision
+  if (!correctForMCS && zUpstream && *zUpstream < SAbsZBeg - 0.01) {
+    if (*zUpstream < SAbsZEnd) {
+      LOG(warning) << "Upstream Z (" << *zUpstream << ") downstream the front absorber (zAbsorberEnd = " << SAbsZEnd << ")";
+      return false;
+    } else {
+      LOG(warning) << "Upstream Z (" << *zUpstream << ") inside the front absorber (" << SAbsZBeg << ", " << SAbsZEnd << ")";
       return false;
     }
   }
@@ -328,6 +343,10 @@ bool TrackExtrap::extrapToVertex(TrackParam& trackParam, double xVtx, double yVt
     trackXYZIn[2] = SAbsZBeg;
     trackXYZIn[0] = trackXYZOut[0] + (xVtx - trackXYZOut[0]) / (zVtx - trackXYZOut[2]) * (trackXYZIn[2] - trackXYZOut[2]);
     trackXYZIn[1] = trackXYZOut[1] + (yVtx - trackXYZOut[1]) / (zVtx - trackXYZOut[2]) * (trackXYZIn[2] - trackXYZOut[2]);
+  } else if (zUpstream) { // or linear propagation to the upstream track position
+    trackXYZIn[2] = SAbsZBeg;
+    trackXYZIn[0] = trackXYZOut[0] + (xUpstream - trackXYZOut[0]) / (*zUpstream - trackXYZOut[2]) * (trackXYZIn[2] - trackXYZOut[2]);
+    trackXYZIn[1] = trackXYZOut[1] + (yUpstream - trackXYZOut[1]) / (*zUpstream - trackXYZOut[2]) * (trackXYZIn[2] - trackXYZOut[2]);
   } else { // or standard propagation without vertex constraint
     TrackParam trackParamIn(trackParam);
     if (!extrapToZ(trackParamIn, SAbsZBeg)) {


### PR DESCRIPTION
When the track is extrapolated to the vertex (or MFT) without multiple scattering correction, the absorber material crossed (for e.g. E loss correction) is estimated by propagating the track from downstream, without information from upstream. This PR allows to provide an upstream point (typically the vertex or the MFT track position) to better estimate the path through the absorber. If no information is provided, the behavior is unchanged.
