### PR TITLE
DPL Analysis: Improve arrow schema serialization

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -256,7 +256,7 @@ struct TableMetadata {
 
   static std::shared_ptr<arrow::Schema> getSchema()
   {
-    return std::make_shared<arrow::Schema>([]<typename... C>(framework::pack<C...>&& p){ return o2::soa::createFieldsFromColumns(p); }(persistent_columns_t{}));
+    return std::make_shared<arrow::Schema>([]<typename... C>(framework::pack<C...>&& p) { return o2::soa::createFieldsFromColumns(p); }(persistent_columns_t{}));
   }
 };
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -34,7 +34,6 @@
 #include <concepts>
 #include <cstring>
 #include <gsl/span> // IWYU pragma: export
-#include <limits>
 
 namespace o2::framework
 {
@@ -53,6 +52,12 @@ void dereferenceWithWrongType(const char* getter, const char* target);
 void missingFilterDeclaration(int hash, int ai);
 void notBoundTable(const char* tableName);
 void* extractCCDBPayload(char* payload, size_t size, TClass const* cl, const char* what);
+
+template <typename... C>
+auto createFieldsFromColumns(framework::pack<C...>)
+{
+  return std::vector<std::shared_ptr<arrow::Field>>{C::asArrowField()...};
+}
 } // namespace o2::soa
 
 namespace o2::soa
@@ -248,6 +253,11 @@ struct TableMetadata {
       return -1;
     }
   }
+
+  static std::shared_ptr<arrow::Schema> getSchema()
+  {
+    return std::make_shared<arrow::Schema>([]<typename... C>(framework::pack<C...>&& p){ return o2::soa::createFieldsFromColumns(p); }(columns{}));
+  }
 };
 
 template <typename D>
@@ -405,12 +415,6 @@ struct Binding {
     return nullptr;
   }
 };
-
-template <typename... C>
-auto createFieldsFromColumns(framework::pack<C...>)
-{
-  return std::vector<std::shared_ptr<arrow::Field>>{C::asArrowField()...};
-}
 
 using SelectionVector = std::vector<int64_t>;
 

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -256,7 +256,7 @@ struct TableMetadata {
 
   static std::shared_ptr<arrow::Schema> getSchema()
   {
-    return std::make_shared<arrow::Schema>([]<typename... C>(framework::pack<C...>&& p){ return o2::soa::createFieldsFromColumns(p); }(columns{}));
+    return std::make_shared<arrow::Schema>([]<typename... C>(framework::pack<C...>&& p){ return o2::soa::createFieldsFromColumns(p); }(persistent_columns_t{}));
   }
 };
 
@@ -690,7 +690,7 @@ struct Column {
 
   static auto asArrowField()
   {
-    return std::make_shared<arrow::Field>(inherited_t::mLabel, framework::expressions::concreteArrowType(framework::expressions::selectArrowType<type>()));
+    return std::make_shared<arrow::Field>(inherited_t::mLabel, soa::asArrowDataType<type>());
   }
 
   /// FIXME: rather than keeping this public we should have a protected

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -29,7 +29,7 @@
 namespace o2::framework
 {
 std::string serializeProjectors(std::vector<framework::expressions::Projector>& projectors);
-std::string serializeSchema(std::shared_ptr<arrow::Schema>& schema);
+std::string serializeSchema(std::shared_ptr<arrow::Schema> schema);
 }  // namespace o2::framework
 
 namespace o2::soa
@@ -44,6 +44,16 @@ constexpr auto tableRef2ConfigParamSpec()
     {"\"\""}};
 }
 
+template <TableRef R>
+constexpr auto tableRef2Schema()
+{
+    return o2::framework::ConfigParamSpec{
+      std::string{"input-schema:"} + o2::aod::label<R>(),
+      framework::VariantType::String,
+      framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()),
+      {"\"\""}};
+}
+
 namespace
 {
 template <soa::with_sources T>
@@ -54,6 +64,16 @@ inline constexpr auto getSources()
       return std::vector{soa::tableRef2ConfigParamSpec<refs[Is]>()...};
     }(std::make_index_sequence<N>());
   }.template operator()<T::sources.size(), T::sources>();
