### PR TITLE
Make sure extra tracks are randomized to avoid PHOS hole losses

### DIFF
--- a/DataFormats/Headers/include/Headers/Stack.h
+++ b/DataFormats/Headers/include/Headers/Stack.h
@@ -39,7 +39,7 @@ struct Stack {
   struct freeobj {
     freeobj(memory_resource* mr, size_t s) : resource(mr), size(s) {}
     memory_resource* resource{nullptr};
-    size_t           size{0};
+    size_t size{0};
     void operator()(std::byte* ptr) { resource->deallocate(ptr, size, alignof(std::max_align_t)); }
   };
 

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -272,7 +272,7 @@ void TrackInterpolation::process()
   trackIndices.insert(trackIndices.end(), mTrackIndices[mTrackTypes[GTrackID::ITSTPCTOF]].begin(), mTrackIndices[mTrackTypes[GTrackID::ITSTPCTOF]].end());
   trackIndices.insert(trackIndices.end(), mTrackIndices[mTrackTypes[GTrackID::ITSTPC]].begin(), mTrackIndices[mTrackTypes[GTrackID::ITSTPC]].end());
 
-  int nSeeds = mSeeds.size();
+  int nSeeds = mSeeds.size(), lastChecked = 0;
   int maxOutputTracks = (mMaxTracksPerTF >= 0) ? mMaxTracksPerTF + mAddTracksForMapPerTF : nSeeds;
   mTrackData.reserve(maxOutputTracks);
   mClRes.reserve(maxOutputTracks * param::NPadRows);
@@ -286,51 +286,65 @@ void TrackInterpolation::process()
     if (mParams->enableTrackDownsampling && !isTrackSelected(mSeeds[seedIndex])) {
       continue;
     }
+
+    auto addPart = [this, seedIndex](GTrackID::Source src) {
+      this->mGIDs.push_back(this->mGIDtables[seedIndex][src]);
+      this->mGIDtables.push_back(this->mRecoCont->getSingleDetectorRefs(this->mGIDs.back()));
+      this->mTrackTimes.push_back(this->mTrackTimes[seedIndex]);
+      this->mSeeds.push_back(this->mSeeds[seedIndex]);
+    };
+
+    GTrackID::mask_t partsAdded;
     if (!mSingleSourcesConfigured && !mSourcesConfiguredMap[mGIDs[seedIndex].getSource()]) {
       auto src = findValidSource(mSourcesConfiguredMap, static_cast<GTrackID::Source>(mGIDs[seedIndex].getSource()));
       if (src == GTrackID::ITSTPCTRD || src == GTrackID::ITSTPC) {
-        LOGP(debug, "process: Found valid source {}", GTrackID::getSourceName(src));
-        mGIDs.push_back(mGIDtables[seedIndex][src]);
-        mGIDtables.push_back(mRecoCont->getSingleDetectorRefs(mGIDs.back()));
-        mTrackTimes.push_back(mTrackTimes[seedIndex]);
-        mSeeds.push_back(mSeeds[seedIndex]);
+        LOGP(debug, "process {}: Found valid source {} for {} | nseeds:{} mSeeds:{} used: {}", iSeed, GTrackID::getSourceName(src), GTrackID::getSourceName(mGIDs[seedIndex].getSource()), nSeeds, mSeeds.size(), mTrackDataCompact.size());
+        addPart(src);
       }
     }
     if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
-      LOG(debug) << "We already have reached mMaxTracksPerTF, but we continue to create seeds until mAddTracksForMapPerTF is also reached";
+      if (!maxTracksReached) {
+        LOGP(info, "We already have reached mMaxTracksPerTF={}, but we continue to create seeds until mAddTracksForMapPerTF={} is also reached, iSeed: {} of {} inital seeds", mMaxTracksPerTF, mAddTracksForMapPerTF, iSeed, nSeeds);
+      }
+      maxTracksReached = true;
       continue;
     }
     if (mGIDs[seedIndex].includesDet(DetID::TRD) || mGIDs[seedIndex].includesDet(DetID::TOF)) {
       interpolateTrack(seedIndex);
+      LOGP(debug, "interpolateTrack {} {}, accepted: {}", iSeed, GTrackID::getSourceName(mGIDs[seedIndex].getSource()), mTrackDataCompact.size());
       if (mProcessSeeds) {
-        if (mGIDs[seedIndex].includesDet(DetID::TRD) && mGIDs[seedIndex].includesDet(DetID::TOF)) {
-          mGIDs.push_back(mGIDtables[seedIndex][GTrackID::ITSTPCTRD]);
-          mGIDtables.push_back(mRecoCont->getSingleDetectorRefs(mGIDs.back()));
-          mTrackTimes.push_back(mTrackTimes[seedIndex]);
-          mSeeds.push_back(mSeeds[seedIndex]);
+        if (mGIDs[seedIndex].includesDet(DetID::TRD) && mGIDs[seedIndex].includesDet(DetID::TOF) && !partsAdded[GTrackID::ITSTPCTRD]) {
+          addPart(GTrackID::ITSTPCTRD);
         }
-        mGIDs.push_back(mGIDtables[seedIndex][GTrackID::ITSTPC]);
-        mGIDtables.push_back(mRecoCont->getSingleDetectorRefs(mGIDs.back()));
-        mTrackTimes.push_back(mTrackTimes[seedIndex]);
-        mSeeds.push_back(mSeeds[seedIndex]);
+        if (!partsAdded[GTrackID::ITSTPC]) {
+          addPart(GTrackID::ITSTPC);
+        }
       }
     } else {
       extrapolateTrack(seedIndex);
+      LOGP(debug, "extrapolateTrack {} {}, accepted: {}", iSeed, GTrackID::getSourceName(mGIDs[seedIndex].getSource()), mTrackDataCompact.size());
     }
+    lastChecked = iSeed;
   }
