### PR TITLE
GPU Framework: fixed mismatch between CUDA and HIP launch bounds definition

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstructionKernelMacros.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionKernelMacros.h
@@ -32,6 +32,21 @@
 #define GPUCA_M_KRNL_NAME(...) GPUCA_M_KRNL_NAME_A(GPUCA_M_STRIP(__VA_ARGS__))
 
 #if defined(GPUCA_GPUCODE) || defined(GPUCA_GPUCODE_HOSTONLY)
+
+#if defined(__HIPCC__) && !defined(GPUCA_GPUCODE_NO_LAUNCH_BOUNDS)
+  static_assert(GPUCA_PAR_AMD_EUS_PER_CU > 0);
+  #define GPUCA_MIN_WARPS_PER_EU(maxThreadsPerBlock, minBlocksPerCU) GPUCA_CEIL_INT_DIV((minBlocksPerCU) * (maxThreadsPerBlock), (GPUCA_WARP_SIZE * GPUCA_PAR_AMD_EUS_PER_CU))
+
+  #define GPUCA_LB_ARGS_1(maxThreadsPerBlock) maxThreadsPerBlock
+  #define GPUCA_LB_ARGS_2(maxThreadsPerBlock, minBlocksPerCU) maxThreadsPerBlock, GPUCA_MIN_WARPS_PER_EU(maxThreadsPerBlock, minBlocksPerCU)
+
+  #define GPUCA_LAUNCH_BOUNDS_SELECT(n, ...) GPUCA_M_CAT(GPUCA_LB_ARGS_, n)(__VA_ARGS__)
+  #define GPUCA_LAUNCH_BOUNDS_DISP(...) GPUCA_LAUNCH_BOUNDS_SELECT(GPUCA_M_COUNT(__VA_ARGS__), __VA_ARGS__)
+  #define GPUCA_KRNL_REG_DEFAULT(args) __launch_bounds__(GPUCA_LAUNCH_BOUNDS_DISP(GPUCA_M_MAX2_3(GPUCA_M_STRIP(args))))
+#elif !defined(GPUCA_GPUCODE_NO_LAUNCH_BOUNDS)
+  #define GPUCA_KRNL_REG_DEFAULT(args) __launch_bounds__(GPUCA_M_MAX2_3(GPUCA_M_STRIP(args)))
+#endif
+
 #ifndef GPUCA_KRNL_REG
 #define GPUCA_KRNL_REG(...)
 #endif

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAGenRTC.cxx
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAGenRTC.cxx
@@ -74,7 +74,7 @@ int32_t GPUReconstructionCUDA::genRTC(std::string& filename, uint32_t& nCompile)
     }
     fclose(fp);
   }
