### PR TITLE
DPL Websocket: Add protocol param to encode_websocket_handshake_reply which allows a response Sec-WebSocket-Accept in handshake.

### DIFF
--- a/Framework/Core/src/DPLWebSocket.cxx
+++ b/Framework/Core/src/DPLWebSocket.cxx
@@ -276,7 +276,7 @@ void WSDPLHandler::endHeaders()
   }
   /// Create an appropriate reply
   LOG(debug) << "Got upgrade request with nonce " << mHeaders["sec-websocket-key"].c_str();
-  std::string reply = encode_websocket_handshake_reply(mHeaders["sec-websocket-key"].c_str());
+  std::string reply = encode_websocket_handshake_reply(mHeaders["sec-websocket-key"].c_str(), "dpl");
   mHandshaken = true;
 
   uv_buf_t bfr = uv_buf_init(strdup(reply.data()), reply.size());

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -214,7 +214,7 @@ std::string HTTPParserHelpers::calculateAccept(const char* nonce)
   return fmt::format("{}", base);
 }
 
-std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol = "")
+std::string encode_websocket_handshake_reply(char const* nonce)
 {
   constexpr auto res =
     "HTTP/1.1 101 Switching Protocols\r\n"

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -216,24 +216,14 @@ std::string HTTPParserHelpers::calculateAccept(const char* nonce)
 
 std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol = "")
 {
-  if (strlen(protocol) == 0) {
-    constexpr auto res =
-      "HTTP/1.1 101 Switching Protocols\r\n"
-      "Upgrade: websocket\r\n"
-      "Connection: Upgrade\r\n"
-      "Access-Control-Allow-Origin: \"*\"\r\n"
-      "Sec-WebSocket-Accept: {}\r\n\r\n";
-    return fmt::format(res, HTTPParserHelpers::calculateAccept(nonce));
-  } else {
-    constexpr auto res =
-      "HTTP/1.1 101 Switching Protocols\r\n"
-      "Upgrade: websocket\r\n"
-      "Connection: Upgrade\r\n"
-      "Access-Control-Allow-Origin: \"*\"\r\n"
-      "Sec-WebSocket-Protocol: {}\r\n"
-      "Sec-WebSocket-Accept: {}\r\n\r\n";
-    return fmt::format(res, protocol, HTTPParserHelpers::calculateAccept(nonce));
-  }
+  constexpr auto res =
+    "HTTP/1.1 101 Switching Protocols\r\n"
+    "Upgrade: websocket\r\n"
+    "Connection: Upgrade\r\n"
+    "Access-Control-Allow-Origin: \"*\"\r\n"
+    "{}"   
+    "Sec-WebSocket-Accept: {}\r\n\r\n";
+  return fmt::format(res, protocol && protocol[0] ? fmt::format("Sec-WebSocket-Protocol: {}\r\n", protocol) : "", HTTPParserHelpers::calculateAccept(nonce));
 }
 
 void parse_http_request(char* start, size_t size, HTTPParser* parser)

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -225,6 +225,18 @@ std::string encode_websocket_handshake_reply(char const* nonce)
   return fmt::format(res, HTTPParserHelpers::calculateAccept(nonce));
 }
 
+std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol)
+{
+  constexpr auto res =
+    "HTTP/1.1 101 Switching Protocols\r\n"
+    "Upgrade: websocket\r\n"
+    "Connection: Upgrade\r\n"
+    "Access-Control-Allow-Origin: \"*\"\r\n"
+    "Sec-WebSocket-Protocol: {}\r\n"
+    "Sec-WebSocket-Accept: {}\r\n\r\n";
+  return fmt::format(res, protocol, HTTPParserHelpers::calculateAccept(nonce));
+}
+
 void parse_http_request(char* start, size_t size, HTTPParser* parser)
 {
   enum HTTPState state = HTTPState::IN_START;

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -214,27 +214,26 @@ std::string HTTPParserHelpers::calculateAccept(const char* nonce)
   return fmt::format("{}", base);
 }
 
