### PR TITLE
DPL: fix error reporting

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -2107,7 +2107,7 @@ void DataProcessingDevice::handleData(ServiceRegistryRef ref, InputChannelInfo& 
           LOGP(debug, "Got DomainInfoHeader, new oldestPossibleTimeslice {} on channel {}", oldestPossibleTimeslice, info.id.value);
           parts.At(headerIndex).reset(nullptr);
           parts.At(payloadIndex).reset(nullptr);
-        }
+        } break;
         case InputType::Invalid: {
           reportError("Invalid part found.");
         } break;


### PR DESCRIPTION

Any oldest possible timeframe message was accounted as error.

Maybe we should simply drop the metric...
