### PR TITLE
IWYU: avoid spurious unused include report

### DIFF
--- a/Framework/Core/include/Framework/WorkflowSpec.h
+++ b/Framework/Core/include/Framework/WorkflowSpec.h
@@ -12,7 +12,7 @@
 #define O2_FRAMEWORK_WORKFLOWSPEC_H_
 
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/AlgorithmSpec.h"
+#include "Framework/AlgorithmSpec.h" // IWYU pragma: export
 
 #include <vector>
 #include <functional>


### PR DESCRIPTION

Using WorkflowSpec without an AlgorithmSpec does not make much sense.
