### PR TITLE
Moved configFile check + expand env vars

### DIFF
--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -279,11 +279,6 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
       LOG(fatal) << "No configuration file provided for hybrid generator";
       return;
     }
-    // check if file named config exists and it's not empty
-    else if (gSystem->AccessPathName(config.c_str())) {
-      LOG(fatal) << "Configuration file for hybrid generator does not exist";
-      return;
-    }
     auto& hybrid = o2::eventgen::GeneratorHybrid::Instance(config);
     primGen->AddGenerator(&hybrid);
 #endif

--- a/Generators/src/GeneratorHybrid.cxx
+++ b/Generators/src/GeneratorHybrid.cxx
@@ -615,17 +615,23 @@ Bool_t GeneratorHybrid::confSetter(const auto& gen)
 
 Bool_t GeneratorHybrid::parseJSON(const std::string& path)
 {
+  auto expandedPath = o2::utils::expandShellVarsInFileName(path);
+  // Check if configuration file exists
+  if (gSystem->AccessPathName(expandedPath.c_str())) {
+    LOG(fatal) << "Configuration file " << expandedPath << " for hybrid generator does not exist";
+    return false;
+  }
   // Parse JSON file to build map
-  std::ifstream fileStream(path, std::ios::in);
+  std::ifstream fileStream(expandedPath, std::ios::in);
   if (!fileStream.is_open()) {
-    LOG(error) << "Cannot open " << path;
+    LOG(error) << "Cannot open " << expandedPath;
     return false;
   }
   rapidjson::IStreamWrapper isw(fileStream);
   rapidjson::Document doc;
   doc.ParseStream(isw);
   if (doc.HasParseError()) {
-    LOG(error) << "Error parsing provided json file " << path;
+    LOG(error) << "Error parsing provided json file " << expandedPath;
     LOG(error) << "  - Error -> " << rapidjson::GetParseError_En(doc.GetParseError());
     return false;
   }


### PR DESCRIPTION
- Moved configuration file check to GeneratorHybrid instead of GeneratorFactory. 
- Environment variables in configFile are now expanded automatically => this is needed when parsing the path via an ini file for example