-  if (mSeeds.size() > nSeeds) {
-    LOGP(info, "Up to {} tracks out of {} additional seeds will be processed", mAddTracksForMapPerTF, mSeeds.size() - nSeeds);
+  std::vector<int> remSeeds;
+  if (mSeeds.size() > ++lastChecked) {
+    remSeeds.resize(mSeeds.size() - lastChecked);
+    std::iota(remSeeds.begin(), remSeeds.end(), lastChecked);
+    std::shuffle(remSeeds.begin(), remSeeds.end(), g);
+    LOGP(info, "Up to {} tracks out of {} additional seeds will be processed in random order, of which {} are stripped versions, accepted seeds: {}", mAddTracksForMapPerTF, remSeeds.size(), mSeeds.size() - nSeeds, mTrackDataCompact.size());
   }
-  for (int iSeed = nSeeds; iSeed < (int)mSeeds.size(); ++iSeed) {
-    if (!mProcessSeeds && mAddTracksForMapPerTF > 0 && mTrackDataCompact.size() >= mMaxTracksPerTF + mAddTracksForMapPerTF) {
-      LOG(info) << "Maximum number of additional tracks per TF reached. Skipping the remaining " << mSeeds.size() - iSeed << " tracks.";
+  int extraChecked = 0;
+  for (int iSeed : remSeeds) {
+    if (mAddTracksForMapPerTF > 0 && mTrackDataCompact.size() >= mMaxTracksPerTF + mAddTracksForMapPerTF) {
+      LOGP(info, "Maximum number {} of additional tracks per TF reached. Skipping the remaining {} tracks", mAddTracksForMapPerTF, remSeeds.size() - extraChecked);
       break;
     }
-    // this loop will only be entered in case mProcessSeeds is set
-    LOGP(debug, "Processing additional track {}", mGIDs[iSeed].asString());
+    extraChecked++;
     if (mGIDs[iSeed].includesDet(DetID::TRD) || mGIDs[iSeed].includesDet(DetID::TOF)) {
       interpolateTrack(iSeed);
+      LOGP(debug, "extra check {} of {}, seed {} interpolateTrack {}, used: {}", extraChecked, remSeeds.size(), iSeed, GTrackID::getSourceName(mGIDs[iSeed].getSource()), mTrackDataCompact.size());
     } else {
+      LOGP(debug, "extra check {} of {}, seed {} extrapolateTrack {}, used: {}", extraChecked, remSeeds.size(), iSeed, GTrackID::getSourceName(mGIDs[iSeed].getSource()), mTrackDataCompact.size());
       extrapolateTrack(iSeed);
     }
   }


### PR DESCRIPTION
The tracks with TRD/TOF are prioritized as of higher quality and we accept a limited min. amount of tracks per TF (1) before swithing to extra tracks (whose max accepted number is also capped). Therefore this guaranteed minimum will be typically affected by the PHOS hole, the same is true for the ITS-TPC stripped versions of these global tracks which are added for additional processing if ITS only extrapolation is asked.

When processing extra tracks, the algorithm was considering only these stripped ITS-TPC tracks, so the ITS extrapolation were also affected by the PHOS hole. This PR makes sure that the extra tracks processing starts from the first seed abandoned due to meeting the condition (1), and that the remaining tracks are processed in the random order.