### PR TITLE
ITS: make CA tracker the default

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -26,7 +26,7 @@ namespace its
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, TrackingMode::Type trmode, const bool overrideBeamPosition = false,
+framework::WorkflowSpec getWorkflow(bool useMC, bool useCMtracker, TrackingMode::Type trmode, const bool overrideBeamPosition = false,
                                     bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool useGeom = false, int useTrig = 0,
                                     bool useGPUWF = false, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU);
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -29,7 +29,7 @@ namespace o2::its::reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC,
-                                    bool useCAtracker,
+                                    bool useCMtracker,
                                     TrackingMode::Type trmode,
                                     const bool overrideBeamPosition,
                                     bool upstreamDigits,
@@ -51,7 +51,9 @@ framework::WorkflowSpec getWorkflow(bool useMC,
     specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
   }
   if ((trmode != TrackingMode::Off) && (TrackerParamConfig::Instance().trackingMode != TrackingMode::Off)) {
-    if (useCAtracker) {
+    if (useCMtracker) {
+      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, useGeom, useTrig, trmode));
+    } else {
       if (useGPUWF) {
         o2::gpu::GPURecoWorkflowSpec::Config cfg{
           .itsTriggerType = useTrig,
@@ -83,8 +85,6 @@ framework::WorkflowSpec getWorkflow(bool useMC,
       } else {
         specs.emplace_back(o2::its::getTrackerSpec(useMC, useGeom, useTrig, trmode, overrideBeamPosition, dtype));
       }
-    } else {
-      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, useGeom, useTrig, trmode));
     }
     if (!disableRootOutput) {
       specs.emplace_back(o2::its::getTrackWriterSpec(useMC));

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -41,7 +41,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"clusters-from-upstream", o2::framework::VariantType::Bool, false, {"clusters will be provided from upstream, skip clusterizer"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
-    {"trackerCA", o2::framework::VariantType::Bool, false, {"use trackerCA (default: trackerCM)"}},
+    {"trackerCA", o2::framework::VariantType::Bool, false, {"use trackerCA (deprecated)"}}, // keep this around to not break scripts
+    {"trackerCM", o2::framework::VariantType::Bool, false, {"use trackerCM (default: trackerCA)"}},
     {"ccdb-meanvertex-seed", o2::framework::VariantType::Bool, false, {"use MeanVertex from CCDB if available to provide beam position seed (default: false)"}},
     {"select-with-triggers", o2::framework::VariantType::String, "none", {"use triggers to prescale processed ROFs: phys, trd, none"}},
     {"tracking-mode", o2::framework::VariantType::String, "sync", {"sync,async,cosmics,unset,off"}},
@@ -64,7 +65,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // Update the (declared) parameters if changed from the command line
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto beamPosOVerride = configcontext.options().get<bool>("ccdb-meanvertex-seed");
-  auto useCAtracker = configcontext.options().get<bool>("trackerCA");
+  auto useCMtracker = configcontext.options().get<bool>("trackerCM");
   auto trmode = configcontext.options().get<std::string>("tracking-mode");
   auto selTrig = configcontext.options().get<std::string>("select-with-triggers");
   auto useGpuWF = configcontext.options().get<bool>("use-gpu-workflow");
@@ -89,7 +90,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
   auto wf = o2::its::reco_workflow::getWorkflow(useMC,
-                                                useCAtracker,
+                                                useCMtracker,
                                                 o2::its::TrackingMode::fromString(trmode),
                                                 beamPosOVerride,
                                                 extDigits,


### PR DESCRIPTION
This makes the commissioned CA tracker the default, so I never again can forget specifying `--trackerCA` (now a no-op).
@mpuccio 

(Also I think this is safe since I do not know anybody using the cooked tracker)