### PR TITLE
TRD add digit phases to CTF encoding, collapse phases on reading.

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
@@ -59,7 +59,7 @@ class Digit
   Digit(int det, int row, int pad, ArrayADC adc, int phase = 0);
   Digit(int det, int row, int pad); // add adc data and pretrigger phase in a separate step
   Digit(int det, int rob, int mcm, int channel, ArrayADC adc, int phase = 0);
-  Digit(int det, int rob, int mcm, int channel); // add adc data in a seperate step
+  Digit(int det, int rob, int mcm, int channel, int phase = 0); // add adc data
 
   // Copy
   Digit(const Digit&) = default;
@@ -74,9 +74,11 @@ class Digit
   void setDetector(int det) { mDetector = ((mDetector & 0xf000) | (det & 0xfff)); }
   void setADC(ArrayADC const& adc) { mADC = adc; }
   void setADC(const gsl::span<ADC_t>& adc) { std::copy(adc.begin(), adc.end(), mADC.begin()); }
-  void setPreTrigPhase(int phase) { mDetector = (((phase & 0xf) << 12) | (mDetector & 0xfff)); }
+  // set the trigger phase make sure it is mapped to 2 bits as it can only have 4 valid numbers shifted 0,3,6,9 or 1,4,7,10 etc.
+  void setPreTrigPhase(int phase);
   // Get methods
   int getDetector() const { return mDetector & 0xfff; }
+  int getDetectorInFull() const { return mDetector; } // return the entire mDetector 16 bits, so far only for CTF encoding.
   int getHCId() const { return (mDetector & 0xfff) * 2 + (mROB % 2); }
   int getPadRow() const { return HelperMethods::getPadRowFromMCM(mROB, mMCM); }
   int getPadCol() const { return HelperMethods::getPadColFromADC(mROB, mMCM, mChannel); }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/PHData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/PHData.h
@@ -61,6 +61,66 @@ class PHData
 
   ClassDefNV(PHData, 1);
 };
+
+/*
+  This data type is used to send around the information required to fill PH plots per chamber
+
+  |19|18|17|16|15|14|13|12|11|10|09|08|07|06|05|04|03|02|01|00|
+  -------------------------------------------------------------
+  |type |nNeighb |   time bin   |        detector number      |
+  -------------------------------------------------------------
+*/
+/*
+  This data type is used to send around the information required to fill PH plots per chamber
+
+  |15|14|13|12|11|10|09|08|07|06|05|04|03|02|01|00|
+  ------------------------------------------------
+  |                 ADC sum for all neigbours     |
+  ------------------------------------------------
+*/
+
+class PHDataHD
+{
+ public:
+  enum Origin : uint8_t {
+    ITSTPCTRD,
+    TPCTRD,
+    TRACKLET,
+    OTHER
+  };
+
+  PHDataHD() = default;
+  PHDataHD(int adc, int det, int tb, int nb, int type) { set(adc, det, tb, nb, type); }
+
+  void set(int adc, int det, int tb, int nb, int type)
+  {
+    mDetector = det;
+    mTimeBin = tb;
+    mType = type;
+    mNNeighbours = nb;
+    mADC = adc;
+  }
+
+  // the ADC sum for given time bin for up to three neighbours
+  int getADC() const { return mADC; }
+  // the TRD detector number
+  int getDetector() const { return mDetector; }
+  // the given time bin
+  int getTimebin() const { return mTimeBin; }
+  // number of neighbouring digits for which the ADC is accumulated
+  int getNNeighbours() const { return mNNeighbours; }
+  // the origin of this point: digit on ITS-TPC-TRD track, ... (see enum Origin above)
+  int getType() const { return mType; }
+
+ private:
+  uint16_t mDetector{0};
+  uint8_t mTimeBin{0};
+  uint8_t mType{0};
+  uint8_t mNNeighbours{0};
+  uint16_t mADC{0};
+
+  ClassDefNV(PHDataHD, 1);
+};
 } // namespace o2::trd
 
 #endif // ALICEO2_TRD_PHDATA_H_

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -43,6 +43,7 @@
 #pragma link C++ class o2::trd::ChannelInfo + ;
 #pragma link C++ class o2::trd::ChannelInfoContainer + ;
 #pragma link C++ struct o2::trd::PHData + ;
+#pragma link C++ struct o2::trd::PHDataHD + ;
 #pragma link C++ class o2::trd::TRDDataCountersPerTimeFrame + ;
 #pragma link C++ class o2::trd::DataCountersPerTrigger + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
