### PR TITLE
[CleanUp] Add fully qualified names for std::string and std::map

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -556,7 +556,7 @@ class CcdbApi //: public DatabaseInterface
    * @param tcl The TClass object describing the serialized type
    * @return raw pointer to created object
    */
-  void* downloadFilesystemContent(std::string const& fullUrl, std::type_info const& tinfo, std::map<string, string>* headers) const;
+  void* downloadFilesystemContent(std::string const& fullUrl, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const;
 
   // initialize the TGrid (Alien connection)
   bool initTGrid() const;

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -297,7 +297,7 @@ void CcdbApi::updateMetaInformationInLocalFile(std::string const& filename, std:
  */
 std::string sanitizeObjectName(const std::string& objectName)
 {
-  string tmpObjectName = objectName;
+  std::string tmpObjectName = objectName;
   tmpObjectName.erase(std::remove_if(tmpObjectName.begin(), tmpObjectName.end(),
                                      [](auto const& c) -> bool { return (!std::isalnum(c) && c != '_' && c != '/' && c != '.'); }),
                       tmpObjectName.end());
@@ -431,7 +431,7 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
     CURLcode res = CURL_LAST;
 
     for (size_t hostIndex = 0; hostIndex < hostsPool.size() && res > 0; hostIndex++) {
-      string fullUrl = getFullUrlForStorage(curl, path, objectType, metadata, sanitizedStartValidityTimestamp, sanitizedEndValidityTimestamp, hostIndex);
+      std::string fullUrl = getFullUrlForStorage(curl, path, objectType, metadata, sanitizedStartValidityTimestamp, sanitizedEndValidityTimestamp, hostIndex);
       LOG(debug3) << "Full URL Encoded: " << fullUrl;
       /* what URL that receives this POST */
       curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
@@ -476,30 +476,30 @@ int CcdbApi::storeAsTFile(const TObject* rootObject, std::string const& path, st
   return storeAsBinaryFile(img->data(), img->size(), info.getFileName(), info.getObjectType(), path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
 }
 
-string CcdbApi::getFullUrlForStorage(CURL* curl, const string& path, const string& objtype,
-                                     const map<string, string>& metadata,
-                                     long startValidityTimestamp, long endValidityTimestamp, int hostIndex) const
+std::string CcdbApi::getFullUrlForStorage(CURL* curl, const std::string& path, const std::string& objtype,
+                                          const std::map<std::string, std::string>& metadata,
+                                          long startValidityTimestamp, long endValidityTimestamp, int hostIndex) const
 {
   // Prepare timestamps
-  string startValidityString = getTimestampString(startValidityTimestamp < 0 ? getCurrentTimestamp() : startValidityTimestamp);
-  string endValidityString = getTimestampString(endValidityTimestamp < 0 ? getFutureTimestamp(60 * 60 * 24 * 1) : endValidityTimestamp);
+  std::string startValidityString = getTimestampString(startValidityTimestamp < 0 ? getCurrentTimestamp() : startValidityTimestamp);
+  std::string endValidityString = getTimestampString(endValidityTimestamp < 0 ? getFutureTimestamp(60 * 60 * 24 * 1) : endValidityTimestamp);
   // Get url
-  string url = getHostUrl(hostIndex);
+  std::string url = getHostUrl(hostIndex);
   // Build URL
-  string fullUrl = url + "/" + path + "/" + startValidityString + "/" + endValidityString + "/";
+  std::string fullUrl = url + "/" + path + "/" + startValidityString + "/" + endValidityString + "/";
   // Add type as part of metadata
   // we need to URL encode the object type, since in case it has special characters (like the "<", ">" for templated classes) it won't work otherwise
   char* objtypeEncoded = curl_easy_escape(curl, objtype.c_str(), objtype.size());
-  fullUrl += "ObjectType=" + string(objtypeEncoded) + "/";
+  fullUrl += "ObjectType=" + std::string(objtypeEncoded) + "/";
   curl_free(objtypeEncoded);
   // Add general metadata
   for (auto& kv : metadata) {
-    string mfirst = kv.first;
-    string msecond = kv.second;
+    std::string mfirst = kv.first;
+    std::string msecond = kv.second;
     // same trick for the metadata as for the object type
     char* mfirstEncoded = curl_easy_escape(curl, mfirst.c_str(), mfirst.size());
     char* msecondEncoded = curl_easy_escape(curl, msecond.c_str(), msecond.size());
-    fullUrl += string(mfirstEncoded) + "=" + string(msecondEncoded) + "/";
+    fullUrl += std::string(mfirstEncoded) + "=" + std::string(msecondEncoded) + "/";
     curl_free(mfirstEncoded);
     curl_free(msecondEncoded);
   }
@@ -507,26 +507,26 @@ string CcdbApi::getFullUrlForStorage(CURL* curl, const string& path, const strin
 }
 
 // todo make a single method of the one above and below
-string CcdbApi::getFullUrlForRetrieval(CURL* curl, const string& path, const map<string, string>& metadata, long timestamp, int hostIndex) const
+std::string CcdbApi::getFullUrlForRetrieval(CURL* curl, const std::string& path, const std::map<std::string, std::string>& metadata, long timestamp, int hostIndex) const
 {
   if (mInSnapshotMode) {
     return getSnapshotFile(mSnapshotTopPath, path);
   }
 
   // Prepare timestamps
-  string validityString = getTimestampString(timestamp < 0 ? getCurrentTimestamp() : timestamp);
+  std::string validityString = getTimestampString(timestamp < 0 ? getCurrentTimestamp() : timestamp);
   // Get host url
-  string hostUrl = getHostUrl(hostIndex);
+  std::string hostUrl = getHostUrl(hostIndex);
   // Build URL
-  string fullUrl = hostUrl + "/" + path + "/" + validityString + "/";
+  std::string fullUrl = hostUrl + "/" + path + "/" + validityString + "/";
   // Add metadata
   for (auto& kv : metadata) {
-    string mfirst = kv.first;
-    string msecond = kv.second;
+    std::string mfirst = kv.first;
+    std::string msecond = kv.second;
     // trick for the metadata in case it contains special characters
     char* mfirstEncoded = curl_easy_escape(curl, mfirst.c_str(), mfirst.size());
     char* msecondEncoded = curl_easy_escape(curl, msecond.c_str(), msecond.size());
-    fullUrl += string(mfirstEncoded) + "=" + string(msecondEncoded) + "/";
+    fullUrl += std::string(mfirstEncoded) + "=" + std::string(msecondEncoded) + "/";
     curl_free(mfirstEncoded);
     curl_free(msecondEncoded);
   }
@@ -755,7 +755,7 @@ bool CcdbApi::receiveObject(void* dataHolder, std::string const& path, std::map<
     CURLcode curlResultCode = CURL_LAST;
 
     for (size_t hostIndex = 0; hostIndex < hostsPool.size() && (responseCode >= 400 || curlResultCode > 0); hostIndex++) {
-      string fullUrl = getFullUrlForRetrieval(curlHandle, path, metadata, timestamp, hostIndex);
+      std::string fullUrl = getFullUrlForRetrieval(curlHandle, path, metadata, timestamp, hostIndex);
       curl_easy_setopt(curlHandle, CURLOPT_URL, fullUrl.c_str());
 
       curlResultCode = CURL_perform(curlHandle);
@@ -885,7 +885,7 @@ void CcdbApi::snapshot(std::string const& ccdbrootpath, std::string const& local
 {
   // query all subpaths to ccdbrootpath
   const auto allfolders = getAllFolders(ccdbrootpath);
-  std::map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
   for (auto& folder : allfolders) {
     retrieveBlob(folder, localDir, metadata, timestamp);
   }
@@ -977,7 +977,7 @@ bool CcdbApi::initTGrid() const
   return gGrid != nullptr;
 }
 
-void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info const& tinfo, std::map<string, string>* headers) const
+void* CcdbApi::downloadFilesystemContent(std::string const& url, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const
 {
   if ((url.find("alien:/", 0) != std::string::npos) && !initTGrid()) {
     return nullptr;
@@ -1016,7 +1016,7 @@ void* CcdbApi::interpretAsTMemFileAndExtract(char* contentptr, size_t contentsiz
 }
 
 // navigate sequence of URLs until TFile content is found; object is extracted and returned
-void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string const& url, std::type_info const& tinfo, std::map<string, string>* headers) const
+void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string const& url, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const
 {
   // a global internal data structure that can be filled with HTTP header information
   // static --> to avoid frequent alloc/dealloc as optimization
@@ -1164,7 +1164,7 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
 
   CURL* curl_handle = curl_easy_init();
   curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, mUniqueAgentID.c_str());
-  string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp); // todo check if function still works correctly in case mInSnapshotMode
+  std::string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp); // todo check if function still works correctly in case mInSnapshotMode
   // if we are in snapshot mode we can simply open the file; extract the object and return
   if (mInSnapshotMode) {
     auto res = extractFromLocalFile(fullUrl, tinfo, headers);
@@ -1218,8 +1218,8 @@ std::string CcdbApi::list(std::string const& path, bool latestOnly, std::string 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, mUniqueAgentID.c_str());
 
     struct curl_slist* headers = nullptr;
-    headers = curl_slist_append(headers, (string("Accept: ") + returnFormat).c_str());
-    headers = curl_slist_append(headers, (string("Content-Type: ") + returnFormat).c_str());
+    headers = curl_slist_append(headers, (std::string("Accept: ") + returnFormat).c_str());
+    headers = curl_slist_append(headers, (std::string("Content-Type: ") + returnFormat).c_str());
     if (createdNotAfter >= 0) {
       headers = curl_slist_append(headers, ("If-Not-After: " + std::to_string(createdNotAfter)).c_str());
     }
@@ -1230,7 +1230,7 @@ std::string CcdbApi::list(std::string const& path, bool latestOnly, std::string 
 
     curlSetSSLOptions(curl);
 
-    string fullUrl;
+    std::string fullUrl;
     // Perform the request, res will get the return code
     for (size_t hostIndex = 0; hostIndex < hostsPool.size() && res != CURLE_OK; hostIndex++) {
       fullUrl = getHostUrl(hostIndex);
@@ -1290,7 +1290,7 @@ void CcdbApi::truncate(std::string const& path) const
   CURLcode res;
   stringstream fullUrl;
   for (size_t i = 0; i < hostsPool.size(); i++) {
-    string url = getHostUrl(i);
+    std::string url = getHostUrl(i);
     fullUrl << url << "/truncate/" << path;
 
     curl = curl_easy_init();
@@ -1436,7 +1436,7 @@ std::map<std::string, std::string> CcdbApi::retrieveHeaders(std::string const& p
   auto do_remote_header_call = [this, &path, &metadata, timestamp]() -> std::map<std::string, std::string> {
     CURL* curl = curl_easy_init();
     CURLcode res = CURL_LAST;
-    string fullUrl = getFullUrlForRetrieval(curl, path, metadata, timestamp);
+    std::string fullUrl = getFullUrlForRetrieval(curl, path, metadata, timestamp);
     std::map<std::string, std::string> headers;
 
     if (curl != nullptr) {
@@ -1632,12 +1632,12 @@ int CcdbApi::updateMetadata(std::string const& path, std::map<std::string, std::
       fullUrl << "?";
 
       for (auto& kv : metadata) {
-        string mfirst = kv.first;
-        string msecond = kv.second;
+        std::string mfirst = kv.first;
+        std::string msecond = kv.second;
         // same trick for the metadata as for the object type
         char* mfirstEncoded = curl_easy_escape(curl, mfirst.c_str(), mfirst.size());
         char* msecondEncoded = curl_easy_escape(curl, msecond.c_str(), msecond.size());
-        fullUrl << string(mfirstEncoded) + "=" + string(msecondEncoded) + "&";
+        fullUrl << std::string(mfirstEncoded) + "=" + std::string(msecondEncoded) + "&";
         curl_free(mfirstEncoded);
         curl_free(msecondEncoded);
       }
@@ -1728,7 +1728,7 @@ void CcdbApi::scheduleDownload(RequestContext& requestContext, size_t* requestCo
 
   CURL* curl_handle = curl_easy_init();
   curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, mUniqueAgentID.c_str());
-  string fullUrl = getFullUrlForRetrieval(curl_handle, requestContext.path, requestContext.metadata, requestContext.timestamp);
+  std::string fullUrl = getFullUrlForRetrieval(curl_handle, requestContext.path, requestContext.metadata, requestContext.timestamp);
   curl_slist* options_list = nullptr;
   initCurlHTTPHeaderOptionsForRetrieve(curl_handle, options_list, requestContext.timestamp, &requestContext.headers,
                                        requestContext.etag, requestContext.createdNotAfter, requestContext.createdNotBefore);

--- a/CCDB/test/testBasicCCDBManager.cxx
+++ b/CCDB/test/testBasicCCDBManager.cxx
@@ -26,7 +26,7 @@
 
 using namespace o2::ccdb;
 
-static string basePath;
+static std::string basePath;
 std::string ccdbUrl = "http://ccdb-test.cern.ch:8080";
 bool hostReachable = false;
 
@@ -43,7 +43,7 @@ struct Fixture {
     std::cout << "Is host reachable ? --> " << hostReachable << std::endl;
     char hostname[_POSIX_HOST_NAME_MAX];
     gethostname(hostname, _POSIX_HOST_NAME_MAX);
-    basePath = string("Test/") + hostname + "/pid" + getpid() + "/BasicCCDBManager/";
+    basePath = std::string("Test/") + hostname + "/pid" + getpid() + "/BasicCCDBManager/";
     std::cout << "Path we will use in this test suite : " + basePath << std::endl;
   }
   ~Fixture()

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -45,8 +45,8 @@ using namespace o2::ccdb;
 namespace utf = boost::unit_test;
 namespace tt = boost::test_tools;
 
-static string ccdbUrl;
-static string basePath;
+static std::string ccdbUrl;
+static std::string basePath;
 bool hostReachable = false;
 
 /**
@@ -63,7 +63,7 @@ struct Fixture {
     cout << "Is host reachable ? --> " << hostReachable << endl;
     char hostname[_POSIX_HOST_NAME_MAX];
     gethostname(hostname, _POSIX_HOST_NAME_MAX);
-    basePath = string("Test/TestCcdbApi/") + hostname + "/pid" + getpid() + "/";
+    basePath = std::string("Test/TestCcdbApi/") + hostname + "/pid" + getpid() + "/";
     // Replace dashes by underscores to avoid problems in the creation of local directories
     std::replace(basePath.begin(), basePath.end(), '-','_');
     cout << "Path we will use in this test suite : " + basePath << endl;
@@ -72,7 +72,7 @@ struct Fixture {
   {
     if (hostReachable) {
       CcdbApi api;
-      map<string, string> metadata;
+      std::map<std::string, std::string> metadata;
       api.init(ccdbUrl);
       api.truncate(basePath + "*");
       cout << "Test data truncated (" << basePath << ")" << endl;
@@ -104,7 +104,7 @@ struct test_fixture {
   ~test_fixture() = default;
 
   CcdbApi api;
-  map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
 };
 
 BOOST_AUTO_TEST_CASE(storeTMemFile_test, *utf::precondition(if_reachable()))
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(store_retrieve_TMemFile_templated_test, *utf::precondition(
   BOOST_CHECK(f.api.retrieveFromTFileAny<o2::utils::RootChain>(basePath + "CCDBPath", f.metadata) == nullptr);
 
   // try to get the headers back and to find the metadata
-  map<string, string> md;
+  std::map<std::string, std::string> md;
   path2 = f.api.retrieveFromTFileAny<o2::ccdb::IdPath>(basePath + "CCDBPath", f.metadata, -1, &md);
   BOOST_CHECK_EQUAL(md.count("Hello"), 1);
   BOOST_CHECK_EQUAL(md["Hello"], "World");
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(delete_test, *utf::precondition(if_reachable()))
   BOOST_CHECK(h2 == nullptr);
 }
 
-void countItems(const string& s, int& countObjects, int& countSubfolders)
+void countItems(const std::string& s, int& countObjects, int& countSubfolders)
 {
   countObjects = 0;
   countSubfolders = 0;
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(list_test, *utf::precondition(if_reachable()))
   test_fixture f;
 
   // test non-empty top dir
-  string s = f.api.list("", "application/json"); // top dir
+  std::string s = f.api.list("", "application/json"); // top dir
   long nbLines = std::count(s.begin(), s.end(), '\n') + 1;
   BOOST_CHECK(nbLines > 5);
 
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(TestHeaderParsing)
 BOOST_AUTO_TEST_CASE(TestFetchingHeaders, *utf::precondition(if_reachable()))
 {
   // first store the object
-  string objectPath = basePath + "objectETag";
+  std::string objectPath = basePath + "objectETag";
   test_fixture f;
   TH1F h1("objectETag", "objectETag", 100, 0, 99);
   f.api.storeAsTFile(&h1, objectPath, f.metadata);
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE(TestFetchingHeaders, *utf::precondition(if_reachable()))
   std::string etag;
   std::vector<std::string> headers;
   std::vector<std::string> pfns;
-  string path = objectPath + "/" + std::to_string(getCurrentTimestamp());
+  std::string path = objectPath + "/" + std::to_string(getCurrentTimestamp());
   auto updated = CcdbApi::getCCDBEntryHeaders("http://ccdb-test.cern.ch:8080/" + path, etag, headers);
   BOOST_CHECK_EQUAL(updated, true);
   BOOST_REQUIRE(headers.size() != 0);
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE(TestRetrieveHeaders, *utf::precondition(if_reachable()))
 
   TH1F h1("object1", "object1", 100, 0, 99);
   cout << "storing object 1 in " << basePath << "Test" << endl;
-  map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
   metadata["custom"] = "whatever";
   f.api.storeAsTFile(&h1, basePath + "Test", metadata);
 
@@ -498,7 +498,7 @@ BOOST_AUTO_TEST_CASE(TestUpdateMetadata, *utf::precondition(if_reachable()))
   // upload an object
   TH1F h1("object1", "object1", 100, 0, 99);
   cout << "storing object 1 in " << basePath << "Test" << endl;
-  map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
   metadata["custom"] = "whatever";
   metadata["id"] = "first";
   f.api.storeAsTFile(&h1, basePath + "Test", metadata);
@@ -507,10 +507,10 @@ BOOST_AUTO_TEST_CASE(TestUpdateMetadata, *utf::precondition(if_reachable()))
   std::map<std::string, std::string> headers = f.api.retrieveHeaders(basePath + "Test", metadata);
   BOOST_CHECK(headers.count("custom") > 0);
   BOOST_CHECK(headers.at("custom") == "whatever");
-  string firstID = headers.at("ETag");
+  std::string firstID = headers.at("ETag");
   firstID.erase(std::remove(firstID.begin(), firstID.end(), '"'), firstID.end());
 
-  map<string, string> newMetadata;
+  std::map<std::string, std::string> newMetadata;
   newMetadata["custom"] = "somethingelse";
 
   // update the metadata and check
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(TestUpdateMetadata, *utf::precondition(if_reachable()))
   // get id
   cout << "get id" << endl;
   headers = f.api.retrieveHeaders(basePath + "Test", metadata);
-  string secondID = headers.at("ETag");
+  std::string secondID = headers.at("ETag");
   secondID.erase(std::remove(secondID.begin(), secondID.end(), '"'), secondID.end());
 
   // update the metadata by id

--- a/CCDB/test/testCcdbApiMultipleUrls.cxx
+++ b/CCDB/test/testCcdbApiMultipleUrls.cxx
@@ -24,8 +24,8 @@ using namespace o2::ccdb;
 namespace utf = boost::unit_test;
 namespace tt = boost::test_tools;
 
-static string ccdbUrl;
-static string basePath;
+static std::string ccdbUrl;
+static std::string basePath;
 bool hostReachable = false;
 
 /**
@@ -40,14 +40,14 @@ struct Fixture {
     cout << "ccdb url: " << ccdbUrl << endl;
     hostReachable = api.isHostReachable();
     cout << "Is host reachable ? --> " << hostReachable << endl;
-    basePath = string("Test/pid") + getpid() + "/";
+    basePath = std::string("Test/pid") + getpid() + "/";
     cout << "Path we will use in this test suite : " + basePath << endl;
   }
   ~Fixture()
   {
     if (hostReachable) {
       CcdbApi api;
-      map<string, string> metadata;
+      std::map<std::string, std::string> metadata;
       api.init(ccdbUrl);
       api.truncate(basePath + "*");
       cout << "Test data truncated (" << basePath << ")" << endl;
@@ -79,7 +79,7 @@ struct test_fixture {
   ~test_fixture() = default;
 
   CcdbApi api;
-  map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
 };
 
 BOOST_AUTO_TEST_CASE(storeAndRetrieve, *utf::precondition(if_reachable()))

--- a/CCDB/test/testCcdbApi_ConfigParam.cxx
+++ b/CCDB/test/testCcdbApi_ConfigParam.cxx
@@ -47,8 +47,8 @@ using namespace o2::ccdb;
 namespace utf = boost::unit_test;
 namespace tt = boost::test_tools;
 
-static string ccdbUrl;
-static string basePath;
+static std::string ccdbUrl;
+static std::string basePath;
 bool hostReachable = false;
 
 /**
@@ -64,14 +64,14 @@ struct Fixture {
     hostReachable = api.isHostReachable();
     char hostname[_POSIX_HOST_NAME_MAX];
     gethostname(hostname, _POSIX_HOST_NAME_MAX);
-    basePath = string("Test/") + hostname + "/pid" + getpid() + "/";
+    basePath = std::string("Test/") + hostname + "/pid" + getpid() + "/";
     cout << "Path we will use in this test suite : " + basePath << endl;
   }
   ~Fixture()
   {
     if (hostReachable) {
       CcdbApi api;
-      map<string, string> metadata;
+      std::map<std::string, std::string> metadata;
       api.init(ccdbUrl);
       api.truncate(basePath + "*");
       cout << "Test data truncated (" << basePath << ")" << endl;
@@ -103,7 +103,7 @@ struct test_fixture {
   ~test_fixture() = default;
 
   CcdbApi api;
-  map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
 };
 
 BOOST_AUTO_TEST_CASE(testConfigParamRetrieval, *utf::precondition(if_reachable()))

--- a/CCDB/test/testCcdbApi_alien.cxx
+++ b/CCDB/test/testCcdbApi_alien.cxx
@@ -29,7 +29,7 @@ using namespace o2::ccdb;
 namespace utf = boost::unit_test;
 namespace tt = boost::test_tools;
 
-static string ccdbUrl;
+static std::string ccdbUrl;
 bool hostReachable = false;
 
 /**
@@ -71,7 +71,7 @@ struct test_fixture {
   ~test_fixture() = default;
 
   CcdbApi api;
-  map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
 };
 
 // handle the case where the object comes from alien and redirect does not work with curl

--- a/DataFormats/Detectors/CTP/src/CTPRateFetcher.cxx
+++ b/DataFormats/Detectors/CTP/src/CTPRateFetcher.cxx
@@ -254,7 +254,7 @@ void CTPRateFetcher::setupRun(int runNumber, o2::ccdb::BasicCCDBManager* ccdb, u
     return;
   }
   mLHCIFdata = *ptrLHCIFdata;
-  std::map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
   metadata["runNumber"] = std::to_string(mRunNumber);
   auto ptrConfig = ccdb->getSpecific<ctp::CTPConfiguration>("CTP/Config/Config", timeStamp, metadata);
   if (ptrConfig == nullptr) {

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1674,11 +1674,11 @@ void AODProducerWorkflowDPL::init(InitContext& ic)
 {
   mTimer.Stop();
   o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
-  mLPMProdTag = ic.options().get<string>("lpmp-prod-tag");
-  mAnchorPass = ic.options().get<string>("anchor-pass");
-  mAnchorProd = ic.options().get<string>("anchor-prod");
-  mUser = ic.options().get<string>("created-by");
-  mRecoPass = ic.options().get<string>("reco-pass");
+  mLPMProdTag = ic.options().get<std::string>("lpmp-prod-tag");
+  mAnchorPass = ic.options().get<std::string>("anchor-pass");
+  mAnchorProd = ic.options().get<std::string>("anchor-prod");
+  mUser = ic.options().get<std::string>("created-by");
+  mRecoPass = ic.options().get<std::string>("reco-pass");
   mTFNumber = ic.options().get<int64_t>("aod-timeframe-id");
   mRecoOnly = ic.options().get<int>("reco-mctracks-only");
   mTruncate = ic.options().get<int>("enable-truncation");

--- a/Detectors/CPV/calib/macros/makeBadMapFromPedestalRun.C
+++ b/Detectors/CPV/calib/macros/makeBadMapFromPedestalRun.C
@@ -75,7 +75,7 @@ void makeBadMapFromPedestalRun(const char* ccdbURI = "http://ccdb-test.cern.ch:8
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdbURI);            // or http://localhost:8080 for a local installation
   api.storeAsTFileAny(&badMap, "CPV/Calib/BadChannelMap", metadata, timeStamp, timeStamp + 31536000000);
 }

--- a/Detectors/CTP/macro/GetAndSave.C
+++ b/Detectors/CTP/macro/GetAndSave.C
@@ -44,7 +44,7 @@ void GetAndSave(std::string ccdbHost = "http://ccdb-test.cern.ch:8080")
   for (auto const& run : runs) {
     CTPConfiguration ctpcfg;
     CTPRunScalers scl;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     metadata["runNumber"] = run;
     CTPRunScalers* ctpscalers = mgr.getSpecific<CTPRunScalers>(CCDBPathCTPScalers, timestamps[i], metadata);
     if (ctpscalers == nullptr) {

--- a/Detectors/CTP/macro/SaveInputsConfig.C
+++ b/Detectors/CTP/macro/SaveInputsConfig.C
@@ -41,7 +41,7 @@ void SaveInputsConfig(std::string filename = "inputs.cfg", std::string ccdbHost 
   long tmax = timeStamp + time365days;
   o2::ccdb::CcdbApi api;
   api.init(ccdbHost);           // or http://localhost:8080 for a local installation
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   // store abitrary user object in strongly typed manner
   api.storeAsTFileAny(&ctpcfginps, "CTP/Calib/Inputs", metadata, tmin, tmax);
 }

--- a/Detectors/CTP/macro/TestFetcher.C
+++ b/Detectors/CTP/macro/TestFetcher.C
@@ -27,7 +27,7 @@ void TestFetcher(int runNumber = 557251)
   fetcher.setupRun(runNumber, &ccdb, ts, 0);
   ccdb.setURL("http://ali-qcdb-gpn.cern.ch:8083/");
   std::string QCDBPathCTPScalers = "qc/CTP/Scalers";
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   std::string run = std::to_string(runNumber);
   metadata["runNumber"] = run;
   CTPRunScalers* ctpscalers = ccdb.getSpecific<CTPRunScalers>(QCDBPathCTPScalers, ts, metadata);

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -194,7 +194,7 @@ o2::ctp::CTPConfiguration* Digitizer::getDefaultCTPConfiguration()
   }
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setURL(mCCDBServer);
-  map<string, string> metadata = {};
+  std::map<std::string, std::string> metadata = {};
   long timestamp = 1546300800000;
 
   auto config = mgr.getSpecific<CTPConfiguration>(o2::ctp::CCDBPathCTPConfig, timestamp, metadata);

--- a/Detectors/CTP/workflowScalers/src/ctpCCDBManager.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctpCCDBManager.cxx
@@ -40,7 +40,7 @@ int ctpCCDBManager::saveRunScalersToCCDB(CTPRunScalers& scalers, long timeStart,
   long tmin = timeStart - time10min;
   long tmax = timeStop + time3days;
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = std::to_string(scalers.getRunNumber());
   api.init(mCCDBHost.c_str()); // or http://localhost:8080 for a local installation
   // store abitrary user object in strongly typed manner
@@ -68,7 +68,7 @@ int ctpCCDBManager::saveRunScalersToQCDB(CTPRunScalers& scalers, long timeStart,
   long tmin = timeStart - time10min;
   long tmax = timeStop + time3days;
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = std::to_string(scalers.getRunNumber());
   api.init(mQCDBHost.c_str()); // or http://localhost:8080 for a local installation
   // store abitrary user object in strongly typed manner
@@ -95,7 +95,7 @@ int ctpCCDBManager::saveRunConfigToCCDB(CTPConfiguration* cfg, long timeStart)
   long tmin = timeStart - time10min;
   long tmax = timeStart + time3days;
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = std::to_string(cfg->getRunNumber());
   api.init(mCCDBHost.c_str()); // or http://localhost:8080 for a local installation
   // store abitrary user object in strongly typed manner
@@ -125,7 +125,7 @@ int ctpCCDBManager::saveSoxOrbit(uint32_t runNumber, uint32_t soxOrbit, long tim
   long tmin = timestamp / 1000;
   long tmax = tmin + 381928219;
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = std::to_string(runNumber);
   api.init(mCCDBHost.c_str()); // or http://localhost:8080 for a local installation
 
@@ -155,7 +155,7 @@ int ctpCCDBManager::saveOrbitReset(long timeStamp)
   long tmin = timeStamp / 1000;
   long tmax = tmin + 381928219;
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(mCCDBHost.c_str());  // or http://localhost:8080 for a local installation
 
   // store abitrary user object in strongly typed manner
@@ -184,7 +184,7 @@ int ctpCCDBManager::saveCtpCfg(uint32_t runNumber, long timeStart)
     long tmin = timeStart - time10min;
     long tmax = timeStart + time3days;
     o2::ccdb::CcdbApi api;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     metadata["runNumber"] = std::to_string(runNumber);
     api.init(mCCDBHost.c_str()); // or http://localhost:8080 for a local installation
     // store abitrary user object in strongly typed manner
@@ -201,7 +201,7 @@ CTPConfiguration ctpCCDBManager::getConfigFromCCDB(long timestamp, std::string r
 {
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setURL(mCCDBHost);
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = run;
   auto ctpconfigdb = mgr.getSpecific<CTPConfiguration>(CCDBPathCTPConfig, timestamp, metadata);
   if (ctpconfigdb == nullptr) {
@@ -228,7 +228,7 @@ CTPRunScalers ctpCCDBManager::getScalersFromCCDB(long timestamp, std::string run
 {
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setURL(mCCDBHost);
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = run;
   auto ctpscalers = mgr.getSpecific<CTPRunScalers>(mCCDBPathCTPScalers, timestamp, metadata);
   if (ctpscalers == nullptr) {

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -1790,7 +1790,7 @@ void Geometry::SetMisalMatrixFromCcdb(const char* path, int timestamp) const
 {
   LOG(info) << "Using CCDB to obtain EMCal alignment.";
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init("http://alice-ccdb.cern.ch");
   TObjArray* matrices = api.retrieveFromTFileAny<TObjArray>(path, metadata, timestamp);
 

--- a/Detectors/FIT/FT0/macros/FT0Misaligner.C
+++ b/Detectors/FIT/FT0/macros/FT0Misaligner.C
@@ -55,7 +55,7 @@ void FT0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
     std::string path = objectPath.empty() ? o2::base::DetectorNameConf::getAlignmentPath(detFT0) : objectPath;
     LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
     // store abitrary user object in strongly typed manner
     api.storeAsTFileAny(&params, path, metadata, tmin, tmax);

--- a/Detectors/FIT/FV0/calibration/macros/readChannelTimeOffsetFV0CalibObjectFromCCDB.C
+++ b/Detectors/FIT/FV0/calibration/macros/readChannelTimeOffsetFV0CalibObjectFromCCDB.C
@@ -22,8 +22,8 @@ int readChannelTimeOffsetFV0CalibObjectFromCCDB(const std::string url = "http://
 {
   o2::ccdb::CcdbApi api;
   api.init(url);
-  map<string, string> metadata;
-  map<string, string> headers;
+  std::map<std::string, std::string> metadata;
+  std::map<std::string, std::string> headers;
   auto retrieved = api.retrieveFromTFileAny<o2::fv0::FV0ChannelTimeCalibrationObject>("FV0/Calib/ChannelTimeOffset", metadata, -1, &headers);
 
   std::cout << "--- HEADERS ---" << std::endl;

--- a/Detectors/FIT/FV0/macros/FV0Misaligner.C
+++ b/Detectors/FIT/FV0/macros/FV0Misaligner.C
@@ -54,7 +54,7 @@ void FV0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
     std::string path = objectPath.empty() ? o2::base::DetectorNameConf::getAlignmentPath(detFV0) : objectPath;
     LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
     // store abitrary user object in strongly typed manner
     api.storeAsTFileAny(&params, path, metadata, tmin, tmax);

--- a/Detectors/FIT/common/dcsmonitoring/include/FITDCSMonitoring/FITDCSConfigProcessorSpec.h
+++ b/Detectors/FIT/common/dcsmonitoring/include/FITDCSMonitoring/FITDCSConfigProcessorSpec.h
@@ -47,7 +47,7 @@ class FITDCSConfigProcessor : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final
   {
     initDCSConfigReader();
-    mDCSConfigReader->setFileNameDChM(ic.options().get<string>("filename-dchm"));
+    mDCSConfigReader->setFileNameDChM(ic.options().get<std::string>("filename-dchm"));
     mDCSConfigReader->setValidDaysDChM(ic.options().get<uint>("valid-days-dchm"));
     mDCSConfigReader->setCcdbPathDChM(mDetectorName + "/Calib/DeadChannelMap");
     mVerbose = ic.options().get<bool>("use-verbose-mode");

--- a/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
+++ b/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
@@ -277,13 +277,13 @@ bool GRPDCSDPsProcessor::processLHCIFDPs(const DPCOM& dpcom)
   }
 
   for (int ibeam = 0; ibeam < GRPLHCInfo::BeamAliases::NBeamAliases; ++ibeam) {
-    if (aliasStr.find(static_cast<std::string>(GRPLHCInfo::beamAliases[ibeam])) != string::npos) {
+    if (aliasStr.find(static_cast<std::string>(GRPLHCInfo::beamAliases[ibeam])) != std::string::npos) {
       updateVector(dpid, mLHCInfo.mIntensityBeam[ibeam], aliasStr, dpcomdata.get_epoch_time(), val);
       return true;
     }
   }
 
-  if (aliasStr.find("BPTX") != string::npos) {
+  if (aliasStr.find("BPTX") != std::string::npos) {
     if (aliasStr == static_cast<std::string>(GRPLHCInfo::bptxAliases[GRPLHCInfo::BPTXAliases::BPTX_deltaT_B1_B2])) {
       updateVector(dpid, mLHCInfo.mBPTXdeltaT, aliasStr, dpcomdata.get_epoch_time(), val);
       return true;
@@ -318,7 +318,7 @@ bool GRPDCSDPsProcessor::processLHCIFDPs(const DPCOM& dpcom)
   }
 
   for (int ibkg = 0; ibkg < 3; ++ibkg) {
-    if (aliasStr.find(static_cast<std::string>(GRPLHCInfo::bkgAliases[ibkg])) != string::npos) {
+    if (aliasStr.find(static_cast<std::string>(GRPLHCInfo::bkgAliases[ibkg])) != std::string::npos) {
       updateVector(dpid, mLHCInfo.mBackground[ibkg], aliasStr, dpcomdata.get_epoch_time(), val);
       return true;
     }

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -268,10 +268,10 @@ int main(int argc, char** argv)
     add_option("run,r", bpo::value<int>(), "run number");
     add_option("run-type,t", bpo::value<int>()->default_value(int(GRPECSObject::RunType::NONE)), "run type");
     add_option("hbf-per-tf,n", bpo::value<int>()->default_value(128), "number of HBFs per TF");
-    add_option("detectors,d", bpo::value<string>()->default_value("all"), "comma separated list of detectors");
-    add_option("continuous,c", bpo::value<string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");
-    add_option("triggering,g", bpo::value<string>()->default_value("FT0,FV0"), "comma separated list of detectors providing a trigger");
-    add_option("flps,f", bpo::value<string>()->default_value(""), "comma separated list of FLPs in the data taking");
+    add_option("detectors,d", bpo::value<std::string>()->default_value("all"), "comma separated list of detectors");
+    add_option("continuous,c", bpo::value<std::string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");
+    add_option("triggering,g", bpo::value<std::string>()->default_value("FT0,FV0"), "comma separated list of detectors providing a trigger");
+    add_option("flps,f", bpo::value<std::string>()->default_value(""), "comma separated list of FLPs in the data taking");
     add_option("start-time,s", bpo::value<long>()->default_value(0), "ECS run start time in ms, now() if 0");
     add_option("end-time,e", bpo::value<long>()->default_value(0), "ECS run end time in ms, start-time+3days is used if 0");
     add_option("start-time-ctp", bpo::value<long>()->default_value(0), "run start CTP time in ms, same as ECS if not set or 0");
@@ -279,7 +279,7 @@ int main(int argc, char** argv)
     add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
     add_option("ccdb-server-input", bpo::value<std::string>()->default_value(""), "CCDB server for inputs (if needed, e.g. CTPConfig), dy default ccdb-server is used");
     add_option("meta-data,m", bpo::value<std::string>()->default_value("")->implicit_value(""), "metadata as key1=value1;key2=value2;..");
-    add_option("refresh", bpo::value<string>()->default_value("")->implicit_value("async"), R"(refresh server cache after upload: "none" (or ""), "async" (non-blocking) and "sync" (blocking))");
+    add_option("refresh", bpo::value<std::string>()->default_value("")->implicit_value("async"), R"(refresh server cache after upload: "none" (or ""), "async" (non-blocking) and "sync" (blocking))");
     add_option("marginSOR", bpo::value<long>()->default_value(4 * o2::ccdb::CcdbObjectInfo::DAY), "validity at SOR");
     add_option("marginEOR", bpo::value<long>()->default_value(10 * o2::ccdb::CcdbObjectInfo::MINUTE), "validity margin to add after EOR");
     add_option("original-run,o", bpo::value<int>()->default_value(0), "if >0, use as the source run to create CTP/Config/Config object");
@@ -313,7 +313,7 @@ int main(int argc, char** argv)
     std::cerr << opt_general << std::endl;
     exit(3);
   }
-  std::string refreshStr = vm["refresh"].as<string>();
+  std::string refreshStr = vm["refresh"].as<std::string>();
   CCDBRefreshMode refresh = CCDBRefreshMode::NONE;
   if (!refreshStr.empty() && refreshStr != "none") {
     if (refreshStr == "async") {

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
@@ -43,7 +43,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   bool writeUnbinnedResiduals = false;
   bool writeBinnedResiduals = false;
   bool writeTrackData = false;
-  auto outputType = configcontext.options().get<string>("output-type");
+  auto outputType = configcontext.options().get<std::string>("output-type");
   std::vector<std::string> outputTypes;
   size_t pos = 0;
   while ((pos = outputType.find(",")) != std::string::npos) {

--- a/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
+++ b/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
@@ -210,7 +210,7 @@ void TestDataReader::run(ProcessingContext& pc)
 
     size_t pos = mNowFolderNames[i].find_last_of("/");
 
-    if (pos != string::npos) {
+    if (pos != std::string::npos) {
       mRunID = mNowFolderNames[i].substr(pos + 1);
     }
 
@@ -232,7 +232,7 @@ void TestDataReader::run(ProcessingContext& pc)
       // Getting the FileID
       string FileIDS;
       pos = mDiffFileNames[i][0].find_last_of("/");
-      if (pos != string::npos) {
+      if (pos != std::string::npos) {
         FileIDS = mDiffFileNames[i][0].substr(pos + 1);
       }
 

--- a/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
+++ b/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
@@ -78,7 +78,7 @@ void ITSMisaligner(const std::string& ccdbHost = "http://localhost:8080", long t
     std::string path = objectPath.empty() ? o2::base::DetectorNameConf::getAlignmentPath(detITS) : objectPath;
     LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
     // store abitrary user object in strongly typed manner
     api.storeAsTFileAny(&params, path, metadata, tmin, tmax);

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -136,7 +136,7 @@ class ITSDCSParser : public Task
   std::string mCcdbUrl = "";
 
   // Vector containing all the staves listed in the EOR file
-  std::vector<string> mSavedStaves = {};
+  std::vector<std::string> mSavedStaves = {};
 
   // Disabled chip map
   o2::itsmft::NoiseMap mDeadMap;

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -386,9 +386,9 @@ void ITSDCSParser::saveToOutput()
 void ITSDCSParser::saveMissingToOutput()
 {
   // Loop on the missing staves
-  std::vector<string> missingStaves;
-  std::vector<string> listStaves = this->listStaves();
-  std::vector<string> savedStaves = this->mSavedStaves;
+  std::vector<std::string> missingStaves;
+  std::vector<std::string> listStaves = this->listStaves();
+  std::vector<std::string> savedStaves = this->mSavedStaves;
   std::sort(savedStaves.begin(), savedStaves.end());
   std::set_difference(listStaves.begin(), listStaves.end(), savedStaves.begin(), savedStaves.end(),
                       std::inserter(missingStaves, missingStaves.begin()));
@@ -557,7 +557,7 @@ std::vector<std::string> ITSDCSParser::listStaves()
   std::string stavenum = "";
   for (int i = 0; i < 7; i++) {
     for (int j = 0; j < stavesPerLayer[i]; j++) {
-      string stavestring = std::to_string(j);
+      std::string stavestring = std::to_string(j);
       int precision = 2 - std::min(2, (int)(stavestring.size()));
       stavenum = std::string(precision, '0').append(std::to_string(j));
       std::string stave = "L" + std::to_string(i) + "_" + stavenum;

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
@@ -299,8 +299,8 @@ void NoiseCalibratorSpec::sendOutputCcdbMerge(DataAllocator& output)
 
   auto payload = mCalibrator->getNoiseMap();
   //  const auto& payload = mCalibrator->getNoiseMap(starTF, endTF); //For TimeSlot calibration
-  map<string, string> headers;
-  map<std::string, std::string> filter;
+  std::map<std::string, std::string> headers;
+  std::map<std::string, std::string> filter;
   auto* payloadPrev1 = api.retrieveFromTFileAny<o2::itsmft::NoiseMap>(mPathSingle, filter, -1, &headers);
   long validtime = std::stol(headers["Valid-From"]);
   auto mergedPL = payload;
@@ -424,8 +424,8 @@ void NoiseCalibratorSpec::sendOutputDcsMerge(DataAllocator& output)
   auto payload = mCalibrator->getNoiseMap();
   //  const auto& payload = mCalibrator->getNoiseMap(starTF, endTF); //For TimeSlot calibration
 
-  map<string, string> headers;
-  map<std::string, std::string> filter;
+  std::map<std::string, std::string> headers;
+  std::map<std::string, std::string> filter;
   auto* payloadPrev1 = api.retrieveFromTFileAny<o2::itsmft::NoiseMap>(mPathSingle, filter, -1, &headers);
   long validtime = std::stol(headers["Valid-From"]);
   auto mergedPL = payload;

--- a/Detectors/ITSMFT/MFT/condition/macros/readAlpideCCDB.C
+++ b/Detectors/ITSMFT/MFT/condition/macros/readAlpideCCDB.C
@@ -14,7 +14,7 @@ void readAlpideCCDB(long timestamp = -1, float thresh = 0)
   o2::ccdb::CcdbApi api;
   // api.init("alice-ccdb.cern.ch");
   api.init("ccdb-test.cern.ch");
-  map<string, string> headers;
+  std::map<std::string, std::string> headers;
   map<std::string, std::string> filter;
   auto calib = api.retrieveFromTFileAny<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>>("MFT/Config/AlpideParam/", filter, timestamp, &headers);
   calib->printKeyValues();

--- a/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignRecordSpec.cxx
@@ -121,7 +121,7 @@ class AlignRecordTask
     mImproveCutChi2 = 2. * trackerParam.sigmaCutForImprovement * trackerParam.sigmaCutForImprovement;
 
     // Configuration for chamber fixing
-    auto input_fixchambers = ic.options().get<string>("fix-chamber");
+    auto input_fixchambers = ic.options().get<std::string>("fix-chamber");
     std::stringstream string_chambers(input_fixchambers);
     string_chambers >> std::ws;
     while (string_chambers.good()) {
@@ -132,8 +132,8 @@ class AlignRecordTask
     }
 
     // Init for output saving
-    auto OutputRecFileName = ic.options().get<string>("output-record-data");
-    auto OutputConsFileName = ic.options().get<string>("output-record-constraint");
+    auto OutputRecFileName = ic.options().get<std::string>("output-record-data");
+    auto OutputConsFileName = ic.options().get<std::string>("output-record-constraint");
     mAlign.init(OutputRecFileName, OutputConsFileName);
 
     ic.services().get<CallbackService>().set<CallbackService::Id::Stop>([this]() {

--- a/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
+++ b/Detectors/MUON/MCH/Align/src/AlignmentSpec.cxx
@@ -167,7 +167,7 @@ class AlignmentTask
 
       LOG(info) << "Loading magnetic field and reference geometry from input files";
 
-      auto grpFile = ic.options().get<string>("grp-file");
+      auto grpFile = ic.options().get<std::string>("grp-file");
       if (std::filesystem::exists(grpFile)) {
         const auto grp = parameters::GRPObject::loadFrom(grpFile);
         base::Propagator::initFieldFromGRP(grp);
@@ -178,7 +178,7 @@ class AlignmentTask
         LOG(fatal) << "No GRP file";
       }
 
-      IdealGeoFileName = ic.options().get<string>("geo-file-ideal");
+      IdealGeoFileName = ic.options().get<std::string>("geo-file-ideal");
       if (std::filesystem::exists(IdealGeoFileName)) {
         base::GeometryManager::loadGeometry(IdealGeoFileName.c_str());
         transformation = geo::transformationFromTGeoManager(*gGeoManager);
@@ -190,7 +190,7 @@ class AlignmentTask
         LOG(fatal) << "No ideal geometry";
       }
 
-      RefGeoFileName = ic.options().get<string>("geo-file-ref");
+      RefGeoFileName = ic.options().get<std::string>("geo-file-ref");
       if (std::filesystem::exists(RefGeoFileName)) {
         base::GeometryManager::loadGeometry(RefGeoFileName.c_str());
         transformation = geo::transformationFromTGeoManager(*gGeoManager);
@@ -205,7 +205,7 @@ class AlignmentTask
       if (doReAlign) {
         LOG(info) << "Re-alignment mode";
         LOG(info) << "Loading re-alignment geometry";
-        NewGeoFileName = ic.options().get<string>("geo-file-new");
+        NewGeoFileName = ic.options().get<std::string>("geo-file-new");
         if (std::filesystem::exists(NewGeoFileName)) {
           base::GeometryManager::loadGeometry(NewGeoFileName.c_str());
           transformation = geo::transformationFromTGeoManager(*gGeoManager);
@@ -246,7 +246,7 @@ class AlignmentTask
     mImproveCutChi2 = 2. * trackerParam.sigmaCutForImprovement * trackerParam.sigmaCutForImprovement;
 
     // Fix chambers
-    TString chambersString = ic.options().get<string>("fix-chamber");
+    TString chambersString = ic.options().get<std::string>("fix-chamber");
     std::unique_ptr<TObjArray> objArray(chambersString.Tokenize(","));
     if (objArray->GetEntries() > 0) {
       for (int iVar = 0; iVar < objArray->GetEntries(); ++iVar) {
@@ -256,8 +256,8 @@ class AlignmentTask
     }
 
     // Fix DEs
-    TString DEString = ic.options().get<string>("fix-de");
-    TString MaskDEString = ic.options().get<string>("mask-fix-de");
+    TString DEString = ic.options().get<std::string>("fix-de");
+    TString MaskDEString = ic.options().get<std::string>("mask-fix-de");
     std::unique_ptr<TObjArray> objArrayDE(DEString.Tokenize(","));
     std::unique_ptr<TObjArray> objArrayMask(MaskDEString.Tokenize(","));
     if (objArrayDE->GetEntries() > 0) {
@@ -271,7 +271,7 @@ class AlignmentTask
     }
 
     doMatched = ic.options().get<bool>("matched");
-    outFileName = ic.options().get<string>("output");
+    outFileName = ic.options().get<std::string>("output");
     readFromRec = ic.options().get<bool>("use-record");
 
     if (readFromRec) {

--- a/Detectors/MUON/MCH/Geometry/Test/Helpers.cxx
+++ b/Detectors/MUON/MCH/Geometry/Test/Helpers.cxx
@@ -166,7 +166,7 @@ void zeroMisAlignGeometry(const std::string& ccdbHost, const std::string& fileNa
     std::string path = objectPath.empty() ? o2::base::DetectorNameConf::getAlignmentPath(detMCH) : objectPath;
     LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
     // store abitrary user object in strongly typed manner
     api.storeAsTFileAny(&params, path, metadata, tmin, tmax);

--- a/Detectors/MUON/MCH/Geometry/Test/misAlign.C
+++ b/Detectors/MUON/MCH/Geometry/Test/misAlign.C
@@ -89,7 +89,7 @@ void misAlign(Double_t xcartmisaligm = 0.01, Double_t xcartmisaligw = 0.0,
     std::string path = objectPath.empty() ? o2::base::DetectorNameConf::getAlignmentPath(detMCH) : objectPath;
     LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
     // store abitrary user object in strongly typed manner
     api.storeAsTFileAny(&params, path, metadata, tmin, tmax);

--- a/Detectors/TPC/calibration/src/CalculatedEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalculatedEdx.cxx
@@ -566,7 +566,7 @@ void CalculatedEdx::loadCalibsFromCCDB(long runNumberOrTimeStamp, const bool isM
   mCalibCont.setResidualCorrection(*residualCorr);
 
   // set the zero supression threshold map
-  std::unordered_map<string, o2::tpc::CalDet<float>>* zeroSupressionThresholdMap = cm.getForTimeStamp<std::unordered_map<string, o2::tpc::CalDet<float>>>(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::ConfigFEEPad), tRun);
+  std::unordered_map<std::string, o2::tpc::CalDet<float>>* zeroSupressionThresholdMap = cm.getForTimeStamp<std::unordered_map<std::string, o2::tpc::CalDet<float>>>(o2::tpc::CDBTypeMap.at(o2::tpc::CDBType::ConfigFEEPad), tRun);
   mCalibCont.setZeroSupresssionThreshold(zeroSupressionThresholdMap->at("ThresholdMap"));
 
   // set the magnetic field
@@ -624,7 +624,7 @@ void CalculatedEdx::setGainMapResidualFromFile(const char* folder, const char* f
   std::unique_ptr<TFile> gainMapResidualFile(TFile::Open(fmt::format("{}{}", folder, file).data()));
   if (!gainMapResidualFile->IsZombie()) {
     LOGP(info, "Using file: {}", gainMapResidualFile->GetName());
-    std::unordered_map<string, o2::tpc::CalDet<float>>* gainMapResidual = (std::unordered_map<string, o2::tpc::CalDet<float>>*)gainMapResidualFile->Get(object);
+    std::unordered_map<std::string, o2::tpc::CalDet<float>>* gainMapResidual = (std::unordered_map<std::string, o2::tpc::CalDet<float>>*)gainMapResidualFile->Get(object);
     mCalibCont.setGainMapResidual(gainMapResidual->at("GainMap"));
   }
 }
@@ -644,7 +644,7 @@ void CalculatedEdx::setZeroSuppressionThresholdFromFile(const char* folder, cons
   std::unique_ptr<TFile> zeroSuppressionFile(TFile::Open(fmt::format("{}{}", folder, file).data()));
   if (!zeroSuppressionFile->IsZombie()) {
     LOGP(info, "Using file: {}", zeroSuppressionFile->GetName());
-    std::unordered_map<string, o2::tpc::CalDet<float>>* zeroSupressionThresholdMap = (std::unordered_map<string, o2::tpc::CalDet<float>>*)zeroSuppressionFile->Get(object);
+    std::unordered_map<std::string, o2::tpc::CalDet<float>>* zeroSupressionThresholdMap = (std::unordered_map<std::string, o2::tpc::CalDet<float>>*)zeroSuppressionFile->Get(object);
     mCalibCont.setZeroSupresssionThreshold(zeroSupressionThresholdMap->at("ThresholdMap"));
   }
 }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -139,7 +139,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     if (matcher == ConcreteDataMatcher(gDataOriginTPC, "RESIDUALGAINMAP", 0)) {
       if (!mUsingDefaultGainMapForFirstIter) {
         LOGP(info, "Updating reference gain map from previous iteration from CCDB");
-        const auto* gainMapResidual = static_cast<std::unordered_map<string, o2::tpc::CalDet<float>>*>(obj);
+        const auto* gainMapResidual = static_cast<std::unordered_map<std::string, o2::tpc::CalDet<float>>*>(obj);
         mPadGainTracks.setRefGainMap(gainMapResidual->at("GainMap"));
       } else {
         // just skip for the first time asking for an object -> not gain map will be used as reference

--- a/Detectors/TRD/base/macros/OCDB2CCDB.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDB.C
@@ -266,7 +266,7 @@ void OCDB2CCDB(long timeStamp = -1, TString ccdbPath = "http://localhost:8080", 
   //Connect to CCDB
   //
   o2::ccdb::CcdbApi ccdb;
-  map<string, string> metadata;               // do we want to store any meta data?
+  std::map<std::string, std::string> metadata; // do we want to store any meta data?
   ccdb.init(ccdbPath.Data());
 
   AliTRDCalChamberStatus* chamberStatus = 0;

--- a/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
@@ -206,7 +206,7 @@ void OCDB2CCDBTrapConfig(TString ccdbPath = "http://localhost:8080", Int_t run =
   //Connect to CCDB
   //
   o2::ccdb::CcdbApi ccdb;
-  map<string, string> metadata;               // do we want to store any meta data?
+  std::map<std::string, std::string> metadata; // do we want to store any meta data?
   metadata.emplace(std::make_pair("UploadedBy", "marten"));
   metadata.emplace(std::make_pair("Description", "Default TRAP config for Run 3 simulations in LS2"));
   ccdb.init(ccdbPath.Data());

--- a/Detectors/TRD/base/macros/PrintTrapConfig.C
+++ b/Detectors/TRD/base/macros/PrintTrapConfig.C
@@ -236,7 +236,7 @@ void PrintTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/alic
   //Connect to CCDB
   //
   o2::ccdb::CcdbApi ccdb;
-  map<string, string> metadata;               // do we want to store any meta data?
+  std::map<std::string, std::string> metadata; // do we want to store any meta data?
   ccdb.init("http://ccdb-test.cern.ch:8080"); // or http://localhost:8080 for a local installation
 
   /*

--- a/Detectors/TRD/base/macros/Readocdb.C
+++ b/Detectors/TRD/base/macros/Readocdb.C
@@ -251,7 +251,7 @@ void Readocdb(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data/
   //Connect to CCDB
   //
   o2::ccdb::CcdbApi ccdb;
-  map<string, string> metadata;               // do we want to store any meta data?
+  std::map<std::string, std::string> metadata; // do we want to store any meta data?
   ccdb.init("http://ccdb-test.cern.ch:8080"); // or http://localhost:8080 for a local installation
 
   AliTRDCalChamberStatus* chamberStatus = 0;

--- a/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/DCSProcessor.h
@@ -96,7 +96,7 @@ class DCSProcessor
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDCurrentsDPsInfo() const { return mTRDDCSCurrents; }
   const std::unordered_map<DPID, TRDDCSMinMaxMeanInfo>& getTRDEnvDPsInfo() const { return mTRDDCSEnv; }
   const std::array<int, constants::MAXCHAMBER>& getTRDFedChamberStatusDPsInfo() const { return mTRDDCSFedChamberStatus; }
-  const std::array<string, constants::MAXCHAMBER>& getTRDFedCFGtagDPsInfo() const { return mTRDDCSFedCFGtag; }
+  const std::array<std::string, constants::MAXCHAMBER>& getTRDFedCFGtagDPsInfo() const { return mTRDDCSFedCFGtag; }
 
   // settings
   void setCurrentTS(TFType tf) { mCurrentTS = tf; }
@@ -124,7 +124,7 @@ class DCSProcessor
   std::unordered_map<DPID, float> mTRDDCSVoltages;                ///< anode and drift voltages
   std::unordered_map<DPID, TRDDCSMinMaxMeanInfo> mTRDDCSEnv;      ///< environment parameters (temperatures, pressures, humidity)
   std::array<int, constants::MAXCHAMBER> mTRDDCSFedChamberStatus; ///< fed chamber status
-  std::array<string, constants::MAXCHAMBER> mTRDDCSFedCFGtag;     ///< fed config tag
+  std::array<std::string, constants::MAXCHAMBER> mTRDDCSFedCFGtag; ///< fed config tag
 
   // helper variables
   std::unordered_map<DPID, bool> mPids;                 ///< flag for each DP whether it has been processed at least once

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -120,7 +120,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
     } else if (type == DPVAL_INT) {
       LOG(info) << "Processing DP = " << dpcom << ", with value = " << o2::dcs::getValue<int32_t>(dpcom);
     } else if (type == DPVAL_STRING) {
-      LOG(info) << "Processing DP = " << dpcom << ", with value = " << o2::dcs::getValue<string>(dpcom);
+      LOG(info) << "Processing DP = " << dpcom << ", with value = " << o2::dcs::getValue<std::string>(dpcom);
     }
   }
   auto flags = dpcom.data.get_flags();
@@ -265,15 +265,15 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
         int chamberId = getChamberIdFromAlias(dpid.get_alias());
         auto& dpInfoFedCFGtag = mTRDDCSFedCFGtag[chamberId];
         if (etime != mLastDPTimeStamps[dpid]) {
-          if (dpInfoFedCFGtag != o2::dcs::getValue<string>(dpcom)) {
+          if (dpInfoFedCFGtag != o2::dcs::getValue<std::string>(dpcom)) {
             // If value changes after processing and DPs should not be updated, log change as warning (for now)
             if (mPids[dpid] && !(mFedCFGtagCompleteDPs && mFirstRunEntryForFedCFGtagUpdate)) {
               // Issue an alarm if counter is lower than maximum, warning otherwise
               if (mFedCFGtagAlarmCounter < mFedAlarmCounterMax) {
-                LOG(alarm) << "CFGtag change " << dpid.get_alias() << " : " << dpInfoFedCFGtag << " -> " << o2::dcs::getValue<string>(dpcom) << ", run = " << mCurrentRunNumber;
+                LOG(alarm) << "CFGtag change " << dpid.get_alias() << " : " << dpInfoFedCFGtag << " -> " << o2::dcs::getValue<std::string>(dpcom) << ", run = " << mCurrentRunNumber;
                 mFedCFGtagAlarmCounter++;
               } else if (mVerbosity > 0) {
-                LOG(warn) << "CFGtag change " << dpid.get_alias() << " : " << dpInfoFedCFGtag << " -> " << o2::dcs::getValue<string>(dpcom) << ", run = " << mCurrentRunNumber;
+                LOG(warn) << "CFGtag change " << dpid.get_alias() << " : " << dpInfoFedCFGtag << " -> " << o2::dcs::getValue<std::string>(dpcom) << ", run = " << mCurrentRunNumber;
               }
             }
           }

--- a/Detectors/ZDC/macro/CreateBaselineCalib.C
+++ b/Detectors/ZDC/macro/CreateBaselineCalib.C
@@ -79,7 +79,7 @@ void CreateBaselineCalib(long tmin = 0, long tmax = -1, std::string ccdbHost = "
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateBaselineCalibConfig.C
+++ b/Detectors/ZDC/macro/CreateBaselineCalibConfig.C
@@ -48,7 +48,7 @@ void CreateBaselineCalibConfig(long tmin = 0, long tmax = -1, std::string ccdbHo
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateEnergyCalib.C
+++ b/Detectors/ZDC/macro/CreateEnergyCalib.C
@@ -58,7 +58,7 @@ void CreateEnergyCalib(long tmin = 0, long tmax = -1, std::string ccdbHost = "")
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateInterCalibConfig.C
+++ b/Detectors/ZDC/macro/CreateInterCalibConfig.C
@@ -61,7 +61,7 @@ void CreateInterCalibConfig(long tmin = 0, long tmax = -1, std::string ccdbHost 
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -150,7 +150,7 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1, std::string ccdbHost = ""
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateRecoConfigZDC.C
+++ b/Detectors/ZDC/macro/CreateRecoConfigZDC.C
@@ -150,7 +150,7 @@ void CreateRecoConfigZDC(long tmin = 0, long tmax = -1, std::string ccdbHost = "
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateSimCondition.C
+++ b/Detectors/ZDC/macro/CreateSimCondition.C
@@ -148,7 +148,7 @@ void CreateSimCondition(long tmin = 0, long tmax = -1, std::string ccdbHost = ""
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateSimCondition_pp.C
+++ b/Detectors/ZDC/macro/CreateSimCondition_pp.C
@@ -101,7 +101,7 @@ void CreateSimCondition_pp(long tmin = 0, long tmax = -1, std::string ccdbHost =
   conf.print();
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   if (ccdbHost.size() == 0 || ccdbHost == "external") {
     ccdbHost = "http://alice-ccdb.cern.ch:8080";
   } else if (ccdbHost == "internal") {

--- a/Detectors/ZDC/macro/CreateTDCCalib.C
+++ b/Detectors/ZDC/macro/CreateTDCCalib.C
@@ -63,7 +63,7 @@ void CreateTDCCalib(long tmin = 0, long tmax = -1, std::string ccdbHost = "", fl
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "Storing " << o2::zdc::CCDBPathTDCCalib << " on CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateTDCCalibConfig.C
+++ b/Detectors/ZDC/macro/CreateTDCCalibConfig.C
@@ -60,7 +60,7 @@ void CreateTDCCalibConfig(long tmin = 0, long tmax = -1, std::string ccdbHost = 
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateTDCCorr.C
+++ b/Detectors/ZDC/macro/CreateTDCCorr.C
@@ -99,7 +99,7 @@ void CreateTDCCorr(long tmin = 0, long tmax = -1, std::string ccdbHost = "")
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/Detectors/ZDC/macro/CreateTowerCalib.C
+++ b/Detectors/ZDC/macro/CreateTowerCalib.C
@@ -75,7 +75,7 @@ void CreateTowerCalib(long tmin = 0, long tmax = -1, std::string ccdbHost = "")
   }
 
   o2::ccdb::CcdbApi api;
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   api.init(ccdb_host.c_str());
   LOG(info) << "CCDB server: " << api.getURL();
   // store abitrary user object in strongly typed manner

--- a/EventVisualisation/View/src/EventManagerFrame.cxx
+++ b/EventVisualisation/View/src/EventManagerFrame.cxx
@@ -398,12 +398,12 @@ void EventManagerFrame::createOutreachScreenshot()
   if (skipCounter > 0) {
     skipCounter--;
   } else {
-    string fileName = this->mEventManager->getInstance().getDataSource()->getEventName();
+    std::string fileName = this->mEventManager->getInstance().getDataSource()->getEventName();
     if (fileName.size() < 5) {
       return;
     }
 
-    string imageFolder = ConfigurationManager::getScreenshotPath("outreach");
+    std::string imageFolder = ConfigurationManager::getScreenshotPath("outreach");
     if (!std::filesystem::is_directory(imageFolder)) {
       std::filesystem::create_directory(imageFolder);
     }

--- a/GPU/Workflow/src/GPUWorkflowTPC.cxx
+++ b/GPU/Workflow/src/GPUWorkflowTPC.cxx
@@ -250,14 +250,14 @@ void GPURecoWorkflowSpec::finaliseCCDBTPC(ConcreteDataMatcher& matcher, void* ob
   } else if (matcher == ConcreteDataMatcher(gDataOriginTPC, "PADGAINRESIDUAL", 0)) {
     LOGP(info, "Updating residual gain map from CCDB");
     copyCalibsToBuffer();
-    const auto* gainMapResidual = static_cast<std::unordered_map<string, o2::tpc::CalDet<float>>*>(obj);
+    const auto* gainMapResidual = static_cast<std::unordered_map<std::string, o2::tpc::CalDet<float>>*>(obj);
     const float minResidualGain = 0.7f;
     const float maxResidualGain = 1.3f;
     mdEdxCalibContainerBufferNew.get()->setGainMapResidual(gainMapResidual->at("GainMap"), minResidualGain, maxResidualGain);
   } else if (matcher == ConcreteDataMatcher(gDataOriginTPC, "PADTHRESHOLD", 0)) {
     LOGP(info, "Updating threshold map from CCDB");
     copyCalibsToBuffer();
-    const auto* thresholdMap = static_cast<std::unordered_map<string, o2::tpc::CalDet<float>>*>(obj);
+    const auto* thresholdMap = static_cast<std::unordered_map<std::string, o2::tpc::CalDet<float>>*>(obj);
     mdEdxCalibContainerBufferNew.get()->setZeroSupresssionThreshold(thresholdMap->at("ThresholdMap"));
   } else if (matcher == ConcreteDataMatcher(gDataOriginTPC, "TOPOLOGYGAIN", 0) && !(dEdxCalibContainer->isTopologyCorrectionSplinesSet())) {
     LOGP(info, "Updating Q topology correction from CCDB");

--- a/macro/CreateCTPOrbitResetObject.C
+++ b/macro/CreateCTPOrbitResetObject.C
@@ -17,7 +17,7 @@ void CreateCTPOrbitResetObject(const std::string& ccdbHost = "http://ccdb-test.c
   const std::string objName{"CTP/Calib/OrbitReset"};
   o2::ccdb::CcdbApi api;
   api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["comment"] = "CTP Orbit reset";
   api.storeAsTFileAny(&rt, objName, metadata, tmin, tmax);
   LOGP(info, "Uploaded CTP Oribt reset time {} to {}", t, objName);

--- a/macro/UploadDummyAlignment.C
+++ b/macro/UploadDummyAlignment.C
@@ -24,7 +24,7 @@ void UploadDummyAlignment(const std::string& ccdbHost = "http://ccdb-test.cern.c
     if (!dets[id]) {
       continue;
     }
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     DetID det(id);
     metadata["comment"] = fmt::format("Empty alignment object for {}", det.getName());
     metadata["default"] = "true"; // tag default objects

--- a/macro/UploadMatBudLUT.C
+++ b/macro/UploadMatBudLUT.C
@@ -21,7 +21,7 @@ bool UploadMatBudLUT(const std::string& matLUTFile, long tmin = 0, long tmax = -
 
   o2::ccdb::CcdbApi api;
   api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["comment"] = "Material lookup table";
   api.storeAsTFileAny(lut, url, metadata, tmin, tmax);
   return true;


### PR DESCRIPTION
## Namespace cleanup - Change in other libraries will affect O2 

## Story of what happened 

I was contacted by @costing, who relayed a report from @vkucera regarding problematic headers. It was discovered while running `clang-tidy` on `O2Physics`. The issue was that while running `cland-tidy` it would include the header `TJAlienCredentials.h`  from the `JAlien-ROOT` or `libjalienO2` libraries instead of `#include <string>`.

Specifically, the header contained the following lines:

```cpp
using std::map;
using std::string;
```

These `using` declarations in a header file pollute the global namespace for every file that uses them. A common place where this was spread was through `CCDBApi.h`, which includes `TJAlienCredentials.h`, thereby spreading the `using std::string` declaration across many parts that uses CCDB API.

I am new to C++ so I had to find some sources that confirmed why the change should be considered:
- [ALICE Coding Guidelines)](https://rawgit.com/AliceO2Group/CodingGuidelines/master/coding_guidelines.html?showone=Using_declarations_and_directives#Using_declarations_and_directives)
- [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#do-not-use-using-namespace-std)
- [LearnCpp.com on Using Declarations](https://www.learncpp.com/cpp-tutorial/using-declarations-and-using-directives/)

### The proposed change in the other repo's:
**In external repos**: Removed `using std::string` and `using std::map` from `TJAlienCredentials.h`  
  - [Merge request to JAlien-ROOT](https://gitlab.cern.ch/jalien/jalien-root/-/merge_requests/88)
  - [Merge request to libjalienO2](https://gitlab.cern.ch/jalien/libjalieno2/-/merge_requests/3)
  
# What this PR does
I updated all affected files in O2 to explicitly use `std::` where needed for compilation to complete.
That is, this compilation command completed:
```bash
aliBuild build O2 --defaults o2
```

## Some smaller potential issues
- Some comments may be slightly misaligned due to code edits.
- I may have added `std::` in places where it wasn’t strictly necessary due to `using std::string;` declarations in the same `.cxx` files.
- Other, unknown to me, repositories might still rely on the polluted namespace and could break when the updated headers are published.

## A bit about me 🧑‍💻 
- Background in Software Engineering
- First experience working with C++ in a large codebase

Please let me know if anything is not how it should be and I'll fix it. (I do not know if I got the o2codechecker to run properly)