-std::string encode_websocket_handshake_reply(char const* nonce)
+std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol = "")
 {
-  constexpr auto res =
-    "HTTP/1.1 101 Switching Protocols\r\n"
-    "Upgrade: websocket\r\n"
-    "Connection: Upgrade\r\n"
-    "Access-Control-Allow-Origin: \"*\"\r\n"
-    "Sec-WebSocket-Accept: {}\r\n\r\n";
-  return fmt::format(res, HTTPParserHelpers::calculateAccept(nonce));
-}
-
-std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol)
-{
-  constexpr auto res =
-    "HTTP/1.1 101 Switching Protocols\r\n"
-    "Upgrade: websocket\r\n"
-    "Connection: Upgrade\r\n"
-    "Access-Control-Allow-Origin: \"*\"\r\n"
-    "Sec-WebSocket-Protocol: {}\r\n"
-    "Sec-WebSocket-Accept: {}\r\n\r\n";
-  return fmt::format(res, protocol, HTTPParserHelpers::calculateAccept(nonce));
+  if (strlen(protocol) == 0) {
+    constexpr auto res =
+      "HTTP/1.1 101 Switching Protocols\r\n"
+      "Upgrade: websocket\r\n"
+      "Connection: Upgrade\r\n"
+      "Access-Control-Allow-Origin: \"*\"\r\n"
+      "Sec-WebSocket-Accept: {}\r\n\r\n";
+    return fmt::format(res, HTTPParserHelpers::calculateAccept(nonce));
+  } else {
+    constexpr auto res =
+      "HTTP/1.1 101 Switching Protocols\r\n"
+      "Upgrade: websocket\r\n"
+      "Connection: Upgrade\r\n"
+      "Access-Control-Allow-Origin: \"*\"\r\n"
+      "Sec-WebSocket-Protocol: {}\r\n"
+      "Sec-WebSocket-Accept: {}\r\n\r\n";
+    return fmt::format(res, protocol, HTTPParserHelpers::calculateAccept(nonce));
+  }
 }
 
 void parse_http_request(char* start, size_t size, HTTPParser* parser)

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -221,7 +221,7 @@ std::string encode_websocket_handshake_reply(char const* nonce, char const* prot
     "Upgrade: websocket\r\n"
     "Connection: Upgrade\r\n"
     "Access-Control-Allow-Origin: \"*\"\r\n"
-    "{}"   
+    "{}"
     "Sec-WebSocket-Accept: {}\r\n\r\n";
   return fmt::format(res, protocol && protocol[0] ? fmt::format("Sec-WebSocket-Protocol: {}\r\n", protocol) : "", HTTPParserHelpers::calculateAccept(nonce));
 }

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -214,7 +214,7 @@ std::string HTTPParserHelpers::calculateAccept(const char* nonce)
   return fmt::format("{}", base);
 }
 
-std::string encode_websocket_handshake_reply(char const* nonce)
+std::string encode_websocket_handshake_reply(char const* nonce, const char* protocol)
 {
   constexpr auto res =
     "HTTP/1.1 101 Switching Protocols\r\n"

--- a/Framework/Core/src/HTTPParser.h
+++ b/Framework/Core/src/HTTPParser.h
@@ -126,6 +126,8 @@ std::string encode_websocket_handshake_request(const char* path, const char* pro
 /// Encodes the server reply for a given websocket connection
 /// @a nonce the nonce of the request.
 std::string encode_websocket_handshake_reply(char const* nonce);
+/// @a protocol the websocket subprotocol to confirm (optional)
+std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol);
 
 /// Encodes the buffer @a src which is @a size long to a number of buffers suitable to be sent via libuv.
 /// If @a binary is provided the binary bit is set.

--- a/Framework/Core/src/HTTPParser.h
+++ b/Framework/Core/src/HTTPParser.h
@@ -125,9 +125,8 @@ std::string encode_websocket_handshake_request(const char* path, const char* pro
 
 /// Encodes the server reply for a given websocket connection
 /// @a nonce the nonce of the request.
-std::string encode_websocket_handshake_reply(char const* nonce);
 /// @a protocol the websocket subprotocol to confirm (optional)
-std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol);
+std::string encode_websocket_handshake_reply(char const* nonce, char const* protocol = "");
 
 /// Encodes the buffer @a src which is @a size long to a number of buffers suitable to be sent via libuv.
 /// If @a binary is provided the binary bit is set.


### PR DESCRIPTION
Add protocol param to encode_websocket_handshake_reply which allows a response Sec-WebSocket-Accept in handshake. If no protocol is given to the function, Sec-WebSocket-Accept is not returned in the response.