### PR TITLE
IWYU: export commonly used headers

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -11,7 +11,7 @@
 #ifndef O2_FRAMEWORK_ANALYSISDATAMODEL_H_
 #define O2_FRAMEWORK_ANALYSISDATAMODEL_H_
 
-#include "Framework/ASoA.h"
+#include "Framework/ASoA.h" // IWYU pragma: export
 
 #include <cmath>
 #include <bitset>

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -21,12 +21,12 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/SendingPolicy.h"
-#include "Framework/WorkflowSpec.h"
+#include "Framework/WorkflowSpec.h" // IWYU pragma: export
 #include "Framework/ConfigContext.h"
 #include "Framework/CustomWorkflowTerminationHook.h"
 #include "Framework/CommonServices.h"
 #include "Framework/WorkflowCustomizationHelpers.h"
-#include "Framework/Logger.h"
+#include "Framework/Logger.h" // IWYU pragma: export
 #include "Framework/CheckTypes.h"
 #include "Framework/StructToTuple.h"
 #include "ResourcePolicy.h"


### PR DESCRIPTION

- Avoid fairlogger/Logger.h suggested everywhere
- Avoid exposing WorkflowSpec.h everywhere we have a runDataProcessing.h
- Cannot use AnalysisDataModel without ASoA.h
