### PR TITLE
Geo: Fix Run 4 barrel beam pipe section

### DIFF
--- a/Detectors/Passive/src/PipeRun4.cxx
+++ b/Detectors/Passive/src/PipeRun4.cxx
@@ -215,8 +215,7 @@ void PipeRun4::ConstructGeometry()
   voberylliumTube->SetLineColor(kRed);
 
   TGeoTube* berylliumTubeVacuum =
-    new TGeoTube("IP_PIPEVACUUMsh", 0., kBeryliumSectionOuterRadius - kBeryliumSectionThickness,
-                 (kBeryliumSectionZmax - kBeryliumSectionZmin) / 2);
+    new TGeoTube("IP_PIPEVACUUMsh", 0., kBeryliumSectionOuterRadius, (kBeryliumSectionZmax - kBeryliumSectionZmin) / 2);
   TGeoVolume* voberylliumTubeVacuum = new TGeoVolume("IP_PIPEMOTHER", berylliumTubeVacuum, kMedVac);
   voberylliumTubeVacuum->AddNode(voberylliumTube, 1, gGeoIdentity);
   voberylliumTubeVacuum->SetVisibility(0);


### PR DESCRIPTION
Fix wrong radius of wrap-vol for the inner section of the beam pipe, introduced in #13772. 
This disables effectively this part of the pipe since it is the mother volume of the actual pipe (the wrap-vol is smaller than the child volume).
This puzzled us for a while now since for ITS3 this improves the IP resolution by quite a large bit at low-pt.
Material before:
<img width="1598" height="775" alt="ITS3_material_map_before" src="https://github.com/user-attachments/assets/64c6715a-4e97-4952-8521-b00c6e941704" />
Material after:
<img width="1598" height="775" alt="ITS3_material_map" src="https://github.com/user-attachments/assets/3d2028de-939c-4235-9595-e393439ad5b2" />

@fgrosa @ChunzhengLab this is hopefully all lets rerun the sims from scratch (for proper hit generation).

@hahassan7 or is there something I am overlooking?
