### PR TITLE
DPL Analysis: add an example of the string filter

### DIFF
--- a/Framework/TestWorkflows/src/o2TestHistograms.cxx
+++ b/Framework/TestWorkflows/src/o2TestHistograms.cxx
@@ -39,7 +39,7 @@ DECLARE_SOA_TABLE(SkimmedExampleTrack, "AOD", "SKIMEXTRK", //!
 struct EtaAndClsHistogramsSimple {
   OutputObj<TH2F> etaClsH{TH2F("eta_vs_pt", "#eta vs pT", 102, -2.01, 2.01, 100, 0, 10)};
   Produces<o2::aod::SkimmedExampleTrack> skimEx;
-  Configurable<std::string> trackFilterString{"track-filter","o2::aod::track::pt < 10.f", "Track filter string"};
+  Configurable<std::string> trackFilterString{"track-filter", "o2::aod::track::pt < 10.f", "Track filter string"};
   Filter trackFilter = o2::aod::track::pt < 10.f;
 
   void init(InitContext&)
@@ -62,7 +62,7 @@ struct EtaAndClsHistogramsSimple {
 struct EtaAndClsHistogramsIUSimple {
   OutputObj<TH2F> etaClsH{TH2F("eta_vs_pt", "#eta vs pT", 102, -2.01, 2.01, 100, 0, 10)};
   Produces<o2::aod::SkimmedExampleTrack> skimEx;
-  Configurable<std::string> trackFilterString{"track-filter","o2::aod::track::pt < 10.f", "Track filter string"};
+  Configurable<std::string> trackFilterString{"track-filter", "o2::aod::track::pt < 10.f", "Track filter string"};
   Filter trackFilter = o2::aod::track::pt < 10.f;
 
   void init(InitContext&)
@@ -84,7 +84,7 @@ struct EtaAndClsHistogramsIUSimple {
 
 struct EtaAndClsHistogramsFull {
   OutputObj<TH3F> etaClsH{TH3F("eta_vs_cls_vs_sigmapT", "#eta vs N_{cls} vs sigma_{1/pT}", 102, -2.01, 2.01, 160, -0.5, 159.5, 100, 0, 10)};
-  Configurable<std::string> trackFilterString{"track-filter","o2::aod::track::pt < 10.f", "Track filter string"};
+  Configurable<std::string> trackFilterString{"track-filter", "o2::aod::track::pt < 10.f", "Track filter string"};
   Filter trackFilter = o2::aod::track::pt < 10.f;
 
   void init(InitContext&)

--- a/Framework/TestWorkflows/src/o2TestHistograms.cxx
+++ b/Framework/TestWorkflows/src/o2TestHistograms.cxx
@@ -39,8 +39,17 @@ DECLARE_SOA_TABLE(SkimmedExampleTrack, "AOD", "SKIMEXTRK", //!
 struct EtaAndClsHistogramsSimple {
   OutputObj<TH2F> etaClsH{TH2F("eta_vs_pt", "#eta vs pT", 102, -2.01, 2.01, 100, 0, 10)};
   Produces<o2::aod::SkimmedExampleTrack> skimEx;
+  Configurable<std::string> trackFilterString{"track-filter","o2::aod::track::pt < 10.f", "Track filter string"};
+  Filter trackFilter = o2::aod::track::pt < 10.f;
 
-  void process(aod::Tracks const& tracks, aod::FT0s const&)
+  void init(InitContext&)
+  {
+    if (!trackFilterString->empty()) {
+      trackFilter = trackFilterString;
+    }
+  }
+
+  void process(soa::Filtered<aod::Tracks> const& tracks, aod::FT0s const&)
   {
     LOGP(info, "Invoking the simple one");
     for (auto& track : tracks) {
@@ -53,10 +62,19 @@ struct EtaAndClsHistogramsSimple {
 struct EtaAndClsHistogramsIUSimple {
   OutputObj<TH2F> etaClsH{TH2F("eta_vs_pt", "#eta vs pT", 102, -2.01, 2.01, 100, 0, 10)};
   Produces<o2::aod::SkimmedExampleTrack> skimEx;
+  Configurable<std::string> trackFilterString{"track-filter","o2::aod::track::pt < 10.f", "Track filter string"};
+  Filter trackFilter = o2::aod::track::pt < 10.f;
 
-  void process(aod::TracksIU const& tracks, aod::FT0s const&)
+  void init(InitContext&)
   {
-    LOGP(info, "Invoking the simple one");
+    if (!trackFilterString->empty()) {
+      trackFilter = trackFilterString;
+    }
+  }
+
+  void process(soa::Filtered<aod::TracksIU> const& tracks, aod::FT0s const&)
+  {
+    LOGP(info, "Invoking the simple one IU");
     for (auto& track : tracks) {
       etaClsH->Fill(track.eta(), track.pt());
       skimEx(track.pt(), track.eta());
@@ -66,8 +84,17 @@ struct EtaAndClsHistogramsIUSimple {
 
 struct EtaAndClsHistogramsFull {
   OutputObj<TH3F> etaClsH{TH3F("eta_vs_cls_vs_sigmapT", "#eta vs N_{cls} vs sigma_{1/pT}", 102, -2.01, 2.01, 160, -0.5, 159.5, 100, 0, 10)};
+  Configurable<std::string> trackFilterString{"track-filter","o2::aod::track::pt < 10.f", "Track filter string"};
+  Filter trackFilter = o2::aod::track::pt < 10.f;
 
-  void process(soa::Join<aod::FullTracks, aod::TracksCov> const& tracks)
+  void init(InitContext&)
+  {
+    if (!trackFilterString->empty()) {
+      trackFilter = trackFilterString;
+    }
+  }
+
+  void process(soa::Filtered<soa::Join<aod::FullTracks, aod::TracksCov>> const& tracks)
   {
     LOGP(info, "Invoking the run 3 one");
     for (auto& track : tracks) {


### PR DESCRIPTION
Extend the histograms test workflow to use string-based filter.

Note that string filters need the full namespace prefix for the column designators, i.e. `o2::aod::track::pt`,