### PR TITLE
Fix unwanted behaviour in signal filtering with embedding pattern different from `@0:e1`

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2126,9 +2126,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
                          0,
                          sourceID);
         }
-        if (sourceID != 0 || !mUseSigFiltMC) {
-          mcColToEvSrc.emplace_back(std::vector<int>{iCol, sourceID, eventID}); // point background and injected signal events to one collision
-        }
+        mcColToEvSrc.emplace_back(std::vector<int>{iCol, sourceID, eventID}); // point background and injected signal events to one collision
       }
     }
   }


### PR DESCRIPTION
In https://github.com/AliceO2Group/AliceO2/pull/14698 I wrongly thought that I could exclude the particles from background event to count the collisions to reduce the size of the vector, without considering that if the embedding pattern different from `@0:e1`, there are collisions with only background particles.
This PR fixes this bug @sawenzel 