### PR TITLE
DPL Analysis: add `clamp` node to constrain a result of an expression between two values

### DIFF
--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -546,6 +546,14 @@ inline Node updateParameters(Node const& pexp, int bins, std::vector<T> const& p
   return result;
 }
 
+/// clamping functional
+template <typename T>
+inline Node clamp(Node&& expr, T low, T hi)
+{
+  auto copy = expr;
+  return ifnode(Node{copy} < LiteralNode{low}, LiteralNode{low}, ifnode(Node{copy} > LiteralNode{hi}, LiteralNode{hi}, Node{copy}));
+}
+
 /// A struct, containing the root of the expression tree
 struct Filter {
   Filter() = default;

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -290,6 +290,13 @@ TEST_CASE("TestConditionalExpressions")
   auto gandiva_condition2 = makeCondition(gandiva_tree2);
   auto gandiva_filter2 = createFilter(schema2, gandiva_condition2);
   REQUIRE(gandiva_tree2->ToString() == "bool greater_than((float) fSigned1Pt, (const float) 0 raw(0)) && if (bool less_than(float absf((float) fEta), (const float) 1 raw(3f800000)) && if (bool less_than((float) fPt, (const float) 1 raw(3f800000))) { bool greater_than((float) fPhi, (const float) 1.5708 raw(3fc90fdb)) } else { bool less_than((float) fPhi, (const float) 1.5708 raw(3fc90fdb)) }) { bool greater_than(float absf((float) fX), (const float) 1 raw(3f800000)) } else { bool greater_than(float absf((float) fY), (const float) 1 raw(3f800000)) }");
+
+  // clamp
+  Projector clp = clamp(o2::aod::track::pt, 1.0f, 10.f);
+  auto clpspecs = createOperations(clp);
+  auto schemaclp = std::make_shared<arrow::Schema>(std::vector{o2::aod::track::Pt::asArrowField()});
+  auto gandiva_tree_clp = createExpressionTree(clpspecs, schemaclp);
+  REQUIRE(gandiva_tree_clp->ToString() == "if (bool less_than((float) fPt, (const float) 1 raw(3f800000))) { (const float) 1 raw(3f800000) } else { if (bool greater_than((float) fPt, (const float) 10 raw(41200000))) { (const float) 10 raw(41200000) } else { (float) fPt } }");
 }
 
 TEST_CASE("TestBinnedExpressions")


### PR DESCRIPTION
Example: 
```cpp
Projector p = clamp(o2::aod::track::pt, 1.0f, 10.f);
```