### PR TITLE
DPL Analysis: use label+origin as binding for tables

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -375,6 +375,12 @@ consteval const char* signature()
   return o2::aod::Hash<R.desc_hash>::str;
 }
 
+template <soa::TableRef R>
+constexpr std::string binding()
+{
+  return std::string{label<R>()} + "/" + origin_str<R>();
+}
+
 /// hash identification concepts
 template <typename T>
 concept is_aod_hash = requires(T t) { t.hash; t.str; };

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -185,7 +185,7 @@ template <TableRef R>
 constexpr auto tableRef2Schema()
 {
   return o2::framework::ConfigParamSpec{
-    std::string{"input-schema:"} + o2::aod::label<R>(),
+    std::string{"input-schema:"} + o2::aod::binding<R>(),
     framework::VariantType::String,
     framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()),
     {"\"\""}};
@@ -258,9 +258,9 @@ inline constexpr auto getIndexMapping()
     ([&idx]<TableRef ref, typename C>() mutable {
       constexpr auto pos = o2::aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::template getIndexPosToKey<Key>();
       if constexpr (pos == -1) {
-        idx.emplace_back(o2::aod::label<ref>(), C::columnLabel(), IndexKind::IdxSelf, pos);
+        idx.emplace_back(o2::aod::binding<ref>(), C::columnLabel(), IndexKind::IdxSelf, pos);
       } else {
-        idx.emplace_back(o2::aod::label<ref>(), C::columnLabel(), getIndexKind<typename C::type>(), pos);
+        idx.emplace_back(o2::aod::binding<ref>(), C::columnLabel(), getIndexKind<typename C::type>(), pos);
       }
     }.template operator()<refs[Is], typename framework::pack_element_t<Is, indices>>(),
      ...);
