### PR TITLE
ITS3: improvements for simulation and reconstruction

### DIFF
--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -333,9 +333,6 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// Sym name of the chip in the given layer/halfbarrel/stave/substave/module
   static const char* composeSymNameChip(int lr, int hba, int sta, int ssta, int mod, int chip, bool isITS3 = false);
 
-  // create matrix for transformation from tracking frame to local one for ITS3
-  const Mat3D getT2LMatrixITS3(int isn, float alpha);
-
   TString getMatrixPath(int index) const;
 
   /// Get the transformation matrix of the SENSOR (not necessary the same as the chip)

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -900,19 +900,6 @@ TGeoHMatrix& GeometryTGeo::createT2LMatrix(int isn)
 }
 
 //__________________________________________________________________________
-const o2::math_utils::Transform3D GeometryTGeo::getT2LMatrixITS3(int isn, float alpha)
-{
-  // create for sensor isn the TGeo matrix for Tracking to Local frame transformations with correction for effective thickness
-  static TGeoHMatrix t2l;
-  t2l.Clear();
-  t2l.RotateZ(alpha * RadToDeg()); // rotate in direction of normal to the tangent to the cylinder
-  const TGeoHMatrix& matL2G = getMatrixL2G(isn);
-  const auto& matL2Gi = matL2G.Inverse();
-  t2l.MultiplyLeft(&matL2Gi);
-  return Mat3D(t2l);
-}
-
-//__________________________________________________________________________
 int GeometryTGeo::extractVolumeCopy(const char* name, const char* prefix) const
 {
   TString nms = name;

--- a/Detectors/Upgrades/ITS3/base/include/ITS3Base/SpecsV2.h
+++ b/Detectors/Upgrades/ITS3/base/include/ITS3Base/SpecsV2.h
@@ -102,9 +102,9 @@ constexpr double lengthSensitive{nRSUs * rsu::length};
 namespace carbonfoam
 {
 // TODO: Waiting for the further information from WP5(Corrado)
-constexpr double longeronsWidth{2.0 * mm};                                 // what is the height of the longerons?
-constexpr double longeronsLength{263 * mm};                                // from blueprint
 constexpr double HringLength{6.0 * mm};                                    // from blueprint
+constexpr double longeronsWidth{2.0 * mm};                                 // what is the height of the longerons?
+constexpr double longeronsLength{segment::length - 2 * HringLength};       // 263mm from blueprint; overrriden to be consitent
 constexpr double edgeBetwChipAndFoam{1.0 * mm};                            // from blueprint but not used cause forms are already overlapping
 constexpr double gapBetwHringsLongerons{0.05 * mm};                        // from blueprint
 constexpr std::array<int, 3> nHoles{11, 11, 11};                           // how many holes for each layer?

--- a/Detectors/Upgrades/ITS3/base/include/ITS3Base/SpecsV2.h
+++ b/Detectors/Upgrades/ITS3/base/include/ITS3Base/SpecsV2.h
@@ -28,9 +28,9 @@
 // color: for visulisation
 namespace o2::its3::constants
 {
-constexpr double cm{1e+2}; // This is the default unit of TGeo so we use this as scale
-constexpr double mu{1e-6 * cm};
-constexpr double mm{1e-3 * cm};
+constexpr double cm{1.0}; // This is the default unit of TGeo so we use this as scale
+constexpr double mu{1e-4 * cm};
+constexpr double mm{1e-1 * cm};
 namespace pixelarray
 {
 constexpr double width{9.197 * mm};
@@ -108,7 +108,8 @@ constexpr double HringLength{6.0 * mm};                                    // fr
 constexpr double edgeBetwChipAndFoam{1.0 * mm};                            // from blueprint but not used cause forms are already overlapping
 constexpr double gapBetwHringsLongerons{0.05 * mm};                        // from blueprint
 constexpr std::array<int, 3> nHoles{11, 11, 11};                           // how many holes for each layer?
-constexpr std::array<double, 3> radiusHoles{1.0 * mm, 1.0 * mm, 2.0 * mm}; // what is the radius of the holes for each layer?
+constexpr std::array<double, 3> radiusHoles{1.0 * mm, 1.0 * mm, 2.0 * mm}; // TODO what is the radius of the holes for each layer?
+constexpr double thicknessOuterFoam{7 * mm};                               // TODO: lack of carbon foam radius for layer 2, use 0.7 cm as a temporary value
 constexpr EColor color{kGray};
 } // namespace carbonfoam
 namespace metalstack
@@ -212,6 +213,18 @@ inline bool isDetITS3(T detID)
 }
 
 } // namespace detID
+
+// services
+namespace services
+{
+// FIXME these value are hallucinated since this not yet defined
+constexpr double thickness{2.2 * mm};                                         // thickness of structure
+constexpr double radiusInner{radiiOuter[2] + carbonfoam::thicknessOuterFoam}; // inner radius of services
+constexpr double radiusOuter{radiusInner + thickness};                        // outer radius of services
+constexpr double length{20 * cm};                                             // length
+constexpr EColor color{kBlue};
+} // namespace services
+
 } // namespace o2::its3::constants
 
 #endif

