### PR TITLE
Revert "DPL Analysis: prevent slice cache from updating when not required by enabled process functions"

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1400,10 +1400,10 @@ namespace o2::framework
 
 struct PreslicePolicyBase {
   const std::string binding;
-  Entry bindingKey;
+  StringPair bindingKey;
 
   bool isMissing() const;
-  Entry const& getBindingKey() const;
+  StringPair const& getBindingKey() const;
 };
 
 struct PreslicePolicySorted : public PreslicePolicyBase {
@@ -1428,7 +1428,7 @@ struct PresliceBase : public Policy {
   const std::string binding;
 
   PresliceBase(expressions::BindingNode index_)
-    : Policy{PreslicePolicyBase{{o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name})}, Entry(o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name}), std::string{index_.name})}, {}}
+    : Policy{PreslicePolicyBase{{o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name})}, std::make_pair(o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name}), std::string{index_.name})}, {}}
   {
   }
 
@@ -1508,7 +1508,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
 {
   if constexpr (OPT) {
     if (container.isMissing()) {
-      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.key.c_str());
+      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.second.c_str());
     }
   }
   uint64_t offset = 0;
@@ -1545,7 +1545,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
 {
   if constexpr (OPT) {
     if (container.isMissing()) {
-      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.key.c_str());
+      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.second.c_str());
     }
   }
   auto selection = container.getSliceFor(value);
@@ -1574,7 +1574,7 @@ auto doFilteredSliceBy(T const* table, o2::framework::PresliceBase<C, framework:
 {
   if constexpr (OPT) {
     if (container.isMissing()) {
-      missingOptionalPreslice(getLabelFromType<T>().data(), container.bindingKey.key.c_str());
+      missingOptionalPreslice(getLabelFromType<T>().data(), container.bindingKey.second.c_str());
     }
   }
   uint64_t offset = 0;

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -534,43 +534,39 @@ static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& asso
 /// Preslice handling
 template <typename T>
   requires(!is_preslice<T>)
-bool registerCache(T&, Cache&, Cache&)
+bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>&)
 {
   return false;
 }
 
 template <is_preslice T>
   requires std::same_as<typename T::policy_t, framework::PreslicePolicySorted>
-bool registerCache(T& preslice, Cache& bsks, Cache&)
+bool registerCache(T& preslice, std::vector<StringPair>& bsks, std::vector<StringPair>&)
 {
   if constexpr (T::optional) {
     if (preslice.binding == "[MISSING]") {
       return true;
     }
   }
-  auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.binding == preslice.bindingKey.binding) && (entry.key == preslice.bindingKey.key); });
+  auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.first == preslice.bindingKey.first) && (entry.second == preslice.bindingKey.second); });
   if (locate == bsks.end()) {
     bsks.emplace_back(preslice.getBindingKey());
-  } else if (locate->enabled == false) {
-    locate->enabled = true;
   }
   return true;
 }
 
 template <is_preslice T>
   requires std::same_as<typename T::policy_t, framework::PreslicePolicyGeneral>
