### PR TITLE
[EMCAL-1154] Adjust CellLabels for cross talk emulation

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <gsl/span>
+#include <vector>
 
 namespace o2
 {
@@ -34,10 +35,15 @@ class CellLabel
  public:
   // CellLabel() = default;
 
-  /// \brief Constructor
+  /// \brief Constructor using std::vector by moving NOT copying
   /// \param labels list of mc labels
   /// \param amplitudeFractions list of amplitude fractions
-  CellLabel(const gsl::span<const int> labels, const gsl::span<const float> amplitudeFractions);
+  CellLabel(std::vector<int> labels, std::vector<float> amplitudeFractions);
+
+  /// \brief Constructor using gsl::span
+  /// \param labels list of mc labels
+  /// \param amplitudeFractions list of amplitude fractions
+  CellLabel(gsl::span<const int> labels, gsl::span<const float> amplitudeFractions);
 
   // ~CellLabel() = default;
   // CellLabel(const CellLabel& clus) = default;
@@ -52,21 +58,21 @@ class CellLabel
   int32_t GetLabel(size_t index) const { return mLabels[index]; }
 
   /// \brief Getter for labels
-  gsl::span<const int32_t> GetLabels() const { return mLabels; }
+  std::vector<int32_t> GetLabels() const { return mLabels; }
 
   /// \brief Getter for amplitude fraction
   /// \param index index which amplitude fraction to get
   float GetAmplitudeFraction(size_t index) const { return mAmplitudeFraction[index]; }
 
   /// \brief Getter for amplitude fractions
-  gsl::span<const float> GetAmplitudeFractions() const { return mAmplitudeFraction; }
+  std::vector<float> GetAmplitudeFractions() const { return mAmplitudeFraction; }
 
   /// \brief Getter for label with leading amplitude fraction
   int32_t GetLeadingMCLabel() const;
 
  protected:
-  gsl::span<const int32_t> mLabels;          ///< List of MC particles that generated the cluster, ordered in deposited energy.
-  gsl::span<const float> mAmplitudeFraction; ///< List of the fraction of the cell energy coming from a MC particle. Index aligns with mLabels!
+  std::vector<int32_t> mLabels;          ///< List of MC particles that generated the cluster, ordered in deposited energy.
+  std::vector<float> mAmplitudeFraction; ///< List of the fraction of the cell energy coming from a MC particle. Index aligns with mLabels!
 };
 
 } // namespace emcal

--- a/DataFormats/Detectors/EMCAL/src/CellLabel.cxx
+++ b/DataFormats/Detectors/EMCAL/src/CellLabel.cxx
@@ -16,10 +16,19 @@
 #include <cstddef>
 #include <cstdint>
 #include <gsl/span>
+#include <vector>
+#include <utility>
 
 using namespace o2::emcal;
 
-CellLabel::CellLabel(const gsl::span<const int> labels, const gsl::span<const float> amplitudeFractions) : mLabels(labels), mAmplitudeFraction(amplitudeFractions)
+CellLabel::CellLabel(std::vector<int> labels, std::vector<float> amplitudeFractions) : mLabels(std::move(labels)), mAmplitudeFraction(std::move(amplitudeFractions))
+{
+  if (labels.size() != amplitudeFractions.size()) {
+    LOG(error) << "Size of labels " << labels.size() << " does not match size of amplitude fraction " << amplitudeFractions.size() << " !";
+  }
+}
+
+CellLabel::CellLabel(gsl::span<const int> labels, gsl::span<const float> amplitudeFractions) : mLabels(labels.begin(), labels.end()), mAmplitudeFraction(amplitudeFractions.begin(), amplitudeFractions.end())
 {
   if (labels.size() != amplitudeFractions.size()) {
     LOG(error) << "Size of labels " << labels.size() << " does not match size of amplitude fraction " << amplitudeFractions.size() << " !";


### PR DESCRIPTION
- The CellLabel class used gsl::span as its members to store the mcLabels and amplitude fractions. However, when we want to use the cross talk emulation, we want to add new cells which happens inside the cross talk emulation function. Outside of this function the newley added CellLabels would point to dangling memory. That's why the members needed to be changed to std::vectors. Also a move constructor was added.