### PR TITLE
start_tmux.sh: use o2-ccdb.internal for ccdb requests

### DIFF
--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -38,7 +38,7 @@ if [[ "0$FST_TMUX_NO_EPN" != "01" ]]; then
   [[ -z $EPNPIPELINES ]] && export EPNPIPELINES=1
   [[ -z $O2_GPU_DOUBLE_PIPELINE ]] && export O2_GPU_DOUBLE_PIPELINE=1
   [[ -z $O2_GPU_RTC ]] && export O2_GPU_RTC=1
-  [[ -z $DPL_CONDITION_BACKEND ]] && export DPL_CONDITION_BACKEND="http://localhost:8084"
+  [[ -z $DPL_CONDITION_BACKEND ]] && export DPL_CONDITION_BACKEND="http://o2-ccdb.internal"
   export ALL_EXTRA_CONFIG="$ALL_EXTRA_CONFIG;NameConf.mCCDBServer=${DPL_CONDITION_BACKEND};"
   export GEN_TOPO_QC_OVERRIDE_CCDB_SERVER="${DPL_CONDITION_BACKEND}"
   [[ -z $NUM_DPL_WORKFLOWS ]] && NUM_DPL_WORKFLOWS=2


### PR DESCRIPTION
This is to avoid caching default objects with infinite validity to localhost:8084 which are then picked up by synthetic / replay runs in online for which there actually are valid objects.