### PR TITLE
DataModel: improve DataHeader formatter

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeaderHelpers.h
+++ b/DataFormats/Headers/include/Headers/DataHeaderHelpers.h
@@ -79,7 +79,8 @@ struct fmt::formatter<o2::header::DataHeader> {
                  fmt::format("  payloadSize  : {}\n", (long long unsigned int)h.payloadSize) +
                  fmt::format("  firstTForbit : {}\n", h.firstTForbit) +
                  fmt::format("  tfCounter    : {}\n", h.tfCounter) +
-                 fmt::format("  runNumber    : {}\n", h.runNumber);
+                 fmt::format("  runNumber    : {}\n", h.runNumber) +
+                 fmt::format("  split        : {}/{}\n", h.splitPayloadIndex, h.splitPayloadParts);
       return fmt::format_to(ctx.out(), "{}", res);
     } else {
       auto res = fmt::format("{}/{}/{}",


### PR DESCRIPTION

Add splitPayloadIndex / splitPayloadParts to the default printout

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/14942).
* #14910 (2 commits)
* #14859 (2 commits)
* __->__ #14942