### PR TITLE
[MFT] Fixing wrong call of functions in construction of NoiseMaps

### DIFF
--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
@@ -79,12 +79,12 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
         sendOutputCcdbMerge(pc.outputs());
       } else if (mOutputType.compare("DCS") == 0) {
         LOG(info) << "Sending an object to DCS-Merge";
-        sendOutputDcsMerge(ec.outputs());
+        sendOutputDcsMerge(pc.outputs());
       } else {
         LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
-        sendOutputCcdb(ec.outputs());
-        sendOutputDcsMerge(ec.outputs());
-        sendOutputCcdbMerge(ec.outputs());
+        sendOutputCcdb(pc.outputs());
+        sendOutputDcsMerge(pc.outputs());
+        sendOutputCcdbMerge(pc.outputs());
       }
       pc.services().get<ControlService>().readyToQuit(mStopMeOnly ? QuitRequest::Me : QuitRequest::All);
     }
@@ -103,12 +103,12 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
         sendOutputCcdbMerge(pc.outputs());
       } else if (mOutputType.compare("DCS") == 0) {
         LOG(info) << "Sending an object to DCS-Merge";
-        sendOutputDcsMerge(ec.outputs());
+        sendOutputDcsMerge(pc.outputs());
       } else {
         LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
-        sendOutputCcdb(ec.outputs());
-        sendOutputDcsMerge(ec.outputs());
-        sendOutputCcdbMerge(ec.outputs());
+        sendOutputCcdb(pc.outputs());
+        sendOutputDcsMerge(pc.outputs());
+        sendOutputCcdbMerge(pc.outputs());
       }
       pc.services().get<ControlService>().readyToQuit(mStopMeOnly ? QuitRequest::Me : QuitRequest::All);
     }

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
@@ -78,13 +78,13 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
         LOG(info) << "Sending an object to Production-CCDBMerge";
         sendOutputCcdbMerge(pc.outputs());
       } else if (mOutputType.compare("DCS") == 0) {
-    LOG(info) << "Sending an object to DCS-Merge";
-    sendOutputDcsMerge(ec.outputs());
+        LOG(info) << "Sending an object to DCS-Merge";
+        sendOutputDcsMerge(ec.outputs());
       } else {
-    LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
-    sendOutputCcdb(ec.outputs());
-    sendOutputDcsMerge(ec.outputs());
-    sendOutputCcdbMerge(ec.outputs());
+        LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
+        sendOutputCcdb(ec.outputs());
+        sendOutputDcsMerge(ec.outputs());
+        sendOutputCcdbMerge(ec.outputs());
       }
       pc.services().get<ControlService>().readyToQuit(mStopMeOnly ? QuitRequest::Me : QuitRequest::All);
     }
@@ -102,13 +102,13 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
         LOG(info) << "Sending an object to Production-CCDBMerge";
         sendOutputCcdbMerge(pc.outputs());
       } else if (mOutputType.compare("DCS") == 0) {
-    LOG(info) << "Sending an object to DCS-Merge";
-    sendOutputDcsMerge(ec.outputs());
+        LOG(info) << "Sending an object to DCS-Merge";
+        sendOutputDcsMerge(ec.outputs());
       } else {
-    LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
-    sendOutputCcdb(ec.outputs());
-    sendOutputDcsMerge(ec.outputs());
-    sendOutputCcdbMerge(ec.outputs());
+        LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
+        sendOutputCcdb(ec.outputs());
+        sendOutputDcsMerge(ec.outputs());
+        sendOutputCcdbMerge(ec.outputs());
       }
       pc.services().get<ControlService>().readyToQuit(mStopMeOnly ? QuitRequest::Me : QuitRequest::All);
     }

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
@@ -78,13 +78,13 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
         LOG(info) << "Sending an object to Production-CCDBMerge";
         sendOutputCcdbMerge(pc.outputs());
       } else if (mOutputType.compare("DCS") == 0) {
-        LOG(info) << "Sending an object to DCS-CCDB";
-        sendOutputDcs(pc.outputs());
+    LOG(info) << "Sending an object to DCS-Merge";
+    sendOutputDcsMerge(ec.outputs());
       } else {
-        LOG(info) << "Sending an object to Production-CCDB and DCS-CCDB";
-        sendOutputCcdbDcs(pc.outputs());
-        LOG(info) << "Sending an object to Production-CCDBMerge";
-        sendOutputCcdbMerge(pc.outputs());
+    LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
+    sendOutputCcdb(ec.outputs());
+    sendOutputDcsMerge(ec.outputs());
+    sendOutputCcdbMerge(ec.outputs());
       }
       pc.services().get<ControlService>().readyToQuit(mStopMeOnly ? QuitRequest::Me : QuitRequest::All);
     }
@@ -102,13 +102,13 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
         LOG(info) << "Sending an object to Production-CCDBMerge";
         sendOutputCcdbMerge(pc.outputs());
       } else if (mOutputType.compare("DCS") == 0) {
-        LOG(info) << "Sending an object to DCS-CCDB";
-        sendOutputDcs(pc.outputs());
+    LOG(info) << "Sending an object to DCS-Merge";
+    sendOutputDcsMerge(ec.outputs());
       } else {
-        LOG(info) << "Sending an object to Production-CCDB and DCS-CCDB";
-        sendOutputCcdbDcs(pc.outputs());
-        LOG(info) << "Sending an object to Production-CCDBMerge";
-        sendOutputCcdbMerge(pc.outputs());
+    LOG(info) << "Sending an object to Production-CCDB, Production-CCDB-Merge and DCS-Merge";
+    sendOutputCcdb(ec.outputs());
+    sendOutputDcsMerge(ec.outputs());
+    sendOutputCcdbMerge(ec.outputs());
       }
       pc.services().get<ControlService>().readyToQuit(mStopMeOnly ? QuitRequest::Me : QuitRequest::All);
     }
@@ -385,7 +385,7 @@ void NoiseCalibratorSpec::sendOutputDcs(DataAllocator& output)
 void NoiseCalibratorSpec::sendOutputDcsMerge(DataAllocator& output)
 {
 
-  LOG(info) << "DCS mode";
+  LOG(info) << "DCS-Merge mode";
 
   static bool done = false;
   if (done) {


### PR DESCRIPTION
Keeping the same function calls in run as in EoS to avoid duplication of objects