### PR TITLE
[Common] Add eta, omega and eta' to PhysicsConstants.h

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -31,6 +31,9 @@ namespace o2::constants::physics
 /// \note Follow kCamelCase naming convention
 /// \link https://root.cern/doc/master/TPDGCode_8h.html
 enum Pdg {
+  kEta = 221,
+  kOmega = 223,
+  kEtaPrime = 331,
   kB0 = 511,
   kB0Bar = -511,
   kBPlus = 521,
@@ -93,6 +96,9 @@ enum Pdg {
 };
 
 /// \brief Declarations of masses for additional particles
+constexpr double MassEta = 0.547862;
+constexpr double MassOmega = 0.78266;
+constexpr double MassEtaPrime = 0.95778;
 constexpr double MassB0 = 5.27966;
 constexpr double MassB0Bar = 5.27966;
 constexpr double MassBPlus = 5.27934;

--- a/Common/Constants/include/CommonConstants/make_pdg_header.py
+++ b/Common/Constants/include/CommonConstants/make_pdg_header.py
@@ -86,6 +86,9 @@ class PdgROOT(Enum):
 
 # Enum of additional particles
 class Pdg(Enum):
+    kEta = 221
+    kOmega = 223
+    kEtaPrime = 331
     kB0 = 511
     kB0Bar = -511
     kBPlus = 521


### PR DESCRIPTION
- Add eta, omega and etaPrime meson to the PhysicsConstants.h with PDG value and mass since they are missing here and are not defined in ROOTs `TPDGCode.h` by updating `make_pdg_header.py` and running the script and copying the output to the header file