### PR TITLE
Fix one-off index problem when copying collision contexts

### DIFF
--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -708,7 +708,7 @@ DigitizationContext DigitizationContext::extractSingleTimeframe(int timeframeid,
     auto tf_ranges = timeframeindices.at(timeframeid);
 
     auto startindex = std::get<0>(tf_ranges);
-    auto endindex = std::get<1>(tf_ranges);
+    auto endindex = std::get<1>(tf_ranges) + 1; // +1 due to endindex being "including"
     auto earlyindex = std::get<2>(tf_ranges);
 
     if (earlyindex >= 0) {


### PR DESCRIPTION
Fixing https://its.cern.ch/jira/browse/O2-6437