### PR TITLE
[EMCAL-689] EMCAL/Geometry: Add function to load alignment matrix fro…

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -22,7 +22,9 @@
 #include <TNamed.h>
 #include <TParticle.h>
 #include <TVector3.h>
+#include <TObjArray.h>
 
+#include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsEMCAL/Constants.h"
 #include "EMCALBase/GeometryBase.h"
 #include "MathUtils/Cartesian.h"
@@ -57,7 +59,7 @@ class Geometry
   /// | EMCAL_COMPLETE12SMV1_DCAL             | Full EMCAL, 10 DCAL Supermodules (not used in practice)  |
   /// | EMCAL_COMPLETE12SMV1_DCAL_8SM         | Full EMCAL, 8 DCAL Supermodules (run2)                   |
   /// | EMCAL_COMPLETE12SMV1_DCAL_DEV         | Full EMCAL, DCAL development geometry (not used)         |
-  Geometry(const std::string_view name, const std::string_view mcname = "", const std::string_view mctitle = "");
+  explicit Geometry(const std::string_view name, const std::string_view mcname = "", const std::string_view mctitle = "");
 
   /// \brief Copy constructor.
   Geometry(const Geometry& geom);
@@ -563,6 +565,11 @@ class Geometry
   /// Move from header due to coding violations : Dec 2,2011 by PAI
   ///
   void SetMisalMatrix(const TGeoHMatrix* m, Int_t smod) const;
+
+  ///
+  /// Method to set shift-rotational matrixes from CCDB
+  ///
+  void SetMisalMatrixFromCcdb(const char* path = "Users/m/mhemmer/EMCAL/Config/GeometryAligned", int timestamp = 10000) const;
 
   ///
   /// Transform clusters cell position into global with alternative method, taking into account the depth calculation.

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -8,16 +8,21 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#include "EMCALBase/Geometry.h"
+
+#include <fairlogger/Logger.h>
+
 #include <iomanip>
+#include <string>
+#include <algorithm>
+#include <cstdio>
+#include <tuple>
 
 #include <TGeoBBox.h>
 #include <TGeoManager.h>
 #include <TGeoMatrix.h>
 #include <TList.h>
 
-#include <fairlogger/Logger.h>
-
-#include "EMCALBase/Geometry.h"
 #include "EMCALBase/ShishKebabTrd1Module.h"
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -1557,6 +1562,7 @@ const TGeoHMatrix* Geometry::GetMatrixForSuperModule(Int_t smod) const
 
   if (!SMODULEMATRIX[smod]) {
     if (gGeoManager) {
+      LOG(info) << "Loading EMCAL misalignment matrix for SM " << smod << " from GeoManager.";
       SetMisalMatrix(GetMatrixForSuperModuleFromGeoManager(smod), smod);
     } else {
       LOG(fatal) << "Cannot find EMCAL misalignment matrices! Recover them either: \n"
@@ -1759,6 +1765,25 @@ void Geometry::SetMisalMatrix(const TGeoHMatrix* m, Int_t smod) const
     }
   } else {
     LOG(fatal) << "Wrong supermodule index -> " << smod << std::endl;
+  }
+}
+
+void Geometry::SetMisalMatrixFromCcdb(const char* path, int timestamp) const
+{
+  LOG(info) << "Using CCDB to obtain EMCal alignment.";
+  o2::ccdb::CcdbApi api;
+  map<string, string> metadata; // can be empty
+  api.init("http://alice-ccdb.cern.ch");
+  TObjArray* matrices = api.retrieveFromTFileAny<TObjArray>(path, metadata, timestamp);
+
+  for (int iSM = 0; iSM < mNumberOfSuperModules; ++iSM) {
+    TGeoHMatrix* mat = reinterpret_cast<TGeoHMatrix*>(matrices->At(iSM));
+    if (mat) {
+
+      SetMisalMatrix(mat, iSM);
+    } else {
+      LOG(info) << "Could not obtain Alignment Matrix for SM " << iSM;
+    }
   }
 }
 


### PR DESCRIPTION
…m CCDB

- Add function `SetMisalMatrixFromCcdb` to set the missalignment matrices for the EMCal via the CCDB. This way they are not laoded from the GeoManager. The function expects a path inside the ccdb, which by default is set to `"Users/m/mhemmer/EMCAL/Config/GeometryAligned"` and the timestamp. Currently in the CCDB we only have the old Run 2 alignment object. Once we have the new alignment objects we can uplaod them and via the correct time stamp load them fittingly.