### PR TITLE
ITS: simplify parallel_for loops

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -212,14 +212,10 @@ void TrackerTraits<nLayers>::computeLayerTracklets(const int iteration, int iROF
           }
         });
 
-      tbb::parallel_for(
-        tbb::blocked_range<int>(0, mTrkParams[iteration].TrackletsPerRoad()),
-        [&](auto const& Layers) {
-          for (int iLayer{Layers.begin()}; iLayer < Layers.end(); ++iLayer) {
-            std::exclusive_scan(perROFCount[iLayer].begin(), perROFCount[iLayer].end(), perROFCount[iLayer].begin(), 0);
-            mTimeFrame->getTracklets()[iLayer].resize(perROFCount[iLayer].back());
-          }
-        });
+      tbb::parallel_for(0, mTrkParams[iteration].TrackletsPerRoad(), [&](const int iLayer) {
+        std::exclusive_scan(perROFCount[iLayer].begin(), perROFCount[iLayer].end(), perROFCount[iLayer].begin(), 0);
+        mTimeFrame->getTracklets()[iLayer].resize(perROFCount[iLayer].back());
+      });
 
       tbb::parallel_for(
         tbb::blocked_range2d<int, int>(0, mTrkParams[iteration].TrackletsPerRoad(), 1,
@@ -241,61 +237,53 @@ void TrackerTraits<nLayers>::computeLayerTracklets(const int iteration, int iROF
         });
     }
 
