### PR TITLE
DPL Analysis: add `PresliceGroup`

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1465,6 +1465,24 @@ using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 template <typename T>
 concept is_preslice = std::derived_from<T, PreslicePolicyBase>;
 
+/// Can be user to group together a number of Preslice declaration
+/// to avoid the limit of 100 data members per task
+///
+/// struct MyTask
+///   struct : public PresliceGroup {
+///     Preslice<aod::Tracks> perCol = aod::track::collisonId;
+///     Preslice<aod::McParticles> perMcCol = aod::mcparticle::mcCollisionId;
+///   } preslices;
+///
+/// individual components can be access with
+///
+/// preslices.perCol;
+struct PresliceGroup {
+};
+
+template <typename T>
+concept is_preslice_group = std::derived_from<T, PresliceGroup>;
+
 } // namespace o2::framework
 
 namespace o2::soa

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -543,7 +543,7 @@ static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& asso
 
 /// Preslice handling
 template <typename T>
-  requires(!is_preslice<T>)
+  requires(!is_preslice<T> && !is_preslice_group<T>)
 bool registerCache(T&, Cache&, Cache&)
 {
   return false;
@@ -585,8 +585,15 @@ bool registerCache(T& preslice, Cache&, Cache& bsksU)
   return true;
 }
 
+template <is_preslice_group T>
+bool registerCache(T& presliceGroup, Cache& bsks, Cache& bsksU)
+{
+  homogeneous_apply_refs<true>([&bsks, &bsksU](auto& preslice){ return registerCache(preslice, bsks, bsksU); }, presliceGroup);
+  return true;
+}
+
 template <typename T>
-  requires(!is_preslice<T>)
+  requires(!is_preslice<T> && !is_preslice_group<T>)
 bool updateSliceInfo(T&, ArrowTableSlicingCache&)
 {
   return false;
@@ -615,6 +622,13 @@ static bool updateSliceInfo(T& preslice, ArrowTableSlicingCache& cache)
     }
   }
   preslice.updateSliceInfo(cache.getCacheUnsortedFor(preslice.getBindingKey()));
+  return true;
+}
+
+template <is_preslice_group T>
+static bool updateSliceInfo(T& presliceGroup, ArrowTableSlicingCache& cache)
+{
+  homogeneous_apply_refs<true>([&cache](auto& preslice){ return updateSliceInfo(preslice, cache); }, presliceGroup);
   return true;
 }
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -588,7 +588,7 @@ bool registerCache(T& preslice, Cache&, Cache& bsksU)
 template <is_preslice_group T>
 bool registerCache(T& presliceGroup, Cache& bsks, Cache& bsksU)
 {
-  homogeneous_apply_refs<true>([&bsks, &bsksU](auto& preslice){ return registerCache(preslice, bsks, bsksU); }, presliceGroup);
+  homogeneous_apply_refs<true>([&bsks, &bsksU](auto& preslice) { return registerCache(preslice, bsks, bsksU); }, presliceGroup);
   return true;
 }
 
@@ -628,7 +628,7 @@ static bool updateSliceInfo(T& preslice, ArrowTableSlicingCache& cache)
 template <is_preslice_group T>
 static bool updateSliceInfo(T& presliceGroup, ArrowTableSlicingCache& cache)
 {
-  homogeneous_apply_refs<true>([&cache](auto& preslice){ return updateSliceInfo(preslice, cache); }, presliceGroup);
+  homogeneous_apply_refs<true>([&cache](auto& preslice) { return updateSliceInfo(preslice, cache); }, presliceGroup);
   return true;
 }
 

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -13,6 +13,7 @@
 #include "TestClasses.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include <iostream>
 
 #include <catch_amalgamated.hpp>
 
@@ -185,6 +186,17 @@ struct LTask {
   void process(aod::McCollision const&, soa::SmallGroups<soa::Join<aod::Collisions, aod::McCollisionLabels>> const&) {}
 };
 
+struct MTask {
+  SliceCache cache;
+  struct : public PresliceGroup {
+    Preslice<aod::Tracks> perCol = aod::track::collisionId;
+    PresliceOptional<aod::Tracks> perPart = aod::mctracklabel::mcParticleId;
+    PresliceUnsorted<aod::McCollisionLabels> perMcCol = aod::mccollisionlabel::mcCollisionId;
+    PresliceUnsortedOptional<aod::Collisions> perMcColopt = aod::mccollisionlabel::mcCollisionId;
+  } foo;
+  void process(aod::McCollision const&, soa::SmallGroups<soa::Join<aod::Collisions, aod::McCollisionLabels>> const&) {}
+};
+
 TEST_CASE("AdaptorCompilation")
 {
   auto cfgc = makeEmptyConfigContext();
@@ -258,6 +270,9 @@ TEST_CASE("AdaptorCompilation")
 
   auto task12 = adaptAnalysisTask<LTask>(*cfgc, TaskName{"test12"});
   REQUIRE(task12.inputs.size() == 3);
+
+  auto task13 = adaptAnalysisTask<MTask>(*cfgc, TaskName{"test13"});
+  REQUIRE(task13.inputs.size() == 3);
 }
 
 TEST_CASE("TestPartitionIteration")

--- a/Framework/Core/test/test_Concepts.cxx
+++ b/Framework/Core/test/test_Concepts.cxx
@@ -87,6 +87,14 @@ TEST_CASE("IdentificationConcepts")
   Preslice<o2::aod::Tracks> ps = o2::aod::track::collisionId;
   REQUIRE(is_preslice<decltype(ps)>);
 
+  struct : PresliceGroup {
+    Preslice<o2::aod::Tracks> pc = o2::aod::track::collisionId;
+    Preslice<o2::aod::McParticles> pmcc = o2::aod::mcparticle::mcCollisionId;
+  } preslices;
+  REQUIRE(is_preslice_group<decltype(preslices)>);
+  REQUIRE(is_preslice<decltype(preslices.pc)>);
+  REQUIRE(is_preslice<decltype(preslices.pmcc)>);
+
   REQUIRE(has_filtered_policy<soa::Filtered<o2::aod::Tracks>::iterator>);
 
   REQUIRE(is_filtered_iterator<soa::Filtered<o2::aod::Tracks>::iterator>);
@@ -162,6 +170,7 @@ TEST_CASE("IdentificationConcepts")
   expressions::Filter f = o2::aod::track::pt > 1.0f;
   REQUIRE(expressions::is_filter<decltype(f)>);
 
+  // Combinations
   using C = SameKindPair<aod::Collisions, aod::Tracks, ColumnBinningPolicy<aod::collision::PosZ>>;
   REQUIRE(is_combinations_generator<C>);
 }


### PR DESCRIPTION
Introduces `PresliceGroup`, that functions similar to `ConfigurableGroup` and `ProducesGroup`.

Example:
```cpp
  struct : public PresliceGroup {
    Preslice<o2::aod::Tracks> pc = o2::aod::track::collisionId;
    Preslice<o2::aod::McParticles> pmcc = o2::aod::mcparticle::mcCollisionId;
  } preslices;
```

@nzardosh 