### PR TITLE
Add ITS fake clusters information to the mcMask

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1141,18 +1141,16 @@ void AODProducerWorkflowDPL::fillMCTrackLabelsTable(MCTrackLabelCursorType& mcTr
             }
             if (trackIndex.includesDet(DetID::ITS)) {
               auto itsGID = data.getITSContributorGID(trackIndex);
-              if (itsGID.isIndexSet()) {
-                auto itsSource = itsGID.getSource();
-                if (itsSource == GIndex::ITS) {
-                  auto& itsTrack = data.getITSTrack(itsGID);
-                  for (unsigned int iL = 0; iL < 7; ++iL) {
-                    if (itsTrack.isFakeOnLayer(iL)) {
-                      labelHolder.labelMask |= (0x1 << iL);
-                    }
+              auto itsSource = itsGID.getSource();
+              if (itsSource == GIndex::ITS) {
+                auto& itsTrack = data.getITSTrack(itsGID);
+                for (unsigned int iL = 0; iL < 7; ++iL) {
+                  if (itsTrack.isFakeOnLayer(iL)) {
+                    labelHolder.labelMask |= (0x1 << iL);
                   }
-                } else if (itsSource == GIndex::ITSAB) {
-                  labelHolder.labelMask |= (data.getTrackMCLabel(itsGID).isFake() << 12);
                 }
+              } else if (itsSource == GIndex::ITSAB) {
+                labelHolder.labelMask |= (data.getTrackMCLabel(itsGID).isFake() << 12);
               }
             }
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1126,7 +1126,7 @@ void AODProducerWorkflowDPL::fillMCTrackLabelsTable(MCTrackLabelCursorType& mcTr
           if (!needToStore(mGIDToTableID)) {
             continue;
           }
-          if (mcTruth.isValid()) { // if not set, -1 will be stored
+          if (mcTruth.isValid()) {                                                                               // if not set, -1 will be stored
             labelHolder.labelID = (mToStore[mcTruth.getSourceID()][mcTruth.getEventID()])[mcTruth.getTrackID()]; // defined by TPC if it contributes, otherwise: by ITS
             if (mcTruth.isFake()) {
               labelHolder.labelMask |= (0x1 << 15);
@@ -1139,6 +1139,23 @@ void AODProducerWorkflowDPL::fillMCTrackLabelsTable(MCTrackLabelCursorType& mcTr
                 }
               }
             }
+            if (trackIndex.includesDet(DetID::ITS)) {
+              auto itsGID = data.getITSContributorGID(trackIndex);
+              if (itsGID.isIndexSet()) {
+                auto itsSource = itsGID.getSource();
+                if (itsSource == GIndex::ITS) {
+                  auto& itsTrack = data.getITSTrack(itsGID);
+                  for (unsigned int iL = 0; iL < 7; ++iL) {
+                    if (itsTrack.isFakeOnLayer(iL)) {
+                      labelHolder.labelMask |= (0x1 << iL);
+                    }
+                  }
+                } else if (itsSource == GIndex::ITSAB) {
+                  labelHolder.labelMask |= (data.getTrackMCLabel(itsGID).isFake() << 12);
+                }
+              }
+            }
+
           } else if (mcTruth.isNoise()) {
             labelHolder.labelMask |= (0x1 << 14);
           }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -2017,7 +2017,7 @@ namespace aod
 namespace mctracklabel
 {
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle
-DECLARE_SOA_COLUMN(McMask, mcMask, uint16_t);     //! Bit mask to indicate detector mismatches (bit ON means mismatch). Bit 0-6: mismatch at ITS layer. Bit 7-9: # of TPC mismatches in the ranges 0, 1, 2-3, 4-7, 8-15, 16-31, 32-63, >64. Bit 10: TRD, bit 11: TOF, bit 15: indicates negative label
+DECLARE_SOA_COLUMN(McMask, mcMask, uint16_t);     //! Bit mask to indicate detector mismatches (bit ON means mismatch). Bit 0-6: mismatch at ITS layer. Bit 12: ITSAB tracklet mismatch. Bit 13: ITS-TPC mismatch. Bit 14: isNoise == True (global track), Bit 15: isFake == True (global track)
 } // namespace mctracklabel
 
 DECLARE_SOA_TABLE(McTrackLabels, "AOD", "MCTRACKLABEL", //! Table joined to the track table containing the MC index


### PR DESCRIPTION
BITS 0-6 were not set, in contrary to what was stated in the mcMask description in `AnalysisDataModel.h` . 
I also added a bit to account for fake AB ITS tracklets (BIT 12) and fixed the description of the last three bits in`AnalysisDataModel.h` 

Could you please have a look?
@shahor02 @jgrosseo @ddobrigk 