### PR TITLE
Increase minimum read timeout to 5s in CcdbApi.cxx

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -232,7 +232,7 @@ void CcdbApi::init(std::string const& host)
                deploymentMode == o2::framework::DeploymentMode::FST) {
       mCurlTimeoutDownload = 15;
     } else if (deploymentMode == o2::framework::DeploymentMode::Local) {
-      mCurlTimeoutDownload = 1;
+      mCurlTimeoutDownload = 5;
     }
   }
 


### PR DESCRIPTION
Increase the minimum read timeout from 1 to 5s as this case is also used when reading from the production CCDB instance and 1s can be too little at times (especially at large RTTs). And there are no alternatives to use.