### PR TITLE
TPC QC: Add getter for occupancy to Cluster class

### DIFF
--- a/Detectors/TPC/qc/include/TPCQC/Clusters.h
+++ b/Detectors/TPC/qc/include/TPCQC/Clusters.h
@@ -17,10 +17,10 @@
 #ifndef AliceO2_TPC_CLUSTERS_H
 #define AliceO2_TPC_CLUSTERS_H
 
-//root includes
+// root includes
 #include "TCanvas.h"
 
-//o2 includes
+// o2 includes
 #include "TPCBase/CalDet.h"
 #include "TPCBase/Sector.h"
 #include "DataFormatsTPC/Defs.h"
@@ -74,6 +74,8 @@ class Clusters
   CalPad& getSigmaTime() { return mSigmaTime; }
   CalPad& getSigmaPad() { return mSigmaPad; }
   CalPad& getTimeBin() { return mTimeBin; }
+
+  CalPad getOccupancy(int nHBFPerTF = 32);
 
   void endTF() { ++mProcessedTFs; }
 

--- a/Detectors/TPC/qc/src/Clusters.cxx
+++ b/Detectors/TPC/qc/src/Clusters.cxx
@@ -22,8 +22,10 @@
 #include "TPCBase/ROC.h"
 #include "TPCBase/CRU.h"
 #include "TPCBase/Mapper.h"
+#include "TPCBase/ParameterElectronics.h"
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/KrCluster.h"
+#include "CommonConstants/LHCConstants.h"
 
 ClassImp(o2::tpc::qc::Clusters);
 
@@ -150,6 +152,15 @@ void Clusters::reset()
 
   mIsNormalized = false;
   mProcessedTFs = 0;
+}
+
+//______________________________________________________________________________
+o2::tpc::CalPad Clusters::getOccupancy(int nHBFPerTF)
+{
+  o2::tpc::CalPad Occupancy = mNClusters;
+  Occupancy /= float(mProcessedTFs * (o2::constants::lhc::LHCMaxBunches * nHBFPerTF) / float(o2::tpc::ParameterElectronics::TIMEBININBC));
+  return Occupancy;
+  ;
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/qc/src/Clusters.cxx
+++ b/Detectors/TPC/qc/src/Clusters.cxx
@@ -157,12 +157,10 @@ void Clusters::reset()
 //______________________________________________________________________________
 o2::tpc::CalPad Clusters::getOccupancy(int nHBFPerTF)
 {
-  o2::tpc::CalPad Occupancy = mNClusters;
-  Occupancy /= float(mProcessedTFs * (o2::constants::lhc::LHCMaxBunches * nHBFPerTF) / float(o2::tpc::ParameterElectronics::TIMEBININBC));
-  return Occupancy;
-  ;
+  o2::tpc::CalPad occupancy = mNClusters;
+  occupancy /= float(mProcessedTFs * (o2::constants::lhc::LHCMaxBunches * nHBFPerTF) / float(o2::tpc::ParameterElectronics::TIMEBININBC));
+  return occupancy;
 }
-
 //______________________________________________________________________________
 void Clusters::merge(Clusters& clusters)
 {


### PR DESCRIPTION
Picking up on #12643 so occupancy can be tracked in TPC QC.