### PR TITLE
Check consistency of the TPC scaling request and map mean scaler

### DIFF
--- a/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
+++ b/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
@@ -92,6 +92,7 @@ class BarrelAlignmentSpec : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(tpcOpt.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(tpcOpt.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(tpcOpt.checkCTPIDCconsistency);
   }
   ~BarrelAlignmentSpec() override = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -66,6 +66,7 @@ class CosmicsMatchingSpec : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~CosmicsMatchingSpec() override = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
@@ -62,6 +62,7 @@ class SecondaryVertexingSpec : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~SecondaryVertexingSpec() override = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
@@ -62,6 +62,7 @@ class TOFMatcherSpec : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TOFMatcherSpec() override = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -75,6 +75,7 @@ class TPCITSMatchingDPL : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TPCITSMatchingDPL() override = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
@@ -55,6 +55,7 @@ class TPCTrackStudySpec : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TPCTrackStudySpec() final = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/study/src/TrackMCStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TrackMCStudy.cxx
@@ -88,6 +88,7 @@ class TrackMCStudy : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TrackMCStudy() final = default;
   void init(InitContext& ic) final;

--- a/Detectors/GlobalTrackingWorkflow/study/src/TrackingStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TrackingStudy.cxx
@@ -75,6 +75,7 @@ class TrackingStudySpec : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TrackingStudySpec() final = default;
   void init(InitContext& ic) final;

--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -42,6 +42,7 @@ struct CorrectionMapsLoaderGloOpts {
   int lumiMode = 0; ///< what corrections method to use: 0: classical scaling, 1: Using of the derivative map, 2: Using of the derivative map for MC
   bool enableMShapeCorrection = false;
   bool requestCTPLumi = true; //< request CTP Lumi regardless of what is used for corrections scaling
+  bool checkCTPIDCconsistency = true; //< check the selected CTP or IDC scaling source being consistent with mean scaler of the map
 
   bool needTPCScalersWorkflow() const
   {
@@ -63,6 +64,7 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
   void init(o2::framework::InitContext& ic);
   void copySettings(const CorrectionMapsLoader& src);
   void updateInverse(); /// recalculate inverse correction
+  void checkMeanScaleConsistency(float meanLumi, float threshold) const;
   float getMapMeanRate(const o2::gpu::TPCFastTransform* mp, bool lumiOverridden) const;
 
   static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, std::vector<o2::framework::ConfigParamSpec>& options, const CorrectionMapsLoaderGloOpts& gloOpts);

--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -138,6 +138,7 @@ void CorrectionMapsLoader::addGlobalOptions(std::vector<ConfigParamSpec>& option
   addOption(options, ConfigParamSpec{"corrmap-lumi-mode", o2::framework::VariantType::Int, 0, {"scaling mode: (default) 0 = static + scale * full; 1 = full + scale * derivative; 2 = full + scale * derivative (for MC)"}});
   addOption(options, ConfigParamSpec{"enable-M-shape-correction", o2::framework::VariantType::Bool, false, {"Enable M-shape distortion correction"}});
   addOption(options, ConfigParamSpec{"disable-ctp-lumi-request", o2::framework::VariantType::Bool, false, {"do not request CTP lumi (regardless what is used for corrections)"}});
+  addOption(options, ConfigParamSpec{"disable-lumi-type-consistency-check", o2::framework::VariantType::Bool, false, {"disable check of selected CTP or IDC scaling source being consistent with the map"}});
 }
 
 //________________________________________________________
@@ -148,6 +149,7 @@ CorrectionMapsLoaderGloOpts CorrectionMapsLoader::parseGlobalOptions(const o2::f
   tpcopt.lumiMode = opts.get<int>("corrmap-lumi-mode");
   tpcopt.enableMShapeCorrection = opts.get<bool>("enable-M-shape-correction");
   tpcopt.requestCTPLumi = !opts.get<bool>("disable-ctp-lumi-request");
+  tpcopt.checkCTPIDCconsistency = !opts.get<bool>("disable-lumi-type-consistency-check");
   if (!tpcopt.requestCTPLumi && tpcopt.lumiType == 1) {
     LOGP(fatal, "Scaling with CTP Lumi is requested but this input is disabled");
   }
@@ -192,6 +194,9 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
     } else if (getLumiScaleType() == 2) {
       mapMeanRate = mCorrMap->getIDC();
     }
+    if (mCheckCTPIDCConsistency) {
+      checkMeanScaleConsistency(mapMeanRate, mCorrMap->getCTP2IDCFallBackThreshold());
+    }
     if (getMeanLumiOverride() == 0 && mapMeanRate > 0.) {
       setMeanLumi(mapMeanRate, false);
     }
@@ -217,6 +222,9 @@ bool CorrectionMapsLoader::accountCCDBInputs(const ConcreteDataMatcher& matcher,
       mapRefMeanRate = mCorrMapRef->getLumi();
     } else if (getLumiScaleType() == 2) {
       mapRefMeanRate = mCorrMapRef->getIDC();
+    }
+    if (mCheckCTPIDCConsistency) {
+      checkMeanScaleConsistency(mapRefMeanRate, mCorrMapRef->getCTP2IDCFallBackThreshold());
     }
     if (getMeanLumiRefOverride() == 0) {
       setMeanLumiRef(mapRefMeanRate);
@@ -325,6 +333,19 @@ void CorrectionMapsLoader::updateInverse()
     TPCFastSpaceChargeCorrectionHelper::instance()->initInverse(corr, scaling, false);
   } else {
     LOGP(info, "Reinitializing inverse correction with lumi scale mode {} not supported for now", mLumiScaleMode);
+  }
+}
+
+void CorrectionMapsLoader::checkMeanScaleConsistency(float meanLumi, float threshold) const
+{
+  if (getLumiScaleType() == 1) {
+    if (meanLumi < threshold) {
+      LOGP(fatal, "CTP Lumi scaling source is requested, but the map mean scale {} is below the threshold {}", meanLumi, threshold);
+    }
+  } else if (getLumiScaleType() == 2) {
+    if (meanLumi > threshold) {
+      LOGP(fatal, "IDC scaling source is requested, but the map mean scale {} is above the threshold {}", meanLumi, threshold);
+    }
   }
 }
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -54,6 +54,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     }
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
 
   void init(o2::framework::InitContext& ic) final

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -456,6 +456,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     cfg.runTPCTracking = true;
     cfg.lumiScaleType = sclOpts.lumiType;
     cfg.lumiScaleMode = sclOpts.lumiMode;
