### PR TITLE
Revert "Fix in TRD sector getter"

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/GeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/GeometryBase.h
@@ -38,7 +38,7 @@ class GeometryBase
     }
   }
   GPUd() bool getSMstatus(int sm) const { return (mSMStatus & (0x1 << sm)) != 0; }
-  GPUd() static int getDetectorSec(int det) { return (det / (constants::NLAYER * constants::NSTACK)); }
+  GPUd() static int getDetectorSec(int det) { return (det % (constants::NLAYER * constants::NSTACK)); }
   GPUd() static int getDetectorSec(int layer, int stack) { return (layer + stack * constants::NLAYER); }
   GPUd() static int getDetector(int layer, int stack, int sector) { return (layer + stack * constants::NLAYER + sector * constants::NLAYER * constants::NSTACK); }
   GPUd() static int getLayer(int det) { return (det % constants::NLAYER); }


### PR DESCRIPTION
This reverts commit 7262c36703fb88bab6bcd1e76484aef06b2c1727. The correction of https://github.com/AliceO2Group/AliceO2/pull/14589 was actually not needed, just the name of the method is misleading.

At least the https://github.com/AliceO2Group/AliceO2/blob/cd8e5769a716fb9e2a684bc1d6964f1116d50c74/Detectors/TRD/simulation/src/Detector.cxx#L108-L111 uses this method to get detector ID within the sector rather than the sector ID.