### PR TITLE
DPL Analysis: Generalize aod-spawner

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -142,6 +142,7 @@ o2_add_library(Framework
                        src/Array2D.cxx
                        src/Variant.cxx
                        src/VariantJSONHelpers.cxx
+                       src/ExpressionJSONHelpers.cxx
                        src/VariantPropertyTreeHelpers.cxx
                        src/WorkflowCustomizationHelpers.cxx
                        src/WorkflowHelpers.cxx

--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -12,10 +12,7 @@
 #ifndef O2_FRAMEWORK_AODREADERHELPERS_H_
 #define O2_FRAMEWORK_AODREADERHELPERS_H_
 
-#include "Framework/TableBuilder.h"
 #include "Framework/AlgorithmSpec.h"
-#include "Framework/Logger.h"
-#include "Framework/RootMessageContext.h"
 #include <uv.h>
 
 namespace o2::framework::readers
@@ -24,7 +21,7 @@ namespace o2::framework::readers
 
 struct AODReaderHelpers {
   static AlgorithmSpec rootFileReaderCallback();
-  static AlgorithmSpec aodSpawnerCallback(std::vector<InputSpec>& requested);
+  static AlgorithmSpec aodSpawnerCallback(ConfigContext const& ctx);
   static AlgorithmSpec indexBuilderCallback(std::vector<InputSpec>& requested);
 };
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1293,10 +1293,14 @@ concept with_ccdb_urls = requires {
 };
 
 template <typename T>
-concept with_base_table = not_void<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::base_table_t>;
+concept with_base_table = requires {
+  typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::base_table_t;
+};
 
 template <typename T>
-concept with_expression_pack = not_void<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::expression_pack_t>;
+concept with_expression_pack = requires {
+  typename T::expression_pack_t{};
+};
 
 template <size_t N1, std::array<TableRef, N1> os1, size_t N2, std::array<TableRef, N2> os2>
 consteval bool is_compatible()

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1270,6 +1270,7 @@ struct TableIterator : IP, C... {
 
 struct ArrowHelpers {
   static std::shared_ptr<arrow::Table> joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<const char* const> labels);
+  static std::shared_ptr<arrow::Table> joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<const std::string> labels);
   static std::shared_ptr<arrow::Table> concatTables(std::vector<std::shared_ptr<arrow::Table>>&& tables);
 };
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1295,6 +1295,9 @@ concept with_ccdb_urls = requires {
 template <typename T>
 concept with_base_table = not_void<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::base_table_t>;
 
+template <typename T>
+concept with_expression_pack = not_void<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::expression_pack_t>;
+
 template <size_t N1, std::array<TableRef, N1> os1, size_t N2, std::array<TableRef, N2> os2>
 consteval bool is_compatible()
 {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -26,10 +26,11 @@
 #include "Framework/Traits.h"
 
 #include <string>
-namespace o2::framework {
+namespace o2::framework
+{
 std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors);
 std::string serializeSchema(std::shared_ptr<arrow::Schema>& schema);
-}
+}  // namespace o2::framework
 
 namespace o2::soa
 {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -38,6 +38,8 @@ constexpr auto tableRef2ConfigParamSpec()
     {"\"\""}};
 }
 
+std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors);
+
 namespace
 {
 template <soa::with_sources T>
@@ -97,6 +99,26 @@ constexpr auto getCCDBMetadata() -> std::vector<framework::ConfigParamSpec>
 {
   return {};
 }
+
+template <soa::with_expression_pack T>
+constexpr auto getExpressionMetadata() -> std::optional<framework::ConfigParamSpec>
+{
+  using expression_pack_t = T::expression_pack_t;
+
+  auto projectors = []<typename... C>(framework::pack<C...>) -> std::vector<framework::expressions::Projector> {
+    return {C::Projector()...};
+  }(expression_pack_t{});
+
+  auto json = serializeProjectors(projectors);
+  return framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}};
+}
+
+template <typename T>
+constexpr auto getExpressionMetadata() -> std::optional<framework::ConfigParamSpec>
+{
+  return {};
+}
+
 }  // namespace
 
 template <TableRef R>
@@ -107,6 +129,10 @@ constexpr auto tableRef2InputSpec()
   metadata.insert(metadata.end(), m.begin(), m.end());
   auto ccdbMetadata = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), ccdbMetadata.begin(), ccdbMetadata.end());
+  auto p = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  if (p) {
+    metadata.insert(metadata.end(), p.value());
+  }
 
   return framework::InputSpec{
     o2::aod::label<R>(),

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -28,6 +28,7 @@
 #include <string>
 namespace o2::framework {
 std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors);
+std::string serializeSchema(std::shared_ptr<arrow::Schema>& schema);
 }
 
 namespace o2::soa
@@ -113,8 +114,11 @@ constexpr auto getExpressionMetadata() -> std::vector<framework::ConfigParamSpec
     return result;
   }(expression_pack_t{});
 
+  auto schema = std::make_shared<arrow::Schema>(o2::soa::createFieldsFromColumns(expression_pack_t{}));
+
   auto json = framework::serializeProjectors(projectors);
-  return {framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}}};
+  return {framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}},
+          framework::ConfigParamSpec{"schema", framework::VariantType::String, framework::serializeSchema(schema), {"\"\""}}};
 }
 
 template <typename T>

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -26,6 +26,10 @@
 #include "Framework/Traits.h"
 
 #include <string>
+namespace o2::framework {
+std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors);
+}
+
 namespace o2::soa
 {
 template <TableRef R>
@@ -37,8 +41,6 @@ constexpr auto tableRef2ConfigParamSpec()
     aod::sourceSpec<R>(),
     {"\"\""}};
 }
-
-std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors);
 
 namespace
 {
@@ -101,20 +103,23 @@ constexpr auto getCCDBMetadata() -> std::vector<framework::ConfigParamSpec>
 }
 
 template <soa::with_expression_pack T>
-constexpr auto getExpressionMetadata() -> std::optional<framework::ConfigParamSpec>
+constexpr auto getExpressionMetadata() -> std::vector<framework::ConfigParamSpec>
 {
   using expression_pack_t = T::expression_pack_t;
 
   auto projectors = []<typename... C>(framework::pack<C...>) -> std::vector<framework::expressions::Projector> {
-    return {C::Projector()...};
+    std::vector<framework::expressions::Projector> result;
+    (result.emplace_back(std::move(C::Projector())), ...);
+    return result;
   }(expression_pack_t{});
 
-  auto json = serializeProjectors(projectors);
-  return framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}};
+  auto json = framework::serializeProjectors(projectors);
+  return {framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}}};
 }
 
 template <typename T>
-constexpr auto getExpressionMetadata() -> std::optional<framework::ConfigParamSpec>
+  requires(!soa::with_expression_pack<T>)
+constexpr auto getExpressionMetadata() -> std::vector<framework::ConfigParamSpec>
 {
   return {};
 }
@@ -130,9 +135,7 @@ constexpr auto tableRef2InputSpec()
   auto ccdbMetadata = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), ccdbMetadata.begin(), ccdbMetadata.end());
   auto p = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
