### PR TITLE
[EMCAL-539] Fix in trigger simulation to not accept every event as MB

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -72,6 +72,7 @@ class Digitizer : public TObject
   double getEventTime() const { return mDigits.getEventTime(); }
   bool isLive(double t) const { return mDigits.isLive(t); }
   bool isLive() const { return mDigits.isLive(); }
+  bool isCurrentEventTriggered() const { return mDigits.isCurrentEventTriggered(); }
 
   void setDebugStreaming(bool doStreaming) { mEnableDebugStreaming = doStreaming; }
 

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -60,8 +60,21 @@ class DigitsWriteoutBuffer
 
   double getTriggerTime() const { return mTriggerTime; }
   double getEventTime() const { return mLastEventTime; }
-  bool isLive(double t) const { return ((t - mTriggerTime) < mLiveTime || (t - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)); }
-  bool isLive() const { return ((mLastEventTime - mTriggerTime) < mLiveTime || (mLastEventTime - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)); }
+  bool isLive(double t) const
+  {
+    return ((t - mTriggerTime) < mLiveTime || (t - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime));
+  }
+  bool isLive() const
+  {
+    return ((mLastEventTime - mTriggerTime) < (mLiveTime - mPreTriggerTime) || (mLastEventTime - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime));
+  }
+
+  /// Check if current collision was triggered
+  /// \return true if event was triggered
+  bool isCurrentEventTriggered() const
+  {
+    return mLastEventTime == mTriggerTime;
+  }
 
   // function returns true if the collision occurs 600ns before the readout window is open
   // Look here for more details https://alice.its.cern.ch/jira/browse/EMCAL-681

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -332,15 +332,17 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
     if (!trigger.any()) {
       continue;
     }
+
+    mDigitizer.setEventTime(timesview[collID], trigger.any());
+    if (!mDigitizer.isCurrentEventTriggered()) {
+      LOG(debug) << "reject collision";
+      continue;
+    }
+    LOG(debug) << "accept collision";
+
     // Trigger sim: Prepare CTP input digit
     acceptedTriggers.push_back(std::make_tuple(timesview[collID], trigger));
     LOG(debug) << "EMCAL TRU simulation: Sending trg = " << trigger << " to CTP";
-
-    mDigitizer.setEventTime(timesview[collID], trigger.any());
-
-    if (!mDigitizer.isLive()) {
-      continue;
-    }
 
     // for each collision, loop over the constituents event and source IDs
     // (background signal merging is basically taking place here)


### PR DESCRIPTION
- Only events where EMCal is triggered should be given the trigger flag. This was previously not the case