### PR TITLE
DPL: allow to disable oldest possible timeframe propagation with a label

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -108,6 +108,7 @@ o2_add_library(Framework
                        src/SimpleOptionsRetriever.cxx
                        src/O2ControlHelpers.cxx
                        src/O2ControlLabels.cxx
+                       src/CommonLabels.cxx
                        src/O2ControlParameters.cxx
                        src/O2DataModelHelpers.cxx
                        src/OutputSpec.cxx

--- a/Framework/Core/include/Framework/CommonLabels.h
+++ b/Framework/Core/include/Framework/CommonLabels.h
@@ -1,0 +1,26 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_COMMONLABELS_H
+#define O2_FRAMEWORK_COMMONLABELS_H
+
+#include "Framework/DataProcessorLabel.h"
+
+namespace o2::framework
+{
+
+// Label to disable forwarding/advertising of DomainInfoHeader (oldest possible outputs)
+// When present on a DataProcessor, no DomainInfoHeader messages will be sent downstream.
+const extern DataProcessorLabel suppressDomainInfoLabel;
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_COMMONLABELS_H

--- a/Framework/Core/src/CommonLabels.cxx
+++ b/Framework/Core/src/CommonLabels.cxx
@@ -1,0 +1,19 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/CommonLabels.h"
+
+namespace o2::framework
+{
+
+const DataProcessorLabel suppressDomainInfoLabel = {"suppress-domain-info"};
+
+} // namespace o2::framework

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -45,6 +45,7 @@
 #include "Framework/DefaultsHelpers.h"
 #include "Framework/Signpost.h"
 #include "Framework/DriverConfig.h"
+#include "Framework/CommonLabels.h"
 
 #include "TextDriverClient.h"
 #include "WSDriverClient.h"
@@ -601,6 +602,12 @@ o2::framework::ServiceSpec
         if (input.matcher.lifetime == Lifetime::Timeframe || input.matcher.lifetime == Lifetime::QA || input.matcher.lifetime == Lifetime::Sporadic || input.matcher.lifetime == Lifetime::Optional) {
           LOGP(detail, "Found a real data input, we cannot update the oldest possible timeslice when sending messages");
           decongestion->isFirstInTopology = false;
+          break;
+        }
+      }
+      for (const auto& label : services.get<DeviceSpec const>().labels) {
+        if (label == suppressDomainInfoLabel) {
+          decongestion->suppressDomainInfo = true;
           break;
         }
       }

--- a/Framework/Core/src/DataProcessingHelpers.cxx
+++ b/Framework/Core/src/DataProcessingHelpers.cxx
@@ -34,6 +34,7 @@
 #include "Framework/DeviceStateEnums.h"
 #include "Headers/DataHeader.h"
 #include "Framework/DataProcessingHeader.h"
+#include "DecongestionService.h"
 
 #include <fairmq/Device.h>
 #include <fairmq/Channel.h>
@@ -83,6 +84,9 @@ void doSendOldestPossibleTimeframe(ServiceRegistryRef ref, fair::mq::TransportFa
 
 bool DataProcessingHelpers::sendOldestPossibleTimeframe(ServiceRegistryRef const& ref, ForwardChannelInfo const& info, ForwardChannelState& state, size_t timeslice)
 {
+  if (ref.get<DecongestionService>().suppressDomainInfo) {
+    return false;
+  }
   if (state.oldestForChannel.value >= timeslice) {
     return false;
   }
@@ -93,6 +97,9 @@ bool DataProcessingHelpers::sendOldestPossibleTimeframe(ServiceRegistryRef const
 
 bool DataProcessingHelpers::sendOldestPossibleTimeframe(ServiceRegistryRef const& ref, OutputChannelInfo const& info, OutputChannelState& state, size_t timeslice)
 {
+  if (ref.get<DecongestionService>().suppressDomainInfo) {
+    return false;
+  }
   if (state.oldestForChannel.value >= timeslice) {
     return false;
   }

--- a/Framework/Core/src/DecongestionService.h
+++ b/Framework/Core/src/DecongestionService.h
@@ -18,6 +18,8 @@ namespace o2::framework
 struct DecongestionService {
   /// Wether we are a source in the processing chain
   bool isFirstInTopology = true;
+  /// do not advertise/forward DomainInfoHeader from this device
+  bool suppressDomainInfo = false;
   /// The last timeslice which the ExpirationHandler::Creator callback
   /// created. This can be used to skip dummy iterations.
   size_t nextEnumerationTimeslice = 0;


### PR DESCRIPTION
This allows to disable all DomainInfoHeader propagation with a corresponding DataProcessorLabel. It addresses the issue reported in QC-1320, where remote QC workflows were getting flooded with a DIH for each QC task instance in the setup.