### PR TITLE
AOD: TrackQA use outer ITS ref. for residuals to TPC

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2717,7 +2717,7 @@ AODProducerWorkflowDPL::TrackQA AODProducerWorkflowDPL::processBarrelTrackQA(int
     if (auto itsContGID = data.getITSContributorGID(trackIndex); itsContGID.isIndexSet() && itsContGID.getSource() != GIndex::ITSAB) {
       const auto& itsOrig = data.getITSTrack(itsContGID);
       o2::track::TrackPar gloCopy = trackPar;
-      o2::track::TrackPar itsCopy = itsOrig;
+      o2::track::TrackPar itsCopy = itsOrig.getParamOut();
       o2::track::TrackPar tpcCopy = tpcOrig;
       if (prop->propagateToX(gloCopy, o2::aod::track::trackQARefRadius, prop->getNominalBz(), o2::base::Propagator::MAX_SIN_PHI, o2::base::Propagator::MAX_STEP, mMatCorr) &&
           prop->propagateToAlphaX(tpcCopy, gloCopy.getAlpha(), o2::aod::track::trackQARefRadius, false, o2::base::Propagator::MAX_SIN_PHI, o2::base::Propagator::MAX_STEP, 1, mMatCorr) &&


### PR DESCRIPTION
@miranov25 after taking to @mpuccio and @hscheid, I realised that the current residuals are biased since they the take the innermost representation of the track while one should take the outermost one to compare to TPC.