### PR TITLE
ITS: fix clusterSize propagation

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -180,7 +180,7 @@ int TimeFrame<nLayers>::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
         locXYZ = dict->getClusterCoordinates(c, patt, false);
         clusterSize = patt.getNPixels();
       }
-      mClusterSize.push_back(std::clamp(clusterSize, 0u, 255u));
+      mClusterSize[clusterId] = std::clamp(clusterSize, 0u, 255u);
       auto sensorID = c.getSensorID();
       // Inverse transformation to the local --> tracking
       auto trkXYZ = geom->getMatrixT2L(sensorID) ^ locXYZ;


### PR DESCRIPTION
After recent refactoring, this started to push to the end of the vector, which was preallocated. 
@ddobrigk this should fix the cluster size in ao2d.