### PR TITLE
Bugfix for vertex copying in collision context

### DIFF
--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -705,7 +705,7 @@ DigitizationContext DigitizationContext::extractSingleTimeframe(int timeframeid,
     }
     std::copy(mEventRecords.begin() + startindex, mEventRecords.begin() + endindex, std::back_inserter(r.mEventRecords));
     std::copy(mEventParts.begin() + startindex, mEventParts.begin() + endindex, std::back_inserter(r.mEventParts));
-    if (mInteractionVertices.size() > endindex) {
+    if (mInteractionVertices.size() >= endindex) {
       std::copy(mInteractionVertices.begin() + startindex, mInteractionVertices.begin() + endindex, std::back_inserter(r.mInteractionVertices));
     }
 

--- a/Steer/src/CollisionContextTool.cxx
+++ b/Steer/src/CollisionContextTool.cxx
@@ -594,7 +594,7 @@ int main(int argc, char* argv[])
         std::stringstream str;
         str << path_prefix << tf_output_counter++ << "/collisioncontext.root";
         copy.saveToFile(str.str());
-        LOG(info) << "----";
+        LOG(info) << "---- CollisionContext for timeframe " << tf_id << " -----";
         copy.printCollisionSummary();
       }
     }

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -762,9 +762,8 @@ int main(int argc, char* argv[])
   // Handle mergerpid status separately
   if (cpid == mergerpid) {
     if (WIFEXITED(status)) {
-      // anything other than 128 is indicative of error
-      if (WEXITSTATUS(status) != 128) {
-        LOG(error) << "Merger process exited with abnormal code " << WEXITSTATUS(status);
+      if (WEXITSTATUS(status) != 0 || WEXITSTATUS(status) != 128) {
+        LOG(error) << "Merger process exited with abnormal exit status " << WEXITSTATUS(status);
         errored = true;
       }
     } else if (WIFSIGNALED(status)) {


### PR DESCRIPTION
* Fixes a bug where the primary vertices were uninitialized in the last timeframe of a MC job.
* Smaller improvement in exit code handling in o2-sim