--- a/Detectors/Upgrades/ITS3/macros/align/CheckResidualsITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/align/CheckResidualsITS3.C
@@ -66,16 +66,11 @@ std::optional<Cluster> propagateTo(Track& trk, const o2::itsmft::CompClusterExt&
   ++cTotal;
   auto chipID = clus.getSensorID();
   float sigmaY2{0}, sigmaZ2{0}, sigmaYZ{0};
+  auto isITS3 = o2::its3::constants::detID::isDetITS3(chipID);
   const float alpha = o2::its::GeometryTGeo::Instance()->getSensorRefAlpha(clus.getSensorID());   // alpha for the tracking frame
   const auto locC = o2::its3::ioutils::extractClusterData(clus, pattIt, mDict, sigmaY2, sigmaZ2); // get cluster in sensor local frame with errors
-  Point3D trkC;
-  auto isITS3 = o2::its3::constants::detID::isDetITS3(chipID);
-  if (isITS3) {
-    trkC = o2::its::GeometryTGeo::Instance()->getT2LMatrixITS3(chipID, alpha) ^ (locC); // cluster position in the tracking frame
-  } else {
-    trkC = o2::its::GeometryTGeo::Instance()->getMatrixT2L(chipID) ^ (locC); // cluster position in the tracking frame
-  }
-  const auto gloC = o2::its::GeometryTGeo::Instance()->getMatrixL2G(chipID)(locC); // global cluster position
+  Point3D trkC = o2::its::GeometryTGeo::Instance()->getMatrixT2L(chipID) ^ (locC);                // cluster position in the tracking frame
+  const auto gloC = o2::its::GeometryTGeo::Instance()->getMatrixL2G(chipID)(locC);                // global cluster position
   const auto bz = o2::base::Propagator::Instance()->getNominalBz();
 
   // rotate the parameters to the tracking frame then propagate to the clusters'x

--- a/Detectors/Upgrades/ITS3/macros/test/buildMatBudLUT.C
+++ b/Detectors/Upgrades/ITS3/macros/test/buildMatBudLUT.C
@@ -18,6 +18,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "ITS3Simulation/DescriptorInnerBarrelITS3.h"
+#include "ITS3Base/SpecsV2.h"
 #include "CommonUtils/NameConf.h"
 #include <TFile.h>
 #include <TSystem.h>
@@ -30,7 +31,7 @@ o2::base::MatLayerCylSet mbLUT;
 
 bool testMBLUT(const std::string& lutFile = "matbud.root");
 
-bool buildMatBudLUT(int nTst = 30, int maxLr = -1, const std::string& outFile = "matbud.root", const std::string& geomName = "");
+bool buildMatBudLUT(int nTst = 60, int maxLr = -1, const std::string& outFile = "matbud.root", const std::string& geomName = "");
 
 struct LrData {
   float rMin = 0.f;
@@ -50,7 +51,7 @@ bool buildMatBudLUT(int nTst, int maxLr, const std::string& outFile, const std::
   auto geomName = o2::base::NameConf::getGeomFileName(geomNameInput);
   if (gSystem->AccessPathName(geomName.c_str())) { // if needed, create geometry
     std::cout << geomName << " does not exist. Will create it\n";
-    gSystem->Exec("$O2_ROOT/bin/o2-sim -n 0");
+    gSystem->Exec("$O2_ROOT/bin/o2-sim -n 0 --detectorList ALICE2.1");
   }
   o2::base::GeometryManager::loadGeometry(geomNameInput);
   configLayers();
@@ -62,7 +63,7 @@ bool buildMatBudLUT(int nTst, int maxLr, const std::string& outFile, const std::
   }
   for (int i = 0; i < maxLr; i++) {
     auto& l = lrData[i];
-    printf("L:%3d %6.2f<R<%6.2f ZH=%5.1f | dz = %6.2f drph = %6.2f\n", i, l.rMin, l.rMax, l.zHalf, l.dZMin, l.dRPhiMin);
+    printf("L:%3d %6.4f<R<%6.4f ZH=%5.4f | dz = %6.4f drph = %6.4f\n", i, l.rMin, l.rMax, l.zHalf, l.dZMin, l.dRPhiMin);
     mbLUT.addLayer(l.rMin, l.rMax, l.zHalf, l.dZMin, l.dRPhiMin);
   }
 
@@ -185,87 +186,78 @@ void configLayers()
   const float kToler = 1e-3; //
   float drStep = 0.f, zSpanH = 0.f, zBin = 0.f, rphiBin = 0.f, phiBin = 0.f;
 
-  o2::itsmft::ChipMappingITS mp;
-  int nStave = 0;
-  //                           rMin    rMax   zHalf
-  lrData.emplace_back(0.0f, 1.65f, 30.f);
+  // Vacuum inside beam pipe
+  lrData.emplace_back(0.0f, 1.6f, 30.f);
 
   // beam pipe
-  lrData.emplace_back(lrData.back().rMax, 1.8f, 30.f);
+  lrData.emplace_back(lrData.back().rMax, 1.65f, 30.f);
 
   //===================================================================================
   // ITS3 Inner Barrel
-  drStep = 0.2;
+  drStep = 0.1;
   zSpanH = 20.;
-  rphiBin = 0.2; // 0.1
+  rphiBin = 0.1;
+  zBin = 0.1;
+
+  //  air and sensitive layers
+  for (int iLayer{0}; iLayer < (int)o2::its3::constants::nLayers; ++iLayer) {
+    lrData.emplace_back(lrData.back().rMax, o2::its3::constants::radiiInner[iLayer], zSpanH, zBin, rphiBin);
+    lrData.emplace_back(lrData.back().rMax, o2::its3::constants::radiiOuter[iLayer], zSpanH, zBin, rphiBin);
+  }
+
+  rphiBin = 0.1;
   zBin = 0.5;
-  float drStepChip = 0.054;       // gap and chip width
-  float drStepChip4Layer = 0.074; // gap and chip width
 
-  // Layer 1
-  lrData.emplace_back(LrData(1.8f, 1.8f + drStepChip, zSpanH, zBin, rphiBin));
-  // Air
-  do {
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 2.4f - drStep + kToler);
-  lrData.emplace_back(LrData(lrData.back().rMax, 2.4f, zSpanH, zBin, rphiBin));
-
-  // Layer 2
-  lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStepChip, zSpanH, zBin, rphiBin));
-  // Air
-  do {
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 3.0f - drStep + kToler);
-  lrData.emplace_back(LrData(lrData.back().rMax, 3.0f, zSpanH, zBin, rphiBin));
-
-  // Layer 3
-  lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStepChip, zSpanH, zBin, rphiBin));
+  // services
+  lrData.emplace_back(lrData.back().rMax, o2::its3::constants::services::radiusOuter, zSpanH, zBin, rphiBin);
 
   //===================================================================================
   // air space between Inner and Middle Barrels