+}
+
+template <soa::with_sources T>
+inline constexpr auto getSourceSchemas()
+{
+    return []<size_t N, std::array<soa::TableRef, N> refs>() {
+        return []<size_t... Is>(std::index_sequence<Is...>) {
+            return std::vector{soa::tableRef2Schema<refs[Is]>()...};
+        }(std::make_index_sequence<N>());
+    }.template operator()<T::sources.size(), T::sources>();
 }
 
 template <soa::with_ccdb_urls T>
@@ -73,11 +93,19 @@ template <soa::with_sources T>
 constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
 {
   std::vector<framework::ConfigParamSpec> inputMetadata;
+
   auto inputSources = getSources<T>();
   std::sort(inputSources.begin(), inputSources.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name < b.name; });
   auto last = std::unique(inputSources.begin(), inputSources.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name == b.name; });
   inputSources.erase(last, inputSources.end());
   inputMetadata.insert(inputMetadata.end(), inputSources.begin(), inputSources.end());
+
+  auto inputSchemas = getSourceSchemas<T>();
+  std::sort(inputSchemas.begin(), inputSchemas.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name < b.name; });
+  last = std::unique(inputSchemas.begin(), inputSchemas.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name == b.name; });
+  inputSchemas.erase(last, inputSchemas.end());
+  inputMetadata.insert(inputMetadata.end(), inputSchemas.begin(), inputSchemas.end());
+
   return inputMetadata;
 }
 
@@ -115,11 +143,8 @@ constexpr auto getExpressionMetadata() -> std::vector<framework::ConfigParamSpec
     return result;
   }(expression_pack_t{});
 
-  auto schema = std::make_shared<arrow::Schema>(o2::soa::createFieldsFromColumns(expression_pack_t{}));
-
   auto json = framework::serializeProjectors(projectors);
-  return {framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}},
-          framework::ConfigParamSpec{"schema", framework::VariantType::String, framework::serializeSchema(schema), {"\"\""}}};
+  return {framework::ConfigParamSpec{"projectors", framework::VariantType::String, json, {"\"\""}}};
 }
 
 template <typename T>
@@ -141,6 +166,9 @@ constexpr auto tableRef2InputSpec()
   metadata.insert(metadata.end(), ccdbMetadata.begin(), ccdbMetadata.end());
   auto p = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), p.begin(), p.end());
+  if constexpr(!soa::with_ccdb_urls<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
+    metadata.emplace_back(framework::ConfigParamSpec{"schema", framework::VariantType::String, framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()), {"\"\""}});
+  }
 
   return framework::InputSpec{
     o2::aod::label<R>(),

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -47,11 +47,11 @@ constexpr auto tableRef2ConfigParamSpec()
 template <TableRef R>
 constexpr auto tableRef2Schema()
 {
-    return o2::framework::ConfigParamSpec{
-      std::string{"input-schema:"} + o2::aod::label<R>(),
-      framework::VariantType::String,
-      framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()),
-      {"\"\""}};
+  return o2::framework::ConfigParamSpec{
+    std::string{"input-schema:"} + o2::aod::label<R>(),
+    framework::VariantType::String,
+    framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()),
+    {"\"\""}};
 }
 
 namespace
@@ -69,11 +69,11 @@ inline constexpr auto getSources()
 template <soa::with_sources T>
 inline constexpr auto getSourceSchemas()
 {
-    return []<size_t N, std::array<soa::TableRef, N> refs>() {
-        return []<size_t... Is>(std::index_sequence<Is...>) {
-            return std::vector{soa::tableRef2Schema<refs[Is]>()...};
-        }(std::make_index_sequence<N>());
-    }.template operator()<T::sources.size(), T::sources>();
+  return []<size_t N, std::array<soa::TableRef, N> refs>() {
+    return []<size_t... Is>(std::index_sequence<Is...>) {
+      return std::vector{soa::tableRef2Schema<refs[Is]>()...};
+    }(std::make_index_sequence<N>());
+  }.template operator()<T::sources.size(), T::sources>();
 }
 
 template <soa::with_ccdb_urls T>