-bool registerCache(T& preslice, Cache&, Cache& bsksU)
+bool registerCache(T& preslice, std::vector<StringPair>&, std::vector<StringPair>& bsksU)
 {
   if constexpr (T::optional) {
     if (preslice.binding == "[MISSING]") {
       return true;
     }
   }
-  auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.binding == preslice.bindingKey.binding) && (entry.key == preslice.bindingKey.key); });
+  auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.first == preslice.bindingKey.first) && (entry.second == preslice.bindingKey.second); });
   if (locate == bsksU.end()) {
     bsksU.emplace_back(preslice.getBindingKey());
-  } else if (locate->enabled == false) {
-    locate->enabled = true;
   }
   return true;
 }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -66,20 +66,20 @@ concept is_enumeration = is_enumeration_v<std::decay_t<T>>;
 namespace {
 struct AnalysisDataProcessorBuilder {
   template <typename G, typename... Args>
-  static void addGroupingCandidates(Cache& bk, Cache& bku, bool enabled)
+  static void addGroupingCandidates(std::vector<StringPair>& bk, std::vector<StringPair>& bku)
   {
-    [&bk, &bku, enabled]<typename... As>(framework::pack<As...>) mutable {
+    [&bk, &bku]<typename... As>(framework::pack<As...>) mutable {
       std::string key;
       if constexpr (soa::is_iterator<std::decay_t<G>>) {
         key = std::string{"fIndex"} + o2::framework::cutString(soa::getLabelFromType<std::decay_t<G>>());
       }
-      ([&bk, &bku, &key, enabled]() mutable {
+      ([&bk, &bku, &key]() mutable {
         if constexpr (soa::relatedByIndex<std::decay_t<G>, std::decay_t<As>>()) {
           auto binding = soa::getLabelFromTypeForKey<std::decay_t<As>>(key);
           if constexpr (o2::soa::is_smallgroups<std::decay_t<As>>) {
-            framework::updatePairList(bku, binding, key, enabled);
+            framework::updatePairList(bku, binding, key);
           } else {
-            framework::updatePairList(bk, binding, key, enabled);
+            framework::updatePairList(bk, binding, key);
           }
         }
       }(),
@@ -147,7 +147,7 @@ struct AnalysisDataProcessorBuilder {
   /// helper to parse the process arguments
   /// 1. enumeration (must be the only argument)
   template <typename R, typename C, is_enumeration A>
-  static void inputsFromArgs(R (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&, Cache&, Cache&)
+  static void inputsFromArgs(R (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&, std::vector<StringPair>&, std::vector<StringPair>&)
   {
     std::vector<ConfigParamSpec> inputMetadata;
     // FIXME: for the moment we do not support begin, end and step.
@@ -156,17 +156,17 @@ struct AnalysisDataProcessorBuilder {
 
   /// 2. grouping case - 1st argument is an iterator
   template <typename R, typename C, soa::is_iterator A, soa::is_table... Args>
-  static void inputsFromArgs(R (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, Cache& bk, Cache& bku)
+  static void inputsFromArgs(R (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<StringPair>& bk, std::vector<StringPair>& bku)
     requires(std::is_lvalue_reference_v<A> && (std::is_lvalue_reference_v<Args> && ...))
   {
-    addGroupingCandidates<A, Args...>(bk, bku, value);
+    addGroupingCandidates<A, Args...>(bk, bku);
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(A, Args...)>();
     addInputsAndExpressions<typename std::decay_t<A>::parent_t, Args...>(hash, name, value, inputs, eInfos);
   }
 
   /// 3. generic case
   template <typename R, typename C, soa::is_table... Args>
-  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, Cache&, Cache&)
+  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<StringPair>&, std::vector<StringPair>&)
     requires(std::is_lvalue_reference_v<Args> && ...)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(Args...)>();
@@ -480,8 +480,8 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<InputSpec> inputs;
   std::vector<ConfigParamSpec> options;
   std::vector<ExpressionInfo> expressionInfos;
-  Cache bindingsKeys;
-  Cache bindingsKeysUnsorted;
+  std::vector<StringPair> bindingsKeys;
+  std::vector<StringPair> bindingsKeysUnsorted;
 
   /// make sure options and configurables are set before expression infos are created
   homogeneous_apply_refs([&options, &hash](auto& element) { return analysis_task_parsers::appendOption(options, element); }, *task.get());

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -34,64 +34,51 @@ struct SliceInfoUnsortedPtr {
   gsl::span<int64_t const> getSliceFor(int value) const;
 };
 
-struct Entry {
-  std::string binding;
-  std::string key;
-  bool enabled;
+using StringPair = std::pair<std::string, std::string>;
 
-  Entry(std::string b, std::string k, bool e = true)
-    : binding{b},
-      key{k},
-      enabled{e}
-  {
-  }
-};
-
-using Cache = std::vector<Entry>;
-
-void updatePairList(Cache& list, std::string const& binding, std::string const& key, bool enabled);
+void updatePairList(std::vector<StringPair>& list, std::string const& binding, std::string const& key);
 
 struct ArrowTableSlicingCacheDef {
   constexpr static ServiceKind service_kind = ServiceKind::Global;
-  Cache bindingsKeys;
-  Cache bindingsKeysUnsorted;
+  std::vector<StringPair> bindingsKeys;
+  std::vector<StringPair> bindingsKeysUnsorted;
 
-  void setCaches(Cache&& bsks);
-  void setCachesUnsorted(Cache&& bsks);
+  void setCaches(std::vector<StringPair>&& bsks);
+  void setCachesUnsorted(std::vector<StringPair>&& bsks);
 };
 
 struct ArrowTableSlicingCache {
   constexpr static ServiceKind service_kind = ServiceKind::Stream;
 
-  Cache bindingsKeys;
+  std::vector<StringPair> bindingsKeys;
   std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int32Type>>> values;
   std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int64Type>>> counts;
 
-  Cache bindingsKeysUnsorted;
+  std::vector<StringPair> bindingsKeysUnsorted;
   std::vector<std::vector<int>> valuesUnsorted;
   std::vector<ListVector> groups;
 
-  ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted = {});
+  ArrowTableSlicingCache(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted = {});
 
   // set caching information externally
-  void setCaches(Cache&& bsks, Cache&& bsksUnsorted = {});
+  void setCaches(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted = {});
 
   // update slicing info cache entry (assumes it is already present)
   arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table> const& table);
   arrow::Status updateCacheEntryUnsorted(int pos, std::shared_ptr<arrow::Table> const& table);
 
   // helper to locate cache position
-  std::pair<int, bool> getCachePos(Entry const& bindingKey) const;
-  int getCachePosSortedFor(Entry const& bindingKey) const;
-  int getCachePosUnsortedFor(Entry const& bindingKey) const;
+  std::pair<int, bool> getCachePos(StringPair const& bindingKey) const;
+  int getCachePosSortedFor(StringPair const& bindingKey) const;
+  int getCachePosUnsortedFor(StringPair const& bindingKey) const;
 
   // get slice from cache for a given value
-  SliceInfoPtr getCacheFor(Entry const& bindingKey) const;
-  SliceInfoUnsortedPtr getCacheUnsortedFor(Entry const& bindingKey) const;
+  SliceInfoPtr getCacheFor(StringPair const& bindingKey) const;
+  SliceInfoUnsortedPtr getCacheUnsortedFor(StringPair const& bindingKey) const;
   SliceInfoPtr getCacheForPos(int pos) const;
   SliceInfoUnsortedPtr getCacheUnsortedForPos(int pos) const;
 
-  static void validateOrder(Entry const& bindingKey, std::shared_ptr<arrow::Table> const& input);
+  static void validateOrder(StringPair const& bindingKey, std::shared_ptr<arrow::Table> const& input);
 };
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -55,7 +55,7 @@ struct GroupSlicer {
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
-      auto bk = Entry(binding, mIndexColumnName);
+      auto bk = std::make_pair(binding, mIndexColumnName);
       if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
         if (table.size() == 0) {
           return;

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -197,7 +197,7 @@ bool PreslicePolicyBase::isMissing() const
   return binding == "[MISSING]";
 }
 
-Entry const& PreslicePolicyBase::getBindingKey() const
+StringPair const& PreslicePolicyBase::getBindingKey() const
 {
   return bindingKey;
 }

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -567,27 +567,26 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
     .name = "arrow-slicing-cache",
     .uniqueId = CommonServices::simpleServiceId<ArrowTableSlicingCache>(),
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions&) { return ServiceHandle{TypeIdHelpers::uniqueId<ArrowTableSlicingCache>(),
-                                                                                                         new ArrowTableSlicingCache(Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeys},
-                                                                                                                                    Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeysUnsorted}),
+                                                                                                         new ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>{services.get<ArrowTableSlicingCacheDef>().bindingsKeys}, std::vector{services.get<ArrowTableSlicingCacheDef>().bindingsKeysUnsorted}),
                                                                                                          ServiceKind::Stream, typeid(ArrowTableSlicingCache).name()}; },
     .configure = CommonServices::noConfiguration(),
     .preProcessing = [](ProcessingContext& pc, void* service_ptr) {
       auto* service = static_cast<ArrowTableSlicingCache*>(service_ptr);
       auto& caches = service->bindingsKeys;
-      for (auto i = 0u; i < caches.size(); ++i) {
-        if (caches[i].enabled && pc.inputs().getPos(caches[i].binding.c_str()) >= 0) {
-          auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].binding.c_str())->asArrowTable());
+      for (auto i = 0; i < caches.size(); ++i) {
+        if (pc.inputs().getPos(caches[i].first.c_str()) >= 0) {
+          auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].first.c_str())->asArrowTable());
           if (!status.ok()) {
-            throw runtime_error_f("Failed to update slice cache for %s/%s", caches[i].binding.c_str(), caches[i].key.c_str());
+            throw runtime_error_f("Failed to update slice cache for %s/%s", caches[i].first.c_str(), caches[i].second.c_str());
           }
         }
       }
       auto& unsortedCaches = service->bindingsKeysUnsorted;
-      for (auto i = 0u; i < unsortedCaches.size(); ++i) {
-        if (unsortedCaches[i].enabled && pc.inputs().getPos(unsortedCaches[i].binding.c_str()) >= 0) {
-          auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].binding.c_str())->asArrowTable());
+      for (auto i = 0; i < unsortedCaches.size(); ++i) {
+        if (pc.inputs().getPos(unsortedCaches[i].first.c_str()) >= 0) {
+          auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].first.c_str())->asArrowTable());
           if (!status.ok()) {
-            throw runtime_error_f("failed to update slice cache (unsorted) for %s/%s", unsortedCaches[i].binding.c_str(), unsortedCaches[i].key.c_str());
+            throw runtime_error_f("failed to update slice cache (unsorted) for %s/%s", unsortedCaches[i].first.c_str(), unsortedCaches[i].second.c_str());
           }
         }
       } },

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -11,7 +11,6 @@
 
 #include "Framework/ArrowTableSlicingCache.h"
 #include "Framework/RuntimeError.h"
