### PR TITLE
ITS3: fix recently added service material

### DIFF
--- a/Detectors/Upgrades/ITS3/base/include/ITS3Base/SpecsV2.h
+++ b/Detectors/Upgrades/ITS3/base/include/ITS3Base/SpecsV2.h
@@ -221,7 +221,7 @@ namespace services
 constexpr double thickness{2.2 * mm};                                         // thickness of structure
 constexpr double radiusInner{radiiOuter[2] + carbonfoam::thicknessOuterFoam}; // inner radius of services
 constexpr double radiusOuter{radiusInner + thickness};                        // outer radius of services
-constexpr double length{20 * cm};                                             // length
+constexpr double length{segment::length + (1 * cm)};                          // length
 constexpr EColor color{kBlue};
 } // namespace services
 

--- a/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3.h
+++ b/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3.h
@@ -48,7 +48,7 @@ class DescriptorInnerBarrelITS3 : public o2::its::DescriptorInnerBarrel
   static constexpr double mTolerance{1e-3};
   static constexpr double mWrapperMinRadiusITS3{constants::radiiInner[0] - mTolerance};
   static constexpr double mWrapperMaxRadiusITS3{constants::services::radiusOuter + mTolerance};
-  static constexpr double mWrapperZSpanITS3{constants::services::length + mTolerance};
+  static constexpr double mWrapperZSpanITS3{constants::services::length * 2 + mTolerance}; // z length is divided in half
 
  private:
   std::array<std::unique_ptr<ITS3Layer>, constants::nLayers> mIBLayers;

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Services.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Services.cxx
@@ -31,8 +31,8 @@ void ITS3Services::createCYSSAssembly(TGeoVolume* motherVolume)
 
   // Cylinder
   auto cyssInnerCylSh = new TGeoTubeSeg(constants::services::radiusInner, constants::services::radiusOuter, constants::services::length / 2, 180, 360);
-  auto medPrepreg = gGeoManager->GetMedium("IT3_AS4C200$");
-  auto cyssInnerCylShVol = new TGeoVolume("IBCYSSCylinder", cyssInnerCylSh, medPrepreg);
+  auto medRohacell = gGeoManager->GetMedium("IT3_RIST110$");
+  auto cyssInnerCylShVol = new TGeoVolume("IBCYSSCylinder", cyssInnerCylSh, medRohacell);
   cyssInnerCylShVol->SetLineColor(constants::services::color);
   cyssVol->AddNode(cyssInnerCylShVol, 1, new TGeoTranslation(0, 0, 0));
   cyssVol->AddNode(cyssInnerCylShVol, 2, new TGeoCombiTrans(0, 0, 0, new TGeoRotation("", 180, 0, 0)));

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Services.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Services.cxx
@@ -30,13 +30,16 @@ void ITS3Services::createCYSSAssembly(TGeoVolume* motherVolume)
   motherVolume->AddNode(cyssVol, 1., nullptr);
 
   // Cylinder
-  auto cyssInnerCylSh = new TGeoTubeSeg(constants::services::radiusInner, constants::services::radiusOuter, constants::services::length, 180, 360);
+  auto cyssInnerCylSh = new TGeoTubeSeg(constants::services::radiusInner, constants::services::radiusOuter, constants::services::length / 2, 180, 360);
   auto medPrepreg = gGeoManager->GetMedium("IT3_AS4C200$");
   auto cyssInnerCylShVol = new TGeoVolume("IBCYSSCylinder", cyssInnerCylSh, medPrepreg);
+  cyssInnerCylShVol->SetLineColor(constants::services::color);
   cyssVol->AddNode(cyssInnerCylShVol, 1, new TGeoTranslation(0, 0, 0));
   cyssVol->AddNode(cyssInnerCylShVol, 2, new TGeoCombiTrans(0, 0, 0, new TGeoRotation("", 180, 0, 0)));
 
   // TODO Cone
+  // For now the wrapping volume just extends beyond the cylinder if something is added beyond that this volume has to
+  // be exteneded.
 }
 
 } // namespace o2::its3


### PR DESCRIPTION
Wrong material used in the geometry leading to deterioration in DCA results, also fixed the length of the wrapping volume.