### PR TITLE
Event mixing: Do not use arrow functions in groupTable

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2157,61 +2157,14 @@ void emptyColumnLabel();
 
 namespace row_helpers
 {
-template <soa::is_persistent_column... Cs>
-std::array<arrow::ChunkedArray*, sizeof...(Cs)> getArrowColumns(arrow::Table* table, framework::pack<Cs...>)
-{
-  return std::array<arrow::ChunkedArray*, sizeof...(Cs)>{o2::soa::getIndexFromLabel(table, Cs::columnLabel())...};
-}
-
-template <soa::is_persistent_column... Cs>
-std::array<std::shared_ptr<arrow::Array>, sizeof...(Cs)> getChunks(arrow::Table* table, framework::pack<Cs...>, uint64_t ci)
-{
-  return std::array<std::shared_ptr<arrow::Array>, sizeof...(Cs)>{o2::soa::getIndexFromLabel(table, Cs::columnLabel())->chunk(ci)...};
-}
-
-template <typename T, soa::is_persistent_column C>
-typename C::type getSingleRowData(arrow::Table* table, T& rowIterator, uint64_t ci = std::numeric_limits<uint64_t>::max(), uint64_t ai = std::numeric_limits<uint64_t>::max(), uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
-{
-  if (ci == std::numeric_limits<uint64_t>::max() || ai == std::numeric_limits<uint64_t>::max()) {
-    auto colIterator = static_cast<C>(rowIterator).getIterator();
-    ci = colIterator.mCurrentChunk;
-    ai = *(colIterator.mCurrentPos) - colIterator.mFirstIndex;
-  }
-  return std::static_pointer_cast<o2::soa::arrow_array_for_t<typename C::type>>(o2::soa::getIndexFromLabel(table, C::columnLabel())->chunk(ci))->raw_values()[ai];
-}
-
-template <typename T, soa::is_dynamic_column C>
-typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = std::numeric_limits<uint64_t>::max(), uint64_t ai = std::numeric_limits<uint64_t>::max(), uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
-{
-  if (globalIndex != std::numeric_limits<uint64_t>::max() && globalIndex != *std::get<0>(rowIterator.getIndices())) {
-    rowIterator.setCursor(globalIndex);
-  }
-  return rowIterator.template getDynamicColumn<C>();
-}
-
-template <typename T, soa::is_index_column C>
-typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = std::numeric_limits<uint64_t>::max(), uint64_t ai = std::numeric_limits<uint64_t>::max(), uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
-{
-  if (globalIndex != std::numeric_limits<uint64_t>::max() && globalIndex != *std::get<0>(rowIterator.getIndices())) {
-    rowIterator.setCursor(globalIndex);
-  }
-  return rowIterator.template getId<C>();
-}
-
-template <typename T, typename... Cs>
-std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, uint64_t ci = std::numeric_limits<uint64_t>::max(), uint64_t ai = std::numeric_limits<uint64_t>::max(), uint64_t globalIndex = std::numeric_limits<uint64_t>::max())
-{
-  return std::make_tuple(getSingleRowData<T, Cs>(table, rowIterator, ci, ai, globalIndex)...);
-}
-
-namespace
-{
 template <typename R, typename T, typename C>
 R getColumnValue(const T& rowIterator)
 {
   return static_cast<R>(static_cast<C>(rowIterator).get());
 }
 
+namespace
+{
 template <typename R, typename T>
 using ColumnGetterFunction = R (*)(const T&);
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2186,7 +2186,7 @@ typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = s
   if (globalIndex != std::numeric_limits<uint64_t>::max() && globalIndex != *std::get<0>(rowIterator.getIndices())) {
     rowIterator.setCursor(globalIndex);
   }
-  return static_cast<C>(rowIterator).get();
+  return rowIterator.template getDynamicColumn<C>();
 }
 
 template <typename T, soa::is_index_column C>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2186,7 +2186,7 @@ typename C::type getSingleRowData(arrow::Table*, T& rowIterator, uint64_t ci = s
   if (globalIndex != std::numeric_limits<uint64_t>::max() && globalIndex != *std::get<0>(rowIterator.getIndices())) {
     rowIterator.setCursor(globalIndex);
   }
-  return rowIterator.template getDynamicColumn<C>();
+  return static_cast<C>(rowIterator).get();
 }
 
 template <typename T, soa::is_index_column C>

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -78,11 +78,6 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 {
   std::vector<BinningIndex> groupedIndices;
 
-  // TODO: Check if this check can be now skipped
-  if (table.size() == 0) {
-    return groupedIndices;
-  }
-
   for(auto rowIterator : table) {
       auto values = binningPolicy.getBinningValues(rowIterator);
       auto val = binningPolicy.getBin(values);

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -78,12 +78,12 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 {
   std::vector<BinningIndex> groupedIndices;
 
-  for(auto rowIterator : table) {
-      auto values = binningPolicy.getBinningValues(rowIterator);
-      auto val = binningPolicy.getBin(values);
-      if (val != outsider) {
-        groupedIndices.emplace_back(val, *std::get<1>(rowIterator.getIndices()));
-      }
+  for (auto rowIterator : table) {
+    auto values = binningPolicy.getBinningValues(rowIterator);
+    auto val = binningPolicy.getBin(values);
+    if (val != outsider) {
+      groupedIndices.emplace_back(val, *std::get<1>(rowIterator.getIndices()));
+    }
   }
 
   // Do a stable sort so that same categories entries are

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -76,77 +76,19 @@ void dataSizeVariesBetweenColumns();
 template <template <typename... Cs> typename BP, typename T, typename... Cs>
 std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPolicy, int minCatSize, int outsider)
 {
-  arrow::Table* arrowTable = table.asArrowTable().get();
-  auto rowIterator = table.begin();
-
-  uint64_t ind = 0;
-  uint64_t selInd = 0;
-  gsl::span<int64_t const> selectedRows;
   std::vector<BinningIndex> groupedIndices;
 
-  // Separate check to account for Filtered size different from arrow table
+  // TODO: Check if this check can be now skipped
   if (table.size() == 0) {
     return groupedIndices;
   }
 
-  if constexpr (soa::is_filtered_table<T>) {
-    selectedRows = table.getSelectedRows(); // vector<int64_t>
-  }
-
-  auto persistentColumns = typename BP<Cs...>::persistent_columns_t{};
-  constexpr auto persistentColumnsCount = pack_size(persistentColumns);
-  auto arrowColumns = o2::soa::row_helpers::getArrowColumns(arrowTable, persistentColumns);
-  auto chunksCount = arrowColumns[0]->num_chunks();
-  for (int i = 1; i < persistentColumnsCount; i++) {
-    if (arrowColumns[i]->num_chunks() != chunksCount) {
-      dataSizeVariesBetweenColumns();
-    }
-  }
-
-  for (uint64_t ci = 0; ci < chunksCount; ++ci) {
-    auto chunks = o2::soa::row_helpers::getChunks(arrowTable, persistentColumns, ci);
-    auto chunkLength = std::get<0>(chunks)->length();
-    for_<persistentColumnsCount - 1>([&chunks, &chunkLength](auto i) {
-      if (std::get<i.value + 1>(chunks)->length() != chunkLength) {
-        dataSizeVariesBetweenColumns();
-      }
-    });
-
-    if constexpr (soa::is_filtered_table<T>) {
-      if (selectedRows[ind] >= selInd + chunkLength) {
-        selInd += chunkLength;
-        continue; // Go to the next chunk, no value selected in this chunk
-      }
-    }
-
-    uint64_t ai = 0;
-    while (ai < chunkLength) {
-      if constexpr (soa::is_filtered_table<T>) {
-        ai += selectedRows[ind] - selInd;
-        selInd = selectedRows[ind];
-      }
-
-      auto values = binningPolicy.getBinningValues(rowIterator, arrowTable, ci, ai, ind);
+  for(auto rowIterator : table) {
+      auto values = binningPolicy.getBinningValues(rowIterator);
       auto val = binningPolicy.getBin(values);
       if (val != outsider) {
-        groupedIndices.emplace_back(val, ind);
+        groupedIndices.emplace_back(val, *std::get<1>(rowIterator.getIndices()));
       }
-      ind++;
-
-      if constexpr (soa::is_filtered_table<T>) {
-        if (ind >= selectedRows.size()) {
-          break;
-        }
-      } else {
-        ai++;
-      }
-    }
-
-    if constexpr (soa::is_filtered_table<T>) {
-      if (ind == selectedRows.size()) {
-        break;
-      }
-    }
   }
 
   // Do a stable sort so that same categories entries are

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -243,13 +243,13 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   template <typename T, typename T2>
   auto getBinningValue(T& rowIterator, uint64_t globalIndex = -1) const
   {
+    if (globalIndex != -1) {
+      rowIterator.setCursor(globalIndex);
+    }
     if constexpr (has_type<T2>(pack<Ls...>{})) {
-      if (globalIndex != -1) {
-        rowIterator.setCursor(globalIndex);
-      }
       return std::get<T2>(mBinningFunctions)(rowIterator);
     } else {
-      return soa::row_helpers::getSingleRowData<T, T2>(rowIterator, globalIndex);
+      return soa::row_helpers::getColumnValue<typename T2::type, T, T2>(rowIterator);
     }
   }
 
@@ -286,7 +286,10 @@ struct ColumnBinningPolicy : BinningPolicyBase<sizeof...(Ts)> {
   template <typename T>
   auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(rowIterator, globalIndex)...);
+    if (globalIndex != -1) {
+      rowIterator.setCursor(globalIndex);
+    }
+    return std::make_tuple(soa::row_helpers::getColumnValue<typename Ts::type, T, Ts>(rowIterator)...);
   }
 
   template <typename T>
@@ -311,7 +314,10 @@ struct NoBinningPolicy {
   template <typename T>
   auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(rowIterator, globalIndex));
+    if (globalIndex != -1) {
+      rowIterator.setCursor(globalIndex);
+    }
+    return std::make_tuple(soa::row_helpers::getColumnValue<typename C::type, T, C>(rowIterator));
   }
 
   template <typename T>

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -260,7 +260,7 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
   {
     return getBinningValues(rowIterator, globalIndex);
   }
@@ -315,7 +315,7 @@ struct NoBinningPolicy {
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
   {
     return getBinningValues(rowIterator, globalIndex);
   }

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -241,7 +241,7 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
   }
 
   template <typename T, typename T2>
-  auto getBinningValue(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValue(T& rowIterator, uint64_t globalIndex = -1) const
   {
     if constexpr (has_type<T2>(pack<Ls...>{})) {
       if (globalIndex != -1) {
@@ -249,20 +249,20 @@ struct FlexibleBinningPolicy<std::tuple<Ls...>, Ts...> : BinningPolicyBase<sizeo
       }
       return std::get<T2>(mBinningFunctions)(rowIterator);
     } else {
-      return soa::row_helpers::getSingleRowData<T, T2>(table, rowIterator, ci, ai, globalIndex);
+      return soa::row_helpers::getSingleRowData<T, T2>(rowIterator, globalIndex);
     }
   }
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(getBinningValue<T, Ts>(rowIterator, table, ci, ai, globalIndex)...);
+    return std::make_tuple(getBinningValue<T, Ts>(rowIterator, globalIndex)...);
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
+    return getBinningValues(rowIterator, globalIndex);
   }
 
   template <typename... T2s>
@@ -284,15 +284,15 @@ struct ColumnBinningPolicy : BinningPolicyBase<sizeof...(Ts)> {
   }
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(table, rowIterator, ci, ai, globalIndex)...);
+    return std::make_tuple(soa::row_helpers::getSingleRowData<T, Ts>(rowIterator, globalIndex)...);
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
+    return getBinningValues(rowIterator, globalIndex);
   }
 
   int getBin(std::tuple<typename Ts::type...> const& data) const
@@ -309,15 +309,15 @@ struct NoBinningPolicy {
   NoBinningPolicy() = default;
 
   template <typename T>
-  auto getBinningValues(T& rowIterator, arrow::Table* table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(T& rowIterator, uint64_t globalIndex = -1) const
   {
-    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(table, rowIterator, ci, ai, globalIndex));
+    return std::make_tuple(soa::row_helpers::getSingleRowData<T, C>(rowIterator, globalIndex));
   }
 
   template <typename T>
-  auto getBinningValues(typename T::iterator rowIterator, T& table, uint64_t ci = -1, uint64_t ai = -1, uint64_t globalIndex = -1) const
+  auto getBinningValues(typename T::iterator rowIterator, uint64_t globalIndex = -1) const
   {
-    return getBinningValues(rowIterator, table.asArrowTable().get(), ci, ai, globalIndex);
+    return getBinningValues(rowIterator, globalIndex);
   }
 
   int getBin(std::tuple<typename C::type> const& data) const


### PR DESCRIPTION
Rewrite groupTable() to use the O2 table iterators instead of manually iterating over Apache Arrow chunked columns.
Credits to @mytkom for the idea and most of the implementation.

It gives a 2x speed-up to the creation of a blocked combination policy -- see the results (mean of 5 benchmark runs) in the table below.
This does not affect the running time of creation of a combination generator and generation of combinations.

| Table size | Real time after the simplification (ns) | Real time before the simplification (ns) |
| ----------------| ----------------------------------------------------- | ---------------------------------------------------------- |
| 4 | 282.39 | 713.76
| 8 | 402.68 | 1,121.59
| 16 | 646.18 | 1,911.54
| 32 | 1,102.81 | 3,364.43
| 64 | 2,090.18 | 6,332.45
| 128 | 3,945.50 | 12,165.50
| 256 | 7,946.86 | 23,717.70
| 512 | 16,024.30 | 46,894.60
| 1024 | 32,856.40 | 95,093.30
| 2048 | 67,987.50 | 192,691.00
| 4096 | 150,429.00 | 392,947.00
| 8192 | 336,427.00 | 825,430.00
| 16384 | 716,285.00 | 1,674,110.00
| 32768 | 1,467,430.00 | 3,434,070.00
| 65536 | 3,011,900.00 | 6,886,320.00
| 131072 | 6,172,810.00 | 13,968,900.00
| 262144 | 12,517,400.00 | 28,290,700.00
| 524288 | 25,900,100.00 | 57,190,100.00
| 1048576 | 58,248,200.00 | 120,218,000.00
| 2097152 | 136,993,000.00 | 262,650,000.00

FYI @mytkom @chefxxx @MykhailoShamrai