+  int nStave = 0;
   zSpanH = 40.;
   zBin = 5.;
   rphiBin = 2.;
-  lrData.emplace_back(LrData(lrData.back().rMax, 19.0, zSpanH, zBin, rphiBin));
+  lrData.emplace_back(lrData.back().rMax, 19.0, zSpanH, zBin, rphiBin);
 
   //===================================================================================
   // ITS Middle Barrel
+  o2::itsmft::ChipMappingITS mp;
   nStave = mp.getNStavesOnLr(3); // Lr 3
   zSpanH = 55.;
   zBin = 0.5;
-  drStep = 0.2;
+  drStep = 0.3;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 20.5 + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 21.4 - kToler);
 
   drStep = 0.5;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 24. + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 23.4 - kToler);
 
   nStave = mp.getNStavesOnLr(3); // Lr 4
   drStep = 0.2;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 25.6 + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 26.2 - kToler);
   drStep = 0.5;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 29. + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 29. - kToler);
 
   //===================================================================================
 
   // air space between Middle and Outer Barrels
   zSpanH = 80.f;
-  lrData.emplace_back(LrData(lrData.back().rMax, 33.5, zSpanH));
+  lrData.emplace_back(lrData.back().rMax, 33.5, zSpanH);
 
   //===================================================================================
   // ITS Outer barrel
