### PR TITLE
DPL: do not calculate context quantities if the GUI is disabled

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -852,7 +852,10 @@ auto flushMetrics(ServiceRegistryRef registry, DataProcessingStats& stats) -> vo
     }
     monitoring.send(std::move(metric));
   });
-  relayer.sendContextState();
+  // Do not even calculate GUI related quantities if the GUI is disabled.
+  if (registry.get<DriverConfig const>().driverHasGUI) {
+    relayer.sendContextState();
+  }
   monitoring.flushBuffer();
   O2_SIGNPOST_END(monitoring_service, sid, "flush", "done flushing metrics");
 };


### PR DESCRIPTION

Correct solution would be to do that on demand, quick fix for now.