-  if (p) {
-    metadata.insert(metadata.end(), p.value());
-  }
+  metadata.insert(metadata.end(), p.begin(), p.end());
 
   return framework::InputSpec{
     o2::aod::label<R>(),

--- a/Framework/Core/include/Framework/ExpressionJSONHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionJSONHelpers.h
@@ -13,11 +13,12 @@
 
 #include "Framework/Expressions.h"
 
-namespace o2::framework {
+namespace o2::framework
+{
 struct ExpressionJSONHelpers {
   static std::unique_ptr<expressions::Node> read(std::istream& s);
   static void write(std::ostream& o, expressions::Node* n);
 };
-}
+} // namespace o2::framework
 
 #endif // FRAMEWORK_EXPRESSIONJSONHELPERS_H

--- a/Framework/Core/include/Framework/ExpressionJSONHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionJSONHelpers.h
@@ -16,8 +16,9 @@
 namespace o2::framework
 {
 struct ExpressionJSONHelpers {
-  static std::unique_ptr<expressions::Node> read(std::istream& s);
-  static void write(std::ostream& o, expressions::Node* n);
+  // static std::unique_ptr<expressions::Node> read(std::istream& s);
+  static std::vector<expressions::Projector> read(std::istream& s);
+  static void write(std::ostream& o, std::vector<expressions::Projector>& projectors);
 };
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/ExpressionJSONHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionJSONHelpers.h
@@ -1,0 +1,23 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_EXPRESSIONJSONHELPERS_H
+#define FRAMEWORK_EXPRESSIONJSONHELPERS_H
+
+#include "Framework/Expressions.h"
+
+namespace o2::framework {
+struct ExpressionJSONHelpers {
+  static std::unique_ptr<expressions::Node> read(std::istream& s);
+  static void write(std::ostream& o, expressions::Node* n);
+};
+}
+
+#endif // FRAMEWORK_EXPRESSIONJSONHELPERS_H

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -627,6 +627,7 @@ struct Filter {
   Filter(std::unique_ptr<Node>&& ptr)
   {
     node = std::move(ptr);
+    (void)designateSubtrees(node.get());
   }
 
   Filter(Node&& node_) : node{std::make_unique<Node>(std::forward<Node>(node_))}
@@ -636,7 +637,6 @@ struct Filter {
 
   Filter(Filter&& other) : node{std::forward<std::unique_ptr<Node>>(other.node)}
   {
-    (void)designateSubtrees(node.get());
   }
 
   Filter(std::string const& input_) : input{input_} {}

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -110,6 +110,8 @@ std::string upcastTo(atype::type f);
 
 /// An expression tree node corresponding to a literal value
 struct LiteralNode {
+  using var_t = LiteralValue::stored_type;
+
   LiteralNode()
     : value{-1},
       type{atype::INT32}
@@ -120,7 +122,12 @@ struct LiteralNode {
   {
   }
 
-  using var_t = LiteralValue::stored_type;
+  LiteralNode(var_t v, atype::type t)
+    : value{v},
+      type{t}
+  {
+  }
+
   var_t value;
   atype::type type = atype::NA;
 };
@@ -616,6 +623,11 @@ inline Node ncfg(T defaultValue, std::string path)
 /// A struct, containing the root of the expression tree
 struct Filter {
   Filter() = default;
+
+  Filter(std::unique_ptr<Node>&& ptr)
+  {
+    node = std::move(ptr);
+  }
 
   Filter(Node&& node_) : node{std::make_unique<Node>(std::forward<Node>(node_))}
   {

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -18,7 +18,6 @@
 #include "arrow/type_traits.h"
 
 // Apparently needs to be on top of the arrow includes.
-#include <sstream>
 
 #include <arrow/chunked_array.h>
 #include <arrow/status.h>
@@ -795,6 +794,10 @@ auto makeEmptyTable(const char* name, framework::pack<Cs...> p)
 
 std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema, size_t nColumns,
                                             expressions::Projector* projectors, const char* name, std::shared_ptr<gandiva::Projector>& projector);
+
+std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema,
+                                            const char* name, size_t nColumns,
+                                            const std::shared_ptr<gandiva::Projector>& projector);
 
 /// Expression-based column generator to materialize columns
 template <aod::is_aod_hash D>

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -19,6 +19,7 @@
 #include "Framework/CallbackService.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/ExpressionJSONHelpers.h"
 
 #include <Monitoring/Monitoring.h>
 
@@ -134,12 +135,32 @@ auto make_spawn(InputSpec const& input, ProcessingContext& pc)
   (typename metadata_t::expression_pack_t{});
   return o2::framework::spawner<D>(extractOriginals<sources.size(), sources>(pc), input.binding.c_str(), projectors.data(), projector, schema);
 }
+
+struct Spawnable {
+  std::vector<expressions::Projector> projectors;
+  std::vector<std::string> labels;
+  std::shared_ptr<arrow::Schema> schema;
+
+  Spawnable(InputSpec const& spec)
+  {
+    auto loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& spc){ return spc.name.compare("projectors") == 0; });
+    std::stringstream iws(loc->defaultValue.get<std::string>());
+    projectors = ExpressionJSONHelpers::read(iws);
+    for (auto& i : spec.metadata) {
+      if (i.name.starts_with("input:")) {
+        labels.emplace_back(i.name.substr(6));
+      }
+    }
+  }
+};
 } // namespace
 
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& /*ic*/) {
-    return [requested](ProcessingContext& pc) {
+    std::vector<Spawnable> spawnables;
+
+    return [requested, spawnables](ProcessingContext& pc) {
       auto outputs = pc.outputs();
       // spawn tables
       for (auto& input : requested) {

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -44,28 +44,6 @@ auto setEOSCallback(InitContext& ic)
     });
 }
 
-template <typename... Ts>
-static inline auto doExtractOriginal(framework::pack<Ts...>, ProcessingContext& pc)
-{
-  if constexpr (sizeof...(Ts) == 1) {
-    return pc.inputs().get<TableConsumer>(aod::MetadataTrait<framework::pack_element_t<0, framework::pack<Ts...>>>::metadata::tableLabel())->asArrowTable();
-  } else {
-    return std::vector{pc.inputs().get<TableConsumer>(aod::MetadataTrait<Ts>::metadata::tableLabel())->asArrowTable()...};
-  }
-}
-
-template <typename... Os>
-static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingContext& pc)
-{
-  return std::make_tuple(extractTypedOriginal<Os>(pc)...);
-}
-
-template <typename... Os>
-static inline auto extractOriginalsVector(framework::pack<Os...>, ProcessingContext& pc)
-{
-  return std::vector{extractOriginal<Os>(pc)...};
-}
-
 template <size_t N, std::array<soa::TableRef, N> refs>
 static inline auto extractOriginals(ProcessingContext& pc)
 {

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -138,8 +138,7 @@ auto make_spawn(InputSpec const& input, ProcessingContext& pc)
   return o2::framework::spawner<D>(extractOriginals<sources.size(), sources>(pc), input.binding.c_str(), projectors.data(), projector, schema);
 }
 
-struct Maker
-{
+struct Maker {
   std::string binding;
   std::vector<std::string> labels;
   std::vector<std::shared_ptr<gandiva::Expression>> expressions;
@@ -169,7 +168,6 @@ struct Maker
 
     return spawnerHelper(fullTable, schema, binding.c_str(), schema->num_fields(), projector);
   }
-
 };
 
 struct Spawnable {
@@ -185,17 +183,17 @@ struct Spawnable {
   header::DataHeader::SubSpecificationType version;
 
   Spawnable(InputSpec const& spec)
-  : binding{spec.binding}
+    : binding{spec.binding}
   {
     auto&& [origin_, description_, version_] = DataSpecUtils::asConcreteDataMatcher(spec);
     origin = origin_;
     description = description_;
     version = version_;
-    auto loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& cps){ return cps.name.compare("projectors") == 0; });
+    auto loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& cps) { return cps.name.compare("projectors") == 0; });
     std::stringstream iws(loc->defaultValue.get<std::string>());
     projectors = ExpressionJSONHelpers::read(iws);
 
-    loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& cps){ return cps.name.compare("schema") == 0; });
+    loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& cps) { return cps.name.compare("schema") == 0; });
     iws.clear();
     iws.str(loc->defaultValue.get<std::string>());
     outputSchema = ArrowJSONHelpers::read(iws);
@@ -209,14 +207,14 @@ struct Spawnable {
     std::vector<std::shared_ptr<arrow::Field>> fields;
     for (auto& p : projectors) {
       expressions::walk(p.node.get(),
-      [&fields](expressions::Node* n) mutable {
-        if (n->self.index() == 1) {
-          auto& b = std::get<expressions::BindingNode>(n->self);
-          if ( std::find_if(fields.begin(), fields.end(), [&b](std::shared_ptr<arrow::Field> const& field){ return field->name() == b.name; }) == fields.end() ) {
-            fields.emplace_back(std::make_shared<arrow::Field>(b.name, expressions::concreteArrowType(b.type)));
-          }
-        }
-      });
+                        [&fields](expressions::Node* n) mutable {
+                          if (n->self.index() == 1) {
+                            auto& b = std::get<expressions::BindingNode>(n->self);
+                            if (std::find_if(fields.begin(), fields.end(), [&b](std::shared_ptr<arrow::Field> const& field) { return field->name() == b.name; }) == fields.end()) {
+                              fields.emplace_back(std::make_shared<arrow::Field>(b.name, expressions::concreteArrowType(b.type)));
+                            }
+                          }
+                        });
     }
     inputSchema = std::make_shared<arrow::Schema>(fields);
 
@@ -227,8 +225,7 @@ struct Spawnable {
           expressions::createExpressionTree(
             expressions::createOperations(p),
             inputSchema),
-          outputSchema->field(i))
-        );
+          outputSchema->field(i)));
       ++i;
     }
   }
@@ -248,10 +245,8 @@ struct Spawnable {
       outputSchema,
       origin,
       description,
-      version
-    };
+      version};
   }
-
 };
 
 } // namespace

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -12,14 +12,16 @@
 #include "Framework/AODReaderHelpers.h"
 #include "Framework/AnalysisHelpers.h"
 #include "Framework/AnalysisDataModelHelpers.h"
-#include "Framework/DataProcessingHelpers.h"
 #include "Framework/ExpressionHelpers.h"
+#include "Framework/DataProcessingHelpers.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/CallbackService.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/DataSpecUtils.h"
-#include "Framework/ExpressionJSONHelpers.h"
+#include "ExpressionJSONHelpers.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/AnalysisContext.h"
 
 #include <Monitoring/Monitoring.h>
 
@@ -136,72 +138,141 @@ auto make_spawn(InputSpec const& input, ProcessingContext& pc)
   return o2::framework::spawner<D>(extractOriginals<sources.size(), sources>(pc), input.binding.c_str(), projectors.data(), projector, schema);
 }
 
