### PR TITLE
GPU: Some maintenance, and use <array> for CUDA / ROCm, but not yet for OpenCL

### DIFF
--- a/Common/DCAFitter/include/DCAFitter/DCAFitterN.h
+++ b/Common/DCAFitter/include/DCAFitter/DCAFitterN.h
@@ -110,11 +110,11 @@ class DCAFitterN
   using MatSymND = o2::math_utils::SMatrix<double, N, N, o2::math_utils::MatRepSym<double, N>>;
   using MatStdND = o2::math_utils::SMatrix<double, N, N, o2::math_utils::MatRepStd<double, N>>;
   using TrackCoefVtx = MatStd3D;
-  using ArrTrack = o2::gpu::gpustd::array<Track, N>;         // container for prongs (tracks) at single vertex cand.
-  using ArrTrackCovI = o2::gpu::gpustd::array<TrackCovI, N>; // container for inv.cov.matrices at single vertex cand.
-  using ArrTrCoef = o2::gpu::gpustd::array<TrackCoefVtx, N>; // container of TrackCoefVtx coefficients at single vertex cand.
-  using ArrTrDer = o2::gpu::gpustd::array<TrackDeriv, N>;    // container of Track 1st and 2nd derivative over their X param
-  using ArrTrPos = o2::gpu::gpustd::array<Vec3D, N>;         // container of Track positions
+  using ArrTrack = std::array<Track, N>;         // container for prongs (tracks) at single vertex cand.
+  using ArrTrackCovI = std::array<TrackCovI, N>; // container for inv.cov.matrices at single vertex cand.
+  using ArrTrCoef = std::array<TrackCoefVtx, N>; // container of TrackCoefVtx coefficients at single vertex cand.
+  using ArrTrDer = std::array<TrackDeriv, N>;    // container of Track 1st and 2nd derivative over their X param
+  using ArrTrPos = std::array<Vec3D, N>;         // container of Track positions
 
  public:
   enum BadCovPolicy : uint8_t { // if encountering non-positive defined cov. matrix, the choice is:
@@ -158,7 +158,7 @@ class DCAFitterN
   GPUd() const auto getPCACandidatePos(int cand = 0) const
   {
     const auto& vd = mPCA[mOrder[cand]];
-    return o2::gpu::gpustd::array<float, 3>{static_cast<float>(vd[0]), static_cast<float>(vd[1]), static_cast<float>(vd[2])};
+    return std::array<float, 3>{static_cast<float>(vd[0]), static_cast<float>(vd[1]), static_cast<float>(vd[2])};
   }
 
   ///< return position of quality-ordered candidate in the internal structures
@@ -213,7 +213,7 @@ class DCAFitterN
 
   GPUd() MatSym3D calcPCACovMatrix(int cand = 0) const;
 
-  o2::gpu::gpustd::array<float, 6> calcPCACovMatrixFlat(int cand = 0) const
+  std::array<float, 6> calcPCACovMatrixFlat(int cand = 0) const
   {
     auto m = calcPCACovMatrix(cand);
     return {static_cast<float>(m(0, 0)), static_cast<float>(m(1, 0)), static_cast<float>(m(1, 1)), static_cast<float>(m(2, 0)), static_cast<float>(m(2, 1)), static_cast<float>(m(2, 2))};
@@ -364,39 +364,39 @@ class DCAFitterN
 
  private:
   // vectors of 1st derivatives of track local residuals over X parameters
-  o2::gpu::gpustd::array<o2::gpu::gpustd::array<Vec3D, N>, N> mDResidDx;
+  std::array<std::array<Vec3D, N>, N> mDResidDx;
   // vectors of 1nd derivatives of track local residuals over X parameters
   // (cross-derivatives DR/(dx_j*dx_k) = 0 for j!=k, therefore the hessian is diagonal)
-  o2::gpu::gpustd::array<o2::gpu::gpustd::array<Vec3D, N>, N> mD2ResidDx2;
+  std::array<std::array<Vec3D, N>, N> mD2ResidDx2;
   VecND mDChi2Dx;      // 1st derivatives of chi2 over tracks X params
   MatSymND mD2Chi2Dx2; // 2nd derivatives of chi2 over tracks X params (symmetric matrix)
   MatSymND mCosDif;    // matrix with cos(alp_j-alp_i) for j<i
   MatSymND mSinDif;    // matrix with sin(alp_j-alp_i) for j<i
-  o2::gpu::gpustd::array<const Track*, N> mOrigTrPtr;
-  o2::gpu::gpustd::array<TrackAuxPar, N> mTrAux; // Aux track info for each track at each cand. vertex
-  CrossInfo mCrossings;                          // info on track crossing
+  std::array<const Track*, N> mOrigTrPtr;
+  std::array<TrackAuxPar, N> mTrAux; // Aux track info for each track at each cand. vertex
+  CrossInfo mCrossings;              // info on track crossing
 
-  o2::gpu::gpustd::array<ArrTrackCovI, MAXHYP> mTrcEInv; // errors for each track at each cand. vertex
-  o2::gpu::gpustd::array<ArrTrack, MAXHYP> mCandTr;      // tracks at each cond. vertex (Note: Errors are at seed XY point)
-  o2::gpu::gpustd::array<ArrTrCoef, MAXHYP> mTrCFVT;     // TrackCoefVtx for each track at each cand. vertex
-  o2::gpu::gpustd::array<ArrTrDer, MAXHYP> mTrDer;       // Track derivativse
-  o2::gpu::gpustd::array<ArrTrPos, MAXHYP> mTrPos;       // Track positions
-  o2::gpu::gpustd::array<ArrTrPos, MAXHYP> mTrRes;       // Track residuals
-  o2::gpu::gpustd::array<Vec3D, MAXHYP> mPCA;            // PCA for each vertex candidate
-  o2::gpu::gpustd::array<float, MAXHYP> mChi2 = {0};     // Chi2 at PCA candidate
-  o2::gpu::gpustd::array<int, MAXHYP> mNIters;           // number of iterations for each seed
-  o2::gpu::gpustd::array<bool, MAXHYP> mTrPropDone{};    // Flag that the tracks are fully propagated to PCA
-  o2::gpu::gpustd::array<bool, MAXHYP> mPropFailed{};    // Flag that some propagation failed for this PCA candidate
+  std::array<ArrTrackCovI, MAXHYP> mTrcEInv; // errors for each track at each cand. vertex
+  std::array<ArrTrack, MAXHYP> mCandTr;      // tracks at each cond. vertex (Note: Errors are at seed XY point)
+  std::array<ArrTrCoef, MAXHYP> mTrCFVT;     // TrackCoefVtx for each track at each cand. vertex
+  std::array<ArrTrDer, MAXHYP> mTrDer;       // Track derivativse
+  std::array<ArrTrPos, MAXHYP> mTrPos;       // Track positions
+  std::array<ArrTrPos, MAXHYP> mTrRes;       // Track residuals
+  std::array<Vec3D, MAXHYP> mPCA;            // PCA for each vertex candidate
+  std::array<float, MAXHYP> mChi2 = {0};     // Chi2 at PCA candidate
+  std::array<int, MAXHYP> mNIters;           // number of iterations for each seed
+  std::array<bool, MAXHYP> mTrPropDone{};    // Flag that the tracks are fully propagated to PCA
+  std::array<bool, MAXHYP> mPropFailed{};    // Flag that some propagation failed for this PCA candidate
   LogLogThrottler mLoggerBadCov{};
   LogLogThrottler mLoggerBadInv{};
   LogLogThrottler mLoggerBadProp{};
   MatSym3D mWeightInv; // inverse weight of single track, [sum{M^T E M}]^-1 in EQ.T
-  o2::gpu::gpustd::array<int, MAXHYP> mOrder{0};
+  std::array<int, MAXHYP> mOrder{0};
   int mCurHyp = 0;
   int mCrossIDCur = 0;
   int mCrossIDAlt = -1;
   BadCovPolicy mBadCovPolicy{BadCovPolicy::Discard};                                              // what to do in case of non-pos-def. cov. matrix, see BadCovPolicy enum
-  o2::gpu::gpustd::array<FitStatus, MAXHYP> mFitStatus{};                                         // fit status of each hypothesis fit
+  std::array<FitStatus, MAXHYP> mFitStatus{};                                                     // fit status of each hypothesis fit
   bool mAllowAltPreference = true;                                                                // if the fit converges to alternative PCA seed, abandon the current one
   bool mUseAbsDCA = false;                                                                        // use abs. distance minimization rather than chi2
   bool mWeightedFinalPCA = false;                                                                 // recalculate PCA as a cov-matrix weighted mean, even if absDCA method was used
@@ -657,7 +657,7 @@ template <int N, typename... Args>
 GPUd() void DCAFitterN<N, Args...>::calcChi2Derivatives()
 {
   //< calculate 1st and 2nd derivatives of wighted DCA (chi2) over track parameters X, see EQ.Chi2 in the ref
-  o2::gpu::gpustd::array<o2::gpu::gpustd::array<Vec3D, N>, N> covIDrDx; // tempory vectors of covI_j * dres_j/dx_i
+  std::array<std::array<Vec3D, N>, N> covIDrDx; // tempory vectors of covI_j * dres_j/dx_i
 
   // chi2 1st derivative
   for (int i = N; i--;) {
@@ -1175,13 +1175,13 @@ GPUd() o2::track::TrackParCov DCAFitterN<N, Args...>::createParentTrackParCov(in
 {
   const auto& trP = getTrack(0, cand);
   const auto& trN = getTrack(1, cand);
-  o2::gpu::gpustd::array<float, 21> covV = {0.};
-  o2::gpu::gpustd::array<float, 3> pvecV = {0.};
+  std::array<float, 21> covV = {0.};
+  std::array<float, 3> pvecV = {0.};
   int q = 0;
   for (int it = 0; it < N; it++) {
     const auto& trc = getTrack(it, cand);
-    o2::gpu::gpustd::array<float, 3> pvecT = {0.};
-    o2::gpu::gpustd::array<float, 21> covT = {0.};
+    std::array<float, 3> pvecT = {0.};
+    std::array<float, 21> covT = {0.};
     trc.getPxPyPzGlo(pvecT);
     trc.getCovXYZPxPyPzGlo(covT);
     constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
@@ -1210,18 +1210,18 @@ GPUd() o2::track::TrackPar DCAFitterN<N, Args...>::createParentTrackPar(int cand
   const auto& trP = getTrack(0, cand);
   const auto& trN = getTrack(1, cand);
   const auto& wvtx = getPCACandidate(cand);
-  o2::gpu::gpustd::array<float, 3> pvecV = {0.};
+  std::array<float, 3> pvecV = {0.};
   int q = 0;
   for (int it = 0; it < N; it++) {
     const auto& trc = getTrack(it, cand);
-    o2::gpu::gpustd::array<float, 3> pvecT = {0.};
+    std::array<float, 3> pvecT = {0.};
     trc.getPxPyPzGlo(pvecT);
     for (int i = 0; i < 3; i++) {
       pvecV[i] += pvecT[i];
     }
     q += trc.getCharge();
   }
-  const o2::gpu::gpustd::array<float, 3> vertex = {(float)wvtx[0], (float)wvtx[1], (float)wvtx[2]};
+  const std::array<float, 3> vertex = {(float)wvtx[0], (float)wvtx[1], (float)wvtx[2]};
   return o2::track::TrackPar(vertex, pvecV, q, sectorAlpha);
 }
 

--- a/Common/MathUtils/include/MathUtils/SMatrixGPU.h
+++ b/Common/MathUtils/include/MathUtils/SMatrixGPU.h
@@ -25,12 +25,12 @@
 #define ALICEO2_SMATRIX_GPU_H
 
 #include "GPUCommonDef.h"
-#include "GPUCommonArray.h"
 #include "GPUCommonMath.h"
 #include "GPUCommonAlgorithm.h"
 #include "GPUCommonLogger.h"
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <type_traits>
+#include <array>
 #endif
 
 namespace o2::math_utils::detail
@@ -283,14 +283,14 @@ struct make_indices : make_indices_impl<0, indices<>, N> {
 };
 
 template <int I0, class F, int... I>
-constexpr auto do_make(F f, indices<I...>) -> gpu::gpustd::array<int, sizeof...(I)>
+constexpr auto do_make(F f, indices<I...>) -> std::array<int, sizeof...(I)>
 {
-  gpu::gpustd::array<int, sizeof...(I)> retarr = {f(I0 + I)...};
+  std::array<int, sizeof...(I)> retarr = {f(I0 + I)...};
   return retarr;
 }
 
 template <int N, int I0 = 0, class F>
-constexpr auto make(F f) -> gpu::gpustd::array<int, N>
+constexpr auto make(F f) -> std::array<int, N>
 {
   return do_make<I0>(f, typename make_indices<N>::type());
 }

--- a/Common/MathUtils/include/MathUtils/SMatrixGPU.h
+++ b/Common/MathUtils/include/MathUtils/SMatrixGPU.h
@@ -29,7 +29,9 @@
 #include "GPUCommonMath.h"
 #include "GPUCommonAlgorithm.h"
 #include "GPUCommonLogger.h"
-#include "GPUCommonTypeTraits.h"
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits>
+#endif
 
 namespace o2::math_utils::detail
 {

--- a/Common/MathUtils/include/MathUtils/detail/basicMath.h
+++ b/Common/MathUtils/include/MathUtils/detail/basicMath.h
@@ -16,14 +16,15 @@
 #ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BASICMATH_H_
 #define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BASICMATH_H_
 
-#ifndef GPUCA_GPUCODE_DEVICE
-#include <cmath>
-#include <tuple>
-#endif
-#include "GPUCommonArray.h"
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
 #include "CommonConstants/MathConstants.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <cmath>
+#include <tuple>
+#include <array>
+#endif
 
 namespace o2
 {

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -16,15 +16,16 @@
 #ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_TRIGONOMETRIC_H_
 #define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_TRIGONOMETRIC_H_
 
-#ifndef GPUCA_GPUCODE_DEVICE
-#include <cmath>
-#include <tuple>
-#endif
-#include "GPUCommonArray.h"
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
 #include "CommonConstants/MathConstants.h"
 #include "MathUtils/detail/basicMath.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <cmath>
+#include <tuple>
+#include <array>
+#endif
 
 namespace o2
 {
@@ -156,7 +157,7 @@ GPUhdi() std::tuple<T, T> rotateZInv(T xG, T yG, T snAlp, T csAlp)
 #endif
 
 template <typename T>
-GPUhdi() void rotateZ(gpu::gpustd::array<T, 3>& xy, T alpha)
+GPUhdi() void rotateZ(std::array<T, 3>& xy, T alpha)
 {
   // transforms vector in tracking frame alpha to global frame
   T sin, cos;

--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -170,14 +170,14 @@ class TrackITSExt : public TrackITS
   using TrackITS::TrackITS;              // inherit base constructors
 
   GPUh() TrackITSExt(o2::track::TrackParCov&& parCov, short ncl, float chi2,
-                     o2::track::TrackParCov&& outer, o2::gpu::gpustd::array<int, MaxClusters> cls)
+                     o2::track::TrackParCov&& outer, std::array<int, MaxClusters> cls)
     : TrackITS(parCov, chi2, outer), mIndex{cls}
   {
     setNumberOfClusters(ncl);
   }
 
   GPUh() TrackITSExt(o2::track::TrackParCov& parCov, short ncl, float chi2, std::uint32_t rof,
-                     o2::track::TrackParCov& outer, o2::gpu::gpustd::array<int, MaxClusters> cls)
+                     o2::track::TrackParCov& outer, std::array<int, MaxClusters> cls)
     : TrackITS(parCov, chi2, outer), mIndex{cls}
   {
     setNumberOfClusters(ncl);
@@ -205,13 +205,13 @@ class TrackITSExt : public TrackITS
     mIndex[layer] = idx;
   }
 
-  GPUh() o2::gpu::gpustd::array<int, MaxClusters>& getClusterIndexes()
+  GPUh() std::array<int, MaxClusters>& getClusterIndexes()
   {
     return mIndex;
   }
 
  private:
-  o2::gpu::gpustd::array<int, MaxClusters> mIndex = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}; ///< Indices of associated clusters
+  std::array<int, MaxClusters> mIndex = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}; ///< Indices of associated clusters
   ClassDefNV(TrackITSExt, 2);
 };
 } // namespace its

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
@@ -14,10 +14,10 @@
 
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
-#include "GPUCommonArray.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <iosfwd>
+#include <array>
 #endif
 
 /// \author ruben.shahoyan@cern.ch
@@ -67,7 +67,7 @@ class DCA
  private:
   float mY = 0.f;
   float mZ = 0.f;
-  gpu::gpustd::array<float, 3> mCov; ///< s2y, syz, s2z
+  std::array<float, 3> mCov; ///< s2y, syz, s2z
 
   ClassDefNV(DCA, 1);
 };

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -29,7 +29,6 @@
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 #include "GPUCommonMath.h"
-#include "GPUCommonArray.h"
 #include "GPUROOTCartesianFwd.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
@@ -39,6 +38,7 @@
 #include <cstring>
 #include <iosfwd>
 #include <type_traits>
+#include <array>
 #endif
 
 #ifndef GPUCA_ALIGPUCODE // Used only by functions that are hidden on the GPU
@@ -128,9 +128,9 @@ class TrackParametrization
 
  public:
   using value_t = value_T;
-  using dim2_t = gpu::gpustd::array<value_t, 2>;
-  using dim3_t = gpu::gpustd::array<value_t, 3>;
-  using params_t = gpu::gpustd::array<value_t, kNParams>;
+  using dim2_t = std::array<value_t, 2>;
+  using dim3_t = std::array<value_t, 3>;
+  using params_t = std::array<value_t, kNParams>;
 
   struct yzerr_t { // 2 measurement with error
     dim2_t yz;
@@ -209,7 +209,7 @@ class TrackParametrization
   GPUd() math_utils::Point3D<value_t> getXYZGlo() const;
   GPUd() void getXYZGlo(dim3_t& xyz) const;
   GPUd() bool getPxPyPzGlo(dim3_t& pxyz) const;
-  GPUd() bool getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const;
+  GPUd() bool getPosDirGlo(std::array<value_t, 9>& posdirp) const;
 
   // methods for track params estimate at other point
   GPUd() bool getYZAt(value_t xk, value_t b, value_t& y, value_t& z) const;

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -29,6 +29,7 @@
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 #include "GPUCommonMath.h"
+#include "GPUCommonArray.h"
 #include "GPUROOTCartesianFwd.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -38,14 +38,14 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   static_assert(std::is_floating_point_v<value_t>);
 #endif
 
-  using covMat_t = gpu::gpustd::array<value_t, kCovMatSize>;
+  using covMat_t = std::array<value_t, kCovMatSize>;
   using MatrixDSym5 = o2::math_utils::SMatrix<double, kNParams, kNParams, o2::math_utils::MatRepSym<double, kNParams>>;
   using MatrixD5 = o2::math_utils::SMatrix<double, kNParams, kNParams, o2::math_utils::MatRepStd<double, kNParams, kNParams>>;
 
   GPUhd() TrackParametrizationWithError();
   GPUd() TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par, const covMat_t& cov, int charge = 1, const PID pid = PID::Pion);
   GPUd() TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
-                                       const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true, const PID pid = PID::Pion);
+                                       const std::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true, const PID pid = PID::Pion);
 
   GPUhdDefault() TrackParametrizationWithError(const TrackParametrizationWithError& src) = default;
   GPUdDefault() TrackParametrizationWithError(TrackParametrizationWithError&& src) = default;
@@ -57,7 +57,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   using TrackParametrization<value_T>::set;
   GPUd() void set(value_t x, value_t alpha, const params_t& par, const covMat_t& cov, int charge = 1, const PID pid = PID::Pion);
   GPUd() void set(value_t x, value_t alpha, const value_t* par, const value_t* cov, int charge = 1, const PID pid = PID::Pion);
-  GPUd() void set(const dim3_t& xyz, const dim3_t& pxpypz, const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true, const PID pid = PID::Pion);
+  GPUd() void set(const dim3_t& xyz, const dim3_t& pxpypz, const std::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true, const PID pid = PID::Pion);
   GPUd() const covMat_t& getCov() const;
   GPUd() value_t getSigmaY2() const;
   GPUd() value_t getSigmaZY() const;
@@ -77,7 +77,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   GPUd() value_t getCovarElem(int i, int j) const;
   GPUd() value_t getDiagError2(int i) const;
 
-  GPUd() bool getCovXYZPxPyPzGlo(gpu::gpustd::array<value_t, kLabCovMatSize>& c) const;
+  GPUd() bool getCovXYZPxPyPzGlo(std::array<value_t, kLabCovMatSize>& c) const;
 
   GPUd() void print() const;
   GPUd() void printHexadecimal();

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackUtils.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackUtils.h
@@ -18,9 +18,9 @@
 #define INCLUDE_RECONSTRUCTIONDATAFORMATS_TRACKUTILS_H_
 
 #include "GPUCommonRtypes.h"
-#include "GPUCommonArray.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
+#include <array>
 #include <cmath>
 #endif
 
@@ -39,11 +39,11 @@ template <typename value_T = float>
 GPUd() value_T BetheBlochSolidOpt(value_T bg);
 
 template <typename value_T = float>
-GPUd() void g3helx3(value_T qfield, value_T step, gpu::gpustd::array<value_T, 7>& vect);
+GPUd() void g3helx3(value_T qfield, value_T step, std::array<value_T, 7>& vect);
 
 //____________________________________________________
 template <typename value_T>
-GPUd() void g3helx3(value_T qfield, value_T step, gpu::gpustd::array<value_T, 7>& vect)
+GPUd() void g3helx3(value_T qfield, value_T step, std::array<value_T, 7>& vect)
 {
   /******************************************************************
    *                                                                *

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -14,7 +14,6 @@
 
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
-#include "GPUCommonArray.h"
 #include <MathUtils/Cartesian.h>
 
 #include "CommonDataFormat/TimeStamp.h"
@@ -22,6 +21,7 @@
 #include <iosfwd>
 #include <string>
 #include <type_traits>
+#include <array>
 #endif
 
 namespace o2
@@ -42,7 +42,7 @@ class VertexBase
   static constexpr int kNCov = 6;
   GPUhdDefault() VertexBase() = default;
   GPUhdDefault() ~VertexBase() = default;
-  GPUhd() VertexBase(const math_utils::Point3D<float>& pos, const gpu::gpustd::array<float, kNCov>& cov) : mPos(pos), mCov(cov)
+  GPUhd() VertexBase(const math_utils::Point3D<float>& pos, const std::array<float, kNCov>& cov) : mPos(pos), mCov(cov)
   {
   }
 
@@ -65,7 +65,7 @@ class VertexBase
   GPUd() float getSigmaY() const { return gpu::CAMath::Sqrt(getSigmaY2()); }
   GPUd() float getSigmaZ() const { return gpu::CAMath::Sqrt(getSigmaZ2()); }
 
-  GPUd() const gpu::gpustd::array<float, kNCov>& getCov() const { return mCov; }
+  GPUd() const std::array<float, kNCov>& getCov() const { return mCov; }
 
   GPUd() math_utils::Point3D<float> getXYZ() const { return mPos; }
   GPUd() math_utils::Point3D<float>& getXYZ() { return mPos; }
@@ -101,14 +101,14 @@ class VertexBase
     setSigmaXZ(sxz);
     setSigmaYZ(syz);
   }
-  GPUd() void setCov(const gpu::gpustd::array<float, kNCov>& cov) { mCov = cov; }
+  GPUd() void setCov(const std::array<float, kNCov>& cov) { mCov = cov; }
 
   bool operator==(const VertexBase& other) const;
   bool operator!=(const VertexBase& other) const { return !(*this == other); }
 
  protected:
   math_utils::Point3D<float> mPos{0., 0., 0.}; ///< cartesian position
-  gpu::gpustd::array<float, kNCov> mCov{};     ///< errors, see CovElems enum
+  std::array<float, kNCov> mCov{};             ///< errors, see CovElems enum
 
   ClassDefNV(VertexBase, 1);
 };
@@ -130,7 +130,7 @@ class Vertex : public VertexBase
 
   GPUhdDefault() Vertex() = default;
   GPUhdDefault() ~Vertex() = default;
-  GPUhd() Vertex(const math_utils::Point3D<float>& pos, const gpu::gpustd::array<float, kNCov>& cov, ushort nCont, float chi2)
+  GPUhd() Vertex(const math_utils::Point3D<float>& pos, const std::array<float, kNCov>& cov, ushort nCont, float chi2)
     : VertexBase(pos, cov), mChi2(chi2), mNContributors(nCont)
   {
   }

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -130,7 +130,7 @@ GPUd() bool TrackParametrization<value_T>::getPxPyPzGlo(dim3_t& pxyz) const
 
 //____________________________________________________
 template <typename value_T>
-GPUd() bool TrackParametrization<value_T>::getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const
+GPUd() bool TrackParametrization<value_T>::getPosDirGlo(std::array<value_t, 9>& posdirp) const
 {
   // fill vector with lab x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha
   value_t ptI = getPtInv();
@@ -231,7 +231,7 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
   step *= gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
   //
   // get the track x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha in the Global System
-  gpu::gpustd::array<value_t, 9> vecLab{0.f};
+  std::array<value_t, 9> vecLab{0.f};
   if (!getPosDirGlo(vecLab)) {
     return false;
   }
@@ -250,7 +250,7 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
     costet = b[2] / bb;
     sintet = bt / bb;
   }
-  gpu::gpustd::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
+  std::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
                                       -sinphi * vecLab[0] + cosphi * vecLab[1],
                                       sintet * cosphi * vecLab[0] + sintet * sinphi * vecLab[1] + costet * vecLab[2],
                                       costet * cosphi * vecLab[3] + costet * sinphi * vecLab[4] - sintet * vecLab[5],

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -259,7 +259,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dat
 //______________________________________________________________
 template <typename value_T>
 GPUd() TrackParametrizationWithError<value_T>::TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
-                                                                             const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha, const PID pid)
+                                                                             const std::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha, const PID pid)
 {
   // construct track param and covariance from kinematics and lab errors
   set(xyz, pxpypz, cv, charge, sectorAlpha, pid);
@@ -268,7 +268,7 @@ GPUd() TrackParametrizationWithError<value_T>::TrackParametrizationWithError(con
 //______________________________________________________________
 template <typename value_T>
 GPUd() void TrackParametrizationWithError<value_T>::set(const dim3_t& xyz, const dim3_t& pxpypz,
-                                                        const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha, const PID pid)
+                                                        const std::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha, const PID pid)
 {
   // set track param and covariance from kinematics and lab errors
 
@@ -475,7 +475,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, cons
   step *= gpu::CAMath::Sqrt(1.f + this->getTgl() * this->getTgl());
   //
   // get the track x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha in the Global System
-  gpu::gpustd::array<value_t, 9> vecLab{0.f};
+  std::array<value_t, 9> vecLab{0.f};
   if (!this->getPosDirGlo(vecLab)) {
     return false;
   }
@@ -542,7 +542,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, cons
     costet = b[2] / bb;
     sintet = bt / bb;
   }
-  gpu::gpustd::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
+  std::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
                                       -sinphi * vecLab[0] + cosphi * vecLab[1],
                                       sintet * cosphi * vecLab[0] + sintet * sinphi * vecLab[1] + costet * vecLab[2],
                                       costet * cosphi * vecLab[3] + costet * sinphi * vecLab[4] - sintet * vecLab[5],
@@ -1115,7 +1115,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::correctForMaterial(value_t x
 
 //______________________________________________________________
 template <typename value_T>
-GPUd() bool TrackParametrizationWithError<value_T>::getCovXYZPxPyPzGlo(gpu::gpustd::array<value_t, kLabCovMatSize>& cv) const
+GPUd() bool TrackParametrizationWithError<value_T>::getCovXYZPxPyPzGlo(std::array<value_t, kLabCovMatSize>& cv) const
 {
   //---------------------------------------------------------------------
   // This function returns the global covariance matrix of the track params

--- a/DataFormats/common/include/CommonDataFormat/AbstractRef.h
+++ b/DataFormats/common/include/CommonDataFormat/AbstractRef.h
@@ -18,7 +18,10 @@
 
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
-#include "GPUCommonTypeTraits.h"
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits>
+#endif
+
 
 namespace o2::dataformats
 {

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2615,7 +2615,7 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
     o2::track::TrackParametrization<float> tpcTMP = tpcOrig;                                             /// get backup of the track
     const o2::base::Propagator::MatCorrType mMatType = o2::base::Propagator::MatCorrType::USEMatCorrLUT; /// should be parameterized
     const o2::dataformats::VertexBase v = mVtx.getMeanVertex(collisionID < 0 ? 0.f : data.getPrimaryVertex(collisionID).getZ());
-    o2::gpu::gpustd::array<float, 2> dcaInfo{-999., -999.};
+    std::array<float, 2> dcaInfo{-999., -999.};
     if (prop->propagateToDCABxByBz({v.getX(), v.getY(), v.getZ()}, tpcTMP, 2.f, mMatType, &dcaInfo)) {
       trackQAHolder.tpcdcaR = 100. * dcaInfo[0] / sqrt(1. + trackPar.getQ2Pt() * trackPar.getQ2Pt());
       trackQAHolder.tpcdcaZ = 100. * dcaInfo[1] / sqrt(1. + trackPar.getQ2Pt() * trackPar.getQ2Pt());

--- a/Detectors/Align/src/AlignableDetectorTPC.cxx
+++ b/Detectors/Align/src/AlignableDetectorTPC.cxx
@@ -214,8 +214,8 @@ int AlignableDetectorTPC::processPoints(GIndex gid, int npntCut, bool inv)
     auto* sectSensor = (AlignableSensorTPC*)getSensor(currentSector);
     const auto* sysE = sectSensor->getAddError(); // additional syst error
 
-    gpu::gpustd::array<float, 2> p = {y, z};
-    gpu::gpustd::array<float, 3> c = {0, 0, 0};
+    std::array<float, 2> p = {y, z};
+    std::array<float, 3> c = {0, 0, 0};
     mController->getTPCParam()->GetClusterErrors2(sector, currentRow, z, trkParam.getSnp(), trkParam.getTgl(), -1.f, 0.f, 0.f, c[0], c[2]); // TODO: Note this disables occupancy / charge components of the error estimation
     mController->getTPCParam()->UpdateClusterError2ByState(clusterState, c[0], c[2]);
     int nrComb = std::abs(row - currentRow) + 1;

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -17,7 +17,6 @@
 #define ALICEO2_BASE_PROPAGATOR_
 
 #include "GPUCommonRtypes.h"
-#include "GPUCommonArray.h"
 #include "CommonConstants/PhysicsConstants.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/DCA.h"
@@ -25,6 +24,7 @@
 #include "DetectorsBase/MatLayerCylSet.h"
 
 #ifndef GPUCA_GPUCODE
+#include <array>
 #include <string>
 #endif
 
@@ -111,12 +111,12 @@ class PropagatorImpl
 
   GPUd() bool propagateToDCA(const o2::math_utils::Point3D<value_type>& vtx, o2::track::TrackParametrization<value_type>& track, value_type bZ,
                              value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                             gpu::gpustd::array<value_type, 2>* dca = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
+                             std::array<value_type, 2>* dca = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
                              int signCorr = 0, value_type maxD = 999.f) const;
 
   GPUd() bool propagateToDCABxByBz(const o2::math_utils::Point3D<value_type>& vtx, o2::track::TrackParametrization<value_type>& track,
                                    value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                                   gpu::gpustd::array<value_type, 2>* dca = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
+                                   std::array<value_type, 2>* dca = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
                                    int signCorr = 0, value_type maxD = 999.f) const;
 
   PropagatorImpl(PropagatorImpl const&) = delete;

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -170,7 +170,7 @@ GPUd() bool PropagatorImpl<value_T>::PropagateToXBxByBz(TrackParCov_t& track, va
     signCorr = -dir; // sign of eloss correction is not imposed
   }
 
-  gpu::gpustd::array<value_type, 3> b{};
+  std::array<value_type, 3> b{};
   while (math_utils::detail::abs<value_type>(dx) > Epsilon) {
     auto step = math_utils::detail::min<value_type>(math_utils::detail::abs<value_type>(dx), maxStep);
     if (dir < 0) {
@@ -239,7 +239,7 @@ GPUd() bool PropagatorImpl<value_T>::PropagateToXBxByBz(TrackPar_t& track, value
     signCorr = -dir; // sign of eloss correction is not imposed
   }
 
-  gpu::gpustd::array<value_type, 3> b{};
+  std::array<value_type, 3> b{};
   while (math_utils::detail::abs<value_type>(dx) > Epsilon) {
     auto step = math_utils::detail::min<value_type>(math_utils::detail::abs<value_type>(dx), maxStep);
     if (dir < 0) {
@@ -553,7 +553,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats:
 template <typename value_T>
 GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const math_utils::Point3D<value_type>& vtx, TrackPar_t& track, value_type bZ,
                                                     value_type maxStep, PropagatorImpl<value_T>::MatCorrType matCorr,
-                                                    gpu::gpustd::array<value_type, 2>* dca, track::TrackLTIntegral* tofInfo,
+                                                    std::array<value_type, 2>* dca, track::TrackLTIntegral* tofInfo,
                                                     int signCorr, value_type maxD) const
 {
   // propagate track to DCA to the vertex
@@ -601,7 +601,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const math_utils::Point3D<va
 template <typename value_T>
 GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Point3D<value_type>& vtx, TrackPar_t& track,
                                                           value_type maxStep, PropagatorImpl<value_T>::MatCorrType matCorr,
-                                                          gpu::gpustd::array<value_type, 2>* dca, track::TrackLTIntegral* tofInfo,
+                                                          std::array<value_type, 2>* dca, track::TrackLTIntegral* tofInfo,
                                                           int signCorr, value_type maxD) const
 {
   // propagate track to DCA to the vertex

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/Efficiency.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/Efficiency.cxx
@@ -593,7 +593,7 @@ int EfficiencyStudy::getDCAClusterTrackMC(int countDuplicated = 0)
   LOGP(info, "--------------- getDCAClusterTrackMC");
 
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  o2::gpu::gpustd::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
+  std::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
   auto propagator = o2::base::Propagator::Instance();
 
   auto bz = o2::base::Propagator::Instance()->getNominalBz();
@@ -833,7 +833,7 @@ void EfficiencyStudy::countDuplicatedAfterCuts()
   LOGP(info, "--------------- countDuplicatedAfterCuts");
 
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  o2::gpu::gpustd::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
+  std::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
   auto propagator = o2::base::Propagator::Instance();
 
   unsigned int rofIndexTrack = 0;
@@ -1019,7 +1019,7 @@ void EfficiencyStudy::studyDCAcutsMC()
   //  if not, keep it as a fake match -> increase the fake match counter
   //  the efficiency of each one will be match counter / total of the duplicated clusters
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  o2::gpu::gpustd::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
+  std::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
   auto propagator = o2::base::Propagator::Instance();
 
   unsigned int rofIndexTrack = 0;
@@ -1346,7 +1346,7 @@ void EfficiencyStudy::studyClusterSelectionMC()
   }
 
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  o2::gpu::gpustd::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
+  std::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
   auto propagator = o2::base::Propagator::Instance();
 
   unsigned int rofIndexTrack = 0;
@@ -2176,7 +2176,7 @@ void EfficiencyStudy::getEfficiency(bool isMC)
   LOGP(info, "getEfficiency()");
 
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  o2::gpu::gpustd::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
+  std::array<float, 2> clusOriginalDCA, clusDuplicatedDCA;
   auto propagator = o2::base::Propagator::Instance();
 
   unsigned int rofIndexTrack = 0;

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
@@ -358,7 +358,7 @@ void ImpactParameterStudy::process(o2::globaltracking::RecoContainer& recoData)
             auto trueID = trueVec_globID_contr[it];
             const o2::track::TrackParCov& trc = recoData.getTrackParam(trueID);
             auto pt = trc.getPt();
-            o2::gpu::gpustd::array<float, 2> dcaInfo{-999., -999.};
+            std::array<float, 2> dcaInfo{-999., -999.};
             // LOGP(info, " ---> Bz={}", o2::base::Propagator::Instance()->getNominalBz());
             o2::track::TrackPar trcTmp{trc};
             if (o2::base::Propagator::Instance()->propagateToDCABxByBz({Pvtx_refitted.getX(), Pvtx_refitted.getY(), Pvtx_refitted.getZ()}, trcTmp, 2.f, matCorr, &dcaInfo)) {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexingKernels.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexingKernels.h
@@ -22,8 +22,6 @@
 #include "ITStrackingGPU/VertexerTraitsGPU.h"
 #include "ITStrackingGPU/TracerGPU.h"
 
-#include "GPUCommonArray.h"
-
 namespace o2::its::gpu
 {
 #ifdef GPUCA_GPUCODE // GPUg() global kernels must only when compiled by GPU compiler

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexingKernels.cu
@@ -564,7 +564,7 @@ GPUg() void computeVertexKernel(
           histZ[iBin] = 0;
         }
         if (sumWZ > minContributors || vertIndex == 0) {
-          new (vertices + vertIndex) Vertex{o2::math_utils::Point3D<float>(beamPosition[0], beamPosition[1], wZ / sumWZ), o2::gpu::gpustd::array<float, 6>{ex, 0, ey, 0, 0, ez}, static_cast<ushort>(sumWZ), 0};
+          new (vertices + vertIndex) Vertex{o2::math_utils::Point3D<float>(beamPosition[0], beamPosition[1], wZ / sumWZ), std::array<float, 6>{ex, 0, ey, 0, 0, ez}, static_cast<ushort>(sumWZ), 0};
         } else {
           new (vertices + vertIndex) Vertex{};
         }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -16,14 +16,13 @@
 #ifndef TRACKINGITSU_INCLUDE_CACLUSTER_H_
 #define TRACKINGITSU_INCLUDE_CACLUSTER_H_
 
+#include "GPUCommonRtypes.h"
+#include "ITStracking/Definitions.h"
+#include "ITStracking/MathUtils.h"
+
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <array>
 #endif
-
-#include "GPUCommonRtypes.h"
-#include "GPUCommonArray.h"
-#include "ITStracking/Definitions.h"
-#include "ITStracking/MathUtils.h"
 
 namespace o2
 {
@@ -61,15 +60,15 @@ GPUhdi() void Cluster::print() const
 
 struct TrackingFrameInfo {
   TrackingFrameInfo() = default;
-  TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, o2::gpu::gpustd::array<float, 2>&& posTF, o2::gpu::gpustd::array<float, 3>&& covTF);
+  TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, std::array<float, 2>&& posTF, std::array<float, 3>&& covTF);
 
   float xCoordinate;
   float yCoordinate;
   float zCoordinate;
   float xTrackingFrame;
   float alphaTrackingFrame;
-  o2::gpu::gpustd::array<float, 2> positionTrackingFrame = {-1., -1.};
-  o2::gpu::gpustd::array<float, 3> covarianceTrackingFrame = {999., 999., 999.};
+  std::array<float, 2> positionTrackingFrame = {-1., -1.};
+  std::array<float, 3> covarianceTrackingFrame = {999., 999., 999.};
   GPUdi() void print() const
   {
 #if !defined(GPUCA_GPUCODE_DEVICE) || (!defined(__OPENCL__) && defined(GPUCA_GPU_DEBUG_PRINT))

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -16,17 +16,17 @@
 #ifndef TRACKINGITSU_INCLUDE_CONSTANTS_H_
 #define TRACKINGITSU_INCLUDE_CONSTANTS_H_
 
-#ifndef GPUCA_GPUCODE_DEVICE
-#include <climits>
-#include <vector>
-#endif
-
 #include "ITStracking/Definitions.h"
 #include "CommonConstants/MathConstants.h"
 
 #include "GPUCommonMath.h"
 #include "GPUCommonDef.h"
-#include "GPUCommonArray.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <climits>
+#include <vector>
+#include <array>
+#endif
 
 namespace o2
 {
@@ -54,9 +54,9 @@ constexpr int ClustersPerCell{3};
 constexpr int UnusedIndex{-1};
 constexpr float Resolution{0.0005f};
 
-GPUhdi() constexpr o2::gpu::gpustd::array<float, 3> VertexerHistogramVolume()
+GPUhdi() constexpr std::array<float, 3> VertexerHistogramVolume()
 {
-  return o2::gpu::gpustd::array<float, 3>{{1.98, 1.98, 40.f}};
+  return std::array<float, 3>{{1.98, 1.98, 40.f}};
 }
 } // namespace its
 
@@ -66,24 +66,24 @@ constexpr int LayersNumber{7};
 constexpr int TrackletsPerRoad{LayersNumber - 1};
 constexpr int CellsPerRoad{LayersNumber - 2};
 
-GPUhdi() constexpr o2::gpu::gpustd::array<float, LayersNumber> LayersZCoordinate()
+GPUhdi() constexpr std::array<float, LayersNumber> LayersZCoordinate()
 {
   constexpr double s = 1.; // safety margin
-  return o2::gpu::gpustd::array<float, LayersNumber>{16.333f + s, 16.333f + s, 16.333f + s, 42.140f + s, 42.140f + s, 73.745f + s, 73.745f + s};
+  return std::array<float, LayersNumber>{16.333f + s, 16.333f + s, 16.333f + s, 42.140f + s, 42.140f + s, 73.745f + s, 73.745f + s};
 }
 
-GPUhdi() constexpr o2::gpu::gpustd::array<float, LayersNumber> LayersRCoordinate()
+GPUhdi() constexpr std::array<float, LayersNumber> LayersRCoordinate()
 {
-  return o2::gpu::gpustd::array<float, LayersNumber>{{2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f}};
+  return std::array<float, LayersNumber>{{2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f}};
 }
 
 constexpr int ZBins{256};
 constexpr int PhiBins{128};
 constexpr float InversePhiBinSize{PhiBins / constants::math::TwoPi};
-GPUhdi() constexpr o2::gpu::gpustd::array<float, LayersNumber> InverseZBinSize()
+GPUhdi() constexpr std::array<float, LayersNumber> InverseZBinSize()
 {
   constexpr auto zSize = LayersZCoordinate();
-  return o2::gpu::gpustd::array<float, LayersNumber>{0.5f * ZBins / (zSize[0]), 0.5f * ZBins / (zSize[1]), 0.5f * ZBins / (zSize[2]),
+  return std::array<float, LayersNumber>{0.5f * ZBins / (zSize[0]), 0.5f * ZBins / (zSize[1]), 0.5f * ZBins / (zSize[2]),
                                                      0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),
                                                      0.5f * ZBins / (zSize[6])};
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
@@ -17,7 +17,9 @@
 #include "ITStracking/MathUtils.h"
 #include "ITStracking/IndexTableUtils.h"
 
-#include "GPUCommonArray.h"
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <array>
+#endif
 
 namespace o2
 {
@@ -92,8 +94,8 @@ bool Cluster::operator==(const Cluster& rhs) const
          this->indexTableBinIndex == rhs.indexTableBinIndex;
 }
 
-TrackingFrameInfo::TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, o2::gpu::gpustd::array<float, 2>&& posTF,
-                                     o2::gpu::gpustd::array<float, 3>&& covTF)
+TrackingFrameInfo::TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, std::array<float, 2>&& posTF,
+                                     std::array<float, 3>&& covTF)
   : xCoordinate{x}, yCoordinate{y}, zCoordinate{z}, xTrackingFrame{xTF}, alphaTrackingFrame{alpha}, positionTrackingFrame{posTF}, covarianceTrackingFrame{covTF}
 {
   // Nothing to do

--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -19,13 +19,15 @@
 #include "GPUCommonRtypes.h"
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
-#include "GPUCommonTypeTraits.h"
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits>
+#endif
 #if !defined(GPUCA_GPUCODE)
 #include "CommonDataFormat/InteractionRecord.h"
 #endif
 #if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 #include "Headers/DAQID.h"
-#endif // GPUCA_GPUCODE / GPUCA_STANDALONE
+#endif
 
 namespace o2
 {

--- a/Detectors/TPC/qc/src/Tracks.cxx
+++ b/Detectors/TPC/qc/src/Tracks.cxx
@@ -13,6 +13,7 @@
 
 #include <cmath>
 #include <memory>
+#include <array>
 
 // root includes
 #include "TFile.h"
@@ -21,7 +22,6 @@
 // o2 includes
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTPC/dEdxInfo.h"
-#include "GPUCommonArray.h"
 #include "DetectorsBase/Propagator.h"
 #include "TPCQC/Tracks.h"
 #include "TPCQC/Helpers.h"
@@ -179,7 +179,7 @@ bool Tracks::processTrack(const o2::tpc::TrackTPC& track)
 
       if (propagator->getMatLUT() && propagator->hasMagFieldSet()) {
         // ---| fill DCA histos |---
-        o2::gpu::gpustd::array<float, 2> dca;
+        std::array<float, 2> dca;
         o2::track::TrackPar propTrack(track);
         if (propagator->propagateToDCABxByBz(mPositionOfPV, propTrack, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrLUT, &dca)) {
           const auto phi = o2::math_utils::to02PiGen(track.getPhi());

--- a/Detectors/TPC/workflow/src/MIPTrackFilterSpec.cxx
+++ b/Detectors/TPC/workflow/src/MIPTrackFilterSpec.cxx
@@ -178,7 +178,7 @@ bool MIPTrackFilterDevice::acceptDCA(const TrackTPC& track)
   }
 
   auto propagator = o2::base::Propagator::Instance();
-  o2::gpu::gpustd::array<float, 2> dca;
+  std::array<float, 2> dca;
   const o2::math_utils::Point3D<float> refPoint{0, 0, 0};
   o2::track::TrackPar propTrack(track);
   const auto ok = propagator->propagateToDCABxByBz(refPoint, propTrack, 2., o2::base::Propagator::MatCorrType::USEMatCorrLUT, &dca);

--- a/Detectors/TPC/workflow/src/TPCRefitter.cxx
+++ b/Detectors/TPC/workflow/src/TPCRefitter.cxx
@@ -421,7 +421,7 @@ void TPCRefitterSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 bool TPCRefitterSpec::getDCAs(const o2::track::TrackPar& track, float& dcar, float& dcaz)
 {
   auto propagator = o2::base::Propagator::Instance();
-  o2::gpu::gpustd::array<float, 2> dca;
+  std::array<float, 2> dca;
   const o2::math_utils::Point3D<float> refPoint{0, 0, 0};
   o2::track::TrackPar propTrack(track);
   const auto ok = propagator->propagateToDCABxByBz(refPoint, propTrack, 2., o2::base::Propagator::MatCorrType::USEMatCorrLUT, &dca);

--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1143,7 +1143,7 @@ class TPCTimeSeries : public Task
     auto propagator = o2::base::Propagator::Instance();
 
     // propagate track to DCA
-    o2::gpu::gpustd::array<float, 2> dca;
+    std::array<float, 2> dca;
     const o2::math_utils::Point3D<float> refPoint{0, 0, 0};
 
     // coarse propagation
@@ -1252,7 +1252,7 @@ class TPCTimeSeries : public Task
 
     // make propagation for ITS-TPC Track
     // check if the track was assigned to ITS track
-    o2::gpu::gpustd::array<float, 2> dcaITSTPC{0, 0};
+    std::array<float, 2> dcaITSTPC{0, 0};
     float deltaP0 = -999;
     float deltaP1 = -999;
     float deltaP2 = -999;
@@ -1270,7 +1270,7 @@ class TPCTimeSeries : public Task
           // store TPC only DCAs
           // propagate to vertex in case the track belongs to vertex
           const bool contributeToVertex = (idxITSTPC.back() != -1);
-          o2::gpu::gpustd::array<float, 2> dcaITSTPCTmp{-1, -1};
+          std::array<float, 2> dcaITSTPCTmp{-1, -1};
 
           if (contributeToVertex) {
             if (propagator->propagateToDCA(vertex.getXYZ(), trackITSTPCTmp, propagator->getNominalBz(), mFineStep, mMatType, &dcaITSTPCTmp)) {
@@ -1279,7 +1279,7 @@ class TPCTimeSeries : public Task
             }
 
             // propagate TPC track to vertex
-            o2::gpu::gpustd::array<float, 2> dcaTPCTmp{-1, -1};
+            std::array<float, 2> dcaTPCTmp{-1, -1};
             if (propagator->propagateToDCA(vertex.getXYZ(), track, propagator->getNominalBz(), mFineStep, mMatType, &dcaTPCTmp)) {
               dcaTPCAtVertex = dcaTPCTmp[0];
             }
@@ -1401,7 +1401,7 @@ class TPCTimeSeries : public Task
         const bool contributeToVertex = (idxITSTPC.back() != -1);
         if (hasITSTPC && contributeToVertex) {
           o2::track::TrackParCov trackITSTPCTmp = tracksITSTPC[idxITSTPC.front()];
-          o2::gpu::gpustd::array<float, 2> dcaITSTPCTmp{-1, -1};
+          std::array<float, 2> dcaITSTPCTmp{-1, -1};
           if (propagator->propagateToDCA(vertex.getXYZ(), trackITSTPCTmp, propagator->getNominalBz(), mFineStep, mMatType, &dcaITSTPCTmp)) {
             o2::track::TrackParCov trackTPC = tracksTPC[iTrk];
             if (trackTPC.rotate(trackITSTPCTmp.getAlpha()) && propagator->propagateTo(trackTPC, trackITSTPCTmp.getX(), false, mMaxSnp, mFineStep, mMatType)) {

--- a/GPU/Common/GPUCommonArray.h
+++ b/GPU/Common/GPUCommonArray.h
@@ -15,12 +15,14 @@
 #ifndef GPUCOMMONARRAY_H
 #define GPUCOMMONARRAY_H
 
-#ifndef GPUCA_GPUCODE_DEVICE
+#if !defined(GPUCA_GPUCODE_DEVICE) || defined(__CUDACC__) || defined(__HIPCC__) // TODO: Get rid of GPUCommonArray once OpenCL supports <array>
+#ifndef GPUCA_GPUCODE_COMPILEKERNELS
 #include <array>
 #endif
+#else
 
 #include "GPUCommonDef.h"
-namespace o2::gpu::gpustd
+namespace std
 {
 #ifdef GPUCA_GPUCODE_DEVICE
 template <typename T, size_t N>
@@ -43,5 +45,7 @@ GPUd() array(T, E...)->array<T, 1 + sizeof...(E)>;
 template <typename T, size_t N>
 using array = std::array<T, N>;
 #endif
-} // namespace o2::gpu::gpustd
+} // namespace std
 #endif
+
+#endif // GPUCOMMONARRAY_H

--- a/GPU/Common/GPUCommonArray.h
+++ b/GPU/Common/GPUCommonArray.h
@@ -48,4 +48,10 @@ using array = std::array<T, N>;
 } // namespace std
 #endif
 
+namespace o2::gpu::gpustd
+{
+template <class T, size_t I>
+using array = ::std::array<T, I>; // temporary alias, to remove dependent types
+} // o2::gpu::gpustd
+
 #endif // GPUCOMMONARRAY_H

--- a/GPU/Common/GPUCommonTypeTraits.h
+++ b/GPU/Common/GPUCommonTypeTraits.h
@@ -17,12 +17,11 @@
 
 #include "GPUCommonDef.h"
 
-#if !defined(GPUCA_GPUCODE_DEVICE) || defined(__CUDACC__) || defined(__HIPCC__)
+#if !defined(GPUCA_GPUCODE_DEVICE) || defined(__CUDACC__) || defined(__HIPCC__) // TODO: Get rid of GPUCommonTypeTraits once OpenCL supports <type_traits>
 #ifndef GPUCA_GPUCODE_COMPILEKERNELS
 #include <type_traits>
 #endif
 #else
-// We just reimplement some type traits in std for the GPU // TODO: Check if meanwhile we can get rid of GPUCommonTypeTraits and GPUCommonArray, and just use the std headers.
 namespace std
 {
 template <bool B, class T, class F>

--- a/GPU/GPUTracking/Base/GPUStdSystemHeaders.h
+++ b/GPU/GPUTracking/Base/GPUStdSystemHeaders.h
@@ -21,5 +21,6 @@
 #include <cfloat>
 #include <cmath>
 #include <type_traits>
+#include <array>
 
 #endif

--- a/GPU/GPUTracking/Base/GPUStdSystemHeaders.h
+++ b/GPU/GPUTracking/Base/GPUStdSystemHeaders.h
@@ -9,24 +9,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file GPUReconstructionHIPIncludesSystem.h
+/// \file GPUStdSystemHeaders.h
 /// \author David Rohr
 
-#ifndef O2_GPU_RECONSTRUCTIONHIPINCLUDESSYSTEM_H
-#define O2_GPU_RECONSTRUCTIONHIPINCLUDESSYSTEM_H
+#ifndef GPUSTDSYSTEMHEADERS_H
+#define GPUSTDSYSTEMHEADERS_H
 
-#ifndef GPUCA_GPUCODE_GENRTC
-#include "GPUStdSystemHeaders.h"
+#include <string>
+#include <cstddef>
+#include <cstdint>
+#include <cfloat>
+#include <cmath>
+#include <type_traits>
+
 #endif
-
-#include <hip/hip_runtime.h>
-#include <hip/hip_ext.h>
-#include <hipcub/hipcub.hpp>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow" // FIXME: Is this still needed?
-#include <thrust/sort.h>
-#include <thrust/execution_policy.h>
-#include <thrust/device_ptr.h>
-#pragma GCC diagnostic pop
-
-#endif // O2_GPU_RECONSTRUCTIONHIPINCLUDESSYSTEM_H

--- a/GPU/GPUTracking/Base/cuda/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/cuda/CMakeLists.txt
@@ -67,7 +67,9 @@ set(GPU_RTC_BIN ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionCUDArtc)
 # cmake-format: off
 add_custom_command(
     OUTPUT ${GPU_RTC_BIN}.src
-    COMMAND cp ${GPUDIR}/Base/cuda/GPUReconstructionCUDAIncludesSystem.h ${GPU_RTC_BIN}.src
+    COMMAND cp ${GPUDIR}/Base/GPUStdSystemHeaders.h ${GPU_RTC_BIN}.src
+    COMMAND cat ${GPUDIR}/Base/cuda/GPUReconstructionCUDAIncludesSystem.h | grep -v GPUStdSystemHeaders.h >> ${GPU_RTC_BIN}.src
+    COMMAND cat ${GPUDIR}/Base/GPUStdSystemHeaders.h >> ${GPU_RTC_BIN}.src
     COMMAND ${CMAKE_CUDA_COMPILER} ${GPU_RTC_DEFINES} ${GPU_RTC_INCLUDES} -std=c++${CMAKE_CUDA_STANDARD} -D__CUDA_ARCH__=${RTC_CUDA_ARCH} -D__CUDACC__ -x c++ -E -Xcompiler "-nostdinc -P" ${GPU_RTC_SRC} >> ${GPU_RTC_BIN}.src
     MAIN_DEPENDENCY ${GPU_RTC_SRC}
     IMPLICIT_DEPENDS CXX ${GPU_RTC_SRC}

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAIncludesSystem.h
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAIncludesSystem.h
@@ -15,9 +15,10 @@
 #ifndef O2_GPU_GPURECONSTRUCTIONCUDAINCLUDESSYSTEM_H
 #define O2_GPU_GPURECONSTRUCTIONCUDAINCLUDESSYSTEM_H
 
-#include <cstdint>
-#include <type_traits>
-#include <string>
+#ifndef GPUCA_GPUCODE_GENRTC
+#include "GPUStdSystemHeaders.h"
+#endif
+
 #include <cuda_runtime.h>
 #include <cuda.h>
 #include <cooperative_groups.h>

--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -114,7 +114,8 @@ set(GPU_RTC_BIN ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionHIPrtc)
 # cmake-format: off
 add_custom_command(
     OUTPUT ${GPU_RTC_BIN}.src
-    COMMAND cp ${GPUDIR}/Base/hip/GPUReconstructionHIPIncludesSystem.h ${GPU_RTC_BIN}.src
+    COMMAND cp ${GPUDIR}/Base/GPUStdSystemHeaders.h ${GPU_RTC_BIN}.src
+    COMMAND cat ${GPUDIR}/Base/hip/GPUReconstructionHIPIncludesSystem.h | grep -v GPUStdSystemHeaders.h >> ${GPU_RTC_BIN}.src
     COMMAND ${CMAKE_HIP_COMPILER} ${GPU_RTC_DEFINES} ${GPU_RTC_INCLUDES} -std=c++${CMAKE_HIP_STANDARD} -D__HIPCC__ -D__HIP_DEVICE_COMPILE__ -x c++ -nostdinc -E -P ${GPU_RTC_SRC} >> ${GPU_RTC_BIN}.src
     MAIN_DEPENDENCY ${GPU_RTC_SRC}
     IMPLICIT_DEPENDS CXX ${GPU_RTC_SRC}

--- a/GPU/GPUTracking/Base/opencl/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 set(CL_SRC ${GPUDIR}/Base/opencl/GPUReconstructionOCL.cl)
 set(CL_BIN ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionOCLCode)
 
-set(OCL_FLAGS -Dcl_clang_storage_class_specifiers -cl-std=CLC++2021 ${GPUCA_OCL_DENORMALS_FLAGS})
+set(OCL_FLAGS -Dcl_clang_storage_class_specifiers -x cl -cl-std=CLC++2021 ${GPUCA_OCL_DENORMALS_FLAGS})
 if(NOT GPUCA_DETERMINISTIC_MODE GREATER_EQUAL ${GPUCA_DETERMINISTIC_MODE_MAP_NO_FAST_MATH})
   set(OCL_FLAGS ${OCL_FLAGS} -cl-mad-enable -cl-no-signed-zeros -cl-fast-relaxed-math)
 else()
@@ -42,6 +42,11 @@ set(HDRS GPUReconstructionOCL.h GPUReconstructionOCLIncludesHost.h)
 if (NOT DEFINED GPUCA_OCL_SPIRV_VERSION)
   set(GPUCA_OCL_SPIRV_VERSION 1.2)
 endif()
+
+# execute_process(COMMAND bash -c "${LLVM_CLANG} -stdlib=libc++ -E -H -x c++ - <<< '#include <type_traits>' 2>&1 1>/dev/null | grep type_traits | head -n 1 | sed 's/^\\.* *//'"
+#                 OUTPUT_VARIABLE CLANG_STD_INCLUDE_DIR)
+# get_filename_component(CLANG_STD_INCLUDE_DIR "${CLANG_STD_INCLUDE_DIR}" DIRECTORY)
+# get_filename_component(CLANG_STD_INCLUDE_DIR "${CLANG_STD_INCLUDE_DIR}" ABSOLUTE) # TODO: For using <type_traits> in OpenCL, we would need to add -I${CLANG_STD_INCLUDE_DIR}
 
 if(OPENCL_ENABLED_SPIRV) # BUILD OpenCL intermediate code for SPIR-V target
   # executes clang to create llvm IL code
@@ -71,6 +76,7 @@ if(OPENCL_ENABLED) # BUILD OpenCL source code for runtime compilation target
   add_custom_command(
       OUTPUT ${CL_BIN}.src
       COMMAND ${LLVM_CLANG}
+              -target spir64
               -Wno-unused-command-line-argument
               ${OCL_FLAGS}
               ${OCL_DEFINECL}

--- a/GPU/GPUTracking/Base/opencl/GPUReconstructionOCL.cl
+++ b/GPU/GPUTracking/Base/opencl/GPUReconstructionOCL.cl
@@ -72,6 +72,7 @@ typedef signed char int8_t;
 
 #include "GPUCommonDef.h"
 #include "GPUCommonTypeTraits.h" // TODO: Once possible in OpenCL, should use GPUStdSystemHeaders.h here
+#include "GPUCommonArray.h"      // TODO: Same
 #include "GPUConstantMem.h"
 #include "GPUReconstructionIncludesDeviceAll.h"
 

--- a/GPU/GPUTracking/Base/opencl/GPUReconstructionOCL.cl
+++ b/GPU/GPUTracking/Base/opencl/GPUReconstructionOCL.cl
@@ -70,6 +70,8 @@ typedef signed char int8_t;
 #endif
 #define assert(param)
 
+#include "GPUCommonDef.h"
+#include "GPUCommonTypeTraits.h" // TODO: Once possible in OpenCL, should use GPUStdSystemHeaders.h here
 #include "GPUConstantMem.h"
 #include "GPUReconstructionIncludesDeviceAll.h"
 

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -20,9 +20,9 @@
 // These are basic and non-complex data types, which will also be visible on the GPU.
 // Please add complex data types required on the host but not GPU to GPUHostDataTypes.h and forward-declare!
 #ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits> // for bitfield below
 #include <cstddef>
 #endif
-#include "GPUCommonTypeTraits.h"
 #include "GPUTRDDef.h"
 
 struct AliHLTTPCClusterMCLabel;

--- a/GPU/GPUTracking/DataTypes/GPUTPCGMMergedTrackHit.h
+++ b/GPU/GPUTracking/DataTypes/GPUTPCGMMergedTrackHit.h
@@ -35,7 +35,7 @@ struct GPUTPCGMMergedTrackHit {
                   flagRejectDistance = 0x20,
                   flagRejectErr = 0x40,
                   flagReject = 0x60,
-                  flagNotFit = 0x80 };
+                  flagHighIncl = 0x80 };
 };
 
 struct GPUTPCGMMergedTrackHitXYZ {

--- a/GPU/GPUTracking/Definitions/GPUGetConstexpr.h
+++ b/GPU/GPUTracking/Definitions/GPUGetConstexpr.h
@@ -16,7 +16,9 @@
 #define GPUGETCONSTEXPR_H
 
 #include "GPUCommonDef.h"
-#include "GPUCommonTypeTraits.h"
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits>
+#endif
 
 // This is a temporary workaround required for clang (with c++20), until we can go to C++23 with P2280R4, which allows getting constexpr static values from references
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -1895,7 +1895,7 @@ GPUd() void GPUTPCGMMerger::Finalize1(int32_t nBlocks, int32_t nThreads, int32_t
       uint8_t clusterState = mClusters[trk.FirstClusterRef() + j].state;
       if (!(clusterState & GPUTPCGMMergedTrackHit::flagReject)) {
         weight |= attachGood;
-      } else if (clusterState & GPUTPCGMMergedTrackHit::flagNotFit) {
+      } else if (clusterState & GPUTPCGMMergedTrackHit::flagHighIncl) {
         weight |= attachHighIncl;
       }
       if (mClusters[trk.FirstClusterRef() + j].leg == goodLeg) {

--- a/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
@@ -32,7 +32,7 @@ using namespace o2::gpu;
 using namespace o2::tpc;
 using namespace o2::tpc::constants;
 
-GPUdi() static constexpr uint8_t getFlagsReject() { return GPUTPCGMMergedTrackHit::flagReject | GPUTPCGMMergedTrackHit::flagNotFit; }
+GPUdi() static constexpr uint8_t getFlagsReject() { return GPUTPCGMMergedTrackHit::flagReject | GPUTPCGMMergedTrackHit::flagHighIncl; }
 GPUdi() static uint32_t getFlagsRequired(const GPUSettingsRec& rec) { return rec.tpc.dropSecondaryLegsInOutput ? gputpcgmmergertypes::attachGoodLeg : gputpcgmmergertypes::attachZero; }
 
 namespace o2::gpu::internal

--- a/GPU/GPUTracking/Merger/GPUTPCGMPropagator.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPropagator.h
@@ -53,9 +53,9 @@ class GPUTPCGMPropagator
     updateErrorFitFailed = -1,
     updateErrorClusterRejected = 2,
     updateErrorClusterRejectedDistance = 2,
-    updateErrorEdgeCluster = 3,
-    updateErrorClusterRejectedInInterpolation = 4,
-    updateErrorClusterRejectedInUpdate = 5
+    updateErrorClusterRejectedInInterpolation = 3,
+    updateErrorClusterRejectedInUpdate = 4,
+    updateErrorClusterRejectedEdge = 5
   };
   enum RejectChi2Mode {
     rejectDirect = 1,
@@ -188,7 +188,7 @@ class GPUTPCGMPropagator
   GPUTPCGMPhysicalTrackModel mT0;
   MaterialCorrection mMaterial;
   FieldRegion mFieldRegion = TPC;
-  bool mSeedingErrors = 0;
+  bool mSeedingErrors = 0;    // TODO: Hide variable in Run3 mode
   bool mFitInProjections = 1; // fit (Y,SinPhi,QPt) and (Z,DzDs) paramteres separatelly
   bool mPropagateBzOnly = 0;  // Use Bz only in propagation
   bool mToyMCEvents = 0;      // events are simulated with simple home-made simulation

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -299,7 +299,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(GPUTPCGMMerger* GPUrestrict() merger, int32_
         if (mC[0] > param.rec.tpc.trackFitCovLimit || mC[2] > param.rec.tpc.trackFitCovLimit) {
           break;
         }
-        MarkClusters(clusters, ihitMergeFirst, ihit, wayDirection, GPUTPCGMMergedTrackHit::flagNotFit);
+        MarkClusters(clusters, ihitMergeFirst, ihit, wayDirection, GPUTPCGMMergedTrackHit::flagHighIncl);
         nMissed2++;
         NTolerated++;
         CADEBUG(printf(" --- break (%d, %d)\n", err, err2));
@@ -334,7 +334,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(GPUTPCGMMerger* GPUrestrict() merger, int32_
 #endif
         GPUCA_DEBUG_STREAMER_CHECK(GPUTPCGMPropagator::DebugStreamerVals debugVals;);
         if (param.rec.tpc.rejectEdgeClustersInTrackFit && uncorrectedY > -1e6f && param.rejectEdgeClusterByY(uncorrectedY, cluster.row, CAMath::Sqrt(mC[0]))) { // uncorrectedY > -1e6f implies allowModification
-          retVal = GPUTPCGMPropagator::updateErrorEdgeCluster;
+          retVal = GPUTPCGMPropagator::updateErrorClusterRejectedEdge;
         } else {
           const float time = merger->GetConstantMem()->ioPtrs.clustersNative ? merger->GetConstantMem()->ioPtrs.clustersNative->clustersLinear[cluster.num].getTime() : -1.f;
           const float invSqrtCharge = merger->GetConstantMem()->ioPtrs.clustersNative ? CAMath::InvSqrt(merger->GetConstantMem()->ioPtrs.clustersNative->clustersLinear[cluster.num].qMax) : 0.f;
@@ -363,7 +363,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(GPUTPCGMMerger* GPUrestrict() merger, int32_
         lastUpdateX = mX;
         covYYUpd = mC[0];
         nMissed = nMissed2 = 0;
-        UnmarkClusters(clusters, ihitMergeFirst, ihit, wayDirection, GPUTPCGMMergedTrackHit::flagNotFit);
+        UnmarkClusters(clusters, ihitMergeFirst, ihit, wayDirection, GPUTPCGMMergedTrackHit::flagHighIncl);
         N++;
         ihitStart = ihit;
         float dy = mP[0] - prop.Model().Y();

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
@@ -387,8 +387,8 @@ GPUd() int32_t GPUTrackingRefit::RefitTrack(T& trkX, bool outward, bool resetCov
         TrackParCovChi2 = 0.f;
       }
       CADEBUG(printf("\t%21sPropaga Alpha %8.3f    , X %8.3f - Y %8.3f, Z %8.3f   -   QPt %7.2f (%7.2f), SP %5.2f (%5.2f)   ---   Res %8.3f %8.3f   ---   Cov sY %8.3f sZ %8.3f sSP %8.3f sPt %8.3f   -   YPt %8.3f\n", "", trk.getAlpha(), x, trk.getParams()[0], trk.getParams()[1], trk.getParams()[4], trk.getParams()[4], trk.getParams()[2], trk.getParams()[2], trk.getParams()[0] - y, trk.getParams()[1] - z, sqrtf(trk.getCov()[0]), sqrtf(trk.getCov()[2]), sqrtf(trk.getCov()[5]), sqrtf(trk.getCov()[14]), trk.getCov()[10]));
-      gpu::gpustd::array<float, 2> p = {y, z};
-      gpu::gpustd::array<float, 3> c = {0, 0, 0};
+      std::array<float, 2> p = {y, z};
+      std::array<float, 3> c = {0, 0, 0};
       GPUTPCGMPropagator::GetErr2(c[0], c[2], *mPparam, getPar(trk)[2], getPar(trk)[3], z, x, y, currentRow, clusterState, sector, time, invAvgCharge, invCharge, false);
       TrackParCovChi2 += trk.getPredictedChi2(p, c);
       if (!trk.update(p, c)) {

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
@@ -268,7 +268,7 @@ GPUd() int32_t GPUTrackingRefit::RefitTrack(T& trkX, bool outward, bool resetCov
         if constexpr (std::is_same_v<T, GPUTPCGMMergedTrack>) {
           const auto& hit = mPtrackHits[trkX.FirstClusterRef() + i];
           cl = &mPclusterNative->clustersLinear[hit.num];
-          if (hit.state & (GPUTPCGMMergedTrackHit::flagReject | GPUTPCGMMergedTrackHit::flagNotFit)) {
+          if (hit.state & (GPUTPCGMMergedTrackHit::flagReject | GPUTPCGMMergedTrackHit::flagHighIncl)) {
             cl = nullptr;
             if (i + direction != stop) {
               i += direction;

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
@@ -28,7 +28,10 @@
 #include "GPUCommonArray.h"
 #include "GPUParam.h"
 #include "GPUTrackParamConvert.h"
-#include "GPUCommonTypeTraits.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits>
+#endif
 
 using namespace o2::gpu;
 using namespace o2::track;

--- a/GPU/GPUTracking/Standalone/cmake/config.cmake
+++ b/GPU/GPUTracking/Standalone/cmake/config.cmake
@@ -30,7 +30,7 @@ set(GPUCA_BUILD_DEBUG 0)
 set(GPUCA_BUILD_DEBUG_SANITIZE 0)
 set(GPUCA_DETERMINISTIC_MODE 0)             # OFF / NO_FAST_MATH / OPTO2 / GPU / WHOLEO2
 #set(GPUCA_CUDA_GCCBIN c++-14)
-#set(GPUCA_OPENCL_CLANGBIN clang-19)
+#set(GPUCA_OPENCL_CLANGBIN clang-20)
 set(HIP_AMDGPUTARGET "default")             # "gfx906;gfx908;gfx90a"
 set(CUDA_COMPUTETARGET "default")           # 86 89
 #set(GPUCA_CUDA_COMPILE_MODE perkernel)     # onefile / perkernel / rtc

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -59,8 +59,8 @@ class propagatorInterface<o2::base::Propagator>
   GPUdi() bool update(const float p[2], const float cov[3])
   {
     if (mParam) {
-      gpustd::array<float, 2> pTmp = {p[0], p[1]};
-      gpustd::array<float, 3> covTmp = {cov[0], cov[1], cov[2]};
+      std::array<float, 2> pTmp = {p[0], p[1]};
+      std::array<float, 3> covTmp = {cov[0], cov[1], cov[2]};
       return mParam->update(pTmp, covTmp);
     } else {
       return false;
@@ -69,8 +69,8 @@ class propagatorInterface<o2::base::Propagator>
   GPUdi() float getPredictedChi2(const float p[2], const float cov[3])
   {
     if (mParam) {
-      gpustd::array<float, 2> pTmp = {p[0], p[1]};
-      gpustd::array<float, 3> covTmp = {cov[0], cov[1], cov[2]};
+      std::array<float, 2> pTmp = {p[0], p[1]};
+      std::array<float, 3> covTmp = {cov[0], cov[1], cov[2]};
       return mParam->getPredictedChi2(pTmp, covTmp);
     } else {
       return 99999.f;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerKernels.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerKernels.cxx
@@ -15,9 +15,12 @@
 #include "GPUTRDTrackerKernels.h"
 #include "GPUTRDGeometry.h"
 #include "GPUConstantMem.h"
-#include "GPUCommonTypeTraits.h"
 
 #include "GPUReconstructionThreading.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <type_traits>
+#endif
 
 using namespace o2::gpu;
 

--- a/GPU/GPUTracking/utils/bitfield.h
+++ b/GPU/GPUTracking/utils/bitfield.h
@@ -15,10 +15,6 @@
 #ifndef Q_BITFIELD_H
 #define Q_BITFIELD_H
 
-#if !defined(GPUCA_GPUCODE_DEVICE) && !defined(GPUCA_GPUCODE_COMPILEKERNELS)
-#include <type_traits>
-#endif
-
 template <class T, class S>
 class bitfield
 {
@@ -93,6 +89,7 @@ class bitfield
   }
 
 #if !defined(GPUCA_GPUCODE_DEVICE)
+  static_assert(std::is_void_v<void>, "type_traits header missing");
   static_assert(std::is_integral_v<S>, "Storage type non integral");
   static_assert(sizeof(S) >= sizeof(T), "Storage type has insufficient capacity");
 #endif


### PR DESCRIPTION
- Renames some misleading flags
- Switches CUDA / ROCm to use <array> instead of GPUCommonArray
- Prepare to get rid of GPUCommonTypeTraits and GPUCommonArray once this is possible in OpenCL.
- Contains already some code to use type_traits in OpenCL, which mostly workd, but it turns out <cstdint> pulled in from <type_traits> has typedefs colliding with opencl-c-stdinc.h. Filed a bug report to clang. Let's see. If we are unlucky, these are just incompatible specifications...