### PR TITLE
Fix: apply global density scaling factor in MaterialManager::getDensity

### DIFF
--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -129,9 +129,11 @@ float MaterialManager::getDensity(std::string const& modname)
     initDensityMap();
   }
   if (mDensityMap.find(modname) != mDensityMap.end()) {
-    return mDensityMap[modname];
+    return o2::conf::SimMaterialParams::Instance().globalDensityFactor * mDensityMap[modname];
   }
-  return o2::conf::SimMaterialParams::Instance().globalDensityFactor;
+  LOG(warning) << "MaterialManager::getDensity: Material '" << modname
+                 << "' not found in density map. Returning 0.";
+  return 0.0;
 }
 
 void MaterialManager::Material(const char* modname, Int_t imat, const char* name, Float_t a, Float_t z, Float_t dens,

--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -131,8 +131,7 @@ float MaterialManager::getDensity(std::string const& modname)
   if (mDensityMap.find(modname) != mDensityMap.end()) {
     return o2::conf::SimMaterialParams::Instance().globalDensityFactor * mDensityMap[modname];
   }
-  LOG(warning) << "MaterialManager::getDensity: Material '" << modname
-                 << "' not found in density map. Returning 0.";
+  LOG(warning) << "MaterialManager::getDensity: Material '" << modname << "' not found in density map. Returning 0.";
   return 0.0;
 }
 


### PR DESCRIPTION
Hi,
I believe that the existing function is not scaling the material density by the global factor.
I also added a warning and changed the return value if the density map is not found.

@amorsch 