-#include "Framework/Logger.h"
 
 #include <arrow/compute/api_aggregate.h>
 #include <arrow/compute/kernel.h>
@@ -20,10 +19,10 @@
 namespace o2::framework
 {
 
-void updatePairList(Cache& list, std::string const& binding, std::string const& key, bool enabled = true)
+void updatePairList(std::vector<StringPair>& list, std::string const& binding, std::string const& key)
 {
-  if (std::find_if(list.begin(), list.end(), [&binding, &key](auto const& entry) { return (entry.binding == binding) && (entry.key == key); }) == list.end()) {
-    list.emplace_back(binding, key, enabled);
+  if (std::find_if(list.begin(), list.end(), [&binding, &key](auto const& entry) { return (entry.first == binding) && (entry.second == key); }) == list.end()) {
+    list.emplace_back(binding, key);
   }
 }
 
@@ -66,17 +65,17 @@ gsl::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
   return {(*groups)[value].data(), (*groups)[value].size()};
 }
 
-void ArrowTableSlicingCacheDef::setCaches(Cache&& bsks)
+void ArrowTableSlicingCacheDef::setCaches(std::vector<StringPair>&& bsks)
 {
   bindingsKeys = bsks;
 }
 
-void ArrowTableSlicingCacheDef::setCachesUnsorted(Cache&& bsks)
+void ArrowTableSlicingCacheDef::setCachesUnsorted(std::vector<StringPair>&& bsks)
 {
   bindingsKeysUnsorted = bsks;
 }
 
-ArrowTableSlicingCache::ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted)
+ArrowTableSlicingCache::ArrowTableSlicingCache(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted)
   : bindingsKeys{bsks},
     bindingsKeysUnsorted{bsksUnsorted}
 {
@@ -87,7 +86,7 @@ ArrowTableSlicingCache::ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorte
   groups.resize(bindingsKeysUnsorted.size());
 }
 
