### PR TITLE
DPL Analysis: rework cursor logic keeping the `gsl::span` for VLAs

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -561,21 +561,21 @@ class ColumnIterator : ChunkingPolicy
     mLast = mCurrent + array->length() + (mFirstIndex >> SCALE_FACTOR);
   }
 
-  decltype(auto) operator*() const
+  auto operator*() const
     requires std::same_as<bool, std::decay_t<T>>
   {
     checkSkipChunk();
     return (*(mCurrent - (mOffset >> SCALE_FACTOR) + ((*mCurrentPos + mOffset) >> SCALE_FACTOR)) & (1 << ((*mCurrentPos + mOffset) & 0x7))) != 0;
   }
 
-  decltype(auto) operator*() const
+  auto operator*() const
     requires((!std::same_as<bool, std::decay_t<T>>) && std::same_as<arrow_array_for_t<T>, arrow::ListArray>)
   {
     checkSkipChunk();
     auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
     auto offset = list->value_offset(*mCurrentPos - mFirstIndex);
     auto length = list->value_length(*mCurrentPos - mFirstIndex);
-    return gsl::span{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
+    return std::span<unwrap_t<T> const>{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
   }
 
   decltype(auto) operator*() const
@@ -851,7 +851,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   // which happens below which will properly setup the first index
   // by remapping the filtered index 0 to whatever unfiltered index
   // it belongs to.
-  FilteredIndexPolicy(gsl::span<int64_t const> selection, int64_t rows, uint64_t offset = 0)
+  FilteredIndexPolicy(std::span<int64_t const> selection, int64_t rows, uint64_t offset = 0)
     : IndexPolicyBase{-1, offset},
       mSelectedRows(selection),
       mMaxSelection(selection.size()),
@@ -860,7 +860,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
     this->setCursor(0);
   }
 
-  void resetSelection(gsl::span<int64_t const> selection)
+  void resetSelection(std::span<int64_t const> selection)
   {
     mSelectedRows = selection;
     mMaxSelection = selection.size();
@@ -944,7 +944,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   {
     this->mRowIndex = O2_BUILTIN_LIKELY(mSelectionRow < mMaxSelection) ? mSelectedRows[mSelectionRow] : -1;
   }
-  gsl::span<int64_t const> mSelectedRows;
+  std::span<int64_t const> mSelectedRows;
   int64_t mSelectionRow = 0;
   int64_t mMaxSelection = 0;
   int64_t nRows = 0;
@@ -1428,7 +1428,7 @@ struct PreslicePolicyGeneral : public PreslicePolicyBase {
   void updateSliceInfo(SliceInfoUnsortedPtr&& si);
 
   SliceInfoUnsortedPtr sliceInfo;
-  gsl::span<const int64_t> getSliceFor(int value) const;
+  std::span<const int64_t> getSliceFor(int value) const;
 };
 
 template <typename T, typename Policy, bool OPT = false>
@@ -1453,7 +1453,7 @@ struct PresliceBase : public Policy {
     return Policy::getSliceFor(value, input, offset);
   }
 
-  gsl::span<const int64_t> getSliceFor(int value) const
+  std::span<const int64_t> getSliceFor(int value) const
   {
     if constexpr (OPT) {
       if (Policy::isMissing()) {
@@ -1549,7 +1549,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
 }
 
 template <soa::is_filtered_table T>
-auto doSliceByHelper(T const* table, gsl::span<const int64_t> const& selection)
+auto doSliceByHelper(T const* table, std::span<const int64_t> const& selection)
 {
   auto t = soa::Filtered<typename T::base_t>({table->asArrowTable()}, selection);
   table->copyIndexBindings(t);
@@ -1560,7 +1560,7 @@ auto doSliceByHelper(T const* table, gsl::span<const int64_t> const& selection)
 
 template <soa::is_table T>
   requires(!soa::is_filtered_table<T>)
-auto doSliceByHelper(T const* table, gsl::span<const int64_t> const& selection)
+auto doSliceByHelper(T const* table, std::span<const int64_t> const& selection)
 {
   auto t = soa::Filtered<T>({table->asArrowTable()}, selection);
   table->copyIndexBindings(t);
@@ -1581,7 +1581,7 @@ auto doSliceBy(T const* table, o2::framework::PresliceBase<C, Policy, OPT> const
   return doSliceByHelper(table, selection);
 }
 
-SelectionVector sliceSelection(gsl::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset);
+SelectionVector sliceSelection(std::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset);
 
 template <soa::is_filtered_table T>
 auto prepareFilteredSlice(T const* table, std::shared_ptr<arrow::Table> slice, uint64_t offset)
@@ -2011,7 +2011,7 @@ class Table
     return RowViewSentinel{mEnd};
   }
 
-  filtered_iterator filtered_begin(gsl::span<int64_t const> selection)
+  filtered_iterator filtered_begin(std::span<int64_t const> selection)
   {
     // Note that the FilteredIndexPolicy will never outlive the selection which
     // is held by the table, so we are safe passing the bare pointer. If it does it
@@ -2556,12 +2556,12 @@ consteval auto getIndexTargets()
     _Name_##Ids(_Name_##Ids const& other) = default;                                                     \
     _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                          \
                                                                                                          \
-    gsl::span<const _Type_> inline getIds() const                                                        \
+    std::span<const _Type_> inline getIds() const                                                        \
     {                                                                                                    \
       return _Getter_##Ids();                                                                            \
     }                                                                                                    \
                                                                                                          \
-    gsl::span<const _Type_> _Getter_##Ids() const                                                        \
+    std::span<const _Type_> _Getter_##Ids() const                                                        \
     {                                                                                                    \
       return *mColumnIterator;                                                                           \
     }                                                                                                    \
@@ -2915,12 +2915,12 @@ consteval auto getIndexTargets()
     _Name_##Ids() = default;                                                                             \
     _Name_##Ids(_Name_##Ids const& other) = default;                                                     \
     _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                          \
-    gsl::span<const _Type_> inline getIds() const                                                        \
+    std::span<const _Type_> inline getIds() const                                                        \
     {                                                                                                    \
       return _Getter_##Ids();                                                                            \
     }                                                                                                    \
                                                                                                          \
-    gsl::span<const _Type_> _Getter_##Ids() const                                                        \
+    std::span<const _Type_> _Getter_##Ids() const                                                        \
     {                                                                                                    \
       return *mColumnIterator;                                                                           \
     }                                                                                                    \
@@ -3371,7 +3371,7 @@ class FilteredBase : public T
       mSelectedRowsCache{std::move(selection)},
       mCached{true}
   {
-    mSelectedRows = gsl::span{mSelectedRowsCache};
+    mSelectedRows = std::span{mSelectedRowsCache};
     if (this->tableSize() != 0) {
       mFilteredBegin = table_t::filtered_begin(mSelectedRows);
     }
@@ -3379,7 +3379,7 @@ class FilteredBase : public T
     mFilteredBegin.bindInternalIndices(this);
   }
 
-  FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  FilteredBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : T{std::move(tables), offset},
       mSelectedRows{selection}
   {
@@ -3458,12 +3458,12 @@ class FilteredBase : public T
   static inline auto getSpan(gandiva::Selection const& sel)
   {
     if (sel == nullptr) {
-      return gsl::span<int64_t const>{};
+      return std::span<int64_t const>{};
     }
     auto array = std::static_pointer_cast<arrow::Int64Array>(sel->ToArray());
     auto start = array->raw_values();
     auto stop = start + array->length();
-    return gsl::span{start, stop};
+    return std::span{start, stop};
   }
 
   /// Bind the columns which refer to other tables
@@ -3562,7 +3562,7 @@ class FilteredBase : public T
     resetRanges();
   }
 
-  void sumWithSelection(gsl::span<int64_t const> const& selection)
+  void sumWithSelection(std::span<int64_t const> const& selection)
   {
     mCached = true;
     SelectionVector rowsUnion;
@@ -3572,7 +3572,7 @@ class FilteredBase : public T
     resetRanges();
   }
 
-  void intersectWithSelection(gsl::span<int64_t const> const& selection)
+  void intersectWithSelection(std::span<int64_t const> const& selection)
   {
     mCached = true;
     SelectionVector intersection;
@@ -3591,7 +3591,7 @@ class FilteredBase : public T
   void resetRanges()
   {
     if (mCached) {
-      mSelectedRows = gsl::span{mSelectedRowsCache};
+      mSelectedRows = std::span{mSelectedRowsCache};
     }
     mFilteredEnd.reset(new RowViewSentinel{static_cast<int64_t>(mSelectedRows.size())});
     if (tableSize() == 0) {
@@ -3601,7 +3601,7 @@ class FilteredBase : public T
     }
   }
 
-  gsl::span<int64_t const> mSelectedRows;
+  std::span<int64_t const> mSelectedRows;
   SelectionVector mSelectedRowsCache;
   bool mCached = false;
   iterator mFilteredBegin;
@@ -3637,7 +3637,7 @@ class Filtered : public FilteredBase<T>
   Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
     : FilteredBase<T>(std::move(tables), std::forward<SelectionVector>(selection), offset) {}
 
-  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : FilteredBase<T>(std::move(tables), selection, offset) {}
 
   Filtered<T> operator+(SelectionVector const& selection)
@@ -3647,7 +3647,7 @@ class Filtered : public FilteredBase<T>
     return copy;
   }
 
-  Filtered<T> operator+(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator+(std::span<int64_t const> const& selection)
   {
     Filtered<T> copy(*this);
     copy.sumWithSelection(selection);
@@ -3665,7 +3665,7 @@ class Filtered : public FilteredBase<T>
     return *this;
   }
 
-  Filtered<T> operator+=(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator+=(std::span<int64_t const> const& selection)
   {
     this->sumWithSelection(selection);
     return *this;
@@ -3683,7 +3683,7 @@ class Filtered : public FilteredBase<T>
     return copy;
   }
 
-  Filtered<T> operator*(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator*(std::span<int64_t const> const& selection)
   {
     Filtered<T> copy(*this);
     copy.intersectWithSelection(selection);
@@ -3701,7 +3701,7 @@ class Filtered : public FilteredBase<T>
     return *this;
   }
 
-  Filtered<T> operator*=(gsl::span<int64_t const> const& selection)
+  Filtered<T> operator*=(std::span<int64_t const> const& selection)
   {
     this->intersectWithSelection(selection);
     return *this;
@@ -3809,7 +3809,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     }
   }
 
-  Filtered(std::vector<Filtered<T>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  Filtered(std::vector<Filtered<T>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : FilteredBase<typename T::table_t>(std::move(extractTablesFromFiltered(tables)), selection, offset)
   {
     for (auto& table : tables) {
@@ -3824,7 +3824,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return copy;
   }
 
-  Filtered<Filtered<T>> operator+(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator+(std::span<int64_t const> const& selection)
   {
     Filtered<Filtered<T>> copy(*this);
     copy.sumWithSelection(selection);
@@ -3842,7 +3842,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return *this;
   }
 
-  Filtered<Filtered<T>> operator+=(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator+=(std::span<int64_t const> const& selection)
   {
     this->sumWithSelection(selection);
     return *this;
@@ -3860,7 +3860,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return copy;
   }
 
-  Filtered<Filtered<T>> operator*(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator*(std::span<int64_t const> const& selection)
   {
     Filtered<Filtered<T>> copy(*this);
     copy.intersectionWithSelection(selection);
@@ -3878,7 +3878,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     return *this;
   }
 
-  Filtered<Filtered<T>> operator*=(gsl::span<int64_t const> const& selection)
+  Filtered<Filtered<T>> operator*=(std::span<int64_t const> const& selection)
   {
     this->intersectWithSelection(selection);
     return *this;
@@ -3987,7 +3987,7 @@ struct SmallGroupsBase : public Filtered<T> {
   SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), std::forward<SelectionVector>(selection), offset) {}
 
-  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<int64_t const> const& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), selection, offset) {}
 };
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -575,7 +575,7 @@ class ColumnIterator : ChunkingPolicy
     auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
     auto offset = list->value_offset(*mCurrentPos - mFirstIndex);
     auto length = list->value_length(*mCurrentPos - mFirstIndex);
-    return std::span<unwrap_t<T> const>{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
+    return gsl::span<unwrap_t<T> const>{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
   }
 
   decltype(auto) operator*() const
@@ -2556,12 +2556,12 @@ consteval auto getIndexTargets()
     _Name_##Ids(_Name_##Ids const& other) = default;                                                     \
     _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                          \
                                                                                                          \
-    std::span<const _Type_> inline getIds() const                                                        \
+    gsl::span<const _Type_> inline getIds() const                                                        \
     {                                                                                                    \
       return _Getter_##Ids();                                                                            \
     }                                                                                                    \
                                                                                                          \
-    std::span<const _Type_> _Getter_##Ids() const                                                        \
+    gsl::span<const _Type_> _Getter_##Ids() const                                                        \
     {                                                                                                    \
       return *mColumnIterator;                                                                           \
     }                                                                                                    \
@@ -2915,12 +2915,12 @@ consteval auto getIndexTargets()
     _Name_##Ids() = default;                                                                             \
     _Name_##Ids(_Name_##Ids const& other) = default;                                                     \
     _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                          \
-    std::span<const _Type_> inline getIds() const                                                        \
+    gsl::span<const _Type_> inline getIds() const                                                        \
     {                                                                                                    \
       return _Getter_##Ids();                                                                            \
     }                                                                                                    \
                                                                                                          \
-    std::span<const _Type_> _Getter_##Ids() const                                                        \
+    gsl::span<const _Type_> _Getter_##Ids() const                                                        \
     {                                                                                                    \
       return *mColumnIterator;                                                                           \
     }                                                                                                    \

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -120,7 +120,7 @@ template <typename T>
 concept is_producable = soa::has_metadata<aod::MetadataTrait<T>> || soa::has_metadata<aod::MetadataTrait<typename T::parent_t>>;
 
 template <typename T>
-concept is_enumerated_iterator = requires (T t) { t.globalIndex(); };
+concept is_enumerated_iterator = requires(T t) { t.globalIndex(); };
 
 template <is_producable T>
 struct WritingCursor {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -119,6 +119,9 @@ class TableConsumer;
 template <typename T>
 concept is_producable = soa::has_metadata<aod::MetadataTrait<T>> || soa::has_metadata<aod::MetadataTrait<typename T::parent_t>>;
 
+template <typename T>
+concept is_enumerated_iterator = requires (T t) { t.globalIndex(); };
+
 template <is_producable T>
 struct WritingCursor {
  public:
@@ -126,9 +129,9 @@ struct WritingCursor {
   using cursor_t = decltype(std::declval<TableBuilder>().cursor<persistent_table_t>());
 
   template <typename... Ts>
-  void operator()(Ts... args)
+  void operator()(Ts&&... args)
+    requires(sizeof...(Ts) == framework::pack_size(typename persistent_table_t::persistent_columns_t{}))
   {
-    static_assert(sizeof...(Ts) == framework::pack_size(typename persistent_table_t::persistent_columns_t{}), "Argument number mismatch");
     ++mCount;
     cursor(0, extract(args)...);
   }
@@ -167,15 +170,15 @@ struct WritingCursor {
   decltype(FFL(std::declval<cursor_t>())) cursor;
 
  private:
-  template <typename A>
-    requires requires { &A::globalIndex; }
+  template <is_enumerated_iterator A>
   static decltype(auto) extract(A const& arg)
   {
     return arg.globalIndex();
   }
 
   template <typename A>
-  static decltype(auto) extract(A const& arg)
+    requires(!is_enumerated_iterator<A>)
+  static decltype(auto) extract(A&& arg)
   {
     return arg;
   }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -170,8 +170,7 @@ struct WritingCursor {
   decltype(FFL(std::declval<cursor_t>())) cursor;
 
  private:
-  template <is_enumerated_iterator A>
-  static decltype(auto) extract(A const& arg)
+  static decltype(auto) extract(is_enumerated_iterator auto const& arg)
   {
     return arg.globalIndex();
   }

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -28,10 +28,10 @@ struct SliceInfoPtr {
 };
 
 struct SliceInfoUnsortedPtr {
-  gsl::span<int const> values;
+  std::span<int const> values;
   ListVector const* groups;
 
-  gsl::span<int64_t const> getSliceFor(int value) const;
+  std::span<int64_t const> getSliceFor(int value) const;
 };
 
 struct Entry {

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -264,9 +264,9 @@ struct GroupSlicer {
     std::tuple<A...>* mAt;
     typename grouping_t::iterator mGroupingElement;
     uint64_t position = 0;
-    gsl::span<int64_t const> groupSelection;
-    std::array<gsl::span<int64_t const> const*, sizeof...(A)> selections;
-    std::array<gsl::span<int64_t const>::iterator, sizeof...(A)> starts;
+    std::span<int64_t const> groupSelection;
+    std::array<std::span<int64_t const> const*, sizeof...(A)> selections;
+    std::array<std::span<int64_t const>::iterator, sizeof...(A)> starts;
 
     std::array<SliceInfoPtr, sizeof...(A)> sliceInfos;
     std::array<SliceInfoUnsortedPtr, sizeof...(A)> sliceInfosUnsorted;

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -105,7 +105,7 @@ void addLabelToSchema(std::shared_ptr<arrow::Schema>& schema, const char* label)
 
 struct BuilderUtils {
   template <typename T>
-  static arrow::Status appendToList(std::unique_ptr<arrow::FixedSizeListBuilder>& builder, T* data, int size = 1)
+  static arrow::Status appendToList(std::unique_ptr<arrow::FixedSizeListBuilder>& builder, const T* data, int size = 1)
   {
     using ArrowType = typename detail::ConversionTraits<std::decay_t<T>>::ArrowType;
     using BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
@@ -134,7 +134,7 @@ struct BuilderUtils {
   /// Assumes that the pointer actually points to a buffer
   /// which contains the correct number of elements.
   template <typename HolderType, typename T>
-  static arrow::Status append(HolderType& holder, T* data)
+  static arrow::Status append(HolderType& holder, const T* data)
   {
     if constexpr (std::is_same_v<decltype(holder.builder), std::unique_ptr<arrow::FixedSizeListBuilder>>) {
       return appendToList<T>(holder.builder, data);
@@ -144,21 +144,21 @@ struct BuilderUtils {
   }
   /// Appender for the array case.
   template <typename HolderType, typename T, int N>
-  static arrow::Status append(HolderType& holder, T (&data)[N])
+  static arrow::Status append(HolderType& holder, const T (&data)[N])
   {
     return holder.builder->Append(reinterpret_cast<const uint8_t*>(data));
   }
 
   /// Appender for the array case.
   template <typename HolderType, typename T, int N>
-  static arrow::Status append(HolderType& holder, std::array<T, N> const& data)
+  static arrow::Status append(HolderType& holder, std::array<const T, N> const& data)
   {
     return holder.builder->Append(reinterpret_cast<const uint8_t*>(data.data()));
   }
 
   /// Appender for the vector case.
   template <typename HolderType, typename T>
-  static arrow::Status append(HolderType& holder, std::vector<T> const& data)
+  static arrow::Status append(HolderType& holder, std::span<const T> data)
   {
     using ArrowType = typename detail::ConversionTraits<T>::ArrowType;
     using ValueBuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
@@ -171,7 +171,7 @@ struct BuilderUtils {
   }
 
   template <typename HolderType, typename T>
-  static void unsafeAppend(HolderType& holder, std::vector<T> const& value)
+  static void unsafeAppend(HolderType& holder, std::span<const T> value)
   {
     auto status = append(holder, value);
     if (!status.ok()) {
@@ -300,7 +300,7 @@ struct BuilderMaker<std::span<std::byte>> {
 
 template <typename ITERATOR>
 struct BuilderMaker<std::pair<ITERATOR, ITERATOR>> {
-  using FillType = std::pair<ITERATOR, ITERATOR>;
+  using FillType = std::pair<ITERATOR, ITERATOR> const&;
   using STLValueType = typename ITERATOR::value_type;
   using ArrowType = arrow::ListType;
   using ValueType = typename detail::ConversionTraits<typename ITERATOR::value_type>::ArrowType;
@@ -321,7 +321,7 @@ struct BuilderMaker<std::pair<ITERATOR, ITERATOR>> {
 
 template <typename T, int N>
 struct BuilderMaker<T (&)[N]> {
-  using FillType = T*;
+  using FillType = const T*;
   using STLValueType = T;
   using BuilderType = arrow::FixedSizeListBuilder;
   using ArrowType = arrow::FixedSizeListType;
@@ -343,7 +343,7 @@ struct BuilderMaker<T (&)[N]> {
 
 template <typename T, int N>
 struct BuilderMaker<T[N]> {
-  using FillType = T*;
+  using FillType = const T*;
   using BuilderType = arrow::FixedSizeListBuilder;
   using ArrowType = arrow::FixedSizeListType;
   using ElementType = typename detail::ConversionTraits<T>::ArrowType;
@@ -364,7 +364,7 @@ struct BuilderMaker<T[N]> {
 
 template <typename T, int N>
 struct BuilderMaker<std::array<T, N>> {
-  using FillType = T*;
+  using FillType = const T*;
   using BuilderType = arrow::FixedSizeListBuilder;
   using ArrowType = arrow::FixedSizeListType;
   using ElementType = typename detail::ConversionTraits<T>::ArrowType;
@@ -385,7 +385,7 @@ struct BuilderMaker<std::array<T, N>> {
 
 template <typename T>
 struct BuilderMaker<std::vector<T>> {
-  using FillType = std::vector<T>;
+  using FillType = std::span<const T>;
   using BuilderType = arrow::ListBuilder;
   using ArrowType = arrow::ListType;
   using ElementType = typename detail::ConversionTraits<T>::ArrowType;
@@ -678,7 +678,7 @@ class TableBuilder
   {
     auto persister = persistTuple(framework::pack<ARG0, ARGS...>{}, columnNames);
     // Callback used to fill the builders
-    return [persister = persister](unsigned int slot, typename BuilderMaker<ARG0>::FillType const& arg, typename BuilderMaker<ARGS>::FillType... args) -> void {
+    return [persister = persister](unsigned int slot, typename BuilderMaker<ARG0>::FillType arg, typename BuilderMaker<ARGS>::FillType... args) -> void {
       persister(slot, std::forward_as_tuple(arg, args...));
     };
   }

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -50,7 +50,7 @@ SelectionVector selectionToVector(gandiva::Selection const& sel)
   return rows;
 }
 
-SelectionVector sliceSelection(gsl::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset)
+SelectionVector sliceSelection(std::span<int64_t const> const& mSelectedRows, int64_t nrows, uint64_t offset)
 {
   auto start = offset;
   auto end = start + nrows;
@@ -217,7 +217,7 @@ std::shared_ptr<arrow::Table> PreslicePolicySorted::getSliceFor(int value, std::
   return output;
 }
 
-gsl::span<const int64_t> PreslicePolicyGeneral::getSliceFor(int value) const
+std::span<const int64_t> PreslicePolicyGeneral::getSliceFor(int value) const
 {
   return this->sliceInfo.getSliceFor(value);
 }

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -42,7 +42,7 @@ std::pair<int64_t, int64_t> SliceInfoPtr::getSliceFor(int value) const
   return {offsets[value], sizes[value]};
 }
 
-gsl::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
+std::span<const int64_t> SliceInfoUnsortedPtr::getSliceFor(int value) const
 {
   if (values.empty()) {
     return {};

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1150,8 +1150,8 @@ TEST_CASE("TestListColumns")
   for (auto& row : tbl) {
     auto f = row.l1();
     auto i = row.l2();
-    auto constexpr bf = std::same_as<decltype(f), gsl::span<const float, (size_t)-1>>;
-    auto constexpr bi = std::same_as<decltype(i), gsl::span<const int, (size_t)-1>>;
+    auto constexpr bf = std::same_as<decltype(f), std::span<const float, (size_t)-1>>;
+    auto constexpr bi = std::same_as<decltype(i), std::span<const int, (size_t)-1>>;
     REQUIRE(bf);
     REQUIRE(bi);
     REQUIRE(f.size() == s);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1150,8 +1150,8 @@ TEST_CASE("TestListColumns")
   for (auto& row : tbl) {
     auto f = row.l1();
     auto i = row.l2();
-    auto constexpr bf = std::same_as<decltype(f), std::span<const float, (size_t)-1>>;
-    auto constexpr bi = std::same_as<decltype(i), std::span<const int, (size_t)-1>>;
+    auto constexpr bf = std::same_as<decltype(f), gsl::span<const float, (size_t)-1>>;
+    auto constexpr bi = std::same_as<decltype(i), gsl::span<const int, (size_t)-1>>;
     REQUIRE(bf);
     REQUIRE(bi);
     REQUIRE(f.size() == s);


### PR DESCRIPTION
Replace `gsl::span` with `std::span` almost everywhere.

Make sure the cursor table fill can accept span. 