### PR TITLE
New methods to query AggregatedRunInfo for MC

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -108,16 +108,20 @@ class CCDBManagerInstance
 
   /// retrieve an object of type T from CCDB as stored under path, timestamp and metaData
   template <typename T>
-  T* getSpecific(std::string const& path, long timestamp = -1, MD metaData = MD())
+  T* getSpecific(std::string const& path, long timestamp = -1, MD metaData = MD(), std::map<std::string, std::string>* headers = nullptr)
   {
     // TODO: add some error info/handling when failing
     mMetaData = metaData;
-    return getForTimeStamp<T>(path, timestamp);
+    auto obj = getForTimeStamp<T>(path, timestamp);
+    if (headers) {
+      *headers = mHeaders;
+    }
+    return obj;
   }
 
   /// retrieve an object of type T from CCDB as stored under path and using the timestamp in the middle of the run + metadata. The run number is provided separately to conform to typical analysis use (in which case metadata does not include runNumber)
   template <typename T>
-  T* getSpecificForRun(std::string const& path, int runNumber, MD metaData = MD());
+  T* getSpecificForRun(std::string const& path, int runNumber, MD const& metaData = MD());
 
   /// detect online processing modes (i.e. CCDB objects may be updated in the lifetime of the manager)
   bool isOnline() const { return mDeplMode == o2::framework::DeploymentMode::OnlineAUX || mDeplMode == o2::framework::DeploymentMode::OnlineDDS || mDeplMode == o2::framework::DeploymentMode::OnlineECS; }
@@ -128,6 +132,9 @@ class CCDBManagerInstance
   {
     return getForTimeStamp<T>(path, mTimestamp);
   }
+
+  // gain access to underlaying CCDB layer (to allow for more complex queries without need to reinit another API)
+  CcdbApi& getCCDBAccessor() { return mCCDBAccessor; }
 
   bool isHostReachable() const { return mCCDBAccessor.isHostReachable(); }
 
