### PR TITLE
Skip QED events in TPC QA

### DIFF
--- a/GPU/GPUTracking/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/qa/GPUQA.cxx
@@ -686,6 +686,9 @@ void GPUQA::InitO2MCData(GPUTrackingInOutPointers* updateIOPtr)
 
     mMCInfosCol.resize(nSimTotalEvents);
     for (int32_t iSim = 0; iSim < mcReader.getNSources(); iSim++) {
+      if (iSim == o2::steer::QEDSOURCEID) {
+        continue;
+      }
       for (int32_t i = 0; i < mcReader.getNEvents(iSim); i++) {
         auto ir = evrec[i];
         auto ir0 = o2::raw::HBFUtils::Instance().getFirstIRofTF(ir);


### PR DESCRIPTION
The caching of MC truth info is wrong as in general the same MC event of given source may be reused in multiple collisions (always the case for the QED). For the simulation with QED + hadronic source the processing of QED leads to accessing non-existent interaction record, followed by the crash reported by @ChSonnabend 
```
[1956199:tpc-tracker]: [09:22:00][FATAL] Unhandled o2::framework::runtime_error reached the top of main of o2-tpc-reco-workflow, device shutting down. Reason: Requested IR is ahead of the reference IR
```

For the proper loop over the contribution of different sources to the collision see e.g. https://github.com/AliceO2Group/AliceO2/blob/999ac719cffe2591fe395af9c5d7f21f7b67c778/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx#L120-L138.
Currently, I am simply discarding the QED source (99), but in principle, other sources may also be reused, so the code is not yet safe.