### PR TITLE
DPL Analysis: prevent slice cache from updating unnecessarily

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1400,10 +1400,10 @@ namespace o2::framework
 
 struct PreslicePolicyBase {
   const std::string binding;
-  StringPair bindingKey;
+  Entry bindingKey;
 
   bool isMissing() const;
-  StringPair const& getBindingKey() const;
+  Entry const& getBindingKey() const;
 };
 
 struct PreslicePolicySorted : public PreslicePolicyBase {
@@ -1428,7 +1428,7 @@ struct PresliceBase : public Policy {
   const std::string binding;
 
   PresliceBase(expressions::BindingNode index_)
-    : Policy{PreslicePolicyBase{{o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name})}, std::make_pair(o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name}), std::string{index_.name})}, {}}
+    : Policy{PreslicePolicyBase{{o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name})}, Entry(o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name}), std::string{index_.name})}, {}}
   {
   }
 
@@ -1508,7 +1508,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
 {
   if constexpr (OPT) {
     if (container.isMissing()) {
-      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.second.c_str());
+      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.key.c_str());
     }
   }
   uint64_t offset = 0;
@@ -1545,7 +1545,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
 {
   if constexpr (OPT) {
     if (container.isMissing()) {
-      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.second.c_str());
+      missingOptionalPreslice(getLabelFromType<std::decay_t<T>>().data(), container.bindingKey.key.c_str());
     }
   }
   auto selection = container.getSliceFor(value);
@@ -1574,7 +1574,7 @@ auto doFilteredSliceBy(T const* table, o2::framework::PresliceBase<C, framework:
 {
   if constexpr (OPT) {
     if (container.isMissing()) {
-      missingOptionalPreslice(getLabelFromType<T>().data(), container.bindingKey.second.c_str());
+      missingOptionalPreslice(getLabelFromType<T>().data(), container.bindingKey.key.c_str());
     }
   }
   uint64_t offset = 0;

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -534,39 +534,43 @@ static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& asso
 /// Preslice handling
 template <typename T>
   requires(!is_preslice<T>)
-bool registerCache(T&, std::vector<StringPair>&, std::vector<StringPair>&)
+bool registerCache(T&, Cache&, Cache&)
 {
   return false;
 }
 
 template <is_preslice T>
   requires std::same_as<typename T::policy_t, framework::PreslicePolicySorted>
-bool registerCache(T& preslice, std::vector<StringPair>& bsks, std::vector<StringPair>&)
+bool registerCache(T& preslice, Cache& bsks, Cache&)
 {
   if constexpr (T::optional) {
     if (preslice.binding == "[MISSING]") {
       return true;
     }
   }
-  auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.first == preslice.bindingKey.first) && (entry.second == preslice.bindingKey.second); });
+  auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.binding == preslice.bindingKey.binding) && (entry.key == preslice.bindingKey.key); });
   if (locate == bsks.end()) {
     bsks.emplace_back(preslice.getBindingKey());
+  } else if (locate->enabled == false) {
+    locate->enabled = true;
   }
   return true;
 }
 
 template <is_preslice T>
   requires std::same_as<typename T::policy_t, framework::PreslicePolicyGeneral>
