### PR TITLE
corrected positions of volumes in RB24 after recent Cave updates

### DIFF
--- a/Detectors/FIT/FDD/base/src/Geometry.cxx
+++ b/Detectors/FIT/FDD/base/src/Geometry.cxx
@@ -152,7 +152,7 @@ void Geometry::buildGeometry()
   if (!vCaveRB24) {
     LOG(fatal) << "Could not find the top volume for A-side";
   }
-  const Float_t kPosFDA = 1696.67 - 1313.347; // z-center of assembly (cm)
+  const Float_t kPosFDA = 1696.67 - 1313.347 - 75.; // z-center of assembly (cm)
   vCaveRB24->AddNode(vFDAarray, 1, new TGeoTranslation(0., 0., kPosFDA - kFDACelldz / 2. - 0.1));
   vCaveRB24->AddNode(vFDAarray, 2, new TGeoTranslation(0., 0., kPosFDA + kFDACelldz / 2. + 0.1));
 

--- a/Detectors/Passive/src/Compensator.cxx
+++ b/Detectors/Passive/src/Compensator.cxx
@@ -110,7 +110,7 @@ void Compensator::ConstructGeometry()
 void Compensator::createCompensator()
 {
   auto top = gGeoManager->GetVolume("caveRB24");
-  top->AddNode(createMagnetYoke(), 1, new TGeoTranslation(0., 0., 1075. - 1313.347));
+  top->AddNode(createMagnetYoke(), 1, new TGeoTranslation(0., 0., 1000. - 1313.347));
 }
 
 TGeoVolume* Compensator::createMagnetYoke()

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -2355,7 +2355,7 @@ void Detector::createDetectors()
 
   // --- Positioning the ZEM into the ZDC - rotation for 90 degrees
   // NB -> ZEM is positioned in cave volume
-  const float z0 = 1313.3475; // center of caveRB24 mother volume
+  const float z0 = 1313.3475 + 75.; // center of caveRB24 mother volume
   TVirtualMC::GetMC()->Gspos("ZEM ", 1, "caveRB24", -Geometry::ZEMPOSITION[0], Geometry::ZEMPOSITION[1], Geometry::ZEMPOSITION[2] + Geometry::ZEMDIMENSION[0] - z0, irotzem1, "ONLY");
 
   // Second EM ZDC (same side w.r.t. IP, just on the other side w.r.t. beam pipe)


### PR DESCRIPTION
Corrected positions of volumes in caveRB24 after recent updates to accommodate FOCAL in the barrel volume.
Since the mother volume has been shortened by 150 cm in the z-direction, the volumes have to be moved 75 cm closer to the center. This concerns ZEM , Compensator magnet and FDD (A-side).
