### PR TITLE
ITS3: update matLUT macro

### DIFF
--- a/Detectors/Upgrades/ITS3/macros/test/buildMatBudLUT.C
+++ b/Detectors/Upgrades/ITS3/macros/test/buildMatBudLUT.C
@@ -31,8 +31,6 @@ o2::base::MatLayerCylSet mbLUT;
 
 bool testMBLUT(const std::string& lutFile = "matbud.root");
 
-bool buildMatBudLUT(int nTst = 60, int maxLr = -1, const std::string& outFile = "matbud.root", const std::string& geomName = "");
-
 struct LrData {
   float rMin = 0.f;
   float rMax = 0.f;
@@ -46,14 +44,17 @@ struct LrData {
 std::vector<LrData> lrData;
 void configLayers();
 
-bool buildMatBudLUT(int nTst, int maxLr, const std::string& outFile, const std::string& geomNameInput)
+bool buildMatBudLUT(int nTst = 30, int maxLr = -1, const std::string& outFile = "matbud.root", const std::string& geomNamePrefix = "o2sim", const std::string& opts = "")
 {
-  auto geomName = o2::base::NameConf::getGeomFileName(geomNameInput);
+  auto geomName = o2::base::NameConf::getGeomFileName(geomNamePrefix);
   if (gSystem->AccessPathName(geomName.c_str())) { // if needed, create geometry
-    std::cout << geomName << " does not exist. Will create it\n";
-    gSystem->Exec("$O2_ROOT/bin/o2-sim -n 0 --detectorList ALICE2.1");
+    std::cout << geomName << " does not exist. Will create it on the fly\n";
+    std::stringstream str;
+    // constructing an **unaligned** geom (Geant3 used since faster initialization) --> can be avoided by passing an existing geometry
+    str << "${O2_ROOT}/bin/o2-sim-serial -n 0 -e TGeant3 --detectorList ALICE2.1 --configKeyValues \"" << opts << "\" --field 0  -o " << geomNamePrefix;
+    gSystem->Exec(str.str().c_str());
   }
-  o2::base::GeometryManager::loadGeometry(geomNameInput);
+  o2::base::GeometryManager::loadGeometry(geomNamePrefix);
   configLayers();
 
   if (maxLr < 1) {
@@ -257,7 +258,9 @@ void configLayers()
 
   // air space between Middle and Outer Barrels
   zSpanH = 80.f;
-  lrData.emplace_back(lrData.back().rMax, 33.5, zSpanH);
+  zBin = 10.;
+  rphiBin = lrData.back().rMax * TMath::Pi() * 2 / 18;
+  lrData.emplace_back(lrData.back().rMax, 33.5, zSpanH, zBin, rphiBin);
 
   //===================================================================================
   // ITS Outer barrel
@@ -267,14 +270,14 @@ void configLayers()
   zBin = 1.;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
-    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
+    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 15);
     lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 36. - kToler);
 
   drStep = 1.;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
-    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
+    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 15);
     lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 38.5 - kToler);
 
@@ -282,14 +285,14 @@ void configLayers()
   drStep = 0.25;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
-    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
+    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 15);
     lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 41. - kToler);
 
   drStep = 1.;
   do {
     auto rmean = lrData.back().rMax + drStep / 2;
-    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 10);
+    rphiBin = rmean * TMath::Pi() * 2 / (nStave * 15);
     lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 44. - kToler);
 
@@ -309,15 +312,20 @@ void configLayers()
   } while (lrData.back().rMax < 55. - kToler);
 
   zSpanH = 120.f;
-  lrData.emplace_back(lrData.back().rMax, 56.5, zSpanH);
-  lrData.emplace_back(lrData.back().rMax, 60.5, zSpanH);
-  lrData.emplace_back(lrData.back().rMax, 61.5, zSpanH);
+  zBin = 10.;
+  rphiBin = lrData.back().rMax * TMath::Pi() * 2 / 18;
+  lrData.emplace_back(lrData.back().rMax, 56.5, zSpanH, zBin, rphiBin);
+  rphiBin = lrData.back().rMax * TMath::Pi() * 2 / 18;
+  lrData.emplace_back(lrData.back().rMax, 60.5, zSpanH, zBin, rphiBin);
+  rphiBin = lrData.back().rMax * TMath::Pi() * 2 / 18;
+  lrData.emplace_back(lrData.back().rMax, 61.5, zSpanH, zBin, rphiBin);
 
   zSpanH = 150.f;
   drStep = 3.5;
   zBin = 15.;
-  rphiBin = 10;
   do {
+    auto rmean = lrData.back().rMax + drStep / 2;
+    rphiBin = rmean * TMath::Pi() * 2 / (NSect * 2);
     lrData.emplace_back(lrData.back().rMax, lrData.back().rMax + drStep, zSpanH, zBin, rphiBin);
   } while (lrData.back().rMax < 68.5 - kToler);
 
@@ -343,7 +351,7 @@ void configLayers()
   zBin = 2;
   {
     auto rmean = (lrData.back().rMax + 78.5) / 2;
-    rphiBin = rmean * TMath::Pi() * 2 / (NSect * 12);
+    rphiBin = rmean * TMath::Pi() * 2 / (NSect * 24);
     lrData.emplace_back(lrData.back().rMax, 84.5, zSpanH, zBin, rphiBin);
   }
 


### PR DESCRIPTION
Updates macro to include finer segmentation from #14771. Only modifies material outside ITS onwards.