@@ -56,6 +57,7 @@
 #pragma link C++ class std::vector < o2::trd::GainCalibHistos> + ;
 #pragma link C++ class std::vector < o2::trd::T0FitHistos> + ;
 #pragma link C++ class std::vector < o2::trd::PHData> + ;
+#pragma link C++ class std::vector < o2::trd::PHDataHD> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 #pragma link C++ class std::vector < o2::trd::DataCountersPerTrigger> + ;

--- a/DataFormats/Detectors/TRD/src/Digit.cxx
+++ b/DataFormats/Detectors/TRD/src/Digit.cxx
@@ -12,6 +12,7 @@
 #include "DataFormatsTRD/Digit.h"
 #include <iostream>
 #include <algorithm>
+#include "fairlogger/Logger.h"
 
 namespace o2::trd
 {
@@ -46,12 +47,18 @@ Digit::Digit(int det, int rob, int mcm, int channel, ArrayADC adc, int pretrigph
   setPreTrigPhase(pretrigphase);
 }
 
-Digit::Digit(int det, int rob, int mcm, int channel) // add adc data in a seperate step
+Digit::Digit(int det, int rob, int mcm, int channel, int pretrigphase) // add adc data in a seperate step
 {
   setDetector(det);
   setROB(rob);
   setMCM(mcm);
   setChannel(channel);
+  setPreTrigPhase(pretrigphase);
+}
+
+void Digit::setPreTrigPhase(int phase)
+{
+  mDetector = ((((phase) & 0x3) << 12) | (mDetector & 0xfff));
 }
 
 bool Digit::isSharedDigit() const

--- a/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/PulseHeight.h
@@ -61,6 +61,7 @@ class PulseHeight
 
   /// Access to output
   const std::vector<PHData>& getPHData() { return mPHValues; }
+  const std::vector<PHDataHD>& getPHDataHD() { return mPHValuesHD; }
 
   void createOutputFile();
   void closeOutputFile();
@@ -77,6 +78,7 @@ class PulseHeight
 
   // output
   std::vector<PHData> mPHValues, *mPHValuesPtr{&mPHValues}; ///< vector of values used to fill the PH spectra per detector
+  std::vector<PHDataHD> mPHValuesHD, *mPHValuesHDPtr{&mPHValuesHD}; ///< vector of values used to fill the High definition PH spectra per detector with pretrigger phase
   std::vector<int> mDistances, *mDistancesPtr{&mDistances}; ///< pad distance between tracklet column and digit ADC maximum
   std::unique_ptr<TFile> mOutFile{nullptr};                 ///< output file
   std::unique_ptr<TTree> mOutTree{nullptr};                 ///< output tree

--- a/Detectors/TRD/calibration/src/PulseHeight.cxx
+++ b/Detectors/TRD/calibration/src/PulseHeight.cxx
@@ -23,6 +23,7 @@ using namespace o2::trd::constants;
 void PulseHeight::reset()
 {
   mPHValues.clear();
+  mPHValuesHD.clear();
   mDistances.clear();
 }
 
@@ -39,6 +40,7 @@ void PulseHeight::createOutputFile()
   }
   mOutTree = std::make_unique<TTree>("ph", "Data points for PH histograms");
   mOutTree->Branch("values", &mPHValuesPtr);
+  mOutTree->Branch("valuesHD", &mPHValuesHDPtr);
   mOutTree->Branch("dist", &mDistancesPtr);
   mWriteOutput = true;
   LOG(info) << "Writing PH data points to local file trd_PH.root";
@@ -178,13 +180,17 @@ void PulseHeight::findDigitsForTracklet(const Tracklet64& trklt, const TriggerRe
       mDistances.push_back(digitTrackletDistance);
       for (int iTb = 0; iTb < TIMEBINS; ++iTb) {
         uint16_t phVal = digit.getADC()[iTb];
+        uint16_t phValHD = (digit.getADC()[iTb] << 2) + digit.getPreTrigPhase();
         if (left) {
           phVal += digitLeft->getADC()[iTb];
+          phValHD += (digitLeft->getADC()[iTb] << 2) + digit.getPreTrigPhase();
         }
         if (right) {
           phVal += digitRight->getADC()[iTb];
+          phValHD += (digitRight->getADC()[iTb] << 2) + digit.getPreTrigPhase();
         }
         mPHValues.emplace_back(phVal, trkltDet, iTb, nNeighbours, type);
+        mPHValuesHD.emplace_back(phValHD, trkltDet, iTb, nNeighbours, type);
       }
     }
   }

--- a/Detectors/TRD/qc/src/RawDataManager.cxx
+++ b/Detectors/TRD/qc/src/RawDataManager.cxx
@@ -23,6 +23,8 @@
 
 #include <set>
 #include <utility>
