### PR TITLE
Cleanup jobutils2 to work on ARM

### DIFF
--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -396,8 +396,8 @@ getNumberOfPhysicalCPUCores() {
   else
     # Do something under GNU/Linux platform
     #
-    # Notice the human readable output of lscpu depends on the version and wether or not you
-    # are inside a container. The following should be more stable.
+# Gets the cores per socket by counting unique cores on socket 0.
+# Gets sockets by counting unique socket ids. The grepping is done in any case  to avoid matching comments. 
     CORESPERSOCKET=$(lscpu -p=cpu,socket | grep "^[0-9]\+,0" | sort | uniq | wc -l)
     SOCKETS=$(lscpu -p=socket | grep -e "^[0-9]" | sort | uniq | wc -l)
   fi

--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -396,8 +396,8 @@ getNumberOfPhysicalCPUCores() {
   else
     # Do something under GNU/Linux platform
     #
-# Gets the cores per socket by counting unique cores on socket 0.
-# Gets sockets by counting unique socket ids. The grepping is done in any case  to avoid matching comments. 
+    # Gets the cores per socket by counting unique cores on socket 0.
+    # Gets sockets by counting unique socket ids. The grepping is done in any case  to avoid matching comments. 
     CORESPERSOCKET=$(lscpu -p=cpu,socket | grep "^[0-9]\+,0" | sort | uniq | wc -l)
     SOCKETS=$(lscpu -p=socket | grep -e "^[0-9]" | sort | uniq | wc -l)
   fi

--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -395,10 +395,13 @@ getNumberOfPhysicalCPUCores() {
     fi
   else
     # Do something under GNU/Linux platform
-    CORESPERSOCKET=`lscpu | grep "Core(s) per socket" | awk '{print $4}'`
-    SOCKETS=`lscpu | grep "Socket(s)" | awk '{print $2}'`
+    #
+    # Notice the human readable output of lscpu depends on the version and wether or not you
+    # are inside a container. The following should be more stable.
+    CORESPERSOCKET=$(lscpu -p=cpu,socket | grep ,0 | sort | uniq | wc -l)
+    SOCKETS=$(lscpu -p=socket | grep -e "^[0-9]" | sort | uniq | wc -l)
   fi
-  N=`bc <<< "${CORESPERSOCKET}*${SOCKETS}"`
+  N=$((${CORESPERSOCKET}*${SOCKETS}))
   echo "${N}"
 }
 

--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -398,7 +398,7 @@ getNumberOfPhysicalCPUCores() {
     #
     # Notice the human readable output of lscpu depends on the version and wether or not you
     # are inside a container. The following should be more stable.
-    CORESPERSOCKET=$(lscpu -p=cpu,socket | grep ,0 | sort | uniq | wc -l)
+    CORESPERSOCKET=$(lscpu -p=cpu,socket | grep "^[0-9]\+,0" | sort | uniq | wc -l)
     SOCKETS=$(lscpu -p=socket | grep -e "^[0-9]" | sort | uniq | wc -l)
   fi
   N=$((${CORESPERSOCKET}*${SOCKETS}))

--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -397,7 +397,7 @@ getNumberOfPhysicalCPUCores() {
     # Do something under GNU/Linux platform
     #
     # Gets the cores per socket by counting unique cores on socket 0.
-    # Gets sockets by counting unique socket ids. The grepping is done in any case  to avoid matching comments. 
+    # Gets sockets by counting unique socket ids. The grepping is done in any case  to avoid matching comments.
     CORESPERSOCKET=$(lscpu -p=cpu,socket | grep "^[0-9]\+,0" | sort | uniq | wc -l)
     SOCKETS=$(lscpu -p=socket | grep -e "^[0-9]" | sort | uniq | wc -l)
   fi


### PR DESCRIPTION

* Avoid dependency on bc for a multiplication
* Make sure the CPU detection does not depend on the lscpu
  human readable output, which is apparently dependent on version /
  presence of a container.
