### PR TITLE
ALICE3-TRK: fix nSimSteps to cover long hits at large Z + prints cleanup

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
@@ -1121,7 +1121,7 @@ void GeometryTGeo::Print(Option_t*) const
     mlot = (i < 4) ? "ML" : "OT";
     LOGF(info, "Layer: %d, %s, %d staves, %d half staves per stave", i, mlot.c_str(), mNumberOfStaves[i], mNumberOfHalfStaves[i]);
   }
-  LOGF(info, "Number of modules per layer MLOT: ");
+  LOGF(info, "Number of modules per stave (half stave) in each ML(OT) layer: ");
   for (int i = 0; i < mNumberOfLayersMLOT; i++) {
     LOGF(info, "%d", mNumberOfModules[i]);
   }

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DPLDigitizerParam.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DPLDigitizerParam.h
@@ -39,7 +39,7 @@ struct DPLDigitizerParam : public o2::conf::ConfigurableParamHelper<DPLDigitizer
   double timeOffset = 0.;                 ///< time offset (in seconds!) to calculate ROFrame from hit time
   int chargeThreshold = 1;                ///< charge threshold in Nelectrons
   int minChargeToAccount = 1;             ///< minimum charge contribution to account
-  int nSimSteps = 25;                     ///< number of steps in response simulation
+  int nSimSteps = 475;                    ///< number of steps in response simulation
   float energyToNElectrons = 1. / 3.6e-9; // conversion of eloss to Nelectrons
 
   float Vbb = 0.0;   ///< back bias absolute value for MFT (in Volt)

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DigiParams.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DigiParams.h
@@ -101,18 +101,18 @@ class DigiParams
 
  private:
   static constexpr double infTime = 1e99;
-  bool mIsContinuous = false;        ///< flag for continuous simulation
-  float mNoisePerPixel = 1.e-8;      ///< ALPIDE Noise per chip
-  int mROFrameLengthInBC = 0;        ///< ROF length in BC for continuos mode
-  float mROFrameLength = 0;          ///< length of RO frame in ns
-  float mStrobeDelay = 0.;           ///< strobe start (in ns) wrt ROF start
-  float mStrobeLength = 0;           ///< length of the strobe in ns (sig. over threshold checked in this window only)
-  double mTimeOffset = -2 * infTime; ///< time offset (in seconds!) to calculate ROFrame from hit time
-  int mROFrameBiasInBC = 0;          ///< misalignment of the ROF start in BC
-  int mChargeThreshold = 1;          ///< charge threshold in Nelectrons
-  int mMinChargeToAccount = 1;       ///< minimum charge contribution to account
-  int mNSimSteps = 25;               ///< number of steps in response simulation
-  float mNSimStepsInv = 0;           ///< its inverse
+  bool mIsContinuous = false;            ///< flag for continuous simulation
+  float mNoisePerPixel = 1.e-8;          ///< ALPIDE Noise per chip
+  int mROFrameLengthInBC = 0;            ///< ROF length in BC for continuos mode
+  float mROFrameLength = 0;              ///< length of RO frame in ns
+  float mStrobeDelay = 0.;               ///< strobe start (in ns) wrt ROF start
+  float mStrobeLength = 0;               ///< length of the strobe in ns (sig. over threshold checked in this window only)
+  double mTimeOffset = -2 * infTime;     ///< time offset (in seconds!) to calculate ROFrame from hit time
+  int mROFrameBiasInBC = 0;              ///< misalignment of the ROF start in BC
+  int mChargeThreshold = 1;              ///< charge threshold in Nelectrons
+  int mMinChargeToAccount = 1;           ///< minimum charge contribution to account
+  int mNSimSteps = 475;                  ///< number of steps in response simulation
+  float mNSimStepsInv = 1. / mNSimSteps; ///< its inverse
 
   float mEnergyToNElectrons = 1. / 3.6e-9; // conversion of eloss to Nelectrons
 

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -476,9 +476,9 @@ bool Detector::ProcessHits(FairVolume* vol)
 
     unsigned short chipID = mGeometryTGeo->getChipIndex(subDetID, volume, layer, stave, halfstave, mod, chip);
 
