### PR TITLE
Make GeneratorHybrid a singleton

### DIFF
--- a/Generators/include/Generators/GeneratorHybrid.h
+++ b/Generators/include/Generators/GeneratorHybrid.h
@@ -54,8 +54,11 @@ class GeneratorHybrid : public Generator
 {
 
  public:
-  GeneratorHybrid(const std::string& inputgens);
-  ~GeneratorHybrid();
+  GeneratorHybrid& operator=(const GeneratorHybrid&) = delete;
+  GeneratorHybrid(const GeneratorHybrid&) = delete;
+
+  // Singleton access method
+  static GeneratorHybrid& Instance(const std::string& inputgens = "");
 
   Bool_t Init() override;
   Bool_t generateEvent() override;
@@ -66,11 +69,13 @@ class GeneratorHybrid : public Generator
   Bool_t confSetter(const auto& gen);
   template <typename T>
   std::string jsonValueToString(const T& value);
-  static std::vector<std::shared_ptr<o2::eventgen::Generator>> const& getGenerators() { return gens; }
+  std::vector<std::shared_ptr<o2::eventgen::Generator>> const& getGenerators() { return gens; }
 
  private:
+  GeneratorHybrid(const std::string& inputgens);
+  ~GeneratorHybrid();
   o2::eventgen::Generator* currentgen = nullptr;
-  static std::vector<std::shared_ptr<o2::eventgen::Generator>> gens;
+  std::vector<std::shared_ptr<o2::eventgen::Generator>> gens;
   const std::vector<std::string> generatorNames = {"extkinO2", "evtpool", "boxgen", "external", "hepmc", "pythia8", "pythia8pp", "pythia8hi", "pythia8hf", "pythia8powheg"};
   std::vector<std::string> mInputGens;
   std::vector<std::string> mGens;

--- a/Generators/include/Generators/GeneratorHybrid.h
+++ b/Generators/include/Generators/GeneratorHybrid.h
@@ -66,10 +66,11 @@ class GeneratorHybrid : public Generator
   Bool_t confSetter(const auto& gen);
   template <typename T>
   std::string jsonValueToString(const T& value);
+  static std::vector<std::shared_ptr<o2::eventgen::Generator>> const& getGenerators() { return gens; }
 
  private:
   o2::eventgen::Generator* currentgen = nullptr;
-  std::vector<std::shared_ptr<o2::eventgen::Generator>> gens;
+  static std::vector<std::shared_ptr<o2::eventgen::Generator>> gens;
   const std::vector<std::string> generatorNames = {"extkinO2", "evtpool", "boxgen", "external", "hepmc", "pythia8", "pythia8pp", "pythia8hi", "pythia8hf", "pythia8powheg"};
   std::vector<std::string> mInputGens;
   std::vector<std::string> mGens;

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -284,8 +284,8 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
       LOG(fatal) << "Configuration file for hybrid generator does not exist";
       return;
     }
-    auto hybrid = new o2::eventgen::GeneratorHybrid(config);
-    primGen->AddGenerator(hybrid);
+    auto& hybrid = o2::eventgen::GeneratorHybrid::Instance(config);
+    primGen->AddGenerator(&hybrid);
 #endif
   } else {
     LOG(fatal) << "Invalid generator";

--- a/Generators/src/GeneratorHybrid.cxx
+++ b/Generators/src/GeneratorHybrid.cxx
@@ -23,7 +23,11 @@ namespace o2
 namespace eventgen
 {
 
-std::vector<std::shared_ptr<o2::eventgen::Generator>> GeneratorHybrid::gens;
+GeneratorHybrid& GeneratorHybrid::Instance(const std::string& inputgens)
+{
+  static GeneratorHybrid instance(inputgens);
+  return instance;
+}
 
 GeneratorHybrid::GeneratorHybrid(const std::string& inputgens)
 {

--- a/Generators/src/GeneratorHybrid.cxx
+++ b/Generators/src/GeneratorHybrid.cxx
@@ -23,6 +23,8 @@ namespace o2
 namespace eventgen
 {
 
+std::vector<std::shared_ptr<o2::eventgen::Generator>> GeneratorHybrid::gens;
+
 GeneratorHybrid::GeneratorHybrid(const std::string& inputgens)
 {
   // This generator has trivial unit conversions


### PR DESCRIPTION
By making the generators list static we can provide info to the other generators in cocktails. 
Currently each generator runs without knowing the information from the others in the hybrid configuration, but this will allow them to "communicate".
I tested it using an external generator which uses the GetParticles().size() as a baseline to change the number of generated particles (boxgen). It's only the first piece of the puzzle and more work is required to take care of different scenarios (like parallel simulations). 