### PR TITLE
[EMCAL-539] Fix min. bias trigger handling for EMCal in simulation

### DIFF
--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -83,16 +83,16 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
             emcMBaccept.set(CTP_NINPUTS - 1, 1);
             inpmaskcoll |= emcMBaccept;
           } // else { // needs to be done always, remove else
-            for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
-              uint64_t mask = inpmaskdebug & detInputName2Mask[ctpinp.name];
-              // uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
-              if (mask) {
-                inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
-              }
+          for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
+            uint64_t mask = inpmaskdebug & detInputName2Mask[ctpinp.name];
+            // uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
+            if (mask) {
+              inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
             }
-            // }
-            // LOG(info) << "EMC input mask:" << inpmaskcoll << " with IR = " << currentIR.bc << ", orbit = " << currentIR.orbit;
-            break;
+          }
+          // }
+          // LOG(info) << "EMC input mask:" << inpmaskcoll << " with IR = " << currentIR.bc << ", orbit = " << currentIR.orbit;
+          break;
         }
         case o2::detectors::DetID::PHS: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::PHS]) {
@@ -153,21 +153,20 @@ void Digitizer::calculateClassMask(const std::bitset<CTP_NINPUTS> ctpinpmask, st
       if (clustername == "emc") {
         tvxMBemc |= tcl.name.find("minbias_TVX_L0") != std::string::npos; // 2022
       }
-      if (tvxMBemc || (ctpinpmask.to_ullong() & tcl.descriptor->getInputsMask()) == tcl.descriptor->getInputsMask()) {
-        // require real physics input in any case
-        if (tvxMBemc) {
-          // if the class is a min. bias class accept it only if the MB-accept bit is set in addition
-          // (fake trigger input)
-          if (ctpinpmask[CTP_NINPUTS - 1]) {
-            classmask |= tcl.classMask;
-            LOG(info) << "adding MBA:" << tcl.name;
-          }
-        } // else {
-          // EMCAL rare triggers - physical trigger input
-          // class identification can be handled like in the case of the other
-          // classes as EMCAL trigger input is required
+      // require real physics input in any case
+      if (tvxMBemc) {
+        // if the class is a min. bias class accept it only if the MB-accept bit is set in addition
+        // (fake trigger input)
+        if (ctpinpmask[CTP_NINPUTS - 1]) {
           classmask |= tcl.classMask;
-          // }
+          LOG(info) << "adding MBA:" << tcl.name;
+        }
+      } else if ((ctpinpmask.to_ullong() & tcl.descriptor->getInputsMask()) == tcl.descriptor->getInputsMask()) {
+        // EMCAL rare triggers - physical trigger input
+        // class identification can be handled like in the case of the other
+        // classes as EMCAL trigger input is required
+        LOG(info) << "adding EMCal rare trigger:" << tcl.name;
+        classmask |= tcl.classMask;
       }
     } else {
       if (tcl.descriptor && ((ctpinpmask.to_ullong() & tcl.descriptor->getInputsMask()) == tcl.descriptor->getInputsMask())) {


### PR DESCRIPTION
- Bug introduced in https://github.com/AliceO2Group/AliceO2/pull/13227 : The decision of the fake trigger bit (if (ctpinpmask[CTP_NINPUTS - 1]) ) was always overwritten as the else case was removed completely.
- This PR reverts this change. Hence, the trigger flag used for analysis kTVXInEMC is now again only true when EMCal was in readout. Before, it was always set when TVX fired.
- Some more changes (L86-L95) due to clang-format