### PR TITLE
Common: ConfKey align prov + print hash

### DIFF
--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -162,7 +162,7 @@ class ConfigurableParam
   virtual std::string getName() const = 0;
 
   // print the current keys and values to screen (optionally with provenance information)
-  virtual void printKeyValues(bool showprov = true, bool useLogger = false) const = 0;
+  virtual void printKeyValues(bool showprov = true, bool useLogger = false, bool withPadding = false, bool showHash = false) const = 0;
 
   // get a single size_t hash_value of this parameter (can be used as a checksum to see
   // if object changed or different)

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -34,7 +34,7 @@ struct ParamDataMember {
   std::string value;
   std::string provenance;
 
-  std::string toString(std::string const& prefix, bool showProv) const;
+  std::string toString(std::string const& prefix, bool showProv, size_t padding = 0) const;
 };
 
 // ----------------------------------------------------------------
@@ -58,8 +58,8 @@ class _ParamHelper
   static void syncCCDBandRegistry(std::string const& mainkey, TClass* cl, void* to, void* from,
                                   std::map<std::string, ConfigurableParam::EParamProvenance>* provmap, size_t offset);
 
-  static void outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger);
-  static void printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger);
+  static void outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger, bool withPadding = false, bool showHash = false);
+  static void printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger, bool withPadding, bool showHash);
 
   static size_t getHashImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members);
 
@@ -100,13 +100,13 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
   // ----------------------------------------------------------------
 
   // one of the key methods, using introspection to print itself
-  void printKeyValues(bool showProv = true, bool useLogger = false) const final
+  void printKeyValues(bool showProv = true, bool useLogger = false, bool withPadding = true, bool showHash = true) const final
   {
     if (!isInitialized()) {
       initialize();
     }
     auto members = getDataMembers();
-    _ParamHelper::printMembersImpl(getName(), members, showProv, useLogger);
+    _ParamHelper::printMembersImpl(getName(), members, showProv, useLogger, withPadding, showHash);
   }
 
   //
@@ -237,13 +237,13 @@ class ConfigurableParamPromoter : public Base, virtual public ConfigurableParam
   // ----------------------------------------------------------------
 
   // one of the key methods, using introspection to print itself
-  void printKeyValues(bool showProv = true, bool useLogger = false) const final
+  void printKeyValues(bool showProv = true, bool useLogger = false, bool withPadding = true, bool showHash = true) const final
   {
     if (!isInitialized()) {
       initialize();
     }
     auto members = getDataMembers();
-    _ParamHelper::printMembersImpl(getName(), members, showProv, useLogger);
+    _ParamHelper::printMembersImpl(getName(), members, showProv, useLogger, withPadding, showHash);
   }
 
   //

--- a/Common/Utils/src/ConfigurableParamHelper.cxx
+++ b/Common/Utils/src/ConfigurableParamHelper.cxx
@@ -26,6 +26,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/functional/hash.hpp>
 #include <functional>
+#include <format>
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
@@ -35,16 +36,25 @@ using namespace o2::conf;
 
 // ----------------------------------------------------------------------
 
-std::string ParamDataMember::toString(std::string const& prefix, bool showProv) const
+std::string ParamDataMember::toString(std::string const& prefix, bool showProv, size_t padding) const
 {
-  std::string nil = "<null>";
-
+  const std::string label = prefix + "." + name + " : " + value;
   std::ostringstream out;
-  out << prefix << "." << name << " : " << value;
+  out << label;
 
   if (showProv) {
-    std::string prov = (provenance.compare("") == 0 ? nil : provenance);
-    out << "\t\t[ " + prov + " ]";
+    std::string prov = (provenance.compare("") == 0 ? "<null>" : provenance);
+    if (padding) {
+      size_t len = label.size() - prefix.size() - 5; // 4 four the extra chars + 1 for the maxpad
+      if (len < padding) {
+        out << std::string(padding - len, ' ');
+      } else {
+        out << ' ';
+      }
+      out << "[ " + prov + " ]";
+    } else {
+      out << "\t\t[ " + prov + " ]";
+    }
   }
   return out.str();
 }
@@ -308,23 +318,40 @@ void _ParamHelper::fillKeyValuesImpl(std::string const& mainkey, TClass* cl, voi
 
 // ----------------------------------------------------------------------
 
-void _ParamHelper::printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger)
+void _ParamHelper::printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger, bool withPadding, bool showHash)
 {
 
-  _ParamHelper::outputMembersImpl(std::cout, mainkey, members, showProv, useLogger);
+  _ParamHelper::outputMembersImpl(std::cout, mainkey, members, showProv, useLogger, withPadding, showHash);
 }
 
-void _ParamHelper::outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger)
+void _ParamHelper::outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger, bool withPadding, bool showHash)
 {
   if (members == nullptr) {
     return;
   }
 
+  size_t maxpad{0};
+  if (withPadding) {
+    for (auto& member : *members) {
+      maxpad = std::max(maxpad, member.name.size() + member.value.size());
+    }
+  }
+
+  if (showHash) {
+    std::string shash = std::format("{:07x}", getHashImpl(mainkey, members));
+    shash = shash.substr(0, 7);
+    if (useLogger) {
+      LOG(info) << mainkey << " [Hash#" << shash << "]";
+    } else {
+      out << mainkey << " [Hash#" << shash << "]\n";
+    }
+  }
+
   for (auto& member : *members) {
     if (useLogger) {
-      LOG(info) << member.toString(mainkey, showProv);
+      LOG(info) << member.toString(mainkey, showProv, maxpad);
     } else {
-      out << member.toString(mainkey, showProv) << "\n";
+      out << member.toString(mainkey, showProv, maxpad) << "\n";
     }
   }
 }


### PR DESCRIPTION
The first change is of course just a visual aid but the second one I find useful for quick comparisons of parameters (and the machinery was anyways there). Let me know what you think.
<img width="374" alt="image" src="https://github.com/user-attachments/assets/72c8fc1d-c532-4e7f-ae53-6fb2e04c9999" />
