### PR TITLE
DPL: avoid unintialised member

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -678,7 +678,7 @@ DataRelayer::RelayChoice
       }
       index.publishSlot(slot);
       index.markAsDirty(slot, true);
-      return RelayChoice{.type = RelayChoice::Type::WillRelay};
+      return RelayChoice{.type = RelayChoice::Type::WillRelay, .timeslice = timeslice};
   }
   O2_BUILTIN_UNREACHABLE();
 }


### PR DESCRIPTION

Not actually used in this particular case, however better safe than sorry.
