### PR TITLE
ITS3: use const view of ROFs, prepareROFData

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -90,12 +90,14 @@ struct TimeFrame {
   int loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const itsmft::Cluster> clusters,
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
 
-  int loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
+  int loadROFrameData(gsl::span<const o2::itsmft::ROFRecord> rofs,
                       gsl::span<const itsmft::CompClusterExt> clusters,
                       gsl::span<const unsigned char>::iterator& pattIt,
                       const itsmft::TopologyDictionary* dict,
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
   void resetROFrameData(size_t nROFs);
+  void prepareROFrameData(gsl::span<const o2::itsmft::ROFRecord> rofs,
+                          gsl::span<const itsmft::CompClusterExt> clusters);
 
   int getTotalClusters() const;
   auto& getTotVertIteration() { return mTotVertPerIteration; }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingInterface.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingInterface.h
@@ -78,7 +78,7 @@ class ITSTrackingInterface
   TimeFrameN* mTimeFrame = nullptr;
 
  protected:
-  virtual void loadROF(gsl::span<itsmft::ROFRecord>& trackROFspan,
+  virtual void loadROF(gsl::span<const itsmft::ROFRecord>& trackROFspan,
                        gsl::span<const itsmft::CompClusterExt> clusters,
                        gsl::span<const unsigned char>::iterator& pattIt,
                        const dataformats::MCTruthContainer<MCCompLabel>* mcLabels);

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -103,28 +103,17 @@ void TimeFrame<nLayers>::addPrimaryVerticesContributorLabelsInROF(const bounded_
 }
 
 template <int nLayers>
-int TimeFrame<nLayers>::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
+int TimeFrame<nLayers>::loadROFrameData(gsl::span<const o2::itsmft::ROFRecord> rofs,
                                         gsl::span<const itsmft::CompClusterExt> clusters,
                                         gsl::span<const unsigned char>::iterator& pattIt,
                                         const itsmft::TopologyDictionary* dict,
                                         const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
-  resetROFrameData(rofs.size());
-
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
 
-  mNrof = rofs.size();
-  clearResizeBoundedVector(mClusterSize, clusters.size(), mMemoryPool.get());
-  std::array<int, nLayers> clusterCountPerLayer{};
-  for (const auto& clus : clusters) {
-    ++clusterCountPerLayer[geom->getLayer(clus.getSensorID())];
-  }
-  for (int iLayer{0}; iLayer < nLayers; ++iLayer) {
-    mUnsortedClusters[iLayer].reserve(clusterCountPerLayer[iLayer]);
-    mTrackingFrameInfo[iLayer].reserve(clusterCountPerLayer[iLayer]);
-    mClusterExternalIndices[iLayer].reserve(clusterCountPerLayer[iLayer]);
-  }
+  resetROFrameData(rofs.size());
+  prepareROFrameData(rofs, clusters);
 
   for (size_t iRof{0}; iRof < rofs.size(); ++iRof) {
     const auto& rof = rofs[iRof];
@@ -182,7 +171,7 @@ int TimeFrame<nLayers>::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
   }
 
   return mNrof;
-} // namespace o2::its
+}
 
 template <int nLayers>
 void TimeFrame<nLayers>::resetROFrameData(size_t nRofs)
@@ -198,6 +187,24 @@ void TimeFrame<nLayers>::resetROFrameData(size_t nRofs)
       deepVectorClear(mNTrackletsPerCluster[iLayer], mMemoryPool.get());
       deepVectorClear(mNTrackletsPerClusterSum[iLayer], mMemoryPool.get());
     }
+  }
+}
+
+template <int nLayers>
+void TimeFrame<nLayers>::prepareROFrameData(gsl::span<const o2::itsmft::ROFRecord> rofs,
+                                            gsl::span<const itsmft::CompClusterExt> clusters)
+{
+  GeometryTGeo* geom = GeometryTGeo::Instance();
+  mNrof = rofs.size();
+  clearResizeBoundedVector(mClusterSize, clusters.size(), mMemoryPool.get());
+  std::array<int, nLayers> clusterCountPerLayer{};
+  for (const auto& clus : clusters) {
+    ++clusterCountPerLayer[geom->getLayer(clus.getSensorID())];
+  }
+  for (int iLayer{0}; iLayer < nLayers; ++iLayer) {
+    mUnsortedClusters[iLayer].reserve(clusterCountPerLayer[iLayer]);
+    mTrackingFrameInfo[iLayer].reserve(clusterCountPerLayer[iLayer]);
+    mClusterExternalIndices[iLayer].reserve(clusterCountPerLayer[iLayer]);
   }
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -139,11 +139,10 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
   mTracker->setBz(o2::base::Propagator::Instance()->getNominalBz());
 
   gsl::span<const unsigned char>::iterator pattIt = patterns.begin();
-
-  gsl::span<itsmft::ROFRecord> trackROFspan(trackROFvec);
+  gsl::span<const itsmft::ROFRecord> trackROFspan(trackROFvec);
   loadROF(trackROFspan, compClusters, pattIt, labels);
   pattIt = patterns.begin();
-  std::vector<int> savedROF;
+
   auto logger = [&](const std::string& s) { LOG(info) << s; };
   auto fatalLogger = [&](const std::string& s) { LOG(fatal) << s; };
   auto errorLogger = [&](const std::string& s) { LOG(error) << s; };
@@ -406,7 +405,7 @@ void ITSTrackingInterface::setTraitsFromProvider(VertexerTraitsN* vertexerTraits
   mVertexer->setMemoryPool(mMemoryPool);
 }
 
-void ITSTrackingInterface::loadROF(gsl::span<itsmft::ROFRecord>& trackROFspan,
+void ITSTrackingInterface::loadROF(gsl::span<const itsmft::ROFRecord>& trackROFspan,
                                    gsl::span<const itsmft::CompClusterExt> clusters,
                                    gsl::span<const unsigned char>::iterator& pattIt,
                                    const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/IOUtils.h
@@ -72,7 +72,7 @@ void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             const its3::TopologyDictionary* dict);
 
 int loadROFrameDataITS3(its::TimeFrame<7>* tf,
-                        gsl::span<o2::itsmft::ROFRecord> rofs,
+                        gsl::span<const o2::itsmft::ROFRecord> rofs,
                         gsl::span<const itsmft::CompClusterExt> clusters,
                         gsl::span<const unsigned char>::iterator& pattIt,
                         const its3::TopologyDictionary* dict,

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TrackingInterface.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TrackingInterface.h
@@ -28,7 +28,7 @@ class ITS3TrackingInterface final : public its::ITSTrackingInterface
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  protected:
-  void loadROF(gsl::span<itsmft::ROFRecord>& trackROFspan,
+  void loadROF(gsl::span<const itsmft::ROFRecord>& trackROFspan,
                gsl::span<const itsmft::CompClusterExt> clusters,
                gsl::span<const unsigned char>::iterator& pattIt,
                const dataformats::MCTruthContainer<MCCompLabel>* mcLabels) final;

--- a/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/IOUtils.cxx
@@ -58,22 +58,22 @@ void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
 }
 
 int loadROFrameDataITS3(its::TimeFrame<7>* tf,
-                        gsl::span<o2::itsmft::ROFRecord> rofs,
+                        gsl::span<const o2::itsmft::ROFRecord> rofs,
                         gsl::span<const itsmft::CompClusterExt> clusters,
                         gsl::span<const unsigned char>::iterator& pattIt,
                         const its3::TopologyDictionary* dict,
                         const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
-  tf->resetROFrameData(rofs.size());
-
   auto geom = its::GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
 
-  tf->mNrof = 0;
+  tf->resetROFrameData(rofs.size());
+  tf->prepareROFrameData(rofs, clusters);
 
   its::bounded_vector<uint8_t> clusterSizeVec(clusters.size(), tf->getMemoryPool().get());
 
-  for (auto& rof : rofs) {
+  for (size_t iRof{0}; iRof < rofs.size(); ++iRof) {
+    const auto& rof = rofs[iRof];
     for (int clusterId{rof.getFirstEntry()}; clusterId < rof.getFirstEntry() + rof.getNEntries(); ++clusterId) {
       auto& c = clusters[clusterId];
       auto sensorID = c.getSensorID();
@@ -108,9 +108,8 @@ int loadROFrameDataITS3(its::TimeFrame<7>* tf,
       tf->addClusterExternalIndexToLayer(layer, clusterId);
     }
     for (unsigned int iL{0}; iL < tf->getUnsortedClusters().size(); ++iL) {
-      tf->mROFramesClusters[iL].push_back(tf->getUnsortedClusters()[iL].size());
+      tf->mROFramesClusters[iL][iRof + 1] = tf->getUnsortedClusters()[iL].size();
     }
-    tf->mNrof++;
   }
 
   tf->setClusterSize(clusterSizeVec);

--- a/Detectors/Upgrades/ITS3/reconstruction/src/TrackingInterface.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/TrackingInterface.cxx
@@ -74,7 +74,7 @@ void ITS3TrackingInterface::finaliseCCDB(framework::ConcreteDataMatcher& matcher
   }
 }
 
-void ITS3TrackingInterface::loadROF(gsl::span<itsmft::ROFRecord>& trackROFspan,
+void ITS3TrackingInterface::loadROF(gsl::span<const itsmft::ROFRecord>& trackROFspan,
                                     gsl::span<const itsmft::CompClusterExt> clusters,
                                     gsl::span<const unsigned char>::iterator& pattIt,
                                     const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)


### PR DESCRIPTION
This adds a new function, refactoring code already present for ITS2 into a new function `prepareROFData`.
Allowing it to be called for ITS3 as well without replicating.
Also, the code now explicitly takes a const view of the ROFs (more a cosmetic change).
Additionally, due to recent refactoring in the base code, this fixes ITS3 tracking (...again).