### PR TITLE
[Framework] Configurable.h: Fix PROCESS_SWITCH(_FULL) namespace issue

### DIFF
--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -114,9 +114,9 @@ template <typename T>
 concept is_process_configurable = is_configurable<T> && requires(T& t) { t.process; };
 
 #define PROCESS_SWITCH(_Class_, _Name_, _Help_, _Default_) \
-  decltype(ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_}) do##_Name_ = ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_};
+  decltype(o2::framework::ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_}) do##_Name_ = o2::framework::ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_};
 #define PROCESS_SWITCH_FULL(_Class_, _Method_, _Name_, _Help_, _Default_) \
-  decltype(ProcessConfigurable{&_Class_ ::_Method_, #_Name_, _Default_, _Help_}) do##_Name_ = ProcessConfigurable{&_Class_ ::_Method_, #_Name_, _Default_, _Help_};
+  decltype(o2::framework::ProcessConfigurable{&_Class_ ::_Method_, #_Name_, _Default_, _Help_}) do##_Name_ = o2::framework::ProcessConfigurable{&_Class_ ::_Method_, #_Name_, _Default_, _Help_};
 
 template <typename T, ConfigParamKind K, typename IP>
 std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)


### PR DESCRIPTION
- The macro `PROCESS_SWITCH` and `PROCESS_SWITCH_FULL` required one to use `using namespace o2::framework` otherwise one would get `Use of undeclared identifier 'ProcessConfigurable'` since macros are expanded as plain text and do not see any namespace that they might be living in. This PR should fix this behavior by explicitly using the namespace in the macro definition.