### PR TITLE
ITSMFT: scaffolding for staggered digitization

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/src/ROFRecord.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ROFRecord.cxx
@@ -9,20 +9,22 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "DataFormatsITSMFT/ROFRecord.h"
 #include <iostream>
-#include "fmt/format.h"
+#include <format>
+
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "Framework/Logger.h"
 
 using namespace o2::itsmft;
 
 std::string ROFRecord::asString() const
 {
-  return fmt::format("ROF: {} | {} entries starting from {}", mROFrame, getNEntries(), getFirstEntry());
+  return std::format("ROF: {} | {} entries starting from {} | IR: {}", mROFrame, getNEntries(), getFirstEntry(), mBCData.asString());
 }
 
 void ROFRecord::print() const
 {
-  std::cout << this << "\n\t" << mBCData << std::endl;
+  LOG(info) << asString();
 }
 
 std::ostream& operator<<(std::ostream& stream, ROFRecord const& rec)
@@ -33,12 +35,12 @@ std::ostream& operator<<(std::ostream& stream, ROFRecord const& rec)
 
 std::string MC2ROFRecord::asString() const
 {
-  return fmt::format("MCEventID: {} ROFs: {}-{} Entry in ROFRecords: {}", eventRecordID, minROF, maxROF, rofRecordID);
+  return std::format("MCEventID: {} ROFs: {}-{} Entry in ROFRecords: {}", eventRecordID, minROF, maxROF, rofRecordID);
 }
 
 void MC2ROFRecord::print() const
 {
-  std::cout << this << std::endl;
+  LOG(info) << asString();
 }
 
 std::ostream& operator<<(std::ostream& stream, MC2ROFRecord const& rec)

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -176,7 +176,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   bool getChipId(int index, int& lay, int& hba, int& sta, int& ssta, int& mod, int& chip) const;
 
   /// Get chip layer, from 0
-  int getLayer(int index) const;
+  int getLayer(int index) const final;
 
   /// Get chip half barrel, from 0
   int getHalfBarrel(int index) const;
@@ -216,7 +216,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
     return getSymbolicName(getChipIndex(lay, hba, sta, det));
   }
 
-  /// Get the transformation matrix for a given chip (NOT A SENSOR!!!) 'index' by quering the TGeoManager
+  /// Get the transformation matrix for a given chip (NOT A SENSOR!!!) 'index' by querying the TGeoManager
   TGeoHMatrix* getMatrix(int index) const { return o2::base::GeometryManager::getMatrix(getDetID(), index); }
   TGeoHMatrix* getMatrix(int lay, int hba, int sta, int sens) const { return getMatrix(getChipIndex(lay, hba, sta, sens)); }
   bool getOriginalMatrix(int index, TGeoHMatrix& m) const
@@ -336,7 +336,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   TString getMatrixPath(int index) const;
 
   /// Get the transformation matrix of the SENSOR (not necessary the same as the chip)
-  /// for a given chip 'index' by quering the TGeoManager
+  /// for a given chip 'index' by querying the TGeoManager
   TGeoHMatrix* extractMatrixSensor(int index) const;
 
   // create matrix for transformation from sensor local frame to global one
@@ -407,7 +407,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   std::vector<int> mNumberOfChipsPerStave;      ///< number of chips per stave
   std::vector<int> mNumberOfChipsPerHalfBarrel; ///< number of chips per halfbarrel
   std::vector<int> mNumberOfChipsPerLayer;      ///< number of chips per stave
-  std::vector<int> mLastChipIndex;              ///< max ID of the detctor in the layer
+  std::vector<int> mLastChipIndex;              ///< max ID of the detector in the layer
   std::array<bool, MAXLAYERS> mIsLayerITS3;     ///< flag with the information of the ITS version (ITS2 or ITS3)
   std::array<char, MAXLAYERS> mLayerToWrapper;  ///< Layer to wrapper correspondence
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
@@ -95,7 +95,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   Int_t getSensorIndex(Int_t half, Int_t disk, Int_t ladder, Int_t sensor) const;
 
   /// get layer index (0:9) from the chip index
-  Int_t getLayer(Int_t index) const;
+  Int_t getLayer(Int_t index) const final;
 
   /// This routine computes the half, disk, ladder and sensor number
   /// given the sensor index number
@@ -122,7 +122,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   {
     return extractNumberOfDisks(half);
   }
