### PR TITLE
ITS: create artefacts labels only on demand 

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -80,6 +80,8 @@ struct TrackingParameters {
   float TrackFollowerNSigmaCutZ = 1.f;
   float TrackFollowerNSigmaCutPhi = 1.f;
 
+  bool createArtefactLabels{false};
+
   bool PrintMemory = false; // print allocator usage in epilog report
   size_t MaxMemory = std::numeric_limits<size_t>::max();
   bool DropTFUponFailure = false;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -97,6 +97,8 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   bool doUPCIteration = false;             // Perform an additional iteration for UPC events on tagged vertices. You want to combine this config with VertexerParamConfig.nIterations=2
   int nIterations = MaxIter;               // overwrite the number of iterations
 
+  bool createArtefactLabels{false}; // create on-the-fly labels for the artefacts
+
   int nThreads = 1;
   bool printMemory = false;
   size_t maxMemory = std::numeric_limits<size_t>::max();

--- a/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
@@ -187,6 +187,8 @@ std::vector<TrackingParameters> TrackingMode::getTrackingParameters(TrackingMode
       p.MinPt[lslot] *= bFactor;
     }
 
+    p.createArtefactLabels = tc.createArtefactLabels;
+
     p.PrintMemory = tc.printMemory;
     p.MaxMemory = tc.maxMemory;
     p.DropTFUponFailure = tc.dropTFUponFailure;

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -666,7 +666,6 @@ void TimeFrame<nLayers>::wipe()
   deepVectorClear(mROFramesPV);
   deepVectorClear(mPrimaryVertices);
   deepVectorClear(mRoads);
-  deepVectorClear(mRoadLabels);
   deepVectorClear(mMSangles);
   deepVectorClear(mPhiCuts);
   deepVectorClear(mPositionResolution);
@@ -676,9 +675,15 @@ void TimeFrame<nLayers>::wipe()
   deepVectorClear(mTrackletsIndexROF);
   deepVectorClear(mPrimaryVertices);
   deepVectorClear(mTrackletClusters);
-  deepVectorClear(mVerticesContributorLabels);
   deepVectorClear(mLines);
-  deepVectorClear(mLinesLabels);
+  if (hasMCinformation()) {
+    deepVectorClear(mLinesLabels);
+    deepVectorClear(mVerticesContributorLabels);
+    deepVectorClear(mTrackletLabels);
+    deepVectorClear(mCellLabels);
+    deepVectorClear(mRoadLabels);
+    deepVectorClear(mTracksLabel);
+  }
 }
 
 template class TimeFrame<7>;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -272,7 +272,7 @@ void TrackerTraits<nLayers>::computeLayerTracklets(const int iteration, int iROF
       });
 
     /// Create tracklets labels
-    if (mTimeFrame->hasMCinformation()) {
+    if (mTimeFrame->hasMCinformation() && mTrkParams[iteration].createArtefactLabels) {
       tbb::parallel_for(
         tbb::blocked_range<int>(0, mTrkParams[iteration].TrackletsPerRoad()),
         [&](const tbb::blocked_range<int>& Layers) {
@@ -313,7 +313,7 @@ void TrackerTraits<nLayers>::computeLayerCells(const int iteration)
     if (iLayer > 0) {
       deepVectorClear(mTimeFrame->getCellsLookupTable()[iLayer - 1]);
     }
-    if (mTimeFrame->hasMCinformation()) {
+    if (mTimeFrame->hasMCinformation() && mTrkParams[iteration].createArtefactLabels) {
       deepVectorClear(mTimeFrame->getCellsLabel(iLayer));
     }
   }
@@ -458,7 +458,7 @@ void TrackerTraits<nLayers>::computeLayerCells(const int iteration)
   });
 
   /// Create cells labels
-  if (mTimeFrame->hasMCinformation()) {
+  if (mTimeFrame->hasMCinformation() && mTrkParams[iteration].createArtefactLabels) {
     tbb::parallel_for(
       tbb::blocked_range<int>(0, mTrkParams[iteration].CellsPerRoad()),
       [&](const tbb::blocked_range<int>& Layers) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -459,13 +459,18 @@ void TrackerTraits<nLayers>::computeLayerCells(const int iteration)
 
   /// Create cells labels
   if (mTimeFrame->hasMCinformation()) {
-    for (int iLayer{0}; iLayer < mTrkParams[iteration].CellsPerRoad(); ++iLayer) {
-      for (const auto& cell : mTimeFrame->getCells()[iLayer]) {
-        MCCompLabel currentLab{mTimeFrame->getTrackletsLabel(iLayer)[cell.getFirstTrackletIndex()]};
-        MCCompLabel nextLab{mTimeFrame->getTrackletsLabel(iLayer + 1)[cell.getSecondTrackletIndex()]};
-        mTimeFrame->getCellsLabel(iLayer).emplace_back(currentLab == nextLab ? currentLab : MCCompLabel());
-      }
-    }
+    tbb::parallel_for(
+      tbb::blocked_range<int>(0, mTrkParams[iteration].CellsPerRoad()),
+      [&](const tbb::blocked_range<int>& Layers) {
+        for (int iLayer = Layers.begin(); iLayer < Layers.end(); ++iLayer) {
+          mTimeFrame->getCellsLabel(iLayer).reserve(mTimeFrame->getCells()[iLayer].size());
+          for (const auto& cell : mTimeFrame->getCells()[iLayer]) {
+            MCCompLabel currentLab{mTimeFrame->getTrackletsLabel(iLayer)[cell.getFirstTrackletIndex()]};
+            MCCompLabel nextLab{mTimeFrame->getTrackletsLabel(iLayer + 1)[cell.getSecondTrackletIndex()]};
+            mTimeFrame->getCellsLabel(iLayer).emplace_back(currentLab == nextLab ? currentLab : MCCompLabel());
+          }
+        }
+      });
   }
 }
 


### PR DESCRIPTION
This parallizes the label creation for the Cells.
Also makes the label creation on demand only since we in the last step in MC anyways compute the track labels via the clusters so there is no need to calculate them if we are not debugging, spares both cpu cycles and memory.