-    Print(vol, volume, subDetID, layer, stave, halfstave, mod, chip, chipID);
+    // Print(vol, volume, subDetID, layer, stave, halfstave, mod, chip, chipID);
 
-    mGeometryTGeo->Print();
+    // mGeometryTGeo->Print();
 
     Hit* p = addHit(stack->GetCurrentTrackNumber(), chipID, mTrackData.mPositionStart.Vect(), positionStop.Vect(),
                     mTrackData.mMomentumStart.Vect(), mTrackData.mMomentumStart.E(), positionStop.T(),

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKLayer.cxx
@@ -126,12 +126,12 @@ TGeoVolume* TRKLayer::createChip(std::string type)
 
     TGeoCombiTrans* transSens = new TGeoCombiTrans();
     transSens->SetTranslation(0, -(mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
-    LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
     chipVol->AddNode(sensVol, 1, transSens);
 
     TGeoCombiTrans* transMetal = new TGeoCombiTrans();
     transMetal->SetTranslation(0, mSensorThickness / 2, 0); // TO BE CHECKED !!!
-    LOGP(info, "Inserting {} in {} ", metalVol->GetName(), chipVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", metalVol->GetName(), chipVol->GetName());
     chipVol->AddNode(metalVol, 1, transMetal);
 
     // deadVol = createDeadzone("cylinder");
@@ -145,17 +145,17 @@ TGeoVolume* TRKLayer::createChip(std::string type)
 
     TGeoCombiTrans* transSens = new TGeoCombiTrans();
     transSens->SetTranslation(-mDeadzoneWidth / 2, -(mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
-    LOGP(info, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
     chipVol->AddNode(sensVol, 1, transSens);
 
     TGeoCombiTrans* transDead = new TGeoCombiTrans();
     transDead->SetTranslation((mChipWidth - mDeadzoneWidth) / 2, -(mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
-    LOGP(info, "Inserting {} in {} ", deadVol->GetName(), chipVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", deadVol->GetName(), chipVol->GetName());
     chipVol->AddNode(deadVol, 1, transDead);
 
     TGeoCombiTrans* transMetal = new TGeoCombiTrans();
     transMetal->SetTranslation(0, mSensorThickness / 2, 0); // TO BE CHECKED !!!
-    LOGP(info, "Inserting {} in {} ", metalVol->GetName(), chipVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", metalVol->GetName(), chipVol->GetName());
     chipVol->AddNode(metalVol, 1, transMetal);
   } else {
     LOGP(fatal, "Sensor of type '{}' is not implemented", type);
@@ -179,7 +179,7 @@ TGeoVolume* TRKLayer::createModule(std::string type)
     moduleVol = new TGeoVolume(moduleName.c_str(), module, medAir);
 
     TGeoVolume* chipVol = createChip("cylinder");
-    LOGP(info, "Inserting {} in {} ", chipVol->GetName(), moduleVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", chipVol->GetName(), moduleVol->GetName());
     moduleVol->AddNode(chipVol, 1, nullptr);
   } else if (type == "flat") {
     double moduleWidth = constants::moduleMLOT::width;
@@ -201,7 +201,7 @@ TGeoVolume* TRKLayer::createModule(std::string type)
       TGeoRotation* rot = new TGeoRotation();
       rot->RotateY(180);
       transLeft->SetRotation(rot);
-      LOGP(info, "Inserting {} in {} ", chipVolLeft->GetName(), moduleVol->GetName());
+      LOGP(debug, "Inserting {} in {} ", chipVolLeft->GetName(), moduleVol->GetName());
       moduleVol->AddNode(chipVolLeft, iChip * 2, transLeft);
 
       double xRight = +moduleWidth / 2 - constants::moduleMLOT::gaps::outerEdgeLongSide - constants::moduleMLOT::chip::width / 2;
@@ -209,7 +209,7 @@ TGeoVolume* TRKLayer::createModule(std::string type)
 
       TGeoCombiTrans* transRight = new TGeoCombiTrans();
       transRight->SetTranslation(xRight, 0, zRight); // TO BE CHECKED !!!
-      LOGP(info, "Inserting {} in {} ", chipVolRight->GetName(), moduleVol->GetName());
+      LOGP(debug, "Inserting {} in {} ", chipVolRight->GetName(), moduleVol->GetName());
       moduleVol->AddNode(chipVolRight, iChip * 2 + 1, transRight);
     }
   } else {
@@ -234,7 +234,7 @@ TGeoVolume* TRKLayer::createHalfStave(std::string type)
     halfStaveVol = new TGeoVolume(halfStaveName.c_str(), halfStave, medAir);
 
     TGeoVolume* moduleVol = createModule("cylinder");
-    LOGP(info, "Inserting {} in {} ", moduleVol->GetName(), halfStaveVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", moduleVol->GetName(), halfStaveVol->GetName());
     halfStaveVol->AddNode(moduleVol, 1, nullptr);
   } else if (type == "flat") {
     double moduleLength = constants::moduleMLOT::length;
@@ -253,7 +253,7 @@ TGeoVolume* TRKLayer::createHalfStave(std::string type)
       TGeoCombiTrans* trans = new TGeoCombiTrans();
       trans->SetTranslation(0, 0, zPos); // TO BE CHECKED !!!
 
-      LOGP(info, "Inserting {} in {} ", moduleVol->GetName(), halfStaveVol->GetName());
+      LOGP(debug, "Inserting {} in {} ", moduleVol->GetName(), halfStaveVol->GetName());
       halfStaveVol->AddNode(moduleVol, iModule, trans);
     }
   }
@@ -273,7 +273,7 @@ TGeoVolume* TRKLayer::createStave(std::string type)
     staveVol = new TGeoVolume(staveName.c_str(), stave, medAir);
 
     TGeoVolume* moduleVol = createModule("cylinder");
-    LOGP(info, "Inserting {} in {} ", moduleVol->GetName(), staveVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", moduleVol->GetName(), staveVol->GetName());
     staveVol->AddNode(moduleVol, 1, nullptr);
   } else if (type == "flat") {
     double moduleLength = constants::moduleMLOT::length;
@@ -292,7 +292,7 @@ TGeoVolume* TRKLayer::createStave(std::string type)
       TGeoCombiTrans* trans = new TGeoCombiTrans();
       trans->SetTranslation(0, 0, zPos); // TO BE CHECKED !!!
 
-      LOGP(info, "Inserting {} in {} ", moduleVol->GetName(), staveVol->GetName());
+      LOGP(debug, "Inserting {} in {} ", moduleVol->GetName(), staveVol->GetName());
       staveVol->AddNode(moduleVol, iModule, trans);
     }
   } else if (type == "staggered") {
@@ -312,12 +312,12 @@ TGeoVolume* TRKLayer::createStave(std::string type)
 
     TGeoCombiTrans* transLeft = new TGeoCombiTrans();
     transLeft->SetTranslation(-halfstaveWidth / 2 + 0.05, 0, 0); // TO BE CHECKED !!! 1mm overlap between the modules
-    LOGP(info, "Inserting {} in {} ", halfStaveVolLeft->GetName(), staveVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", halfStaveVolLeft->GetName(), staveVol->GetName());
     staveVol->AddNode(halfStaveVolLeft, 0, transLeft);
 
     TGeoCombiTrans* transRight = new TGeoCombiTrans();
     transRight->SetTranslation(halfstaveWidth / 2 - 0.05, 0.2, 0); // TO BE CHECKED !!! 1mm overlap between the modules
-    LOGP(info, "Inserting {} in {} ", halfStaveVolRight->GetName(), staveVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", halfStaveVolRight->GetName(), staveVol->GetName());
     staveVol->AddNode(halfStaveVolRight, 1, transRight);
   } else {
     LOGP(fatal, "Chip of type '{}' is not implemented", type);
@@ -345,7 +345,7 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
     layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
 
     TGeoVolume* staveVol = createStave("cylinder");
-    LOGP(info, "Inserting {} in {} ", staveVol->GetName(), layerVol->GetName());
+    LOGP(debug, "Inserting {} in {} ", staveVol->GetName(), layerVol->GetName());
     layerVol->AddNode(staveVol, 1, nullptr);
   } else if (mLayout == eLayout::kTurboStaves) {
     double layerLength = constants::moduleMLOT::length * mNumberOfModules;
@@ -381,7 +381,7 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
       trans->SetRotation(rot);
       trans->SetTranslation(mInnerRadius * std::cos(2. * TMath::Pi() * iStave / nStaves), mInnerRadius * std::sin(2 * TMath::Pi() * iStave / nStaves), 0);
 
-      LOGP(info, "Inserting {} in {} ", staveVol->GetName(), layerVol->GetName());
+      LOGP(debug, "Inserting {} in {} ", staveVol->GetName(), layerVol->GetName());
       layerVol->AddNode(staveVol, iStave, trans);
     }
   } else if (mLayout == kStaggered) {
@@ -414,7 +414,7 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
       trans->SetRotation(rot);
       trans->SetTranslation(mInnerRadius * std::cos(2. * TMath::Pi() * iStave / nStaves), mInnerRadius * std::sin(2 * TMath::Pi() * iStave / nStaves), 0);
 
-      LOGP(info, "Inserting {} in {} ", staveVol->GetName(), layerVol->GetName());
+      LOGP(debug, "Inserting {} in {} ", staveVol->GetName(), layerVol->GetName());
       layerVol->AddNode(staveVol, iStave, trans);
     }
   } else {
@@ -422,7 +422,7 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
   }
   layerVol->SetLineColor(kYellow);
 
-  LOGP(info, "Inserting {} in {} ", layerVol->GetName(), motherVolume->GetName());
+  LOGP(debug, "Inserting {} in {} ", layerVol->GetName(), motherVolume->GetName());
   motherVolume->AddNode(layerVol, 1, nullptr);
 }
 // ClassImp(TRKLayer);

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/VDLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/VDLayer.cxx
@@ -190,7 +190,7 @@ void VDCylindricalLayer::createLayer(TGeoVolume* motherVolume, TGeoMatrix* combi
     LOGP(error, "VDCylindricalLayer::createSensor() returned null");
     return;
   }
-  LOGP(info, "Inserting {} in {} ", sensorVol->GetName(), layerVol->GetName());
+  LOGP(debug, "Inserting {} in {} ", sensorVol->GetName(), layerVol->GetName());
   layerVol->AddNode(sensorVol, 1, nullptr);
 
   // Tiling: edge-to-edge if sensor shorter than layer; else single centered
@@ -244,7 +244,7 @@ void VDRectangularLayer::createLayer(TGeoVolume* motherVolume, TGeoMatrix* combi
     return;
   }
 
-  LOGP(info, "Inserting {} in {} ", sensorVol->GetName(), layerVol->GetName());
+  LOGP(debug, "Inserting {} in {} ", sensorVol->GetName(), layerVol->GetName());
   layerVol->AddNode(sensorVol, 1, nullptr);
 
   // Tiling along Z, edge - to - edge if needed


### PR DESCRIPTION
* Prints cleanup: removing unnecessary prints or setting them to a debug level
* nSimSteps set to 475 to cover all the pixels involved in long hits, for large Z coordinates