-  /// Returns the number of halfs MFT
+  /// Returns the number of halves MFT
   Int_t getNumberOfHalfs()
   {
     return extractNumberOfHalves();
@@ -181,7 +181,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   Int_t extractVolumeCopy(const Char_t* name, const Char_t* prefix) const;
 
   /// Get the transformation matrix of the sensor [...]
-  /// for a given sensor 'index' by quering the TGeoManager
+  /// for a given sensor 'index' by querying the TGeoManager
   TGeoHMatrix* extractMatrixSensor(Int_t index) const;
 
   // Create matrix for transformation from sensor local frame to global one

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
@@ -26,17 +26,44 @@ constexpr float DEFStrobeDelay = o2::constants::lhc::LHCBunchSpacingNS * 4; // ~
 
 template <int N>
 struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<N>> {
+  static constexpr int getNLayers()
+  {
+    return N == o2::detectors::DetID::ITS ? 7 : 10;
+  }
 
   static constexpr std::string_view getParamName()
   {
     return N == o2::detectors::DetID::ITS ? ParamName[0] : ParamName[1];
   }
-  int roFrameLengthInBC = DEFROFLengthBC();           ///< ROF length in BC for continuos mode
-  float roFrameLengthTrig = DEFROFLengthTrig();       ///< length of RO frame in ns for triggered mode
-  float strobeDelay = DEFStrobeDelay;                 ///< strobe start (in ns) wrt ROF start
-  float strobeLengthCont = -1.;                       ///< if < 0, full ROF length - delay
-  float strobeLengthTrig = 100.;                      ///< length of the strobe in ns (sig. over threshold checked in this window only)
-  int roFrameBiasInBC = DEFROFBiasInBC();             ///< bias of the start of ROF wrt orbit start: t_irof = (irof*roFrameLengthInBC + roFrameBiasInBC)*BClengthMUS
+
+  int roFrameLengthInBC = DEFROFLengthBC();      ///< ROF length in BC for continuous mode
+  float roFrameLengthTrig = DEFROFLengthTrig();  ///< length of RO frame in ns for triggered mode
+  float strobeDelay = DEFStrobeDelay;            ///< strobe start (in ns) wrt ROF start
+  float strobeLengthCont = -1.;                  ///< if < 0, full ROF length - delay
+  float strobeLengthTrig = 100.;                 ///< length of the strobe in ns (sig. over threshold checked in this window only)
+  int roFrameBiasInBC = DEFROFBiasInBC();        ///< bias of the start of ROF wrt orbit start: t_irof = (irof*roFrameLengthInBC + roFrameBiasInBC)*BClengthMUS
+  int roFrameLayerLengthInBC[getNLayers()] = {}; ///< staggering ROF length in BC for continuous mode per layer
+  int roFrameLayerBiasInBC[getNLayers()] = {};   ///< staggering ROF bias in BC for continuous mode per layer
+  int roFrameLayerDelayInBC[getNLayers()] = {};  ///< staggering ROF delay in BC for continuous mode per layer
+
+  static constexpr bool supportsStaggering() noexcept { return (N == o2::detectors::DetID::ITS) ? false : false; }
+  // test if staggering is on
+  bool withStaggering() const noexcept
+  {
+    if constexpr (!supportsStaggering()) {
+      return false;
+    }
+    for (int i{0}; i < getNLayers(); ++i) {
+      if (roFrameLayerLengthInBC[i] != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+  // get ROF length for any layer
+  int getROFLengthInBC(int layer) const noexcept { return (withStaggering()) ? roFrameLayerLengthInBC[layer] : roFrameLengthInBC; }
+  int getROFBiasInBC(int layer) const noexcept { return (withStaggering()) ? roFrameLayerBiasInBC[layer] : roFrameBiasInBC; }
+  int getROFDelayInBC(int layer) const noexcept { return (withStaggering()) ? roFrameLayerDelayInBC[layer] : 0; }
 
   // boilerplate stuff + make principal key
   O2ParamDef(DPLAlpideParam, getParamName().data());
@@ -46,7 +73,7 @@ struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<
 
   static constexpr int DEFROFLengthBC()
   {
-    // default ROF length in BC for continuos mode
+    // default ROF length in BC for continuous mode
     // allowed values: 1,2,3,4,6,9,11,12,18,22,27,33,36
     return N == o2::detectors::DetID::ITS ? o2::constants::lhc::LHCMaxBunches / 4 : o2::constants::lhc::LHCMaxBunches / 18;
   }

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/GeometryTGeo.h
@@ -11,7 +11,7 @@
 
 /// \file GeometryTGeo.h
 /// \brief Definition of the GeometryTGeo class : common part for ITS and MFT
-/// \brief collects ITS and MFT common methods to acces matrices
+/// \brief collects ITS and MFT common methods to access matrices
 
 /// \author ruben.shahoyan@cern.ch
 #ifndef ALICEO2_ITSMFT_GEOMETRYTGEO_H_
@@ -37,7 +37,8 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   ~GeometryTGeo() override = default;
 
   Int_t getNumberOfChips() const { return mSize; }
-  /// build detector layout data, must be overriden by detector
+  virtual Int_t getLayer(Int_t index) const { return -1; };
+  /// build detector layout data, must be overridden by detector
   virtual void Build(int loadTrans) = 0;
 
   bool isOwner() const { return mOwner; }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
@@ -15,8 +15,10 @@
 #ifndef ALICEO2_ITSMFT_DIGIPARAMS_H
 #define ALICEO2_ITSMFT_DIGIPARAMS_H
 
+#include <vector>
+#include <algorithm>
 #include <Rtypes.h>
-#include <ITSMFTSimulation/AlpideSignalTrapezoid.h>
+#include "ITSMFTSimulation/AlpideSignalTrapezoid.h"
 #include "ITSMFTBase/DPLAlpideParam.h"
 
 ////////////////////////////////////////////////////////////
@@ -51,24 +53,24 @@ class DigiParams
   void setContinuous(bool v) { mIsContinuous = v; }
   bool isContinuous() const { return mIsContinuous; }
 
-  int getROFrameLengthInBC() const { return mROFrameLengthInBC; }
-  void setROFrameLengthInBC(int n) { mROFrameLengthInBC = n; }
+  int getROFrameLengthInBC(int layer = -1) const { return layer < 0 ? mROFrameLengthInBC : mROFrameLayerLengthInBC[layer]; }
+  void setROFrameLengthInBC(int n, int layer = -1) { layer < 0 ? mROFrameLengthInBC = n : mROFrameLayerLengthInBC[layer] = n; }
 
-  void setROFrameLength(float ns);
-  float getROFrameLength() const { return mROFrameLength; }
-  float getROFrameLengthInv() const { return mROFrameLengthInv; }
+  void setROFrameLength(float ns, int layer = -1);
+  float getROFrameLength(int layer = -1) const { return layer < 0 ? mROFrameLength : mROFrameLayerLength[layer]; }
+  float getROFrameLengthInv(int layer = -1) const { return layer < 0 ? mROFrameLengthInv : mROFrameLayerLengthInv[layer]; }
 
   void setStrobeDelay(float ns) { mStrobeDelay = ns; }
-  float getStrobeDelay() const { return mStrobeDelay; }
+  float getStrobeDelay(int layer = -1) const { return layer < 0 ? mStrobeDelay : mStrobeLayerDelay[layer]; }
 
   void setStrobeLength(float ns) { mStrobeLength = ns; }
-  float getStrobeLength() const { return mStrobeLength; }
+  float getStrobeLength(int layer = -1) const { return layer < 0 ? mStrobeLength : mStrobeLayerLength[layer]; }
 
   void setTimeOffset(double sec) { mTimeOffset = sec; }
   double getTimeOffset() const { return mTimeOffset; }
 
-  void setROFrameBiasInBC(int n) { mROFrameBiasInBC = n; }
-  int getROFrameBiasInBC() const { return mROFrameBiasInBC; }
+  void setROFrameBiasInBC(int n, int layer = -1) { layer < 0 ? mROFrameBiasInBC = n : mROFrameLayerBiasInBC[layer] = n; }
+  int getROFrameBiasInBC(int layer = -1) const { return layer < 0 ? mROFrameBiasInBC : mROFrameLayerBiasInBC[layer]; }
 
   void setChargeThreshold(int v, float frac2Account = 0.1);
   void setNSimSteps(int v);
@@ -96,13 +98,19 @@ class DigiParams
   const SignalShape& getSignalShape() const { return mSignalShape; }
   SignalShape& getSignalShape() { return (SignalShape&)mSignalShape; }
 
+  bool withStaggering() const noexcept { return !mROFrameLayerLength.empty(); }
+  void addROFrameLayerLengthInBC(int len) { mROFrameLayerLengthInBC.push_back(len); }
+  void addROFrameLayerBiasInBC(int len) { mROFrameLayerBiasInBC.push_back(len); }
+  void addStrobeLength(float ns) { mStrobeLayerLength.push_back(ns); }
+  void addStrobeDelay(float ns) { mStrobeLayerDelay.push_back(ns); }
+
   virtual void print() const;
 
  private:
   static constexpr double infTime = 1e99;
   bool mIsContinuous = false;              ///< flag for continuous simulation
   float mNoisePerPixel = 1.e-8;            ///< ALPIDE Noise per chip
-  int mROFrameLengthInBC = 0;              ///< ROF length in BC for continuos mode
+  int mROFrameLengthInBC = 0;              ///< ROF length in BC for continuous mode
   float mROFrameLength = 0;                ///< length of RO frame in ns
   float mStrobeDelay = 0.;                 ///< strobe start (in ns) wrt ROF start
   float mStrobeLength = 0;                 ///< length of the strobe in ns (sig. over threshold checked in this window only)
@@ -115,17 +123,24 @@ class DigiParams
 
   float mVbb = 0.0;   ///< back bias absolute value for MFT (in Volt)
   float mIBVbb = 0.0; ///< back bias absolute value for ITS Inner Barrel (in Volt)
-  float mOBVbb = 0.0; ///< back bias absolute value for ITS Outter Barrel (in Volt)
+  float mOBVbb = 0.0; ///< back bias absolute value for ITS Outer Barrel (in Volt)
+
+  std::vector<int> mROFrameLayerLengthInBC; ///< staggering ROF length in BC for continuous mode per layer
+  std::vector<int> mROFrameLayerBiasInBC;   ///< staggering ROF bias in BC for continuous mode per layer
+  std::vector<float> mROFrameLayerLength;   ///< staggering ROF length in ns for continuous mode per layer
+  std::vector<float> mStrobeLayerLength;    ///< staggering length of the strobe in ns (sig. over threshold checked in this window only)
+  std::vector<float> mStrobeLayerDelay;     ///< staggering delay of the strobe in ns
 
   o2::itsmft::AlpideSignalTrapezoid mSignalShape; ///< signal timeshape parameterization
 
   const o2::itsmft::AlpideSimResponse* mAlpSimResponse = nullptr; //!< pointer on external response
 
   // auxiliary precalculated parameters
-  float mROFrameLengthInv = 0; ///< inverse length of RO frame in ns
-  float mNSimStepsInv = 0;     ///< its inverse
+  float mROFrameLengthInv = 0;               ///< inverse length of RO frame in ns
+  std::vector<float> mROFrameLayerLengthInv; // inverse length of RO frame in ns per layer
+  float mNSimStepsInv = 0;                   ///< its inverse
 
-  ClassDef(DigiParams, 2);
+  ClassDef(DigiParams, 3);
 };
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -49,6 +49,8 @@ class Digitizer : public TObject
 
  public:
   Digitizer() = default;
+  Digitizer(Digitizer&&) = delete;
+  Digitizer& operator=(Digitizer&&) = delete;
   ~Digitizer() override = default;
   Digitizer(const Digitizer&) = delete;
   Digitizer& operator=(const Digitizer&) = delete;
@@ -56,7 +58,7 @@ class Digitizer : public TObject
   void setDigits(std::vector<o2::itsmft::Digit>* dig) { mDigits = dig; }
   void setMCLabels(o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mclb) { mMCLabels = mclb; }
   void setROFRecords(std::vector<o2::itsmft::ROFRecord>* rec) { mROFRecords = rec; }
-  o2::itsmft::DigiParams& getParams() { return (o2::itsmft::DigiParams&)mParams; }
+  o2::itsmft::DigiParams& getParams() { return mParams; }
   const o2::itsmft::DigiParams& getParams() const { return mParams; }
   void setNoiseMap(const o2::itsmft::NoiseMap* mp) { mNoiseMap = mp; }
   void setDeadChannelsMap(const o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
@@ -67,17 +69,17 @@ class Digitizer : public TObject
   auto getChipResponse(int chipID);
 
   /// Steer conversion of hits to digits
-  void process(const std::vector<Hit>* hits, int evID, int srcID);
-  void setEventTime(const o2::InteractionTimeRecord& irt);
+  void process(const std::vector<Hit>* hits, int evID, int srcID, int layer = -1);
+  void setEventTime(const o2::InteractionTimeRecord& irt, int layer = -1);
   double getEndTimeOfROFMax() const
   {
     ///< return the time corresponding to end of the last reserved ROFrame : mROFrameMax
-    return mParams.getROFrameLength() * (mROFrameMax + 1) + mParams.getTimeOffset();
+    return (mParams.getROFrameLength() * (double)(mROFrameMax + 1)) + mParams.getTimeOffset();
   }
 
   void setContinuous(bool v) { mParams.setContinuous(v); }
   bool isContinuous() const { return mParams.isContinuous(); }
-  void fillOutputContainer(uint32_t maxFrame = 0xffffffff);
+  void fillOutputContainer(uint32_t maxFrame = 0xffffffff, int layer = -1);
 
   void setDigiParams(const o2::itsmft::DigiParams& par) { mParams = par; }
   const o2::itsmft::DigiParams& getDigitParams() const { return mParams; }
@@ -92,11 +94,17 @@ class Digitizer : public TObject
     mEventROFrameMin = 0xffffffff;
     mEventROFrameMax = 0;
   }
+  void resetROFrameBounds()
+  {
+    mROFrameMin = 0;
+    mROFrameMax = 0;
+    mNewROFrame = 0;
+  }
 
  private:
-  void processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID);
+  void processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID, int lay);
   void registerDigits(ChipDigitsContainer& chip, uint32_t roFrame, float tInROF, int nROF,
-                      uint16_t row, uint16_t col, int nEle, o2::MCCompLabel& lbl);
+                      uint16_t row, uint16_t col, int nEle, o2::MCCompLabel& lbl, int lay);
 
   ExtraDig* getExtraDigBuffer(uint32_t roFrame)
   {
@@ -115,7 +123,7 @@ class Digitizer : public TObject
   o2::itsmft::DigiParams mParams;          ///< digitization parameters
   o2::InteractionTimeRecord mEventTime;    ///< global event time and interaction record
   o2::InteractionRecord mIRFirstSampledTF; ///< IR of the 1st sampled IR, noise-only ROFs will be inserted till this IR only
-  double mCollisionTimeWrtROF;
+  double mCollisionTimeWrtROF{};
   uint32_t mROFrameMin = 0; ///< lowest RO frame of current digits
   uint32_t mROFrameMax = 0; ///< highest RO frame of current digits
   uint32_t mNewROFrame = 0; ///< ROFrame corresponding to provided time

--- a/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
@@ -26,12 +26,17 @@ DigiParams::DigiParams()
   setNSimSteps(mNSimSteps);
 }
 
-void DigiParams::setROFrameLength(float lNS)
+void DigiParams::setROFrameLength(float lNS, int layer)
 {
   // set ROFrame length in nanosecongs
-  mROFrameLength = lNS;
-  assert(mROFrameLength > 1.);
-  mROFrameLengthInv = 1. / mROFrameLength;
+  assert(lNS > 1.f);
+  if (layer < 0) {
+    mROFrameLength = lNS;
+    mROFrameLengthInv = 1.f / mROFrameLength;
+  } else {
+    mROFrameLayerLength.push_back(lNS);
+    mROFrameLayerLengthInv.push_back(1.f / lNS);
+  }
 }
 
 void DigiParams::setNSimSteps(int v)
@@ -58,17 +63,24 @@ void DigiParams::setChargeThreshold(int v, float frac2Account)
 //______________________________________________
 void DigiParams::print() const
 {
-  // print settings
-  printf("Alpide digitization params:\n");
-  printf("Continuous readout             : %s\n", mIsContinuous ? "ON" : "OFF");
-  printf("Readout Frame Length(ns)       : %f\n", mROFrameLength);
-  printf("Strobe delay (ns)              : %f\n", mStrobeDelay);
-  printf("Strobe length (ns)             : %f\n", mStrobeLength);
-  printf("Threshold (N electrons)        : %d\n", mChargeThreshold);
-  printf("Min N electrons to account     : %d\n", mMinChargeToAccount);
-  printf("Number of charge sharing steps : %d\n", mNSimSteps);
-  printf("ELoss to N electrons factor    : %e\n", mEnergyToNElectrons);
-  printf("Noise level per pixel          : %e\n", mNoisePerPixel);
-  printf("Charge time-response:\n");
+  LOGF(info, "Alpide digitization params:");
+  LOGF(info, "Continuous readout               : %s", mIsContinuous ? "ON" : "OFF");
+  if (withStaggering()) {
+    for (int i{0}; i < (int)mROFrameLayerLengthInBC.size(); ++i) {
+      LOGF(info, " Readout Frame Layer:%d Length(ns)[BC]      : %f [%d]", i, mROFrameLayerLength[i], mROFrameLayerLengthInBC[i]);
+      LOGF(info, "Strobe delay Layer %d (ns)                : %f", i, mStrobeDelay);
+      LOGF(info, "Strobe length Layer %d (ns)               : %f", i, mStrobeLength);
+    }
+  } else {
+    LOGF(info, "Readout Frame Length(ns)         : %f", mROFrameLength);
+    LOGF(info, "Strobe delay (ns)                : %f", mStrobeDelay);
+    LOGF(info, "Strobe length (ns)               : %f", mStrobeLength);
+  }
+  LOGF(info, "Threshold (N electrons)          : %d", mChargeThreshold);
+  LOGF(info, "Min N electrons to account       : %d", mMinChargeToAccount);
+  LOGF(info, "Number of charge sharing steps   : %d", mNSimSteps);
+  LOGF(info, "ELoss to N electrons factor      : %e", mEnergyToNElectrons);
+  LOGF(info, "Noise level per pixel            : %e", mNoisePerPixel);
+  LOGF(info, "Charge time-response:");
   mSignalShape.print();
 }

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -13,6 +13,7 @@
 /// \brief Implementation of the ITS/MFT digitizer
 
 #include "DataFormatsITSMFT/Digit.h"
+#include "Framework/Logger.h"
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSMFTSimulation/DPLDigitizerParam.h"
 #include "ITSMFTSimulation/Digitizer.h"
@@ -21,10 +22,11 @@
 #include "DetectorsRaw/HBFUtils.h"
 
 #include <TRandom.h>
+#include <algorithm>
 #include <climits>
 #include <vector>
+#include <ranges>
 #include <numeric>
-#include <fairlogger/Logger.h> // for LOG
 
 using o2::itsmft::Digit;
 using o2::itsmft::Hit;
@@ -73,14 +75,14 @@ void Digitizer::init()
   } else {
     LOG(fatal) << "Invalid ITS Inner Barrel back-bias value";
   }
-  if (doptITS.OBVbb == 0.0) { // for ITS Outter Barrel
+  if (doptITS.OBVbb == 0.0) { // for ITS Outer Barrel
     mAlpSimRespOB = mAlpSimResp[0];
     LOG(info) << "Choosing Vbb=0V for ITS OB";
   } else if (doptITS.OBVbb == 3.0) {
     mAlpSimRespOB = mAlpSimResp[1];
     LOG(info) << "Choosing Vbb=-3V for ITS OB";
   } else {
-    LOG(fatal) << "Invalid ITS Outter Barrel back-bias value";
+    LOG(fatal) << "Invalid ITS Outer Barrel back-bias value";
   }
   mParams.print();
   mIRFirstSampledTF = o2::raw::HBFUtils::Instance().getFirstSampledTFIR();
@@ -98,47 +100,53 @@ auto Digitizer::getChipResponse(int chipID)
 
   if (chipID < 432) { // in ITS Inner Barrel
     return mAlpSimRespIB;
-  } else { // in ITS Outter Barrel
+  } else { // in ITS Outer Barrel
     return mAlpSimRespOB;
   }
 }
 
 //_______________________________________________________________________
