### PR TITLE
ITS: skip processing entirely if no clusters/rofs in TF

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -99,7 +99,7 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
   irFrames.reserve(trackROFvec.size());
   int nBCPerTF = alpParams.roFrameLengthInBC;
 
-  LOGP(info, "ITSTracker pulled {} clusters, {} RO frames", compClusters.size(), trackROFvec.size());
+  LOGP(info, "ITSTracker pulled {} clusters, {} RO frames {}", compClusters.size(), trackROFvec.size(), compClusters.empty() ? " -> received no processable data will skip" : "");
   const dataformats::MCTruthContainer<MCCompLabel>* labels = nullptr;
   gsl::span<itsmft::MC2ROFRecord const> mc2rofs;
   if (mIsMC) {
@@ -157,7 +157,9 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
   if (mRunVertexer) {
     vertROFvec.reserve(trackROFvec.size());
     // Run seeding vertexer
-    vertexerElapsedTime = mVertexer->clustersToVertices(logger);
+    if (!compClusters.empty()) {
+      vertexerElapsedTime = mVertexer->clustersToVertices(logger);
+    }
   } else { // cosmics
     mTimeFrame->resetRofPV();
   }
@@ -226,7 +228,7 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
       mTimeFrame->addPrimaryVertices(vtxVecLoc, 0);
     }
   }
-  if (mRunVertexer) {
+  if (mRunVertexer && !compClusters.empty()) {
     LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} ({} + {}) vertices found in {}/{} ROFs",
                              vertexerElapsedTime,
                              mTimeFrame->getPrimaryVerticesNum(),
@@ -244,14 +246,15 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
   if (mCosmicsProcessing && compClusters.size() > 1500 * trackROFspan.size()) {
     LOG(error) << "Cosmics processing was requested with an average detector occupancy exceeding 1.e-7, skipping TF processing.";
   } else {
-
-    mTimeFrame->setMultiplicityCutMask(processingMask);
-    mTimeFrame->setROFMask(processUPCMask);
-    // Run CA tracker
-    if (mMode == o2::its::TrackingMode::Async && o2::its::TrackerParamConfig::Instance().fataliseUponFailure) {
-      mTracker->clustersToTracks(logger, fatalLogger);
-    } else {
-      mTracker->clustersToTracks(logger, errorLogger);
+    if (!compClusters.empty()) {
+      mTimeFrame->setMultiplicityCutMask(processingMask);
+      mTimeFrame->setROFMask(processUPCMask);
+      // Run CA tracker
+      if (mMode == o2::its::TrackingMode::Async && o2::its::TrackerParamConfig::Instance().fataliseUponFailure) {
+        mTracker->clustersToTracks(logger, fatalLogger);
+      } else {
+        mTracker->clustersToTracks(logger, errorLogger);
+      }
     }
     size_t totTracks{mTimeFrame->getNumberOfTracks()}, totClusIDs{mTimeFrame->getNumberOfUsedClusters()};
     if (totTracks) {


### PR DESCRIPTION
Should fix the error reported in https://its.cern.ch/jira/browse/O2-6264 for test 1.
The issue seems to be that sometimes there are TFs which do not contain any digits/rof information for ITS.
The cpu code handles this correctly the gpu code does not since it tries to then to pin empty buffers.
This fixes this by entirely skipping any processing if there are no clusters/rofs received.
```
[3403294:its-clusterer]: [10:28:20][INFO] ITSClusterer pulled 0 digits, in 0 RO frames
[3403294:its-clusterer]: [10:28:20][INFO] ITSClusterer pulled 0 labels
[3403296:its-tracker]: [10:28:21][INFO] ITSTracker pulled 0 clusters, 0 RO frames  -> received no processable data will skip
```
I tested that downstream devices that use ITS track info handle this situation by running the pvertexer just on ITS (is this enough as a test?).