### PR TITLE
Revert "Fix one-off index problem when copying collision contexts"

### DIFF
--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -708,7 +708,7 @@ DigitizationContext DigitizationContext::extractSingleTimeframe(int timeframeid,
     auto tf_ranges = timeframeindices.at(timeframeid);
 
     auto startindex = std::get<0>(tf_ranges);
-    auto endindex = std::get<1>(tf_ranges) + 1; // +1 due to endindex being "including"
+    auto endindex = std::get<1>(tf_ranges);
     auto earlyindex = std::get<2>(tf_ranges);
 
     if (earlyindex >= 0) {


### PR DESCRIPTION
This reverts commit db55f0819ad84a35d9e59bb688e2ab5196e54fb1.

Apparently it causes another problem for the last timeframe in an anchoredMC simulation. Reverting for now and taking another look.