-void Digitizer::process(const std::vector<Hit>* hits, int evID, int srcID)
+void Digitizer::process(const std::vector<Hit>* hits, int evID, int srcID, int layer)
 {
   // digitize single event, the time must have been set beforehand
+  // opt. apply a filter on the layer of the processed hits
 
-  LOG(debug) << "Digitizing " << mGeometry->getName() << " hits of entry " << evID << " from source "
+  LOG(debug) << "Digitizing " << mGeometry->getName() << ":" << layer << " hits of entry " << evID << " from source "
              << srcID << " at time " << mEventTime << " ROFrame= " << mNewROFrame << ")"
              << " cont.mode: " << isContinuous()
              << " Min/Max ROFrames " << mROFrameMin << "/" << mROFrameMax;
 
   // is there something to flush ?
   if (mNewROFrame > mROFrameMin) {
-    fillOutputContainer(mNewROFrame - 1); // flush out all frame preceding the new one
+    fillOutputContainer(mNewROFrame - 1, layer); // flush out all frame preceding the new one
   }
 
   int nHits = hits->size();
   std::vector<int> hitIdx(nHits);
   std::iota(std::begin(hitIdx), std::end(hitIdx), 0);
   // sort hits to improve memory access
-  std::sort(hitIdx.begin(), hitIdx.end(),
-            [hits](auto lhs, auto rhs) {
-              return (*hits)[lhs].GetDetectorID() < (*hits)[rhs].GetDetectorID();
-            });
-  for (int i : hitIdx) {
-    processHit((*hits)[i], mROFrameMax, evID, srcID);
+  std::sort(hitIdx.begin(), hitIdx.end(), [hits](auto lhs, auto rhs) {
+    return (*hits)[lhs].GetDetectorID() < (*hits)[rhs].GetDetectorID();
+  });
+  for (int i : hitIdx | std::views::filter([&](int idx) {
+                 if (layer < 0) {
+                   return true;
+                 }
+                 return mGeometry->getLayer((*hits)[idx].GetDetectorID()) == layer;
+               })) {
+    processHit((*hits)[i], mROFrameMax, evID, srcID, layer);
   }
+
   // in the triggered mode store digits after every MC event
   // TODO: in the real triggered mode this will not be needed, this is actually for the
   // single event processing only
   if (!mParams.isContinuous()) {
-    fillOutputContainer(mROFrameMax);
+    fillOutputContainer(mROFrameMax, layer);
   }
 }
 
 //_______________________________________________________________________
-void Digitizer::setEventTime(const o2::InteractionTimeRecord& irt)
+void Digitizer::setEventTime(const o2::InteractionTimeRecord& irt, int layer)
 {
   // assign event time in ns
   mEventTime = irt;
@@ -161,13 +169,13 @@ void Digitizer::setEventTime(const o2::InteractionTimeRecord& irt)
       // this event is before the first RO
       mIsBeforeFirstRO = true;
     } else {
-      mNewROFrame = nbc / mParams.getROFrameLengthInBC();
+      mNewROFrame = nbc / mParams.getROFrameLengthInBC(layer);
       mIsBeforeFirstRO = false;
     }
     LOG(debug) << " NewROFrame " << mNewROFrame << " nbc " << nbc;
 
     // in continuous mode depends on starts of periodic readout frame
-    mCollisionTimeWrtROF += (nbc % mParams.getROFrameLengthInBC()) * o2::constants::lhc::LHCBunchSpacingNS;
+    mCollisionTimeWrtROF += (nbc % mParams.getROFrameLengthInBC(layer)) * o2::constants::lhc::LHCBunchSpacingNS;
   } else {
     mNewROFrame = 0;
   }
@@ -183,16 +191,14 @@ void Digitizer::setEventTime(const o2::InteractionTimeRecord& irt)
 }
 
 //_______________________________________________________________________
-void Digitizer::fillOutputContainer(uint32_t frameLast)
+void Digitizer::fillOutputContainer(uint32_t frameLast, int layer)
 {
   // fill output with digits from min.cached up to requested frame, generating the noise beforehand
-  if (frameLast > mROFrameMax) {
-    frameLast = mROFrameMax;
-  }
+  frameLast = std::min(frameLast, mROFrameMax);
   // make sure all buffers for extra digits are created up to the maxFrame
   getExtraDigBuffer(mROFrameMax);
 
-  LOG(info) << "Filling " << mGeometry->getName() << " digits output for RO frames " << mROFrameMin << ":"
+  LOG(info) << "Filling " << mGeometry->getName() << " digits:" << layer << " output for RO frames " << mROFrameMin << ":"
             << frameLast;
 
   o2::itsmft::ROFRecord rcROF;
@@ -204,7 +210,7 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
 
     auto& extra = *(mExtraBuff.front().get());
     for (auto& chip : mChips) {
-      if (chip.isDisabled()) {
+      if (chip.isDisabled() || (layer >= 0 && mGeometry->getLayer(chip.getChipIndex()) != layer)) {
         continue;
       }
       chip.addNoise(mROFrameMin, mROFrameMin, &mParams);
@@ -236,7 +242,7 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
     // finalize ROF record
     rcROF.setNEntries(mDigits->size() - rcROF.getFirstEntry()); // number of digits
     if (isContinuous()) {
-      rcROF.getBCData().setFromLong(mIRFirstSampledTF.toLong() + mROFrameMin * mParams.getROFrameLengthInBC());
+      rcROF.getBCData().setFromLong(mIRFirstSampledTF.toLong() + mROFrameMin * mParams.getROFrameLengthInBC(layer));
     } else {
       rcROF.getBCData() = mEventTime; // RSTODO do we need to add trigger delay?
     }
@@ -251,7 +257,7 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
 }
 
 //_______________________________________________________________________
-void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID)
+void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID, int lay)
 {
   // convert single hit to digits
   auto chipID = hit.GetDetectorID();
@@ -284,14 +290,12 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
   }
   float tTot = mParams.getSignalShape().getMaxDuration();
   // frame of the hit signal start wrt event ROFrame
-  int roFrameRel = int(timeInROF * mParams.getROFrameLengthInv());
+  int roFrameRel = int(timeInROF * mParams.getROFrameLengthInv(lay));
   // frame of the hit signal end  wrt event ROFrame: in the triggered mode we read just 1 frame
-  uint32_t roFrameRelMax = mParams.isContinuous() ? (timeInROF + tTot) * mParams.getROFrameLengthInv() : roFrameRel;
+  uint32_t roFrameRelMax = mParams.isContinuous() ? (timeInROF + tTot) * mParams.getROFrameLengthInv(lay) : roFrameRel;
   int nFrames = roFrameRelMax + 1 - roFrameRel;
   uint32_t roFrameMax = mNewROFrame + roFrameRelMax;
-  if (roFrameMax > maxFr) {
-    maxFr = roFrameMax; // if signal extends beyond current maxFrame, increase the latter
-  }
+  maxFr = std::max(roFrameMax, maxFr); // if signal extends beyond current maxFrame, increase the latter
 
   // here we start stepping in the depth of the sensor to generate charge diffusion
   float nStepsInv = mParams.getNSimStepsInv();
@@ -332,17 +336,13 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
   }
   rowS -= AlpideRespSimMat::NPix / 2;
   rowE += AlpideRespSimMat::NPix / 2;
-  if (rowS < 0) {
-    rowS = 0;
-  }
+  rowS = std::max(rowS, 0);
   if (rowE >= Segmentation::NRows) {
     rowE = Segmentation::NRows - 1;
   }
   colS -= AlpideRespSimMat::NPix / 2;
   colE += AlpideRespSimMat::NPix / 2;
-  if (colS < 0) {
-    colS = 0;
-  }
+  colS = std::max(colS, 0);
   if (colE >= Segmentation::NCols) {
     colE = Segmentation::NCols - 1;
   }
@@ -362,7 +362,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
 
   const o2::itsmft::AlpideSimResponse* resp = getChipResponse(chipID);
 
-  // take into account that the AlpideSimResponse depth defintion has different min/max boundaries
+  // take into account that the AlpideSimResponse depth definition has different min/max boundaries
   // although the max should coincide with the surface of the epitaxial layer, which in the chip
   // local coordinates has Y = +SensorLayerThickness/2
 
@@ -379,7 +379,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
       rowPrev = row;
       colPrev = col;
     }
-    bool flipCol, flipRow;
+    bool flipCol = false, flipRow = false;
     // note that response needs coordinates along column row (locX) (locZ) then depth (locY)
     auto rspmat = resp->getResponse(xyzLocS.X() - cRowPix, xyzLocS.Z() - cColPix, xyzLocS.Y(), flipRow, flipCol);
 
