### PR TITLE
GPU CUDA ORT: Fix usage of OrtCUDAProviderOptionsV2

### DIFF
--- a/GPU/GPUTracking/Base/cuda/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/cuda/CMakeLists.txt
@@ -114,7 +114,6 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
     ${MODULE}
     SOURCES ${SRCS}
     PUBLIC_LINK_LIBRARIES O2::GPUTracking O2::ITStrackingCUDA
-    PRIVATE_LINK_LIBRARIES onnxruntime::onnxruntime
     PRIVATE_INCLUDE_DIRECTORIES
       ${CMAKE_SOURCE_DIR}/Detectors/Base/src
       ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
@@ -139,6 +138,7 @@ if (onnxruntime_FOUND)
   target_compile_definitions(${targetName} PRIVATE
                                            $<$<BOOL:${ORT_CUDA_BUILD}>:ORT_CUDA_BUILD>
                                            $<$<BOOL:${ORT_TENSORRT_BUILD}>:ORT_TENSORRT_BUILD>)
+  target_link_libraries(${targetName} PRIVATE onnxruntime::onnxruntime)
 endif()
 
 # Setting target architecture and adding GPU libraries

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -643,9 +643,8 @@ void GPUReconstructionCUDA::SetONNXGPUStream(Ort::SessionOptions& session_option
   // UpdateCUDAProviderOptions(cuda_options, keys.data(), values.data(), keys.size());
 
   // this implicitly sets "has_user_compute_stream"
-  cuda_options->has_user_compute_stream = 1;
   ORTCHK(api->UpdateCUDAProviderOptionsWithValue(cuda_options, "user_compute_stream", mInternals->Streams[stream]));
-  session_options.AppendExecutionProvider_CUDA_V2(cuda_options);
+  ORTCHK(api->SessionOptionsAppendExecutionProvider_CUDA_V2(session_options, cuda_options));
 
   // Finally, don't forget to release the provider options
   api->ReleaseCUDAProviderOptions(cuda_options);

--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -162,7 +162,6 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
     ${MODULE}
     SOURCES ${SRCS}
     PUBLIC_LINK_LIBRARIES O2::GPUTracking O2::ITStrackingHIP
-    PRIVATE_LINK_LIBRARIES onnxruntime::onnxruntime
     PRIVATE_INCLUDE_DIRECTORIES
       ${CMAKE_SOURCE_DIR}/Detectors/Base/src
       ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
@@ -194,6 +193,7 @@ if (onnxruntime_FOUND)
   target_compile_definitions(${targetName} PRIVATE
                                            $<$<BOOL:${ORT_ROCM_BUILD}>:ORT_ROCM_BUILD>
                                            $<$<BOOL:${ORT_MIGRAPHX_BUILD}>:ORT_MIGRAPHX_BUILD>)
+  target_link_libraries(${targetName} PRIVATE onnxruntime::onnxruntime)
 endif()
 
 add_library(${MODULE}_CXX OBJECT ${SRCS_CXX}) # Adding a C++ library for the .cxx code of the HIP library, such that it does not link to HIP libraries, and CMake HIP Language doesn't add HIP compile flags.


### PR DESCRIPTION
@ChSonnabend : Haven't tested it yet, but this fixes the compilation of the CUDA ORT code.
It seems compared to `OrtCUDAProviderOptions`, `OrtCUDAProviderOptionsV2` is intentionally an incomplete type and cannot be manipulated directly, but must only be updated via `UpdateCUDAProviderOptions`: https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#cc.