### PR TITLE
Add possibility for headers only object

### DIFF
--- a/CCDB/src/UploadTool.cxx
+++ b/CCDB/src/UploadTool.cxx
@@ -147,33 +147,41 @@ int main(int argc, char* argv[])
     meta[p.first] = p.second;
   }
 
-  TFile f(filename.c_str());
-  auto key = f.GetKey(keyname.c_str());
-  if (key) {
-    // get type of key
-    auto classname = key->GetClassName();
-    auto tcl = TClass::GetClass(classname);
-    auto object = f.Get<void>(keyname.c_str());
-    if (tcl->InheritsFrom("TTree")) {
-      auto tree = static_cast<TTree*>(object);
-      tree->LoadBaskets(0x1L << 32); // make tree memory based
-      tree->SetDirectory(nullptr);
-    }
-    // convert classname to typeinfo
-    // typeinfo
-    auto ti = tcl->GetTypeInfo();
-
-    std::cout << " Uploading an object of type " << key->GetClassName()
-              << " to path " << path << " with timestamp validity from " << starttimestamp
-              << " to " << endtimestamp << "\n";
-
-    api.storeAsTFile_impl(object, *ti, path, meta, starttimestamp, endtimestamp);
+  if (filename == "headersOnly") {
+    api.storeAsBinaryFile(nullptr, 0, "ignored", "", path, meta, starttimestamp, endtimestamp);
     if (!api.isSnapshotMode() && meta.find("adjustableEOV") != meta.end() && meta.find("default") == meta.end()) {
-      o2::ccdb::CcdbObjectInfo oi(path, classname, filename, meta, starttimestamp, endtimestamp);
+      o2::ccdb::CcdbObjectInfo oi(path, "", "", meta, starttimestamp, endtimestamp);
       o2::ccdb::adjustOverriddenEOV(api, oi);
     }
   } else {
-    std::cerr << "Key " << keyname << " does not exist\n";
+    TFile f(filename.c_str());
+    auto key = f.GetKey(keyname.c_str());
+    if (key) {
+      // get type of key
+      auto classname = key->GetClassName();
+      auto tcl = TClass::GetClass(classname);
+      auto object = f.Get<void>(keyname.c_str());
+      if (tcl->InheritsFrom("TTree")) {
+        auto tree = static_cast<TTree*>(object);
+        tree->LoadBaskets(0x1L << 32); // make tree memory based
+        tree->SetDirectory(nullptr);
+      }
+      // convert classname to typeinfo
+      // typeinfo
+      auto ti = tcl->GetTypeInfo();
+
+      std::cout << " Uploading an object of type " << key->GetClassName()
+                << " to path " << path << " with timestamp validity from " << starttimestamp
+                << " to " << endtimestamp << "\n";
+
+      api.storeAsTFile_impl(object, *ti, path, meta, starttimestamp, endtimestamp);
+      if (!api.isSnapshotMode() && meta.find("adjustableEOV") != meta.end() && meta.find("default") == meta.end()) {
+        o2::ccdb::CcdbObjectInfo oi(path, classname, filename, meta, starttimestamp, endtimestamp);
+        o2::ccdb::adjustOverriddenEOV(api, oi);
+      }
+    } else {
+      std::cerr << "Key " << keyname << " does not exist\n";
+    }
   }
 
   return 0;


### PR DESCRIPTION
In case the file name is set to 'headersOnly' an empty object with only headers is created. This is e.g. necessary for pure redirect entries.