-    tbb::parallel_for(
-      tbb::blocked_range<int>(0, mTrkParams[iteration].TrackletsPerRoad()),
-      [&](const tbb::blocked_range<int>& Layers) {
-        for (int iLayer = Layers.begin(); iLayer < Layers.end(); ++iLayer) {
-          /// Sort tracklets
-          auto& trkl{mTimeFrame->getTracklets()[iLayer]};
-          tbb::parallel_sort(trkl.begin(), trkl.end(), [](const Tracklet& a, const Tracklet& b) -> bool {
-            if (a.firstClusterIndex != b.firstClusterIndex) {
-              return a.firstClusterIndex < b.firstClusterIndex;
-            }
-            return a.secondClusterIndex < b.secondClusterIndex;
-          });
-          /// Remove duplicates
-          trkl.erase(std::unique(trkl.begin(), trkl.end(), [](const Tracklet& a, const Tracklet& b) -> bool {
-                       return a.firstClusterIndex == b.firstClusterIndex && a.secondClusterIndex == b.secondClusterIndex;
-                     }),
-                     trkl.end());
-          trkl.shrink_to_fit();
-          if (iLayer > 0) { /// recalculate lut
-            auto& lut{mTimeFrame->getTrackletsLookupTable()[iLayer - 1]};
-            if (!trkl.empty()) {
-              for (const auto& tkl : trkl) {
-                lut[tkl.firstClusterIndex + 1]++;
-              }
-              std::inclusive_scan(lut.begin(), lut.end(), lut.begin());
-            }
-          }
+    tbb::parallel_for(0, mTrkParams[iteration].TrackletsPerRoad(), [&](const int iLayer) {
+      /// Sort tracklets
+      auto& trkl{mTimeFrame->getTracklets()[iLayer]};
+      tbb::parallel_sort(trkl.begin(), trkl.end(), [](const Tracklet& a, const Tracklet& b) -> bool {
+        if (a.firstClusterIndex != b.firstClusterIndex) {
+          return a.firstClusterIndex < b.firstClusterIndex;
         }
+        return a.secondClusterIndex < b.secondClusterIndex;
       });
+      /// Remove duplicates
+      trkl.erase(std::unique(trkl.begin(), trkl.end(), [](const Tracklet& a, const Tracklet& b) -> bool {
+                   return a.firstClusterIndex == b.firstClusterIndex && a.secondClusterIndex == b.secondClusterIndex;
+                 }),
+                 trkl.end());
+      trkl.shrink_to_fit();
+      if (iLayer > 0) { /// recalculate lut
+        auto& lut{mTimeFrame->getTrackletsLookupTable()[iLayer - 1]};
+        if (!trkl.empty()) {
+          for (const auto& tkl : trkl) {
+            lut[tkl.firstClusterIndex + 1]++;
+          }
+          std::inclusive_scan(lut.begin(), lut.end(), lut.begin());
+        }
+      }
+    });
 
     /// Create tracklets labels
     if (mTimeFrame->hasMCinformation() && mTrkParams[iteration].createArtefactLabels) {
-      tbb::parallel_for(
-        tbb::blocked_range<int>(0, mTrkParams[iteration].TrackletsPerRoad()),
-        [&](const tbb::blocked_range<int>& Layers) {
-          for (int iLayer = Layers.begin(); iLayer < Layers.end(); ++iLayer) {
-            for (auto& trk : mTimeFrame->getTracklets()[iLayer]) {
-              MCCompLabel label;
-              int currentId{mTimeFrame->getClusters()[iLayer][trk.firstClusterIndex].clusterId};
-              int nextId{mTimeFrame->getClusters()[iLayer + 1][trk.secondClusterIndex].clusterId};
-              for (const auto& lab1 : mTimeFrame->getClusterLabels(iLayer, currentId)) {
-                for (const auto& lab2 : mTimeFrame->getClusterLabels(iLayer + 1, nextId)) {
-                  if (lab1 == lab2 && lab1.isValid()) {
-                    label = lab1;
-                    break;
-                  }
-                }
-                if (label.isValid()) {
-                  break;
-                }
+      tbb::parallel_for(0, mTrkParams[iteration].TrackletsPerRoad(), [&](const int iLayer) {
+        for (auto& trk : mTimeFrame->getTracklets()[iLayer]) {
+          MCCompLabel label;
+          int currentId{mTimeFrame->getClusters()[iLayer][trk.firstClusterIndex].clusterId};
+          int nextId{mTimeFrame->getClusters()[iLayer + 1][trk.secondClusterIndex].clusterId};
+          for (const auto& lab1 : mTimeFrame->getClusterLabels(iLayer, currentId)) {
+            for (const auto& lab2 : mTimeFrame->getClusterLabels(iLayer + 1, nextId)) {
+              if (lab1 == lab2 && lab1.isValid()) {
+                label = lab1;
+                break;
               }
-              mTimeFrame->getTrackletsLabel(iLayer).emplace_back(label);
+            }
+            if (label.isValid()) {
+              break;
             }
           }
-        });
+          mTimeFrame->getTrackletsLabel(iLayer).emplace_back(label);
+        }
+      });
     }
   });
 } // namespace o2::its
@@ -402,76 +390,60 @@ void TrackerTraits<nLayers>::computeLayerCells(const int iteration)
       return foundCells;
     };
 
-    tbb::parallel_for(
-      tbb::blocked_range<int>(0, mTrkParams[iteration].CellsPerRoad()),
-      [&](const tbb::blocked_range<int>& Layers) {
-        for (int iLayer = Layers.begin(); iLayer < Layers.end(); ++iLayer) {
-          if (mTimeFrame->getTracklets()[iLayer + 1].empty() ||
-              mTimeFrame->getTracklets()[iLayer].empty()) {
-            continue;
+    tbb::parallel_for(0, mTrkParams[iteration].CellsPerRoad(), [&](const int iLayer) {
+      if (mTimeFrame->getTracklets()[iLayer + 1].empty() ||
+          mTimeFrame->getTracklets()[iLayer].empty()) {
+        return;
+      }
+
+      auto& layerCells = mTimeFrame->getCells()[iLayer];
+      const int currentLayerTrackletsNum{static_cast<int>(mTimeFrame->getTracklets()[iLayer].size())};
+      bounded_vector<int> perTrackletCount(currentLayerTrackletsNum + 1, 0, mMemoryPool.get());
+      if (mTaskArena->max_concurrency() <= 1) {
+        for (int iTracklet{0}; iTracklet < currentLayerTrackletsNum; ++iTracklet) {
+          perTrackletCount[iTracklet] = forTrackletCells(PassMode::OnePass{}, iLayer, layerCells, iTracklet);
+        }
+        std::exclusive_scan(perTrackletCount.begin(), perTrackletCount.end(), perTrackletCount.begin(), 0);
+      } else {
+        tbb::parallel_for(0, currentLayerTrackletsNum, [&](const int iTracklet) {
+          perTrackletCount[iTracklet] = forTrackletCells(PassMode::TwoPassCount{}, iLayer, layerCells, iTracklet);
+        });
+
+        std::exclusive_scan(perTrackletCount.begin(), perTrackletCount.end(), perTrackletCount.begin(), 0);
+        auto totalCells{perTrackletCount.back()};
+        if (totalCells == 0) {
+          return;
+        }
+        layerCells.resize(totalCells);
+
+        tbb::parallel_for(0, currentLayerTrackletsNum, [&](const int iTracklet) {
+          int offset = perTrackletCount[iTracklet];
+          if (offset == perTrackletCount[iTracklet + 1]) {
+            return;
           }
+          forTrackletCells(PassMode::TwoPassInsert{}, iLayer, layerCells, iTracklet, offset);
+        });
+      }
 
-          auto& layerCells = mTimeFrame->getCells()[iLayer];
-          const int currentLayerTrackletsNum{static_cast<int>(mTimeFrame->getTracklets()[iLayer].size())};
-          bounded_vector<int> perTrackletCount(currentLayerTrackletsNum + 1, 0, mMemoryPool.get());
-          if (mTaskArena->max_concurrency() <= 1) {
-            for (int iTracklet{0}; iTracklet < currentLayerTrackletsNum; ++iTracklet) {
-              perTrackletCount[iTracklet] = forTrackletCells(PassMode::OnePass{}, iLayer, layerCells, iTracklet);
-            }
-            std::exclusive_scan(perTrackletCount.begin(), perTrackletCount.end(), perTrackletCount.begin(), 0);
-          } else {
-            tbb::parallel_for(
-              tbb::blocked_range<int>(0, currentLayerTrackletsNum),
-              [&](const tbb::blocked_range<int>& Tracklets) {
-                for (int iTracklet = Tracklets.begin(); iTracklet < Tracklets.end(); ++iTracklet) {
-                  perTrackletCount[iTracklet] = forTrackletCells(PassMode::TwoPassCount{}, iLayer, layerCells, iTracklet);
-                }
-              });
+      if (iLayer > 0) {
+        auto& lut = mTimeFrame->getCellsLookupTable()[iLayer - 1];
+        lut.resize(currentLayerTrackletsNum + 1);
+        std::copy_n(perTrackletCount.begin(), currentLayerTrackletsNum + 1, lut.begin());
+      }
+    });
 
-            std::exclusive_scan(perTrackletCount.begin(), perTrackletCount.end(), perTrackletCount.begin(), 0);
-            auto totalCells{perTrackletCount.back()};
-            if (totalCells == 0) {
-              continue;
-            }
-            layerCells.resize(totalCells);
-
-            tbb::parallel_for(
-              tbb::blocked_range<int>(0, currentLayerTrackletsNum),
-              [&](const tbb::blocked_range<int>& Tracklets) {
-                for (int iTracklet = Tracklets.begin(); iTracklet < Tracklets.end(); ++iTracklet) {
-                  int offset = perTrackletCount[iTracklet];
-                  if (offset == perTrackletCount[iTracklet + 1]) {
-                    continue;
-                  }
-                  forTrackletCells(PassMode::TwoPassInsert{}, iLayer, layerCells, iTracklet, offset);
-                }
-              });
-          }
-
-          if (iLayer > 0) {
-            auto& lut = mTimeFrame->getCellsLookupTable()[iLayer - 1];
-            lut.resize(currentLayerTrackletsNum + 1);
-            std::copy_n(perTrackletCount.begin(), currentLayerTrackletsNum + 1, lut.begin());
-          }
+    /// Create cells labels
+    if (mTimeFrame->hasMCinformation() && mTrkParams[iteration].createArtefactLabels) {
+      tbb::parallel_for(0, mTrkParams[iteration].CellsPerRoad(), [&](const int iLayer) {
+        mTimeFrame->getCellsLabel(iLayer).reserve(mTimeFrame->getCells()[iLayer].size());
+        for (const auto& cell : mTimeFrame->getCells()[iLayer]) {
+          MCCompLabel currentLab{mTimeFrame->getTrackletsLabel(iLayer)[cell.getFirstTrackletIndex()]};
+          MCCompLabel nextLab{mTimeFrame->getTrackletsLabel(iLayer + 1)[cell.getSecondTrackletIndex()]};
+          mTimeFrame->getCellsLabel(iLayer).emplace_back(currentLab == nextLab ? currentLab : MCCompLabel());
         }
       });
+    }
   });
-
-  /// Create cells labels
-  if (mTimeFrame->hasMCinformation() && mTrkParams[iteration].createArtefactLabels) {
-    tbb::parallel_for(
-      tbb::blocked_range<int>(0, mTrkParams[iteration].CellsPerRoad()),
-      [&](const tbb::blocked_range<int>& Layers) {
-        for (int iLayer = Layers.begin(); iLayer < Layers.end(); ++iLayer) {
-          mTimeFrame->getCellsLabel(iLayer).reserve(mTimeFrame->getCells()[iLayer].size());
-          for (const auto& cell : mTimeFrame->getCells()[iLayer]) {
-            MCCompLabel currentLab{mTimeFrame->getTrackletsLabel(iLayer)[cell.getFirstTrackletIndex()]};
-            MCCompLabel nextLab{mTimeFrame->getTrackletsLabel(iLayer + 1)[cell.getSecondTrackletIndex()]};
-            mTimeFrame->getCellsLabel(iLayer).emplace_back(currentLab == nextLab ? currentLab : MCCompLabel());
-          }
-        }
-      });
-  }
 }
 
 template <int nLayers>
@@ -554,13 +526,9 @@ void TrackerTraits<nLayers>::findCellsNeighbours(const int iteration)
         }
       } else {
         bounded_vector<int> perCellCount(nCells + 1, 0, mMemoryPool.get());
-        tbb::parallel_for(
-          tbb::blocked_range<int>(0, nCells),
-          [&](const tbb::blocked_range<int>& Cells) {
-            for (int iCell = Cells.begin(); iCell < Cells.end(); ++iCell) {
-              perCellCount[iCell] = forCellNeighbour(PassMode::TwoPassCount{}, iCell);
-            }
-          });
+        tbb::parallel_for(0, nCells, [&](const int iCell) {
+          perCellCount[iCell] = forCellNeighbour(PassMode::TwoPassCount{}, iCell);
+        });
 
         std::exclusive_scan(perCellCount.begin(), perCellCount.end(), perCellCount.begin(), 0);
         int totalCellNeighbours = perCellCount.back();
@@ -570,17 +538,13 @@ void TrackerTraits<nLayers>::findCellsNeighbours(const int iteration)
         }
         cellsNeighbours.resize(totalCellNeighbours);
 
-        tbb::parallel_for(
-          tbb::blocked_range<int>(0, nCells),
-          [&](const tbb::blocked_range<int>& Cells) {
-            for (int iCell = Cells.begin(); iCell < Cells.end(); ++iCell) {
-              int offset = perCellCount[iCell];
-              if (offset == perCellCount[iCell + 1]) {
-                continue;
-              }
-              forCellNeighbour(PassMode::TwoPassInsert{}, iCell, offset);
-            }
-          });
+        tbb::parallel_for(0, nCells, [&](const int iCell) {
+          int offset = perCellCount[iCell];
+          if (offset == perCellCount[iCell + 1]) {
+            return;
+          }
+          forCellNeighbour(PassMode::TwoPassInsert{}, iCell, offset);
+        });
       }
 
       if (cellsNeighbours.empty()) {
@@ -607,7 +571,7 @@ void TrackerTraits<nLayers>::findCellsNeighbours(const int iteration)
         while (++it != cellsNeighbours.end() && it->nextCell == cellIdx) {
           maxLvl = std::max(maxLvl, it->level);
         }
-        o2::gpu::CAMath::AtomicMax(mTimeFrame->getCells()[iLayer + 1][cellIdx].getLevelPtr(), maxLvl);
+        mTimeFrame->getCells()[iLayer + 1][cellIdx].setLevel(maxLvl);
       }
     }
   });
