### PR TITLE
Revert "GPU Common: Workaround for removing gpustd::array, temporary alias for O2Physics"

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -29,7 +29,6 @@
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 #include "GPUCommonMath.h"
-#include "GPUCommonArray.h"
 #include "GPUROOTCartesianFwd.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/GPU/Common/GPUCommonArray.h
+++ b/GPU/Common/GPUCommonArray.h
@@ -48,10 +48,4 @@ using array = std::array<T, N>;
 } // namespace std
 #endif
 
-namespace o2::gpu::gpustd
-{
-template <class T, size_t I>
-using array = ::std::array<T, I>; // temporary alias, to remove dependent types
-} // o2::gpu::gpustd
-
 #endif // GPUCOMMONARRAY_H


### PR DESCRIPTION
This reverts commit a850e9eb3e6a634a1e87a70170c05ad6d8bce3af.

Don't merge yet, want to test the CI and give people few days to update O2Physics.