### PR TITLE
HepMC: Remove default backgrounding mode

### DIFF
--- a/Generators/include/Generators/GeneratorFileOrCmdParam.h
+++ b/Generators/include/Generators/GeneratorFileOrCmdParam.h
@@ -35,7 +35,7 @@ struct GeneratorFileOrCmdParam : public o2::conf::ConfigurableParamHelper<Genera
   std::string seedSwitch = "-s";
   std::string bMaxSwitch = "-b";
   std::string nEventsSwitch = "-n";
-  std::string backgroundSwitch = "&";
+  std::string backgroundSwitch = ""; // SW: might not be relevant at all since we launch inside fork+exec
   O2ParamDef(GeneratorFileOrCmdParam, "GeneratorFileOrCmd");
 };
 


### PR DESCRIPTION
Removing the default & at the end of HepMC child processes. This should not be needed and actually leads to children be executed outside of the process tree of simulation. This in turn corrupts CPU and MEM monitoring in O2DPG MC workflows.

Changing default for now but maybe we can eventually get rid of this completely.