### PR TITLE
ITS: use faster atan2 for trackleting

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
@@ -29,14 +29,13 @@
 #include "ITStracking/IndexTableUtils.h"
 #include "ITStracking/MathUtils.h"
 #include "ITStracking/ExternalAllocator.h"
-#include "DataFormatsITS/TrackITS.h"
-#include "ReconstructionDataFormats/Vertex.h"
-
 #include "ITStrackingGPU/TrackerTraitsGPU.h"
 #include "ITStrackingGPU/TrackingKernels.h"
 #include "ITStrackingGPU/Utils.h"
 
-// O2 track model
+#include "MathUtils/Utils.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "ReconstructionDataFormats/Vertex.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "DetectorsBase/Propagator.h"
 using namespace o2::track;
@@ -629,7 +628,7 @@ GPUg() void computeLayerTrackletsMultiROFKernel(
                 if constexpr (initRun) {
                   trackletsLUT[layerIndex][currentSortedIndex]++; // we need l0 as well for usual exclusive sums.
                 } else {
-                  const float phi{o2::gpu::CAMath::ATan2(currentCluster.yCoordinate - nextCluster.yCoordinate, currentCluster.xCoordinate - nextCluster.xCoordinate)};
+                  const float phi{o2::math_utils::fastATan2(currentCluster.yCoordinate - nextCluster.yCoordinate, currentCluster.xCoordinate - nextCluster.xCoordinate)};
                   const float tanL{(currentCluster.zCoordinate - nextCluster.zCoordinate) / (currentCluster.radius - nextCluster.radius)};
                   const int nextSortedIndex{ROFClusters[layerIndex + 1][targetROF] + nextClusterIndex};
                   new (tracklets[layerIndex] + trackletsLUT[layerIndex][currentSortedIndex] + storedTracklets) Tracklet{currentSortedIndex, nextSortedIndex, tanL, phi, pivotROF, targetROF};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -18,8 +18,8 @@
 
 #include "ITStracking/Constants.h"
 #include "ITStracking/Cluster.h"
+#include "MathUtils/Utils.h"
 #include "GPUCommonRtypes.h"
-#include "GPUCommonMath.h"
 #include "GPUCommonDef.h"
 #include "GPUCommonLogger.h"
 
@@ -67,8 +67,8 @@ GPUhdi() Tracklet::Tracklet(const int firstClusterOrderingIndex, const int secon
     secondClusterIndex{secondClusterOrderingIndex},
     tanLambda{(firstCluster.zCoordinate - secondCluster.zCoordinate) /
               (firstCluster.radius - secondCluster.radius)},
-    phi{o2::gpu::GPUCommonMath::ATan2(firstCluster.yCoordinate - secondCluster.yCoordinate,
-                                      firstCluster.xCoordinate - secondCluster.xCoordinate)},
+    phi{o2::math_utils::fastATan2(firstCluster.yCoordinate - secondCluster.yCoordinate,
+                                  firstCluster.xCoordinate - secondCluster.xCoordinate)},
     rof{static_cast<short>(rof0), static_cast<short>(rof1)}
 {
   // Nothing to do

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -173,7 +173,7 @@ void TrackerTraits<nLayers>::computeLayerTracklets(const int iteration, int iROF
 
                 if (deltaZ / sigmaZ < mTrkParams[iteration].NSigmaCut &&
                     ((deltaPhi < mTimeFrame->getPhiCut(iLayer) || o2::gpu::GPUCommonMath::Abs(deltaPhi - o2::constants::math::TwoPI) < mTimeFrame->getPhiCut(iLayer)))) {
-                  const float phi{o2::gpu::CAMath::ATan2(currentCluster.yCoordinate - nextCluster.yCoordinate, currentCluster.xCoordinate - nextCluster.xCoordinate)};
+                  const float phi{o2::math_utils::fastATan2(currentCluster.yCoordinate - nextCluster.yCoordinate, currentCluster.xCoordinate - nextCluster.xCoordinate)};
                   const float tanL = (currentCluster.zCoordinate - nextCluster.zCoordinate) / (currentCluster.radius - nextCluster.radius);
                   if constexpr (decltype(Tag)::value == PassMode::OnePass::value) {
                     tracklets.emplace_back(currentSortedIndex, mTimeFrame->getSortedIndex(targetROF, iLayer + 1, iNext), tanL, phi, pivotROF, targetROF);


### PR DESCRIPTION
Instead of using the full atan2 which is rather expensive one can use a faster approximate method.
The speedup on cpu is around 10% for the trackleting phases (on cpu this is 5% of the total time with 20 threads, so a gain of around 0.5%)
On gpu the speedup is much less 0.5% (prob. within fluctuations, on gpu this phase is around 26% of the total time with <<<30,256>>>, so only 0.13% faster).

The difference in output is minimal (below per-mille). Below is the comparison. The plot in the bottom right shows that after switching with deterministic mode the gpu part still 1:1 reproduces the cpu output.

<img width="796" height="1172" alt="ptRatioCN" src="https://github.com/user-attachments/assets/3a2f63df-ce39-4f5c-8009-7dfbeaced5b6" />
