### PR TITLE
GPU TPC: added dynamic buffer allocation during track-model decoding

### DIFF
--- a/GPU/GPUTracking/DataCompression/GPUTPCDecompression.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCDecompression.cxx
@@ -117,8 +117,10 @@ void GPUTPCDecompression::RegisterMemoryAllocation()
 
 void GPUTPCDecompression::SetMaxData(const GPUTrackingInOutPointers& io)
 {
-  mMaxNativeClustersPerBuffer = *std::max_element(mInputGPU.nSliceRowClusters, mInputGPU.nSliceRowClusters + mInputGPU.nSliceRows);
-  float clsRatio = mInputGPU.nUnattachedClusters > 0 ? float(mInputGPU.nAttachedClusters) / float(mInputGPU.nUnattachedClusters) : 1.0f;
-  mMaxNativeClustersPerBuffer *= clsRatio;
-  mMaxNativeClustersPerBuffer = std::min(mMaxNativeClustersPerBuffer, mRec->GetProcessingSettings().tpcMaxAttachedClustersPerSectorRow);
+  uint32_t maxAttachedClsMargin1 = *std::max_element(mInputGPU.nSliceRowClusters, mInputGPU.nSliceRowClusters + mInputGPU.nSliceRows);
+  float clsRatio1 = std::max(mInputGPU.nUnattachedClusters > 0 ? float(mInputGPU.nAttachedClusters) / float(mInputGPU.nUnattachedClusters) : 1.5f, 1.5f); // minimum raio = 1.5
+  maxAttachedClsMargin1 *= clsRatio1;
+  uint32_t maxAttachedClsMargin2 = mInputGPU.nAttachedClusters / mInputGPU.nSliceRows * 3;                                               // mean #attached cls per SectorRow multiplied by tuned number 3
+  mMaxNativeClustersPerBuffer = std::max({maxAttachedClsMargin1, maxAttachedClsMargin2, 1000u});                                         // take biggest margin, 1000 clusters minimum
+  mMaxNativeClustersPerBuffer = std::min(mMaxNativeClustersPerBuffer, mRec->GetProcessingSettings().tpcMaxAttachedClustersPerSectorRow); // upperbound given by configurable param
 }

--- a/GPU/GPUTracking/DataCompression/GPUTPCDecompression.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCDecompression.cxx
@@ -118,9 +118,9 @@ void GPUTPCDecompression::RegisterMemoryAllocation()
 void GPUTPCDecompression::SetMaxData(const GPUTrackingInOutPointers& io)
 {
   uint32_t maxAttachedClsMargin1 = *std::max_element(mInputGPU.nSliceRowClusters, mInputGPU.nSliceRowClusters + mInputGPU.nSliceRows);
-  float clsRatio1 = std::max(mInputGPU.nUnattachedClusters > 0 ? float(mInputGPU.nAttachedClusters) / float(mInputGPU.nUnattachedClusters) : 1.5f, 1.5f); // minimum raio = 1.5
+  float clsRatio1 = (mInputGPU.nUnattachedClusters > 0 ? float(mInputGPU.nAttachedClusters) / float(mInputGPU.nUnattachedClusters) : 1.0f) * 1.5f;
   maxAttachedClsMargin1 *= clsRatio1;
-  uint32_t maxAttachedClsMargin2 = mInputGPU.nAttachedClusters / mInputGPU.nSliceRows * 3;                                               // mean #attached cls per SectorRow multiplied by tuned number 3
+  uint32_t maxAttachedClsMargin2 = mInputGPU.nAttachedClusters / mInputGPU.nSliceRows * 3.5;                                             // mean #attached cls per SectorRow multiplied by 3.5 (tuned)
   mMaxNativeClustersPerBuffer = std::max({maxAttachedClsMargin1, maxAttachedClsMargin2, 1000u});                                         // take biggest margin, 1000 clusters minimum
   mMaxNativeClustersPerBuffer = std::min(mMaxNativeClustersPerBuffer, mRec->GetProcessingSettings().tpcMaxAttachedClustersPerSectorRow); // upperbound given by configurable param
 }

--- a/GPU/GPUTracking/DataCompression/GPUTPCDecompression.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCDecompression.cxx
@@ -18,6 +18,7 @@
 #include "GPUO2DataTypes.h"
 #include "GPUMemorySizeScalers.h"
 #include "GPULogging.h"
+#include <algorithm>
 
 using namespace o2::gpu;
 
@@ -116,5 +117,8 @@ void GPUTPCDecompression::RegisterMemoryAllocation()
 
 void GPUTPCDecompression::SetMaxData(const GPUTrackingInOutPointers& io)
 {
-  mMaxNativeClustersPerBuffer = mRec->GetProcessingSettings().tpcMaxAttachedClustersPerSectorRow;
+  mMaxNativeClustersPerBuffer = *std::max_element(mInputGPU.nSliceRowClusters, mInputGPU.nSliceRowClusters + mInputGPU.nSliceRows);
+  float clsRatio = mInputGPU.nUnattachedClusters > 0 ? float(mInputGPU.nAttachedClusters) / float(mInputGPU.nUnattachedClusters) : 1.0f;
+  mMaxNativeClustersPerBuffer *= clsRatio;
+  mMaxNativeClustersPerBuffer = std::min(mMaxNativeClustersPerBuffer, mRec->GetProcessingSettings().tpcMaxAttachedClustersPerSectorRow);
 }


### PR DESCRIPTION
Dynamic buffer utilization for track-model decoding based on input data. Added margin based on the ratio between attached and unattached clusters.
Tests on PbPb simulated datasets, memSize limited to 15GB:
| Interaction Rate | Device Memory Before (Bytes) | Device Memory After (Bytes) |
|----------|----------|----------|
| 5kHz | 3,940,286,464 | 665,190,400 |
| 47kHz | 5,647,106,048 | 3,087,728,640 |
| 50kHz | 5,537,529,856 | 2,975,465,472 |