### PR TITLE
ITS: GPU accept mc in config

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -63,6 +63,7 @@ framework::WorkflowSpec getWorkflow(bool useMC,
         cfg.runITSTracking = true;
         cfg.itsTriggerType = useTrig;
         cfg.itsOverrBeamEst = overrideBeamPosition;
+        cfg.processMC = useMC;
 
         Inputs ggInputs;
         auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false, true, false, true, true,


### PR DESCRIPTION
Needed for reproducer for MC labels using the gpu workflow.
Just propagates the '--disable-mc' to the gpu workflow.