### PR TITLE
Avoid including BasicCCDBManager in headers exposed to ROOT.

### DIFF
--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/CTPRateFetcher.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/CTPRateFetcher.h
@@ -14,14 +14,16 @@
 
 #include <string>
 
-#include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/GRPLHCIFData.h"
 #include "DataFormatsCTP/Configuration.h"
 #include "DataFormatsCTP/Scalers.h"
 
-namespace o2
+namespace o2::ccdb
 {
-namespace ctp
+class BasicCCDBManager;
+}
+
+namespace o2::ctp
 {
 
 class CTPRateFetcher
@@ -54,7 +56,7 @@ class CTPRateFetcher
   o2::parameters::GRPLHCIFData mLHCIFdata{};
   ClassDefNV(CTPRateFetcher, 1);
 };
-} // namespace ctp
-} // namespace o2
+} // namespace o2::ctp
+
 
 #endif // COMMON_CCDB_CTPRATEFETCHER_H_

--- a/DataFormats/Detectors/CTP/src/CTPRateFetcher.cxx
+++ b/DataFormats/Detectors/CTP/src/CTPRateFetcher.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "DataFormatsCTP/CTPRateFetcher.h"
+#include "CCDB/BasicCCDBManager.h"
 
 #include <map>
 #include <vector>


### PR DESCRIPTION

Root will happily embed references to curl.h and / or the kernel headers if found on the build machine
and die if they are not there on the node.