@@ -276,54 +268,58 @@ void configLayers()
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 36. + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 36. - kToler);
 
   drStep = 1.;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 38.5 + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 38.5 - kToler);
 
   nStave = mp.getNStavesOnLr(6); // Lr 6
   drStep = 0.25;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 41. + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 41. - kToler);
 
   drStep = 1.;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 44. + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 44. - kToler);
 
   //===================================================================================
 
   zSpanH = 100.f;
   zBin = 5.;
-  lrData.emplace_back(LrData(lrData.back().rMax, 47., zSpanH, zBin));
+  lrData.emplace_back(lrData.back().rMax, 44.8, zSpanH, zBin);
+  lrData.emplace_back(lrData.back().rMax, 46.2, zSpanH, zBin);
+  lrData.emplace_back(lrData.back().rMax, 47.0, zSpanH, zBin);
 
   drStep = 2.;
   zBin = 5.;
   rphiBin = 2.;
   do {
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 53. + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 55. - kToler);
 
   zSpanH = 120.f;
-  lrData.emplace_back(LrData(lrData.back().rMax, 56.5, zSpanH));
+  lrData.emplace_back(lrData.back().rMax, 56.5, zSpanH);
+  lrData.emplace_back(lrData.back().rMax, 60.5, zSpanH);
+  lrData.emplace_back(lrData.back().rMax, 61.5, zSpanH);
 
   zSpanH = 150.f;
-  drStep = 4.;
+  drStep = 3.5;
   zBin = 15.;
   rphiBin = 10;
   do {
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
-  } while (lrData.back().rMax < 68.5 + kToler);
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
+  } while (lrData.back().rMax < 68.5 - kToler);
 
   zSpanH = 250.f;
   zBin = 25.;
@@ -331,7 +327,7 @@ void configLayers()
   {
     auto rmean = (lrData.back().rMax + 76) / 2.;
     rphiBin = rmean * TMath::Pi() * 2 / (NSect * 2);
-    lrData.emplace_back(LrData(lrData.back().rMax, 76, zSpanH, zBin, rphiBin));
+    lrData.emplace_back(lrData.back().rMax, 76, zSpanH, zBin, rphiBin);
   }
   // TPC inner vessel
   // up to r = 78.5
