### PR TITLE
Add compatibility with std::pmr

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/Dispatcher.h
+++ b/Utilities/DataSampling/include/DataSampling/Dispatcher.h
@@ -65,7 +65,6 @@ class Dispatcher : public framework::Task
 
  private:
   DataSamplingHeader prepareDataSamplingHeader(const DataSamplingPolicy& policy, header::DataHeader const& original);
-  header::Stack extractAdditionalHeaders(const char* inputHeaderStack) const;
   void reportStats(monitoring::Monitoring& monitoring) const;
   void send(framework::DataAllocator& dataAllocator, const framework::DataRef& inputData, const framework::Output& output) const;
 

--- a/Utilities/DataSampling/src/Dispatcher.cxx
+++ b/Utilities/DataSampling/src/Dispatcher.cxx
@@ -29,6 +29,7 @@
 
 #include <Configuration/ConfigurationInterface.h>
 #include <Configuration/ConfigurationFactory.h>
+#include <stdexcept>
 
 using namespace o2::configuration;
 using namespace o2::monitoring;
@@ -77,6 +78,42 @@ void Dispatcher::init(InitContext& ctx)
   mDeviceID.runtimeInit(spec.id.substr(0, DataSamplingHeader::deviceIDTypeSize).c_str());
 }
 
+header::Stack extractAdditionalHeaders(const char* inputHeaderStack)
+{
+  std::array<header::BaseHeader const*, 5> headers;
+  int count = 0;
+  const auto* first = header::BaseHeader::get(reinterpret_cast<const std::byte*>(inputHeaderStack));
+  for (const auto* current = first; current != nullptr; current = current->next()) {
+    if (current->description != header::DataHeader::sHeaderType && current->description != DataProcessingHeader::sHeaderType) {
+      headers[count++] = current;
+    }
+  }
+
+  // Poor man runtime pack expansion.
+  switch (count) {
+    case 0:
+      return header::Stack{};
+    case 1:
+      return header::Stack{*headers[0]};
+    case 2:
+      return header::Stack{*headers[0], *headers[1]};
+    case 3:
+      return header::Stack{*headers[0], *headers[1], *headers[2]};
+    case 4:
+      return header::Stack{*headers[0], *headers[1], *headers[2], *headers[3]};
+    case 5:
+      return header::Stack{*headers[0], *headers[1], *headers[2], *headers[3], *headers[4]};
+    case 6:
+      return header::Stack{*headers[0], *headers[1], *headers[2], *headers[3], *headers[4], *headers[5]};
+    case 7:
+      return header::Stack{*headers[0], *headers[1], *headers[2], *headers[3], *headers[4], *headers[5], *headers[6]};
+    case 8:
+      return header::Stack{*headers[0], *headers[1], *headers[2], *headers[3], *headers[4], *headers[5], *headers[6], *headers[7]};
+    default:
+      throw std::runtime_error(fmt::format("Too many headers to copy {}", count));
+  }
+}
+
 void Dispatcher::run(ProcessingContext& ctx)
 {
   // todo: consider matching (and deciding) in completion policy to save some time
@@ -106,7 +143,7 @@ void Dispatcher::run(ProcessingContext& ctx)
             // so that custom data-dependent headers are passed forward,
             // and we add a DataSamplingHeader.
             header::Stack headerStack{
-              std::move(extractAdditionalHeaders(part.header)),
+              extractAdditionalHeaders(part.header),
               dsheader};
             const auto* partInputHeader = DataRefUtils::getHeader<header::DataHeader*>(part);
 
@@ -154,21 +191,6 @@ DataSamplingHeader Dispatcher::prepareDataSamplingHeader(const DataSamplingPolic
     policy.getTotalEvaluatedMessages(),
     mDeviceID,
     original};
-}
-
-header::Stack Dispatcher::extractAdditionalHeaders(const char* inputHeaderStack) const
-{
-  header::Stack headerStack;
-
-  const auto* first = header::BaseHeader::get(reinterpret_cast<const std::byte*>(inputHeaderStack));
-  for (const auto* current = first; current != nullptr; current = current->next()) {
-    if (current->description != header::DataHeader::sHeaderType &&
-        current->description != DataProcessingHeader::sHeaderType) {
-      headerStack = std::move(header::Stack{std::move(headerStack), *current});
-    }
-  }
-
-  return headerStack;
 }
 
 void Dispatcher::send(DataAllocator& dataAllocator, const DataRef& inputData, const Output& output) const


### PR DESCRIPTION

The move assign operator is deleted is std::pmr::polymorphic_allocator so we cannot iterate
anymore at runtime on the headers in the stack and move them.
