### PR TITLE
TPC: Fix digitizer workflow to load GEM params from CCDB before creating Polya file

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -286,7 +286,7 @@ int getNumTPCLanes(std::vector<int> const& sectors, ConfigContext const& configc
 
 // ------------------------------------------------------------------
 
-void initTPC()
+void initTPC(long timestamp)
 {
   // We only want to do this for the DPL master
   // I am not aware of an easy way to query if "I am DPL master" so
@@ -308,6 +308,12 @@ void initTPC()
 
   auto& cdb = o2::tpc::CDBInterface::instance();
   cdb.setUseDefaults();
+
+  // IMPORTANT: load ParameterGEM from CCDB
+  auto& ccdbManager = o2::ccdb::BasicCCDBManager::instance();
+  ccdbManager.getSpecific<o2::tpc::ParameterGEM>(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::ParGEM), timestamp);
+  LOGP(info, "initTPC: TPC GEM param updated for time {}", timestamp);
+  o2::tpc::ParameterGEM::Instance().printKeyValues(true, true);
   // by invoking this constructor we make sure that a common file will be created
   // in future we should take this from OCDB and just forward per message
   const static auto& ampl = o2::tpc::GEMAmplification::instance();
@@ -592,7 +598,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   if (isEnabled(o2::detectors::DetID::TPC)) {
     if (!helpasked && ismaster) {
-      initTPC();
+      initTPC(hbfu.startTime);
     }
 
     tpcsectors = o2::RangeTokenizer::tokenize<int>(configcontext.options().get<std::string>("tpc-sectors"));


### PR DESCRIPTION
The initTPC() function is updated to load GEM parameters from the CCDB using the provided timestamp. This ensures that the Polya file is generated with the correct amplification function with the tuning gain value from the CCDB. Previously, the Polya file was created using default GEM parameters, which led to inconsistencies in anchored MC.