-  const std::string launchBounds = o2::gpu::internal::GPUDefParametersExport(*mParDevice, true) +
+  const std::string launchBounds = o2::gpu::internal::GPUDefParametersExport(*mParDevice, true, mParDevice->par_AMD_EUS_PER_CU ? (mParDevice->par_AMD_EUS_PER_CU * mWarpSize) : 0) +
                                    "#define GPUCA_WARP_SIZE " + std::to_string(mWarpSize) + "\n";
   if (GetProcessingSettings().rtctech.printLaunchBounds || GetProcessingSettings().debugLevel >= 3) {
     GPUInfo("RTC Launch Bounds:\n%s", launchBounds.c_str());

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAKernels.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAKernels.cu
@@ -74,7 +74,7 @@ inline void GPUReconstructionCUDA::runKernelBackend(const krnlSetupTime& _xyz, c
 }
 
 #undef GPUCA_KRNL_REG
-#define GPUCA_KRNL_REG(args) __launch_bounds__(GPUCA_M_MAX2_3(GPUCA_M_STRIP(args)))
+#define GPUCA_KRNL_REG(...) GPUCA_KRNL_REG_DEFAULT(__VA_ARGS__)
 
 // clang-format off
 #if defined(GPUCA_KERNEL_COMPILE_MODE) && GPUCA_KERNEL_COMPILE_MODE != 1 // ---------- COMPILE_MODE = perkernel ----------

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDARTCCalls.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDARTCCalls.cu
@@ -15,7 +15,7 @@
 #define GPUCA_GPUCODE_HOSTONLY
 #define GPUCA_GPUCODE_NO_LAUNCH_BOUNDS
 
-#define GPUCA_KRNL_REG(args) __launch_bounds__(GPUCA_M_MAX2_3(GPUCA_M_STRIP(args)))
+#define GPUCA_KRNL_REG(args) __launch_bounds__(GPUCA_M_STRIP(args))
 
 #include "GPUReconstructionCUDAIncludesSystem.h"
 #include "GPUReconstructionCUDADef.h"

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAkernel.template.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAkernel.template.cu
@@ -14,7 +14,7 @@
 
 #define GPUCA_GPUCODE_COMPILEKERNELS
 #include "GPUReconstructionCUDAIncludesSystem.h"
-#define GPUCA_KRNL_REG(args) __launch_bounds__(GPUCA_M_MAX2_3(GPUCA_M_STRIP(args)))
+#define GPUCA_KRNL_REG(...) GPUCA_KRNL_REG_DEFAULT(__VA_ARGS__)
 #define GPUCA_KRNL(...) GPUCA_KRNLGPU(__VA_ARGS__);
 #include "GPUReconstructionCUDADef.h"
 #include "GPUReconstructionKernelMacros.h"

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIPkernel.template.hip
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIPkernel.template.hip
@@ -14,7 +14,7 @@
 
 #define GPUCA_GPUCODE_COMPILEKERNELS
 #include "GPUReconstructionHIPIncludesSystem.h"
-#define GPUCA_KRNL_REG(args) __launch_bounds__(GPUCA_M_MAX2_3(GPUCA_M_STRIP(args)))
+#define GPUCA_KRNL_REG(...) GPUCA_KRNL_REG_DEFAULT(__VA_ARGS__)
 #define GPUCA_KRNL(...) GPUCA_KRNLGPU(__VA_ARGS__);
 #include "GPUReconstructionHIPDef.h"
 #include "GPUReconstructionKernelMacros.h"

--- a/GPU/GPUTracking/Definitions/GPUDefMacros.h
+++ b/GPU/GPUTracking/Definitions/GPUDefMacros.h
@@ -50,5 +50,7 @@
 #define GPUCA_UNROLL(...)
 #endif
 
+#define GPUCA_CEIL_INT_DIV(a, b) (((a) + (b) - 1) / (b))
+
 #endif
 // clang-format on

--- a/GPU/GPUTracking/Definitions/GPUDefParametersDefaults.h
+++ b/GPU/GPUTracking/Definitions/GPUDefParametersDefaults.h
@@ -25,6 +25,7 @@
   // GPU-architecture-dependent default settings
   #if defined(GPUCA_GPUTYPE_MI2xx)
     #define GPUCA_WARP_SIZE 64
+    #define GPUCA_PAR_AMD_EUS_PER_CU 4
     #define GPUCA_THREAD_COUNT_DEFAULT 256
     #define GPUCA_LB_GPUTPCCreateTrackingData 256
     #define GPUCA_LB_GPUTPCStartHitsSorter 512, 1
@@ -88,6 +89,7 @@
     #define GPUCA_PAR_COMP_GATHER_MODE 3
   #elif defined(GPUCA_GPUTYPE_VEGA)
     #define GPUCA_WARP_SIZE 64
+    #define GPUCA_PAR_AMD_EUS_PER_CU 4
     #define GPUCA_THREAD_COUNT_DEFAULT 256
     #define GPUCA_LB_GPUTPCCreateTrackingData 128
     #define GPUCA_LB_GPUTPCStartHitsSorter 1024, 2
@@ -275,6 +277,9 @@
   // Default settings for GPU, if not already set for selected GPU type
   #ifndef GPUCA_WARP_SIZE
     #define GPUCA_WARP_SIZE 32
+  #endif
+  #ifndef GPUCA_PAR_AMD_EUS_PER_CU
+    #define GPUCA_PAR_AMD_EUS_PER_CU 0
   #endif
   #ifndef GPUCA_THREAD_COUNT_DEFAULT
     #define GPUCA_THREAD_COUNT_DEFAULT 256

--- a/GPU/GPUTracking/Definitions/GPUDefParametersLoad.template.inc
+++ b/GPU/GPUTracking/Definitions/GPUDefParametersLoad.template.inc
@@ -39,23 +39,23 @@ static GPUDefParameters GPUDefParametersLoad()
   };
 }
 