@@ -389,12 +389,12 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
     }
 
     for (int irow = AlpideRespSimMat::NPix; irow--;) {
-      int rowDest = row + irow - AlpideRespSimMat::NPix / 2 - rowS; // destination row in the respMatrix
+      int rowDest = row + irow - (AlpideRespSimMat::NPix / 2) - rowS; // destination row in the respMatrix
       if (rowDest < 0 || rowDest >= rowSpan) {
         continue;
       }
       for (int icol = AlpideRespSimMat::NPix; icol--;) {
-        int colDest = col + icol - AlpideRespSimMat::NPix / 2 - colS; // destination column in the respMatrix
+        int colDest = col + icol - (AlpideRespSimMat::NPix / 2) - colS; // destination column in the respMatrix
         if (colDest < 0 || colDest >= colSpan) {
           continue;
         }
@@ -426,35 +426,31 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
         continue;
       }
       //
-      registerDigits(chip, roFrameAbs, timeInROF, nFrames, rowIS, colIS, nEle, lbl);
+      registerDigits(chip, roFrameAbs, timeInROF, nFrames, rowIS, colIS, nEle, lbl, lay);
     }
   }
 }
 
 //________________________________________________________________________________
 void Digitizer::registerDigits(ChipDigitsContainer& chip, uint32_t roFrame, float tInROF, int nROF,
-                               uint16_t row, uint16_t col, int nEle, o2::MCCompLabel& lbl)
+                               uint16_t row, uint16_t col, int nEle, o2::MCCompLabel& lbl, int lay)
 {
   // Register digits for given pixel, accounting for the possible signal contribution to
   // multiple ROFrame. The signal starts at time tInROF wrt the start of provided roFrame
   // In every ROFrame we check the collected signal during strobe
 
-  float tStrobe = mParams.getStrobeDelay() - tInROF; // strobe start wrt signal start
+  float tStrobe = mParams.getStrobeDelay(lay) - tInROF; // strobe start wrt signal start
   for (int i = 0; i < nROF; i++) {
     uint32_t roFr = roFrame + i;
-    int nEleROF = mParams.getSignalShape().getCollectedCharge(nEle, tStrobe, tStrobe + mParams.getStrobeLength());
-    tStrobe += mParams.getROFrameLength(); // for the next ROF
+    int nEleROF = mParams.getSignalShape().getCollectedCharge(nEle, tStrobe, tStrobe + mParams.getStrobeLength(lay));
+    tStrobe += mParams.getROFrameLength(lay); // for the next ROF
 
     // discard too small contributions, they have no chance to produce a digit
     if (nEleROF < mParams.getMinChargeToAccount()) {
       continue;
     }
-    if (roFr > mEventROFrameMax) {
-      mEventROFrameMax = roFr;
-    }
-    if (roFr < mEventROFrameMin) {
-      mEventROFrameMin = roFr;
-    }
+    mEventROFrameMax = std::max(roFr, mEventROFrameMax);
+    mEventROFrameMin = std::min(roFr, mEventROFrameMin);
     auto key = chip.getOrderingKey(roFr, row, col);
     PreDigit* pd = chip.findDigit(key);
     if (!pd) {

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitReaderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitReaderSpec.h
@@ -16,6 +16,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/GBTCalibData.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
@@ -34,64 +35,67 @@ namespace o2
 namespace itsmft
 {
 
+template <int N>
 class DigitReader : public Task
 {
  public:
+  static constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+  static constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+  static constexpr int NLayers{o2::itsmft::DPLAlpideParam<N>::getNLayers()};
+  static constexpr int RLayers = o2::itsmft::DPLAlpideParam<N>::supportsStaggering() ? NLayers : 1;
+
   DigitReader() = delete;
-  DigitReader(o2::detectors::DetID id, bool useMC, bool useCalib, bool triggerOut);
+  DigitReader(bool useMC, bool useCalib, bool triggerOut);
   ~DigitReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  protected:
   void connectTree(const std::string& filename);
+  template <typename Ptr>
+  void setBranchAddress(const std::string& base, Ptr& addr, int layer = -1);
+  std::string getBranchName(const std::string& base, int index);
 
-  std::vector<o2::itsmft::Digit> mDigits, *mDigitsPtr = &mDigits;
+  std::array<std::vector<o2::itsmft::Digit>*, NLayers> mDigits;
   std::vector<o2::itsmft::GBTCalibData> mCalib, *mCalibPtr = &mCalib;
-  std::vector<o2::itsmft::ROFRecord> mDigROFRec, *mDigROFRecPtr = &mDigROFRec;
-  std::vector<o2::itsmft::MC2ROFRecord> mDigMC2ROFs, *mDigMC2ROFsPtr = &mDigMC2ROFs;
-  o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel> mConstLabels;
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
+  std::array<std::vector<o2::itsmft::ROFRecord>*, NLayers> mDigROFRec;
+  std::array<std::vector<o2::itsmft::MC2ROFRecord>*, NLayers> mDigMC2ROFs;
+  std::array<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>, NLayers> mConstLabels;
+  std::array<o2::dataformats::IOMCTruthContainerView*, NLayers> mPLabels;
 
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
-  bool mUseMC = true;    // use MC truth
-  bool mUseCalib = true; // send calib data
-  bool mTriggerOut = true; // send dummy triggers vector
+  bool mUseMC = true;        // use MC truth
+  bool mUseCalib = true;     // send calib data
+  bool mTriggerOut = true;   // send dummy triggers vector
   bool mUseIRFrames = false; // selected IRFrames modes
   int mROFBiasInBC = 0;
   int mROFLengthInBC = 0;
   int mNRUs = 0;
-  std::string mDetName = "";
-  std::string mDetNameLC = "";
-  std::string mFileName = "";
+  std::string mDetName;
+  std::string mDetNameLC;
+  std::string mFileName;
   std::string mDigTreeName = "o2sim";
   std::string mDigitBranchName = "Digit";
-  std::string mDigROFBranchName = "DigitROF";
+  std::string mDigitROFBranchName = "DigitROF";
   std::string mCalibBranchName = "Calib";
 
-  std::string mDigtMCTruthBranchName = "DigitMCTruth";
-  std::string mDigtMC2ROFBranchName = "DigitMC2ROF";
+  std::string mDigitMCTruthBranchName = "DigitMCTruth";
+  std::string mDigitMC2ROFBranchName = "DigitMC2ROF";
 };
 
-class ITSDigitReader : public DigitReader
+class ITSDigitReader : public DigitReader<o2::detectors::DetID::ITS>
 {
  public:
   ITSDigitReader(bool useMC = true, bool useCalib = false, bool useTriggers = true)
-    : DigitReader(o2::detectors::DetID::ITS, useMC, useCalib, useTriggers)
-  {
-    mOrigin = o2::header::gDataOriginITS;
-  }
+    : DigitReader<o2::detectors::DetID::ITS>(useMC, useCalib, useTriggers) {}
 };
 
-class MFTDigitReader : public DigitReader
+class MFTDigitReader : public DigitReader<o2::detectors::DetID::MFT>
 {
  public:
   MFTDigitReader(bool useMC = true, bool useCalib = false, bool useTriggers = true)
-    : DigitReader(o2::detectors::DetID::MFT, useMC, useCalib, useTriggers)
-  {
-    mOrigin = o2::header::gDataOriginMFT;
-  }
+    : DigitReader<o2::detectors::DetID::MFT>(useMC, useCalib, useTriggers) {}
 };
 
 /// create a processor spec

--- a/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
@@ -11,6 +11,7 @@
 
 /// @file   DigitReaderSpec.cxx
 
+#include <string>
 #include <vector>
 
 #include "TTree.h"
@@ -39,25 +40,28 @@ namespace o2
 namespace itsmft
 {
 
-DigitReader::DigitReader(o2::detectors::DetID id, bool useMC, bool useCalib, bool triggerOut)
+template <int N>
+DigitReader<N>::DigitReader(bool useMC, bool useCalib, bool triggerOut) : mUseMC(useMC), mUseCalib(useCalib), mTriggerOut(triggerOut), mDetNameLC(mDetName = ID.getName()), mDigTreeName("o2sim")
 {
-  assert(id == o2::detectors::DetID::ITS || id == o2::detectors::DetID::MFT);
-  mDetNameLC = mDetName = id.getName();
-  mDigTreeName = "o2sim";
-
   mDigitBranchName = mDetName + mDigitBranchName;
-  mDigROFBranchName = mDetName + mDigROFBranchName;
+  mDigitROFBranchName = mDetName + mDigitROFBranchName;
   mCalibBranchName = mDetName + mCalibBranchName;
 
-  mDigtMCTruthBranchName = mDetName + mDigtMCTruthBranchName;
-  mDigtMC2ROFBranchName = mDetName + mDigtMC2ROFBranchName;
-  mTriggerOut = triggerOut;
-  mUseMC = useMC;
-  mUseCalib = useCalib;
+  mDigitMCTruthBranchName = mDetName + mDigitMCTruthBranchName;
+  mDigitMC2ROFBranchName = mDetName + mDigitMC2ROFBranchName;
+
   std::transform(mDetNameLC.begin(), mDetNameLC.end(), mDetNameLC.begin(), ::tolower);
+
+  for (uint32_t i = 0; i < NLayers; ++i) {
+    mDigits[i] = nullptr;
+    mDigROFRec[i] = nullptr;
+    mDigMC2ROFs[i] = nullptr;
+    mPLabels[i] = nullptr;
+  }
 }
 
-void DigitReader::init(InitContext& ic)
+template <int N>
+void DigitReader<N>::init(InitContext& ic)
 {
   mFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
                                             ic.options().get<std::string>((mDetNameLC + "-digit-infile").c_str()));
@@ -67,23 +71,23 @@ void DigitReader::init(InitContext& ic)
   connectTree(mFileName);
 }
 
-void DigitReader::run(ProcessingContext& pc)
+template <int N>
+void DigitReader<N>::run(ProcessingContext& pc)
 {
   const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+  const auto& alpideParam = o2::itsmft::DPLAlpideParam<N>::Instance();
   if (tinfo.globalRunNumberChanged && mUseIRFrames) { // new run is starting: 1st call
     // TODO: we have to find a way define CCDBInput for IRFrames mode only using DPL fetcher
     auto& ccdb = o2::ccdb::BasicCCDBManager::instance();
     auto rlim = ccdb.getRunDuration(tinfo.runNumber);
     long ts = (rlim.first + rlim.second) / 2;
-    if (mOrigin == o2::header::gDataOriginITS) {
+    if constexpr (N == o2::detectors::DetID::ITS) {
       ccdb.getForTimeStamp<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>>("ITS/Config/AlpideParam", ts);
-      const auto& alpideParam = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
       mROFBiasInBC = alpideParam.roFrameBiasInBC;
       mROFLengthInBC = alpideParam.roFrameLengthInBC;
       mNRUs = o2::itsmft::ChipMappingITS::getNRUs();
     } else {
       ccdb.getForTimeStamp<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>>("MFT/Config/AlpideParam", ts);
-      const auto& alpideParam = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
       mROFBiasInBC = alpideParam.roFrameBiasInBC;
       mROFLengthInBC = alpideParam.roFrameLengthInBC;
       mNRUs = o2::itsmft::ChipMappingMFT::getNRUs();
@@ -93,38 +97,37 @@ void DigitReader::run(ProcessingContext& pc)
   if (mUseIRFrames) {
     irFrames = pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("driverInfo");
   }
-  static o2::dataformats::IOMCTruthContainerView* plabels = nullptr;
-  if (mUseMC && !plabels) {
-    mTree->SetBranchAddress(mDigtMCTruthBranchName.c_str(), &plabels);
-  }
-  auto ent = mTree->GetReadEntry();
 
+  auto ent = mTree->GetReadEntry();
   if (!mUseIRFrames) {
     ent++;
     assert(ent < mTree->GetEntries()); // this should not happen
     mTree->GetEntry(ent);
-    LOG(info) << mDetName << "DigitReader pushes " << mDigROFRec.size() << " ROFRecords, " << mDigits.size() << " digits at entry " << ent;
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, mDigROFRec);
-    pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0}, mDigits);
+    for (uint32_t iLayer = 0; iLayer < RLayers; ++iLayer) {
+      LOG(info) << mDetName << "DigitReader:" << iLayer << " pushes " << mDigROFRec[iLayer]->size() << " ROFRecords, " << mDigits[iLayer]->size() << " digits at entry " << ent;
+      pc.outputs().snapshot(Output{Origin, "DIGITSROF", iLayer}, *mDigROFRec[iLayer]);
+      pc.outputs().snapshot(Output{Origin, "DIGITS", iLayer}, *mDigits[iLayer]);
+      if (mUseMC) {
+        auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{Origin, "DIGITSMCTR", iLayer});
+        mPLabels[iLayer]->copyandflatten(sharedlabels);
+        delete mPLabels[iLayer];
+        mPLabels[iLayer] = nullptr;
+        pc.outputs().snapshot(Output{Origin, "DIGITSMC2ROF", iLayer}, *mDigMC2ROFs[iLayer]);
+      }
+    }
     if (mUseCalib) {
-      pc.outputs().snapshot(Output{mOrigin, "GBTCALIB", 0}, mCalib);
+      pc.outputs().snapshot(Output{Origin, "GBTCALIB", 0}, mCalib);
     }
     if (mTriggerOut) {
       std::vector<o2::itsmft::PhysTrigger> dummyTrig;
-      pc.outputs().snapshot(Output{mOrigin, "PHYSTRIG", 0}, dummyTrig);
-    }
-    if (mUseMC) {
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
-      plabels->copyandflatten(sharedlabels);
-      delete plabels;
-      plabels = nullptr;
-      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, mDigMC2ROFs);
+      pc.outputs().snapshot(Output{Origin, "PHYSTRIG", 0}, dummyTrig);
     }
     if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
       pc.services().get<ControlService>().endOfStream();
       pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     }
   } else { // need to select particulars IRs range, presumably from the same tree entry
+           // TODO implement for staggering
     std::vector<o2::itsmft::Digit> digitsSel;
     std::vector<o2::itsmft::GBTCalibData> calibSel;
     std::vector<o2::itsmft::ROFRecord> digROFRecSel;
@@ -144,33 +147,33 @@ void DigitReader::run(ProcessingContext& pc)
         // do we need to read a new entry?
         if (ent > mTree->GetReadEntry()) {
           if (mUseMC) {
-            delete plabels;
-            plabels = nullptr;
-            mConstLabels.clear();
-            mTree->SetBranchAddress(mDigtMCTruthBranchName.c_str(), &plabels);
+            delete mPLabels[0];
+            mPLabels[0] = nullptr;
+            mConstLabels[0].clear();
+            mTree->SetBranchAddress(mDigitMCTruthBranchName.c_str(), &mPLabels[0]);
           }
           mTree->GetEntry(ent);
           if (mUseMC) {
-            plabels->copyandflatten(mConstLabels);
-            delete plabels;
-            plabels = nullptr;
+            mPLabels[0]->copyandflatten(mConstLabels[0]);
+            delete mPLabels[0];
+            mPLabels[0] = nullptr;
           }
         }
         std::vector<int> rofOld2New;
-        rofOld2New.resize(mDigROFRec.size(), -1);
+        rofOld2New.resize(mDigROFRec[0]->size(), -1);
 
-        if (mDigROFRec.front().getBCData() <= irMax && (mDigROFRec.back().getBCData() + mROFLengthInBC - 1) >= irMin) { // there is an overlap
-          for (int irof = 0; irof < (int)mDigROFRec.size(); irof++) {
-            const auto& rof = mDigROFRec[irof];
+        if (mDigROFRec[0]->front().getBCData() <= irMax && (mDigROFRec[0]->back().getBCData() + mROFLengthInBC - 1) >= irMin) { // there is an overlap
+          for (int irof = 0; irof < (int)mDigROFRec[0]->size(); irof++) {
+            const auto& rof = mDigROFRec[0]->at(irof);
             if (irfSel.check({rof.getBCData(), rof.getBCData() + mROFLengthInBC - 1}) != -1) {
               rofOld2New[irof] = (int)digROFRecSel.size();
               LOGP(debug, "Adding selected ROF {}", rof.getBCData().asString());
               digROFRecSel.push_back(rof);
               int offs = digitsSel.size();
               digROFRecSel.back().setFirstEntry(offs);
-              std::copy(mDigits.begin() + rof.getFirstEntry(), mDigits.begin() + rof.getFirstEntry() + rof.getNEntries(), std::back_inserter(digitsSel));
+              std::copy(mDigits[0]->begin() + rof.getFirstEntry(), mDigits[0]->begin() + rof.getFirstEntry() + rof.getNEntries(), std::back_inserter(digitsSel));
               for (int id = 0; id < rof.getNEntries(); id++) { // copy MC info
-                digitLabelsSel.addElements(id + offs, mConstLabels.getLabels(id + rof.getFirstEntry()));
+                digitLabelsSel.addElements(id + offs, mConstLabels[0].getLabels(id + rof.getFirstEntry()));
               }
               if (mCalib.size() >= size_t((irof + 1) * mNRUs)) {
                 std::copy(mCalib.begin() + irof * mNRUs, mCalib.begin() + (irof + 1) * mNRUs, std::back_inserter(calibSel));
@@ -179,7 +182,7 @@ void DigitReader::run(ProcessingContext& pc)
           }
         }
         if (mUseMC) {
-          digMC2ROFsSel = mDigMC2ROFs;
+          digMC2ROFsSel = *mDigMC2ROFs[0];
           for (auto& mc2rof : digMC2ROFsSel) {
             if (mc2rof.rofRecordID < 0) {
               continue; // did not contribute even to the original data
@@ -198,26 +201,26 @@ void DigitReader::run(ProcessingContext& pc)
             mc2rof.maxROF = mx;
           }
         }
-        if (mDigROFRec.back().getBCData() + mROFLengthInBC - 1 < irMax) { // need to check the next entry
+        if (mDigROFRec[0]->back().getBCData() + mROFLengthInBC - 1 < irMax) { // need to check the next entry
           ent++;
           continue;
         }
         break; // push collected data
       }
     }
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, digROFRecSel);
-    pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0}, digitsSel);
+    pc.outputs().snapshot(Output{Origin, "DIGITSROF", 0}, digROFRecSel);
+    pc.outputs().snapshot(Output{Origin, "DIGITS", 0}, digitsSel);
     if (mUseCalib) {
-      pc.outputs().snapshot(Output{mOrigin, "GBTCALIB", 0}, calibSel);
+      pc.outputs().snapshot(Output{Origin, "GBTCALIB", 0}, calibSel);
     }
     if (mTriggerOut) {
       std::vector<o2::itsmft::PhysTrigger> dummyTrig;
-      pc.outputs().snapshot(Output{mOrigin, "PHYSTRIG", 0}, dummyTrig);
+      pc.outputs().snapshot(Output{Origin, "PHYSTRIG", 0}, dummyTrig);
     }
     if (mUseMC) {
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{Origin, "DIGITSMCTR", 0});
       digitLabelsSel.flatten_to(sharedlabels);
-      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, digMC2ROFsSel);
+      pc.outputs().snapshot(Output{Origin, "DIGITSMC2ROF", 0}, digMC2ROFsSel);
     }
 
     if (!irFrames.size() || irFrames.back().isLast()) {
@@ -227,77 +230,99 @@ void DigitReader::run(ProcessingContext& pc)
   }
 }
 
-void DigitReader::connectTree(const std::string& filename)
+template <int N>
+void DigitReader<N>::connectTree(const std::string& filename)
 {
   mTree.reset(nullptr); // in case it was already loaded
   mFile.reset(TFile::Open(filename.c_str()));
   assert(mFile && !mFile->IsZombie());
   mTree.reset((TTree*)mFile->Get(mDigTreeName.c_str()));
   assert(mTree);
-
-  mTree->SetBranchAddress(mDigROFBranchName.c_str(), &mDigROFRecPtr);
-  mTree->SetBranchAddress(mDigitBranchName.c_str(), &mDigitsPtr);
+  for (uint32_t iLayer = 0; iLayer < RLayers; ++iLayer) {
+    setBranchAddress(mDigitROFBranchName, mDigROFRec[iLayer], iLayer);
+    setBranchAddress(mDigitBranchName, mDigits[iLayer], iLayer);
+    if (mUseMC) {
+      if (!mTree->GetBranch(getBranchName(mDigitMC2ROFBranchName, iLayer).c_str()) || !mTree->GetBranch(getBranchName(mDigitMCTruthBranchName, iLayer).c_str())) {
+        throw std::runtime_error("MC data requested but not found in the tree");
+      }
+      setBranchAddress(mDigitMC2ROFBranchName, mDigMC2ROFs[iLayer], iLayer);
+      if (!mPLabels[iLayer]) {
+        setBranchAddress(mDigitMCTruthBranchName, mPLabels[iLayer], iLayer);
+      }
+    }
+  }
   if (mUseCalib) {
     if (!mTree->GetBranch(mCalibBranchName.c_str())) {
       throw std::runtime_error("GBT calibration data requested but not found in the tree");
     }
-    mTree->SetBranchAddress(mCalibBranchName.c_str(), &mCalibPtr);
-  }
-  if (mUseMC) {
-    if (!mTree->GetBranch(mDigtMC2ROFBranchName.c_str()) || !mTree->GetBranch(mDigtMCTruthBranchName.c_str())) {
-      throw std::runtime_error("MC data requested but not found in the tree");
-    }
-    mTree->SetBranchAddress(mDigtMC2ROFBranchName.c_str(), &mDigMC2ROFsPtr);
+    setBranchAddress(mCalibBranchName, mCalibPtr);
   }
   LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
 }
 
+template <int N>
+std::string DigitReader<N>::getBranchName(const std::string& base, int index)
+{
+  if constexpr (!o2::itsmft::DPLAlpideParam<N>::supportsStaggering()) {
+    return base;
+  }
+  return base + "_" + std::to_string(index);
+}
+
+template <int N>
+template <typename Ptr>
+void DigitReader<N>::setBranchAddress(const std::string& base, Ptr& addr, int layer)
+{
+  const auto name = getBranchName(base, layer);
+  if (Int_t ret = mTree->SetBranchAddress(name.c_str(), &addr); ret != 0) {
+    LOGP(fatal, "failed to set branch address for {} ret={}", name, ret);
+  }
+}
+
+namespace
+{
+template <int N>
+std::vector<OutputSpec> makeOutChannels(bool mctruth, bool useCalib)
+{
+  constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+  std::vector<OutputSpec> outputs;
+  static constexpr int RLayers = o2::itsmft::DPLAlpideParam<N>::supportsStaggering() ? o2::itsmft::DPLAlpideParam<N>::getNLayers() : 1;
+  for (int iLayer = 0; iLayer < RLayers; ++iLayer) {
+    outputs.emplace_back(Origin, "DIGITS", iLayer, Lifetime::Timeframe);
+    outputs.emplace_back(Origin, "DIGITSROF", iLayer, Lifetime::Timeframe);
+    if (mctruth) {
+      outputs.emplace_back(Origin, "DIGITSMC2ROF", iLayer, Lifetime::Timeframe);
+      outputs.emplace_back(Origin, "DIGITSMCTR", iLayer, Lifetime::Timeframe);
+    }
+  }
+  if (useCalib) {
+    outputs.emplace_back(Origin, "GBTCALIB", 0, Lifetime::Timeframe);
+  }
+  outputs.emplace_back(Origin, "PHYSTRIG", 0, Lifetime::Timeframe);
+  return outputs;
+}
+} // namespace
+
 DataProcessorSpec getITSDigitReaderSpec(bool useMC, bool useCalib, bool useTriggers, std::string defname)
 {
-  std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("ITS", "DIGITS", 0, Lifetime::Timeframe);
-  outputSpec.emplace_back("ITS", "DIGITSROF", 0, Lifetime::Timeframe);
-  if (useCalib) {
-    outputSpec.emplace_back("ITS", "GBTCALIB", 0, Lifetime::Timeframe);
-  }
-  if (useMC) {
-    outputSpec.emplace_back("ITS", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    outputSpec.emplace_back("ITS", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
-  }
-  if (useTriggers) {
-    outputSpec.emplace_back("ITS", "PHYSTRIG", 0, Lifetime::Timeframe);
-  }
   return DataProcessorSpec{
-    "its-digit-reader",
-    Inputs{},
-    outputSpec,
-    AlgorithmSpec{adaptFromTask<ITSDigitReader>(useMC, useCalib)},
-    Options{
+    .name = "its-digit-reader",
+    .inputs = Inputs{},
+    .outputs = makeOutChannels<o2::detectors::DetID::ITS>(useMC, useCalib),
+    .algorithm = AlgorithmSpec{adaptFromTask<ITSDigitReader>(useMC, useCalib)},
+    .options = Options{
       {"its-digit-infile", VariantType::String, defname, {"Name of the input digit file"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 }
 
 DataProcessorSpec getMFTDigitReaderSpec(bool useMC, bool useCalib, bool useTriggers, std::string defname)
 {
-  std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("MFT", "DIGITS", 0, Lifetime::Timeframe);
-  outputSpec.emplace_back("MFT", "DIGITSROF", 0, Lifetime::Timeframe);
-  if (useCalib) {
-    outputSpec.emplace_back("MFT", "GBTCALIB", 0, Lifetime::Timeframe);
-  }
-  if (useMC) {
-    outputSpec.emplace_back("MFT", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    outputSpec.emplace_back("MFT", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
-  }
-  if (useTriggers) {
-    outputSpec.emplace_back("MFT", "PHYSTRIG", 0, Lifetime::Timeframe);
-  }
   return DataProcessorSpec{
-    "mft-digit-reader",
-    Inputs{},
-    outputSpec,
-    AlgorithmSpec{adaptFromTask<MFTDigitReader>(useMC, useCalib)},
-    Options{
+    .name = "mft-digit-reader",
+    .inputs = Inputs{},
+    .outputs = makeOutChannels<o2::detectors::DetID::MFT>(useMC, useCalib),
+    .algorithm = AlgorithmSpec{adaptFromTask<MFTDigitReader>(useMC, useCalib)},
+    .options = Options{
       {"mft-digit-infile", VariantType::String, defname, {"Name of the input digit file"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 }

--- a/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
@@ -12,6 +12,9 @@
 /// @brief  Processor spec for a ROOT file writer for ITSMFT digits
 
 #include "ITSMFTWorkflow/DigitWriterSpec.h"
+#include "Framework/ConcreteDataMatcher.h"
+#include "Framework/DataRef.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/GBTCalibData.h"
@@ -39,14 +42,24 @@ using MCCont = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
 
 /// create the processor spec
 /// describing a processor receiving digits for ITS/MFT and writing them to file
-DataProcessorSpec getDigitWriterSpec(bool mctruth, bool dec, bool calib, o2::header::DataOrigin detOrig, o2::detectors::DetID detId)
+template <int N>
+DataProcessorSpec getDigitWriterSpec(bool mctruth, bool dec, bool calib)
 {
-  std::string detStr = o2::detectors::DetID::getName(detId);
+  static constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+  constexpr int NLayers = o2::itsmft::DPLAlpideParam<N>::supportsStaggering() ? o2::itsmft::DPLAlpideParam<N>::getNLayers() : 1;
+  std::string detStr = o2::detectors::DetID::getName(N);
   std::string detStrL = dec ? "o2_" : ""; // for decoded digits prepend by o2
   detStrL += detStr;
   std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
-  auto logger = [](std::vector<o2::itsmft::Digit> const& inDigits) {
-    LOG(info) << "RECEIVED DIGITS SIZE " << inDigits.size();
+  auto digitSizes = std::make_shared<std::array<size_t, NLayers>>();
+  auto digitSizeGetter = [digitSizes](std::vector<o2::itsmft::Digit> const& inDigits, DataRef const& ref) {
+    auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    (*digitSizes)[dh->subSpecification] = inDigits.size();
+  };
+  auto rofSizes = std::make_shared<std::array<size_t, NLayers>>();
+  auto rofSizeGetter = [rofSizes](std::vector<o2::itsmft::ROFRecord> const& inROFs, DataRef const& ref) {
+    auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    (*rofSizes)[dh->subSpecification] = inROFs.size();
   };
 
   // the callback to be set as hook for custom action when the writer is closed
@@ -71,9 +84,11 @@ DataProcessorSpec getDigitWriterSpec(bool mctruth, bool dec, bool calib, o2::hea
   // handler for labels
   // This is necessary since we can't store the original label buffer in a ROOT entry -- as is -- if it exceeds a certain size.
   // We therefore convert it to a special split class.
-  auto fillLabels = [](TBranch& branch, std::vector<char> const& labelbuffer, DataRef const& /*ref*/) {
+  auto fillLabels = [digitSizes, rofSizes](TBranch& branch, std::vector<char> const& labelbuffer, DataRef const& ref) {
     o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> labels(labelbuffer);
-    LOG(info) << "WRITING " << labels.getNElements() << " LABELS ";
+    auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    auto layer = static_cast<size_t>(dh->subSpecification);
+    LOG(info) << "WRITING " << labels.getNElements() << " LABELS FOR " << layer << " WITH " << (*digitSizes)[layer] << " DIGITS IN " << (*rofSizes)[layer] << " ROFS";
 
     o2::dataformats::IOMCTruthContainerView outputcontainer;
     auto ptr = &outputcontainer;
@@ -83,35 +98,56 @@ DataProcessorSpec getDigitWriterSpec(bool mctruth, bool dec, bool calib, o2::hea
     br->ResetAddress();
   };
 
+  auto getIndex = [](DataRef const& ref) -> size_t {
+    auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    return static_cast<size_t>(dh->subSpecification);
+  };
+  auto getName = [](std::string base, size_t index) -> std::string {
+    if constexpr (o2::itsmft::DPLAlpideParam<N>::supportsStaggering()) {
+      return base += "_" + std::to_string(index);
+    }
+    return base;
+  };
   return MakeRootTreeWriterSpec((detStr + "DigitWriter" + (dec ? "_dec" : "")).c_str(),
                                 (detStrL + "digits.root").c_str(),
-                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Digits tree"},
+                                MakeRootTreeWriterSpec::TreeAttributes{.name = "o2sim", .title = detStr + " Digits tree"},
                                 MakeRootTreeWriterSpec::CustomClose(finishWriting),
-                                // in case of labels we first read them as std::vector<char> and process them correctly in the fillLabels hook
-                                BranchDefinition<std::vector<char>>{InputSpec{(detStr + "_digitsMCTR").c_str(), detOrig, "DIGITSMCTR", 0},
-                                                                    (detStr + "DigitMCTruth").c_str(),
-                                                                    (mctruth ? 1 : 0), fillLabels},
-                                BranchDefinition<std::vector<itsmft::MC2ROFRecord>>{InputSpec{(detStr + "_digitsMC2ROF").c_str(), detOrig, "DIGITSMC2ROF", 0},
-                                                                                    (detStr + "DigitMC2ROF").c_str(),
-                                                                                    (mctruth ? 1 : 0)},
-                                BranchDefinition<std::vector<itsmft::Digit>>{InputSpec{(detStr + "digits").c_str(), detOrig, "DIGITS", 0},
-                                                                             (detStr + "Digit").c_str(),
-                                                                             logger},
-                                BranchDefinition<std::vector<itsmft::GBTCalibData>>{InputSpec{(detStr + "calib").c_str(), detOrig, "GBTCALIB", 0},
-                                                                                    (detStr + "Calib").c_str(),
-                                                                                    (calib ? 1 : 0)},
-                                BranchDefinition<std::vector<itsmft::ROFRecord>>{InputSpec{(detStr + "digitsROF").c_str(), detOrig, "DIGITSROF", 0},
-                                                                                 (detStr + "DigitROF").c_str()})();
+                                BranchDefinition<std::vector<itsmft::Digit>>{InputSpec{detStr + "digits", ConcreteDataTypeMatcher{Origin, "DIGITS"}},
+                                                                             detStr + "Digit", "digit-branch",
+                                                                             NLayers,
+                                                                             digitSizeGetter,
+                                                                             getIndex,
+                                                                             getName},
+                                BranchDefinition<std::vector<itsmft::ROFRecord>>{InputSpec{detStr + "digitsROF", ConcreteDataTypeMatcher{Origin, "DIGITSROF"}},
+                                                                                 detStr + "DigitROF", "digit-rof-branch",
+                                                                                 NLayers,
+                                                                                 rofSizeGetter,
+                                                                                 getIndex,
+                                                                                 getName},
+                                BranchDefinition<std::vector<char>>{InputSpec{detStr + "_digitsMCTR", ConcreteDataTypeMatcher{Origin, "DIGITSMCTR"}},
+                                                                    detStr + "DigitMCTruth", "digit-mctruth-branch",
+                                                                    (mctruth ? NLayers : 0),
+                                                                    fillLabels,
+                                                                    getIndex,
+                                                                    getName},
+                                BranchDefinition<std::vector<itsmft::MC2ROFRecord>>{InputSpec{detStr + "_digitsMC2ROF", ConcreteDataTypeMatcher{Origin, "DIGITSMC2ROF"}},
+                                                                                    detStr + "DigitMC2ROF", "digit-mc2rof-branch",
+                                                                                    (mctruth ? NLayers : 0),
+                                                                                    getIndex,
+                                                                                    getName},
+                                BranchDefinition<std::vector<itsmft::GBTCalibData>>{InputSpec{detStr + "calib", ConcreteDataTypeMatcher{Origin, "GBTCALIB"}},
+                                                                                    detStr + "Calib", "digit-calib-branch",
+                                                                                    (calib ? 1 : 0)})();
 }
 
 DataProcessorSpec getITSDigitWriterSpec(bool mctruth, bool dec, bool calib)
 {
-  return getDigitWriterSpec(mctruth, dec, calib, o2::header::gDataOriginITS, o2::detectors::DetID::ITS);
+  return getDigitWriterSpec<o2::detectors::DetID::ITS>(mctruth, dec, calib);
 }
 
 DataProcessorSpec getMFTDigitWriterSpec(bool mctruth, bool dec, bool calib)
 {
-  return getDigitWriterSpec(mctruth, dec, calib, o2::header::gDataOriginMFT, o2::detectors::DetID::MFT);
+  return getDigitWriterSpec<o2::detectors::DetID::MFT>(mctruth, dec, calib);
 }
 
 } // end namespace itsmft

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -17,12 +17,13 @@
 #include "Framework/Lifetime.h"
 #include "Framework/Task.h"
 #include "Framework/CCDBParamSpec.h"
-#include "Steer/HitProcessingManager.h" // for DigitizationContext
+#include "SimulationDataFormat/DigitizationContext.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/NoiseMap.h"
 #include "DataFormatsITSMFT/TimeDeadMap.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "DetectorsBase/BaseDPLDigitizer.h"
+#include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsCommonDataFormats/SimTraits.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
@@ -36,20 +37,25 @@
 #include <TChain.h>
 #include <TStopwatch.h>
 #include <string>
+#include <format>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
 
-namespace o2
-{
-namespace itsmft
+namespace o2::itsmft
 {
 
 using namespace o2::base;
+template <int N>
 class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
 {
  public:
+  static constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+  static constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+  static constexpr int NLayers{o2::itsmft::DPLAlpideParam<N>::getNLayers()};
+
   using BaseDPLDigitizer::init;
+
   void initDigitizerTask(framework::InitContext& ic) override
   {
     mDisableQED = ic.options().get<bool>("disable-qed");
@@ -60,121 +66,174 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     if (mFinished) {
       return;
     }
+
     mFirstOrbitTF = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
-    mID == o2::detectors::DetID::ITS ? updateTimeDependentParams<o2::detectors::DetID::ITS>(pc) : updateTimeDependentParams<o2::detectors::DetID::MFT>(pc);
-    std::string detStr = mID.getName();
+    const o2::InteractionRecord firstIR(0, mFirstOrbitTF);
+    updateTimeDependentParams(pc);
+
+    TStopwatch timer;
+    timer.Start();
+    LOG(info) << " CALLING ITS DIGITIZATION ";
+
     // read collision context from input
     auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
-    context->initSimChains(mID, mSimChains);
+    context->initSimChains(ID, mSimChains);
     const bool withQED = context->isQEDProvided() && !mDisableQED;
     auto& timesview = context->getEventRecords(withQED);
     LOG(info) << "GOT " << timesview.size() << " COLLISSION TIMES";
-    LOG(info) << "SIMCHAINS " << mSimChains.size();
+    LOG(info) << "SIMCHAINS: " << mSimChains.size();
 
     // if there is nothing to do ... return
     if (timesview.size() == 0) {
       return;
     }
-    TStopwatch timer;
-    timer.Start();
-    LOG(info) << " CALLING ITS DIGITIZATION ";
 
-    mDigitizer.setDigits(&mDigits);
-    mDigitizer.setROFRecords(&mROFRecords);
-    mDigitizer.setMCLabels(&mLabels);
+    uint64_t nDigits{0};
+    constexpr uint32_t nLayers = (DPLAlpideParam<N>::supportsStaggering()) ? NLayers : 1;
+    for (uint32_t iLayer = 0; iLayer < nLayers; ++iLayer) {
+      const int layer = (DPLAlpideParam<N>::supportsStaggering()) ? iLayer : -1;
+      mDigitizer.setDigits(&mDigits[iLayer]);
+      mDigitizer.setROFRecords(&mROFRecords[iLayer]);
+      mDigitizer.setMCLabels(&mLabels[iLayer]);
+      mDigitizer.resetROFrameBounds();
 
-    // digits are directly put into DPL owned resource
-    auto& digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{mOrigin, "DIGITS", 0});
+      // digits are directly put into DPL owned resource
+      auto& digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{Origin, "DIGITS", iLayer});
 
-    auto accumulate = [this, &digitsAccum]() {
-      // accumulate result of single event processing, called after processing every event supplied
-      // AND after the final flushing via digitizer::fillOutputContainer
-      if (!mDigits.size()) {
-        return; // no digits were flushed, nothing to accumulate
-      }
-      auto ndigAcc = digitsAccum.size();
-      std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(digitsAccum));
+      // rofs are accumulated first and the copied
+      const int nROFsPerOrbit = o2::constants::lhc::LHCMaxBunches / DPLAlpideParam<N>::Instance().getROFLengthInBC(iLayer);
+      const int nROFsTF = nROFsPerOrbit * raw::HBFUtils::Instance().getNOrbitsPerTF();
+      mROFRecordsAccum[iLayer].reserve(nROFsTF);
 
-      // fix ROFrecords references on ROF entries
-      auto nROFRecsOld = mROFRecordsAccum.size();
+      auto accumulate = [this, &digitsAccum, &iLayer]() {
+        // accumulate result of single event processing on a specific layer, called after processing every event supplied
+        // AND after the final flushing via digitizer::fillOutputContainer
+        if (!mDigits[iLayer].size()) {
+          return; // no digits were flushed, nothing to accumulate
+        }
+        auto ndigAcc = digitsAccum.size();
+        std::copy(mDigits[iLayer].begin(), mDigits[iLayer].end(), std::back_inserter(digitsAccum));
 
-      for (int i = 0; i < mROFRecords.size(); i++) {
-        auto& rof = mROFRecords[i];
-        rof.setFirstEntry(ndigAcc + rof.getFirstEntry());
-        rof.print();
+        // fix ROFrecords references on ROF entries
+        auto nROFRecsOld = mROFRecordsAccum[iLayer].size();
 
-        if (mFixMC2ROF < mMC2ROFRecordsAccum.size()) { // fix ROFRecord entry in MC2ROF records
-          for (int m2rid = mFixMC2ROF; m2rid < mMC2ROFRecordsAccum.size(); m2rid++) {
-            // need to register the ROFRecors entry for MC event starting from this entry
-            auto& mc2rof = mMC2ROFRecordsAccum[m2rid];
-            if (rof.getROFrame() == mc2rof.minROF) {
-              mFixMC2ROF++;
-              mc2rof.rofRecordID = nROFRecsOld + i;
-              mc2rof.print();
+        for (int i = 0; i < mROFRecords[iLayer].size(); i++) {
+          auto& rof = mROFRecords[iLayer][i];
+          rof.setFirstEntry(ndigAcc + rof.getFirstEntry());
+          rof.print();
+
+          if (mFixMC2ROF[iLayer] < mMC2ROFRecordsAccum[iLayer].size()) { // fix ROFRecord entry in MC2ROF records
+            for (int m2rid = mFixMC2ROF[iLayer]; m2rid < mMC2ROFRecordsAccum[iLayer].size(); m2rid++) {
+              // need to register the ROFRecors entry for MC event starting from this entry
+              auto& mc2rof = mMC2ROFRecordsAccum[iLayer][m2rid];
+              if (rof.getROFrame() == mc2rof.minROF) {
+                mFixMC2ROF[iLayer]++;
+                mc2rof.rofRecordID = nROFRecsOld + i;
+                mc2rof.print();
+              }
             }
           }
         }
-      }
 
-      std::copy(mROFRecords.begin(), mROFRecords.end(), std::back_inserter(mROFRecordsAccum));
-      if (mWithMCTruth) {
-        mLabelsAccum.mergeAtBack(mLabels);
-      }
-      LOG(info) << "Added " << mDigits.size() << " digits ";
-      // clean containers from already accumulated stuff
-      mLabels.clear();
-      mDigits.clear();
-      mROFRecords.clear();
-    }; // and accumulate lambda
-
-    auto& eventParts = context->getEventParts(withQED);
-    int bcShift = mDigitizer.getParams().getROFrameBiasInBC();
-    // loop over all composite collisions given from context (aka loop over all the interaction records)
-    for (int collID = 0; collID < timesview.size(); ++collID) {
-      auto irt = timesview[collID];
-      if (irt.toLong() < bcShift) { // due to the ROF misalignment the collision would go to negative ROF ID, discard
-        continue;
-      }
-      irt -= bcShift; // account for the ROF start shift
-
-      mDigitizer.setEventTime(irt);
-      mDigitizer.resetEventROFrames(); // to estimate min/max ROF for this collID
-      // for each collision, loop over the constituents event and source IDs
-      // (background signal merging is basically taking place here)
-      for (auto& part : eventParts[collID]) {
-
-        // get the hits for this event and this source
-        mHits.clear();
-        context->retrieveHits(mSimChains, o2::detectors::SimTraits::DETECTORBRANCHNAMES[mID][0].c_str(), part.sourceID, part.entryID, &mHits);
-
-        if (mHits.size() > 0) {
-          LOG(debug) << "For collision " << collID << " eventID " << part.entryID
-                     << " found " << mHits.size() << " hits ";
-          mDigitizer.process(&mHits, part.entryID, part.sourceID); // call actual digitization procedure
+        std::copy(mROFRecords[iLayer].begin(), mROFRecords[iLayer].end(), std::back_inserter(mROFRecordsAccum[iLayer]));
+        if (mWithMCTruth) {
+          mLabelsAccum[iLayer].mergeAtBack(mLabels[iLayer]);
         }
+        LOG(info) << "Added " << mDigits[iLayer].size() << " digits:" << iLayer;
+        // clean containers from already accumulated stuff
+        mLabels[iLayer].clear();
+        mDigits[iLayer].clear();
+        mROFRecords[iLayer].clear();
+      }; // and accumulate lambda
+
+      const auto& eventParts = context->getEventParts(withQED);
+      const int64_t bcShift = mDigitizer.getParams().getROFrameBiasInBC(layer); // this accounts the misalignment and the opt. imposed rof delay
+      // loop over all composite collisions given from context (aka loop over all the interaction records)
+      for (int collID = 0; collID < timesview.size(); ++collID) {
+        auto irt = timesview[collID];
+        if (irt.toLong() < bcShift) { // due to the ROF misalignment (+opt. delay) the collision would go to negative ROF ID, discard
+          continue;
+        }
+        irt -= bcShift; // account for the ROF start shift
+
+        mDigitizer.setEventTime(irt, layer);
+        mDigitizer.resetEventROFrames(); // to estimate min/max ROF for this collID
+        // for each collision, loop over the constituents event and source IDs
+        // (background signal merging is basically taking place here)
+        for (const auto& part : eventParts[collID]) {
+
+          // get the hits for this event and this source
+          mHits.clear();
+          context->retrieveHits(mSimChains, o2::detectors::SimTraits::DETECTORBRANCHNAMES[ID][0].c_str(), part.sourceID, part.entryID, &mHits);
+
+          if (mHits.size() > 0) {
+            LOG(debug) << "For collision " << collID << " eventID " << part.entryID << " found " << mHits.size() << " hits ";
+            mDigitizer.process(&mHits, part.entryID, part.sourceID, layer); // call actual digitization procedure
+          }
+        }
+        mMC2ROFRecordsAccum[iLayer].emplace_back(collID, -1, mDigitizer.getEventROFrameMin(), mDigitizer.getEventROFrameMax());
+        accumulate();
       }
-      mMC2ROFRecordsAccum.emplace_back(collID, -1, mDigitizer.getEventROFrameMin(), mDigitizer.getEventROFrameMax());
+      mDigitizer.fillOutputContainer(0xffffffff, layer);
       accumulate();
-    }
-    mDigitizer.fillOutputContainer();
-    accumulate();
+      nDigits += digitsAccum.size();
 
-    // here we have all digits and labels and we can send them to consumer (aka snapshot it onto output)
-
-    pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0}, mROFRecordsAccum);
-    if (mWithMCTruth) {
-      pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0}, mMC2ROFRecordsAccum);
-      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{mOrigin, "DIGITSMCTR", 0});
-      mLabelsAccum.flatten_to(sharedlabels);
-      // free space of existing label containers
-      mLabels.clear_andfreememory();
-      mLabelsAccum.clear_andfreememory();
+      // here we have all digits and labels and we can send them to consumer (aka snapshot it onto output)
+      // ensure that the rof output is continuous
+      if (nROFsTF != mROFRecordsAccum[iLayer].size()) {
+        // it can happen that in the digitization rofs without contributing hits are skipped
+        // however downstream consumers of the clusters cannot know apriori the time structure
+        // the cluster rofs do not account for the bias so it will start always at BC=0
+        std::vector<o2::itsmft::ROFRecord> expDigitRofVec(nROFsTF);
+        for (int iROF{0}; iROF < nROFsTF; ++iROF) {
+          auto& rof = expDigitRofVec[iROF];
+          int orb = iROF * DPLAlpideParam<N>::Instance().getROFLengthInBC(iLayer) / o2::constants::lhc::LHCMaxBunches + mFirstOrbitTF;
+          int bc = iROF * DPLAlpideParam<N>::Instance().getROFLengthInBC(iLayer) % o2::constants::lhc::LHCMaxBunches;
+          o2::InteractionRecord ir(bc, orb);
+          rof.setBCData(ir);
+          rof.setROFrame(iROF);
+          rof.setNEntries(0);
+          rof.setFirstEntry(-1);
+        }
+        uint32_t prevEntry{0};
+        for (const auto& rof : mROFRecordsAccum[iLayer]) {
+          const auto& ir = rof.getBCData();
+          const auto irToFirst = ir - firstIR;
+          const int irROF = irToFirst.toLong() / DPLAlpideParam<N>::Instance().getROFLengthInBC(iLayer);
+          auto& expROF = expDigitRofVec[irROF];
+          expROF.setFirstEntry(rof.getFirstEntry());
+          expROF.setNEntries(rof.getNEntries());
+          if (expROF.getBCData() != rof.getBCData()) {
+            LOGP(fatal, "detected mismatch between expected ROF:{} and received ROF:{}", expROF.asString(), rof.asString());
+          }
+        }
+        int prevFirst{0};
+        for (auto& rof : expDigitRofVec) {
+          if (rof.getFirstEntry() < 0) {
+            rof.setFirstEntry(prevFirst);
+          }
+          prevFirst = rof.getFirstEntry();
+        }
+        pc.outputs().snapshot(Output{Origin, "DIGITSROF", iLayer}, expDigitRofVec);
+      } else {
+        pc.outputs().snapshot(Output{Origin, "DIGITSROF", iLayer}, mROFRecordsAccum[iLayer]);
+      }
+      if (mWithMCTruth) {
+        pc.outputs().snapshot(Output{Origin, "DIGITSMC2ROF", iLayer}, mMC2ROFRecordsAccum[iLayer]);
+        auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{Origin, "DIGITSMCTR", iLayer});
+        mLabelsAccum[iLayer].flatten_to(sharedlabels);
+        // free space of existing label containers
+        mLabels[iLayer].clear_andfreememory();
+        mLabelsAccum[iLayer].clear_andfreememory();
+      }
     }
-    LOG(info) << mID.getName() << ": Sending ROMode= " << mROMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{mOrigin, "ROMode", 0}, mROMode);
+
+    LOG(info) << ID.getName() << ": Sending ROMode= " << mROMode << " to GRPUpdater";
+    pc.outputs().snapshot(Output{Origin, "ROMode", 0}, mROMode);
 
     timer.Stop();
     LOG(info) << "Digitization took " << timer.CpuTime() << "s";
+    LOG(info) << "Produced " << nDigits << " digits";
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
@@ -184,18 +243,18 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
 
   void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   {
-    if (matcher == ConcreteDataMatcher(mOrigin, "NOISEMAP", 0)) {
-      LOG(info) << mID.getName() << " noise map updated";
+    if (matcher == ConcreteDataMatcher(Origin, "NOISEMAP", 0)) {
+      LOG(info) << ID.getName() << " noise map updated";
       mDigitizer.setNoiseMap((const o2::itsmft::NoiseMap*)obj);
       return;
     }
-    if (matcher == ConcreteDataMatcher(mOrigin, "DEADMAP", 0)) {
-      LOG(info) << mID.getName() << " static dead map updated";
+    if (matcher == ConcreteDataMatcher(Origin, "DEADMAP", 0)) {
+      LOG(info) << ID.getName() << " static dead map updated";
       mDeadMap = (o2::itsmft::NoiseMap*)obj;
       mDigitizer.setDeadChannelsMap(mDeadMap);
       return;
     }
-    if (matcher == ConcreteDataMatcher(mOrigin, "TimeDeadMap", 0)) {
+    if (matcher == ConcreteDataMatcher(Origin, "TimeDeadMap", 0)) {
       o2::itsmft::TimeDeadMap* timedeadmap = (o2::itsmft::TimeDeadMap*)obj;
       if (!timedeadmap->isDefault()) {
         timedeadmap->decodeMap(mFirstOrbitTF, *mDeadMap, true);
@@ -204,30 +263,25 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
         }
         mTimeDeadMapUpdated = true;
         mDigitizer.setDeadChannelsMap(mDeadMap);
-        LOG(info) << mID.getName() << " time-dependent dead map updated";
+        LOG(info) << ID.getName() << " time-dependent dead map updated";
       } else {
-        LOG(info) << mID.getName() << " time-dependent dead map is default/empty";
+        LOG(info) << ID.getName() << " time-dependent dead map is default/empty";
       }
 
       return;
     }
-    if (matcher == ConcreteDataMatcher(mOrigin, "ALPIDEPARAM", 0)) {
-      LOG(info) << mID.getName() << " Alpide param updated";
-      if (mID == o2::detectors::DetID::ITS) {
-        const auto& par = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-        par.printKeyValues();
-      } else {
-        const auto& par = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
-        par.printKeyValues();
-      }
+    if (matcher == ConcreteDataMatcher(Origin, "ALPIDEPARAM", 0)) {
+      LOG(info) << ID.getName() << " Alpide param updated";
+      const auto& par = o2::itsmft::DPLAlpideParam<N>::Instance();
+      par.printKeyValues();
       return;
     }
-    if (matcher == ConcreteDataMatcher(mOrigin, "ALPIDERESPVbb0", 0)) {
-      LOG(info) << mID.getName() << " loaded AlpideResponseData for Vbb=0V";
+    if (matcher == ConcreteDataMatcher(Origin, "ALPIDERESPVbb0", 0)) {
+      LOG(info) << ID.getName() << " loaded AlpideResponseData for Vbb=0V";
       mDigitizer.setAlpideResponse((o2::itsmft::AlpideSimResponse*)obj, 0);
     }
-    if (matcher == ConcreteDataMatcher(mOrigin, "ALPIDERESPVbbM3", 0)) {
-      LOG(info) << mID.getName() << " loaded AlpideResponseData for Vbb=-3V";
+    if (matcher == ConcreteDataMatcher(Origin, "ALPIDERESPVbbM3", 0)) {
+      LOG(info) << ID.getName() << " loaded AlpideResponseData for Vbb=-3V";
       mDigitizer.setAlpideResponse((o2::itsmft::AlpideSimResponse*)obj, 1);
     }
   }
@@ -235,20 +289,19 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
  protected:
   ITSMFTDPLDigitizerTask(bool mctruth = true) : BaseDPLDigitizer(InitServices::FIELD | InitServices::GEOM), mWithMCTruth(mctruth) {}
 
-  template <int DETID>
   void updateTimeDependentParams(ProcessingContext& pc)
   {
-    std::string detstr(o2::detectors::DetID::getName(DETID));
+    std::string detstr(o2::detectors::DetID::getName(ID));
     pc.inputs().get<o2::itsmft::NoiseMap*>(detstr + "_noise");
     pc.inputs().get<o2::itsmft::NoiseMap*>(detstr + "_dead");
     // TODO: the code should run even if this object does not exist. Or: create default object
     pc.inputs().get<o2::itsmft::TimeDeadMap*>(detstr + "_time_dead");
-    pc.inputs().get<o2::itsmft::DPLAlpideParam<DETID>*>(detstr + "_alppar");
+    pc.inputs().get<o2::itsmft::DPLAlpideParam<N>*>(detstr + "_alppar");
     pc.inputs().get<o2::itsmft::AlpideSimResponse*>(detstr + "_alpiderespvbb0");
     pc.inputs().get<o2::itsmft::AlpideSimResponse*>(detstr + "_alpiderespvbbm3");
 
-    auto& dopt = o2::itsmft::DPLDigitizerParam<DETID>::Instance();
-    auto& aopt = o2::itsmft::DPLAlpideParam<DETID>::Instance();
+    auto& dopt = o2::itsmft::DPLDigitizerParam<N>::Instance();
+    auto& aopt = o2::itsmft::DPLAlpideParam<N>::Instance();
     auto& digipar = mDigitizer.getParams();
     digipar.setContinuous(dopt.continuous);
     digipar.setROFrameBiasInBC(aopt.roFrameBiasInBC);
@@ -272,15 +325,29 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     digipar.setIBVbb(dopt.IBVbb);
     digipar.setOBVbb(dopt.OBVbb);
     digipar.setVbb(dopt.Vbb);
+    // staggering parameters
+    if constexpr (o2::itsmft::DPLAlpideParam<N>::supportsStaggering()) {
+      const bool withStag = aopt.withStaggering();
+      for (int iLayer{0}; iLayer < o2::itsmft::DPLAlpideParam<N>::getNLayers(); ++iLayer) {
+        const int nLayer = (withStag) ? iLayer : -1;
+        auto frameNS = aopt.getROFLengthInBC(nLayer) * o2::constants::lhc::LHCBunchSpacingNS;
+        digipar.addROFrameLayerLengthInBC(aopt.getROFLengthInBC(nLayer));
+        // NOTE: the rof delay looks from the digitizer like an additional bias
+        digipar.addROFrameLayerBiasInBC(aopt.getROFBiasInBC(nLayer) + aopt.getROFDelayInBC(nLayer));
+        digipar.addStrobeDelay(aopt.strobeDelay);
+        digipar.addStrobeLength(aopt.strobeLengthCont > 0 ? aopt.strobeLengthCont : frameNS - aopt.strobeDelay);
+        digipar.setROFrameLength(aopt.getROFLengthInBC(nLayer) * o2::constants::lhc::LHCBunchSpacingNS, iLayer);
+      }
+    }
 
     mROMode = digipar.isContinuous() ? o2::parameters::GRPObject::CONTINUOUS : o2::parameters::GRPObject::PRESENT;
-    LOG(info) << mID.getName() << " simulated in "
+    LOG(info) << detstr << " simulated in "
               << ((mROMode == o2::parameters::GRPObject::CONTINUOUS) ? "CONTINUOUS" : "TRIGGERED")
               << " RO mode";
 
     // configure digitizer
     o2::itsmft::GeometryTGeo* geom = nullptr;
-    if (mID == o2::detectors::DetID::ITS) {
+    if constexpr (N == o2::detectors::DetID::ITS) {
       geom = o2::its::GeometryTGeo::Instance();
     } else {
       geom = o2::mft::GeometryTGeo::Instance();
@@ -294,81 +361,61 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
   bool mFinished = false;
   bool mDisableQED = false;
   unsigned long mFirstOrbitTF = 0x0;
-  o2::detectors::DetID mID;
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
   o2::itsmft::Digitizer mDigitizer;
-  std::vector<o2::itsmft::Digit> mDigits;
-  std::vector<o2::itsmft::ROFRecord> mROFRecords;
-  std::vector<o2::itsmft::ROFRecord> mROFRecordsAccum;
+  std::array<std::vector<o2::itsmft::Digit>, NLayers> mDigits;
+  std::array<std::vector<o2::itsmft::ROFRecord>, NLayers> mROFRecords;
+  std::array<std::vector<o2::itsmft::ROFRecord>, NLayers> mROFRecordsAccum;
   std::vector<o2::itsmft::Hit> mHits;
   std::vector<o2::itsmft::Hit>* mHitsP = &mHits;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabels;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabelsAccum;
-  std::vector<o2::itsmft::MC2ROFRecord> mMC2ROFRecordsAccum;
+  std::array<o2::dataformats::MCTruthContainer<o2::MCCompLabel>, NLayers> mLabels;
+  std::array<o2::dataformats::MCTruthContainer<o2::MCCompLabel>, NLayers> mLabelsAccum;
+  std::array<std::vector<o2::itsmft::MC2ROFRecord>, NLayers> mMC2ROFRecordsAccum;
   std::vector<TChain*> mSimChains;
   o2::itsmft::NoiseMap* mDeadMap = nullptr;
 
-  int mFixMC2ROF = 0;                                                             // 1st entry in mc2rofRecordsAccum to be fixed for ROFRecordID
+  std::array<int, NLayers> mFixMC2ROF{}; // 1st entry in mc2rofRecordsAccum to be fixed for ROFRecordID
   bool mTimeDeadMapUpdated = false;
   o2::parameters::GRPObject::ROMode mROMode = o2::parameters::GRPObject::PRESENT; // readout mode
 };
 
 //_______________________________________________
-class ITSDPLDigitizerTask : public ITSMFTDPLDigitizerTask
+class ITSDPLDigitizerTask : public ITSMFTDPLDigitizerTask<o2::detectors::DetID::ITS>
 {
  public:
-  // FIXME: origin should be extractable from the DetID, the problem is 3d party header dependencies
-  static constexpr o2::detectors::DetID::ID DETID = o2::detectors::DetID::ITS;
-  static constexpr o2::header::DataOrigin DETOR = o2::header::gDataOriginITS;
-  ITSDPLDigitizerTask(bool mctruth = true) : ITSMFTDPLDigitizerTask(mctruth)
-  {
-    mID = DETID;
-    mOrigin = DETOR;
-  }
+  ITSDPLDigitizerTask(bool mctruth = true) : ITSMFTDPLDigitizerTask<o2::detectors::DetID::ITS>(mctruth) {}
 };
-
-constexpr o2::detectors::DetID::ID ITSDPLDigitizerTask::DETID;
-constexpr o2::header::DataOrigin ITSDPLDigitizerTask::DETOR;
 
 //_______________________________________________
-class MFTDPLDigitizerTask : public ITSMFTDPLDigitizerTask
+class MFTDPLDigitizerTask : public ITSMFTDPLDigitizerTask<o2::detectors::DetID::MFT>
 {
  public:
-  // FIXME: origina should be extractable from the DetID, the problem is 3d party header dependencies
-  static constexpr o2::detectors::DetID::ID DETID = o2::detectors::DetID::MFT;
-  static constexpr o2::header::DataOrigin DETOR = o2::header::gDataOriginMFT;
-  MFTDPLDigitizerTask(bool mctruth) : ITSMFTDPLDigitizerTask(mctruth)
-  {
-    mID = DETID;
-    mOrigin = DETOR;
-  }
+  MFTDPLDigitizerTask(bool mctruth = true) : ITSMFTDPLDigitizerTask<o2::detectors::DetID::MFT>(mctruth) {}
 };
 
-constexpr o2::detectors::DetID::ID MFTDPLDigitizerTask::DETID;
-constexpr o2::header::DataOrigin MFTDPLDigitizerTask::DETOR;
-
+namespace
+{
+template <int N>
 std::vector<OutputSpec> makeOutChannels(o2::header::DataOrigin detOrig, bool mctruth)
 {
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(detOrig, "DIGITS", 0, Lifetime::Timeframe);
-  outputs.emplace_back(detOrig, "DIGITSROF", 0, Lifetime::Timeframe);
-  if (mctruth) {
-    outputs.emplace_back(detOrig, "DIGITSMC2ROF", 0, Lifetime::Timeframe);
-    outputs.emplace_back(detOrig, "DIGITSMCTR", 0, Lifetime::Timeframe);
+  constexpr uint32_t nLayers = (DPLAlpideParam<N>::supportsStaggering()) ? DPLAlpideParam<N>::getNLayers() : 1;
+  for (uint32_t iLayer = 0; iLayer < nLayers; ++iLayer) {
+    outputs.emplace_back(detOrig, "DIGITS", iLayer, Lifetime::Timeframe);
+    outputs.emplace_back(detOrig, "DIGITSROF", iLayer, Lifetime::Timeframe);
+    if (mctruth) {
+      outputs.emplace_back(detOrig, "DIGITSMC2ROF", iLayer, Lifetime::Timeframe);
+      outputs.emplace_back(detOrig, "DIGITSMCTR", iLayer, Lifetime::Timeframe);
+    }
   }
   outputs.emplace_back(detOrig, "ROMode", 0, Lifetime::Timeframe);
   return outputs;
 }
+} // namespace
 
 DataProcessorSpec getITSDigitizerSpec(int channel, bool mctruth)
 {
-  std::string detStr = o2::detectors::DetID::getName(ITSDPLDigitizerTask::DETID);
-  auto detOrig = ITSDPLDigitizerTask::DETOR;
-  std::stringstream parHelper;
-  parHelper << "Params as " << o2::itsmft::DPLDigitizerParam<ITSDPLDigitizerTask::DETID>::getParamName().data() << ".<param>=value;... with"
-            << o2::itsmft::DPLDigitizerParam<ITSDPLDigitizerTask::DETID>::Instance()
-            << "\n or " << o2::itsmft::DPLAlpideParam<ITSDPLDigitizerTask::DETID>::getParamName().data() << ".<param>=value;... with"
-            << o2::itsmft::DPLAlpideParam<ITSDPLDigitizerTask::DETID>::Instance();
+  std::string detStr = o2::detectors::DetID::getName(ITSDPLDigitizerTask::ID);
+  auto detOrig = ITSDPLDigitizerTask::Origin;
   std::vector<InputSpec> inputs;
   inputs.emplace_back("collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   inputs.emplace_back("ITS_noise", "ITS", "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/NoiseMap"));
@@ -377,19 +424,18 @@ DataProcessorSpec getITSDigitizerSpec(int channel, bool mctruth)
   inputs.emplace_back("ITS_alppar", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam"));
   inputs.emplace_back("ITS_alpiderespvbb0", "ITS", "ALPIDERESPVbb0", 0, Lifetime::Condition, ccdbParamSpec("ITSMFT/Calib/ALPIDEResponseVbb0"));
   inputs.emplace_back("ITS_alpiderespvbbm3", "ITS", "ALPIDERESPVbbM3", 0, Lifetime::Condition, ccdbParamSpec("ITSMFT/Calib/ALPIDEResponseVbbM3"));
-
-  return DataProcessorSpec{(detStr + "Digitizer").c_str(),
-                           inputs, makeOutChannels(detOrig, mctruth),
-                           AlgorithmSpec{adaptFromTask<ITSDPLDigitizerTask>(mctruth)},
-                           Options{
+  return DataProcessorSpec{.name = detStr + "Digitizer",
+                           .inputs = inputs,
+                           .outputs = makeOutChannels<o2::detectors::DetID::ITS>(detOrig, mctruth),
+                           .algorithm = AlgorithmSpec{adaptFromTask<ITSDPLDigitizerTask>(mctruth)},
+                           .options = Options{
                              {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
 }
 
 DataProcessorSpec getMFTDigitizerSpec(int channel, bool mctruth)
 {
-  std::string detStr = o2::detectors::DetID::getName(MFTDPLDigitizerTask::DETID);
-  auto detOrig = MFTDPLDigitizerTask::DETOR;
-  std::stringstream parHelper;
+  std::string detStr = o2::detectors::DetID::getName(MFTDPLDigitizerTask::ID);
+  auto detOrig = MFTDPLDigitizerTask::Origin;
   std::vector<InputSpec> inputs;
   inputs.emplace_back("collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   inputs.emplace_back("MFT_noise", "MFT", "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/NoiseMap"));
@@ -398,15 +444,12 @@ DataProcessorSpec getMFTDigitizerSpec(int channel, bool mctruth)
   inputs.emplace_back("MFT_alppar", "MFT", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("MFT/Config/AlpideParam"));
   inputs.emplace_back("MFT_alpiderespvbb0", "MFT", "ALPIDERESPVbb0", 0, Lifetime::Condition, ccdbParamSpec("ITSMFT/Calib/ALPIDEResponseVbb0"));
   inputs.emplace_back("MFT_alpiderespvbbm3", "MFT", "ALPIDERESPVbbM3", 0, Lifetime::Condition, ccdbParamSpec("ITSMFT/Calib/ALPIDEResponseVbbM3"));
-  parHelper << "Params as " << o2::itsmft::DPLDigitizerParam<ITSDPLDigitizerTask::DETID>::getParamName().data() << ".<param>=value;... with"
-            << o2::itsmft::DPLDigitizerParam<ITSDPLDigitizerTask::DETID>::Instance()
-            << " or " << o2::itsmft::DPLAlpideParam<ITSDPLDigitizerTask::DETID>::getParamName().data() << ".<param>=value;... with"
-            << o2::itsmft::DPLAlpideParam<ITSDPLDigitizerTask::DETID>::Instance();
-  return DataProcessorSpec{(detStr + "Digitizer").c_str(),
-                           inputs, makeOutChannels(detOrig, mctruth),
-                           AlgorithmSpec{adaptFromTask<MFTDPLDigitizerTask>(mctruth)},
-                           Options{{"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
+  return DataProcessorSpec{.name = detStr + "Digitizer",
+                           .inputs = inputs,
+                           .outputs = makeOutChannels<o2::detectors::DetID::MFT>(detOrig, mctruth),
+                           .algorithm = AlgorithmSpec{adaptFromTask<MFTDPLDigitizerTask>(mctruth)},
+                           .options = Options{{"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
 }
 
-} // end namespace itsmft
-} // end namespace o2
+} // namespace o2::itsmft
+  // end namespace o2


### PR DESCRIPTION
This adds the possibility to 'stagger' the ITS/MFT detector digitisation. Currently this is disabled and steered by the a flag in the DPLAlpideParam. The output e.g. Branch names, digits themselves does not change from before.