### PR TITLE
Example to run HERWIG7 with o2-sim

### DIFF
--- a/run/SimExamples/HepMC_HERWIG7/LHC.in
+++ b/run/SimExamples/HepMC_HERWIG7/LHC.in
@@ -1,0 +1,49 @@
+# -*- ThePEG-repository -*-
+################################################################################
+# This file contains our best tune to UE data from ATLAS at 7 TeV. More recent
+# tunes and tunes for other centre-of-mass energies as well as more usage
+# instructions can be obtained from this Herwig wiki page:
+# http://projects.hepforge.org/herwig/trac/wiki/MB_UE_tunes
+# The model for soft interactions and diffractions is explained in
+# [S. Gieseke, P. Kirchgaesser, F. Loshaj, arXiv:1612.04701]
+################################################################################
+
+read snippets/PPCollider.in
+
+##################################################
+# Technical parameters for this run
+##################################################
+cd /Herwig/Generators
+##################################################
+# LHC physics parameters (override defaults here)
+##################################################
+set EventGenerator:EventHandler:LuminosityFunction:Energy 13600.0
+
+# Minimum Bias
+read snippets/MB.in
+
+# Recommended set of parameters for MB/UE runs
+
+set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.5
+set /Herwig/UnderlyingEvent/MPIHandler:pTmin0 3.502683
+set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.402055
+set /Herwig/UnderlyingEvent/MPIHandler:Power 0.416852
+set /Herwig/Partons/RemnantDecayer:ladderPower -0.08
+set /Herwig/Partons/RemnantDecayer:ladderNorm 0.95
+
+##################################################
+# Analyses
+##################################################
+## Hepmc file creation
+create ThePEG::HepMCFile /Herwig/Analysis/HepMC HepMCAnalysis.so
+set /Herwig/Analysis/HepMC:PrintEvent 10
+set /Herwig/Analysis/HepMC:Format GenEvent
+set /Herwig/Analysis/HepMC:Units GeV_mm
+set /Herwig/Analysis/HepMC:Filename herwig.hepmc
+insert /Herwig/Generators/EventGenerator:AnalysisHandlers 0 /Herwig/Analysis/HepMC
+
+
+##################################################
+# Save run for later usage with 'Herwig run'
+##################################################
+saverun LHC EventGenerator

--- a/run/SimExamples/HepMC_HERWIG7/README.md
+++ b/run/SimExamples/HepMC_HERWIG7/README.md
@@ -1,0 +1,25 @@
+<!-- doxy
+\page refrunSimExamplesHepMC_HERWIG7 Example HepMC_HERWIG7
+/doxy -->
+
+The usage of HERWIG7 with the O2 machinery is presented in this short manual.
+The example generates HEPMC3 data using the Herwig executable and then
+reads the data via the hepmc generator defined in o2-sim.
+
+# Files description
+
+Two files are provided in the folder:
+- **runo2sim.sh** &rarr; allows the generation of events using o2-sim
+- **LHC.in** &rarr; example input file for the configuration of the HERWIG generator
+
+## runo2sim.sh
+
+The script works after loading any O2sim version containing HERWIG7 as a package (dependence of AliGenO2).
+
+If no parameters are provided, the script will run with default values (energy and nEvents provided in the LHC.in file), but few flags are available to change the settings on-the-fly:
+- **-m , --more** &rarr; feeds the simulation with advanced parameters provided to the configuration key flags
+- **-n , --nevents** &rarr; changes the number of events in the .in file or gets the one in the file if no events are provided
+- **-i , --input** &rarr; .in filename for HERWIG7 configuration
+- **-j , --jobs** &rarr; sets the number of workers (2 jobs by default)
+- **-e , --ecm** &rarr; sets the center-of-mass energy in the input file
+- **-h , --help** &rarr; prints usage instructions

