### PR TITLE
DPL: adapt to arrow 20.0.0

### DIFF
--- a/Framework/AnalysisSupport/src/RNTuplePlugin.cxx
+++ b/Framework/AnalysisSupport/src/RNTuplePlugin.cxx
@@ -30,6 +30,8 @@
 #include <arrow/array/array_primitive.h>
 #include <arrow/array/builder_nested.h>
 #include <arrow/array/builder_primitive.h>
+#include <arrow/array/util.h>
+#include <arrow/record_batch.h>
 #include <arrow/dataset/file_base.h>
 
 #if __has_include(<ROOT/RFieldBase.hxx>)
@@ -859,18 +861,19 @@ arrow::Result<arrow::RecordBatchGenerator> RNTupleFileFormat::ScanBatchesAsync(
         }
         switch (listSize) {
           case -1: {
-            auto varray = std::make_shared<arrow::PrimitiveArray>(physicalField->type()->field(0)->type(), totalSize, arrowValuesBuffer);
-            array = std::make_shared<arrow::ListArray>(physicalField->type(), readEntries, arrowOffsetBuffer, varray);
+            auto vdata = std::make_shared<arrow::ArrayData>(physicalField->type()->field(0)->type(), totalSize, std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, arrowValuesBuffer});
+            array = std::make_shared<arrow::ListArray>(physicalField->type(), readEntries, arrowOffsetBuffer, arrow::MakeArray(vdata));
           } break;
           case 1: {
             totalSize = readEntries * listSize;
-            array = std::make_shared<arrow::PrimitiveArray>(physicalField->type(), readEntries, arrowValuesBuffer);
+            auto data = std::make_shared<arrow::ArrayData>(physicalField->type(), readEntries, std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, arrowValuesBuffer});
+            array = arrow::MakeArray(data);
 
           } break;
           default: {
             totalSize = readEntries * listSize;
-            auto varray = std::make_shared<arrow::PrimitiveArray>(physicalField->type()->field(0)->type(), totalSize, arrowValuesBuffer);
-            array = std::make_shared<arrow::FixedSizeListArray>(physicalField->type(), readEntries, varray);
+            auto vdata = std::make_shared<arrow::ArrayData>(physicalField->type()->field(0)->type(), totalSize, std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, arrowValuesBuffer});
+            array = std::make_shared<arrow::FixedSizeListArray>(physicalField->type(), readEntries, arrow::MakeArray(vdata));
           }
         }
       }

--- a/Framework/AnalysisSupport/src/TTreePlugin.cxx
+++ b/Framework/AnalysisSupport/src/TTreePlugin.cxx
@@ -27,6 +27,8 @@
 #include <arrow/array/array_primitive.h>
 #include <arrow/array/builder_nested.h>
 #include <arrow/array/builder_primitive.h>
+#include <arrow/array/util.h>
+#include <arrow/record_batch.h>
 #include <TTree.h>
 #include <TBranch.h>
 #include <TFile.h>
@@ -35,7 +37,6 @@
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
-#include <iostream>
 
 O2_DECLARE_DYNAMIC_LOG(root_arrow_fs);
 
