### PR TITLE
TPC: Use CTP as fallback if no IDCs are available

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CorrectionMapsLoader.h
@@ -79,6 +79,7 @@ class CorrectionMapsLoader : public o2::gpu::CorrectionMapsHelper
   float mInstLumiCTPFactor = 1.0; // multiplicative factor for inst. lumi
   int mLumiCTPSource = 0;         // 0: main, 1: alternative CTP lumi source
   std::unique_ptr<o2::gpu::TPCFastTransform> mCorrMapMShape{nullptr};
+  bool mIDC2CTPFallbackActive = false; // flag indicating that fallback from IDC to CTP scaling is active
 #endif
 };
 

--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -61,16 +61,8 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
       if (canUseCTPScaling) {
         LOGP(info, "Invalid TPC scaler value {} received for IDC-based scaling! Using CTP fallback", tpcScaler);
         mIDC2CTPFallbackActive = true;
-        if (std::abs(getMeanLumi() - mCorrMap->getLumi()) > 1e-6f) {
-          // update only mean lumi if changed
-          setMeanLumi(mCorrMap->getLumi(), false);
-          setUpdatedMap();
-        }
-        if (std::abs(getMeanLumiRef() - mCorrMapRef->getLumi()) > 1e-6f) {
-          // update only mean lumi ref if changed
-          setMeanLumiRef(mCorrMapRef->getLumi());
-          setUpdatedMapRef();
-        }
+        setMeanLumi(mCorrMap->getLumi(), false);
+        setMeanLumiRef(mCorrMapRef->getLumi());
         setLumiScaleType(1);
       } else if (mCorrMap) {
         // CTP scaling is not possible, dont do any scaling to avoid applying wrong corrections
@@ -84,9 +76,7 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
         LOGP(info, "Valid TPC scaler value {} received, switching back to IDC-based scaling", tpcScaler);
         mIDC2CTPFallbackActive = false;
         setMeanLumi(mCorrMap->getIDC(), false);
-        setUpdatedMap();
         setMeanLumiRef(mCorrMapRef->getIDC());
-        setUpdatedMapRef();
         setLumiScaleType(2);
       }
       // correct IDC received

--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -53,6 +53,47 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
   o2::ctp::LumiInfo lumiObj;
   static o2::ctp::LumiInfo lumiPrev;
 
+  if (getLumiScaleType() == 2 || mIDC2CTPFallbackActive) {
+    float tpcScaler = pc.inputs().get<float>("tpcscaler");
+    // check if tpcScaler is valid and CTP fallback is allowed
+    if (tpcScaler == -1.f) {
+      const bool canUseCTPScaling = mCorrMap && mCorrMapRef && mCorrMap->isIDCSet() && mCorrMapRef->isIDCSet() && mCorrMap->isLumiSet() && mCorrMapRef->isLumiSet();
+      if (canUseCTPScaling) {
+        LOGP(info, "Invalid TPC scaler value {} received for IDC-based scaling! Using CTP fallback", tpcScaler);
+        mIDC2CTPFallbackActive = true;
+        if (std::abs(getMeanLumi() - mCorrMap->getLumi()) > 1e-6f) {
+          // update only mean lumi if changed
+          setMeanLumi(mCorrMap->getLumi(), false);
+          setUpdatedMap();
+        }
+        if (std::abs(getMeanLumiRef() - mCorrMapRef->getLumi()) > 1e-6f) {
+          // update only mean lumi ref if changed
+          setMeanLumiRef(mCorrMapRef->getLumi());
+          setUpdatedMapRef();
+        }
+        setLumiScaleType(1);
+      } else if (mCorrMap) {
+        // CTP scaling is not possible, dont do any scaling to avoid applying wrong corrections
+        const float storedIDC = mCorrMap->getIDC();
+        LOGP(warning, "Invalid TPC scaler value {} received for IDC-based scaling! CTP fallback not possible, using stored IDC of {} from the map to avoid applying wrong corrections", tpcScaler, storedIDC);
+        setInstLumi(storedIDC);
+      }
+    } else {
+      if (mIDC2CTPFallbackActive) {
+        // reset back to normal operation
+        LOGP(info, "Valid TPC scaler value {} received, switching back to IDC-based scaling", tpcScaler);
+        mIDC2CTPFallbackActive = false;
+        setMeanLumi(mCorrMap->getIDC(), false);
+        setUpdatedMap();
+        setMeanLumiRef(mCorrMapRef->getIDC());
+        setUpdatedMapRef();
+        setLumiScaleType(2);
+      }
+      // correct IDC received
+      setInstLumi(tpcScaler);
+    }
+  }
+
   if (getLumiCTPAvailable() && mInstCTPLumiOverride <= 0.) {
     if (pc.inputs().get<gsl::span<char>>("CTPLumi").size() == sizeof(o2::ctp::LumiInfo)) {
       lumiPrev = lumiObj = pc.inputs().get<o2::ctp::LumiInfo>("CTPLumi");
@@ -67,10 +108,7 @@ void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc)
       setInstLumi(getInstLumiCTP());
     }
   }
-  if (getLumiScaleType() == 2) {
-    float tpcScaler = pc.inputs().get<float>("tpcscaler");
-    setInstLumi(tpcScaler);
-  }
+
   if (getUseMShapeCorrection()) {
     LOGP(info, "Setting M-Shape map");
     const auto mapMShape = pc.inputs().get<o2::gpu::TPCFastTransform*>("mshape");
@@ -317,6 +355,7 @@ void CorrectionMapsLoader::copySettings(const CorrectionMapsLoader& src)
   mLumiCTPSource = src.mLumiCTPSource;
   mLumiScaleMode = src.mLumiScaleMode;
   mScaleInverse = src.getScaleInverse();
+  mIDC2CTPFallbackActive = src.mIDC2CTPFallbackActive;
 }
 
 void CorrectionMapsLoader::updateInverse()


### PR DESCRIPTION
This PR adds a fallback to CTP scaling in case the IDCs are missing. When IDCs are missing, the default IDC object is used, which is =-1. In that case a wrong scaling is applied.
Local test with few TFs looks good so far:
<img width="2285" height="744" alt="CTP_Fallback" src="https://github.com/user-attachments/assets/82803121-ba0f-4733-a6ef-51dbb92b7504" />
