### PR TITLE
[EMCAL-688] ClusterFactory: remove std::optional

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -12,7 +12,6 @@
 #define ALICEO2_EMCAL_CLUSTERFACTORY_H_
 #include <array>
 #include <vector>
-#include <optional>
 #include <utility>
 #include <gsl/span>
 #include "Rtypes.h"
@@ -336,7 +335,7 @@ class ClusterFactory
   bool getUseWeightExotic() const { return mUseWeightExotic; }
   void setUseWeightExotic(float useWeightExotic) { mUseWeightExotic = useWeightExotic; }
 
-  void setContainer(gsl::span<const o2::emcal::Cluster> clusterContainer, gsl::span<const InputType> cellContainer, gsl::span<const int> indicesContainer, std::optional<gsl::span<const o2::emcal::CellLabel>> cellLabelContainer = std::nullopt)
+  void setContainer(gsl::span<const o2::emcal::Cluster> clusterContainer, gsl::span<const InputType> cellContainer, gsl::span<const int> indicesContainer, gsl::span<const o2::emcal::CellLabel> cellLabelContainer = {})
   {
     mClustersContainer = clusterContainer;
     mInputsContainer = cellContainer;
@@ -344,8 +343,8 @@ class ClusterFactory
     if (!getLookUpInit()) {
       setLookUpTable();
     }
-    if (cellLabelContainer) {
-      mCellLabelContainer = cellLabelContainer.value();
+    if (!cellLabelContainer.empty()) {
+      mCellLabelContainer = cellLabelContainer;
     }
   }
 


### PR DESCRIPTION
- std::optional creates copies, potentially slowing down the code and increase memory usage. Instead we just use a gsl::span here and check if it is empty or not.