### PR TITLE
ITS: if TF dropped clear tracks

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -66,6 +66,7 @@ void Tracker::clustersToTracks(const LogFunc& logger, const LogFunc& error)
     LOGP(error, "Exception: {}", err.what());
     if (mTrkParams[iteration].DropTFUponFailure) {
       mMemoryPool->print();
+      mTimeFrame->wipe();
       ++mNumberOfDroppedTFs;
       error("...Dropping Timeframe...");
     } else {


### PR DESCRIPTION
Erroneously removed in b733857a11 (not used in the apass2 prod tag.)