### PR TITLE
DPL Analysis: `as<T>(cfg)` for adjusting the types of configurables in expressions

### DIFF
--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -12,13 +12,11 @@
 #define O2_FRAMEWORK_EXPRESSIONS_H_
 
 #include "Framework/BasicOps.h"
-#include "Framework/CompilerBuiltins.h"
 #include "Framework/Pack.h"
 #include "Framework/Configurable.h"
 #include "Framework/Variant.h"
 #include "Framework/InitContext.h"
 #include "Framework/ConfigParamRegistry.h"
-#include "Framework/RuntimeError.h"
 #include <arrow/type_fwd.h>
 #include <gandiva/gandiva_aliases.h>
 #include <arrow/type.h>
@@ -143,13 +141,17 @@ struct OpNode {
 /// A placeholder node for simple type configurable
 struct PlaceholderNode : LiteralNode {
   template <typename T>
+    requires(variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown)
   PlaceholderNode(Configurable<T> const& v) : LiteralNode{v.value}, name{v.name}
   {
-    if constexpr (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown) {
-      retrieve = [](InitContext& context, char const* name) { return LiteralNode::var_t{context.options().get<T>(name)}; };
-    } else {
-      unknownParameterUsed(name.c_str());
-    }
+    retrieve = [](InitContext& context, char const* name) { return LiteralNode::var_t{context.options().get<T>(name)}; };
+  }
+
+  template <typename T, typename AT>
+    requires((std::convertible_to<T, AT>) && (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown))
+  PlaceholderNode(Configurable<T> const& v, AT*) : LiteralNode{static_cast<AT>(v.value)}, name{v.name}
+  {
+    retrieve = [](InitContext& context, char const* name) { return LiteralNode::var_t{static_cast<AT>(context.options().get<T>(name))}; };
   }
 
   PlaceholderNode(PlaceholderNode const& other) = default;
@@ -162,6 +164,12 @@ struct PlaceholderNode : LiteralNode {
   std::string const& name;
   LiteralNode::var_t (*retrieve)(InitContext&, char const*);
 };
+
+template <typename AT, typename T>
+PlaceholderNode as(Configurable<T> const& v)
+{
+  return PlaceholderNode(v, (AT*)nullptr);
+}
 
 /// A placeholder node for parameters taken from an array
 struct ParameterNode : LiteralNode {

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -146,6 +146,15 @@ TEST_CASE("TestTreeParsing")
   REQUIRE(ptfilterspecs2[0].left == (DatumSpec{std::string{"fPt"}, typeid(o2::aod::track::Pt).hash_code(), atype::FLOAT}));
   REQUIRE(ptfilterspecs2[0].right == (DatumSpec{LiteralNode::var_t{1.0f}, atype::FLOAT}));
   REQUIRE(ptfilterspecs2[0].result == (DatumSpec{0u, atype::BOOL}));
+
+  Configurable<int> cvalue{"cvalue", 1, "test value"};
+  Filter testFilter = o2::aod::track::tpcNClsShared < as<uint8_t>(cvalue);
+  REQUIRE(testFilter.node->self.index() == 2);
+  REQUIRE(testFilter.node->left->self.index() == 1);
+  REQUIRE(testFilter.node->right->self.index() == 3);
+  REQUIRE(std::get<PlaceholderNode>(testFilter.node->right->self).name == "cvalue");
+  auto testSpecs = createOperations(testFilter);
+  REQUIRE(testSpecs[0].right == (DatumSpec{LiteralNode::var_t{(uint8_t)1}, atype::UINT8}));
 }
 
 TEST_CASE("TestGandivaTreeCreation")


### PR DESCRIPTION
As Gandiva does not handle conversions with unsigned integer types internally, it is not trivial to apply filters for some of the columns. This feature creates a workaround, for example the following code
```cpp
  Configurable<int> cvalue{"cvalue", 1, "test value"};
  Filter testFilter = o2::aod::track::tpcNClsShared < as<uint8_t>(cvalue);
```
will create a valid filter where `cvalue` will be properly updated and cast to `uint8_t` for comparison with the column of the same type, but it can be provided normally in configuration JSON as a simple `int` unlike for the `uint8_t` configurable that will be parsed as a character by C++. 