### PR TITLE
Generalize IR setting

### DIFF
--- a/Steer/src/CollisionContextTool.cxx
+++ b/Steer/src/CollisionContextTool.cxx
@@ -556,8 +556,10 @@ int main(int argc, char* argv[])
   float sgnIRate = -1.;
   for (auto& p : ispecs) {
     prefixes.push_back(p.name);
-    if (p.name == "sgn") {
-      // Setting interaction rate in the digitizer context as provided by the O2DPG workflow
+    // Set the interaction rate from the first pattern with a valid value.
+    // This handles both simple signal-only productions (where "sgn" has the rate)
+    // and embedding productions (where "bkg" has the rate and "sgn" syncs to it)
+    if (sgnIRate < 0 && p.interactionRate > 0) {
       LOG(debug) << "Setting signal interaction rate to " << p.interactionRate << " Hz in the digitization context.";
       sgnIRate = p.interactionRate;
       digicontext.setDigitizerInteractionRate(p.interactionRate);


### PR DESCRIPTION
New IR rate setting method picks the first valid value of the patterns provided making it work both in the signal-only case and in productions with embedding. 