### PR TITLE
Use new User Agent in CCDB

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -40,13 +40,13 @@
 #include <algorithm>
 #include <filesystem>
 #include <boost/algorithm/string.hpp>
-#include <boost/asio/ip/host_name.hpp>
 #include <iostream>
 #include <mutex>
 #include <boost/interprocess/sync/named_semaphore.hpp>
 #include <regex>
 #include <cstdio>
 #include <string>
+#include <TAlienUserAgent.h>
 #include <unordered_set>
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -117,13 +117,7 @@ CcdbApi::~CcdbApi()
 
 void CcdbApi::setUniqueAgentID()
 {
-  std::string host = boost::asio::ip::host_name();
-  char const* jobID = getenv("ALIEN_PROC_ID");
-  if (jobID) {
-    mUniqueAgentID = fmt::format("{}-{}-{}-{}", host, getCurrentTimestamp() / 1000, o2::utils::Str::getRandomString(6), jobID);
-  } else {
-    mUniqueAgentID = fmt::format("{}-{}-{}", host, getCurrentTimestamp() / 1000, o2::utils::Str::getRandomString(6));
-  }
+  mUniqueAgentID = TAlienUserAgent::BasedOnEnvironment().ToString();
 }
 
 bool CcdbApi::checkAlienToken()


### PR DESCRIPTION
This changes the HTTP User Agent that is used when accessing CCDB. 
The changes come from the libjalienO2 library.
 
For more details see [this merge request](https://gitlab.cern.ch/jalien/libjalieno2/-/merge_requests/4).

~~Waiting for the new tag to be picked up alisw/alidist#6048~~
It has now been approved