### PR TITLE
adding pdg code for eta meson

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -31,6 +31,7 @@ namespace o2::constants::physics
 /// \note Follow kCamelCase naming convention
 /// \link https://root.cern/doc/master/TPDGCode_8h.html
 enum Pdg {
+  kEta = 221,
   kB0 = 511,
   kB0Bar = -511,
   kBPlus = 521,


### PR DESCRIPTION
added missing Pdg code for eta meson (221), which is also not included in root TPDGCode