### PR TITLE
ITS: GPU: reverse destruction order to fix crash

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainITS.cxx
+++ b/GPU/GPUTracking/Global/GPUChainITS.cxx
@@ -30,11 +30,11 @@ class GPUFrameworkExternalAllocator final : public o2::its::ExternalAllocator
     return mFWReco->AllocateDirectMemory(size, mType);
   }
   void deallocate(char* ptr, size_t size) final {} // this is a simple no-op
-  void pushTagOnStack(uint64_t tag)
+  void pushTagOnStack(uint64_t tag) final
   {
     mFWReco->PushNonPersistentMemory(tag);
   }
-  void popTagOffStack(uint64_t tag)
+  void popTagOffStack(uint64_t tag) final
   {
     mFWReco->PopNonPersistentMemory(GPUDataTypes::RecoStep::ITSTracking, tag);
   }
@@ -45,11 +45,7 @@ class GPUFrameworkExternalAllocator final : public o2::its::ExternalAllocator
 };
 } // namespace o2::its
 
-GPUChainITS::~GPUChainITS()
-{
-  mITSTrackerTraits.reset();
-  mITSVertexerTraits.reset();
-}
+GPUChainITS::~GPUChainITS() = default;
 
 GPUChainITS::GPUChainITS(GPUReconstruction* rec) : GPUChain(rec) {}
 

--- a/GPU/GPUTracking/Global/GPUChainITS.h
+++ b/GPU/GPUTracking/Global/GPUChainITS.h
@@ -34,7 +34,7 @@ class GPUChainITS final : public GPUChain
   friend class GPUReconstruction;
 
  public:
-  ~GPUChainITS() override;
+  ~GPUChainITS() final;
   int32_t Init() override;
   int32_t PrepareEvent() override;
   int32_t Finalize() override;
@@ -50,10 +50,10 @@ class GPUChainITS final : public GPUChain
 
  protected:
   GPUChainITS(GPUReconstruction* rec);
+  std::unique_ptr<o2::its::GPUFrameworkExternalAllocator> mFrameworkAllocator;
+  std::unique_ptr<o2::its::TimeFrame<7>> mITSTimeFrame;
   std::unique_ptr<o2::its::TrackerTraits<7>> mITSTrackerTraits;
   std::unique_ptr<o2::its::VertexerTraits<7>> mITSVertexerTraits;
-  std::unique_ptr<o2::its::TimeFrame<7>> mITSTimeFrame;
-  std::unique_ptr<o2::its::GPUFrameworkExternalAllocator> mFrameworkAllocator;
 };
 } // namespace o2::gpu
 


### PR DESCRIPTION
Fixes crashes in the GPU test:
```
[1172:gpu-reconstruction_t1]: *** Program crashed (Segmentation fault)
[1172:gpu-reconstruction_t1]: Backtrace by DPL:
[1172:gpu-reconstruction_t1]: Executable is /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/bin/o2-gpu-reco-workflow
[1172:gpu-reconstruction_t1]:     /lib64/libc.so.6:     ?? ??:0
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2ITStracking.so: o2::its::ExternalAllocatorAdaptor::do_deallocate(void*, unsigned long, unsign
ed long)
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2ITStracking.so: o2::its::BoundedMemoryResource::do_deallocate(void*, unsigned long, unsigned 
long)
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUTracking.so: o2::its::TimeFrame<7>::~TimeFrame()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUTrackingHIP.so: o2::its::gpu::TimeFrameGPU<7>::~TimeFrameGPU()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUTracking.so: o2::gpu::GPUChainITS::~GPUChainITS()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUTracking.so: o2::gpu::GPUChainITS::~GPUChainITS()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUTracking.so: o2::gpu::GPUReconstruction::Exit()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUO2Interface.so: o2::gpu::GPUO2Interface::Deinitialize()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUO2Interface.so: o2::gpu::GPUO2Interface::~GPUO2Interface()
[1172:gpu-reconstruction_t1]:     /cvmfs/alice.cern.ch/el9-x86_64/Packages/O2/daily-20251126-0000-1/lib/libO2GPUWorkflow.so: o2::gpu::GPURecoWorkflowSpec::deinitialize()
[1172:gpu-reconstruction_t1]:     o2-gpu-reco-workflow() [0x41364e]:     _Z23callWorkflowTerminationISt8functionIFvPKcEEQrQRT__Xcl9customizefp_EEEvS6_S2_ at runDataProcessing.h:158
[1172:gpu-reconstruction_t1]:     /lib64/libc.so.6:     ?? ??:0
[1172:gpu-reconstruction_t1]:     /lib64/libc.so.6:     ?? ??:0
[1172:gpu-reconstruction_t1]:     o2-gpu-reco-workflow() [0x413b65]:     _start at ??:?
[1172:gpu-reconstruction_t1]: Backtrace complete.
[ERROR] Workflow crashed - PID 1172 (gpu-reconstruction_t1) did not exit correctly however it's not clear why. Exit code forced to 128.
```

The issue is that after #14681, I relied on the framework pointer being around when calling the TimeFrame destructor, which is fine when using the gpu framework held by the its reco workflow (`o2-its-reco-workflow --use-gpu-workflow`). However, running in the real gpu-reco-workflow this is not the case. The framework allocator was destructed before the destructor of the TimeFrame was called (c++ clears them in reverse member declaration order). The solution is simply to reverse the member order.