### PR TITLE
Always check gGrid before calling TGrid::Connect to alien

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -958,14 +958,14 @@ void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info 
 
 bool CcdbApi::initTGrid() const
 {
-  if (mNeedAlienToken && !mAlienInstance) {
+  if (mNeedAlienToken && !gGrid) {
     static bool allowNoToken = getenv("ALICEO2_CCDB_NOTOKENCHECK") && atoi(getenv("ALICEO2_CCDB_NOTOKENCHECK"));
     if (!allowNoToken && !checkAlienToken()) {
       LOG(fatal) << "Alien Token Check failed - Please get an alien token before running with https CCDB endpoint, or alice-ccdb.cern.ch!";
     }
-    mAlienInstance = TGrid::Connect("alien");
+    TGrid::Connect("alien");
     static bool errorShown = false;
-    if (!mAlienInstance && errorShown == false) {
+    if (!gGrid && errorShown == false) {
       if (allowNoToken) {
         LOG(error) << "TGrid::Connect returned nullptr. May be due to missing alien token";
       } else {
@@ -974,7 +974,7 @@ bool CcdbApi::initTGrid() const
       errorShown = true;
     }
   }
-  return mAlienInstance != nullptr;
+  return gGrid != nullptr;
 }
 
 void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info const& tinfo, std::map<string, string>* headers) const

--- a/Detectors/TRD/base/macros/OCDB2CCDB.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDB.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 // Use this macro to extract TRD calibration data from run2 for O2 calibrations class
 // Alot of this was taken from OCDBtoTree.C in AliRoot/TRD/macros/
 // Usage:
@@ -230,7 +241,7 @@ void OCDB2CCDB(long timeStamp = -1, TString ccdbPath = "http://localhost:8080", 
   TTimeStamp jobStartTime;
   // if the storage is on alien than we need to do some extra stuff
   TString storageString(storageURI);
-  if (storageString.Contains("alien://")) {
+  if (storageString.Contains("alien://") && !gGrid) {
     TGrid::Connect("alien://");
   }
 

--- a/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 // Use this macro to extract TRD calibration data from run2 for O2 calibrations class
 // Alot of this was taken from OCDBtoTree.C in AliRoot/TRD/macros/
 // Usage:
@@ -172,7 +183,7 @@ void OCDB2CCDBTrapConfig(TString ccdbPath = "http://localhost:8080", Int_t run =
   TTimeStamp jobStartTime;
   // if the storage is on alien than we need to do some extra stuff
   TString storageString(storageURI);
-  if (storageString.Contains("raw://")) {
+  if (storageString.Contains("raw://") && !gGrid) {
     TGrid::Connect("alien://");
   }
 

--- a/Detectors/TRD/base/macros/PrintTrapConfig.C
+++ b/Detectors/TRD/base/macros/PrintTrapConfig.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 // Use this macro to extract TRD calibration data from run2 for O2 calibrations class
 // Alot of this was taken from OCDBtoTree.C in AliRoot/TRD/macros/
 // Usage:
@@ -200,7 +211,7 @@ void PrintTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/alic
   TTimeStamp jobStartTime;
   // if the storage is on alien than we need to do some extra stuff
   TString storageString(storageURI);
-  if (storageString.Contains("alien://")) {
+  if (storageString.Contains("alien://") && !gGrid) {
     TGrid::Connect("alien://");
   }
 

--- a/Detectors/TRD/base/macros/Readocdb.C
+++ b/Detectors/TRD/base/macros/Readocdb.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 // Use this macro to extract TRD calibration data from run2 for O2 calibrations class
 // Alot of this was taken from OCDBtoTree.C in AliRoot/TRD/macros/
 // Usage:
@@ -217,7 +228,7 @@ void Readocdb(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data/
   TTimeStamp jobStartTime;
   // if the storage is on alien than we need to do some extra stuff
   TString storageString(storageURI);
-  if (storageString.Contains("alien://")) {
+  if (storageString.Contains("alien://") && !gGrid) {
     TGrid::Connect("alien://");
   }
 

--- a/Framework/AODMerger/src/aodMerger.cxx
+++ b/Framework/AODMerger/src/aodMerger.cxx
@@ -107,7 +107,6 @@ int main(int argc, char* argv[])
   std::ifstream in;
   in.open(inputCollection);
   TString line;
-  bool connectedToAliEn = false;
   TMap* metaData = nullptr;
   TMap* parentFiles = nullptr;
   int totalMergedDFs = 0;
@@ -119,10 +118,9 @@ int main(int argc, char* argv[])
       continue;
     }
 
-    if (line.BeginsWith("alien:") && !connectedToAliEn) {
+    if (line.BeginsWith("alien:") && !gGrid) {
       printf("Connecting to AliEn...");
       TGrid::Connect("alien:");
-      connectedToAliEn = true; // Only try once
     }
 
     printf("Processing input file: %s\n", line.Data());

--- a/Framework/AODMerger/src/aodThinner.cxx
+++ b/Framework/AODMerger/src/aodThinner.cxx
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
   }
   TDirectory* outputDir = nullptr;
 
-  if (inputFileName.find("alien:") == 0) {
+  if (inputFileName.find("alien:") == 0 && !gGrid) {
     printf("Connecting to AliEn...");
     TGrid::Connect("alien:");
   }

--- a/Framework/AnalysisSupport/src/DataInputDirector.cxx
+++ b/Framework/AnalysisSupport/src/DataInputDirector.cxx
@@ -114,7 +114,7 @@ void DataInputDescriptor::addFileNameHolder(FileNameHolder* fn)
   // remove leading file:// from file name
   if (fn->fileName.rfind("file://", 0) == 0) {
     fn->fileName.erase(0, 7);
-  } else if (!mAlienSupport && fn->fileName.rfind("alien://", 0) == 0) {
+  } else if (!mAlienSupport && fn->fileName.rfind("alien://", 0) == 0 && !gGrid) {
     LOGP(debug, "AliEn file requested. Enabling support.");
     TGrid::Connect("alien://");
     mAlienSupport = true;

--- a/Framework/AnalysisSupport/src/Plugin.cxx
+++ b/Framework/AnalysisSupport/src/Plugin.cxx
@@ -192,7 +192,7 @@ struct DiscoverMetadataInAOD : o2::framework::ConfigDiscoveryPlugin {
           std::getline(file, filename);
           file.close();
         }
-        if (filename.rfind("alien://", 0) == 0) {
+        if (filename.rfind("alien://", 0) == 0 && !gGrid) {
           TGrid::Connect("alien://");
         }
         LOGP(info, "Loading metadata from file {} in PID {}", filename, getpid());
@@ -245,7 +245,7 @@ struct DiscoverMetadataInAOD : o2::framework::ConfigDiscoveryPlugin {
             }
           }
 
-          if (parentFilename.starts_with("alien://")) {
+          if (parentFilename.starts_with("alien://") && !gGrid) {
             TGrid::Connect("alien://");
           }
 

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -177,9 +177,9 @@ GeneratorFromO2Kine::GeneratorFromO2Kine(const char* name)
   setPositionUnit(1.);
   setTimeUnit(1.);
 
-  if (strncmp(name, "alien:/", 7) == 0) {
-    mAlienInstance = TGrid::Connect("alien");
-    if (!mAlienInstance) {
+  if (strncmp(name, "alien:/", 7) == 0 && !gGrid) {
+    TGrid::Connect("alien:");
+    if (!gGrid) {
       LOG(fatal) << "Could not connect to alien, did you check the alien token?";
       return;
     }


### PR DESCRIPTION
Suppress local caches of the TGrid::Connect pointer. Muliple TGrid::Connect lead to jalien connection loss.