-#define GPUCA_EXPORT_KERNEL_LB(name)                                            \
-  if (par.par_LB_maxThreads[i] > 0) {                                           \
-    o << "#define GPUCA_LB_" GPUCA_M_STR(name) " " << par.par_LB_maxThreads[i]; \
-    if (par.par_LB_minBlocks[i] > 0) {                                          \
-      o << ", " << par.par_LB_minBlocks[i];                                     \
-    }                                                                           \
-    if (!forRTC && par.par_LB_forceBlocks[i] > 0) {                             \
-      o << ", " << par.par_LB_forceBlocks[i];                                   \
-    }                                                                           \
-    o << "\n";                                                                  \
-  }                                                                             \
+#define GPUCA_EXPORT_KERNEL_LB(name)                                                                                                                     \
+  if (par.par_LB_maxThreads[i] > 0) {                                                                                                                    \
+    o << "#define GPUCA_LB_" GPUCA_M_STR(name) " " << par.par_LB_maxThreads[i];                                                                          \
+    if (par.par_LB_minBlocks[i] > 0) {                                                                                                                   \
+      o << ", " << GPUCA_CEIL_INT_DIV(par.par_LB_maxThreads[i] * par.par_LB_minBlocks[i], (minBlockFactor ? minBlockFactor : par.par_LB_maxThreads[i])); \
+    }                                                                                                                                                    \
+    if (!forRTC && par.par_LB_forceBlocks[i] > 0) {                                                                                                      \
+      o << ", " << par.par_LB_forceBlocks[i];                                                                                                            \
+    }                                                                                                                                                    \
+    o << "\n";                                                                                                                                           \
+  }                                                                                                                                                      \
   i++;
 
 #define GPUCA_EXPORT_KERNEL_PARAM(name) \
   o << "#define GPUCA_PAR_" GPUCA_M_STR(name) " " << GPUCA_M_CAT(par.par_, name) << "\n";
 
-static std::string GPUDefParametersExport(const GPUDefParameters& par, bool forRTC)
+static std::string GPUDefParametersExport(const GPUDefParameters& par, bool forRTC, int32_t minBlockFactor = 0)
 {
   std::stringstream o; // clang-format off
   int32_t i = 0;

--- a/GPU/GPUTracking/kernels.cmake
+++ b/GPU/GPUTracking/kernels.cmake
@@ -147,7 +147,8 @@ o2_gpu_kernel_add_parameter(NEIGHBOURS_FINDER_MAX_NNEIGHUP
                             COMP_GATHER_KERNEL
                             COMP_GATHER_MODE
                             SORT_STARTHITS
-                            CF_SCAN_WORKGROUP_SIZE)
+                            CF_SCAN_WORKGROUP_SIZE
+                            AMD_EUS_PER_CU)
 
 o2_gpu_kernel_add_string_parameter(DEDX_STORAGE_TYPE
                                    MERGER_INTERPOLATION_ERROR_TYPE)


### PR DESCRIPTION
Handled mismatch between CUDA and HIP \_\_launch\_bounds\_\_ definitions. Performances remain the same. Added GPUCA_CEIL_INT_DIV macro for integer division with ceiling; this ensures that when computing the number of warps (e.g., 1.4), the result is rounded up to the next integer (e.g., 2) so that enough active warps are allocated per execution unit.