@@ -340,7 +336,7 @@ void configLayers()
   {
     auto rmean = (lrData.back().rMax + 78.5) / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (NSect * 12);
-    lrData.emplace_back(LrData(lrData.back().rMax, 78.5, zSpanH, zBin, rphiBin));
+    lrData.emplace_back(lrData.back().rMax, 78.8, zSpanH, zBin, rphiBin);
   }
   //
   zSpanH = 250.f;
@@ -348,12 +344,12 @@ void configLayers()
   {
     auto rmean = (lrData.back().rMax + 78.5) / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (NSect * 12);
-    lrData.emplace_back(LrData(lrData.back().rMax, 84.5, zSpanH, zBin, rphiBin));
+    lrData.emplace_back(lrData.back().rMax, 84.5, zSpanH, zBin, rphiBin);
   }
 
   // TPC drum
   zSpanH = 250.f;
-  lrData.emplace_back(LrData(lrData.back().rMax, 250.0, zSpanH));
+  lrData.emplace_back(lrData.back().rMax, 250.0, zSpanH);
 
   //===============================
 
@@ -361,12 +357,12 @@ void configLayers()
   zSpanH = 247.f; // ignore large lumps of material at |z|>247
   rphiBin = 2.;
   zBin = 3.;
-  lrData.emplace_back(LrData(lrData.back().rMax, 258., zSpanH, zBin, rphiBin));
+  lrData.emplace_back(lrData.back().rMax, 258., zSpanH, zBin, rphiBin);
 
   zSpanH = 247.f; // ignore large lumps of material at |z|>247
   rphiBin = 2.;
   zBin = 999.; // no segmentation in Z
-  lrData.emplace_back(LrData(lrData.back().rMax, 280., zSpanH, zBin, rphiBin));
+  lrData.emplace_back(lrData.back().rMax, 280., zSpanH, zBin, rphiBin);
 
   // TRD
 
@@ -376,7 +372,7 @@ void configLayers()
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (NSect * 12);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 370);
 
   // TOF
@@ -387,7 +383,7 @@ void configLayers()
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (NSect * 12);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 400);
 
   // rest
@@ -398,7 +394,7 @@ void configLayers()
     zSpanH = lrData.back().rMax;
     auto rmean = lrData.back().rMax + drStep / 2;
     rphiBin = rmean * TMath::Pi() * 2 / (NSect * 12);
-    lrData.emplace_back(LrData(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin));
+    lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 500);
 }
 

