### PR TITLE
ITS no group chips in deadmap calib workflow

### DIFF
--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -236,7 +236,7 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   fi
   # ITS
   if [[ $CALIB_ITS_DEADMAP_TIME == 1 ]]; then
-     add_W o2-itsmft-deadmap-builder-workflow "--ccdb-url $CCDB_POPULATOR_UPLOAD_PATH ${CALIB_ITS_DEADMAP_TIME_OPT:-}"
+     add_W o2-itsmft-deadmap-builder-workflow "--ccdb-url $CCDB_POPULATOR_UPLOAD_PATH ${CALIB_ITS_DEADMAP_TIME_OPT:---no-group-its-lanes --skip-static-map}"
   fi
   # MFT
   if [[ $CALIB_MFT_DEADMAP_TIME == 1 ]]; then


### PR DESCRIPTION
Making `--no-group-its-lanes` default. Static part of the map is not needed when the option is enabled.