@@ -718,13 +682,9 @@ void TrackerTraits<nLayers>::processNeighbours(int iLayer, int iLevel, const bou
       }
     } else {
       bounded_vector<int> perCellCount(nCells + 1, 0, mMemoryPool.get());
-      tbb::parallel_for(
-        tbb::blocked_range<int>(0, nCells),
-        [&](const tbb::blocked_range<int>& Cells) {
-          for (int iCell = Cells.begin(); iCell < Cells.end(); ++iCell) {
-            perCellCount[iCell] = forCellNeighbours(PassMode::TwoPassCount{}, iCell);
-          }
-        });
+      tbb::parallel_for(0, nCells, [&](const int iCell) {
+        perCellCount[iCell] = forCellNeighbours(PassMode::TwoPassCount{}, iCell);
+      });
 
       std::exclusive_scan(perCellCount.begin(), perCellCount.end(), perCellCount.begin(), 0);
       auto totalNeighbours{perCellCount.back()};
@@ -734,17 +694,13 @@ void TrackerTraits<nLayers>::processNeighbours(int iLayer, int iLevel, const bou
       updatedCellSeeds.resize(totalNeighbours);
       updatedCellsIds.resize(totalNeighbours);
 
-      tbb::parallel_for(
-        tbb::blocked_range<int>(0, nCells),
-        [&](const tbb::blocked_range<int>& Cells) {
-          for (int iCell = Cells.begin(); iCell < Cells.end(); ++iCell) {
-            int offset = perCellCount[iCell];
-            if (offset == perCellCount[iCell + 1]) {
-              continue;
-            }
-            forCellNeighbours(PassMode::TwoPassInsert{}, iCell, offset);
-          }
-        });
+      tbb::parallel_for(0, nCells, [&](const int iCell) {
+        int offset = perCellCount[iCell];
+        if (offset == perCellCount[iCell + 1]) {
+          return;
+        }
+        forCellNeighbours(PassMode::TwoPassInsert{}, iCell, offset);
+      });
     }
   });
 
