### PR TITLE
AOD: Possibility to inject additional meta data

### DIFF
--- a/Detectors/AOD/CMakeLists.txt
+++ b/Detectors/AOD/CMakeLists.txt
@@ -42,14 +42,14 @@ o2_add_executable(
   COMPONENT_NAME aod-producer
   TARGETVARNAME targetName
   SOURCES src/aod-producer-workflow.cxx src/AODProducerWorkflowSpec.cxx src/AODMcProducerHelpers.cxx
-  PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version
+  PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version nlohmann_json::nlohmann_json
 )
 
 o2_add_executable(
   workflow
   COMPONENT_NAME aod-mc-producer
   SOURCES src/aod-mc-producer-workflow.cxx src/AODMcProducerWorkflowSpec.cxx src/AODMcProducerHelpers.cxx
-  PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version
+  PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version nlohmann_json::nlohmann_json
 )
 
 o2_add_executable(
@@ -75,7 +75,8 @@ o2_add_executable(
         O2::DataFormatsFT0
         O2::Steer
         O2::ZDCBase
-)
+        nlohmann_json::nlohmann_json
+        )
 
 if (OpenMP_CXX_FOUND)
   target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -102,6 +102,8 @@
 #ifdef WITH_OPENMP
 #include <omp.h>
 #endif
+#include <filesystem>
+#include <nlohmann/json.hpp>
 
 using namespace o2::framework;
 using namespace o2::math_utils::detail;
@@ -1793,6 +1795,38 @@ void AODProducerWorkflowDPL::init(InitContext& ic)
   }
 }
 
+namespace
+{
+void add_additional_meta_info(std::vector<TString>& keys, std::vector<TString>& values)
+{
+  // see if we should put additional meta info (e.g. from MC)
+  auto aod_external_meta_info_file = getenv("AOD_ADDITIONAL_METADATA_FILE");
+  if (aod_external_meta_info_file != nullptr) {
+    LOG(info) << "Trying to inject additional AOD meta-data from " << aod_external_meta_info_file;
+    if (std::filesystem::exists(aod_external_meta_info_file)) {
+      std::ifstream input_file(aod_external_meta_info_file);
+      if (input_file) {
+        nlohmann::json json_data;
+        try {
+          input_file >> json_data;
+        } catch (nlohmann::json::parse_error& e) {
+          std::cerr << "JSON Parse Error: " << e.what() << "\n";
+          std::cerr << "Exception ID: " << e.id << "\n";
+          std::cerr << "Byte position: " << e.byte << "\n";
+          return;
+        }
+        // If parsing succeeds, iterate over key-value pairs
+        for (const auto& [key, value] : json_data.items()) {
+          LOG(info) << "Adding AOD MetaData" << key << " : " << value;
+          keys.push_back(key.c_str());
+          values.push_back(value.get<std::string>());
+        }
+      }
+    }
+  }
+}
+} // namespace
+
 void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 {
   mTimer.Start(false);
@@ -2401,6 +2435,8 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   TString ROOTVersion = ROOT_RELEASE;
   mMetaDataKeys = {"DataType", "Run", "O2Version", "ROOTVersion", "RecoPassName", "AnchorProduction", "AnchorPassName", "LPMProductionTag", "CreatedBy"};
   mMetaDataVals = {dataType, "3", O2Version, ROOTVersion, mRecoPass, mAnchorProd, mAnchorPass, mLPMProdTag, mUser};
+  add_additional_meta_info(mMetaDataKeys, mMetaDataVals);
+
   pc.outputs().snapshot(Output{"AMD", "AODMetadataKeys", 0}, mMetaDataKeys);
   pc.outputs().snapshot(Output{"AMD", "AODMetadataVals", 0}, mMetaDataVals);
 


### PR DESCRIPTION
AOD: Possibility to inject additional meta data
    
Commit provides possibility to inject additional (non-hard-coded)
meta data into AOD. This could be used by MC to add information about
timeframe length used or other specific configurations etc.
    
The commit relates to https://its.cern.ch/jira/browse/O2-6027
    
By default this does not change any production behaviour. Existing
meta data is not touched.
    
This works by generating a simple key-value json (foo.json) like
```
{
    "ALIEN_JDL_MC_ORBITS_PER_TF": "4",
    "ALIEN_JDL_ANCHOR_SIM_OPTIONS": "-gen pythia8"
}
```
    
 and then exporting an environment variable pointing to this json.
    
```
export AOD_ADDITIONAL_METADATA_FILE=${PWD}/foo.json
```