### PR TITLE
Fix application of signal filtering when enabled

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODMcProducerHelpers.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODMcProducerHelpers.h
@@ -315,7 +315,8 @@ uint32_t updateParticles(const ParticleCursor& cursor,
                          bool background = false,
                          uint32_t weightMask = 0xFFFFFFF0,
                          uint32_t momentumMask = 0xFFFFFFF0,
-                         uint32_t positionMask = 0xFFFFFFF0);
+                         uint32_t positionMask = 0xFFFFFFF0,
+                         bool signalFilter = false);
 } // namespace o2::aodmchelpers
 
 #endif /* O2_AODMCPRODUCER_HELPERS */

--- a/Detectors/AOD/src/AODMcProducerHelpers.cxx
+++ b/Detectors/AOD/src/AODMcProducerHelpers.cxx
@@ -305,7 +305,8 @@ uint32_t updateParticles(const ParticleCursor& cursor,
                          bool background,
                          uint32_t weightMask,
                          uint32_t momentumMask,
-                         uint32_t positionMask)
+                         uint32_t positionMask,
+                         bool signalFilter)
 {
   using o2::mcutils::MCTrackNavigator;
   using namespace o2::aod::mcparticle::enums;
@@ -353,6 +354,9 @@ uint32_t updateParticles(const ParticleCursor& cursor,
                        << MCTrackNavigator::isKeepPhysics(track, tracks);
         continue;
       }
+    }
+    if (background && signalFilter) {
+      continue;
     }
 
     // Store this particle.  We mark that putting a 1 in the

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1063,7 +1063,8 @@ void AODProducerWorkflowDPL::fillMCParticlesTable(o2::steer::MCKinematicsReader&
                              source == 0, // background
                              mMcParticleW,
                              mMcParticleMom,
-                             mMcParticlePos);
+                             mMcParticlePos,
+                             mUseSigFiltMC);
 
     mcReader.releaseTracksForSourceAndEvent(source, event);
   }


### PR DESCRIPTION
The latest fix in the signal filtering https://github.com/AliceO2Group/AliceO2/pull/14735 cured the segmentation fault in case of embedding patterns different from `@0:e1`, but also removed the signal filtering at all. This PR restores it @sawenzel 