### PR TITLE
Avoid recompiling fpu.cxx a gazillion of times

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -91,3 +91,6 @@ o2_add_executable(treemergertool
             COMPONENT_NAME CommonUtils
           SOURCES src/TreeMergerTool.cxx
             PUBLIC_LINK_LIBRARIES O2::CommonUtils Boost::program_options ROOT::Core)
+
+add_library(fpu_support OBJECT src/fpu.cxx)
+add_library(O2::fpu_support ALIAS fpu_support)

--- a/cmake/O2AddExecutable.cmake
+++ b/cmake/O2AddExecutable.cmake
@@ -92,7 +92,7 @@ function(o2_add_executable baseTargetName)
   endif()
 
   # add the executable with its sources
-  add_executable(${target} ${A_SOURCES} ${CMAKE_SOURCE_DIR}/Common/Utils/src/fpu.cxx)
+  add_executable(${target} ${A_SOURCES})
 
   # set the executable output name
   set_property(TARGET ${target} PROPERTY OUTPUT_NAME ${exeName})
@@ -118,6 +118,7 @@ function(o2_add_executable baseTargetName)
 
   # needed for fpu.c
   target_link_libraries(${target} PUBLIC ROOT::XMLIO)
+  target_link_libraries(${target} PUBLIC O2::fpu_support)
 
   if(NOT A_NO_INSTALL)
     # install the executable


### PR DESCRIPTION

This will simply link the object file from fpu.cxx,
which will be compiled only once.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/14686).
* #14427
* __->__ #14686