### PR TITLE
ITS: Tracker don't print expected exception

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -66,7 +66,9 @@ void Tracker<nLayers>::clustersToTracks(const LogFunc& logger, const LogFunc& er
     LOGP(error, "Too much memory used during {} in iteration {} in ROF span {}-{} iVtx={}: {:.2f} GB. Current limit is {:.2f} GB, check the detector status and/or the selections.",
          StateNames[mCurState], iteration, iROFs, iROFs + mTrkParams[iteration].nROFsPerIterations, iVertex,
          (double)mTimeFrame->getArtefactsMemory() / GB, (double)mTrkParams[iteration].MaxMemory / GB);
-    LOGP(error, "Exception: {}", err.what());
+    if (typeid(err) != typeid(std::bad_alloc) { // only print if the exceptions is different from what is expected
+      LOGP(error, "Exception: {}", err.what());
+    }
     if (mTrkParams[iteration].DropTFUponFailure) {
       mMemoryPool->print();
       mTimeFrame->wipe();

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -66,7 +66,7 @@ void Tracker<nLayers>::clustersToTracks(const LogFunc& logger, const LogFunc& er
     LOGP(error, "Too much memory used during {} in iteration {} in ROF span {}-{} iVtx={}: {:.2f} GB. Current limit is {:.2f} GB, check the detector status and/or the selections.",
          StateNames[mCurState], iteration, iROFs, iROFs + mTrkParams[iteration].nROFsPerIterations, iVertex,
          (double)mTimeFrame->getArtefactsMemory() / GB, (double)mTrkParams[iteration].MaxMemory / GB);
-    if (typeid(err) != typeid(std::bad_alloc) { // only print if the exceptions is different from what is expected
+    if (typeid(err) != typeid(std::bad_alloc)) { // only print if the exceptions is different from what is expected
       LOGP(error, "Exception: {}", err.what());
     }
     if (mTrkParams[iteration].DropTFUponFailure) {


### PR DESCRIPTION
If we are catching the expected exception std::bad_alloc, the print is superfluous. Also the validation script explicitly regex checks the log for this string leading to jobs being failed although the reco was successful. If the exception is anything different, still print it.