-struct Spawnable {
-  std::vector<expressions::Projector> projectors;
+struct Maker
+{
+  std::string binding;
   std::vector<std::string> labels;
+  std::vector<std::shared_ptr<gandiva::Expression>> expressions;
+  std::shared_ptr<gandiva::Projector> projector = nullptr;
   std::shared_ptr<arrow::Schema> schema;
 
-  Spawnable(InputSpec const& spec)
+  header::DataOrigin origin;
+  header::DataDescription description;
+  header::DataHeader::SubSpecificationType version;
+
+  std::shared_ptr<arrow::Table> make(ProcessingContext& pc)
   {
-    auto loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& spc){ return spc.name.compare("projectors") == 0; });
+    std::vector<std::shared_ptr<arrow::Table>> originals;
+    for (auto const& label : labels) {
+      originals.push_back(pc.inputs().get<TableConsumer>(label)->asArrowTable());
+    }
+    auto fullTable = soa::ArrowHelpers::joinTables(std::move(originals), std::span{labels.begin(), labels.size()});
+    if (projector == nullptr) {
+      auto s = gandiva::Projector::Make(
+        fullTable->schema(),
+        expressions,
+        &projector);
+      if (!s.ok()) {
+        throw o2::framework::runtime_error_f("Failed to create projector: %s", s.ToString().c_str());
+      }
+    }
+
+    return spawnerHelper(fullTable, schema, binding.c_str(), schema->num_fields(), projector);
+  }
+
+};
+
+struct Spawnable {
+  std::string binding;
+  std::vector<std::string> labels;
+  std::vector<expressions::Projector> projectors;
+  std::vector<std::shared_ptr<gandiva::Expression>> expressions;
+  std::shared_ptr<arrow::Schema> outputSchema;
+  std::shared_ptr<arrow::Schema> inputSchema;
+
+  header::DataOrigin origin;
+  header::DataDescription description;
+  header::DataHeader::SubSpecificationType version;
+
+  Spawnable(InputSpec const& spec)
+  : binding{spec.binding}
+  {
+    auto&& [origin_, description_, version_] = DataSpecUtils::asConcreteDataMatcher(spec);
+    origin = origin_;
+    description = description_;
+    version = version_;
+    auto loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& cps){ return cps.name.compare("projectors") == 0; });
     std::stringstream iws(loc->defaultValue.get<std::string>());
     projectors = ExpressionJSONHelpers::read(iws);
+
+    loc = std::find_if(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& cps){ return cps.name.compare("schema") == 0; });
+    iws.clear();
+    iws.str(loc->defaultValue.get<std::string>());
+    outputSchema = ArrowJSONHelpers::read(iws);
+
     for (auto& i : spec.metadata) {
       if (i.name.starts_with("input:")) {
         labels.emplace_back(i.name.substr(6));
       }
     }
+
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (auto& p : projectors) {
+      expressions::walk(p.node.get(),
+      [&fields](expressions::Node* n) mutable {
+        if (n->self.index() == 1) {
+          auto& b = std::get<expressions::BindingNode>(n->self);
+          if ( std::find_if(fields.begin(), fields.end(), [&b](std::shared_ptr<arrow::Field> const& field){ return field->name() == b.name; }) == fields.end() ) {
+            fields.emplace_back(std::make_shared<arrow::Field>(b.name, expressions::concreteArrowType(b.type)));
+          }
+        }
+      });
+    }
+    inputSchema = std::make_shared<arrow::Schema>(fields);
+
+    int i = 0;
+    for (auto& p : projectors) {
+      expressions.push_back(
+        expressions::makeExpression(
+          expressions::createExpressionTree(
+            expressions::createOperations(p),
+            inputSchema),
+          outputSchema->field(i))
+        );
+      ++i;
+    }
   }
+
+  std::shared_ptr<gandiva::Projector> makeProjector()
+  {
+    return expressions::createProjectorHelper(projectors.size(), projectors.data(), inputSchema, outputSchema->fields());
+  }
+
+  Maker createMaker()
+  {
+    return {
+      binding,
+      labels,
+      expressions,
+      nullptr,
+      outputSchema,
+      origin,
+      description,
+      version
+    };
+  }
+
 };
+
 } // namespace
 
-AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec>& requested)
+AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(/*std::vector<InputSpec>& requested*/ ConfigContext const& ctx)
 {
-  return AlgorithmSpec::InitCallback{[requested](InitContext& /*ic*/) {
+  auto& ac = ctx.services().get<AnalysisContext>();
+  return AlgorithmSpec::InitCallback{[requested = ac.spawnerInputs](InitContext& /*ic*/) {
     std::vector<Spawnable> spawnables;
+    for (auto& i : requested) {
+      spawnables.emplace_back(i);
+    }
+    std::vector<Maker> makers;
+    for (auto& s : spawnables) {
+      makers.push_back(s.createMaker());
+    }
 
-    return [requested, spawnables](ProcessingContext& pc) {
+    return [makers](ProcessingContext& pc) mutable {
       auto outputs = pc.outputs();
-      // spawn tables
-      for (auto& input : requested) {
-        auto&& [origin, description, version] = DataSpecUtils::asConcreteDataMatcher(input);
-        if (description == header::DataDescription{"EXTRACK"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACK/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXTRACK_IU"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACK_IU/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXTRACKCOV"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKCOV/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXTRACKCOV_IU"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKCOV_IU/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXTRACKEXTRA"}) {
-          if (version == 0U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKEXTRA/0"_h>>(input, pc));
-          } else if (version == 1U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKEXTRA/1"_h>>(input, pc));
-          } else if (version == 2U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXTRACKEXTRA/2"_h>>(input, pc));
-          }
-        } else if (description == header::DataDescription{"EXMFTTRACK"}) {
-          if (version == 0U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACK/0"_h>>(input, pc));
-          } else if (version == 1U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACK/1"_h>>(input, pc));
-          }
-        } else if (description == header::DataDescription{"EXMFTTRACKCOV"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMFTTRACKCOV/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXFWDTRACK"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXFWDTRACK/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXFWDTRACKCOV"}) {
-          outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXFWDTRACKCOV/0"_h>>(input, pc));
-        } else if (description == header::DataDescription{"EXMCPARTICLE"}) {
-          if (version == 0U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMCPARTICLE/0"_h>>(input, pc));
-          } else if (version == 1U) {
-            outputs.adopt(Output{origin, description, version}, make_spawn<o2::aod::Hash<"EXMCPARTICLE/1"_h>>(input, pc));
-          }
-        } else {
-          throw runtime_error("Not an extended table");
-        }
+      for (auto& maker : makers) {
+        outputs.adopt(Output{maker.origin, maker.description, maker.version}, maker.make(pc));
       }
     };
   }};

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -99,6 +99,36 @@ std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_p
   return arrow::Table::Make(schema, columns);
 }
 
+std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables, std::span<const std::string> labels)
+{
+  if (tables.size() == 1) {
+    return tables[0];
+  }
+  for (auto i = 0U; i < tables.size() - 1; ++i) {
+    if (tables[i]->num_rows() != tables[i + 1]->num_rows()) {
+      throw o2::framework::runtime_error_f("Tables %s and %s have different sizes (%d vs %d) and cannot be joined!",
+                                           labels[i].c_str(), labels[i + 1].c_str(), tables[i]->num_rows(), tables[i + 1]->num_rows());
+    }
+  }
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
+
+  for (auto& t : tables) {
+    auto tf = t->fields();
+    std::copy(tf.begin(), tf.end(), std::back_inserter(fields));
+  }
+
+  auto schema = std::make_shared<arrow::Schema>(fields);
+
+  if (tables[0]->num_rows() != 0) {
+    for (auto& t : tables) {
+      auto tc = t->columns();
+      std::copy(tc.begin(), tc.end(), std::back_inserter(columns));
+    }
+  }
+  return arrow::Table::Make(schema, columns);
+}
+
 std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {
   if (tables.size() == 1) {

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ExpressionHelpers.h"
-#include "Framework/ExpressionJSONHelpers.h"
+#include "ExpressionJSONHelpers.h"
 
 namespace o2::framework
 {
@@ -32,6 +32,13 @@ std::string serializeProjectors(std::vector<framework::expressions::Projector>& 
 {
   std::stringstream osm;
   ExpressionJSONHelpers::write(osm, projectors);
+  return osm.str();
+}
+
+std::string serializeSchema(std::shared_ptr<arrow::Schema>& schema)
+{
+  std::stringstream osm;
+  ArrowJSONHelpers::write(osm, schema);
   return osm.str();
 }
 } // namespace o2::framework

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ExpressionHelpers.h"
+#include "Framework/ExpressionJSONHelpers.h"
 
 namespace o2::framework
 {
@@ -25,5 +26,12 @@ void initializePartitionCaches(std::set<uint32_t> const& hashes, std::shared_ptr
   if (gfilter == nullptr) {
     gfilter = framework::expressions::createFilter(schema, framework::expressions::makeCondition(tree));
   }
+}
+
+std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors)
+{
+  std::stringstream osm;
+  ExpressionJSONHelpers::write(osm, projectors);
+  return osm.str();
 }
 } // namespace o2::framework

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -608,7 +608,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
         spawner->inputs.clear();
         // replace AlgorithmSpec
         // FIXME: it should be made more generic, so it does not need replacement...
-        spawner->algorithm = readers::AODReaderHelpers::aodSpawnerCallback(ac.spawnerInputs);
+        spawner->algorithm = readers::AODReaderHelpers::aodSpawnerCallback(ctx);
         AnalysisSupportHelpers::addMissingOutputsToSpawner({}, ac.spawnerInputs, ac.requestedAODs, *spawner);
       }
 

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -22,7 +22,8 @@
 
 namespace o2::framework
 {
-
+namespace
+{
 using nodes = expressions::Node::self_t;
 enum struct Nodes : int {
   NLITERAL = 0,
@@ -46,7 +47,8 @@ struct Entry {
   ToWrite toWrite = ToWrite::FULL;
 };
 
-std::array<std::string_view, 10> validKeys{
+std::array<std::string_view, 11> validKeys{
+  "projectors",
   "kind",
   "binding",
   "index",
@@ -58,29 +60,29 @@ std::array<std::string_view, 10> validKeys{
   "right",
   "condition"};
 
-namespace
-{
 struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, ExpressionReader> {
   using Ch = rapidjson::UTF8<>::Ch;
   using SizeType = rapidjson::SizeType;
 
   enum struct State {
-    IN_START,
-    IN_STOP,
-    IN_NODE_LITERAL,
-    IN_NODE_BINDING,
-    IN_NODE_OP,
-    IN_NODE_CONDITIONAL,
-    IN_ROOT,
-    IN_LEFT,
-    IN_RIGHT,
-    IN_COND,
-    IN_ERROR
+    IN_START,            // global start
+    IN_LIST,             // opening brace of the list
+    IN_ROOT,             // after encountering the opening of the expression object
+    IN_LEFT,             // in "left" key - subexpression
+    IN_RIGHT,            // in "right" key - subexpression
+    IN_COND,             // in "condition" key - subexpression
+    IN_NODE_LITERAL,     // in literal node
+    IN_NODE_BINDING,     // in binding node
+    IN_NODE_OP,          // in operation node
+    IN_NODE_CONDITIONAL, // in conditional node
+    IN_ERROR             // generic error state
   };
 
   std::stack<State> states;
   std::stack<Entry> path;
   std::ostringstream debug;
+
+  std::vector<expressions::Projector> result;
 
   std::unique_ptr<expressions::Node> rootNode = nullptr;
   std::unique_ptr<expressions::Node> node = nullptr;
@@ -101,6 +103,28 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     states.push(State::IN_START);
   }
 
+  bool StartArray()
+  {
+    debug << "Starting array" << std::endl;
+    if (states.top() == State::IN_START) {
+      states.push(State::IN_LIST);
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool EndArray(SizeType)
+  {
+    debug << "Ending array" << std::endl;
+    if (states.top() == State::IN_LIST) {
+      states.pop();
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
   bool Key(const Ch* str, SizeType, bool)
   {
     debug << "Key(" << str << ")" << std::endl;
@@ -112,8 +136,13 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     }
 
     if (states.top() == State::IN_START) {
+      if (currentKey.compare("projectors") == 0) {
+        return true;
+      }
+    }
+
+    if (states.top() == State::IN_ROOT) {
       if (currentKey.compare("kind") == 0) {
-        states.push(State::IN_ROOT);
         return true;
       } else {
         states.push(State::IN_ERROR); // should start from root node
@@ -228,38 +257,62 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
 
   bool StartObject()
   {
+    // opening brace encountered
     debug << "StartObject()" << std::endl;
-    if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) { // ready to start a new node
-      return true;
-    }
+    // the first opening brace in the input
     if (states.top() == State::IN_START) {
       return true;
     }
+    // the opening of an expression
+    if (states.top() == State::IN_LIST) {
+      states.push(State::IN_ROOT);
+      return true;
+    }
+    // if we are looking at subexpression
+    if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) { // ready to start a new node
+      return true;
+    }
+    // no other object starts are expected
     states.push(State::IN_ERROR);
     return false;
   }
 
   bool EndObject(SizeType)
   {
+    // closing brace encountered
     debug << "EndObject()" << std::endl;
+    // we are closing up an expression
     if (states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_OP || states.top() == State::IN_NODE_BINDING || states.top() == State::IN_NODE_CONDITIONAL) { // finalize node
       // finalize the current node and pop it from the stack (the pointers should be already set
       states.pop();
+      // subexpression
       if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
         states.pop();
+        return true;
       }
+
+      // expression
+      if (states.top() == State::IN_ROOT) {
+        result.emplace_back(std::move(rootNode));
+        states.pop();
+        return true;
+      }
+    }
+
+    // we are closing the list
+    if (states.top() == State::IN_START) {
       return true;
     }
-    if (states.top() == State::IN_ROOT) {
-      return true;
-    }
+    // no other object ends are expectedd
     states.push(State::IN_ERROR);
     return false;
   }
 
   bool Null()
   {
+    // null value
     debug << "Null()" << std::endl;
+    // the subexpression can be empty
     if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
       // empty node, nothing to do
       // move the path state to the next
@@ -281,6 +334,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Bool(bool b)
   {
     debug << "Bool(" << b << ")" << std::endl;
+    // can be a value in a literal node
     if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
       value = b;
       return true;
@@ -292,6 +346,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Int(int i)
   {
     debug << "Int(" << i << ")" << std::endl;
+    // can be a value in a literal node
     if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) { // literal
       switch (type) {
         case atype::INT8:
@@ -312,12 +367,19 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
         case atype::UINT32:
           value = i;
           break;
+        case atype::UINT64:
+          value = (uint64_t)i;
+          break;
+        case atype::INT64:
+          value = (int64_t)i;
+          break;
         default:
           states.push(State::IN_ERROR);
           return false;
       }
       return true;
     }
+    // can be a node kind designator
     if (states.top() == State::IN_ROOT || states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
       if (currentKey.compare("kind") == 0) {
         kind = (Nodes)i;
@@ -347,18 +409,21 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
         }
       }
     }
+    // can be node index
     if (states.top() == State::IN_NODE_BINDING || states.top() == State::IN_NODE_CONDITIONAL || states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_OP) {
       if (currentKey.compare("index") == 0) {
         index = (size_t)i;
         return true;
       }
     }
+    // can be a node type designator
     if (states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_BINDING) {
       if (currentKey.compare("arrow_type") == 0) {
         type = (atype::type)i;
         return true;
       }
     }
+    // can be a node operation designato
     if (states.top() == State::IN_NODE_OP && currentKey.compare("operation") == 0) {
       operation = (BasicOp)i;
       return true;
@@ -370,10 +435,12 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Uint(unsigned i)
   {
     debug << "Uint(" << i << ")" << std::endl;
+    // can be node hash
     if (states.top() == State::IN_NODE_BINDING && currentKey.compare("hash") == 0) {
       hash = i;
       return true;
     }
+    // any positive value will be first read as unsigned, however the actual type is determined by node's arrow_type
     debug << ">> falling back to Int" << std::endl;
     return Int(i);
   }
@@ -381,6 +448,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Int64(int64_t i)
   {
     debug << "Int64(" << i << ")" << std::endl;
+    // can only be a literal node value
     if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
       value = i;
       return true;
@@ -392,6 +460,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Uint64(uint64_t i)
   {
     debug << "Uint64(" << i << ")" << std::endl;
+    // can only be a literal node value
     if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
       value = i;
       return true;
@@ -403,6 +472,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Double(double d)
   {
     debug << "Double(" << d << ")" << std::endl;
+    // can only be a literal node value
     if (states.top() == State::IN_NODE_LITERAL) {
       switch (type) {
         case atype::FLOAT:
@@ -424,6 +494,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool String(const Ch* str, SizeType, bool)
   {
     debug << "String(" << str << ")" << std::endl;
+    // can only be a binding node
     if (states.top() == State::IN_NODE_BINDING && currentKey.compare("binding") == 0) {
       binding = str;
       return true;
@@ -434,7 +505,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
 };
 } // namespace
 
-std::unique_ptr<expressions::Node> o2::framework::ExpressionJSONHelpers::read(std::istream& s)
+std::vector<expressions::Projector> o2::framework::ExpressionJSONHelpers::read(std::istream& s)
 {
   rapidjson::Reader reader;
   rapidjson::IStreamWrapper isw(s);
@@ -446,9 +517,11 @@ std::unique_ptr<expressions::Node> o2::framework::ExpressionJSONHelpers::read(st
     error << "Cannot parse serialized Expression, error: " << rapidjson::GetParseError_En(reader.GetParseErrorCode()) << " at offset: " << reader.GetErrorOffset();
     throw std::runtime_error(error.str());
   }
-  return std::move(ereader.rootNode);
+  return std::move(ereader.result);
 }
 
+namespace
+{
 void writeNodeHeader(rapidjson::Writer<rapidjson::OStreamWrapper>& w, expressions::Node const* node)
 {
   w.Key("kind");
@@ -491,11 +564,8 @@ void writeNodeHeader(rapidjson::Writer<rapidjson::OStreamWrapper>& w, expression
              node->self);
 }
 
-void writeExpression(std::ostream& o, expressions::Node* n)
+void writeExpression(rapidjson::Writer<rapidjson::OStreamWrapper>& w, expressions::Node* n)
 {
-  rapidjson::OStreamWrapper osw(o);
-  rapidjson::Writer<rapidjson::OStreamWrapper> w(osw);
-
   std::stack<Entry> path;
   path.emplace(n, ToWrite::FULL);
   while (!path.empty()) {
@@ -551,9 +621,20 @@ void writeExpression(std::ostream& o, expressions::Node* n)
     }
   }
 }
-} // namespace o2::framework
+} // namespace
 
-void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, expressions::Node* n)
+void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, std::vector<o2::framework::expressions::Projector>& projectors)
 {
-  writeExpression(o, n);
+  rapidjson::OStreamWrapper osw(o);
+  rapidjson::Writer<rapidjson::OStreamWrapper> w(osw);
+  w.StartObject();
+  w.Key("projectors");
+  w.StartArray();
+  for (auto& p : projectors) {
+    writeExpression(w, p.node.get());
+  }
+  w.EndArray();
+  w.EndObject();
 }
+
+} // namespace o2::framework

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -1,0 +1,558 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ExpressionJSONHelpers.h"
+
+#include <rapidjson/reader.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/error/en.h>
+
+#include <stack>
+#include <iostream>
+#include "Framework/VariantHelpers.h"
+
+namespace o2::framework {
+
+using nodes = expressions::Node::self_t;
+enum struct Nodes : int {
+  NLITERAL = 0,
+  NBINDING = 1,
+  NOP = 2,
+  NNPH = 3,
+  NCOND = 4,
+  NPAR = 5
+};
+
+enum struct ToWrite {
+  FULL,
+  LEFT,
+  RIGHT,
+  COND,
+  POP
+};
+
+struct Entry {
+  expressions::Node* ptr = nullptr;
+  ToWrite toWrite = ToWrite::FULL;
+};
+
+std::array<std::string_view, 10> validKeys{
+  "kind",
+  "binding",
+  "index",
+  "arrow_type",
+  "value",
+  "hash",
+  "operation",
+  "left",
+  "right",
+  "condition"};
+
+namespace
+{
+struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, ExpressionReader> {
+  using Ch = rapidjson::UTF8<>::Ch;
+  using SizeType = rapidjson::SizeType;
+
+  enum struct State {
+    IN_START,
+    IN_STOP,
+    IN_NODE_LITERAL,
+    IN_NODE_BINDING,
+    IN_NODE_OP,
+    IN_NODE_CONDITIONAL,
+    IN_ROOT,
+    IN_LEFT,
+    IN_RIGHT,
+    IN_COND,
+    IN_ERROR
+  };
+
+  std::stack<State> states;
+  std::stack<Entry> path;
+  std::ostringstream debug;
+
+  std::unique_ptr<expressions::Node> rootNode = nullptr;
+  std::unique_ptr<expressions::Node> node = nullptr;
+  expressions::LiteralValue::stored_type value;
+  atype::type type;
+  Nodes kind;
+  std::string binding;
+  BasicOp operation;
+  uint32_t hash;
+  size_t index;
+
+  std::string previousKey;
+  std::string currentKey;
+
+  ExpressionReader()
+  {
+    debug << ">>> Start" << std::endl;
+    states.push(State::IN_START);
+  }
+
+  bool Key(const Ch* str, SizeType, bool)
+  {
+    debug << "Key(" << str << ")" << std::endl;
+    previousKey = currentKey;
+    currentKey = str;
+    if (std::find(validKeys.begin(), validKeys.end(), currentKey) == validKeys.end()) {
+      states.push(State::IN_ERROR);
+      return false;
+    }
+
+    if (states.top() == State::IN_START) {
+      if (currentKey.compare("kind") == 0) {
+        states.push(State::IN_ROOT);
+        return true;
+      } else {
+        states.push(State::IN_ERROR); // should start from root node
+        return false;
+      }
+    }
+
+    if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
+      if (currentKey.compare("kind") == 0) {
+        return true;
+      }
+    }
+
+    if (states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_OP || states.top() == State::IN_NODE_BINDING || states.top() == State::IN_NODE_CONDITIONAL) {
+      if (currentKey.compare("index") == 0) {
+        return true;
+      }
+      if (currentKey.compare("left") == 0) {
+        // this is the point where the node header is parsed and we can create it
+        // create a new node instance here and set a pointer to it in a parent (current stack top), based on its state
+        // push the new node into the stack with LEFT state
+        switch (states.top()) {
+          case State::IN_NODE_LITERAL:
+            node = std::make_unique<expressions::Node>(expressions::LiteralNode{value, type});
+            break;
+          case State::IN_NODE_BINDING:
+            node = std::make_unique<expressions::Node>(expressions::BindingNode{hash, type}, binding);
+            break;
+          case State::IN_NODE_OP:
+            node = std::make_unique<expressions::Node>(expressions::OpNode{operation}, expressions::LiteralNode{-1});
+            break;
+          case State::IN_NODE_CONDITIONAL:
+            node = std::make_unique<expressions::Node>(expressions::ConditionalNode{}, expressions::LiteralNode{-1}, expressions::LiteralNode{-1}, expressions::LiteralNode{true});
+            break;
+          default:
+            states.push(State::IN_ERROR);
+            return false;
+        }
+
+        if (path.empty()) {
+          rootNode = std::move(node);
+          path.emplace(rootNode.get(), ToWrite::LEFT);
+        } else {
+          auto* n = path.top().ptr;
+          switch (path.top().toWrite) {
+            case ToWrite::LEFT:
+              n->left = std::move(node);
+              path.top().toWrite = ToWrite::RIGHT;
+              path.emplace(n->left.get(), ToWrite::LEFT);
+              break;
+            case ToWrite::RIGHT:
+              n->right = std::move(node);
+              path.top().toWrite = ToWrite::COND;
+              path.emplace(n->right.get(), ToWrite::LEFT);
+              break;
+            case ToWrite::COND:
+              n->condition = std::move(node);
+              path.pop();
+              path.emplace(n->condition.get(), ToWrite::LEFT);
+              break;
+            default:
+              states.push(State::IN_ERROR);
+              return false;
+          }
+        }
+
+        states.push(State::IN_LEFT);
+        return true;
+      }
+      if (currentKey.compare("right") == 0) {
+        if (states.top() == State::IN_LEFT) {
+          states.pop();
+        }
+        // move the stack state of the node to RIGHT state
+        path.top().toWrite = ToWrite::RIGHT;
+        states.push(State::IN_RIGHT);
+        return true;
+      }
+      if (currentKey.compare("condition") == 0) {
+        if (states.top() == State::IN_RIGHT) {
+          states.pop();
+        }
+        // move the stack state of the node to COND state
+        path.top().toWrite = ToWrite::COND;
+        states.push(State::IN_COND);
+        return true;
+      }
+    }
+
+    if (states.top() == State::IN_NODE_LITERAL) {
+      if (currentKey.compare("arrow_type") == 0 || currentKey.compare("value") == 0) {
+        return true;
+      }
+    }
+
+    if (states.top() == State::IN_NODE_BINDING) {
+      if (currentKey.compare("binding") == 0 || currentKey.compare("hash") == 0 || currentKey.compare("arrow_type") == 0) {
+        return true;
+      }
+    }
+
+    if (states.top() == State::IN_NODE_OP) {
+      if (currentKey.compare("operation") == 0) {
+        return true;
+      }
+    }
+
+    debug << ">>> Unrecognized" << std::endl;
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool StartObject()
+  {
+    debug << "StartObject()" << std::endl;
+    if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) { // ready to start a new node
+      return true;
+    }
+    if (states.top() == State::IN_START) {
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool EndObject(SizeType)
+  {
+    debug << "EndObject()" << std::endl;
+    if (states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_OP || states.top() == State::IN_NODE_BINDING || states.top() == State::IN_NODE_CONDITIONAL) { // finalize node
+      // finalize the current node and pop it from the stack (the pointers should be already set
+      states.pop();
+      if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
+        states.pop();
+      }
+      return true;
+    }
+    if (states.top() == State::IN_ROOT) {
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool Null()
+  {
+    debug << "Null()" << std::endl;
+    if (states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
+      // empty node, nothing to do
+      // move the path state to the next
+      if (path.top().toWrite == ToWrite::LEFT) {
+        path.top().toWrite = ToWrite::RIGHT;
+      } else if (path.top().toWrite == ToWrite::RIGHT) {
+        path.top().toWrite = ToWrite::COND;
+      } else if (path.top().toWrite == ToWrite::COND) {
+        path.pop();
+      }
+
+      states.pop();
+      return true;
+    }
+    states.push(State::IN_ERROR); // no other contexts allow null
+    return false;
+  }
+
+  bool Bool(bool b)
+  {
+    debug << "Bool(" << b << ")" << std::endl;
+    if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
+      value = b;
+      return true;
+    }
+    states.push(State::IN_ERROR); // no other contexts allow booleans
+    return false;
+  }
+
+  bool Int(int i)
+  {
+    debug << "Int(" << i << ")" << std::endl;
+    if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) { // literal
+      switch (type) {
+        case atype::INT8:
+          value = (int8_t)i;
+          break;
+        case atype::INT16:
+          value = (int16_t)i;
+          break;
+        case atype::INT32:
+          value = i;
+          break;
+        case atype::UINT8:
+          value = (uint8_t)i;
+          break;
+        case atype::UINT16:
+          value = (uint16_t)i;
+          break;
+        case atype::UINT32:
+          value = i;
+          break;
+        default:
+          states.push(State::IN_ERROR);
+          return false;
+      }
+      return true;
+    }
+    if (states.top() == State::IN_ROOT || states.top() == State::IN_LEFT || states.top() == State::IN_RIGHT || states.top() == State::IN_COND) {
+      if (currentKey.compare("kind") == 0) {
+        kind = (Nodes)i;
+        switch (kind) {
+          case Nodes::NLITERAL:
+          case Nodes::NNPH:
+          case Nodes::NPAR: {
+            states.push(State::IN_NODE_LITERAL);
+            debug << ">>> Literal node" << std::endl;
+            return true;
+          }
+          case Nodes::NBINDING: {
+            states.push(State::IN_NODE_BINDING);
+            debug << ">>> Binding node" << std::endl;
+            return true;
+          }
+          case Nodes::NOP: {
+            states.push(State::IN_NODE_OP);
+            debug << ">>> Operation node" << std::endl;
+            return true;
+          }
+          case Nodes::NCOND: {
+            states.push(State::IN_NODE_CONDITIONAL);
+            debug << ">>> Conditional node" << std::endl;
+            return true;
+          }
+        }
+      }
+    }
+    if (states.top() == State::IN_NODE_BINDING || states.top() == State::IN_NODE_CONDITIONAL || states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_OP) {
+      if (currentKey.compare("index") == 0) {
+        index = (size_t)i;
+        return true;
+      }
+    }
+    if (states.top() == State::IN_NODE_LITERAL || states.top() == State::IN_NODE_BINDING) {
+      if (currentKey.compare("arrow_type") == 0) {
+        type = (atype::type)i;
+        return true;
+      }
+    }
+    if (states.top() == State::IN_NODE_OP && currentKey.compare("operation") == 0) {
+      operation = (BasicOp)i;
+      return true;
+    }
+    states.push(State::IN_ERROR); // no other contexts allow ints
+    return false;
+  }
+
+  bool Uint(unsigned i)
+  {
+    debug << "Uint(" << i << ")" << std::endl;
+    if (states.top() == State::IN_NODE_BINDING && currentKey.compare("hash") == 0) {
+      hash = i;
+      return true;
+    }
+    debug << ">> falling back to Int" << std::endl;
+    return Int(i);
+  }
+
+  bool Int64(int64_t i)
+  {
+    debug << "Int64(" << i << ")" << std::endl;
+    if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
+      value = i;
+      return true;
+    }
+    states.push(State::IN_ERROR); // no other contexts allow int64s
+    return false;
+  }
+
+  bool Uint64(uint64_t i)
+  {
+    debug << "Uint64(" << i << ")" << std::endl;
+    if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
+      value = i;
+      return true;
+    }
+    states.push(State::IN_ERROR); // no other contexts allow uints
+    return false;
+  }
+
+  bool Double(double d)
+  {
+    debug << "Double(" << d << ")" << std::endl;
+    if (states.top() == State::IN_NODE_LITERAL) {
+      switch (type) {
+        case atype::FLOAT:
+          value = (float)d;
+          break;
+        case atype::DOUBLE:
+          value = d;
+          break;
+        default:
+          states.push(State::IN_ERROR);
+          return false;
+      }
+      return true;
+    }
+    states.push(State::IN_ERROR); // no other contexts allow doubles
+    return false;
+  }
+
+  bool String(const Ch* str, SizeType, bool)
+  {
+    debug << "String(" << str << ")" << std::endl;
+    if (states.top() == State::IN_NODE_BINDING && currentKey.compare("binding") == 0) {
+      binding = str;
+      return true;
+    }
+    states.push(State::IN_ERROR); // no strings are expected
+    return false;
+  }
+};
+} // namespace
+
+std::unique_ptr<expressions::Node> o2::framework::ExpressionJSONHelpers::read(std::istream& s)
+{
+  rapidjson::Reader reader;
+  rapidjson::IStreamWrapper isw(s);
+  ExpressionReader ereader;
+  bool ok = reader.Parse(isw, ereader);
+
+  if (!ok) {
+    std::stringstream error;
+    error << "Cannot parse serialized Expression, error: " << rapidjson::GetParseError_En(reader.GetParseErrorCode()) << " at offset: " << reader.GetErrorOffset();
+    throw std::runtime_error(error.str());
+  }
+  return std::move(ereader.rootNode);
+}
+
+void writeNodeHeader(rapidjson::Writer<rapidjson::OStreamWrapper>& w, expressions::Node const* node)
+{
+  w.Key("kind");
+  w.Int((int)node->self.index());
+  w.Key("index");
+  w.Uint64(node->index);
+  std::visit(overloaded{
+               [&w](expressions::LiteralNode const& node) {
+                 w.Key("arrow_type");
+                 w.Int(node.type);
+                 w.Key("value");
+                 std::visit(overloaded{
+                              [&w](bool v) { w.Bool(v); },
+                              [&w](float v) { w.Double(v); },
+                              [&w](double v) { w.Double(v); },
+                              [&w](uint8_t v) { w.Uint(v); },
+                              [&w](uint16_t v) { w.Uint(v); },
+                              [&w](uint32_t v) { w.Uint(v); },
+                              [&w](uint64_t v) { w.Uint64(v); },
+                              [&w](int8_t v) { w.Int(v); },
+                              [&w](int16_t v) { w.Int(v); },
+                              [&w](int v) { w.Int(v); },
+                              [&w](int64_t v) { w.Int64(v); }},
+                            node.value);
+               },
+               [&w](expressions::BindingNode const& node) {
+                 w.Key("binding");
+                 w.String(node.name);
+                 w.Key("hash");
+                 w.Uint(node.hash);
+                 w.Key("arrow_type");
+                 w.Int(node.type);
+               },
+               [&w](expressions::OpNode const& node) {
+                 w.Key("operation");
+                 w.Int(node.op);
+               },
+               [](expressions::ConditionalNode const&) {
+               }},
+             node->self);
+}
+
+void writeExpression(std::ostream& o, expressions::Node* n)
+{
+  rapidjson::OStreamWrapper osw(o);
+  rapidjson::Writer<rapidjson::OStreamWrapper> w(osw);
+
+  std::stack<Entry> path;
+  path.emplace(n, ToWrite::FULL);
+  while (!path.empty()) {
+    auto& top = path.top();
+
+    if (top.toWrite == ToWrite::FULL) {
+      w.StartObject();
+      writeNodeHeader(w, top.ptr);
+      top.toWrite = ToWrite::LEFT;
+      continue;
+    }
+
+    if (top.toWrite == ToWrite::LEFT) {
+      w.Key("left");
+      top.toWrite = ToWrite::RIGHT;
+      auto* left = top.ptr->left.get();
+      if (left != nullptr) {
+        path.emplace(left, ToWrite::FULL);
+      } else {
+        w.Null();
+      }
+      continue;
+    }
+
+    if (top.toWrite == ToWrite::RIGHT) {
+      w.Key("right");
+      top.toWrite = ToWrite::COND;
+      auto* right = top.ptr->right.get();
+      if (right != nullptr) {
+        path.emplace(right, ToWrite::FULL);
+      } else {
+        w.Null();
+      }
+      continue;
+    }
+
+    if (top.toWrite == ToWrite::COND) {
+      w.Key("condition");
+      top.toWrite = ToWrite::POP;
+      auto* cond = top.ptr->condition.get();
+      if (cond != nullptr) {
+        path.emplace(cond, ToWrite::FULL);
+      } else {
+        w.Null();
+      }
+      continue;
+    }
+
+    if (top.toWrite == ToWrite::POP) {
+      w.EndObject();
+      path.pop();
+      continue;
+    }
+  }
+}
+}
+
+void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, expressions::Node* n)
+{
+  writeExpression(o, n);
+}

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -365,13 +365,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
           value = (uint16_t)i;
           break;
         case atype::UINT32:
-          value = i;
-          break;
-        case atype::UINT64:
-          value = (uint64_t)i;
-          break;
-        case atype::INT64:
-          value = (int64_t)i;
+          value = (uint32_t)i;
           break;
         default:
           states.push(State::IN_ERROR);
@@ -450,7 +444,17 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     debug << "Int64(" << i << ")" << std::endl;
     // can only be a literal node value
     if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
-      value = i;
+      switch (type) {
+        case atype::UINT64:
+          value = (uint64_t)i;
+          break;
+        case atype::INT64:
+          value = (int64_t)i;
+          break;
+        default:
+          states.push(State::IN_ERROR);
+          return false;
+      }
       return true;
     }
     states.push(State::IN_ERROR); // no other contexts allow int64s
@@ -460,13 +464,9 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   bool Uint64(uint64_t i)
   {
     debug << "Uint64(" << i << ")" << std::endl;
-    // can only be a literal node value
-    if (states.top() == State::IN_NODE_LITERAL && currentKey.compare("value") == 0) {
-      value = i;
-      return true;
-    }
-    states.push(State::IN_ERROR); // no other contexts allow uints
-    return false;
+    // any positive value will be first read as unsigned, however the actual type is determined by node's arrow_type
+    debug << ">> falling back to Int64" << std::endl;
+    return Int64(i);
   }
 
   bool Double(double d)

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -20,7 +20,8 @@
 #include <iostream>
 #include "Framework/VariantHelpers.h"
 
-namespace o2::framework {
+namespace o2::framework
+{
 
 using nodes = expressions::Node::self_t;
 enum struct Nodes : int {
@@ -550,7 +551,7 @@ void writeExpression(std::ostream& o, expressions::Node* n)
     }
   }
 }
-}
+} // namespace o2::framework
 
 void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, expressions::Node* n)
 {

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -8,7 +8,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/ExpressionJSONHelpers.h"
+#include "ExpressionJSONHelpers.h"
 
 #include <rapidjson/reader.h>
 #include <rapidjson/prettywriter.h>
@@ -105,7 +105,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
 
   bool StartArray()
   {
-    debug << "Starting array" << std::endl;
+    debug << "StartArray()" << std::endl;
     if (states.top() == State::IN_START) {
       states.push(State::IN_LIST);
       return true;
@@ -116,7 +116,7 @@ struct ExpressionReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
 
   bool EndArray(SizeType)
   {
-    debug << "Ending array" << std::endl;
+    debug << "EndArray()" << std::endl;
     if (states.top() == State::IN_LIST) {
       states.pop();
       return true;
@@ -513,9 +513,7 @@ std::vector<expressions::Projector> o2::framework::ExpressionJSONHelpers::read(s
   bool ok = reader.Parse(isw, ereader);
 
   if (!ok) {
-    std::stringstream error;
-    error << "Cannot parse serialized Expression, error: " << rapidjson::GetParseError_En(reader.GetParseErrorCode()) << " at offset: " << reader.GetErrorOffset();
-    throw std::runtime_error(error.str());
+    throw framework::runtime_error_f("Cannot parse serialized Expression, error: %s at offset: %d", rapidjson::GetParseError_En(reader.GetParseErrorCode()), reader.GetErrorOffset());
   }
   return std::move(ereader.result);
 }
@@ -633,6 +631,192 @@ void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, std::vector<o2
   for (auto& p : projectors) {
     writeExpression(w, p.node.get());
   }
+  w.EndArray();
+  w.EndObject();
+}
+
+namespace {
+struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, SchemaReader> {
+  using Ch = rapidjson::UTF8<>::Ch;
+  using SizeType = rapidjson::SizeType;
+
+  enum struct State {
+    IN_START,
+    IN_LIST,
+    IN_FIELD,
+    IN_ERROR
+  };
+
+  std::stack<State> states;
+  std::ostringstream debug;
+
+  std::shared_ptr<arrow::Schema> schema = nullptr;
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+
+  std::string currentKey;
+
+  std::string name;
+  atype::type type;
+
+  SchemaReader()
+  {
+    debug << ">>> Start" << std::endl;
+    states.push(State::IN_START);
+  }
+
+  bool StartArray()
+  {
+    debug << "Starting array" << std::endl;
+    if (states.top() == State::IN_START && currentKey.compare("fields") == 0) {
+      states.push(State::IN_LIST);
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool EndArray(SizeType)
+  {
+    debug << "Ending array" << std::endl;
+    if (states.top() == State::IN_LIST) {
+      //finalize schema
+      schema = std::make_shared<arrow::Schema>(fields);
+      states.pop();
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool Key(const Ch* str, SizeType, bool)
+  {
+    debug << "Key(" << str << ")" << std::endl;
+    currentKey = str;
+    if (states.top() == State::IN_START) {
+      if (currentKey.compare("fields") == 0) {
+        return true;
+      }
+    }
+
+    if (states.top() == State::IN_FIELD) {
+      if (currentKey.compare("name") == 0) {
+        return true;
+      }
+      if (currentKey.compare("type") == 0) {
+        return true;
+      }
+    }
+
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool StartObject()
+  {
+    debug << "StartObject()" << std::endl;
+    if (states.top() == State::IN_START) {
+      return true;
+    }
+
+    if (states.top() == State::IN_LIST) {
+      states.push(State::IN_FIELD);
+      return true;
+    }
+
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool EndObject(SizeType)
+  {
+    debug << "EndObject()" << std::endl;
+    if (states.top() == State::IN_FIELD) {
+      states.pop();
+      // add a field
+      fields.emplace_back(std::make_shared<arrow::Field>(name, expressions::concreteArrowType(type)));
+      return true;
+    }
+
+    if (states.top() == State::IN_START) {
+      return true;
+    }
+
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool Uint(unsigned i)
+  {
+    debug << "Uint(" << i << ")" << std::endl;
+    if (states.top() == State::IN_FIELD) {
+      if (currentKey.compare("type") == 0) {
+        type = (atype::type)i;
+        return true;
+      }
+    }
+
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool String(const Ch* str, SizeType, bool)
+  {
+    debug << "String(" << str << ")" << std::endl;
+    if (states.top() == State::IN_FIELD) {
+      if (currentKey.compare("name") == 0) {
+        name = str;
+        return true;
+      }
+    }
+
+    states.push(State::IN_ERROR);
+    return false;
+  }
+
+  bool Int(int i) {
+    debug << "Int(" << i << ")" << std::endl;
+    return Uint(i);
+  }
+
+};
+}
+
+std::shared_ptr<arrow::Schema> o2::framework::ArrowJSONHelpers::read(std::istream& s)
+{
+  rapidjson::Reader reader;
+  rapidjson::IStreamWrapper isw(s);
+  SchemaReader sreader;
+
+  bool ok = reader.Parse(isw, sreader);
+
+  if(!ok) {
+    throw framework::runtime_error_f("Cannot parse serialized Expression, error: %s at offset: %d", rapidjson::GetParseError_En(reader.GetParseErrorCode()), reader.GetErrorOffset());
+  }
+  return sreader.schema;
+}
+
+namespace {
+void writeSchema(rapidjson::Writer<rapidjson::OStreamWrapper>& w, arrow::Schema* schema)
+{
+  for (auto& f : schema->fields()) {
+    w.StartObject();
+    w.Key("name");
+    w.String(f->name().c_str());
+    w.Key("type");
+    w.Int(f->type()->id());
+    w.EndObject();
+  }
+}
+}
+
+void o2::framework::ArrowJSONHelpers::write(std::ostream& o, std::shared_ptr<arrow::Schema>& schema)
+{
+  rapidjson::OStreamWrapper osw(o);
+  rapidjson::Writer<rapidjson::OStreamWrapper> w(osw);
+  w.StartObject();
+  w.Key("fields");
+  w.StartArray();
+  writeSchema(w, schema.get());
   w.EndArray();
   w.EndObject();
 }

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -635,7 +635,8 @@ void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, std::vector<o2
   w.EndObject();
 }
 
-namespace {
+namespace
+{
 struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, SchemaReader> {
   using Ch = rapidjson::UTF8<>::Ch;
   using SizeType = rapidjson::SizeType;
@@ -679,7 +680,7 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
   {
     debug << "Ending array" << std::endl;
     if (states.top() == State::IN_LIST) {
-      //finalize schema
+      // finalize schema
       schema = std::make_shared<arrow::Schema>(fields);
       states.pop();
       return true;
@@ -773,13 +774,13 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
     return false;
   }
 
-  bool Int(int i) {
+  bool Int(int i)
+  {
     debug << "Int(" << i << ")" << std::endl;
     return Uint(i);
   }
-
 };
-}
+} // namespace
 
 std::shared_ptr<arrow::Schema> o2::framework::ArrowJSONHelpers::read(std::istream& s)
 {
@@ -789,13 +790,14 @@ std::shared_ptr<arrow::Schema> o2::framework::ArrowJSONHelpers::read(std::istrea
 
   bool ok = reader.Parse(isw, sreader);
 
-  if(!ok) {
+  if (!ok) {
     throw framework::runtime_error_f("Cannot parse serialized Expression, error: %s at offset: %d", rapidjson::GetParseError_En(reader.GetParseErrorCode()), reader.GetErrorOffset());
   }
   return sreader.schema;
 }
 
-namespace {
+namespace
+{
 void writeSchema(rapidjson::Writer<rapidjson::OStreamWrapper>& w, arrow::Schema* schema)
 {
   for (auto& f : schema->fields()) {
@@ -807,7 +809,7 @@ void writeSchema(rapidjson::Writer<rapidjson::OStreamWrapper>& w, arrow::Schema*
     w.EndObject();
   }
 }
-}
+} // namespace
 
 void o2::framework::ArrowJSONHelpers::write(std::ostream& o, std::shared_ptr<arrow::Schema>& schema)
 {

--- a/Framework/Core/src/ExpressionJSONHelpers.h
+++ b/Framework/Core/src/ExpressionJSONHelpers.h
@@ -16,9 +16,13 @@
 namespace o2::framework
 {
 struct ExpressionJSONHelpers {
-  // static std::unique_ptr<expressions::Node> read(std::istream& s);
   static std::vector<expressions::Projector> read(std::istream& s);
   static void write(std::ostream& o, std::vector<expressions::Projector>& projectors);
+};
+
+struct ArrowJSONHelpers {
+  static std::shared_ptr<arrow::Schema> read(std::istream& s);
+  static void write(std::ostream& o, std::shared_ptr<arrow::Schema>& schema);
 };
 } // namespace o2::framework
 

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -130,6 +130,48 @@ std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const&
   return arrow::Table::Make(newSchema, arrays);
 }
 
+std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const& fullTable, std::shared_ptr<arrow::Schema> newSchema,
+                                            const char* name, size_t nColumns,
+                                            std::shared_ptr<gandiva::Projector> const& projector)
+{
+  arrow::TableBatchReader reader(*fullTable);
+  std::shared_ptr<arrow::RecordBatch> batch;
+  arrow::ArrayVector v;
+  std::vector<arrow::ArrayVector> chunks;
+  chunks.resize(nColumns);
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> arrays;
+
+  while (true) {
+    auto s = reader.ReadNext(&batch);
+    if (!s.ok()) {
+      throw runtime_error_f("Cannot read batches from source table to spawn %s: %s", name, s.ToString().c_str());
+    }
+    if (batch == nullptr) {
+      break;
+    }
+    try {
+      s = projector->Evaluate(*batch, arrow::default_memory_pool(), &v);
+      if (!s.ok()) {
+        throw runtime_error_f("Cannot apply projector to source table of %s: %s", name, s.ToString().c_str());
+      }
+    } catch (std::exception& e) {
+      throw runtime_error_f("Cannot apply projector to source table of %s: exception caught: %s", name, e.what());
+    }
+
+    for (auto i = 0U; i < nColumns; ++i) {
+      chunks[i].emplace_back(v.at(i));
+    }
+  }
+
+  arrays.reserve(nColumns);
+  for (auto i = 0U; i < nColumns; ++i) {
+    arrays.push_back(std::make_shared<arrow::ChunkedArray>(chunks[i]));
+  }
+
+  addLabelToSchema(newSchema, name);
+  return arrow::Table::Make(newSchema, arrays);
+}
+
 } // namespace o2::framework
 
 template class arrow::NumericBuilder<arrow::UInt8Type>;

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -38,6 +38,7 @@
 #include <utility>
 #include <vector>
 #include <climits>
+#include <numeric>
 
 O2_DECLARE_DYNAMIC_LOG(workflow_helpers);
 
@@ -435,7 +436,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     "internal-dpl-aod-spawner",
     {},
     {},
-    readers::AODReaderHelpers::aodSpawnerCallback(ac.spawnerInputs),
+    readers::AODReaderHelpers::aodSpawnerCallback(ctx),
     {}};
   AnalysisSupportHelpers::addMissingOutputsToSpawner({}, ac.spawnerInputs, ac.requestedAODs, aodSpawner);
 

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -422,4 +422,7 @@ TEST_CASE("TestExpressionSerialization")
   auto t12 = createExpressionTree(s12, schemap);
   auto t22 = createExpressionTree(s22, schemap);
   REQUIRE(t12->ToString() == t22->ToString());
+
+  std::cout << schemaf->ToString() << std::endl;
+  std::cout << schemap->ToString() << std::endl;
 }

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -397,10 +397,15 @@ TEST_CASE("TestExpressionSerialization")
 {
   Filter f = o2::aod::track::signed1Pt > 0.f && ifnode(nabs(o2::aod::track::eta) < 1.0f, nabs(o2::aod::track::x) > 2.0f, nabs(o2::aod::track::y) > 3.0f);
   Projector p = -1.f * nlog(ntan(o2::constants::math::PIQuarter - 0.5f * natan(o2::aod::fwdtrack::tgl)));
+  Projector p1 = ifnode(o2::aod::track::itsClusterSizes > (uint32_t)0, static_cast<uint8_t>(o2::aod::track::ITS), (uint8_t)0x0) |
+                 ifnode(o2::aod::track::tpcNClsFindable > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TPC), (uint8_t)0x0) |
+                 ifnode(o2::aod::track::trdPattern > (uint8_t)0, static_cast<uint8_t>(o2::aod::track::TRD), (uint8_t)0x0) |
+                 ifnode((o2::aod::track::tofChi2 >= 0.f) && (o2::aod::track::tofExpMom > 0.f), static_cast<uint8_t>(o2::aod::track::TOF), (uint8_t)0x0);
 
   std::vector<Projector> projectors;
   projectors.emplace_back(std::move(f));
   projectors.emplace_back(std::move(p));
+  projectors.emplace_back(std::move(p1));
 
   std::stringstream osm;
   ExpressionJSONHelpers::write(osm, projectors);
@@ -422,6 +427,15 @@ TEST_CASE("TestExpressionSerialization")
   auto t12 = createExpressionTree(s12, schemap);
   auto t22 = createExpressionTree(s22, schemap);
   REQUIRE(t12->ToString() == t22->ToString());
+
+  auto s13 = createOperations(projectors[2]);
+  auto s23 = createOperations(ps[2]);
+  auto schemap1 = std::make_shared<arrow::Schema>(std::vector{o2::aod::track::ITSClusterSizes::asArrowField(), o2::aod::track::TPCNClsFindable::asArrowField(),
+                                                              o2::aod::track::TRDPattern::asArrowField(), o2::aod::track::TOFChi2::asArrowField(),
+                                                              o2::aod::track::TOFExpMom::asArrowField()});
+  auto t13 = createExpressionTree(s13, schemap1);
+  auto t23 = createExpressionTree(s23, schemap1);
+  REQUIRE(t13->ToString() == t23->ToString());
 
   osm.clear();
   osm.str("");

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -12,7 +12,7 @@
 #include "Framework/Configurable.h"
 #include "Framework/ExpressionHelpers.h"
 #include "Framework/AnalysisDataModel.h"
-#include "Framework/ExpressionJSONHelpers.h"
+#include "../src/ExpressionJSONHelpers.h"
 #include <catch_amalgamated.hpp>
 #include <arrow/util/config.h>
 #include <iostream>
@@ -423,6 +423,21 @@ TEST_CASE("TestExpressionSerialization")
   auto t22 = createExpressionTree(s22, schemap);
   REQUIRE(t12->ToString() == t22->ToString());
 
-  std::cout << schemaf->ToString() << std::endl;
-  std::cout << schemap->ToString() << std::endl;
+  osm.clear();
+  osm.str("");
+  ArrowJSONHelpers::write(osm, schemaf);
+
+  ism.clear();
+  ism.str(osm.str());
+  auto newSchemaf = ArrowJSONHelpers::read(ism);
+  REQUIRE(schemaf->ToString() == newSchemaf->ToString());
+
+  osm.clear();
+  osm.str("");
+  ArrowJSONHelpers::write(osm, schemap);
+
+  ism.clear();
+  ism.str(osm.str());
+  auto newSchemap = ArrowJSONHelpers::read(ism);
+  REQUIRE(schemap->ToString() == newSchemap->ToString());
 }

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -396,20 +396,30 @@ TEST_CASE("TestStringExpressionsParsing")
 TEST_CASE("TestExpressionSerialization")
 {
   Filter f = o2::aod::track::signed1Pt > 0.f && ifnode(nabs(o2::aod::track::eta) < 1.0f, nabs(o2::aod::track::x) > 2.0f, nabs(o2::aod::track::y) > 3.0f);
-  auto ops = createOperations(f);
-  auto schema = std::make_shared<arrow::Schema>(std::vector{o2::aod::track::Eta::asArrowField(), o2::aod::track::Signed1Pt::asArrowField(), o2::aod::track::X::asArrowField(), o2::aod::track::Y::asArrowField()});
-  auto tree = createExpressionTree(ops, schema);
+  Projector p = -1.f * nlog(ntan(o2::constants::math::PIQuarter - 0.5f * natan(o2::aod::fwdtrack::tgl)));
+
+  std::vector<Projector> projectors;
+  projectors.emplace_back(std::move(f));
+  projectors.emplace_back(std::move(p));
 
   std::stringstream osm;
-  ExpressionJSONHelpers::write(osm, f.node.get());
+  ExpressionJSONHelpers::write(osm, projectors);
 
   std::stringstream ism;
   ism.str(osm.str());
-  Filter fr = ExpressionJSONHelpers::read(ism);
+  auto ps = ExpressionJSONHelpers::read(ism);
 
-  auto s1 = createOperations(f);
-  auto s2 = createOperations(fr);
-  auto t1 = createExpressionTree(s1, schema);
-  auto t2 = createExpressionTree(s2, schema);
+  auto s1 = createOperations(projectors[0]);
+  auto s2 = createOperations(ps[0]);
+  auto schemaf = std::make_shared<arrow::Schema>(std::vector{o2::aod::track::Eta::asArrowField(), o2::aod::track::Signed1Pt::asArrowField(), o2::aod::track::X::asArrowField(), o2::aod::track::Y::asArrowField()});
+  auto t1 = createExpressionTree(s1, schemaf);
+  auto t2 = createExpressionTree(s2, schemaf);
   REQUIRE(t1->ToString() == t2->ToString());
+
+  auto s12 = createOperations(projectors[1]);
+  auto s22 = createOperations(ps[1]);
+  auto schemap = std::make_shared<arrow::Schema>(std::vector{o2::aod::fwdtrack::Tgl::asArrowField()});
+  auto t12 = createExpressionTree(s12, schemap);
+  auto t22 = createExpressionTree(s22, schemap);
+  REQUIRE(t12->ToString() == t22->ToString());
 }

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -12,6 +12,7 @@
 #include "Framework/Configurable.h"
 #include "Framework/ExpressionHelpers.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/ExpressionJSONHelpers.h"
 #include <catch_amalgamated.hpp>
 #include <arrow/util/config.h>
 #include <iostream>
@@ -390,4 +391,25 @@ TEST_CASE("TestStringExpressionsParsing")
   auto tree2c = createExpressionTree(pcfg2specs, schema);
 
   REQUIRE(tree1c->ToString() == tree2c->ToString());
+}
+
+TEST_CASE("TestExpressionSerialization")
+{
+  Filter f = o2::aod::track::signed1Pt > 0.f && ifnode(nabs(o2::aod::track::eta) < 1.0f, nabs(o2::aod::track::x) > 2.0f, nabs(o2::aod::track::y) > 3.0f);
+  auto ops = createOperations(f);
+  auto schema = std::make_shared<arrow::Schema>(std::vector{o2::aod::track::Eta::asArrowField(), o2::aod::track::Signed1Pt::asArrowField(), o2::aod::track::X::asArrowField(), o2::aod::track::Y::asArrowField()});
+  auto tree = createExpressionTree(ops, schema);
+
+  std::stringstream osm;
+  ExpressionJSONHelpers::write(osm, f.node.get());
+
+  std::stringstream ism;
+  ism.str(osm.str());
+  Filter fr = ExpressionJSONHelpers::read(ism);
+
+  auto s1 = createOperations(f);
+  auto s2 = createOperations(fr);
+  auto t1 = createExpressionTree(s1, schema);
+  auto t2 = createExpressionTree(s2, schema);
+  REQUIRE(t1->ToString() == t2->ToString());
 }


### PR DESCRIPTION
* Add serialization for framework::expressions
* Add serialization for simple arrow::Schema
* Add serialized expressions and schema to DYN input spec metadata
* Make aod-spawner generic by relying on serialized expression metadata