### PR TITLE
Remove references to boost::container::pmr

### DIFF
--- a/DataFormats/Headers/include/Headers/Stack.h
+++ b/DataFormats/Headers/include/Headers/Stack.h
@@ -14,10 +14,7 @@
 #include "MemoryResources/MemoryResources.h"
 #include "Headers/DataHeader.h"
 
-namespace o2
-{
-
-namespace header
+namespace o2::header
 {
 //__________________________________________________________________________________________________
 /// @struct Stack
@@ -45,20 +42,20 @@ struct Stack {
   };
 
  public:
-  using allocator_type = boost::container::pmr::polymorphic_allocator<std::byte>;
+  using allocator_type = fair::mq::pmr::polymorphic_allocator<std::byte>;
   using value_type = std::byte;
-  using BufferType = std::unique_ptr<value_type[], freeobj>; //this gives us proper default move semantics for free
+  using BufferType = std::unique_ptr<value_type[], freeobj>; // this gives us proper default move semantics for free
 
   Stack() = default;
   Stack(Stack&&) = default;
   Stack(Stack&) = delete;
   Stack& operator=(Stack&) = delete;
-  Stack& operator=(Stack&&) = default;
+  Stack& operator=(Stack&&) = delete;
 
-  value_type* data() const { return buffer.get(); }
-  size_t size() const { return bufferSize; }
+  [[nodiscard]] value_type* data() const { return buffer.get(); }
+  [[nodiscard]] size_t size() const { return bufferSize; }
   allocator_type get_allocator() const { return allocator; }
-  const BaseHeader* first() const { return reinterpret_cast<const BaseHeader*>(this->data()); }
+  [[nodiscard]] const BaseHeader* first() const { return reinterpret_cast<const BaseHeader*>(this->data()); }
   static const BaseHeader* firstHeader(std::byte const* buf) { return BaseHeader::get(buf); }
   static const BaseHeader* lastHeader(std::byte const* buf)
   {
@@ -90,9 +87,9 @@ struct Stack {
   /// all headers must derive from BaseHeader, in addition also other stacks can be passed to ctor.
   template <typename FirstArgType, typename... Headers,
             typename std::enable_if_t<
-              !std::is_convertible<FirstArgType, boost::container::pmr::polymorphic_allocator<std::byte>>::value, int> = 0>
+              !std::is_convertible<FirstArgType, fair::mq::pmr::polymorphic_allocator<std::byte>>::value, int> = 0>
   Stack(FirstArgType&& firstHeader, Headers&&... headers)
-    : Stack(boost::container::pmr::new_delete_resource(), std::forward<FirstArgType>(firstHeader),
+    : Stack(fair::mq::pmr::new_delete_resource(), std::forward<FirstArgType>(firstHeader),
             std::forward<Headers>(headers)...)
   {
   }
@@ -122,7 +119,7 @@ struct Stack {
   template <typename T>
   constexpr static size_t calculateSize(T&& h) noexcept
   {
-    //if it's a pointer (to a stack) traverse it
+    // if it's a pointer (to a stack) traverse it
     if constexpr (std::is_convertible_v<T, std::byte*>) {
       const BaseHeader* next = BaseHeader::get(std::forward<T>(h));
       if (!next) {
@@ -133,17 +130,17 @@ struct Stack {
         size += next->size();
       }
       return size;
-      //otherwise get the size directly
+      // otherwise get the size directly
     } else {
       return h.size();
     }
   }
 
-  //recursion terminator
+  // recursion terminator
   constexpr static size_t calculateSize() { return 0; }
 
  private:
-  allocator_type allocator{boost::container::pmr::new_delete_resource()};
+  allocator_type allocator{fair::mq::pmr::new_delete_resource()};
   size_t bufferSize{0};
   BufferType buffer{nullptr, freeobj{allocator.resource()}};
 
@@ -231,7 +228,6 @@ struct Stack {
   }
 };
 
-} // namespace header
-} // namespace o2
+} // namespace o2::header
 
 #endif // HEADERS_STACK_H

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -280,8 +280,8 @@ BOOST_AUTO_TEST_CASE(headerStack_test)
   Stack s2{s1, meta};
   BOOST_CHECK(s2.size() == s1.size() + sizeof(decltype(meta)));
 
-  //check dynamic construction - where we don't have the type information and need to
-  //work with BaseHeader pointers
+  // check dynamic construction - where we don't have the type information and need to
+  // work with BaseHeader pointers
   const test::MetaHeader thead{2};
   o2::header::BaseHeader const* bname = reinterpret_cast<BaseHeader const*>(&thead);
   Stack ds2(s1, *bname);
@@ -313,8 +313,8 @@ BOOST_AUTO_TEST_CASE(headerStack_test)
   BOOST_REQUIRE(h3 != nullptr);
   BOOST_CHECK(h3->secret == 42);
 
-  //test constructing from a buffer and an additional header
-  using namespace boost::container::pmr;
+  // test constructing from a buffer and an additional header
+  using namespace fair::mq::pmr;
   Stack s5(new_delete_resource(), s1.data(), Stack{}, meta);
   BOOST_CHECK(s5.size() == s1.size() + sizeof(meta));
   // check if we can find the header even though there was an empty stack in the middle

--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -115,7 +115,7 @@ class MessageResource : public FairMQMemoryResource
 // A spectator pmr memory resource which only watches the memory of the underlying buffer, does not
 // carry out real allocation. It owns the underlying buffer which is destroyed on deallocation.
 template <typename BufferType>
-class SpectatorMemoryResource : public boost::container::pmr::memory_resource
+class SpectatorMemoryResource : public fair::mq::pmr::memory_resource
 {
  public:
   using buffer_type = BufferType;
@@ -183,10 +183,10 @@ class SpectatorMemoryResource : public boost::container::pmr::memory_resource
 // This in general (as in STL) is a bad idea, but here it is safe to inherit from an allocator since we
 // have no additional data and only override some methods so we don't get into slicing and other problems.
 template <typename T>
-class SpectatorAllocator : public boost::container::pmr::polymorphic_allocator<T>
+class SpectatorAllocator : public fair::mq::pmr::polymorphic_allocator<T>
 {
  public:
-  using boost::container::pmr::polymorphic_allocator<T>::polymorphic_allocator;
+  using fair::mq::pmr::polymorphic_allocator<T>::polymorphic_allocator;
   using propagate_on_container_move_assignment = std::true_type;
 
   // skip default construction of empty elements
@@ -243,7 +243,7 @@ class OwningMessageSpectatorAllocator
     return OwningMessageSpectatorAllocator();
   }
 
-  boost::container::pmr::memory_resource* resource() { return &mResource; }
+  fair::mq::pmr::memory_resource* resource() { return &mResource; }
 
   // skip default construction of empty elements
   // this is important for two reasons: one: it allows us to adopt an existing buffer (e.g. incoming message) and
@@ -269,14 +269,14 @@ class OwningMessageSpectatorAllocator
 
 // The NoConstructAllocator behaves like the normal pmr vector but does not call constructors / destructors
 template <typename T>
-class NoConstructAllocator : public boost::container::pmr::polymorphic_allocator<T>
+class NoConstructAllocator : public fair::mq::pmr::polymorphic_allocator<T>
 {
  public:
-  using boost::container::pmr::polymorphic_allocator<T>::polymorphic_allocator;
+  using fair::mq::pmr::polymorphic_allocator<T>::polymorphic_allocator;
   using propagate_on_container_move_assignment = std::true_type;
 
   template <typename... Args>
-  NoConstructAllocator(Args&&... args) : boost::container::pmr::polymorphic_allocator<T>(std::forward<Args>(args)...)
+  NoConstructAllocator(Args&&... args) : fair::mq::pmr::polymorphic_allocator<T>(std::forward<Args>(args)...)
   {
   }
 
@@ -302,9 +302,9 @@ class NoConstructAllocator : public boost::container::pmr::polymorphic_allocator
 //__________________________________________________________________________________________________
 
 using ByteSpectatorAllocator = SpectatorAllocator<std::byte>;
-using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<std::byte>;
+using BytePmrAllocator = fair::mq::pmr::polymorphic_allocator<std::byte>;
 template <class T>
-using vector = std::vector<T, o2::pmr::polymorphic_allocator<T>>;
+using vector = std::vector<T, fair::mq::pmr::polymorphic_allocator<T>>;
 
 //__________________________________________________________________________________________________
 /// Return a std::vector spanned over the contents of the message, takes ownership of the message

--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(transportallocatormap_test)
   BOOST_CHECK(_tmp == allocZMQ);
 }
 
-using namespace boost::container::pmr;
+using namespace fair::mq::pmr;
 
 BOOST_AUTO_TEST_CASE(allocator_test)
 {

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -59,14 +59,7 @@ struct Output {
 
   Output& operator=(const Output&) = delete;
 
-  Output& operator=(Output&& rhs)
-  {
-    origin = rhs.origin;
-    description = rhs.description;
-    subSpec = rhs.subSpec;
-    metaHeader = std::move(rhs.metaHeader);
-    return *this;
-  }
+  Output& operator=(Output&& rhs) = delete;
 
   bool operator==(const Output& that) const
   {
@@ -74,5 +67,5 @@ struct Output {
   }
 };
 
-} // namespace o2
+} // namespace o2::framework
 #endif

--- a/Framework/Core/test/test_FairMQ.cxx
+++ b/Framework/Core/test/test_FairMQ.cxx
@@ -174,7 +174,7 @@ TEST_CASE("addDataBlockForEach_test")
       int i;
       int j;
     };
-    using namespace boost::container::pmr;
+    using namespace fair::mq::pmr;
     fair::mq::Parts message;
     std::vector<elem, polymorphic_allocator<elem>> vec(polymorphic_allocator<elem>{allocZMQ});
     vec.reserve(100);


### PR DESCRIPTION

Use fair::mq::pmr instead, so that we can then easily migrate fair::mq to std::pmr
while still having backward compatibility.
