### PR TITLE
Glo: only initialzes AB geometry helper up to lowest allowed layer

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -245,8 +245,8 @@ void MatchTPCITS::init()
   }
 #endif
 
-  if (mParams->runAfterBurner) { // only used in AfterBurner
-    mRGHelper.init();            // prepare helper for TPC track / ITS clusters matching
+  if (mParams->runAfterBurner) {            // only used in AfterBurner
+    mRGHelper.init(mParams->lowestLayerAB); // prepare helper for TPC track / ITS clusters matching
   }
 
   clear();

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
@@ -103,7 +103,7 @@ struct RecoGeomHelper {
   static constexpr float ladderWidth() { return o2::itsmft::SegmentationAlpide::SensorSizeRows; }
   static constexpr float ladderWidthInv() { return 1. / ladderWidth(); }
 
-  void init();
+  void init(int minLayer = 0, int maxLayer = getNLayers());
   void print() const;
 
   ClassDefNV(RecoGeomHelper, 0);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
@@ -229,9 +229,9 @@ void RecoGeomHelper::RecoLayer::print() const
 }
 
 //_____________________________________________________________________
-void RecoGeomHelper::init()
+void RecoGeomHelper::init(int minLayer, int maxLayer)
 {
-  for (int il = int(layers.size()); il--;) {
+  for (int il = maxLayer; --il >= minLayer;) {
     auto& lr = layers[il];
     lr.id = il;
     lr.init();


### PR DESCRIPTION
We can skip initializing the layers below the lowest allowed AB layer. This allows to run the AB for ITS3 otherwise the initialization of the RecoGeomHelper is not well defined and crashes for layers < 3 since the chip mapping is not well defined.
Currently we anyways allow AB tracks only to go down to layer 3 by default and this might not change for Run 4 anytime soon. If it does the RecoGeomHelper class has to be adapted then.