### PR TITLE
TPC_MC_anchoring_simple: Added per region relative gas gain to simulate the change in the voltage settings of GEMs

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/ParameterGEM.h
+++ b/Detectors/TPC/base/include/TPCBase/ParameterGEM.h
@@ -54,6 +54,7 @@ struct ParameterGEM : public o2::conf::ConfigurableParamHelper<ParameterGEM> {
   float AbsoluteGain[4] = {14.f, 8.f, 53.f, 240.f};              ///< Absolute gain
   float CollectionEfficiency[4] = {1.f, 0.2f, 0.25f, 1.f};       ///< Collection efficiency
   float ExtractionEfficiency[4] = {0.65f, 0.55f, 0.12f, 0.6f};   ///< Extraction efficiency
+  float RelativeGainStack[4] = {1.f, 1.f, 1.f, 1.f};             ///< Relative gain of the stack per region (IROC, OROC1, OROC2, OROC3) for the EffectiveMode
   float TotalGainStack = 2000.f;                                 ///< Total gain of the stack for the EffectiveMode
   float KappaStack = 1.205f;                                     ///< Variable steering the energy resolution of the full stack for the EffectiveMode
   float EfficiencyStack = 0.528f;                                ///< Variable steering the single electron efficiency of the full stack for the EffectiveMode

--- a/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
@@ -118,8 +118,10 @@ inline int GEMAmplification::getStackAmplification(const CRU& cru, const PadPos&
       break;
     }
     case AmplificationMode::EffectiveMode: {
+      const int region = static_cast<int>(cru.gemStack());
+      const float relativeGain = mGEMParam->RelativeGainStack[region];
       return static_cast<int>(static_cast<float>(getEffectiveStackAmplification(nElectrons)) *
-                              mGainMap->getValue(cru, pos.getRow(), pos.getPad()));
+                              mGainMap->getValue(cru, pos.getRow(), pos.getPad()) * relativeGain);
       break;
     }
   }


### PR DESCRIPTION
Added per region (IROC, OROC1, OROC2, OROC3) relative gas gain to the effective mode of amplification process by simply scaling the outcome of the amplification process. This is done to simulate the change in voltage settings of GEMs in 2024 and 2025.