-void ArrowTableSlicingCache::setCaches(Cache&& bsks, Cache&& bsksUnsorted)
+void ArrowTableSlicingCache::setCaches(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted)
 {
   bindingsKeys = bsks;
   bindingsKeysUnsorted = bsksUnsorted;
@@ -112,7 +111,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
   arrow::Datum value_counts;
   auto options = arrow::compute::ScalarAggregateOptions::Defaults();
   ARROW_ASSIGN_OR_RAISE(value_counts,
-                        arrow::compute::CallFunction("value_counts", {table->GetColumnByName(bindingsKeys[pos].key)},
+                        arrow::compute::CallFunction("value_counts", {table->GetColumnByName(bindingsKeys[pos].second)},
                                                      &options));
   auto pair = static_cast<arrow::StructArray>(value_counts.array());
   values[pos].reset();
@@ -129,11 +128,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
   if (table->num_rows() == 0) {
     return arrow::Status::OK();
   }
-  auto& [b, k, e] = bindingsKeysUnsorted[pos];
-  if (!e) {
-    LOG(debug) << "Update of disabled cache requested";
-    return arrow::Status::OK();
-  }
+  auto& [b, k] = bindingsKeysUnsorted[pos];
   auto column = table->GetColumnByName(k);
   auto row = 0;
   for (auto iChunk = 0; iChunk < column->num_chunks(); ++iChunk) {
@@ -144,7 +139,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
         if (std::find(valuesUnsorted[pos].begin(), valuesUnsorted[pos].end(), v) == valuesUnsorted[pos].end()) {
           valuesUnsorted[pos].push_back(v);
         }
-        if ((int)groups[pos].size() <= v) {
+        if (groups[pos].size() <= v) {
           groups[pos].resize(v + 1);
         }
         (groups[pos])[v].push_back(row);
@@ -156,7 +151,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
   return arrow::Status::OK();
 }
 
-std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey) const
+std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const StringPair& bindingKey) const
 {
   auto pos = getCachePosSortedFor(bindingKey);
   if (pos != -1) {
@@ -166,41 +161,41 @@ std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey
   if (pos != -1) {
     return {pos, false};
   }
-  throw runtime_error_f("%s/%s not found neither in sorted or unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
+  throw runtime_error_f("%s/%s not found neither in sorted or unsorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
 }
 
-int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
+int ArrowTableSlicingCache::getCachePosSortedFor(StringPair const& bindingKey) const
 {
-  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](StringPair const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
   if (locate != bindingsKeys.end()) {
     return std::distance(bindingsKeys.begin(), locate);
   }
   return -1;
 }
 
-int ArrowTableSlicingCache::getCachePosUnsortedFor(Entry const& bindingKey) const
+int ArrowTableSlicingCache::getCachePosUnsortedFor(StringPair const& bindingKey) const
 {
-  auto locate_unsorted = std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate_unsorted = std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](StringPair const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
   if (locate_unsorted != bindingsKeysUnsorted.end()) {
     return std::distance(bindingsKeysUnsorted.begin(), locate_unsorted);
   }
   return -1;
 }
-SliceInfoPtr ArrowTableSlicingCache::getCacheFor(Entry const& bindingKey) const
+SliceInfoPtr ArrowTableSlicingCache::getCacheFor(StringPair const& bindingKey) const
 {
   auto [p, s] = getCachePos(bindingKey);
   if (!s) {
-    throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
+    throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
   }
 
   return getCacheForPos(p);
 }
 
-SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bindingKey) const
+SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const StringPair& bindingKey) const
 {
   auto [p, s] = getCachePos(bindingKey);
   if (s) {
-    throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
+    throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
   }
 
   return getCacheUnsortedForPos(p);
@@ -229,9 +224,9 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedForPos(int pos) con
   };
 }
 
-void ArrowTableSlicingCache::validateOrder(Entry const& bindingKey, const std::shared_ptr<arrow::Table>& input)
+void ArrowTableSlicingCache::validateOrder(StringPair const& bindingKey, const std::shared_ptr<arrow::Table>& input)
 {
-  auto const& [target, key, enabled] = bindingKey;
+  auto const& [target, key] = bindingKey;
   auto column = input->GetColumnByName(key);
   auto array0 = static_cast<arrow::NumericArray<arrow::Int32Type>>(column->chunk(0)->data());
   int32_t prev = 0;

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -683,7 +683,7 @@ TEST_CASE("ArrowDirectSlicing")
 
   std::vector<arrow::Datum> slices;
   std::vector<uint64_t> offsts;
-  auto bk = Entry(soa::getLabelFromType<aod::Events>(), "fID");
+  auto bk = std::make_pair(soa::getLabelFromType<aod::Events>(), "fID");
   ArrowTableSlicingCache cache({bk});
   auto s = cache.updateCacheEntry(0, {evtTable});
   auto lcache = cache.getCacheFor(bk);
@@ -741,7 +741,7 @@ TEST_CASE("TestSlicingException")
   }
   auto evtTable = builderE.finalize();
 
-  auto bk = Entry(soa::getLabelFromType<aod::Events>(), "fID");
+  auto bk = std::make_pair(soa::getLabelFromType<aod::Events>(), "fID");
   ArrowTableSlicingCache cache({bk});
 
   try {


### PR DESCRIPTION
Reverts AliceO2Group/AliceO2#14057 - the slicing cache is erroneously skipped when there is at least one process function with the same grouping that is disabled