--- a/run/SimExamples/HepMC_HERWIG7/runo2sim.sh
+++ b/run/SimExamples/HepMC_HERWIG7/runo2sim.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# This is a simple simulation example on how to generate HEPMC3 data from
+# HERWIG7 and run an ALICE simulation using the o2-sim executable
+# In the script we assume that the .run file has the same name of the input file, so change it accordingly.
+# This script works only with AliGenO2 version containing the HERWIG7 generator
+
+# HERWIG7 and O2 must be loaded
+set -x
+if [ ! "${HERWIG_ROOT}" ]; then
+    echo "This needs HERWIG7 loaded; alienv enter ..."
+    exit 1
+fi
+
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 2
+
+NEV=-1
+more=""
+input="LHC"
+eCM=-1
+JOBS=2
+
+usage()
+{
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+
+  -m,--more    CONFIG      More configurations ($more)
+  -n,--nevents EVENTS      Number of events ($nev)
+  -i,--input   INPUT       Options file fed to HERWIG7 ($input)
+  -j,--jobs    JOBS        Number of jobs ($JOBS)
+  -e,--ecm     ENERGY      Center-of-Mass energy
+  -h,--help                Print these instructions
+  --                       Rest of command line sent to o2-sim
+
+COMMAND must be quoted if it contains spaces or other special
+characters
+
+Below follows the help output of o2-sim
+
+EOF
+}
+
+if [ "$#" -lt 2 ]; then
+    echo "Running with default values"
+fi
+
+while test $# -gt 0 ; do
+    case $1 in
+        -m|--more)    more="$2" ; shift ;;
+        -n|--nevents) NEV=$2 ; shift ;;
+        -i|--input)   input=$2 ; shift ;;
+        -j|--jobs)    JOBS=$2 ; shift ;;
+        -e|--ecm)     eCM=$2 ; shift ;;
+        -h|--help) usage; o2-sim --help full ; exit 0 ;;
+        --)           shift ; break ;;
+        *) echo "Unknown option '$1', did you forget '--'?" >/dev/stderr
+           exit 3
+           ;;
+    esac
+    shift
+done
+
+echo "Input file: $input"
+
+if [ ! -f $input.in ]; then
+    echo "Error: Input file $input.in not found"
+    exit 4
+else
+    if grep -Fq "saverun" $input.in; then
+        sed -i "/saverun/c\saverun $input EventGenerator" $input.in
+    else
+        echo "saverun $input EventGenerator" >> $input.in
+    fi
+fi
+
+# Set number of events to write in HepMC in input file
+if [ ! $NEV -eq -1 ]; then
+    echo "Setting number of events to $NEV"
+    if grep -Fq "PrintEvent" $input.in; then
+        sed -i "/PrintEvent/c\set /Herwig/Analysis/HepMC:PrintEvent $NEV" $input.in
+    else
+        echo "set /Herwig/Analysis/HepMC:PrintEvent $NEV" >> $input.in
+    fi
+else
+    echo "Number of events not set, checking input file..."
+    if grep -Fq "PrintEvent" $input.in; then
+        NEV=$(grep -F "PrintEvent" $input.in | awk '{print $3}')
+        echo "Number of events set to $NEV"
+    else
+        echo "Error: Number of events not set in HERWIG7"
+        exit 5
+    fi
+fi
+
+# Set ECM
+
+if [ ! $eCM -eq -1 ]; then
+    echo "Setting eCM to $eCM"
+    if grep -Fq "Energy" $input.in; then
+        sed -i "/Energy/c\set EventGenerator:EventHandler:LuminosityFunction:Energy $eCM" $input.in
+    else
+        echo "set EventGenerator:EventHandler:LuminosityFunction:Energy $eCM" >> $input.in
+    fi
+else
+    echo "Energy not set, checking input file..."
+    if grep -Fq "Energy" $input.in; then
+        eCM=$(grep -F "Energy" $input.in | awk '{print $3}')
+        echo "Energy set to $eCM"
+    else
+        echo "Error: eCM not set in HERWIG7"
+        exit 6
+    fi
+fi
+
+# Generating events using HERWIG7
+Herwig read --repo=${HERWIG_ROOT}/share/Herwig/HerwigDefaults.rpo $input.in
+Herwig run -N $NEV $input.run
+
+# Starting simulation with o2-sim
+o2-sim -j $JOBS -n ${NEV} -g hepmc  \
+       --configKeyValues "GeneratorFileOrCmd.fileNames=herwig.hepmc;${more}"


### PR DESCRIPTION
A simple example to run the HERWIG generator with HepMC generation has been introduced.
The PR is linked heavily to https://github.com/alisw/alidist/pull/5997, without which the executable will not 
work. An external HERWIG configuration in the O2DPG (without using the HepMC data format) is in the making (last testing steps remaining)