### PR TITLE
ITS: GPU add missing output to GPUWorkflowSpec

### DIFF
--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -1305,6 +1305,7 @@ Outputs GPURecoWorkflowSpec::outputs()
 
     if (mSpecConfig.processMC) {
       outputSpecs.emplace_back(gDataOriginITS, "VERTICESMCTR", 0, Lifetime::Timeframe);
+      outputSpecs.emplace_back(gDataOriginITS, "VERTICESMCPUR", 0, Lifetime::Timeframe);
       outputSpecs.emplace_back(gDataOriginITS, "TRACKSMCTR", 0, Lifetime::Timeframe);
       outputSpecs.emplace_back(gDataOriginITS, "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
     }


### PR DESCRIPTION
was missed initially. compliments #14425 and should now allow ITS MC to be run standalone on gpu. thanks @davidrohr!
tested on the small reproducer, which runs successfully now.