@@ -762,19 +718,18 @@ void TrackerTraits<nLayers>::processNeighbours(int iLayer, int iLevel, const bou
 template <int nLayers>
 void TrackerTraits<nLayers>::findRoads(const int iteration)
 {
-  CA_DEBUGGER(std::cout << "Finding roads, iteration " << iteration << std::endl);
-
   for (int startLevel{mTrkParams[iteration].CellsPerRoad()}; startLevel >= mTrkParams[iteration].CellMinimumLevel(); --startLevel) {
-    CA_DEBUGGER(std::cout << "\t > Processing level " << startLevel << std::endl);
+
     auto seedFilter = [&](const auto& seed) {
       return seed.getQ2Pt() <= 1.e3 && seed.getChi2() <= mTrkParams[0].MaxChi2NDF * ((startLevel + 2) * 2 - 5);
     };
+
     bounded_vector<CellSeedN> trackSeeds(mMemoryPool.get());
-    for (int startLayer{mTrkParams[iteration].CellsPerRoad() - 1}; startLayer >= startLevel - 1; --startLayer) {
+    for (int startLayer{mTrkParams[iteration].NeighboursPerRoad()}; startLayer >= startLevel - 1; --startLayer) {
       if ((mTrkParams[iteration].StartLayerMask & (1 << (startLayer + 2))) == 0) {
         continue;
       }
-      CA_DEBUGGER(std::cout << "\t\t > Starting processing layer " << startLayer << std::endl);
+
       bounded_vector<int> lastCellId(mMemoryPool.get()), updatedCellId(mMemoryPool.get());
       bounded_vector<CellSeedN> lastCellSeed(mMemoryPool.get()), updatedCellSeed(mMemoryPool.get());
 
@@ -844,13 +799,9 @@ void TrackerTraits<nLayers>::findRoads(const int iteration)
         }
       } else {
         bounded_vector<int> perSeedCount(nSeeds + 1, 0, mMemoryPool.get());
-        tbb::parallel_for(
-          tbb::blocked_range<int>(0, nSeeds),
-          [&](const tbb::blocked_range<int>& Seeds) {
-            for (int iSeed = Seeds.begin(); iSeed < Seeds.end(); ++iSeed) {
-              perSeedCount[iSeed] = forSeed(PassMode::TwoPassCount{}, iSeed);
-            }
-          });
+        tbb::parallel_for(0, nSeeds, [&](const int iSeed) {
+          perSeedCount[iSeed] = forSeed(PassMode::TwoPassCount{}, iSeed);
+        });
 
         std::exclusive_scan(perSeedCount.begin(), perSeedCount.end(), perSeedCount.begin(), 0);
         auto totalTracks{perSeedCount.back()};
@@ -859,16 +810,12 @@ void TrackerTraits<nLayers>::findRoads(const int iteration)
         }
         tracks.resize(totalTracks);
 
-        tbb::parallel_for(
-          tbb::blocked_range<int>(0, nSeeds),
-          [&](const tbb::blocked_range<int>& Seeds) {
-            for (int iSeed = Seeds.begin(); iSeed < Seeds.end(); ++iSeed) {
-              if (perSeedCount[iSeed] == perSeedCount[iSeed + 1]) {
-                continue;
-              }
-              forSeed(PassMode::TwoPassInsert{}, iSeed, perSeedCount[iSeed]);
-            }
-          });
+        tbb::parallel_for(0, nSeeds, [&](const int iSeed) {
+          if (perSeedCount[iSeed] == perSeedCount[iSeed + 1]) {
+            return;
+          }
+          forSeed(PassMode::TwoPassInsert{}, iSeed, perSeedCount[iSeed]);
+        });
       }
 
       deepVectorClear(trackSeeds);

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -168,45 +168,41 @@ template <int nLayers>
 void VertexerTraits<nLayers>::computeTracklets(const int iteration)
 {
   mTaskArena->execute([&] {
-    tbb::parallel_for(
-      tbb::blocked_range<short>(0, (short)mTimeFrame->getNrof()),
-      [&](const tbb::blocked_range<short>& Rofs) {
-        for (short pivotRofId = Rofs.begin(); pivotRofId < Rofs.end(); ++pivotRofId) {
-          bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-          short startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
-          short endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
-          for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
-            trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
-              !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(), // Clusters to be matched with the next layer in target rof
-              !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),  // Clusters to be matched with the current layer in pivot rof
-              mTimeFrame->getUsedClustersROF(targetRofId, 0),                                   // Span of the used clusters in the target rof
-              mTimeFrame->getIndexTable(targetRofId, 0).data(),                                 // Index table to access the data on the next layer in target rof
-              mVrtParams[iteration].phiCut,
-              mTimeFrame->getTracklets()[0],                   // Flat tracklet buffer
-              mTimeFrame->getNTrackletsCluster(pivotRofId, 0), // Span of the number of tracklets per each cluster in pivot rof
-              mIndexTableUtils,
-              pivotRofId,
-              targetRofId,
-              gsl::span<int>(), // Offset in the tracklet buffer
-              mVrtParams[iteration].maxTrackletsPerCluster);
-            trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
-              !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
-              !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
-              mTimeFrame->getUsedClustersROF(targetRofId, 2),
-              mTimeFrame->getIndexTable(targetRofId, 2).data(),
-              mVrtParams[iteration].phiCut,
-              mTimeFrame->getTracklets()[1],
-              mTimeFrame->getNTrackletsCluster(pivotRofId, 1), // Span of the number of tracklets per each cluster in pivot rof
-              mIndexTableUtils,
-              pivotRofId,
-              targetRofId,
-              gsl::span<int>(), // Offset in the tracklet buffer
-              mVrtParams[iteration].maxTrackletsPerCluster);
-          }
-          mTimeFrame->getNTrackletsROF(pivotRofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(pivotRofId, 0).begin(), mTimeFrame->getNTrackletsCluster(pivotRofId, 0).end(), 0);
-          mTimeFrame->getNTrackletsROF(pivotRofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(pivotRofId, 1).begin(), mTimeFrame->getNTrackletsCluster(pivotRofId, 1).end(), 0);
-        }
-      });
+    tbb::parallel_for(0, mTimeFrame->getNrof(), [&](const short pivotRofId) {
+      bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
+      short startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
+      short endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
+      for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
+        trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(), // Clusters to be matched with the next layer in target rof
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),  // Clusters to be matched with the current layer in pivot rof
+          mTimeFrame->getUsedClustersROF(targetRofId, 0),                                   // Span of the used clusters in the target rof
+          mTimeFrame->getIndexTable(targetRofId, 0).data(),                                 // Index table to access the data on the next layer in target rof
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[0],                   // Flat tracklet buffer
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 0), // Span of the number of tracklets per each cluster in pivot rof
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          gsl::span<int>(), // Offset in the tracklet buffer
+          mVrtParams[iteration].maxTrackletsPerCluster);
+        trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getUsedClustersROF(targetRofId, 2),
+          mTimeFrame->getIndexTable(targetRofId, 2).data(),
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[1],
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 1), // Span of the number of tracklets per each cluster in pivot rof
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          gsl::span<int>(), // Offset in the tracklet buffer
+          mVrtParams[iteration].maxTrackletsPerCluster);
+      }
+      mTimeFrame->getNTrackletsROF(pivotRofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(pivotRofId, 0).begin(), mTimeFrame->getNTrackletsCluster(pivotRofId, 0).end(), 0);
+      mTimeFrame->getNTrackletsROF(pivotRofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(pivotRofId, 1).begin(), mTimeFrame->getNTrackletsCluster(pivotRofId, 1).end(), 0);
+    });
 
     mTimeFrame->computeTrackletsPerROFScans();
     if (auto tot0 = mTimeFrame->getTotalTrackletsTF(0), tot1 = mTimeFrame->getTotalTrackletsTF(1);
@@ -217,45 +213,41 @@ void VertexerTraits<nLayers>::computeTracklets(const int iteration)
       mTimeFrame->getTracklets()[1].resize(tot1);
     }
 
