### PR TITLE
Avoid early initialization of Cling

### DIFF
--- a/Detectors/TPC/base/src/TPCFlagsMemberCustomStreamer.cxx
+++ b/Detectors/TPC/base/src/TPCFlagsMemberCustomStreamer.cxx
@@ -71,14 +71,8 @@ namespace ROOT
 {
 static __attribute__((used)) int _R__dummyStreamer_3 =
   ([]() {
-    auto cl = TClass::GetClass<o2::tpc::CalArray<o2::tpc::PadFlags>>();
-    if (cl) {
-      if (!getenv("TPC_PADFLAGS_STREAMER_OFF")) {
-        cl->AdoptMemberStreamer("mData", new TMemberStreamer(MemberVectorPadFlagsStreamer));
-      }
-    } else {
-      // we should never come here ... and if we do we should assert/fail
-      assert(false);
+    if (!getenv("TPC_PADFLAGS_STREAMER_OFF")) {
+      ROOT::GenerateInitInstance((o2::tpc::CalArray<o2::tpc::PadFlags> *)nullptr)->AdoptMemberStreamer("mData", new TMemberStreamer(MemberVectorPadFlagsStreamer));
     }
     return 0;
   })();


### PR DESCRIPTION

Requires v6-36-04-alice7 in order to compile / work.
