### PR TITLE
[EMCAL-1154] Add functionality for cross talk emulation

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
@@ -12,10 +12,9 @@
 #ifndef ALICEO2_EMCAL_CELLLABEL_H_
 #define ALICEO2_EMCAL_CELLLABEL_H_
 
-#include <fairlogger/Logger.h>
+#include <cstddef>
+#include <cstdint>
 #include <gsl/span>
-#include <vector>
-#include "Rtypes.h"
 
 namespace o2
 {
@@ -52,9 +51,18 @@ class CellLabel
   /// \param index index which label to get
   int32_t GetLabel(size_t index) const { return mLabels[index]; }
 
+  /// \brief Getter for labels
+  gsl::span<const int32_t> GetLabels() const { return mLabels; }
+
   /// \brief Getter for amplitude fraction
   /// \param index index which amplitude fraction to get
   float GetAmplitudeFraction(size_t index) const { return mAmplitudeFraction[index]; }
+
+  /// \brief Getter for amplitude fractions
+  gsl::span<const float> GetAmplitudeFractions() const { return mAmplitudeFraction; }
+
+  /// \brief Getter for label with leading amplitude fraction
+  int32_t GetLeadingMCLabel() const;
 
  protected:
   gsl::span<const int32_t> mLabels;          ///< List of MC particles that generated the cluster, ordered in deposited energy.

--- a/DataFormats/Detectors/EMCAL/src/CellLabel.cxx
+++ b/DataFormats/Detectors/EMCAL/src/CellLabel.cxx
@@ -12,6 +12,10 @@
 /// \file CellLabel.cxx
 
 #include "DataFormatsEMCAL/CellLabel.h"
+#include "fairlogger/Logger.h"
+#include <cstddef>
+#include <cstdint>
+#include <gsl/span>
 
 using namespace o2::emcal;
 
@@ -20,4 +24,18 @@ CellLabel::CellLabel(const gsl::span<const int> labels, const gsl::span<const fl
   if (labels.size() != amplitudeFractions.size()) {
     LOG(error) << "Size of labels " << labels.size() << " does not match size of amplitude fraction " << amplitudeFractions.size() << " !";
   }
+}
+
+int32_t CellLabel::GetLeadingMCLabel() const
+{
+  size_t maxIndex = 0;
+  float maxFraction = mAmplitudeFraction[0];
+
+  for (size_t i = 1; i < mAmplitudeFraction.size(); ++i) {
+    if (mAmplitudeFraction[i] > maxFraction) {
+      maxFraction = mAmplitudeFraction[i];
+      maxIndex = i;
+    }
+  }
+  return mLabels[maxIndex];
 }

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -12,19 +12,19 @@
 #ifndef ALICEO2_EMCAL_GEOMETRY_H_
 #define ALICEO2_EMCAL_GEOMETRY_H_
 
-#include <exception>
+#include <array>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
 #include <RStringView.h>
+#include <RtypesCore.h>
 #include <TGeoMatrix.h>
-#include <TNamed.h>
+#include <TMath.h>
 #include <TParticle.h>
 #include <TVector3.h>
-#include <TObjArray.h>
 
-#include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsEMCAL/Constants.h"
 #include "EMCALBase/GeometryBase.h"
 #include "MathUtils/Cartesian.h"
@@ -514,6 +514,14 @@ class Geometry
   /// \return row
   /// \return col
   std::tuple<int, int, int> getOnlineID(int towerID);
+
+  ///  \brief Check if 2 cells belong to the same T-Card
+  ///  \param absId1: Reference absId cell
+  ///  \param absId2: Cross checked cell absId
+  ///  \return true if belong to same TCard else false
+  ///  \return rowDiff: Distance in rows
+  ///  \return colDiff: Distance in columns
+  std::tuple<bool, int, int> areAbsIDsFromSameTCard(int absId1, int absId2) const;
 
   /// \brief Temporary link assignment (till final link assignment is known -
   /// \brief eventually taken from CCDB)

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -10,20 +10,38 @@
 // or submit itself to any jurisdiction.
 #include "EMCALBase/Geometry.h"
 
+#include <RtypesCore.h>
+#include <TMath.h>
+#include <TVector3.h>
+#include <TMathBase.h>
+#include <TVector2.h>
+#include <TParticle.h>
+#include <TString.h>
+#include <TGeoNode.h>
+#include <TJAlienCredentials.h>
+#include <TObjArray.h>
 #include <fairlogger/Logger.h>
 
+#include <cstring>
+#include <cctype>
+#include <cmath>
 #include <iomanip>
+#include <ostream>
 #include <string>
 #include <algorithm>
 #include <cstdio>
+#include <string_view>
 #include <tuple>
 
 #include <TGeoBBox.h>
 #include <TGeoManager.h>
 #include <TGeoMatrix.h>
-#include <TList.h>
 
+#include "DataFormatsEMCAL/Constants.h"
+#include "EMCALBase/GeometryBase.h"
+#include "CCDB/CcdbApi.h"
 #include "EMCALBase/ShishKebabTrd1Module.h"
+#include "GPUROOTCartesianFwd.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -1858,4 +1876,45 @@ std::tuple<int, int, int> Geometry::getOnlineID(int towerID)
   }
 
   return std::make_tuple(supermoduleID * 2 + ddlInSupermoudel, row, col);
+}
+
+std::tuple<bool, int, int> Geometry::areAbsIDsFromSameTCard(int absId1, int absId2) const
+{
+
+  int rowDiff = -100;
+  int colDiff = -100;
+
+  if (absId1 == absId2) {
+    return {false, rowDiff, colDiff};
+  }
+
+  // Check if in same SM, if not for sure not same TCard
+  const int sm1 = GetSuperModuleNumber(absId1);
+  const int sm2 = GetSuperModuleNumber(absId2);
+  if (sm1 != sm2) {
+    return {false, rowDiff, colDiff};
+  }
+
+  // Get the column and row of each absId
+  const auto [_, iTower1, iIphi1, iIeta1] = GetCellIndex(absId1);
+  const auto [row1, col1] = GetCellPhiEtaIndexInSModule(sm1, iTower1, iIphi1, iIeta1);
+
+  const auto [__, iTower2, iIphi2, iIeta2] = GetCellIndex(absId2);
+  const auto [row2, col2] = GetCellPhiEtaIndexInSModule(sm2, iTower2, iIphi2, iIeta2);
+
+  // Define corner of TCard for absId1
+  const int tcardRow0 = row1 - row1 % 8;
+  const int tcardCol0 = col1 - col1 % 2;
+
+  // Difference of absId2 from corner of absId1's TCard
+  const int rowOffset = row2 - tcardRow0;
+  const int colOffset = col2 - tcardCol0;
+
+  // Differences between the two cells directly
+  rowDiff = row1 - row2;
+  colDiff = col1 - col2;
+
+  const bool sameTCard = (rowOffset >= 0 && rowOffset < 8 &&
+                          colOffset >= 0 && colOffset < 2);
+  return {sameTCard, rowDiff, colDiff};
 }


### PR DESCRIPTION
These changes are needed for the addition of the cross talk emulation in O2Physics.

Geometry:
  - Add `areAbsIDsFromSameTCard` which checks if two cells are within the same T-Card

CellLabel:
  - Add `GetLabels` which returns the span of all labels
  - Add `GetAmplitudeFractions` which return the span of all amplitude fractions
  - Add `GetLeadingMCLabel` which returns the label with the largest amplitude fraction