### PR TITLE
MaterialManager: Allow density modification on the individual materia…

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimParams.h
+++ b/Common/SimConfig/include/SimConfig/SimParams.h
@@ -44,7 +44,11 @@ struct SimCutParams : public o2::conf::ConfigurableParamHelper<SimCutParams> {
 struct SimMaterialParams : public o2::conf::ConfigurableParamHelper<SimMaterialParams> {
   // Local density value takes precedence over global density value, i.e. local values overwrite the global value.
   float globalDensityFactor = 1.f; // global factor that scales all material densities for systematic studies
-  std::string localDensityFactor; // Expected format: "SimMaterialParams.localDensityFactor=<mod1>:<value1>,<mod2>:<value2>,..."
+  // String to set densities on module or material level. Expected format:
+  // "SimMaterialParams.localDensityFactor=<mod1/matname>:<value1>,<mod2>:<value2>,..."
+  // Example: "SimMaterialParams.localDensityFactor=TPC/Air:1.2,ITS:5." will scale the density of the Air in TPC
+  //           with 1.2 and to 5.0 for all materials in ITS".
+  std::string localDensityFactor;
 
   O2ParamDef(SimMaterialParams, "SimMaterialParams");
 };

--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -218,7 +218,7 @@ class MaterialManager
   std::unordered_map<std::string, float> mDensityMap;
 
   void initDensityMap();
-  float getDensity(std::string const& modname);
+  float getDensity(std::string const& modname, std::string const& matname);
 
   // Hide details by providing these private methods so it cannot happen that special settings
   // are applied as default settings by accident using a boolean flag

--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -123,22 +123,51 @@ void MaterialManager::initDensityMap()
   mDensityMapInitialized = true;
 }
 
-float MaterialManager::getDensity(std::string const& modname)
+float MaterialManager::getDensity(std::string const& modname, std::string const& matname)
 {
+  // This function returns the final density for a material of name matname inside module modname.
+  // The priority is
+  // - return density for a specific module + material if it exists in the lookup
+  // - return density for the module if it exists in the the lookup
+  // - return global density factor
+
+  auto debug = getenv("O2SIM_MATMGR_LOCALDENSITY_DEBUG");
+
   if (!mDensityMapInitialized) {
     initDensityMap();
   }
-  if (mDensityMap.find(modname) != mDensityMap.end()) {
-    return mDensityMap[modname];
+  // density on final material level
+  // (this works by a name lookup of pair "modname/matname")
+  std::string lookupstring = modname + "/" + matname;
+  auto iter = mDensityMap.find(lookupstring);
+  if (iter != mDensityMap.end()) {
+    if (debug) {
+      LOG(info) << "MatManager - " << modname << "/" << matname << " : applying density " << iter->second << " from material match";
+    }
+    return iter->second;
   }
-  return o2::conf::SimMaterialParams::Instance().globalDensityFactor;
+  // density on module level
+  iter = mDensityMap.find(modname);
+  if (iter != mDensityMap.end()) {
+    if (debug) {
+      LOG(info) << "MatManager - " << modname << "/" << matname << " : applying density " << iter->second << " from module match";
+    }
+    return iter->second;
+  }
+  // global factor
+  const auto global = o2::conf::SimMaterialParams::Instance().globalDensityFactor;
+  if (debug && global != 1.0) {
+    LOG(info) << "MatManager - " << modname << "/" << matname << " : applying global density " << iter->second;
+  }
+  return global;
 }
 
 void MaterialManager::Material(const char* modname, Int_t imat, const char* name, Float_t a, Float_t z, Float_t dens,
                                Float_t radl, Float_t absl, Float_t* buf, Int_t nwbuf)
 {
   TString uniquename = modname;
-  auto densityFactor = getDensity(modname);
+  auto densityFactor = getDensity(modname, name);
+
   uniquename.Append("_");
   uniquename.Append(name);
   if (TVirtualMC::GetMC()) {
@@ -173,7 +202,7 @@ void MaterialManager::Mixture(const char* modname, Int_t imat, const char* name,
                               Int_t nlmat, Float_t* wmat)
 {
   TString uniquename = modname;
-  auto densityFactor = getDensity(modname);
+  auto densityFactor = getDensity(modname, name);
   uniquename.Append("_");
   uniquename.Append(name);
 


### PR DESCRIPTION
…l level

We can now scale the material density beyond the module level. We simply need to use "MODULENAME/MATERIAL" strings in the configurable param.

Matching on individual material takes precedence over matching on the module level.

An example is
```
o2-sim --configKeyValues "SimMaterialParams.localDensityFactor=TPC/Air:1.2,TPC:2.0,ITS:5."
```
which will scale TPC air with a factor 1.2, the rest of TPC with factor 2.0 and all of ITS with factor 5.0

Fixes https://its.cern.ch/jira/browse/O2-6294