-    tbb::parallel_for(
-      tbb::blocked_range<short>(0, (short)mTimeFrame->getNrof()),
-      [&](const tbb::blocked_range<short>& Rofs) {
-        for (short pivotRofId = Rofs.begin(); pivotRofId < Rofs.end(); ++pivotRofId) {
-          bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
-          short startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
-          short endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
-          auto mobileOffset0 = mTimeFrame->getNTrackletsROF(pivotRofId, 0);
-          auto mobileOffset1 = mTimeFrame->getNTrackletsROF(pivotRofId, 1);
-          for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
-            trackleterKernelHost<TrackletMode::Layer0Layer1, false>(
-              !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(),
-              !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
-              mTimeFrame->getUsedClustersROF(targetRofId, 0),
-              mTimeFrame->getIndexTable(targetRofId, 0).data(),
-              mVrtParams[iteration].phiCut,
-              mTimeFrame->getTracklets()[0],
-              mTimeFrame->getNTrackletsCluster(pivotRofId, 0),
-              mIndexTableUtils,
-              pivotRofId,
-              targetRofId,
-              mTimeFrame->getExclusiveNTrackletsCluster(pivotRofId, 0),
-              mVrtParams[iteration].maxTrackletsPerCluster);
-            trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
-              !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
-              !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
-              mTimeFrame->getUsedClustersROF(targetRofId, 2),
-              mTimeFrame->getIndexTable(targetRofId, 2).data(),
-              mVrtParams[iteration].phiCut,
-              mTimeFrame->getTracklets()[1],
-              mTimeFrame->getNTrackletsCluster(pivotRofId, 1),
-              mIndexTableUtils,
-              pivotRofId,
-              targetRofId,
-              mTimeFrame->getExclusiveNTrackletsCluster(pivotRofId, 1),
-              mVrtParams[iteration].maxTrackletsPerCluster);
-          }
-        }
-      });
+    tbb::parallel_for(0, mTimeFrame->getNrof(), [&](const short pivotRofId) {
+      bool skipROF = iteration && (int)mTimeFrame->getPrimaryVertices(pivotRofId).size() > mVrtParams[iteration].vertPerRofThreshold;
+      short startROF{std::max((short)0, static_cast<short>(pivotRofId - mVrtParams[iteration].deltaRof))};
+      short endROF{std::min(static_cast<short>(mTimeFrame->getNrof()), static_cast<short>(pivotRofId + mVrtParams[iteration].deltaRof + 1))};
+      auto mobileOffset0 = mTimeFrame->getNTrackletsROF(pivotRofId, 0);
+      auto mobileOffset1 = mTimeFrame->getNTrackletsROF(pivotRofId, 1);
+      for (auto targetRofId = startROF; targetRofId < endROF; ++targetRofId) {
+        trackleterKernelHost<TrackletMode::Layer0Layer1, false>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 0) : gsl::span<Cluster>(),
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getUsedClustersROF(targetRofId, 0),
+          mTimeFrame->getIndexTable(targetRofId, 0).data(),
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[0],
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 0),
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          mTimeFrame->getExclusiveNTrackletsCluster(pivotRofId, 0),
+          mVrtParams[iteration].maxTrackletsPerCluster);
+        trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
+          !skipROF ? mTimeFrame->getClustersOnLayer(targetRofId, 2) : gsl::span<Cluster>(),
+          !skipROF ? mTimeFrame->getClustersOnLayer(pivotRofId, 1) : gsl::span<Cluster>(),
+          mTimeFrame->getUsedClustersROF(targetRofId, 2),
+          mTimeFrame->getIndexTable(targetRofId, 2).data(),
+          mVrtParams[iteration].phiCut,
+          mTimeFrame->getTracklets()[1],
+          mTimeFrame->getNTrackletsCluster(pivotRofId, 1),
+          mIndexTableUtils,
+          pivotRofId,
+          targetRofId,
+          mTimeFrame->getExclusiveNTrackletsCluster(pivotRofId, 1),
+          mVrtParams[iteration].maxTrackletsPerCluster);
+      }
+    });
   });
 
   /// Create tracklets labels for L0-L1, information is as flat as in tracklets vector (no rofId)


### PR DESCRIPTION
This just simplifies the syntax used in parallel_for loops, instead of:
```cpp
tbb::parallel_for(
      tbb::blocked_range<int>(0, mTrkParams[iteration].TrackletsPerRoad()),
      [&](const tbb::blocked_range<int>& Layers) {
        for (int iLayer = Layers.begin(); iLayer < Layers.end(); ++iLayer) {
```

this now just
```cpp
tbb::parallel_for(0, mTrkParams[iteration].TrackletsPerRoad(), [&](const int iLayer) {
```

which I think is much clearer. This does no functional changes.

Also after #14595, I realised I dont need to use an atomic for the level update since this part is sequential anyways.