### PR TITLE
DPL Analysis: protect aod-spawner from empty input

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -156,6 +156,9 @@ struct Maker {
       originals.push_back(pc.inputs().get<TableConsumer>(label)->asArrowTable());
     }
     auto fullTable = soa::ArrowHelpers::joinTables(std::move(originals), std::span{labels.begin(), labels.size()});
+    if (fullTable->num_rows() == 0) {
+      return arrow::Table::MakeEmpty(schema).ValueOrDie();
+    }
     if (projector == nullptr) {
       auto s = gandiva::Projector::Make(
         fullTable->schema(),


### PR DESCRIPTION
Skip applying the projector and directly return an empty table with the predefined schema if the input is an empty table.