### PR TITLE
add best knowldge of collision time in tof matching info

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
@@ -86,6 +86,14 @@ class MatchInfoTOF
                       hasT0_1BCbefore = 0x1 << 8,
                       hasT0_2BCbefore = 0x1 << 9 };
 
+  void setFT0Best(double val, float res = 200.)
+  {
+    mFT0Best = val;
+    mFT0BestRes = res;
+  }
+  double getFT0Best() const { return mFT0Best; }
+  float getFT0BestRes() const { return mFT0BestRes; }
+
  private:
   int mIdLocal;                      // track id in sector of the pair track-TOFcluster
   float mChi2;                       // chi2 of the pair track-TOFcluster
@@ -106,7 +114,10 @@ class MatchInfoTOF
   float mTgeant = 0.0;        ///< geant time in MC
   double mT0true = 0.0;       ///< t0true
 
-  ClassDefNV(MatchInfoTOF, 8);
+  double mFT0Best = 0.0;     //< best info for collision time
+  float mFT0BestRes = 200.0; //< resolution (in ps) of the best info for collision time
+
+  ClassDefNV(MatchInfoTOF, 9);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1581,6 +1581,8 @@ void MatchTOF::doMatchingForTPC(int sec)
 //______________________________________________
 int MatchTOF::findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints, unsigned long firstOrbit)
 {
+  const auto& FT0Params = o2::ft0::InteractionTag::Instance();
+
   if ((!mHasFillScheme) && o2::tof::Utils::hasFillScheme()) {
     mHasFillScheme = true;
     for (int ibc = 0; ibc < o2::tof::Utils::getNinteractionBC(); ibc++) {
@@ -1598,6 +1600,10 @@ int MatchTOF::findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FI
   const int distThr = 8;
 
   for (unsigned int i = 0; i < FITRecPoints.size(); i++) {
+    const auto& ft = FITRecPoints[i];
+    if (!FT0Params.isSelected(ft)) {
+      continue;
+    }
     const o2::InteractionRecord ir = FITRecPoints[i].getInteractionRecord();
     if (mHasFillScheme && !mFillScheme[ir.bc]) {
       continue;
@@ -1702,8 +1708,8 @@ void MatchTOF::BestMatches(std::vector<o2::dataformats::MatchInfoTOFReco>& match
     matchingPair.setT0true(TOFClusWork[matchingPair.getTOFClIndex()].getT0true());
 
     // let's check if cluster has multiple-hits (noferini)
-    if (TOFClusWork[matchingPair.getTOFClIndex()].getNumOfContributingChannels() > 1) {
-      const auto& tofcl = TOFClusWork[matchingPair.getTOFClIndex()];
+    const auto& tofcl = TOFClusWork[matchingPair.getTOFClIndex()];
+    if (tofcl.getNumOfContributingChannels() > 1) {
       // has an additional hit Up or Down (Z-dir)
       matchingPair.setHitPatternUpDown(tofcl.isAdditionalChannelSet(o2::tof::Cluster::kUp) ||
                                        tofcl.isAdditionalChannelSet(o2::tof::Cluster::kUpLeft) ||
@@ -1719,6 +1725,19 @@ void MatchTOF::BestMatches(std::vector<o2::dataformats::MatchInfoTOFReco>& match
                                           tofcl.isAdditionalChannelSet(o2::tof::Cluster::kDownRight) ||
                                           tofcl.isAdditionalChannelSet(o2::tof::Cluster::kUpRight));
     }
+
+    // estimate collision time using FT0 info if available
+    ULong64_t bclongtofCal = (matchingPair.getSignal() - 10000) * o2::tof::Geo::BC_TIME_INPS_INV;
+    double t0Best = bclongtofCal * o2::tof::Geo::BC_TIME_INPS; // here just BC
+    float t0BestRes = 200;
+    if (FITRecPoints.size() > 0) {
+      int index = findFITIndex(bclongtofCal, FITRecPoints, mFirstTForbit);
+      if (index > -1 && FITRecPoints[index].isValidTime(1) && FITRecPoints[index].isValidTime(2)) { // require A and C
+        t0Best += FITRecPoints[index].getCollisionTime(0);
+        t0BestRes = 15;
+      }
+    }
+    matchingPair.setFT0Best(t0Best, t0BestRes);
     matchedTracks[trkTypeSplitted].push_back(matchingPair); // array of MatchInfoTOF
 
     // get fit info

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -114,9 +114,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
 
-  if (!writecalib) {
-    useFIT = false;
-  }
+  //  if (!writecalib) {
+  //    useFIT = false;
+  //  }
 
   LOG(debug) << "TOF MATCHER WORKFLOW configuration";
   LOG(debug) << "TOF track inputs = " << configcontext.options().get<std::string>("track-sources");


### PR DESCRIPTION
Dear @shahor02 , @miranov25 ,
I am preparing a PR to attach the best FT0 info already in the TOF matching info since the info is available in the final stage of TOF matching (it is needed for TOF calibInfo).
I added one double (collision time) and one float (T0 res.) in the TOF matching info (whose output is in any case not persistent)
Once ready it should be easy for you to use it. 