@@ -166,7 +166,7 @@ constexpr auto tableRef2InputSpec()
   metadata.insert(metadata.end(), ccdbMetadata.begin(), ccdbMetadata.end());
   auto p = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), p.begin(), p.end());
-  if constexpr(!soa::with_ccdb_urls<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
+  if constexpr (!soa::with_ccdb_urls<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
     metadata.emplace_back(framework::ConfigParamSpec{"schema", framework::VariantType::String, framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()), {"\"\""}});
   }
 

--- a/Framework/Core/include/Framework/ArrowTypes.h
+++ b/Framework/Core/include/Framework/ArrowTypes.h
@@ -11,6 +11,7 @@
 
 #ifndef O2_FRAMEWORK_ARROWTYPES_H
 #define O2_FRAMEWORK_ARROWTYPES_H
+#include "Framework/Traits.h"
 #include "arrow/type_fwd.h"
 #include <span>
 
@@ -117,5 +118,54 @@ template <typename T>
 using arrow_array_for_t = typename arrow_array_for<T>::type;
 template <typename T>
 using value_for_t = typename arrow_array_for<T>::value_type;
+
+template <class Array>
+using array_element_t = std::decay_t<decltype(std::declval<Array>()[0])>;
+
+template <typename T>
+std::shared_ptr<arrow::DataType> asArrowDataType(int list_size = 1)
+{
+  auto typeGenerator = [](std::shared_ptr<arrow::DataType> const& type, int list_size) -> std::shared_ptr<arrow::DataType> {
+    switch (list_size) {
+      case -1:
+        return arrow::list(type);
+      case 1:
+        return std::move(type);
+      default:
+        return arrow::fixed_size_list(type, list_size);
+    }
+  };
+
+  if constexpr (std::is_arithmetic_v<T>) {
+    if constexpr (std::same_as<T, bool>) {
+      return typeGenerator(arrow::boolean(), list_size);
+    } else if constexpr (std::same_as<T, uint8_t>) {
+      return typeGenerator(arrow::uint8(), list_size);
+    } else if constexpr (std::same_as<T, uint16_t>) {
+      return typeGenerator(arrow::uint16(), list_size);
+    } else if constexpr (std::same_as<T, uint32_t>) {
+      return typeGenerator(arrow::uint32(), list_size);
+    } else if constexpr (std::same_as<T, uint64_t>) {
+      return typeGenerator(arrow::uint64(), list_size);
+    } else if constexpr (std::same_as<T, int8_t>) {
+      return typeGenerator(arrow::int8(), list_size);
+    } else if constexpr (std::same_as<T, int16_t>) {
+      return typeGenerator(arrow::int16(), list_size);
+    } else if constexpr (std::same_as<T, int32_t>) {
+      return typeGenerator(arrow::int32(), list_size);
+    } else if constexpr (std::same_as<T, int64_t>) {
+      return typeGenerator(arrow::int64(), list_size);
+    } else if constexpr (std::same_as<T, float>) {
+      return typeGenerator(arrow::float32(), list_size);
+    } else if constexpr (std::same_as<T, double>) {
+      return typeGenerator(arrow::float64(), list_size);
+    }
+  } else if constexpr (std::is_bounded_array_v<T>) {
+    return asArrowDataType<array_element_t<T>>(std::extent_v<T>);
+  } else if constexpr (o2::framework::is_specialization_v<T, std::vector>) {
+    return asArrowDataType<typename T::value_type>(-1);
+  }
+  return nullptr;
+}
 } // namespace o2::soa
 #endif // O2_FRAMEWORK_ARROWTYPES_H

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -192,6 +192,7 @@ struct Spawnable {
     iws.clear();
     iws.str(loc->defaultValue.get<std::string>());
     outputSchema = ArrowJSONHelpers::read(iws);
+    o2::framework::addLabelToSchema(outputSchema, binding.c_str());
 
     std::vector<std::shared_ptr<arrow::Schema>> schemas;
     for (auto& i : spec.metadata) {
@@ -236,7 +237,6 @@ struct Spawnable {
 
   Maker createMaker() const
   {
-    o2::framework::addLabelToSchema(outputSchema, binding.c_str());
     return {
       binding,
       labels,

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -195,10 +195,11 @@ struct Spawnable {
 
     std::vector<std::shared_ptr<arrow::Schema>> schemas;
     for (auto& i : spec.metadata) {
-      if (i.name.starts_with("input:")) {
-        labels.emplace_back(i.name.substr(6));
+      if (i.name.starts_with("input-schema:")) {
+        labels.emplace_back(i.name.substr(13));
         iws.clear();
-        iws.str(i.defaultValue.get<std::string>());
+        auto json = i.defaultValue.get<std::string>();
+        iws.str(json);
         schemas.emplace_back(ArrowJSONHelpers::read(iws));
       }
     }

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -143,13 +143,14 @@ struct Maker {
   std::vector<std::string> labels;
   std::vector<std::shared_ptr<gandiva::Expression>> expressions;
   std::shared_ptr<gandiva::Projector> projector = nullptr;
-  std::shared_ptr<arrow::Schema> schema;
+  std::shared_ptr<arrow::Schema> schema = nullptr;
+  std::shared_ptr<arrow::Schema> inputSchema = nullptr;
 
   header::DataOrigin origin;
   header::DataDescription description;
   header::DataHeader::SubSpecificationType version;
 
-  std::shared_ptr<arrow::Table> make(ProcessingContext& pc)
+  std::shared_ptr<arrow::Table> make(ProcessingContext& pc) const
   {
     std::vector<std::shared_ptr<arrow::Table>> originals;
     for (auto const& label : labels) {
@@ -158,15 +159,6 @@ struct Maker {
     auto fullTable = soa::ArrowHelpers::joinTables(std::move(originals), std::span{labels.begin(), labels.size()});
     if (fullTable->num_rows() == 0) {
       return arrow::Table::MakeEmpty(schema).ValueOrDie();
-    }
-    if (projector == nullptr) {
-      auto s = gandiva::Projector::Make(
-        fullTable->schema(),
-        expressions,
-        &projector);
-      if (!s.ok()) {
-        throw o2::framework::runtime_error_f("Failed to create projector: %s", s.ToString().c_str());
-      }
     }
 
     return spawnerHelper(fullTable, schema, binding.c_str(), schema->num_fields(), projector);
@@ -201,23 +193,18 @@ struct Spawnable {
     iws.str(loc->defaultValue.get<std::string>());
     outputSchema = ArrowJSONHelpers::read(iws);
 
+    std::vector<std::shared_ptr<arrow::Schema>> schemas;
     for (auto& i : spec.metadata) {
       if (i.name.starts_with("input:")) {
         labels.emplace_back(i.name.substr(6));
+        iws.clear();
+        iws.str(i.defaultValue.get<std::string>());
+        schemas.emplace_back(ArrowJSONHelpers::read(iws));
       }
     }
-
     std::vector<std::shared_ptr<arrow::Field>> fields;
-    for (auto& p : projectors) {
-      expressions::walk(p.node.get(),
-                        [&fields](expressions::Node* n) mutable {
-                          if (n->self.index() == 1) {
-                            auto& b = std::get<expressions::BindingNode>(n->self);
-                            if (std::find_if(fields.begin(), fields.end(), [&b](std::shared_ptr<arrow::Field> const& field) { return field->name() == b.name; }) == fields.end()) {
-                              fields.emplace_back(std::make_shared<arrow::Field>(b.name, expressions::concreteArrowType(b.type)));
-                            }
-                          }
-                        });
+    for (auto& s : schemas) {
+      std::copy(s->fields().begin(), s->fields().end(), std::back_inserter(fields));
     }
     inputSchema = std::make_shared<arrow::Schema>(fields);
 
@@ -233,20 +220,29 @@ struct Spawnable {
     }
   }
 
-  std::shared_ptr<gandiva::Projector> makeProjector()
+  std::shared_ptr<gandiva::Projector> makeProjector() const
   {
-    return expressions::createProjectorHelper(projectors.size(), projectors.data(), inputSchema, outputSchema->fields());
+    std::shared_ptr<gandiva::Projector> p = nullptr;
+    auto s = gandiva::Projector::Make(
+      inputSchema,
+      expressions,
+      &p);
+    if (!s.ok()) {
+      throw o2::framework::runtime_error_f("Failed to create projector: %s", s.ToString().c_str());
+    }
+    return p;
   }
 
-  Maker createMaker()
+  Maker createMaker() const
   {
     o2::framework::addLabelToSchema(outputSchema, binding.c_str());
     return {
       binding,
       labels,
       expressions,
-      nullptr,
+      makeProjector(),
       outputSchema,
+      inputSchema,
       origin,
       description,
       version};

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -35,7 +35,7 @@ std::string serializeProjectors(std::vector<framework::expressions::Projector>& 
   return osm.str();
 }
 
-std::string serializeSchema(std::shared_ptr<arrow::Schema>& schema)
+std::string serializeSchema(std::shared_ptr<arrow::Schema> schema)
 {
   std::stringstream osm;
   ArrowJSONHelpers::write(osm, schema);

--- a/Framework/Core/src/AnalysisSupportHelpers.cxx
+++ b/Framework/Core/src/AnalysisSupportHelpers.cxx
@@ -219,7 +219,6 @@ void AnalysisSupportHelpers::addMissingOutputsToAnalysisCCDBFetcher(
     // FIXME: good enough for now...
     for (auto& i : input.metadata) {
       if ((i.type == VariantType::String) && (i.name.find("input:") != std::string::npos)) {
-        auto value = i.defaultValue.get<std::string>();
         auto spec = DataSpecUtils::fromMetadataString(i.defaultValue.get<std::string>());
         auto j = std::find_if(publisher.inputs.begin(), publisher.inputs.end(), [&](auto x) { return x.binding == spec.binding; });
         if (j == publisher.inputs.end()) {

--- a/Framework/Core/src/ExpressionJSONHelpers.cxx
+++ b/Framework/Core/src/ExpressionJSONHelpers.cxx
@@ -637,6 +637,18 @@ void o2::framework::ExpressionJSONHelpers::write(std::ostream& o, std::vector<o2
 
 namespace
 {
+std::shared_ptr<arrow::DataType> arrowDataTypeFromId(atype::type type, int list_size = 1, atype::type element = atype::NA)
+{
+  switch (list_size) {
+    case -1:
+      return arrow::list(expressions::concreteArrowType(element));
+    case 1:
+      return expressions::concreteArrowType(type);
+    default:
+      return arrow::fixed_size_list(expressions::concreteArrowType(element), list_size);
+  }
+}
+
 struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, SchemaReader> {
   using Ch = rapidjson::UTF8<>::Ch;
   using SizeType = rapidjson::SizeType;
@@ -658,6 +670,8 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
 
   std::string name;
   atype::type type;
+  atype::type element;
+  int list_size = 1;
 
   SchemaReader()
   {
@@ -706,6 +720,12 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
       if (currentKey.compare("type") == 0) {
         return true;
       }
+      if (currentKey.compare("size") == 0) {
+        return true;
+      }
+      if (currentKey.compare("element") == 0) {
+        return true;
+      }
     }
 
     states.push(State::IN_ERROR);
@@ -721,6 +741,9 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
 
     if (states.top() == State::IN_LIST) {
       states.push(State::IN_FIELD);
+      list_size = 1;
+      element = atype::NA;
+      type = atype::NA;
       return true;
     }
 
@@ -734,7 +757,7 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
     if (states.top() == State::IN_FIELD) {
       states.pop();
       // add a field
-      fields.emplace_back(std::make_shared<arrow::Field>(name, expressions::concreteArrowType(type)));
+      fields.emplace_back(std::make_shared<arrow::Field>(name, arrowDataTypeFromId(type, list_size, element)));
       return true;
     }
 
@@ -752,6 +775,14 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
     if (states.top() == State::IN_FIELD) {
       if (currentKey.compare("type") == 0) {
         type = (atype::type)i;
+        return true;
+      }
+      if (currentKey.compare("element") == 0) {
+        element = (atype::type)i;
+        return true;
+      }
+      if (currentKey.compare("size") == 0) {
+        list_size = i;
         return true;
       }
     }
@@ -777,6 +808,10 @@ struct SchemaReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, Sch
   bool Int(int i)
   {
     debug << "Int(" << i << ")" << std::endl;
+    if (states.top() == State::IN_FIELD && currentKey.compare("size") == 0) {
+      list_size = i;
+      return true;
+    }
     return Uint(i);
   }
 };
@@ -791,7 +826,7 @@ std::shared_ptr<arrow::Schema> o2::framework::ArrowJSONHelpers::read(std::istrea
   bool ok = reader.Parse(isw, sreader);
 
   if (!ok) {
-    throw framework::runtime_error_f("Cannot parse serialized Expression, error: %s at offset: %d", rapidjson::GetParseError_En(reader.GetParseErrorCode()), reader.GetErrorOffset());
+    throw framework::runtime_error_f("Cannot parse serialized Schema, error: %s at offset: %d", rapidjson::GetParseError_En(reader.GetParseErrorCode()), reader.GetErrorOffset());
   }
   return sreader.schema;
 }
@@ -804,6 +839,20 @@ void writeSchema(rapidjson::Writer<rapidjson::OStreamWrapper>& w, arrow::Schema*
     w.StartObject();
     w.Key("name");
     w.String(f->name().c_str());
+    auto fixedList = dynamic_cast<arrow::FixedSizeListType*>(f->type().get());
+    if (fixedList != nullptr) {
+      w.Key("size");
+      w.Int(fixedList->list_size());
+      w.Key("element");
+      w.Int(fixedList->field(0)->type()->id());
+    }
+    auto varList = dynamic_cast<arrow::ListType*>(f->type().get());
+    if (varList != nullptr) {
+      w.Key("size");
+      w.Int(-1);
+      w.Key("element");
+      w.Int(varList->field(0)->type()->id());
+    }
     w.Key("type");
     w.Int(f->type()->id());
     w.EndObject();

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -454,4 +454,34 @@ TEST_CASE("TestExpressionSerialization")
   ism.str(osm.str());
   auto newSchemap = ArrowJSONHelpers::read(ism);
   REQUIRE(schemap->ToString() == newSchemap->ToString());
+
+  osm.clear();
+  osm.str("");
+  ArrowJSONHelpers::write(osm, schemap1);
+
+  ism.clear();
+  ism.str(osm.str());
+  auto newSchemap1 = ArrowJSONHelpers::read(ism);
+  REQUIRE(schemap1->ToString() == newSchemap1->ToString());
+
+  osm.clear();
+  osm.str("");
+  auto realisticSchema = std::make_shared<arrow::Schema>(o2::soa::createFieldsFromColumns(o2::aod::MetadataTrait<o2::aod::Hash<"HMPID/1"_h>>::metadata::persistent_columns_t{}));
+  ArrowJSONHelpers::write(osm, realisticSchema);
+
+  ism.clear();
+  ism.str(osm.str());
+  auto restoredSchema = ArrowJSONHelpers::read(ism);
+  REQUIRE(realisticSchema->ToString() == restoredSchema->ToString());
+
+  osm.clear();
+  osm.str("");
+  auto realisticSchema1 = std::make_shared<arrow::Schema>(o2::soa::createFieldsFromColumns(o2::aod::MetadataTrait<o2::aod::Hash<"ZDC/1"_h>>::metadata::persistent_columns_t{}));
+  ArrowJSONHelpers::write(osm, realisticSchema1);
+
+  ism.clear();
+  ism.str(osm.str());
+  auto restoredSchema1 = ArrowJSONHelpers::read(ism);
+  REQUIRE(realisticSchema1->ToString() == restoredSchema1->ToString());
+
 }

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -483,5 +483,4 @@ TEST_CASE("TestExpressionSerialization")
   ism.str(osm.str());
   auto restoredSchema1 = ArrowJSONHelpers::read(ism);
   REQUIRE(realisticSchema1->ToString() == restoredSchema1->ToString());
-
 }


### PR DESCRIPTION
* Support fixed- and variable-size columns when converting to `arrow::Field`
* Add the table schema to its relevant `InputSpec` to support creating empty tables directly
* Add the schemas of tables used as a sources for a generated table in its `InputSpec` metadata
* Add serialization/deserialization for the list-type fields
* Add test for the realistic data model table schemas