### PR TITLE
DPL Analysis: rework table builder cursor signature logic

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -574,7 +574,7 @@ class ColumnIterator : ChunkingPolicy
     auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
     auto offset = list->value_offset(*mCurrentPos - mFirstIndex);
     auto length = list->value_length(*mCurrentPos - mFirstIndex);
-    return gsl::span{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
+    return std::span{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
   }
 
   decltype(auto) operator*() const
@@ -840,7 +840,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   // which happens below which will properly setup the first index
   // by remapping the filtered index 0 to whatever unfiltered index
   // it belongs to.
-  FilteredIndexPolicy(gsl::span<int64_t const> selection, int64_t rows, uint64_t offset = 0)
+  FilteredIndexPolicy(std::span<int64_t const> selection, int64_t rows, uint64_t offset = 0)
     : IndexPolicyBase{-1, offset},
       mSelectedRows(selection),
       mMaxSelection(selection.size()),
@@ -849,7 +849,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
     this->setCursor(0);
   }
 
-  void resetSelection(gsl::span<int64_t const> selection)
+  void resetSelection(std::span<int64_t const> selection)
   {
     mSelectedRows = selection;
     mMaxSelection = selection.size();
@@ -933,7 +933,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   {
     this->mRowIndex = O2_BUILTIN_LIKELY(mSelectionRow < mMaxSelection) ? mSelectedRows[mSelectionRow] : -1;
   }
-  gsl::span<int64_t const> mSelectedRows;
+  std::span<int64_t const> mSelectedRows;
   int64_t mSelectionRow = 0;
   int64_t mMaxSelection = 0;
   int64_t nRows = 0;
@@ -1417,7 +1417,7 @@ struct PreslicePolicyGeneral : public PreslicePolicyBase {
   void updateSliceInfo(SliceInfoUnsortedPtr&& si);
 
   SliceInfoUnsortedPtr sliceInfo;
-  gsl::span<const int64_t> getSliceFor(int value) const;
+  std::span<const int64_t> getSliceFor(int value) const;
 };
 
 template <typename T, typename Policy, bool OPT = false>
@@ -1442,7 +1442,7 @@ struct PresliceBase : public Policy {
     return Policy::getSliceFor(value, input, offset);
   }
 
-  gsl::span<const int64_t> getSliceFor(int value) const
+  std::span<const int64_t> getSliceFor(int value) const
   {
     if constexpr (OPT) {
       if (Policy::isMissing()) {
@@ -1520,7 +1520,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
 }
 
 template <soa::is_filtered_table T>
-auto doSliceByHelper(T const* table, gsl::span<const int64_t> const& selection)
+auto doSliceByHelper(T const* table, std::span<const int64_t> const& selection)
 {
   auto t = soa::Filtered<typename T::base_t>({table->asArrowTable()}, selection);
   table->copyIndexBindings(t);
@@ -1531,7 +1531,7 @@ auto doSliceByHelper(T const* table, gsl::span<const int64_t> const& selection)
 
 template <soa::is_table T>
   requires(!soa::is_filtered_table<T>)
-auto doSliceByHelper(T const* table, gsl::span<const int64_t> const& selection)
+auto doSliceByHelper(T const* table, std::span<const int64_t> const& selection)
 {
   auto t = soa::Filtered<T>({table->asArrowTable()}, selection);
   table->copyIndexBindings(t);
@@ -1552,7 +1552,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
   return doSliceByHelper(table, selection);
 }
 
-SelectionVector sliceSelection(gsl::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset);
+SelectionVector sliceSelection(std::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset);
 
 template <soa::is_filtered_table T>
 auto prepareFilteredSlice(T const* table, std::shared_ptr<arrow::Table> slice, uint64_t offset)
@@ -1982,7 +1982,7 @@ class Table
     return RowViewSentinel{mEnd};
   }
 
-  filtered_iterator filtered_begin(gsl::span<int64_t const> selection)
+  filtered_iterator filtered_begin(std::span<int64_t const> selection)
   {
     // Note that the FilteredIndexPolicy will never outlive the selection which
     // is held by the table, so we are safe passing the bare pointer. If it does it
@@ -2561,12 +2561,12 @@ consteval auto getIndexTargets()
     _Name_##Ids(_Name_##Ids const& other) = default;                                                     \
     _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                          \
                                                                                                          \
-    gsl::span<const _Type_> inline getIds() const                                                        \
+    std::span<const _Type_> inline getIds() const                                                        \
     {                                                                                                    \
       return _Getter_##Ids();                                                                            \
     }                                                                                                    \
                                                                                                          \
-    gsl::span<const _Type_> _Getter_##Ids() const                                                        \
+    std::span<const _Type_> _Getter_##Ids() const                                                        \
     {                                                                                                    \
       return *mColumnIterator;                                                                           \
     }                                                                                                    \
@@ -2918,12 +2918,12 @@ consteval auto getIndexTargets()
     _Name_##Ids() = default;                                                                             \
     _Name_##Ids(_Name_##Ids const& other) = default;                                                     \
     _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                          \
-    gsl::span<const _Type_> inline getIds() const                                                        \
+    std::span<const _Type_> inline getIds() const                                                        \
     {                                                                                                    \
       return _Getter_##Ids();                                                                            \
     }                                                                                                    \
                                                                                                          \
-    gsl::span<const _Type_> _Getter_##Ids() const                                                        \
+    std::span<const _Type_> _Getter_##Ids() const                                                        \
     {                                                                                                    \
       return *mColumnIterator;                                                                           \
     }                                                                                                    \
@@ -3373,7 +3373,7 @@ class FilteredBase : public T
       mSelectedRowsCache{std::move(selection)},
       mCached{true}
   {
-    mSelectedRows = gsl::span{mSelectedRowsCache};
+    mSelectedRows = std::span{mSelectedRowsCache};
     if (this->tableSize() != 0) {
       mFilteredBegin = table_t::filtered_begin(mSelectedRows);
     }
@@ -3381,7 +3381,7 @@ class FilteredBase : public T
     mFilteredBegin.bindInternalIndices(this);
   }
 
-  FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : T{std::move(tables), offset},
       mSelectedRows{selection}
   {
@@ -3460,12 +3460,12 @@ class FilteredBase : public T
   static inline auto getSpan(gandiva::Selection const& sel)
   {
     if (sel == nullptr) {
-      return gsl::span<int64_t const>{};
+      return std::span<int64_t const>{};
     }
     auto array = std::static_pointer_cast<arrow::Int64Array>(sel->ToArray());
     auto start = array->raw_values();
     auto stop = start + array->length();
-    return gsl::span{start, stop};
+    return std::span{start, stop};
   }
 
   /// Bind the columns which refer to other tables
@@ -3564,7 +3564,7 @@ class FilteredBase : public T
     resetRanges();
   }
 
-  void sumWithSelection(gsl::span<int64_t const> const& selection)
+  void sumWithSelection(std::span<int64_t const> const& selection)
   {
     mCached = true;
     SelectionVector rowsUnion;
@@ -3574,7 +3574,7 @@ class FilteredBase : public T
     resetRanges();
   }
 
-  void intersectWithSelection(gsl::span<int64_t const> const& selection)
+  void intersectWithSelection(std::span<int64_t const> const& selection)
   {
     mCached = true;
     SelectionVector intersection;
@@ -3593,7 +3593,7 @@ class FilteredBase : public T
   void resetRanges()
   {
     if (mCached) {
-      mSelectedRows = gsl::span{mSelectedRowsCache};
+      mSelectedRows = std::span{mSelectedRowsCache};
     }
     mFilteredEnd.reset(new RowViewSentinel{static_cast<int64_t>(mSelectedRows.size())});
     if (tableSize() == 0) {
@@ -3603,7 +3603,7 @@ class FilteredBase : public T
     }
   }
 
-  gsl::span<int64_t const> mSelectedRows;
+  std::span<int64_t const> mSelectedRows;
   SelectionVector mSelectedRowsCache;
   bool mCached = false;
   iterator mFilteredBegin;
@@ -3639,7 +3639,7 @@ class Filtered : public FilteredBase<T>
   Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
     : FilteredBase<T>(std::move(tables), std::forward<SelectionVector>(selection), offset) {}
 
-  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : FilteredBase<T>(std::move(tables), selection, offset) {}
 
   Filtered<T> operator+(SelectionVector const& selection)
@@ -3649,7 +3649,7 @@ class Filtered : public FilteredBase<T>
     return copy;
   }
 
-  Filtered<T> operator+(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator+(std::span<int64_t const> const& selection)
   {
     Filtered<T> copy(*this);
     copy.sumWithSelection(selection);
@@ -3667,7 +3667,7 @@ class Filtered : public FilteredBase<T>
     return *this;
   }
 
-  Filtered<T> operator+=(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator+=(std::span<int64_t const> const& selection)
   {
     this->sumWithSelection(selection);
     return *this;
@@ -3685,7 +3685,7 @@ class Filtered : public FilteredBase<T>
     return copy;
   }
 
-  Filtered<T> operator*(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator*(std::span<int64_t const> const& selection)
   {
     Filtered<T> copy(*this);
     copy.intersectWithSelection(selection);
@@ -3703,7 +3703,7 @@ class Filtered : public FilteredBase<T>
     return *this;
   }
 
-  Filtered<T> operator*=(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator*=(std::span<int64_t const> const& selection)
   {
     this->intersectWithSelection(selection);
     return *this;
@@ -3811,7 +3811,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     }
   }
 
-  Filtered(std::vector<Filtered<T>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  Filtered(std::vector<Filtered<T>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : FilteredBase<typename T::table_t>(std::move(extractTablesFromFiltered(tables)), selection, offset)
   {
     for (auto& table : tables) {
@@ -3826,7 +3826,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return copy;
   }
 
-  Filtered<Filtered<T>> operator+(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator+(std::span<int64_t const> const& selection)
   {
     Filtered<Filtered<T>> copy(*this);
     copy.sumWithSelection(selection);
@@ -3844,7 +3844,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return *this;
   }
 
-  Filtered<Filtered<T>> operator+=(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator+=(std::span<int64_t const> const& selection)
   {
     this->sumWithSelection(selection);
     return *this;
@@ -3862,7 +3862,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return copy;
   }
 
-  Filtered<Filtered<T>> operator*(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator*(std::span<int64_t const> const& selection)
   {
     Filtered<Filtered<T>> copy(*this);
     copy.intersectionWithSelection(selection);
@@ -3880,7 +3880,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return *this;
   }
 
-  Filtered<Filtered<T>> operator*=(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator*=(std::span<int64_t const> const& selection)
   {
     this->intersectWithSelection(selection);
     return *this;
@@ -3989,7 +3989,7 @@ struct SmallGroupsBase : public Filtered<T> {
   SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), std::forward<SelectionVector>(selection), offset) {}
 
-  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), selection, offset) {}
 };
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -471,6 +471,12 @@ struct unwrap<std::vector<T>> {
   using type = T;
 };
 
+template <typename T, int N>
+struct unwrap<T[N]> {
+  using type = T[N];
+  using base_type = T;
+};
+
 template <>
 struct unwrap<bool> {
   using type = char;
@@ -560,15 +566,15 @@ class ColumnIterator : ChunkingPolicy
     mLast = mCurrent + array->length() + (mFirstIndex >> SCALE_FACTOR);
   }
 
-  decltype(auto) operator*() const
+  auto operator*() const
     requires std::same_as<bool, std::decay_t<T>>
   {
     checkSkipChunk();
     return (*(mCurrent - (mOffset >> SCALE_FACTOR) + ((*mCurrentPos + mOffset) >> SCALE_FACTOR)) & (1 << ((*mCurrentPos + mOffset) & 0x7))) != 0;
   }
 
-  decltype(auto) operator*() const
-    requires((!std::same_as<bool, std::decay_t<T>>) && std::same_as<arrow_array_for_t<T>, arrow::ListArray>)
+  auto operator*() const
+    requires((!std::same_as<bool, std::decay_t<T>>) && std::same_as<arrow_array_for_t<T>, arrow::ListArray> && !std::same_as<arrow_array_for_t<T>, arrow::FixedSizeListArray>)
   {
     checkSkipChunk();
     auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
@@ -577,8 +583,15 @@ class ColumnIterator : ChunkingPolicy
     return std::span{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
   }
 
-  decltype(auto) operator*() const
-    requires((!std::same_as<bool, std::decay_t<T>>) && !std::same_as<arrow_array_for_t<T>, arrow::ListArray>)
+  auto operator*() const
+    requires((!std::same_as<bool, std::decay_t<T>>) && !std::same_as<arrow_array_for_t<T>, arrow::ListArray> && std::same_as<arrow_array_for_t<T>, arrow::FixedSizeListArray>)
+  {
+    checkSkipChunk();
+    return std::span{reinterpret_cast<const unwrap<T>::base_type*>(mCurrent + (*mCurrentPos >> SCALE_FACTOR)), arrow_array_for<T>::width};
+  }
+
+  auto operator*() const
+    requires((!std::same_as<bool, std::decay_t<T>>) && !std::same_as<arrow_array_for_t<T>, arrow::ListArray> && !std::same_as<arrow_array_for_t<T>, arrow::FixedSizeListArray>)
   {
     checkSkipChunk();
     return *(mCurrent + (*mCurrentPos >> SCALE_FACTOR));

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -120,7 +120,7 @@ template <typename T>
 concept is_producable = soa::has_metadata<aod::MetadataTrait<T>> || soa::has_metadata<aod::MetadataTrait<typename T::parent_t>>;
 
 template <typename T>
-concept is_enumerated_iterator = requires (T t) { t.globalIndex(); };
+concept is_enumerated_iterator = requires(T t) { t.globalIndex(); };
 
 template <is_producable T>
 struct WritingCursor {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -171,14 +171,14 @@ struct WritingCursor {
 
  private:
   template <is_enumerated_iterator A>
-  static decltype(auto) extract(A const& arg)
+  static inline decltype(auto) extract(A const& arg)
   {
     return arg.globalIndex();
   }
 
   template <typename A>
     requires(!is_enumerated_iterator<A>)
-  static decltype(auto) extract(A&& arg)
+  static inline decltype(auto) extract(A&& arg)
   {
     return arg;
   }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -126,7 +126,7 @@ struct WritingCursor {
   using cursor_t = decltype(std::declval<TableBuilder>().cursor<persistent_table_t>());
 
   template <typename... Ts>
-  void operator()(Ts... args)
+  void operator()(Ts&&... args)
   {
     static_assert(sizeof...(Ts) == framework::pack_size(typename persistent_table_t::persistent_columns_t{}), "Argument number mismatch");
     ++mCount;
@@ -175,7 +175,7 @@ struct WritingCursor {
   }
 
   template <typename A>
-  static decltype(auto) extract(A const& arg)
+  static decltype(auto) extract(A&& arg)
   {
     return arg;
   }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -119,6 +119,9 @@ class TableConsumer;
 template <typename T>
 concept is_producable = soa::has_metadata<aod::MetadataTrait<T>> || soa::has_metadata<aod::MetadataTrait<typename T::parent_t>>;
 
+template <typename T>
+concept is_enumerated_iterator = requires (T t) { t.globalIndex(); };
+
 template <is_producable T>
 struct WritingCursor {
  public:
@@ -127,8 +130,8 @@ struct WritingCursor {
 
   template <typename... Ts>
   void operator()(Ts&&... args)
+    requires(sizeof...(Ts) == framework::pack_size(typename persistent_table_t::persistent_columns_t{}))
   {
-    static_assert(sizeof...(Ts) == framework::pack_size(typename persistent_table_t::persistent_columns_t{}), "Argument number mismatch");
     ++mCount;
     cursor(0, extract(args)...);
   }
@@ -167,14 +170,14 @@ struct WritingCursor {
   decltype(FFL(std::declval<cursor_t>())) cursor;
 
  private:
-  template <typename A>
-    requires requires { &A::globalIndex; }
+  template <is_enumerated_iterator A>
   static decltype(auto) extract(A const& arg)
   {
     return arg.globalIndex();
   }
 
   template <typename A>
+    requires(!is_enumerated_iterator<A>)
   static decltype(auto) extract(A&& arg)
   {
     return arg;

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -21,17 +21,17 @@ namespace o2::framework
 using ListVector = std::vector<std::vector<int64_t>>;
 
 struct SliceInfoPtr {
-  gsl::span<int const> values;
-  gsl::span<int64_t const> counts;
+  std::span<int const> values;
+  std::span<int64_t const> counts;
 
   std::pair<int64_t, int64_t> getSliceFor(int value) const;
 };
 
 struct SliceInfoUnsortedPtr {
-  gsl::span<int const> values;
+  std::span<int const> values;
   ListVector const* groups;
 
-  gsl::span<int64_t const> getSliceFor(int value) const;
+  std::span<int64_t const> getSliceFor(int value) const;
 };
 
 struct Entry {

--- a/Framework/Core/include/Framework/ArrowTypes.h
+++ b/Framework/Core/include/Framework/ArrowTypes.h
@@ -64,26 +64,31 @@ struct arrow_array_for<double> {
 };
 template <int N>
 struct arrow_array_for<float[N]> {
+  static constexpr size_t width = N;
   using type = arrow::FixedSizeListArray;
   using value_type = float;
 };
 template <int N>
 struct arrow_array_for<int[N]> {
+  static constexpr size_t width = N;
   using type = arrow::FixedSizeListArray;
   using value_type = int;
 };
 template <int N>
 struct arrow_array_for<short[N]> {
+  static constexpr size_t width = N;
   using type = arrow::FixedSizeListArray;
   using value_type = short;
 };
 template <int N>
 struct arrow_array_for<double[N]> {
+  static constexpr size_t width = N;
   using type = arrow::FixedSizeListArray;
   using value_type = double;
 };
 template <int N>
 struct arrow_array_for<int8_t[N]> {
+  static constexpr size_t width = N;
   using type = arrow::FixedSizeListArray;
   using value_type = int8_t;
 };

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -266,9 +266,9 @@ struct GroupSlicer {
     std::tuple<A...>* mAt;
     typename grouping_t::iterator mGroupingElement;
     uint64_t position = 0;
-    gsl::span<int64_t const> groupSelection;
-    std::array<gsl::span<int64_t const> const*, sizeof...(A)> selections;
-    std::array<gsl::span<int64_t const>::iterator, sizeof...(A)> starts;
+    std::span<int64_t const> groupSelection;
+    std::array<std::span<int64_t const> const*, sizeof...(A)> selections;
+    std::array<std::span<int64_t const>::iterator, sizeof...(A)> starts;
 
     std::array<SliceInfoPtr, sizeof...(A)> sliceInfos;
     std::array<SliceInfoUnsortedPtr, sizeof...(A)> sliceInfosUnsorted;

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -157,7 +157,7 @@ struct BuilderUtils {
 
   /// Appender for the vector case.
   template <typename HolderType, typename T>
-  static arrow::Status append(HolderType& holder, std::vector<T> const& data)
+  static arrow::Status append(HolderType& holder, std::span<T> data)
   {
     using ArrowType = typename detail::ConversionTraits<T>::ArrowType;
     using ValueBuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
@@ -170,7 +170,7 @@ struct BuilderUtils {
   }
 
   template <typename HolderType, typename T>
-  static void unsafeAppend(HolderType& holder, std::vector<T> const& value)
+  static void unsafeAppend(HolderType& holder, std::span<T> value)
   {
     auto status = append(holder, value);
     if (!status.ok()) {
@@ -224,7 +224,7 @@ struct BuilderUtils {
 
 template <typename T>
 struct BuilderMaker {
-  using FillType = T;
+  using FillType = T const&;
   using STLValueType = T;
   using ArrowType = typename detail::ConversionTraits<T>::ArrowType;
   using BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
@@ -276,7 +276,7 @@ struct BuilderMaker<bool> {
 
 template <typename ITERATOR>
 struct BuilderMaker<std::pair<ITERATOR, ITERATOR>> {
-  using FillType = std::pair<ITERATOR, ITERATOR>;
+  using FillType = std::pair<ITERATOR, ITERATOR> const&;
   using STLValueType = typename ITERATOR::value_type;
   using ArrowType = arrow::ListType;
   using ValueType = typename detail::ConversionTraits<typename ITERATOR::value_type>::ArrowType;
@@ -361,7 +361,7 @@ struct BuilderMaker<std::array<T, N>> {
 
 template <typename T>
 struct BuilderMaker<std::vector<T>> {
-  using FillType = std::vector<T>;
+  using FillType = std::span<T>;
   using BuilderType = arrow::ListBuilder;
   using ArrowType = arrow::ListType;
   using ElementType = typename detail::ConversionTraits<T>::ArrowType;
@@ -647,7 +647,7 @@ class TableBuilder
   {
     auto persister = persistTuple(framework::pack<ARG0, ARGS...>{}, columnNames);
     // Callback used to fill the builders
-    return [persister = persister](unsigned int slot, typename BuilderMaker<ARG0>::FillType const& arg, typename BuilderMaker<ARGS>::FillType... args) -> void {
+    return [persister = persister](unsigned int slot, typename BuilderMaker<ARG0>::FillType arg, typename BuilderMaker<ARGS>::FillType... args) -> void {
       persister(slot, std::forward_as_tuple(arg, args...));
     };
   }

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -224,7 +224,7 @@ struct BuilderUtils {
 
 template <typename T>
 struct BuilderMaker {
-  using FillType = T const&;
+  using FillType = T;
   using STLValueType = T;
   using ArrowType = typename detail::ConversionTraits<T>::ArrowType;
   using BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -50,7 +50,7 @@ SelectionVector selectionToVector(gandiva::Selection const& sel)
   return rows;
 }
 
-SelectionVector sliceSelection(gsl::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset)
+SelectionVector sliceSelection(std::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset)
 {
   auto start = offset;
   auto end = start + nrows;
@@ -217,7 +217,7 @@ std::shared_ptr<arrow::Table> PreslicePolicySorted::getSliceFor(int value, std::
   return output;
 }
 
-gsl::span<const int64_t> PreslicePolicyGeneral::getSliceFor(int value) const
+std::span<const int64_t> PreslicePolicyGeneral::getSliceFor(int value) const
 {
   return this->sliceInfo.getSliceFor(value);
 }

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -56,7 +56,7 @@ std::pair<int64_t, int64_t> SliceInfoPtr::getSliceFor(int value) const
   return {offset, 0};
 }
 
-gsl::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
+std::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
 {
   if (values.empty()) {
     return {};

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1150,8 +1150,8 @@ TEST_CASE("TestListColumns")
   for (auto& row : tbl) {
     auto f = row.l1();
     auto i = row.l2();
-    auto constexpr bf = std::same_as<decltype(f), gsl::span<const float, (size_t)-1>>;
-    auto constexpr bi = std::same_as<decltype(i), gsl::span<const int, (size_t)-1>>;
+    auto constexpr bf = std::same_as<decltype(f), std::span<const float, (size_t)-1>>;
+    auto constexpr bi = std::same_as<decltype(i), std::span<const int, (size_t)-1>>;
     REQUIRE(bf);
     REQUIRE(bi);
     REQUIRE(f.size() == s);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1332,7 +1332,7 @@ DECLARE_SOA_COLUMN(One, one, int);
 DECLARE_SOA_COLUMN(Two, two, float);
 DECLARE_SOA_COLUMN(Three, three, double);
 DECLARE_SOA_COLUMN(Four, four, int[2]);
-DECLARE_SOA_DYNAMIC_COLUMN(Five, five, [](const int in[2]) -> float { return (float)in[0] / (float)in[1]; });
+DECLARE_SOA_DYNAMIC_COLUMN(Five, five, [](std::span<const int> in) -> float { return (float)in[0] / (float)in[1]; });
 } // namespace table
 
 DECLARE_SOA_TABLE(MixTest, "AOD", "MIXTST",


### PR DESCRIPTION
* Make sure the `FillType` is a direct type in the definition of `BuilderMaker` for PODs
* Use `FillType` without any additional qualifiers when defining the persister lambda for the `TableBuilder`
* Use `std::span` as `FillType` for vector columns
* `gsl::span` -> `std::span` throughout ASoA
* update the writing cursor in `Produces` to handle changes in `TableBuilder` cursor
* Use `std::span` also for fixed-size array column getters
* Use rvalue for single-value column getters