### PR TITLE
Set default DCA in case of propagate call fail

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -119,6 +119,9 @@ constexpr float MaxPT = 100000.;                  // do not allow pTs exceeding 
 constexpr float MinPTInv = 1. / MaxPT;            // do not allow q/pTs less this value (to avoid NANs)
 constexpr float ELoss2EKinThreshInv = 1. / 0.025; // do not allow E.Loss correction step with dE/Ekin above the inverse of this value
 constexpr int MaxELossIter = 50;                  // max number of iteration for the ELoss to account for BB dependence on beta*gamma
+constexpr float DefaultDCA = 999.f;              // default DCA value
+constexpr float DefaultDCACov = 999.f;           // default DCA cov value
+
 // uncomment this to enable correction for BB dependence on beta*gamma via BB derivative
 // #define _BB_NONCONST_CORR_
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -119,8 +119,8 @@ constexpr float MaxPT = 100000.;                  // do not allow pTs exceeding 
 constexpr float MinPTInv = 1. / MaxPT;            // do not allow q/pTs less this value (to avoid NANs)
 constexpr float ELoss2EKinThreshInv = 1. / 0.025; // do not allow E.Loss correction step with dE/Ekin above the inverse of this value
 constexpr int MaxELossIter = 50;                  // max number of iteration for the ELoss to account for BB dependence on beta*gamma
-constexpr float DefaultDCA = 999.f;              // default DCA value
-constexpr float DefaultDCACov = 999.f;           // default DCA cov value
+constexpr float DefaultDCA = 999.f;               // default DCA value
+constexpr float DefaultDCACov = 999.f;            // default DCA cov value
 
 // uncomment this to enable correction for BB dependence on beta*gamma via BB derivative
 // #define _BB_NONCONST_CORR_

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -378,6 +378,10 @@ GPUd() bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils:
   // Estimate the impact parameter neglecting the track curvature
   value_t d = gpu::CAMath::Abs(x * snp - y * csp);
   if (d > maxD) {
+    if (dca) { // provide default DCA for failed propag
+      (*dca)[0] = o2::track::DefaultDCA;
+      (*dca)[1] = o2::track::DefaultDCA;
+    }
     return false;
   }
   value_t crv = getCurvature(b);
@@ -399,6 +403,10 @@ GPUd() bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils:
 #else
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex " << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z();
 #endif
+    if (dca) { // provide default DCA for failed propag
+      (*dca)[0] = o2::track::DefaultDCA;
+      (*dca)[1] = o2::track::DefaultDCA;
+    }
     return false;
   }
   *this = tmpT;

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -228,8 +228,8 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dat
   value_t d = gpu::CAMath::Abs(x * snp - y * csp);
   if (d > maxD) {
     if (dca) { // provide default DCA for failed propag
-        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
-                o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+      dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+               o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
     }
     return false;
   }
@@ -250,8 +250,8 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dat
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx << " | Track is: " << tmpT.asString();
 #endif
     if (dca) { // provide default DCA for failed propag
-        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
-                o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+      dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+               o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
     }
     return false;
   }

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -227,6 +227,10 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dat
   // Estimate the impact parameter neglecting the track curvature
   value_t d = gpu::CAMath::Abs(x * snp - y * csp);
   if (d > maxD) {
+    if (dca) { // provide default DCA for failed propag
+        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+                o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+    }
     return false;
   }
   value_t crv = this->getCurvature(b);
@@ -245,6 +249,10 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dat
 #if !defined(GPUCA_ALIGPUCODE)
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx << " | Track is: " << tmpT.asString();
 #endif
+    if (dca) { // provide default DCA for failed propag
+        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+                o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+    }
     return false;
   }
   *this = tmpT;

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -564,6 +564,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const o2::dataformats::Verte
   // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
+    if (dca) { // provide default DCA for failed propag
+        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+                o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+    }
     return false;
   }
   value_type crv = track.getCurvature(bZ);
@@ -584,6 +588,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const o2::dataformats::Verte
 #elif !defined(GPUCA_NO_FMT)
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx;
 #endif
+    if (dca) { // provide default DCA for failed propag
+      dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+      o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+    }
     return false;
   }
   track = tmpT;
@@ -613,6 +621,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats:
   // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
+    if (dca) { // provide default DCA for failed propag
+        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+                 o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+    }
     return false;
   }
   value_type crv = track.getCurvature(mNominalBz);
