### PR TITLE
TrackReference: possibility to have unknown DetectorID

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/TrackReference.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/TrackReference.h
@@ -171,7 +171,7 @@ class TrackReference
   float mTrackLength = 0; ///< track length from its origin in cm
   float mTof = 0;         ///< time of flight in cm
   Int_t mUserId = 0;      ///< optional Id defined by user
-  Int_t mDetectorId = 0;  ///< Detector Id
+  Int_t mDetectorId = -1; ///< sensitive Detector Id (-1 if unknown or in passive material)
   SimTrackStatus mStatus; ///< encoding the track status
 
   friend std::ostream& operator<<(std::ostream&, const TrackReference&);

--- a/Detectors/gconfig/src/StandardSteppingTrackRefHook.macro
+++ b/Detectors/gconfig/src/StandardSteppingTrackRefHook.macro
@@ -8,7 +8,7 @@ o2::steer::O2MCApplicationBase::TrackRefFcn trackRefHook() {
     if (vmc->IsTrackStop() && stack->currentTrackLeftTrackRef()) {
        // we add a stopping TrackRef when the current track already
        // registered previous TrackRefs
-       stack->addTrackReference(o2::TrackReference(*vmc, 0));
+       stack->addTrackReference(o2::TrackReference(*vmc, -1));
     }
   };
 }


### PR DESCRIPTION
We've been using 0 as detectorID in generic "Stopping" TrackReferences. Unfortunately, 0 is also the ID of the ITS sensitive detector according to o2::detectors::DetID class.
The commit changes this to using -1, where -1 means simply means "unknown".