### PR TITLE
DPL Analysis: add protect0 node for preventing division by 0 in expressions

### DIFF
--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -17,6 +17,7 @@
 #include "Framework/Variant.h"
 #include "Framework/InitContext.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "CommonConstants/MathConstants.h"
 #include <arrow/type_fwd.h>
 #include <gandiva/gandiva_aliases.h>
 #include <arrow/type.h>
@@ -552,6 +553,13 @@ inline Node clamp(Node&& expr, T low, T hi)
 {
   auto copy = expr;
   return ifnode(Node{copy} < LiteralNode{low}, LiteralNode{low}, ifnode(Node{copy} > LiteralNode{hi}, LiteralNode{hi}, Node{copy}));
+}
+
+/// division by 0 protector
+inline Node protect0(Node&& expr)
+{
+  auto copy = expr;
+  return ifnode(nabs(Node{copy}) < o2::constants::math::Almost0, o2::constants::math::Almost0, Node{copy});
 }
 
 /// A struct, containing the root of the expression tree


### PR DESCRIPTION
Can be used as `1.f / protect0(aod::track::signed1Pt);` replacing zero values by `Almost0` constant. 