@@ -368,7 +368,7 @@ constexpr auto tableRef2InputSpec()
   }
 
   return framework::InputSpec{
-    o2::aod::label<R>(),
+    o2::aod::binding<R>(),
     o2::aod::origin<R>(),
     o2::aod::description(o2::aod::signature<R>()),
     R.version,

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -380,7 +380,7 @@ template <TableRef R>
 constexpr auto tableRef2OutputSpec()
 {
   return framework::OutputSpec{
-    framework::OutputLabel{o2::aod::label<R>()},
+    framework::OutputLabel{o2::aod::binding<R>()},
     o2::aod::origin<R>(),
     o2::aod::description(o2::aod::signature<R>()),
     R.version};
@@ -399,7 +399,7 @@ template <TableRef R>
 constexpr auto tableRef2OutputRef()
 {
   return framework::OutputRef{
-    o2::aod::label<R>(),
+    o2::aod::binding<R>(),
     R.version};
 }
 }  // namespace o2::soa
@@ -503,12 +503,12 @@ struct OutputForTable {
 
   static OutputSpec const spec()
   {
-    return OutputSpec{OutputLabel{aod::label<table_t::ref>()}, o2::aod::origin<table_t::ref>(), o2::aod::description(o2::aod::signature<table_t::ref>()), table_t::ref.version};
+    return OutputSpec{OutputLabel{aod::binding<table_t::ref>()}, o2::aod::origin<table_t::ref>(), o2::aod::description(o2::aod::signature<table_t::ref>()), table_t::ref.version};
   }
 
   static OutputRef ref()
   {
-    return OutputRef{aod::label<table_t::ref>(), table_t::ref.version};
+    return OutputRef{aod::binding<table_t::ref>(), table_t::ref.version};
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -38,7 +38,7 @@ template <size_t N, std::array<soa::TableRef, N> refs>
 static inline auto extractOriginals(ProcessingContext& pc)
 {
   return [&]<size_t... Is>(std::index_sequence<Is...>) -> std::vector<std::shared_ptr<arrow::Table>> {
-    return {pc.inputs().get<TableConsumer>(o2::aod::label<refs[Is]>())->asArrowTable()...};
+    return {pc.inputs().get<TableConsumer>(o2::aod::binding<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
 } // namespace

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -214,7 +214,7 @@ struct AnalysisDataProcessorBuilder {
   template <soa::TableRef R>
   static auto extractTableFromRecord(InputRecord& record)
   {
-    auto table = record.get<TableConsumer>(o2::aod::label<R>())->asArrowTable();
+    auto table = record.get<TableConsumer>(o2::aod::binding<R>())->asArrowTable();
     if (table->num_rows() == 0) {
       table = makeEmptyTable<R>();
     }

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -195,7 +195,7 @@ struct MTask {
     PresliceUnsortedOptional<aod::Collisions> perMcColopt = aod::mccollisionlabel::mcCollisionId;
   } foo;
   void process(aod::McCollision const&, soa::SmallGroups<soa::Join<aod::Collisions, aod::McCollisionLabels>> const&) {}
-};
+};\
 
 TEST_CASE("AdaptorCompilation")
 {
@@ -205,55 +205,55 @@ TEST_CASE("AdaptorCompilation")
   auto task1ng = adaptAnalysisTask<ATask>(*cfgc, TaskName{"test1"});
   REQUIRE(task1ng.inputs.size() == 2);
   REQUIRE(task1ng.outputs.size() == 1);
-  REQUIRE(task1ng.inputs[1].binding == std::string("TracksExtension"));
-  REQUIRE(task1ng.inputs[0].binding == std::string("Tracks"));
-  REQUIRE(task1ng.outputs[0].binding.value == std::string("FooBars"));
+  REQUIRE(task1ng.inputs[1].binding == std::string("TracksExtension/DYN"));
+  REQUIRE(task1ng.inputs[0].binding == std::string("Tracks/AOD"));
+  REQUIRE(task1ng.outputs[0].binding.value == std::string("FooBars/AOD"));
 
   auto task1ngc = adaptAnalysisTask<ATaskconsumer>(*cfgc);
   REQUIRE(task1ngc.inputs.size() == 5);
-  REQUIRE(task1ngc.inputs[0].binding == "Foos");
-  REQUIRE(task1ngc.inputs[1].binding == "Roots");
-  REQUIRE(task1ngc.inputs[2].binding == "B1s");
-  REQUIRE(task1ngc.inputs[3].binding == "B2s");
-  REQUIRE(task1ngc.inputs[4].binding == "B3s");
+  REQUIRE(task1ngc.inputs[0].binding == "Foos/AOD");
+  REQUIRE(task1ngc.inputs[1].binding == "Roots/AOD");
+  REQUIRE(task1ngc.inputs[2].binding == "B1s/AOD");
+  REQUIRE(task1ngc.inputs[3].binding == "B2s/AOD");
+  REQUIRE(task1ngc.inputs[4].binding == "B3s/AOD");
 
   auto task2 = adaptAnalysisTask<BTask>(*cfgc, TaskName{"test2"});
   REQUIRE(task2.inputs.size() == 10);
-  REQUIRE(task2.inputs[2].binding == "TracksExtension");
-  REQUIRE(task2.inputs[1].binding == "Tracks");
-  REQUIRE(task2.inputs[4].binding == "TracksExtra_002Extension");
-  REQUIRE(task2.inputs[3].binding == "TracksExtra");
-  REQUIRE(task2.inputs[6].binding == "TracksCovExtension");
-  REQUIRE(task2.inputs[5].binding == "TracksCov");
-  REQUIRE(task2.inputs[7].binding == "AmbiguousTracks");
-  REQUIRE(task2.inputs[8].binding == "Calos");
-  REQUIRE(task2.inputs[9].binding == "CaloTriggers");
-  REQUIRE(task2.inputs[0].binding == "Collisions_001");
+  REQUIRE(task2.inputs[2].binding == "TracksExtension/DYN");
+  REQUIRE(task2.inputs[1].binding == "Tracks/AOD");
+  REQUIRE(task2.inputs[4].binding == "TracksExtra_002Extension/DYN");
+  REQUIRE(task2.inputs[3].binding == "TracksExtra/AOD");
+  REQUIRE(task2.inputs[6].binding == "TracksCovExtension/DYN");
+  REQUIRE(task2.inputs[5].binding == "TracksCov/AOD");
+  REQUIRE(task2.inputs[7].binding == "AmbiguousTracks/AOD");
+  REQUIRE(task2.inputs[8].binding == "Calos/AOD");
+  REQUIRE(task2.inputs[9].binding == "CaloTriggers/AOD");
+  REQUIRE(task2.inputs[0].binding == "Collisions_001/AOD");
 
   auto task3 = adaptAnalysisTask<CTask>(*cfgc, TaskName{"test3"});
   REQUIRE(task3.inputs.size() == 3);
-  REQUIRE(task3.inputs[0].binding == "Collisions_001");
-  REQUIRE(task3.inputs[1].binding == "Tracks");
-  REQUIRE(task3.inputs[2].binding == "TracksExtension");
+  REQUIRE(task3.inputs[0].binding == "Collisions_001/AOD");
+  REQUIRE(task3.inputs[1].binding == "Tracks/AOD");
+  REQUIRE(task3.inputs[2].binding == "TracksExtension/DYN");
 
   auto task4 = adaptAnalysisTask<DTask>(*cfgc, TaskName{"test4"});
   REQUIRE(task4.inputs.size() == 2);
-  REQUIRE(task4.inputs[0].binding == "Tracks");
-  REQUIRE(task4.inputs[1].binding == "TracksExtension");
+  REQUIRE(task4.inputs[0].binding == "Tracks/AOD");
+  REQUIRE(task4.inputs[1].binding == "TracksExtension/DYN");
 
   auto task5 = adaptAnalysisTask<ETask>(*cfgc, TaskName{"test5"});
   REQUIRE(task5.inputs.size() == 1);
-  REQUIRE(task5.inputs[0].binding == "FooBars");
+  REQUIRE(task5.inputs[0].binding == "FooBars/AOD");
 
   auto task6ng = adaptAnalysisTask<FTask>(*cfgc, TaskName{"test6"});
   REQUIRE(task6ng.inputs.size() == 1);
-  REQUIRE(task6ng.inputs[0].binding == "FooBars");
+  REQUIRE(task6ng.inputs[0].binding == "FooBars/AOD");
 
   auto task7ng = adaptAnalysisTask<GTask>(*cfgc, TaskName{"test7"});
   REQUIRE(task7ng.inputs.size() == 3);
-  REQUIRE(task7ng.inputs[0].binding == "Foos");
-  REQUIRE(task7ng.inputs[1].binding == "Bars");
-  REQUIRE(task7ng.inputs[2].binding == "XYZ");
+  REQUIRE(task7ng.inputs[0].binding == "Foos/AOD");
+  REQUIRE(task7ng.inputs[1].binding == "Bars/AOD");
+  REQUIRE(task7ng.inputs[2].binding == "XYZ/AOD");
 
   auto task8ng = adaptAnalysisTask<HTask>(*cfgc, TaskName{"test8"});
   REQUIRE(task8ng.inputs.size() == 3);


### PR DESCRIPTION
Currently embedding workflows would not work as both inputs would have identical binding based on table label. Using label+origin as binding circumvents this problem.

@nzardosh 