### PR TITLE
GPU: Wshadow compiler directive not needed in HIP Includes System

### DIFF
--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIPIncludesSystem.h
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIPIncludesSystem.h
@@ -23,7 +23,7 @@
 #include <hip/hip_ext.h>
 #include <hipcub/hipcub.hpp>
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow" // FIXME: Is this still needed?
+// #pragma GCC diagnostic ignored "-Wshadow" // VS: This compiler directive for -Wshadow is not needed. 
 #include <thrust/sort.h>
 #include <thrust/execution_policy.h>
 #include <thrust/device_ptr.h>

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIPIncludesSystem.h
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIPIncludesSystem.h
@@ -22,11 +22,8 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_ext.h>
 #include <hipcub/hipcub.hpp>
-#pragma GCC diagnostic push
-// #pragma GCC diagnostic ignored "-Wshadow" // VS: This compiler directive for -Wshadow is not needed. 
 #include <thrust/sort.h>
 #include <thrust/execution_policy.h>
 #include <thrust/device_ptr.h>
-#pragma GCC diagnostic pop
 
 #endif // O2_GPU_RECONSTRUCTIONHIPINCLUDESSYSTEM_H


### PR DESCRIPTION
GCC Compiler directive for Wshadow is not needed, therefore commented the line. 