+#include <algorithm>
+#include <execution>
 
 using namespace o2::trd;
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -259,8 +259,8 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& tr
       uint32_t firstEntryDig = digVec.size();
       int16_t cid = 0;
       for (uint32_t id = 0; id < entriesDig[itrig]; id++) {
-        cid += CIDDig[digCount]; // 1st digit of trigger was encoded with abs CID, then increments
-        auto& dig = digVec.emplace_back(cid, ROBDig[digCount], MCMDig[digCount], chanDig[digCount]);
+        cid += CIDDig[digCount]; // as cid has phase, its stored fully not  // 1st digit of trigger was encoded with abs CID, then increments
+        auto& dig = digVec.emplace_back(cid & 0xfff, ROBDig[digCount], MCMDig[digCount], chanDig[digCount], (cid >> 12) & 0x3);
         dig.setADC({&ADCDig[adcCount], constants::TIMEBINS});
         digCount++;
         adcCount += constants::TIMEBINS;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
@@ -288,12 +288,12 @@ class CTFHelper
     // assume sorting in CID: for the 1st digit of the trigger return the abs CID, for the following ones: difference to previous CID
     value_type operator*() const
     {
-      return (*mTrigStart)[mIndex] ? mData[mIndex].getDetector() : mData[mIndex].getDetector() - mData[mIndex - 1].getDetector();
+      return (*mTrigStart)[mIndex] ? mData[mIndex].getDetectorInFull() : mData[mIndex].getDetectorInFull() - mData[mIndex - 1].getDetectorInFull();
     }
     value_type operator[](difference_type i) const
     {
       size_t id = mIndex + i;
-      return (*mTrigStart)[id] ? mData[id].getDetector() : mData[id].getDetector() - mData[id - 1].getDetector();
+      return (*mTrigStart)[id] ? mData[id].getDetectorInFull() : mData[id].getDetectorInFull() - mData[id - 1].getDetectorInFull();
     }
   };
 

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -301,6 +301,9 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
         DigitHCHeader1 header1;
         header1.word = headers[headerwordcount];
         mPreTriggerPhase = header1.ptrigphase;
+        mPreTriggerPhase &= 0x0f;
+        mPreTriggerPhase /= 3; // remove the "gaps" in the pre trigger phase, so we dont have to sort it out later.
+        LOGP(debug, "Found pretrigger phase of Phase:{:x}", mPreTriggerPhase);
 
         headersfound.set(0);
         if ((header1.numtimebins > TIMEBINS) || (header1.numtimebins < 3) || mTimeBinsFixed && header1.numtimebins != mTimeBins) {
@@ -802,6 +805,7 @@ int CruRawReader::parseDigitLinkData(int maxWords32, int hcid, int& wordsRejecte
           if (exitChannelLoop) {
             break;
           }
+          LOGP(debug, "Adding digit to event record det: {} rob: {} mcm: {} channel: {} Phase:{:x}", hcid / 2, (int)mcmHeader.rob, (int)mcmHeader.mcm, iChannel, mPreTriggerPhase);
           mEventRecords.getCurrentEventRecord().addDigit(Digit(hcid / 2, (int)mcmHeader.rob, (int)mcmHeader.mcm, iChannel, adcValues, mPreTriggerPhase));
           ++mDigitsFound;
         } // end active channel

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDPulseHeightSpec.h
@@ -58,6 +58,8 @@ class PuseHeightDevice : public o2::framework::Task
     if (mRunStopRequested) {
       std::vector<PHData> mPHValues{}; // the calibration expects data at every TF, so inject dummy
       pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHT", 0}, mPHValues);
+      std::vector<PHDataHD> mPHValuesHD{}; // the calibration expects data at every TF, so inject dummy
+      pc.outputs().snapshot(Output{"TRD", "PULSEHEIGHTHD", 0}, mPHValuesHD);
       return;
     }
     RecoContainer recoData;


### PR DESCRIPTION
- extract pretrigger phases from the cruhalfchamber header.
- encode it into the ctf into the upper 2 of 4 bits of the detector number.
- ctf is marginally bigger due to non sequential detector number, but only 2 bits not 4 due to collapsing the phase values in the raw  reader. We only need the relative positions not the actual phase values.
- add the processing of the phases to the pulseheight processing with HD (high definition) appended to the new class, old one left in.
- parallelise the sort of the incoming structurs for the drawing of MCM, Padrow, Detector in TRD/qc/src/ augmented data structures for visualising MCM/Padrows.