### PR TITLE
DPL: add more views on InputSpecs / OutputSpecs / DataProcessors

### DIFF
--- a/Framework/Core/include/Framework/DataSpecViews.h
+++ b/Framework/Core/include/Framework/DataSpecViews.h
@@ -18,8 +18,50 @@ namespace o2::framework::views
 {
 static auto partial_match_filter(auto what)
 {
-  return std::views::filter([&what](auto const& t) -> bool { return DataSpecUtils::partialMatch(t, what); });
+  return std::views::filter([what](auto const& t) -> bool { return DataSpecUtils::partialMatch(t, what); });
 }
+
+static auto exclude_by_name(std::string name)
+{
+  return std::views::filter([name](auto const& t) -> bool { return t.name != name; });
+}
+
+static auto filter_not_matching(auto const& provided)
+{
+  return std::views::filter([&provided](auto const& input) { return std::none_of(provided.begin(), provided.end(), [&input](auto const& output) { return DataSpecUtils::match(input, output); }); });
+}
+
 } // namespace o2::framework::views
+//
+namespace o2::framework::sinks
+{
+template <class Container>
+struct append_to {
+  Container& c;
+  // ends the pipeline, returns the container
+  template <std::ranges::input_range R>
+  friend Container& operator|(R&& r, append_to self)
+  {
+    std::ranges::copy(r, std::back_inserter(self.c));
+    return self.c;
+  }
+};
+
+template <class Container>
+struct update_input_list {
+  Container& c;
+  // ends the pipeline, returns the container
+  template <std::ranges::input_range R>
+  friend Container& operator|(R&& r, update_input_list self)
+  {
+    for (auto& item : r) {
+      auto copy = item;
+      DataSpecUtils::updateInputList(self.c, std::move(copy));
+    }
+    return self.c;
+  }
+};
+
+} // namespace o2::framework::sinks
 
 #endif // O2_FRAMEWORK_DATASPECVIEWS_H_


### PR DESCRIPTION

Useful to reduce the amount of lines of code in various manipulation
parts.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/14588).
* #14567
* #14575
* __->__ #14588