### PR TITLE
TPC: demote errors about IDC CRU orbit/packets mismatches from critical to error

### DIFF
--- a/Detectors/TPC/workflow/src/IDCToVectorSpec.cxx
+++ b/Detectors/TPC/workflow/src/IDCToVectorSpec.cxx
@@ -405,7 +405,7 @@ class IDCToVectorDevice : public o2::framework::Task
 
       for (const auto& inf : infVec) {
         if (!inf.hasBothEPs()) {
-          LOGP(critical, "IDC CRU {:3}: data missing at ({:8}, {:4}) for one or both end points {:02b} in TF {}", cru, inf.heartbeatOrbit, inf.heartbeatBC, inf.epSeen, tfCounter);
+          LOGP(error, "IDC CRU {:3}: data missing at ({:8}, {:4}) for one or both end points {:02b} in TF {}", cru, inf.heartbeatOrbit, inf.heartbeatBC, inf.epSeen, tfCounter);
           hasErrors = true;
         }
       }
@@ -417,12 +417,12 @@ class IDCToVectorDevice : public o2::framework::Task
       }
 
       if (packetsInTF != infVec.size()) {
-        LOGP(critical, "IDC CRU {:3}: number of IDC packets {} does not match max over all CRUs {} in TF {}", cru, packetsInTF, infVec.size(), tfCounter);
+        LOGP(error, "IDC CRU {:3}: number of IDC packets {} does not match max over all CRUs {} in TF {}", cru, packetsInTF, infVec.size(), tfCounter);
         hasErrors = true;
       }
 
       if (!std::equal(infVecComp->begin(), infVecComp->end(), infVec.begin())) {
-        LOGP(critical, "IDC CRU {:3}: mismatch in orbit numbers", cru);
+        LOGP(error, "IDC CRU {:3}: mismatch in orbit numbers", cru);
         hasErrors = true;
       }
     }


### PR DESCRIPTION
Instructions of the ECS shifter for these type of errors were removed from the documentation, so they seem to be not critical for operations. The QC shifter will still see and report them according to their instructions. 