### PR TITLE
Fix alignment so that jemalloc / address sanitizer do no complain

### DIFF
--- a/DataFormats/Headers/include/Headers/Stack.h
+++ b/DataFormats/Headers/include/Headers/Stack.h
@@ -38,7 +38,7 @@ struct Stack {
   struct freeobj {
     freeobj(memory_resource* mr) : resource(mr) {}
     memory_resource* resource{nullptr};
-    void operator()(std::byte* ptr) { resource->deallocate(ptr, 0, 0); }
+    void operator()(std::byte* ptr) { resource->deallocate(ptr, 0, alignof(std::max_align_t)); }
   };
 
  public:


### PR DESCRIPTION

This apparently fixes the issues with std::pmr in DataDistribution.