+    cfg.checkCTPIDCconsistency = sclOpts.checkCTPIDCconsistency;
     cfg.enableMShape = sclOpts.enableMShapeCorrection;
     cfg.enableCTPLumi = sclOpts.requestCTPLumi;
     cfg.decompressTPC = decompressTPC;

--- a/Detectors/TPC/workflow/src/TPCRefitter.cxx
+++ b/Detectors/TPC/workflow/src/TPCRefitter.cxx
@@ -68,6 +68,7 @@ class TPCRefitterSpec final : public Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TPCRefitterSpec() final = default;
   void init(InitContext& ic) final;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -57,6 +57,7 @@ class TRDGlobalTracking : public o2::framework::Task
   {
     mTPCCorrMapsLoader.setLumiScaleType(sclOpts.lumiType);
     mTPCCorrMapsLoader.setLumiScaleMode(sclOpts.lumiMode);
+    mTPCCorrMapsLoader.setCheckCTPIDCConsistency(sclOpts.checkCTPIDCconsistency);
   }
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.h
@@ -106,6 +106,9 @@ class CorrectionMapsHelper
     }
   }
 
+  void setCheckCTPIDCConsistency(bool v) { mCheckCTPIDCConsistency = v; }
+  bool getCheckCTPIDCConsistency() const { return mCheckCTPIDCConsistency; }
+
   GPUd() float getInstLumiCTP() const { return mInstLumiCTP; }
   GPUd() float getInstLumi() const { return mInstLumi; }
   GPUd() float getMeanLumi() const { return mMeanLumi; }
@@ -181,6 +184,7 @@ class CorrectionMapsHelper
   float mInstCTPLumiOverride = -1.f;                  // optional value to override inst lumi from CTP
   bool mEnableMShape = false;                         ///< use v shape correction
   bool mScaleInverse{false};                          // if set to false the inverse correction is already scaled and will not scaled again
+  bool mCheckCTPIDCConsistency{true};                 // check of selected CTP or IDC scaling source being consistent with the map
   o2::gpu::TPCFastTransform* mCorrMap{nullptr};       // current transform
   o2::gpu::TPCFastTransform* mCorrMapRef{nullptr};    // reference transform
   o2::gpu::TPCFastTransform* mCorrMapMShape{nullptr}; // correction map for v-shape distortions on A-side

--- a/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
+++ b/GPU/Workflow/include/GPUWorkflow/GPUWorkflowSpec.h
@@ -105,6 +105,7 @@ class GPURecoWorkflowSpec : public o2::framework::Task
   struct Config {
     int32_t itsTriggerType = 0;
     int32_t lumiScaleMode = 0;
+    bool checkCTPIDCconsistency = true;
     bool enableMShape = false;
     bool enableCTPLumi = false;
     int32_t enableDoublePipeline = 0;

--- a/GPU/Workflow/src/GPUWorkflowTPC.cxx
+++ b/GPU/Workflow/src/GPUWorkflowTPC.cxx
@@ -114,6 +114,7 @@ void GPURecoWorkflowSpec::initFunctionTPCCalib(InitContext& ic)
   mCalibObjects.mFastTransformHelper->setLumiScaleType(mSpecConfig.lumiScaleType);
   mCalibObjects.mFastTransformHelper->setCorrMapMShape(mCalibObjects.mFastTransformMShape.get());
   mCalibObjects.mFastTransformHelper->setLumiScaleMode(mSpecConfig.lumiScaleMode);
+  mCalibObjects.mFastTransformHelper->setCheckCTPIDCConsistency(mSpecConfig.checkCTPIDCconsistency);
   mCalibObjects.mFastTransformHelper->enableMShapeCorrection(mSpecConfig.enableMShape);
   if (mSpecConfig.outputTracks) {
     mCalibObjects.mFastTransformHelper->init(ic);


### PR DESCRIPTION
Unless --disable-lumi-type-consistency-check option is passed. For the CTP Lumi the map->getLumi() must be > map->getCTP2IDCFallBackThreshold(), for the IDC scaling the map->getIDC() must be < map->getCTP2IDCFallBackThreshold(). The default map->getCTP2IDCFallBackThreshold() is 30.

@wiechula 