### PR TITLE
ITS: GPU: disallow nROFsPerIterations

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
@@ -57,8 +57,8 @@ void TrackerTraitsGPU<nLayers>::computeLayerTracklets(const int iteration, int i
 {
   const auto& conf = o2::its::ITSGpuTrackingParamConfig::Instance();
 
-  int startROF{this->mTrkParams[iteration].nROFsPerIterations > 0 ? iROFslice * this->mTrkParams[iteration].nROFsPerIterations : 0};
-  int endROF{o2::gpu::CAMath::Min(this->mTrkParams[iteration].nROFsPerIterations > 0 ? (iROFslice + 1) * this->mTrkParams[iteration].nROFsPerIterations + this->mTrkParams[iteration].DeltaROF : mTimeFrameGPU->getNrof(), mTimeFrameGPU->getNrof())};
+  int startROF{0};
+  int endROF{mTimeFrameGPU->getNrof()};
 
   // start by queuing loading needed of two last layers
   for (int iLayer{nLayers}; iLayer-- > nLayers - 2;) {

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -85,7 +85,7 @@ void Tracker<nLayers>::clustersToTracks(const LogFunc& logger, const LogFunc& er
       }
       double timeTracklets{0.}, timeCells{0.}, timeNeighbours{0.}, timeRoads{0.};
       int nTracklets{0}, nCells{0}, nNeighbours{0}, nTracks{-static_cast<int>(mTimeFrame->getNumberOfTracks())};
-      int nROFsIterations = mTrkParams[iteration].nROFsPerIterations > 0 ? mTimeFrame->getNrof() / mTrkParams[iteration].nROFsPerIterations + bool(mTimeFrame->getNrof() % mTrkParams[iteration].nROFsPerIterations) : 1;
+      int nROFsIterations = (mTrkParams[iteration].nROFsPerIterations > 0 && !mTimeFrame->mIsGPU) ? mTimeFrame->getNrof() / mTrkParams[iteration].nROFsPerIterations + bool(mTimeFrame->getNrof() % mTrkParams[iteration].nROFsPerIterations) : 1;
       iVertex = std::min(maxNvertices, 0);
       logger(std::format("==== ITS {} Tracking iteration {} summary ====", mTraits->getName(), iteration));
 


### PR DESCRIPTION
As it is right now with the overlapping of the dataloading on the first iteration, doing the iteration per rof does not work (I think this only used for Pb-Pb) since the same data would be loaded multiple times leading to OOM. In any case, this option also fundamentally clashes with the gpu processing since it is done in parallel for many rofs. So for now and the test we want to do I want to disallow it summarily on the GPU part.