--- a/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
@@ -33,6 +33,8 @@ void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             const its3::TopologyDictionary* dict)
 {
   auto geom = o2::its::GeometryTGeo::Instance();
+  geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
+
   bool applyMisalignment = false;
   const auto& conf = o2::its::TrackerParamConfig::Instance();
   for (int il = 0; il < geom->getNumberOfLayers(); ++il) {

--- a/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
@@ -48,8 +48,7 @@ void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
     float sigmaY2, sigmaZ2, sigmaYZ = 0;
     auto locXYZ = extractClusterData(c, pattIt, dict, sigmaY2, sigmaZ2);
     const auto detID = c.getSensorID();
-    auto& cl3d = output.emplace_back(detID,
-                                     (its3::constants::detID::isDetITS3(detID) ? geom->getT2LMatrixITS3(detID, geom->getSensorRefAlpha(detID)) : geom->getMatrixT2L(detID)) ^ locXYZ); // local --> tracking
+    auto& cl3d = output.emplace_back(detID, geom->getMatrixT2L(detID) ^ locXYZ); // local --> tracking
     if (applyMisalignment) {
       auto lrID = geom->getLayer(detID);
       sigmaY2 += conf.sysErrY2[lrID];
@@ -79,7 +78,6 @@ int loadROFrameDataITS3(its::TimeFrame<7>* tf,
     for (int clusterId{rof.getFirstEntry()}; clusterId < rof.getFirstEntry() + rof.getNEntries(); ++clusterId) {
       auto& c = clusters[clusterId];
       auto sensorID = c.getSensorID();
-      auto isITS3 = its3::constants::detID::isDetITS3(sensorID);
       auto layer = geom->getLayer(sensorID);
 
       float sigmaY2{0}, sigmaZ2{0}, sigmaYZ{0};
@@ -90,16 +88,11 @@ int loadROFrameDataITS3(its::TimeFrame<7>* tf,
       // Transformation to the local --> global
       auto gloXYZ = geom->getMatrixL2G(sensorID) * locXYZ;
 
-      // for cylindrical layers we have a different alpha for each cluster, for regular silicon detectors instead a single alpha for the whole sensor
+      // Inverse transformation to the local --> tracking
+      o2::math_utils::Point3D<float> trkXYZ = geom->getMatrixT2L(sensorID) ^ locXYZ;
+
+      // Tracking alpha angle
       float alpha = geom->getSensorRefAlpha(sensorID);
-      o2::math_utils::Point3D<float> trkXYZ;
-      if (isITS3) {
-        // Inverse transformation to the local --> tracking
-        trkXYZ = geom->getT2LMatrixITS3(sensorID, alpha) ^ locXYZ;
-      } else {
-        // Inverse transformation to the local --> tracking
-        trkXYZ = geom->getMatrixT2L(sensorID) ^ locXYZ;
-      }
 
       tf->addTrackingFrameInfoToLayer(layer, gloXYZ.x(), gloXYZ.y(), gloXYZ.z(), trkXYZ.x(), alpha,
                                       std::array<float, 2>{trkXYZ.y(), trkXYZ.z()},

--- a/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3.h
+++ b/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3.h
@@ -45,9 +45,10 @@ class DescriptorInnerBarrelITS3 : public o2::its::DescriptorInnerBarrel
   int mNumLayers{constants::nLayers};
 
   // wrapper volume properties
-  static constexpr double mWrapperMinRadiusITS3{1.8};
-  static constexpr double mWrapperMaxRadiusITS3{4.};
-  static constexpr double mWrapperZSpanITS3{constants::segment::length + 5.};
+  static constexpr double mTolerance{1e-3};
+  static constexpr double mWrapperMinRadiusITS3{constants::radiiInner[0] - mTolerance};
+  static constexpr double mWrapperMaxRadiusITS3{constants::services::radiusOuter + mTolerance};
+  static constexpr double mWrapperZSpanITS3{constants::services::length + mTolerance};
 
  private:
   std::array<std::unique_ptr<ITS3Layer>, constants::nLayers> mIBLayers;

--- a/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
@@ -10,7 +10,6 @@
 // or submit itself to any jurisdiction.
 
 #include "ITS3Simulation/DescriptorInnerBarrelITS3.h"
-#include "fairlogger/Logger.h"
 
 using namespace o2::its3;
 
@@ -18,14 +17,12 @@ ClassImp(DescriptorInnerBarrelITS3);
 
 void DescriptorInnerBarrelITS3::createLayer(int iLayer, TGeoVolume* dest)
 {
-  LOGP(debug, "ITS3-IB: Creating Layer {}", iLayer);
   mIBLayers[iLayer] = std::make_unique<ITS3Layer>(iLayer);
   mIBLayers[iLayer]->createLayer(dest);
 }
 
 void DescriptorInnerBarrelITS3::createServices(TGeoVolume* dest)
 {
-  LOGP(debug, "ITS3-IB: Creating Services");
   mServices = std::make_unique<ITS3Services>();
   mServices->createCYSSAssembly(dest);
 }

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -312,8 +312,8 @@ void ITS3Layer::createCarbonForm()
   auto zMoveHringA = new TGeoTranslation(0, 0, -constants::segment::lec::length + HringLength / 2. + constants::segment::length - HringLength);
 
   // Longerons are made by same material
-  [[maybe_unused]] auto longeronR = new TGeoTubeSeg(Form("longeronR%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2, phiSta, phiSta + phiLongeronsCover);
-  [[maybe_unused]] auto longeronL = new TGeoTubeSeg(Form("longeronL%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2, phiEnd - phiLongeronsCover, phiEnd);
+  [[maybe_unused]] auto longeronR = new TGeoTubeSeg(Form("longeronR%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2., phiSta, phiSta + phiLongeronsCover);
+  [[maybe_unused]] auto longeronL = new TGeoTubeSeg(Form("longeronL%d", mNLayer), mRmax, mRmax + dRadius, longeronsLength / 2., phiEnd - phiLongeronsCover, phiEnd);
   TString nameLongerons = Form("longeronR%d + longeronL%d", mNLayer, mNLayer);
   auto longerons = new TGeoCompositeShape(nameLongerons);
   auto longeronsVol = new TGeoVolume(Form("longerons%d", mNLayer), longerons, mCarbon);

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -293,7 +293,7 @@ void ITS3Layer::createCarbonForm()
   if (mNLayer < 2) {
     dRadius = constants::radii[mNLayer + 1] - constants::radii[mNLayer] - constants::totalThickness;
   } else {
-    dRadius = 0.7; // TODO: lack of carbon foam radius for layer 2, use 0.7mm as a temporary value
+    dRadius = constants::carbonfoam::thicknessOuterFoam; // TODO: lack of carbon foam radius for layer 2, use 0.7 cm as a temporary value
   }
   double phiSta = edgeBetwChipAndFoam / (0.5 * constants::radii[mNLayer + 1] + constants::radii[mNLayer]) * o2m::Rad2Deg;
   double phiEnd = (constants::nSegments[mNLayer] * constants::segment::width) / constants::radii[mNLayer] * o2m::Rad2Deg - phiSta;

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Services.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Services.cxx
@@ -13,17 +13,30 @@
 /// \brief Definition of the ITS3Services class
 /// \author Fabrizio Grosa <fgrosa@cern.ch>
 
-#include "ITS3Simulation/ITS3Services.h"
+#include <TGeoManager.h>
+#include <TGeoVolume.h>
+#include <TGeoTube.h>
 
-#include <fairlogger/Logger.h> // for LOG
+#include "ITS3Simulation/ITS3Services.h"
+#include "ITS3Base/SpecsV2.h"
 
 namespace o2::its3
 {
 
 void ITS3Services::createCYSSAssembly(TGeoVolume* motherVolume)
 {
-  // Return the whole assembly
-  LOGP(info, "Creating CYSS Assembly and attaching to {}", motherVolume->GetName());
+  auto cyssVol = new TGeoVolumeAssembly("IBCYSSAssembly");
+  cyssVol->SetVisibility(kTRUE);
+  motherVolume->AddNode(cyssVol, 1., nullptr);
+
+  // Cylinder
+  auto cyssInnerCylSh = new TGeoTubeSeg(constants::services::radiusInner, constants::services::radiusOuter, constants::services::length, 180, 360);
+  auto medPrepreg = gGeoManager->GetMedium("IT3_AS4C200$");
+  auto cyssInnerCylShVol = new TGeoVolume("IBCYSSCylinder", cyssInnerCylSh, medPrepreg);
+  cyssVol->AddNode(cyssInnerCylShVol, 1, new TGeoTranslation(0, 0, 0));
+  cyssVol->AddNode(cyssInnerCylShVol, 2, new TGeoCombiTrans(0, 0, 0, new TGeoRotation("", 180, 0, 0)));
+
+  // TODO Cone
 }
 
 } // namespace o2::its3


### PR DESCRIPTION
Since I am anyways regenerating the material LUT, I thought I would update our build macro and also add some resemblances of the CYSS:
<img width="678" height="541" alt="image" src="https://github.com/user-attachments/assets/d99cd445-004d-4f5d-9da5-3aa1317bffc5" />
Additionally, this fixes the longeron clipping into the Hrings.

Also this removes the unnecessary recalculation of the cached matrix T2L which was done only for ITS3 and ensures that the matrixes are in the cache when converting the clusters and running the global matching wfx (specifically I observed it crashing for running the trd-matching).