@@ -230,11 +237,12 @@ class CCDBManagerInstance
 template <typename T>
 T* CCDBManagerInstance::getForTimeStamp(std::string const& path, long timestamp)
 {
+  mHeaders.clear(); // we clear at the beginning; to allow to retrieve the header information in a subsequent call
   T* ptr = nullptr;
   mQueries++;
   auto start = std::chrono::system_clock::now();
   if (!isCachingEnabled()) {
-    ptr = mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp, nullptr, "",
+    ptr = mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp, &mHeaders, "",
                                                 mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
                                                 mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
     if (!ptr) {
@@ -305,7 +313,6 @@ T* CCDBManagerInstance::getForTimeStamp(std::string const& path, long timestamp)
     } else {
       cached.cacheValidUntil = -1;
     }
-    mHeaders.clear();
     mMetaData.clear();
     if (!ptr) {
       if (mFatalWhenNull) {
@@ -328,7 +335,7 @@ T* CCDBManagerInstance::getForRun(std::string const& path, int runNumber, bool s
 }
 
 template <typename T>
-T* CCDBManagerInstance::getSpecificForRun(std::string const& path, int runNumber, MD metaData)
+T* CCDBManagerInstance::getSpecificForRun(std::string const& path, int runNumber, MD const& metaData)
 {
   auto [start, stop] = getRunDuration(runNumber, mFatalWhenNull);
   if (start < 0 || stop < 0) {

--- a/DataFormats/Parameters/include/DataFormatsParameters/AggregatedRunInfo.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/AggregatedRunInfo.h
@@ -32,7 +32,7 @@ struct AggregatedRunInfo {
   int runNumber = 0;       // run number
   int64_t sor = 0;         // best known timestamp for the start of run
   int64_t eor = 0;         // best known timestamp for end of run
-  int64_t orbitsPerTF = 0; // number of orbits per TF
+  int64_t orbitsPerTF = 0; // number of orbits per TF (takes precedence over that in GRPECS)
   int64_t orbitReset = 0;  // timestamp of orbit reset before run
   int64_t orbitSOR = 0;    // orbit when run starts after orbit reset
   int64_t orbitEOR = 0;    // orbit when run ends after orbit reset
@@ -40,9 +40,27 @@ struct AggregatedRunInfo {
   // we may have pointers to actual data source objects GRPECS, ...
   const o2::parameters::GRPECSObject* grpECS = nullptr; // pointer to GRPECSobject (fetched during struct building)
 
-  // fills and returns AggregatedRunInfo for a given run number.
-  static AggregatedRunInfo buildAggregatedRunInfo(o2::ccdb::CCDBManagerInstance& ccdb, int runnumber);
   static AggregatedRunInfo buildAggregatedRunInfo(int runnumber, long sorMS, long eorMS, long orbitResetMUS, const o2::parameters::GRPECSObject* grpecs, const std::vector<Long64_t>* ctfFirstRunOrbitVec);
+
+  // fills and returns AggregatedRunInfo for a given data run number.
+  static AggregatedRunInfo buildAggregatedRunInfo_DATA(o2::ccdb::CCDBManagerInstance& ccdb, int runnumber);
+
+  // Returns the meta-data (MCProdInfo) associated to production lpm_prod_tag (performed by username)
+  static std::map<std::string, std::string> getMCProdInfo(o2::ccdb::CCDBManagerInstance& ccdb, int runnumber,
+                                                          std::string const& lpm_prod_tag, std::string const& username = "aliprod");
+
+  // function that adjusts with values from MC
+  void adjust_from_MC(o2::ccdb::CCDBManagerInstance& ccdb, int run_number, std::string const& lpm_prod_tag, std::string const& username = "aliprod");
+
+  // Fills and returns AggregatedRunInfo for a given run number.
+  // If a non-empty lpm_prod_tag is given, it will potentially override values with specifics from a
+  // MC production identified by that tag and username.
+  static AggregatedRunInfo buildAggregatedRunInfo(o2::ccdb::CCDBManagerInstance& ccdb,
+                                                  int runnumber,
+                                                  std::string const& lpm_prod_tag = "",
+                                                  std::string const& username = "aliprod");
+
+  ClassDefNV(AggregatedRunInfo, 1);
 };
 
 } // namespace o2::parameters

--- a/DataFormats/Parameters/src/AggregatedRunInfo.cxx
+++ b/DataFormats/Parameters/src/AggregatedRunInfo.cxx
@@ -21,7 +21,7 @@
 
 using namespace o2::parameters;
 
-o2::parameters::AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::CCDBManagerInstance& ccdb, int runnumber)
+o2::parameters::AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo_DATA(o2::ccdb::CCDBManagerInstance& ccdb, int runnumber)
 {
   // TODO: could think about caching results per runnumber to
   // avoid going to CCDB multiple times ---> but should be done inside the CCDBManagerInstance
@@ -82,4 +82,68 @@ o2::parameters::AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo(int 
     }
   }
   return AggregatedRunInfo{runnumber, sorMS, eorMS, nOrbitsPerTF, orbitResetMUS, orbitSOR, orbitEOR, grpecs};
+}
+
+namespace
+{
+
+// get path where to find MC production info
+std::string getFullPath_MC(std::string const& username, std::string const& lpm_prod_tag)
+{
+  // construct the path where to lookup
+  std::string path = "/Users/" + std::string(1, username[0]) + "/" + username;
+  std::string fullpath = path + "/" + "MCProdInfo/" + lpm_prod_tag;
+  return fullpath;
+}
+
+} // namespace
+
+std::map<std::string, std::string> AggregatedRunInfo::getMCProdInfo(o2::ccdb::CCDBManagerInstance& ccdb,
+                                                                    int run_number,
+                                                                    std::string const& lpm_prod_tag,
+                                                                    std::string const& username)
+{
+  std::map<std::string, std::string> metaDataFilter;
+  metaDataFilter["lpm_prod_tag"] = lpm_prod_tag;
+
+  // fetch the meta information for MC productions
+  auto header_data = ccdb.getCCDBAccessor().retrieveHeaders(getFullPath_MC(username, lpm_prod_tag), metaDataFilter, run_number);
+  return header_data;
+}
+
+void AggregatedRunInfo::adjust_from_MC(o2::ccdb::CCDBManagerInstance& ccdb,
+                                       int run_number,
+                                       std::string const& lpm_prod_tag,
+                                       std::string const& username)
+{
+  auto header_data = AggregatedRunInfo::getMCProdInfo(ccdb, run_number, lpm_prod_tag, username);
+
+  // adjust timeframe length if we find entry for MC production
+  auto iter = header_data.find("OrbitsPerTF");
+  if (iter != header_data.end()) {
+    auto mc_orbitsPerTF = std::stoi(iter->second);
+    if (mc_orbitsPerTF != orbitsPerTF) {
+      LOG(info) << "Adjusting OrbitsPerTF from " << orbitsPerTF << " to " << mc_orbitsPerTF << " based on differing MC info";
+      orbitsPerTF = mc_orbitsPerTF;
+    }
+  } else {
+    LOG(warn) << "No OrbitsPerTF information found for MC production " << lpm_prod_tag << " and run number " << run_number;
+  }
+}
+
+AggregatedRunInfo AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::CCDBManagerInstance& ccdb, int run_number, std::string const& lpm_prod_tag, std::string const& username)
+{
+  // (a) lookup the AggregatedRunInfo for the data run
+  // (b) modify/overwrite the info object with MC specific settings if lpm_prod_tag is given
+
+  auto original_info = buildAggregatedRunInfo_DATA(ccdb, run_number);
+
+  if (lpm_prod_tag.size() == 0) {
+    return original_info;
+  }
+
+  // in this case we adjust the info from MC
+  original_info.adjust_from_MC(ccdb, run_number, lpm_prod_tag, username);
+
+  return original_info;
 }

--- a/DataFormats/Parameters/src/AggregatedRunInfo.cxx
+++ b/DataFormats/Parameters/src/AggregatedRunInfo.cxx
@@ -104,7 +104,7 @@ std::map<std::string, std::string> AggregatedRunInfo::getMCProdInfo(o2::ccdb::CC
                                                                     std::string const& username)
 {
   std::map<std::string, std::string> metaDataFilter;
-  metaDataFilter["lpm_prod_tag"] = lpm_prod_tag;
+  metaDataFilter["LPMProductionTag"] = lpm_prod_tag;
 
   // fetch the meta information for MC productions
   auto header_data = ccdb.getCCDBAccessor().retrieveHeaders(getFullPath_MC(username, lpm_prod_tag), metaDataFilter, run_number);


### PR DESCRIPTION
This commit is

* slightly changing BasicCCDBManager to be able to
  - retrieve meta information headers
  - retrieve the underlying CCDB api for reuse

* offering an API to build AggregatedRunInfo with values overwritten from specific MC production settings

  - This could be used from the analysis side. Analysis needs to identify if AOD is from MC, and use the MC production tag (lpm_prod_tag) in the query.

This needs separate upload of MCProdInfo meta-information to CCDB.