### PR TITLE
MCH add cut random fraction setting for the cases with and without ITS

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -379,7 +379,12 @@ if has_processing_step MUON_SYNC_RECO; then
   elif [[ $RUNTYPE == "PHYSICS" && $BEAMTYPE == "pp" || $LIGHTNUCLEI == "1" ]] || [[ $RUNTYPE == "COSMICS" ]]; then
     MCH_CONFIG_KEY+="MCHTracking.chamberResolutionX=0.4;MCHTracking.chamberResolutionY=0.4;MCHTracking.sigmaCutForTracking=7.;MCHTracking.sigmaCutForImprovement=6.;"
   fi
-  has_detector_reco ITS && [[ $RUNTYPE != "COSMICS" ]] && MCH_CONFIG_KEY+="MCHTimeClusterizer.irFramesOnly=true;"
+  if has_detector_reco ITS && [[ $RUNTYPE != "COSMICS" && x"${MCH_DISABLE_ITS_IRFRAMES_SELECTION:-}" != "x1" ]]; then
+    MCH_CONFIG_KEY+="MCHTimeClusterizer.irFramesOnly=true;"
+    [[ -z ${CUT_RANDOM_FRACTION_MCH:-} && -n ${CUT_RANDOM_FRACTION_MCH_WITH_ITS:-} ]] && CUT_RANDOM_FRACTION_MCH=${CUT_RANDOM_FRACTION_MCH_WITH_ITS:-}
+  else
+    [[ -z ${CUT_RANDOM_FRACTION_MCH:-} && -n ${CUT_RANDOM_FRACTION_MCH_NO_ITS:-} ]] && CUT_RANDOM_FRACTION_MCH=${CUT_RANDOM_FRACTION_MCH_NO_ITS:-}
+  fi
   [[ -n ${CUT_RANDOM_FRACTION_MCH:-} ]] && MCH_CONFIG_KEY+="MCHTimeClusterizer.rofRejectionFraction=$CUT_RANDOM_FRACTION_MCH;"
   MCH_CONFIG_KEY+="MCHStatusMap.useHV=false;MCHDigitFilter.statusMask=3;"
   [[ $RUNTYPE == "COSMICS" ]] && [[ -z ${CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow:-} ]] && CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.FullClusterScan=true"


### PR DESCRIPTION
Two new environment variables are introduced to provide the fraction of rejected MCH events separately for the cases where the selection based on ITS IRframes is either enabled (CUT_RANDOM_FRACTION_MCH_WITH_ITS) or disabled (CUT_RANDOM_FRACTION_MCH_NO_ITS).

The selection based on ITS is enabled by default in SYNC processing for physics runs where ITS is included in the data taking. It can be however explicitely disabled by adding MCH_DISABLE_ITS_IRFRAMES_SELECTION=1 to the custom environment variables. In this case, CUT_RANDOM_FRACTION_MCH_NO_ITS is used.

The CUT_RANDOM_FRACTION_MCH variable, as well as the two new ones, can still be overridden by setting them explicitly in the shell environment. Moreover, the ITS selection is applied whenever MCH_DISABLE_ITS_IRFRAMES_SELECTION is undefined, therefore the changes are fully backward compatible.