@@ -729,8 +730,9 @@ arrow::Result<arrow::RecordBatchGenerator> TTreeFileFormat::ScanBatchesAsync(
       std::shared_ptr<arrow::Array> array;
 
       if (listType) {
-        auto varray = std::make_shared<arrow::PrimitiveArray>(datasetField->type()->field(0)->type(), valueOp.rootBranchEntries * valueOp.listSize, valueOp.targetBuffer);
-        array = std::make_shared<arrow::FixedSizeListArray>(datasetField->type(), valueOp.rootBranchEntries, varray);
+        auto vdata = std::make_shared<arrow::ArrayData>(datasetField->type()->field(0)->type(), valueOp.rootBranchEntries * valueOp.listSize,
+                                                        std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, valueOp.targetBuffer});
+        array = std::make_shared<arrow::FixedSizeListArray>(datasetField->type(), valueOp.rootBranchEntries, arrow::MakeArray(vdata));
         // This is a vla, there is also an offset op
         O2_SIGNPOST_EVENT_EMIT(root_arrow_fs, tid, "Op", "Created op for branch %{public}s with %lli entries, size of the buffer %lli.",
                                valueOp.branch->GetName(),
@@ -738,9 +740,10 @@ arrow::Result<arrow::RecordBatchGenerator> TTreeFileFormat::ScanBatchesAsync(
                                valueOp.targetBuffer->size());
       } else if (mapping.vlaIdx != -1) {
         auto& offsetOp = ops[ops.size() - 2];
-        auto varray = std::make_shared<arrow::PrimitiveArray>(datasetField->type()->field(0)->type(), offsetOp.offsetCount, valueOp.targetBuffer);
+        auto vdata = std::make_shared<arrow::ArrayData>(datasetField->type()->field(0)->type(), offsetOp.offsetCount,
+                                                        std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, valueOp.targetBuffer});
         // We have pushed an offset op if this was the case.
-        array = std::make_shared<arrow::ListArray>(datasetField->type(), offsetOp.rootBranchEntries, offsetOp.targetBuffer, varray);
+        array = std::make_shared<arrow::ListArray>(datasetField->type(), offsetOp.rootBranchEntries, offsetOp.targetBuffer, arrow::MakeArray(vdata));
         O2_SIGNPOST_EVENT_EMIT(root_arrow_fs, tid, "Op", "Created op for branch %{public}s with %lli entries, size of the buffer %lli.",
                                offsetOp.branch->GetName(), offsetOp.rootBranchEntries, offsetOp.targetBuffer->size());
         O2_SIGNPOST_EVENT_EMIT(root_arrow_fs, tid, "Op", "Created op for branch %{public}s with %lli entries, size of the buffer %lli.",
@@ -748,7 +751,9 @@ arrow::Result<arrow::RecordBatchGenerator> TTreeFileFormat::ScanBatchesAsync(
                                offsetOp.offsetCount,
                                valueOp.targetBuffer->size());
       } else {
-        array = std::make_shared<arrow::PrimitiveArray>(datasetField->type(), valueOp.rootBranchEntries, valueOp.targetBuffer);
+        auto data = std::make_shared<arrow::ArrayData>(datasetField->type(), valueOp.rootBranchEntries,
+                                                       std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, valueOp.targetBuffer});
+        array = arrow::MakeArray(data);
         O2_SIGNPOST_EVENT_EMIT(root_arrow_fs, tid, "Op", "Created op for branch %{public}s with %lli entries, size of the buffer %lli.",
                                valueOp.branch->GetName(),
                                valueOp.rootBranchEntries,

--- a/Framework/Core/src/EmptyFragment.cxx
+++ b/Framework/Core/src/EmptyFragment.cxx
@@ -9,9 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/EmptyFragment.h"
+#include <arrow/array/data.h>
 #include <arrow/type_fwd.h>
 #include <arrow/array/array_primitive.h>
 #include <arrow/array/array_nested.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <arrow/array/util.h>
 #include <memory>
 
 static constexpr int64_t kBufferMinimumSize = 256;
@@ -35,8 +39,8 @@ arrow::Result<arrow::RecordBatchGenerator> EmptyFragment::ScanBatchesAsync(
         } else {
           size *= field->type()->field(0)->type()->byte_width();
         }
-        auto varray = std::make_shared<arrow::PrimitiveArray>(field->type()->field(0)->type(), mRows * listType->list_size(), GetPlaceholderForOp(size));
-        columns.push_back(std::make_shared<arrow::FixedSizeListArray>(field->type(), (int32_t)mRows, varray));
+        auto vdata = std::make_shared<arrow::ArrayData>(field->type()->field(0)->type(), mRows * listType->list_size(), std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, GetPlaceholderForOp(size)});
+        columns.push_back(std::make_shared<arrow::FixedSizeListArray>(field->type(), (int32_t)mRows, arrow::MakeArray(vdata)));
       } else {
         size_t size = mRows;
         if (field->type()->byte_width() == 0) {
@@ -44,7 +48,8 @@ arrow::Result<arrow::RecordBatchGenerator> EmptyFragment::ScanBatchesAsync(
         } else {
           size *= field->type()->byte_width();
         }
-        columns.push_back(std::make_shared<arrow::PrimitiveArray>(field->type(), mRows, GetPlaceholderForOp(size)));
+        auto data = std::make_shared<arrow::ArrayData>(field->type(), mRows, std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, GetPlaceholderForOp(size)});
+        columns.push_back(arrow::MakeArray(data));
       }
     }
     return arrow::RecordBatch::Make(physical_schema_, mRows, columns);

--- a/Framework/Core/test/o2AO2DToAO3D.cxx
+++ b/Framework/Core/test/o2AO2DToAO3D.cxx
@@ -18,6 +18,7 @@
 #include <TMap.h>
 #include <TTree.h>
 #include <fmt/format.h>
+#include <arrow/record_batch.h>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION

- A few implicit include statements now fixed.
- Constructor of PrimitiveArray was moved to protected by upstream to solve issue https://github.com/apache/arrow/issues/45301. Adapt by using suggested workaround via MakeArray.