@@ -633,6 +645,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats:
 #elif !defined(GPUCA_NO_FMT)
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx;
 #endif
+    if (dca) { // provide default DCA for failed propag
+        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+                 o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+    }
     return false;
   }
   track = tmpT;
@@ -662,6 +678,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const math_utils::Point3D<va
   // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
+    if (dca) { // provide default DCA for failed propag
+      (*dca)[0] = o2::track::DefaultDCA;
+      (*dca)[1] = o2::track::DefaultDCA;
+    }
     return false;
   }
   value_type crv = track.getCurvature(bZ);
@@ -683,6 +703,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const math_utils::Point3D<va
 #else
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex " << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z();
 #endif
+    if (dca) { // provide default DCA for failed propag
+      (*dca)[0] = o2::track::DefaultDCA;
+      (*dca)[1] = o2::track::DefaultDCA;
+    }
     return false;
   }
   track = tmpT;
@@ -710,6 +734,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Poin
   // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
+    if (dca) { // provide default DCA for failed propag
+      (*dca)[0] = o2::track::DefaultDCA;
+      (*dca)[1] = o2::track::DefaultDCA;
+    }
     return false;
   }
   value_type crv = track.getCurvature(mNominalBz);
@@ -731,6 +759,10 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Poin
 #else
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex " << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z();
 #endif
+    if (dca) { // provide default DCA for failed propag
+      (*dca)[0] = o2::track::DefaultDCA;
+      (*dca)[1] = o2::track::DefaultDCA;
+    }
     return false;
   }
   track = tmpT;

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -565,8 +565,8 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const o2::dataformats::Verte
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     if (dca) { // provide default DCA for failed propag
-        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
-                o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+      dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+               o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
     }
     return false;
   }
@@ -590,7 +590,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const o2::dataformats::Verte
 #endif
     if (dca) { // provide default DCA for failed propag
       dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
-      o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+               o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
     }
     return false;
   }
@@ -622,8 +622,8 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats:
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     if (dca) { // provide default DCA for failed propag
-        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
-                 o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+      dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+               o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
     }
     return false;
   }
@@ -646,8 +646,8 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats:
     LOG(debug) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx;
 #endif
     if (dca) { // provide default DCA for failed propag
-        dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
-                 o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
+      dca->set(o2::track::DefaultDCA, o2::track::DefaultDCA,
+               o2::track::DefaultDCACov, o2::track::DefaultDCACov, o2::track::DefaultDCACov);
     }
     return false;
   }


### PR DESCRIPTION
@shahor02: I have realized that a large number of analysis tasks make use of `propagateToDCA` calls but don't check the main `true`/`false` return value of the call. These tasks then proceed to use the DCA stored either via something like a `std::array` or `o2::dataformats::dca`, and in case of a propagation failure, the first option results in undefined behaviour (in case the user did not initialize the floats) and the second results in a fixed value of 0.0f ([initialized](https://github.com/AliceO2Group/AliceO2/blob/d56b3e960180c908487faf9215b6e9ed6fa77c77/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h#L68) in `DCA.h`). 

In principle, users should check the return code and always initialize their `std::array`s, but in practice, it may be best to protect against this behaviour by creating a default return value (e.g. `o2::track::DefaultDCA`) and, in case the `propagateToDCA` call fails and the user provided some DCA, set the DCA to this default value. Further, in conformity with the DCA behaviour at analysis, this default value when propagation fails should be large (and not zero): in the [propagation task at analysis](https://github.com/AliceO2Group/O2Physics/blob/346c08bc84e92f5665faffbe61f66173f1640804/Common/Tools/TrackPropagationModule.h#L218), we use `999.f`, so I'd propose to use that value directly as return value in case propagation fails. 

Notably, the largest impact of this change is for low-p photon conversions (in which deep secondary e+ or e- often fail propagation). The svertexer [accepts V0s made using such tracks](https://github.com/AliceO2Group/AliceO2/blob/d56b3e960180c908487faf9215b6e9ed6fa77c77/Detectors/Vertexing/src/SVertexer.cxx#L429), but analysis might not, since DCAs could be either uninitialized or set to zero (leading to rejection). Currently, the strangeness builder is safe against this behaviour, but multiple other tasks are not. 

Tagging people I discussed this with recently: @njacazio @alcaliva @romainschotter