### PR TITLE
DPL: support submitting directly to slurm

### DIFF
--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -339,6 +339,10 @@ std::string ChannelSpecHelpers::defaultIPCFolder()
   if (channelPrefix) {
     return fmt::format("@dpl_{}_", channelPrefix);
   }
+  channelPrefix = getenv("SLURM_JOB_ID");
+  if (channelPrefix) {
+    return fmt::format("@dpl_{}_", channelPrefix);
+  }
   return "@";
 #else
   /// Find out a place where we can write the sockets


### PR DESCRIPTION

Without this, different jobs on the same machine will cross-talk
due to possible lack of isolation in linux abstract sockets.