-bool registerCache(T& preslice, std::vector<StringPair>&, std::vector<StringPair>& bsksU)
+bool registerCache(T& preslice, Cache&, Cache& bsksU)
 {
   if constexpr (T::optional) {
     if (preslice.binding == "[MISSING]") {
       return true;
     }
   }
-  auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.first == preslice.bindingKey.first) && (entry.second == preslice.bindingKey.second); });
+  auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.binding == preslice.bindingKey.binding) && (entry.key == preslice.bindingKey.key); });
   if (locate == bsksU.end()) {
     bsksU.emplace_back(preslice.getBindingKey());
+  } else if (locate->enabled == false) {
+    locate->enabled = true;
   }
   return true;
 }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -65,21 +65,18 @@ concept is_enumeration = is_enumeration_v<std::decay_t<T>>;
 // the contents of an AnalysisTask...
 namespace {
 struct AnalysisDataProcessorBuilder {
-  template <typename G, typename... Args>
-  static void addGroupingCandidates(std::vector<StringPair>& bk, std::vector<StringPair>& bku)
+  template <soa::is_iterator G, typename... Args>
+  static void addGroupingCandidates(Cache& bk, Cache& bku, bool enabled)
   {
-    [&bk, &bku]<typename... As>(framework::pack<As...>) mutable {
-      std::string key;
-      if constexpr (soa::is_iterator<std::decay_t<G>>) {
-        key = std::string{"fIndex"} + o2::framework::cutString(soa::getLabelFromType<std::decay_t<G>>());
-      }
-      ([&bk, &bku, &key]() mutable {
+    [&bk, &bku, enabled]<typename... As>(framework::pack<As...>) mutable {
+      auto key = std::string{"fIndex"} + o2::framework::cutString(soa::getLabelFromType<std::decay_t<G>>());
+      ([&bk, &bku, &key, enabled]() mutable {
         if constexpr (soa::relatedByIndex<std::decay_t<G>, std::decay_t<As>>()) {
           auto binding = soa::getLabelFromTypeForKey<std::decay_t<As>>(key);
           if constexpr (o2::soa::is_smallgroups<std::decay_t<As>>) {
-            framework::updatePairList(bku, binding, key);
+            framework::updatePairList(bku, binding, key, enabled);
           } else {
-            framework::updatePairList(bk, binding, key);
+            framework::updatePairList(bk, binding, key, enabled);
           }
         }
       }(),
@@ -145,32 +142,70 @@ struct AnalysisDataProcessorBuilder {
   }
 
   /// helper to parse the process arguments
+  template <typename T>
+  inline static bool requestInputsFromArgs(T&, std::string const&, std::vector<InputSpec>&, std::vector<ExpressionInfo>&)
+  {
+    return false;
+  }
+  template <is_process_configurable T>
+  inline static bool requestInputsFromArgs(T& pc, std::string const& name, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eis)
+  {
+    AnalysisDataProcessorBuilder::inputsFromArgs(pc.process, (name + "/" + pc.name).c_str(), pc.value, inputs, eis);
+    return true;
+  }
+  template <typename T>
+  inline static bool requestCacheFromArgs(T&, Cache&, Cache&)
+  {
+    return false;
+  }
+  template <is_process_configurable T>
+  inline static bool requestCacheFromArgs(T& pc, Cache& bk, Cache& bku)
+  {
+    AnalysisDataProcessorBuilder::cacheFromArgs(pc.process, pc.value, bk, bku);
+    return true;
+  }
   /// 1. enumeration (must be the only argument)
   template <typename R, typename C, is_enumeration A>
-  static void inputsFromArgs(R (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&, std::vector<StringPair>&, std::vector<StringPair>&)
+  static void inputsFromArgs(R (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&)//, Cache&, Cache&)
   {
     std::vector<ConfigParamSpec> inputMetadata;
     // FIXME: for the moment we do not support begin, end and step.
     DataSpecUtils::updateInputList(inputs, InputSpec{"enumeration", "DPL", "ENUM", 0, Lifetime::Enumeration, inputMetadata});
   }
 
-  /// 2. grouping case - 1st argument is an iterator
+  /// 2. 1st argument is an iterator
   template <typename R, typename C, soa::is_iterator A, soa::is_table... Args>
-  static void inputsFromArgs(R (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<StringPair>& bk, std::vector<StringPair>& bku)
+  static void inputsFromArgs(R (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)//, Cache& bk, Cache& bku)
     requires(std::is_lvalue_reference_v<A> && (std::is_lvalue_reference_v<Args> && ...))
   {
-    addGroupingCandidates<A, Args...>(bk, bku);
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(A, Args...)>();
     addInputsAndExpressions<typename std::decay_t<A>::parent_t, Args...>(hash, name, value, inputs, eInfos);
   }
 
   /// 3. generic case
   template <typename R, typename C, soa::is_table... Args>
-  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<StringPair>&, std::vector<StringPair>&)
+  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)//, Cache&, Cache&)
     requires(std::is_lvalue_reference_v<Args> && ...)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(Args...)>();
     addInputsAndExpressions<Args...>(hash, name, value, inputs, eInfos);
+  }
+
+  /// 1. enumeration (no grouping)
+  template <typename R, typename C, is_enumeration A>
+  static void cacheFromArgs(R (C::*)(A), bool, Cache&, Cache&)
+  {
+  }
+  /// 2. iterator (the only grouping case)
+  template <typename R, typename C, soa::is_iterator A, soa::is_table... Args>
+  static void cacheFromArgs(R (C::*)(A, Args...), bool value, Cache& bk, Cache& bku)
+  {
+    addGroupingCandidates<A, Args...>(bk, bku, value);
+  }
+  /// 3. generic case (no grouping)
+  template <typename R, typename C, soa::is_table A, soa::is_table... Args>
+  static void cacheFromArgs(R (C::*)(A, Args...), bool, Cache&, Cache&)
+  {
   }
 
   template <soa::TableRef R>
@@ -480,8 +515,6 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<InputSpec> inputs;
   std::vector<ConfigParamSpec> options;
   std::vector<ExpressionInfo> expressionInfos;
-  std::vector<StringPair> bindingsKeys;
-  std::vector<StringPair> bindingsKeysUnsorted;
 
   /// make sure options and configurables are set before expression infos are created
   homogeneous_apply_refs([&options, &hash](auto& element) { return analysis_task_parsers::appendOption(options, element); }, *task.get());
@@ -490,22 +523,14 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   /// parse process functions defined by corresponding configurables
   if constexpr (requires { &T::process; }) {
-    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos, bindingsKeys, bindingsKeysUnsorted);
+    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos);
   }
   homogeneous_apply_refs(
-    overloaded{
-      [name = name_str, &expressionInfos, &inputs, &bindingsKeys, &bindingsKeysUnsorted](framework::is_process_configurable auto& x) mutable {
-        // this pushes (argumentIndex,processHash,schemaPtr,nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
-        AnalysisDataProcessorBuilder::inputsFromArgs(x.process, (name + "/" + x.name).c_str(), x.value, inputs, expressionInfos, bindingsKeys, bindingsKeysUnsorted);
-        return true;
+      [name = name_str, &expressionInfos, &inputs](auto& x) mutable {
+        // this pushes (argumentIndex, processHash, schemaPtr, nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
+        return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos);
       },
-      [](auto&) {
-        return false;
-      }},
     *task.get());
-
-  // add preslice declarations to slicing cache definition
-  homogeneous_apply_refs([&bindingsKeys, &bindingsKeysUnsorted](auto& element) { return analysis_task_parsers::registerCache(element, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
 
   // request base tables for spawnable extended tables and indices to be built
   // this checks for duplications
@@ -526,7 +551,12 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());
   homogeneous_apply_refs([&requiredServices](auto& element) { return analysis_task_parsers::addService(requiredServices, element); }, *task.get());
 
-  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, bindingsKeys, bindingsKeysUnsorted](InitContext& ic) mutable {
+  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos](InitContext& ic) mutable {
+    Cache bindingsKeys;
+    Cache bindingsKeysUnsorted;
+    // add preslice declarations to slicing cache definition
+    homogeneous_apply_refs([&bindingsKeys, &bindingsKeysUnsorted](auto& element) { return analysis_task_parsers::registerCache(element, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
+
     homogeneous_apply_refs([&ic](auto&& element) { return analysis_task_parsers::prepareOption(ic, element); }, *task.get());
     homogeneous_apply_refs([&ic](auto&& element) { return analysis_task_parsers::prepareService(ic, element); }, *task.get());
 
@@ -555,6 +585,16 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     if constexpr (requires { task->init(ic); }) {
       task->init(ic);
     }
+
+    /// parse process functions to enable requested grouping caches - note that at this state process configurables have their final values
+    if constexpr (requires { &T::process; }) {
+      AnalysisDataProcessorBuilder::cacheFromArgs(&T::process, true, bindingsKeys, bindingsKeysUnsorted);
+    }
+    homogeneous_apply_refs(
+      [&bindingsKeys, &bindingsKeysUnsorted](auto& x) mutable {
+        return AnalysisDataProcessorBuilder::requestCacheFromArgs(x, bindingsKeys, bindingsKeysUnsorted);
+      },
+      *task.get());
 
     ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
     ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -166,7 +166,7 @@ struct AnalysisDataProcessorBuilder {
   }
   /// 1. enumeration (must be the only argument)
   template <typename R, typename C, is_enumeration A>
-  static void inputsFromArgs(R (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&)//, Cache&, Cache&)
+  static void inputsFromArgs(R (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&) //, Cache&, Cache&)
   {
     std::vector<ConfigParamSpec> inputMetadata;
     // FIXME: for the moment we do not support begin, end and step.
@@ -175,7 +175,7 @@ struct AnalysisDataProcessorBuilder {
 
   /// 2. 1st argument is an iterator
   template <typename R, typename C, soa::is_iterator A, soa::is_table... Args>
-  static void inputsFromArgs(R (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)//, Cache& bk, Cache& bku)
+  static void inputsFromArgs(R (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos) //, Cache& bk, Cache& bku)
     requires(std::is_lvalue_reference_v<A> && (std::is_lvalue_reference_v<Args> && ...))
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(A, Args...)>();
@@ -184,7 +184,7 @@ struct AnalysisDataProcessorBuilder {
 
   /// 3. generic case
   template <typename R, typename C, soa::is_table... Args>
-  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)//, Cache&, Cache&)
+  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos) //, Cache&, Cache&)
     requires(std::is_lvalue_reference_v<Args> && ...)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<R (C::*)(Args...)>();
@@ -526,10 +526,10 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos);
   }
   homogeneous_apply_refs(
-      [name = name_str, &expressionInfos, &inputs](auto& x) mutable {
-        // this pushes (argumentIndex, processHash, schemaPtr, nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
-        return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos);
-      },
+    [name = name_str, &expressionInfos, &inputs](auto& x) mutable {
+      // this pushes (argumentIndex, processHash, schemaPtr, nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
+      return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos);
+    },
     *task.get());
 
   // request base tables for spawnable extended tables and indices to be built

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -34,51 +34,64 @@ struct SliceInfoUnsortedPtr {
   gsl::span<int64_t const> getSliceFor(int value) const;
 };
 
-using StringPair = std::pair<std::string, std::string>;
+struct Entry {
+  std::string binding;
+  std::string key;
+  bool enabled;
 
-void updatePairList(std::vector<StringPair>& list, std::string const& binding, std::string const& key);
+  Entry(std::string b, std::string k, bool e = true)
+    : binding{b},
+      key{k},
+      enabled{e}
+  {
+  }
+};
+
+using Cache = std::vector<Entry>;
+
+void updatePairList(Cache& list, std::string const& binding, std::string const& key, bool enabled);
 
 struct ArrowTableSlicingCacheDef {
   constexpr static ServiceKind service_kind = ServiceKind::Global;
-  std::vector<StringPair> bindingsKeys;
-  std::vector<StringPair> bindingsKeysUnsorted;
+  Cache bindingsKeys;
+  Cache bindingsKeysUnsorted;
 
-  void setCaches(std::vector<StringPair>&& bsks);
-  void setCachesUnsorted(std::vector<StringPair>&& bsks);
+  void setCaches(Cache&& bsks);
+  void setCachesUnsorted(Cache&& bsks);
 };
 
 struct ArrowTableSlicingCache {
   constexpr static ServiceKind service_kind = ServiceKind::Stream;
 
-  std::vector<StringPair> bindingsKeys;
+  Cache bindingsKeys;
   std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int32Type>>> values;
   std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int64Type>>> counts;
 
-  std::vector<StringPair> bindingsKeysUnsorted;
+  Cache bindingsKeysUnsorted;
   std::vector<std::vector<int>> valuesUnsorted;
   std::vector<ListVector> groups;
 
-  ArrowTableSlicingCache(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted = {});
+  ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted = {});
 
   // set caching information externally
-  void setCaches(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted = {});
+  void setCaches(Cache&& bsks, Cache&& bsksUnsorted = {});
 
   // update slicing info cache entry (assumes it is already present)
   arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table> const& table);
   arrow::Status updateCacheEntryUnsorted(int pos, std::shared_ptr<arrow::Table> const& table);
 
   // helper to locate cache position
-  std::pair<int, bool> getCachePos(StringPair const& bindingKey) const;
-  int getCachePosSortedFor(StringPair const& bindingKey) const;
-  int getCachePosUnsortedFor(StringPair const& bindingKey) const;
+  std::pair<int, bool> getCachePos(Entry const& bindingKey) const;
+  int getCachePosSortedFor(Entry const& bindingKey) const;
+  int getCachePosUnsortedFor(Entry const& bindingKey) const;
 
   // get slice from cache for a given value
-  SliceInfoPtr getCacheFor(StringPair const& bindingKey) const;
-  SliceInfoUnsortedPtr getCacheUnsortedFor(StringPair const& bindingKey) const;
+  SliceInfoPtr getCacheFor(Entry const& bindingKey) const;
+  SliceInfoUnsortedPtr getCacheUnsortedFor(Entry const& bindingKey) const;
   SliceInfoPtr getCacheForPos(int pos) const;
   SliceInfoUnsortedPtr getCacheUnsortedForPos(int pos) const;
 
-  static void validateOrder(StringPair const& bindingKey, std::shared_ptr<arrow::Table> const& input);
+  static void validateOrder(Entry const& bindingKey, std::shared_ptr<arrow::Table> const& input);
 };
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -55,7 +55,7 @@ struct GroupSlicer {
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
-      auto bk = std::make_pair(binding, mIndexColumnName);
+      auto bk = Entry(binding, mIndexColumnName);
       if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
         if (table.size() == 0) {
           return;

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -197,7 +197,7 @@ bool PreslicePolicyBase::isMissing() const
   return binding == "[MISSING]";
 }
 
-StringPair const& PreslicePolicyBase::getBindingKey() const
+Entry const& PreslicePolicyBase::getBindingKey() const
 {
   return bindingKey;
 }

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -567,26 +567,27 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
     .name = "arrow-slicing-cache",
     .uniqueId = CommonServices::simpleServiceId<ArrowTableSlicingCache>(),
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions&) { return ServiceHandle{TypeIdHelpers::uniqueId<ArrowTableSlicingCache>(),
-                                                                                                         new ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>{services.get<ArrowTableSlicingCacheDef>().bindingsKeys}, std::vector{services.get<ArrowTableSlicingCacheDef>().bindingsKeysUnsorted}),
+                                                                                                         new ArrowTableSlicingCache(Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeys},
+                                                                                                                                    Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeysUnsorted}),
                                                                                                          ServiceKind::Stream, typeid(ArrowTableSlicingCache).name()}; },
     .configure = CommonServices::noConfiguration(),
     .preProcessing = [](ProcessingContext& pc, void* service_ptr) {
       auto* service = static_cast<ArrowTableSlicingCache*>(service_ptr);
       auto& caches = service->bindingsKeys;
-      for (auto i = 0; i < caches.size(); ++i) {
-        if (pc.inputs().getPos(caches[i].first.c_str()) >= 0) {
-          auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].first.c_str())->asArrowTable());
+      for (auto i = 0u; i < caches.size(); ++i) {
+        if (caches[i].enabled && pc.inputs().getPos(caches[i].binding.c_str()) >= 0) {
+          auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].binding.c_str())->asArrowTable());
           if (!status.ok()) {
-            throw runtime_error_f("Failed to update slice cache for %s/%s", caches[i].first.c_str(), caches[i].second.c_str());
+            throw runtime_error_f("Failed to update slice cache for %s/%s", caches[i].binding.c_str(), caches[i].key.c_str());
           }
         }
       }
       auto& unsortedCaches = service->bindingsKeysUnsorted;
-      for (auto i = 0; i < unsortedCaches.size(); ++i) {
-        if (pc.inputs().getPos(unsortedCaches[i].first.c_str()) >= 0) {
-          auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].first.c_str())->asArrowTable());
+      for (auto i = 0u; i < unsortedCaches.size(); ++i) {
+        if (unsortedCaches[i].enabled && pc.inputs().getPos(unsortedCaches[i].binding.c_str()) >= 0) {
+          auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].binding.c_str())->asArrowTable());
           if (!status.ok()) {
-            throw runtime_error_f("failed to update slice cache (unsorted) for %s/%s", unsortedCaches[i].first.c_str(), unsortedCaches[i].second.c_str());
+            throw runtime_error_f("failed to update slice cache (unsorted) for %s/%s", unsortedCaches[i].binding.c_str(), unsortedCaches[i].key.c_str());
           }
         }
       } },

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -210,7 +210,7 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bi
   if (s) {
     throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
-  if(!bindingsKeysUnsorted[p].enabled) {
+  if (!bindingsKeysUnsorted[p].enabled) {
     throw runtime_error_f("Disabled unsorted cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -110,7 +110,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
     counts[pos].reset();
     return arrow::Status::OK();
   }
-  auto& [b,k,e] = bindingsKeys[pos];
+  auto& [b, k, e] = bindingsKeys[pos];
   if (!e) {
     throw runtime_error_f("Disabled cache %s/%s update requested", b.c_str(), k.c_str());
   }
@@ -197,7 +197,7 @@ SliceInfoPtr ArrowTableSlicingCache::getCacheFor(Entry const& bindingKey) const
   if (!s) {
     throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
-  if(!bindingsKeys[p].enabled) {
+  if (!bindingsKeys[p].enabled) {
     throw runtime_error_f("Disabled cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 
@@ -210,7 +210,7 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bi
   if (s) {
     throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
-  if(!bindingsKeys[p].enabled) {
+  if (!bindingsKeys[p].enabled) {
     throw runtime_error_f("Disabled unsorted cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -19,10 +19,13 @@
 namespace o2::framework
 {
 
-void updatePairList(std::vector<StringPair>& list, std::string const& binding, std::string const& key)
+void updatePairList(Cache& list, std::string const& binding, std::string const& key, bool enabled = true)
 {
-  if (std::find_if(list.begin(), list.end(), [&binding, &key](auto const& entry) { return (entry.first == binding) && (entry.second == key); }) == list.end()) {
-    list.emplace_back(binding, key);
+  auto locate = std::find_if(list.begin(), list.end(), [&binding, &key](auto const& entry) { return (entry.binding == binding) && (entry.key == key); });
+  if (locate == list.end()) {
+    list.emplace_back(binding, key, enabled);
+  } else if (!locate->enabled && enabled) {
+    locate->enabled = true;
   }
 }
 
@@ -65,17 +68,17 @@ gsl::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
   return {(*groups)[value].data(), (*groups)[value].size()};
 }
 
-void ArrowTableSlicingCacheDef::setCaches(std::vector<StringPair>&& bsks)
+void ArrowTableSlicingCacheDef::setCaches(Cache&& bsks)
 {
   bindingsKeys = bsks;
 }
 
-void ArrowTableSlicingCacheDef::setCachesUnsorted(std::vector<StringPair>&& bsks)
+void ArrowTableSlicingCacheDef::setCachesUnsorted(Cache&& bsks)
 {
   bindingsKeysUnsorted = bsks;
 }
 
-ArrowTableSlicingCache::ArrowTableSlicingCache(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted)
+ArrowTableSlicingCache::ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted)
   : bindingsKeys{bsks},
     bindingsKeysUnsorted{bsksUnsorted}
 {
@@ -86,7 +89,7 @@ ArrowTableSlicingCache::ArrowTableSlicingCache(std::vector<StringPair>&& bsks, s
   groups.resize(bindingsKeysUnsorted.size());
 }
 
-void ArrowTableSlicingCache::setCaches(std::vector<StringPair>&& bsks, std::vector<StringPair>&& bsksUnsorted)
+void ArrowTableSlicingCache::setCaches(Cache&& bsks, Cache&& bsksUnsorted)
 {
   bindingsKeys = bsks;
   bindingsKeysUnsorted = bsksUnsorted;
@@ -107,11 +110,15 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
     counts[pos].reset();
     return arrow::Status::OK();
   }
+  auto& [b,k,e] = bindingsKeys[pos];
+  if (!e) {
+    throw runtime_error_f("Disabled slicing cache of %s by %s update requested - this should not happen.", b.c_str(), k.c_str());
+  }
   validateOrder(bindingsKeys[pos], table);
   arrow::Datum value_counts;
   auto options = arrow::compute::ScalarAggregateOptions::Defaults();
   ARROW_ASSIGN_OR_RAISE(value_counts,
-                        arrow::compute::CallFunction("value_counts", {table->GetColumnByName(bindingsKeys[pos].second)},
+                        arrow::compute::CallFunction("value_counts", {table->GetColumnByName(bindingsKeys[pos].key)},
                                                      &options));
   auto pair = static_cast<arrow::StructArray>(value_counts.array());
   values[pos].reset();
@@ -128,7 +135,10 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
   if (table->num_rows() == 0) {
     return arrow::Status::OK();
   }
-  auto& [b, k] = bindingsKeysUnsorted[pos];
+  auto& [b, k, e] = bindingsKeysUnsorted[pos];
+  if (!e) {
+    throw runtime_error_f("Disabled slicing cache of %s by %s update requested - this should not happen.", b.c_str(), k.c_str());
+  }
   auto column = table->GetColumnByName(k);
   auto row = 0;
   for (auto iChunk = 0; iChunk < column->num_chunks(); ++iChunk) {
@@ -139,7 +149,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
         if (std::find(valuesUnsorted[pos].begin(), valuesUnsorted[pos].end(), v) == valuesUnsorted[pos].end()) {
           valuesUnsorted[pos].push_back(v);
         }
-        if (groups[pos].size() <= v) {
+        if ((int)groups[pos].size() <= v) {
           groups[pos].resize(v + 1);
         }
         (groups[pos])[v].push_back(row);
@@ -151,7 +161,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
   return arrow::Status::OK();
 }
 
-std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const StringPair& bindingKey) const
+std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey) const
 {
   auto pos = getCachePosSortedFor(bindingKey);
   if (pos != -1) {
@@ -161,41 +171,41 @@ std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const StringPair& bindi
   if (pos != -1) {
     return {pos, false};
   }
-  throw runtime_error_f("%s/%s not found neither in sorted or unsorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
+  throw runtime_error_f("%s/%s not found neither in sorted or unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
 }
 
-int ArrowTableSlicingCache::getCachePosSortedFor(StringPair const& bindingKey) const
+int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 {
-  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](StringPair const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
+  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
   if (locate != bindingsKeys.end()) {
     return std::distance(bindingsKeys.begin(), locate);
   }
   return -1;
 }
 
-int ArrowTableSlicingCache::getCachePosUnsortedFor(StringPair const& bindingKey) const
+int ArrowTableSlicingCache::getCachePosUnsortedFor(Entry const& bindingKey) const
 {
-  auto locate_unsorted = std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](StringPair const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
+  auto locate_unsorted = std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
   if (locate_unsorted != bindingsKeysUnsorted.end()) {
     return std::distance(bindingsKeysUnsorted.begin(), locate_unsorted);
   }
   return -1;
 }
-SliceInfoPtr ArrowTableSlicingCache::getCacheFor(StringPair const& bindingKey) const
+SliceInfoPtr ArrowTableSlicingCache::getCacheFor(Entry const& bindingKey) const
 {
   auto [p, s] = getCachePos(bindingKey);
   if (!s) {
-    throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
+    throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 
   return getCacheForPos(p);
 }
 
-SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const StringPair& bindingKey) const
+SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bindingKey) const
 {
   auto [p, s] = getCachePos(bindingKey);
   if (s) {
-    throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.first.c_str(), bindingKey.second.c_str());
+    throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 
   return getCacheUnsortedForPos(p);
@@ -224,9 +234,9 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedForPos(int pos) con
   };
 }
 
-void ArrowTableSlicingCache::validateOrder(StringPair const& bindingKey, const std::shared_ptr<arrow::Table>& input)
+void ArrowTableSlicingCache::validateOrder(Entry const& bindingKey, const std::shared_ptr<arrow::Table>& input)
 {
-  auto const& [target, key] = bindingKey;
+  auto const& [target, key, enabled] = bindingKey;
   auto column = input->GetColumnByName(key);
   auto array0 = static_cast<arrow::NumericArray<arrow::Int32Type>>(column->chunk(0)->data());
   int32_t prev = 0;

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -210,7 +210,7 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bi
   if (s) {
     throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
-  if (!bindingsKeys[p].enabled) {
+  if(!bindingsKeysUnsorted[p].enabled) {
     throw runtime_error_f("Disabled unsorted cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -112,7 +112,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
   }
   auto& [b,k,e] = bindingsKeys[pos];
   if (!e) {
-    throw runtime_error_f("Disabled slicing cache of %s by %s update requested - this should not happen.", b.c_str(), k.c_str());
+    throw runtime_error_f("Disabled cache %s/%s update requested", b.c_str(), k.c_str());
   }
   validateOrder(bindingsKeys[pos], table);
   arrow::Datum value_counts;
@@ -137,7 +137,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
   }
   auto& [b, k, e] = bindingsKeysUnsorted[pos];
   if (!e) {
-    throw runtime_error_f("Disabled slicing cache of %s by %s update requested - this should not happen.", b.c_str(), k.c_str());
+    throw runtime_error_f("Disabled unsorted cache %s/%s update requested", b.c_str(), k.c_str());
   }
   auto column = table->GetColumnByName(k);
   auto row = 0;
@@ -197,6 +197,9 @@ SliceInfoPtr ArrowTableSlicingCache::getCacheFor(Entry const& bindingKey) const
   if (!s) {
     throw runtime_error_f("%s/%s is found in unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
+  if(!bindingsKeys[p].enabled) {
+    throw runtime_error_f("Disabled cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
+  }
 
   return getCacheForPos(p);
 }
@@ -206,6 +209,9 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bi
   auto [p, s] = getCachePos(bindingKey);
   if (s) {
     throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
+  }
+  if(!bindingsKeys[p].enabled) {
+    throw runtime_error_f("Disabled unsorted cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 
   return getCacheUnsortedForPos(p);

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -683,7 +683,7 @@ TEST_CASE("ArrowDirectSlicing")
 
   std::vector<arrow::Datum> slices;
   std::vector<uint64_t> offsts;
-  auto bk = std::make_pair(soa::getLabelFromType<aod::Events>(), "fID");
+  auto bk = Entry(soa::getLabelFromType<aod::Events>(), "fID");
   ArrowTableSlicingCache cache({bk});
   auto s = cache.updateCacheEntry(0, {evtTable});
   auto lcache = cache.getCacheFor(bk);
@@ -741,7 +741,7 @@ TEST_CASE("TestSlicingException")
   }
   auto evtTable = builderE.finalize();
 
-  auto bk = std::make_pair(soa::getLabelFromType<aod::Events>(), "fID");
+  auto bk = Entry(soa::getLabelFromType<aod::Events>(), "fID");
   ArrowTableSlicingCache cache({bk});
 
   try {


### PR DESCRIPTION
* Cache setup now only happens after init when process configurables' values are final
* Add inline constrained functions to avoid using "overloaded"

Tested locally with workflow from https://alimonitor.cern.ch/hyperloop/wagon-test/401431/general that was failing with the previous version of this feature. 