### PR TITLE
TPC: changing uint64_t to unsigned long long for compatibility with Mac

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/DCS.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/DCS.h
@@ -557,13 +557,13 @@ struct RobustPressure {
   Stats cavernAtmosPressure2S;       ///< rolling statistics of cavernAtmosPressure2/surfaceAtmosPressure
   std::vector<uint8_t> isOk;         ///< bit mask of valid sensors: cavernBit 0, cavern2Bit = 1, surfaceBit = 2
   std::vector<float> robustPressure; ///< combined robust pressure value that should be used
-  std::vector<TimeStampType> time;   ///< time stamps of all pressure values
+  std::vector<ULong64_t> time;       ///< time stamps of all pressure values
   TimeStampType timeInterval;        ///< time interval used for rolling statistics
   TimeStampType timeIntervalRef;     ///< reference time interval used for normalization of pressure sensors
   float maxDist{};                   ///< maximum allowed time distance between sensors to be accepted for robust pressure calculation
   float maxDiff{0.2f};               ///< maximum allowed pressure difference between sensors to be accepted for robust pressure calculation
 
-  ClassDefNV(RobustPressure, 1);
+  ClassDefNV(RobustPressure, 2);
 };
 
 struct Pressure {

--- a/DataFormats/Detectors/TPC/src/DCS.cxx
+++ b/DataFormats/Detectors/TPC/src/DCS.cxx
@@ -357,7 +357,7 @@ void Pressure::makeRobustPressure(TimeStampType timeInterval, TimeStampType time
   if (nIntervals == 0) {
     nIntervals = 1; // at least one interval
   }
-  std::vector<TimeStampType> times;
+  std::vector<ULong64_t> times;
   times.reserve(nIntervals);
   for (int i = 0; i < nIntervals; ++i) {
     times.emplace_back(tStart + (i + 0.5) * timeInterval);

--- a/Detectors/TPC/calibration/include/TPCCalibration/PressureTemperatureHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/PressureTemperatureHelper.h
@@ -49,7 +49,7 @@ class PressureTemperatureHelper
   static void setOutputs(std::vector<o2::framework::OutputSpec>& outputs);
 
   /// send temperature and pressure for given time stamp
-  void sendPTForTS(o2::framework::ProcessingContext& pc, const uint64_t timestamp) const;
+  void sendPTForTS(o2::framework::ProcessingContext& pc, const ULong64_t timestamp) const;
 
   /// set fit interval range for temperature in ms
   void setFitIntervalTemp(const int fitIntervalMS) { mFitIntervalMS = fitIntervalMS; }
@@ -58,13 +58,13 @@ class PressureTemperatureHelper
   /// \param timestamps time stamps of the data
   /// \param values data points
   /// \param timestamp time where to interpolate the values
-  float interpolate(const std::vector<uint64_t>& timestamps, const std::vector<float>& values, uint64_t timestamp) const;
+  float interpolate(const std::vector<ULong64_t>& timestamps, const std::vector<float>& values, ULong64_t timestamp) const;
 
   /// get pressure for given time stamp in ms
-  float getPressure(const uint64_t timestamp) const { return interpolate(mPressure.second, mPressure.first, timestamp); }
+  float getPressure(const ULong64_t timestamp) const { return interpolate(mPressure.second, mPressure.first, timestamp); }
 
   /// get temperature for given time stamp in ms
-  dataformats::Pair<float, float> getTemperature(const uint64_t timestamp) const { return dataformats::Pair<float, float>{interpolate(mTemperatureA.second, mTemperatureA.first, timestamp), interpolate(mTemperatureC.second, mTemperatureC.first, timestamp)}; }
+  dataformats::Pair<float, float> getTemperature(const ULong64_t timestamp) const { return dataformats::Pair<float, float>{interpolate(mTemperatureA.second, mTemperatureA.first, timestamp), interpolate(mTemperatureC.second, mTemperatureC.first, timestamp)}; }
 
   static constexpr o2::header::DataDescription getDataDescriptionPressure() { return o2::header::DataDescription{"pressure"}; }
   static constexpr o2::header::DataDescription getDataDescriptionTemperature() { return o2::header::DataDescription{"temperature"}; }
@@ -73,10 +73,10 @@ class PressureTemperatureHelper
   static void addInput(std::vector<o2::framework::InputSpec>& inputs, o2::framework::InputSpec&& isp);
   static void addOutput(std::vector<o2::framework::OutputSpec>& outputs, o2::framework::OutputSpec&& osp);
 
-  std::pair<std::vector<float>, std::vector<uint64_t>> mPressure;     ///< pressure values for both measurements
-  std::pair<std::vector<float>, std::vector<uint64_t>> mTemperatureA; ///< temperature values A-side
-  std::pair<std::vector<float>, std::vector<uint64_t>> mTemperatureC; ///< temperature values C-side
-  int mFitIntervalMS{5 * 60 * 1000};                                  ///< fit interval for the temperature
+  std::pair<std::vector<float>, std::vector<ULong64_t>> mPressure;     ///< pressure values for both measurements
+  std::pair<std::vector<float>, std::vector<ULong64_t>> mTemperatureA; ///< temperature values A-side
+  std::pair<std::vector<float>, std::vector<ULong64_t>> mTemperatureC; ///< temperature values C-side
+  int mFitIntervalMS{5 * 60 * 1000};                                   ///< fit interval for the temperature
 
   ClassDefNV(PressureTemperatureHelper, 1);
 };

--- a/Detectors/TPC/calibration/src/PressureTemperatureHelper.cxx
+++ b/Detectors/TPC/calibration/src/PressureTemperatureHelper.cxx
@@ -91,13 +91,13 @@ void PressureTemperatureHelper::addOutput(std::vector<OutputSpec>& outputs, Outp
   }
 }
 
-float PressureTemperatureHelper::interpolate(const std::vector<uint64_t>& timestamps, const std::vector<float>& values, uint64_t timestamp) const
+float PressureTemperatureHelper::interpolate(const std::vector<ULong64_t>& timestamps, const std::vector<float>& values, ULong64_t timestamp) const
 {
   if (auto idxClosest = o2::math_utils::findClosestIndices(timestamps, timestamp)) {
     auto [idxLeft, idxRight] = *idxClosest;
     if (idxRight > idxLeft) {
-      const uint64_t x0 = timestamps[idxLeft];
-      const uint64_t x1 = timestamps[idxRight];
+      const auto x0 = timestamps[idxLeft];
+      const auto x1 = timestamps[idxRight];
       const float y0 = values[idxLeft];
       const float y1 = values[idxRight];
       const float y = (y0 * (x1 - timestamp) + y1 * (timestamp - x0)) / (x1 - x0);
@@ -109,7 +109,7 @@ float PressureTemperatureHelper::interpolate(const std::vector<uint64_t>& timest
   return 0; // this should never happen
 }
 
-void PressureTemperatureHelper::sendPTForTS(o2::framework::ProcessingContext& pc, const uint64_t timestamp) const
+void PressureTemperatureHelper::sendPTForTS(o2::framework::ProcessingContext& pc, const ULong64_t timestamp) const
 {
   const float pressure = getPressure(timestamp);
   const auto temp = getTemperature(timestamp);

--- a/Detectors/TPC/workflow/src/TPCPressureTemperatureSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCPressureTemperatureSpec.cxx
@@ -57,7 +57,7 @@ class PressureTemperatureDevice : public o2::framework::Task
     mPTHelper.extractCCDBInputs(pc);
     const auto orbitResetTimeMS = o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS();
     const auto firstTFOrbit = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
-    const uint64_t timestamp = orbitResetTimeMS + firstTFOrbit * o2::constants::lhc::LHCOrbitMUS * 0.001;
+    const ULong64_t timestamp = orbitResetTimeMS + firstTFOrbit * o2::constants::lhc::LHCOrbitMUS * 0.001;
     mPTHelper.sendPTForTS(pc, timestamp);
 
     if (mStreamer) {


### PR DESCRIPTION
When reading in pressure objects from Mac I got a warning of type
```
Warning in <TStreamerInfo::BuildCheck>:
   The StreamerInfo of class o2::tpc::dcs::RobustPressure read from file pressure_ccdb_1733011394000_1735656894000.root
   has the same version (=1) as the active class but a different checksum.
   You should update the version to ClassDef(o2::tpc::dcs::RobustPressure,2).
   Do not try to write objects with the current class definition,
   the files will not be readable.

Warning in <TStreamerInfo::CompareContent>: The following data member of
the on-file layout version 1 of class 'o2::tpc::dcs::RobustPressure' differs from
the in-memory layout version 1:
   vector<unsigned long> time; //
vs
   vector<ULong64_t> time; //
```

A similar issue is discussed here https://github.com/root-project/root/issues/17216