### PR TITLE
DPL Analysis: Rework table input record extraction

### DIFF
--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -98,29 +98,6 @@ using o2::monitoring::tags::Value;
 
 namespace o2::framework::readers
 {
-auto setEOSCallback(InitContext& ic)
-{
-  ic.services().get<CallbackService>().set<CallbackService::Id::EndOfStream>(
-    [](EndOfStreamContext& eosc) {
-      auto& control = eosc.services().get<ControlService>();
-      control.endOfStream();
-      control.readyToQuit(QuitRequest::Me);
-    });
-}
-
-template <typename O>
-static inline auto extractTypedOriginal(ProcessingContext& pc)
-{
-  /// FIXME: this should be done in invokeProcess() as some of the originals may be compound tables
-  return O{pc.inputs().get<TableConsumer>(aod::MetadataTrait<O>::metadata::tableLabel())->asArrowTable()};
-}
-
-template <typename... Os>
-static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingContext& pc)
-{
-  return std::make_tuple(extractTypedOriginal<Os>(pc)...);
-}
-
 AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback(ConfigContext const& ctx)
 {
   // aod-parent-base-path-replacement is now a workflow option, so it needs to be

--- a/Framework/AnalysisSupport/src/AODReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODReaderHelpers.cxx
@@ -144,7 +144,7 @@ struct Spawnable {
       iws.str(json);
       schemas.emplace_back(ArrowJSONHelpers::read(iws));
     }
-    for (auto const& i : spec.metadata | views::filter_string_params_starts_with("input:") | std::ranges::views::transform([](auto const& param){
+    for (auto const& i : spec.metadata | views::filter_string_params_starts_with("input:") | std::ranges::views::transform([](auto const& param) {
                            return DataSpecUtils::fromMetadataString(param.defaultValue.template get<std::string>());
                          })) {
       matchers.emplace_back(std::get<ConcreteDataMatcher>(i.matcher));

--- a/Framework/AnalysisSupport/src/AODReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODReaderHelpers.cxx
@@ -18,6 +18,7 @@
 #include "Framework/DataProcessingHelpers.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/DataSpecViews.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/DanglingEdgesContext.h"
 
@@ -29,6 +30,7 @@ struct Buildable {
   bool exclusive = false;
   std::string binding;
   std::vector<std::string> labels;
+  std::vector<framework::ConcreteDataMatcher> matchers;
   header::DataOrigin origin;
   header::DataDescription description;
   header::DataHeader::SubSpecificationType version;
@@ -52,6 +54,7 @@ struct Buildable {
 
     for (auto const& r : records) {
       labels.emplace_back(r.label);
+      matchers.emplace_back(r.matcher);
     }
     outputSchema = std::make_shared<arrow::Schema>([](std::vector<o2::soa::IndexRecord> const& recs) {
                      std::vector<std::shared_ptr<arrow::Field>> fields;
@@ -68,6 +71,7 @@ struct Buildable {
     return {
       exclusive,
       labels,
+      matchers,
       records,
       outputSchema,
       origin,
@@ -105,6 +109,7 @@ namespace
 struct Spawnable {
   std::string binding;
   std::vector<std::string> labels;
+  std::vector<framework::ConcreteDataMatcher> matchers;
   std::vector<expressions::Projector> projectors;
   std::vector<std::shared_ptr<gandiva::Expression>> expressions;
   std::shared_ptr<arrow::Schema> outputSchema;
@@ -132,14 +137,17 @@ struct Spawnable {
     o2::framework::addLabelToSchema(outputSchema, binding.c_str());
 
     std::vector<std::shared_ptr<arrow::Schema>> schemas;
-    for (auto& i : spec.metadata) {
-      if (i.name.starts_with("input-schema:")) {
-        labels.emplace_back(i.name.substr(13));
-        iws.clear();
-        auto json = i.defaultValue.get<std::string>();
-        iws.str(json);
-        schemas.emplace_back(ArrowJSONHelpers::read(iws));
-      }
+    for (auto const& i : spec.metadata | views::filter_string_params_starts_with("input-schema:")) {
+      labels.emplace_back(i.name.substr(13));
+      iws.clear();
+      auto json = i.defaultValue.get<std::string>();
+      iws.str(json);
+      schemas.emplace_back(ArrowJSONHelpers::read(iws));
+    }
+    for (auto const& i : spec.metadata | views::filter_string_params_starts_with("input:") | std::ranges::views::transform([](auto const& param){
+                           return DataSpecUtils::fromMetadataString(param.defaultValue.template get<std::string>());
+                         })) {
+      matchers.emplace_back(std::get<ConcreteDataMatcher>(i.matcher));
     }
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
@@ -169,6 +177,7 @@ struct Spawnable {
     return {
       binding,
       labels,
+      matchers,
       expressions,
       makeProjector(),
       outputSchema,

--- a/Framework/AnalysisSupport/src/AODWriterHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODWriterHelpers.cxx
@@ -185,13 +185,12 @@ AlgorithmSpec AODWriterHelpers::getOutputTTreeWriter(ConfigContext const& ctx)
         }
 
         // get the TableConsumer and corresponding arrow table
-        auto msg = pc.inputs().get(ref.spec->binding);
-        if (msg.header == nullptr) {
+        if (ref.header == nullptr) {
           LOGP(error, "No header for message {}:{}", ref.spec->binding, DataSpecUtils::describe(*ref.spec));
           continue;
         }
-        auto s = pc.inputs().get<TableConsumer>(ref.spec->binding);
-        auto table = s->asArrowTable();
+
+        auto table = pc.inputs().get<TableConsumer>(std::get<ConcreteDataMatcher>(ref.spec->matcher))->asArrowTable();
         if (!table->Validate().ok()) {
           LOGP(warning, "The table \"{}\" is not valid and will not be saved!", tableName);
           continue;

--- a/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
@@ -83,6 +83,7 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& ctx)
       if (m.name.starts_with("input:")) {
         auto name = m.name.substr(6);
         schemaMetadata->Append("sourceTable", name);
+        schemaMetadata->Append("sourceMatcher", DataSpecUtils::describe(std::get<ConcreteDataMatcher>(DataSpecUtils::fromMetadataString(m.defaultValue.get<std::string>()).matcher)));
         continue;
       }
       // Ignore the non ccdb: entries
@@ -109,13 +110,13 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& ctx)
       for (auto& schema : schemas) {
         std::vector<CCDBFetcherHelper::FetchOp> ops;
         auto inputBinding = *schema->metadata()->Get("sourceTable");
+        auto inputMatcher = DataSpecUtils::fromString(*schema->metadata()->Get("sourceMatcher"));
         auto outRouteDesc = *schema->metadata()->Get("outputRoute");
         std::string outBinding = *schema->metadata()->Get("outputBinding");
         O2_SIGNPOST_EVENT_EMIT_INFO(ccdb, sid, "fetchFromAnalysisCCDB",
                                     "Fetching CCDB objects for %{public}s's columns with timestamps from %{public}s and putting them in route %{public}s",
                                     outBinding.c_str(), inputBinding.c_str(), outRouteDesc.c_str());
-        auto ref = inputs.get<TableConsumer>(inputBinding);
-        auto table = ref->asArrowTable();
+        auto table = inputs.get<TableConsumer>(inputMatcher)->asArrowTable();
         // FIXME: make the fTimestamp column configurable.
         auto timestampColumn = table->GetColumnByName("fTimestamp");
         O2_SIGNPOST_EVENT_EMIT_INFO(ccdb, sid, "fetchFromAnalysisCCDB",

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1561,7 +1561,11 @@ template <typename T>
 using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 
 template <typename T>
-concept is_preslice = std::derived_from<T, PreslicePolicyBase> && requires(T) { T::optional; };
+concept is_preslice = std::derived_from<T, PreslicePolicyBase>&&
+  requires(T)
+{
+  T::optional;
+};
 
 /// Can be user to group together a number of Preslice declaration
 /// to avoid the limit of 100 data members per task

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -12,6 +12,7 @@
 #ifndef O2_FRAMEWORK_ASOA_H_
 #define O2_FRAMEWORK_ASOA_H_
 
+#include "Framework/ConcreteDataMatcher.h"
 #include "Framework/Pack.h"                   // IWYU pragma: export
 #include "Framework/FunctionalHelpers.h"      // IWYU pragma: export
 #include "Headers/DataHeader.h"               // IWYU pragma: export
@@ -373,6 +374,12 @@ template <soa::TableRef R>
 consteval const char* signature()
 {
   return o2::aod::Hash<R.desc_hash>::str;
+}
+
+template <soa::TableRef R>
+constexpr framework::ConcreteDataMatcher matcher()
+{
+  return {origin<R>(), header::DataDescription{description_str(signature<R>())}, R.version};
 }
 
 /// hash identification concepts

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -379,7 +379,7 @@ consteval const char* signature()
 template <soa::TableRef R>
 constexpr framework::ConcreteDataMatcher matcher()
 {
-  return {origin<R>(), header::DataDescription{description_str(signature<R>())}, R.version};
+  return {origin<R>(), description(signature<R>()), R.version};
 }
 
 /// hash identification concepts
@@ -1400,6 +1400,12 @@ static constexpr std::pair<bool, std::string> hasKey(std::string const& key)
   return {hasColumnForKey(typename aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::columns{}, key), aod::label<ref>()};
 }
 
+template <TableRef ref>
+static constexpr std::pair<bool, framework::ConcreteDataMatcher> hasKeyM(std::string const& key)
+{
+  return {hasColumnForKey(typename aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::columns{}, key), aod::matcher<ref>()};
+}
+
 template <typename... C>
 static constexpr auto haveKey(framework::pack<C...>, std::string const& key)
 {
@@ -1430,6 +1436,31 @@ static constexpr std::string getLabelFromTypeForKey(std::string const& key)
     notFoundColumn(getLabelFromType<std::decay_t<T>>().data(), key.data());
   } else {
     return "[MISSING]";
+  }
+  O2_BUILTIN_UNREACHABLE();
+}
+
+template <with_originals T, bool OPT = false>
+static constexpr framework::ConcreteDataMatcher getMatcherFromTypeForKey(std::string const& key)
+{
+  if constexpr (T::originals.size() == 1) {
+    auto locate = hasKeyM<T::originals[0]>(key);
+    if (locate.first) {
+      return locate.second;
+    }
+  } else {
+    auto locate = [&]<size_t... Is>(std::index_sequence<Is...>) {
+      return std::vector{hasKeyM<T::originals[Is]>(key)...};
+    }(std::make_index_sequence<T::originals.size()>{});
+    auto it = std::find_if(locate.begin(), locate.end(), [](auto const& x) { return x.first; });
+    if (it != locate.end()) {
+      return it->second;
+    }
+  }
+  if constexpr (!OPT) {
+    notFoundColumn(getLabelFromType<std::decay_t<T>>().data(), key.data());
+  } else {
+    return framework::ConcreteDataMatcher{header::DataOrigin{"AOD"}, header::DataDescription{"[MISSING]"}, 0};
   }
   O2_BUILTIN_UNREACHABLE();
 }
@@ -1484,7 +1515,10 @@ struct PreslicePolicyGeneral : public PreslicePolicyBase {
   std::span<const int64_t> getSliceFor(int value) const;
 };
 
-template <typename T, typename Policy, bool OPT = false>
+template <typename T>
+concept is_preslice_policy = std::derived_from<T, PreslicePolicyBase>;
+
+template <typename T, is_preslice_policy Policy, bool OPT = false>
 struct PresliceBase : public Policy {
   constexpr static bool optional = OPT;
   using target_t = T;
@@ -1492,7 +1526,7 @@ struct PresliceBase : public Policy {
   const std::string binding;
 
   PresliceBase(expressions::BindingNode index_)
-    : Policy{PreslicePolicyBase{{o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name})}, Entry(o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name}), std::string{index_.name})}, {}}
+    : Policy{PreslicePolicyBase{{o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name})}, Entry(o2::soa::getLabelFromTypeForKey<T, OPT>(std::string{index_.name}), o2::soa::getMatcherFromTypeForKey<T, OPT>(std::string{index_.name}), std::string{index_.name})}, {}}
   {
   }
 
@@ -1527,7 +1561,7 @@ template <typename T>
 using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 
 template <typename T>
-concept is_preslice = std::derived_from<T, PreslicePolicyBase>;
+concept is_preslice = std::derived_from<T, PreslicePolicyBase> && requires(T) { T::optional; };
 
 /// Can be user to group together a number of Preslice declaration
 /// to avoid the limit of 100 data members per task
@@ -1674,10 +1708,10 @@ auto doFilteredSliceBy(T const* table, o2::framework::PresliceBase<C, framework:
   return prepareFilteredSlice(table, slice, offset);
 }
 
-template <typename T>
+template <soa::is_table T>
 auto doSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({o2::soa::getLabelFromTypeForKey<T>(node.name), node.name});
+  auto localCache = cache.ptr->getCacheFor({"", o2::soa::getMatcherFromTypeForKey<T>(node.name), node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto t = typename T::self_t({table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count)}, static_cast<uint64_t>(offset));
   if (t.tableSize() != 0) {
@@ -1686,19 +1720,19 @@ auto doSliceByCached(T const* table, framework::expressions::BindingNode const& 
   return t;
 }
 
-template <typename T>
+template <soa::is_filtered_table T>
 auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({o2::soa::getLabelFromTypeForKey<T>(node.name), node.name});
+  auto localCache = cache.ptr->getCacheFor({"", o2::soa::getMatcherFromTypeForKey<T>(node.name), node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto slice = table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count);
   return prepareFilteredSlice(table, slice, offset);
 }
 
-template <typename T>
+template <soa::is_table T>
 auto doSliceByCachedUnsorted(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheUnsortedFor({o2::soa::getLabelFromTypeForKey<T>(node.name), node.name});
+  auto localCache = cache.ptr->getCacheUnsortedFor({"", o2::soa::getMatcherFromTypeForKey<T>(node.name), node.name});
   if constexpr (soa::is_filtered_table<T>) {
     auto t = typename T::self_t({table->asArrowTable()}, localCache.getSliceFor(value));
     if (t.tableSize() != 0) {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -30,6 +30,7 @@ namespace o2::soa
 {
 struct IndexRecord {
   std::string label;
+  framework::ConcreteDataMatcher matcher;
   std::string columnLabel;
   IndexKind kind;
   int pos;
@@ -142,6 +143,7 @@ std::vector<std::shared_ptr<arrow::Table>> extractSources(ProcessingContext& pc,
 struct Spawner {
   std::string binding;
   std::vector<std::string> labels;
+  std::vector<framework::ConcreteDataMatcher> matchers;
   std::vector<std::shared_ptr<gandiva::Expression>> expressions;
   std::shared_ptr<gandiva::Projector> projector = nullptr;
   std::shared_ptr<arrow::Schema> schema = nullptr;
@@ -157,6 +159,7 @@ struct Spawner {
 struct Builder {
   bool exclusive;
   std::vector<std::string> labels;
+  std::vector<framework::ConcreteDataMatcher> matchers;
   std::vector<o2::soa::IndexRecord> records;
   std::shared_ptr<arrow::Schema> outputSchema;
   header::DataOrigin origin;
@@ -258,9 +261,9 @@ inline constexpr auto getIndexMapping()
     ([&idx]<TableRef ref, typename C>() mutable {
       constexpr auto pos = o2::aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::template getIndexPosToKey<Key>();
       if constexpr (pos == -1) {
-        idx.emplace_back(o2::aod::label<ref>(), C::columnLabel(), IndexKind::IdxSelf, pos);
+        idx.emplace_back(o2::aod::label<ref>(), o2::aod::matcher<ref>(), C::columnLabel(), IndexKind::IdxSelf, pos);
       } else {
-        idx.emplace_back(o2::aod::label<ref>(), C::columnLabel(), getIndexKind<typename C::type>(), pos);
+        idx.emplace_back(o2::aod::label<ref>(), o2::aod::matcher<ref>(), C::columnLabel(), getIndexKind<typename C::type>(), pos);
       }
     }.template operator()<refs[Is], typename framework::pack_element_t<Is, indices>>(),
      ...);

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -38,7 +38,7 @@ template <size_t N, std::array<soa::TableRef, N> refs>
 static inline auto extractOriginals(ProcessingContext& pc)
 {
   return [&]<size_t... Is>(std::index_sequence<Is...>) -> std::vector<std::shared_ptr<arrow::Table>> {
-    return {pc.inputs().get<TableConsumer>(o2::aod::label<refs[Is]>())->asArrowTable()...};
+    return {pc.inputs().get<TableConsumer>(o2::aod::matcher<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
 } // namespace
@@ -151,7 +151,7 @@ template <typename T>
 concept with_base_table = requires { T::base_specs(); };
 
 template <with_base_table T>
-bool requestInputs(std::vector<InputSpec>& inputs, T const& entity)
+bool requestInputs(std::vector<InputSpec>& inputs, T const& /*entity*/)
 {
   auto base_specs = T::base_specs();
   for (auto base_spec : base_specs) {
@@ -586,7 +586,7 @@ bool registerCache(T& preslice, Cache& bsks, Cache&)
       return true;
     }
   }
-  auto locate = std::find_if(bsks.begin(), bsks.end(), [&](auto const& entry) { return (entry.binding == preslice.bindingKey.binding) && (entry.key == preslice.bindingKey.key); });
+  auto locate = std::find(bsks.begin(), bsks.end(), preslice.getBindingKey());
   if (locate == bsks.end()) {
     bsks.emplace_back(preslice.getBindingKey());
   } else if (locate->enabled == false) {
@@ -604,7 +604,7 @@ bool registerCache(T& preslice, Cache&, Cache& bsksU)
       return true;
     }
   }
-  auto locate = std::find_if(bsksU.begin(), bsksU.end(), [&](auto const& entry) { return (entry.binding == preslice.bindingKey.binding) && (entry.key == preslice.bindingKey.key); });
+  auto locate = std::find(bsksU.begin(), bsksU.end(), preslice.getBindingKey());
   if (locate == bsksU.end()) {
     bsksU.emplace_back(preslice.getBindingKey());
   } else if (locate->enabled == false) {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -75,11 +75,11 @@ struct AnalysisDataProcessorBuilder {
       auto key = std::string{"fIndex"} + o2::framework::cutString(soa::getLabelFromType<std::decay_t<G>>());
       ([&bk, &bku, &key, enabled]() mutable {
         if constexpr (soa::relatedByIndex<std::decay_t<G>, std::decay_t<As>>()) {
-          auto binding = soa::getLabelFromTypeForKey<std::decay_t<As>>(key);
+          Entry e{soa::getLabelFromTypeForKey<std::decay_t<As>>(key), soa::getMatcherFromTypeForKey<std::decay_t<As>>(key), key, enabled};
           if constexpr (o2::soa::is_smallgroups<std::decay_t<As>>) {
-            framework::updatePairList(bku, binding, key, enabled);
+            framework::updatePairList(bku, e);
           } else {
-            framework::updatePairList(bk, binding, key, enabled);
+            framework::updatePairList(bk, e);
           }
         }
       }(),

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -214,7 +214,7 @@ struct AnalysisDataProcessorBuilder {
   template <soa::TableRef R>
   static auto extractTableFromRecord(InputRecord& record)
   {
-    auto table = record.get<TableConsumer>(o2::aod::label<R>())->asArrowTable();
+    auto table = record.get<TableConsumer>(o2::aod::matcher<R>())->asArrowTable();
     if (table->num_rows() == 0) {
       table = makeEmptyTable<R>();
     }

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -12,6 +12,7 @@
 #ifndef ARROWTABLESLICINGCACHE_H
 #define ARROWTABLESLICINGCACHE_H
 
+#include "Framework/ConcreteDataMatcher.h"
 #include "Framework/ServiceHandle.h"
 #include <arrow/array.h>
 #include <gsl/span>
@@ -36,20 +37,28 @@ struct SliceInfoUnsortedPtr {
 
 struct Entry {
   std::string binding;
+  ConcreteDataMatcher matcher;
   std::string key;
   bool enabled;
 
-  Entry(std::string b, std::string k, bool e = true)
+  Entry(std::string b, ConcreteDataMatcher m, std::string k, bool e = true)
     : binding{b},
+      matcher{m},
       key{k},
       enabled{e}
   {
+  }
+
+  friend bool operator==(Entry const& lhs, Entry const& rhs)
+  {
+    return (lhs.matcher == rhs.matcher) &&
+           (lhs.key == rhs.key);
   }
 };
 
 using Cache = std::vector<Entry>;
 
-void updatePairList(Cache& list, std::string const& binding, std::string const& key, bool enabled);
+void updatePairList(Cache& list, Entry& entry);
 
 struct ArrowTableSlicingCacheDef {
   constexpr static ServiceKind service_kind = ServiceKind::Global;

--- a/Framework/Core/include/Framework/ConcreteDataMatcher.h
+++ b/Framework/Core/include/Framework/ConcreteDataMatcher.h
@@ -56,7 +56,7 @@ struct ConcreteDataMatcher {
   header::DataDescription description;
   header::DataHeader::SubSpecificationType subSpec;
 
-  ConcreteDataMatcher(header::DataOrigin origin_,
+  constexpr ConcreteDataMatcher(header::DataOrigin origin_,
                       header::DataDescription description_,
                       header::DataHeader::SubSpecificationType subSpec_)
     : origin(origin_),

--- a/Framework/Core/include/Framework/ConcreteDataMatcher.h
+++ b/Framework/Core/include/Framework/ConcreteDataMatcher.h
@@ -57,8 +57,8 @@ struct ConcreteDataMatcher {
   header::DataHeader::SubSpecificationType subSpec;
 
   constexpr ConcreteDataMatcher(header::DataOrigin origin_,
-                      header::DataDescription description_,
-                      header::DataHeader::SubSpecificationType subSpec_)
+                                header::DataDescription description_,
+                                header::DataHeader::SubSpecificationType subSpec_)
     : origin(origin_),
       description(description_),
       subSpec(subSpec_)

--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -214,6 +214,9 @@ struct DataSpecUtils {
   /// Create an InputSpec from metadata string
   static InputSpec fromMetadataString(std::string s);
 
+  /// Create a concrete data matcher from serialized string
+  static ConcreteDataMatcher fromString(std::string s);
+
   /// Get the origin, if available
   static std::optional<header::DataOrigin> getOptionalOrigin(InputSpec const& spec);
 

--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -127,6 +127,9 @@ struct DataSpecUtils {
   /// unique way a description should be done, so we keep this outside.
   static std::string describe(OutputSpec const& spec);
 
+  /// Describes a ConcreteDataMatcher
+  static std::string describe(ConcreteDataMatcher const& matcher);
+
   /// Provide a unique label for the input spec. Again this is outside because there
   /// is no standard way of doing it, so better not to pollute the API.
   static std::string label(InputSpec const& spec);

--- a/Framework/Core/include/Framework/DataSpecViews.h
+++ b/Framework/Core/include/Framework/DataSpecViews.h
@@ -43,6 +43,13 @@ static auto filter_string_params_with(std::string match)
   });
 }
 
+static auto filter_string_params_starts_with(std::string match)
+{
+  return std::views::filter([match](auto const& param) {
+    return (param.type == VariantType::String) && (param.name.starts_with(match));
+  });
+}
+
 static auto input_to_output_specs()
 {
   return std::views::transform([](auto const& input) {

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -55,7 +55,7 @@ struct GroupSlicer {
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
-      auto bk = Entry(binding, mIndexColumnName);
+      auto bk = Entry(binding, o2::soa::getMatcherFromTypeForKey<std::decay_t<T>>(mIndexColumnName), mIndexColumnName);
       if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
         if (table.size() == 0) {
           return;

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -513,15 +513,22 @@ class InputRecord
   }
 
   template <typename T>
-    requires(std::same_as<T, TableConsumer>)
+    requires(std::same_as<T, DataRef>)
   decltype(auto) get(ConcreteDataMatcher matcher, int part = 0)
   {
     auto pos = getPos(matcher);
     if (pos < 0) {
       auto msg = describeAvailableInputs();
-      throw runtime_error_f("InputRecord::get: no input with binding %s found. %s", DataSpecUtils::describe(matcher), msg.c_str());
+      throw runtime_error_f("InputRecord::get: no input with binding %s found. %s", DataSpecUtils::describe(matcher).c_str(), msg.c_str());
     }
-    auto ref = getByPos(pos, part);
+    return getByPos(pos, part);
+  }
+
+  template <typename T>
+    requires(std::same_as<T, TableConsumer>)
+  decltype(auto) get(ConcreteDataMatcher matcher, int part = 0)
+  {
+    auto ref = get<DataRef>(matcher, part);
     auto data = reinterpret_cast<uint8_t const*>(ref.payload);
     return std::make_unique<TableConsumer>(data, DataRefUtils::getPayloadSize(ref));
   }

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -189,6 +189,7 @@ class InputRecord
   };
 
   int getPos(const char* name) const;
+  int getPos(ConcreteDataMatcher matcher) const;
   [[nodiscard]] static InputPos getPos(std::vector<InputRoute> const& routes, ConcreteDataMatcher matcher);
   [[nodiscard]] static DataRef getByPos(std::vector<InputRoute> const& routes, InputSpan const& span, int pos, int part = 0);
 
@@ -509,6 +510,20 @@ class InputRecord
     cache.idToMetadata[id] = DataRefUtils::extractCCDBHeaders(ref);
     oldId.value = id.value;
     return cache.idToMetadata[id];
+  }
+
+  template <typename T>
+    requires(std::same_as<T, TableConsumer>)
+  decltype(auto) get(ConcreteDataMatcher matcher, int part = 0)
+  {
+    auto pos = getPos(matcher);
+    if (pos < 0) {
+      auto msg = describeAvailableInputs();
+      throw runtime_error_f("InputRecord::get: no input with binding %s found. %s", DataSpecUtils::describe(matcher), msg.c_str());
+    }
+    auto ref = getByPos(pos, part);
+    auto data = reinterpret_cast<uint8_t const*>(ref.payload);
+    return std::make_unique<TableConsumer>(data, DataRefUtils::getPayloadSize(ref));
   }
 
   /// Helper method to be used to check if a given part of the InputRecord is present.

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -185,18 +185,18 @@ std::string serializeIndexRecords(std::vector<o2::soa::IndexRecord>& irs)
   return osm.str();
 }
 
-std::vector<std::shared_ptr<arrow::Table>> extractSources(ProcessingContext& pc, std::vector<std::string> const& labels)
+std::vector<std::shared_ptr<arrow::Table>> extractSources(ProcessingContext& pc, std::vector<ConcreteDataMatcher> const& matchers)
 {
   std::vector<std::shared_ptr<arrow::Table>> tables;
-  for (auto const& label : labels) {
-    tables.emplace_back(pc.inputs().get<TableConsumer>(label.c_str())->asArrowTable());
+  for (auto const& matcher : matchers) {
+    tables.emplace_back(pc.inputs().get<TableConsumer>(matcher)->asArrowTable());
   }
   return tables;
 }
 
 std::shared_ptr<arrow::Table> Spawner::materialize(ProcessingContext& pc) const
 {
-  auto tables = extractSources(pc, labels);
+  auto tables = extractSources(pc, matchers);
   auto fullTable = soa::ArrowHelpers::joinTables(std::move(tables), std::span{labels.begin(), labels.size()});
   if (fullTable->num_rows() == 0) {
     return arrow::Table::MakeEmpty(schema).ValueOrDie();
@@ -212,7 +212,7 @@ std::shared_ptr<arrow::Table> Builder::materialize(ProcessingContext& pc)
     builders->reserve(records.size());
   }
   std::shared_ptr<arrow::Table> result;
-  auto tables = extractSources(pc, labels);
+  auto tables = extractSources(pc, matchers);
   result = o2::soa::IndexBuilder::materialize(*builders.get(), std::move(tables), records, outputSchema, exclusive);
   return result;
 }

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -751,7 +751,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
       auto& caches = service->bindingsKeys;
       for (auto i = 0u; i < caches.size(); ++i) {
         if (caches[i].enabled && pc.inputs().getPos(caches[i].binding.c_str()) >= 0) {
-          auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].binding.c_str())->asArrowTable());
+          auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].matcher)->asArrowTable());
           if (!status.ok()) {
             throw runtime_error_f("Failed to update slice cache for %s/%s", caches[i].binding.c_str(), caches[i].key.c_str());
           }
@@ -760,7 +760,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
       auto& unsortedCaches = service->bindingsKeysUnsorted;
       for (auto i = 0u; i < unsortedCaches.size(); ++i) {
         if (unsortedCaches[i].enabled && pc.inputs().getPos(unsortedCaches[i].binding.c_str()) >= 0) {
-          auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].binding.c_str())->asArrowTable());
+          auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].matcher)->asArrowTable());
           if (!status.ok()) {
             throw runtime_error_f("failed to update slice cache (unsorted) for %s/%s", unsortedCaches[i].binding.c_str(), unsortedCaches[i].key.c_str());
           }

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -37,12 +37,12 @@ std::shared_ptr<arrow::ChunkedArray> GetColumnByNameCI(std::shared_ptr<arrow::Ta
 }
 } // namespace
 
-void updatePairList(Cache& list, std::string const& binding, std::string const& key, bool enabled = true)
+void updatePairList(Cache& list, Entry& entry)
 {
-  auto locate = std::find_if(list.begin(), list.end(), [&binding, &key](auto const& entry) { return (entry.binding == binding) && (entry.key == key); });
+  auto locate = std::find(list.begin(), list.end(), entry);
   if (locate == list.end()) {
-    list.emplace_back(binding, key, enabled);
-  } else if (!locate->enabled && enabled) {
+    list.emplace_back(entry);
+  } else if (!locate->enabled && entry.enabled) {
     locate->enabled = true;
   }
 }
@@ -110,7 +110,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
   if (table->num_rows() == 0) {
     return arrow::Status::OK();
   }
-  auto& [b, k, e] = bindingsKeys[pos];
+  auto& [b, m, k, e] = bindingsKeys[pos];
   if (!e) {
     throw runtime_error_f("Disabled cache %s/%s update requested", b.c_str(), k.c_str());
   }
@@ -169,7 +169,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntryUnsorted(int pos, const st
   if (table->num_rows() == 0) {
     return arrow::Status::OK();
   }
-  auto& [b, k, e] = bindingsKeysUnsorted[pos];
+  auto& [b, m, k, e] = bindingsKeysUnsorted[pos];
   if (!e) {
     throw runtime_error_f("Disabled unsorted cache %s/%s update requested", b.c_str(), k.c_str());
   }
@@ -210,7 +210,7 @@ std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey
 
 int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 {
-  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate = std::find(bindingsKeys.begin(), bindingsKeys.end(), bindingKey);//std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
   if (locate != bindingsKeys.end()) {
     return std::distance(bindingsKeys.begin(), locate);
   }
@@ -219,7 +219,7 @@ int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 
 int ArrowTableSlicingCache::getCachePosUnsortedFor(Entry const& bindingKey) const
 {
-  auto locate_unsorted = std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate_unsorted = std::find(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), bindingKey);//std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
   if (locate_unsorted != bindingsKeysUnsorted.end()) {
     return std::distance(bindingsKeysUnsorted.begin(), locate_unsorted);
   }
@@ -269,7 +269,10 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedForPos(int pos) con
 
 void ArrowTableSlicingCache::validateOrder(Entry const& bindingKey, const std::shared_ptr<arrow::Table>& input)
 {
-  auto const& [target, key, enabled] = bindingKey;
+  auto const& [target, matcher, key, enabled] = bindingKey;
+  if (!enabled) {
+    return;
+  }
   auto column = o2::framework::GetColumnByNameCI(input, key);
   auto array0 = static_cast<arrow::NumericArray<arrow::Int32Type>>(column->chunk(0)->data());
   int32_t prev = 0;

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -210,7 +210,7 @@ std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey
 
 int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 {
-  auto locate = std::find(bindingsKeys.begin(), bindingsKeys.end(), bindingKey);//std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate = std::find(bindingsKeys.begin(), bindingsKeys.end(), bindingKey); // std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
   if (locate != bindingsKeys.end()) {
     return std::distance(bindingsKeys.begin(), locate);
   }
@@ -219,7 +219,7 @@ int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 
 int ArrowTableSlicingCache::getCachePosUnsortedFor(Entry const& bindingKey) const
 {
-  auto locate_unsorted = std::find(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), bindingKey);//std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate_unsorted = std::find(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), bindingKey); // std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
   if (locate_unsorted != bindingsKeysUnsorted.end()) {
     return std::distance(bindingsKeysUnsorted.begin(), locate_unsorted);
   }

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -210,7 +210,7 @@ std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey
 
 int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 {
-  auto locate = std::find(bindingsKeys.begin(), bindingsKeys.end(), bindingKey); // std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate = std::find(bindingsKeys.begin(), bindingsKeys.end(), bindingKey);
   if (locate != bindingsKeys.end()) {
     return std::distance(bindingsKeys.begin(), locate);
   }
@@ -219,7 +219,7 @@ int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
 
 int ArrowTableSlicingCache::getCachePosUnsortedFor(Entry const& bindingKey) const
 {
-  auto locate_unsorted = std::find(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), bindingKey); // std::find_if(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), [&](Entry const& bk) { return (bindingKey.binding == bk.binding) && (bindingKey.key == bk.key); });
+  auto locate_unsorted = std::find(bindingsKeysUnsorted.begin(), bindingsKeysUnsorted.end(), bindingKey);
   if (locate_unsorted != bindingsKeysUnsorted.end()) {
     return std::distance(bindingsKeysUnsorted.begin(), locate_unsorted);
   }

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -89,7 +89,7 @@ std::string DataSpecUtils::describe(OutputSpec const& spec)
                     spec.matcher);
 }
 
-static std::string describe(ConcreteDataMatcher const& matcher)
+std::string DataSpecUtils::describe(ConcreteDataMatcher const& matcher)
 {
   return join(matcher, "/");
 }

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -669,16 +669,39 @@ InputSpec DataSpecUtils::fromMetadataString(std::string s)
   if (std::distance(words, std::sregex_iterator()) != 4) {
     throw runtime_error_f("Malformed input spec metadata: %s", s.c_str());
   }
-  std::vector<std::string> data;
+  std::array<std::string, 4> data;
+  auto pos = 0;
   for (auto i = words; i != std::sregex_iterator(); ++i) {
-    data.emplace_back(i->str());
+    data[pos] = i->str();
+    ++pos;
   }
   char origin[4];
   char description[16];
   std::memcpy(&origin, data[1].c_str(), 4);
   std::memcpy(&description, data[2].c_str(), 16);
   auto version = static_cast<o2::header::DataHeader::SubSpecificationType>(std::atoi(data[3].c_str()));
-  return InputSpec{data[0], header::DataOrigin{origin}, header::DataDescription{description}, version, Lifetime::Timeframe};
+  return {data[0], header::DataOrigin{origin}, header::DataDescription{description}, version, Lifetime::Timeframe};
+}
+
+ConcreteDataMatcher DataSpecUtils::fromString(std::string s)
+{
+  std::regex word_regex("(\\w+)");
+  auto words = std::sregex_iterator(s.begin(), s.end(), word_regex);
+  if (std::distance(words, std::sregex_iterator()) != 3) {
+    throw runtime_error_f("Malformed serialized matcher: %s", s.c_str());
+  }
+  std::array<std::string, 3> data;
+  auto pos = 0;
+  for (auto i = words; i != std::sregex_iterator(); ++i) {
+    data[pos] = i->str();
+    ++pos;
+  }
+  char origin[4];
+  char description[16];
+  std::memcpy(&origin, data[0].c_str(), 4);
+  std::memcpy(&description, data[1].c_str(), 16);
+  auto version = static_cast<o2::header::DataHeader::SubSpecificationType>(std::atoi(data[2].c_str()));
+  return {header::DataOrigin{origin}, header::DataDescription{description}, version};
 }
 
 std::optional<header::DataOrigin> DataSpecUtils::getOptionalOrigin(InputSpec const& spec)

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -89,6 +89,11 @@ std::string DataSpecUtils::describe(OutputSpec const& spec)
                     spec.matcher);
 }
 
+static std::string describe(ConcreteDataMatcher const& matcher)
+{
+  return join(matcher, "/");
+}
+
 template <HasMatcher T>
 size_t DataSpecUtils::describe(char* buffer, size_t size, T const& spec)
 {

--- a/Framework/Core/src/IndexJSONHelpers.cxx
+++ b/Framework/Core/src/IndexJSONHelpers.cxx
@@ -41,6 +41,7 @@ struct IndexRecordsReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<
   std::string currentKey;
   std::string label;
   std::string columnLabel;
+  std::string matcherStr;
   o2::soa::IndexKind kind;
   int pos;
 
@@ -87,6 +88,9 @@ struct IndexRecordsReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<
       if (currentKey.compare("label") == 0) {
         return true;
       }
+      if (currentKey.compare("matcher") == 0) {
+        return true;
+      }
       if (currentKey.compare("column") == 0) {
         return true;
       }
@@ -127,7 +131,7 @@ struct IndexRecordsReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<
     if (states.top() == State::IN_RECORD) {
       states.pop();
       // add a record
-      records.emplace_back(label, columnLabel, kind, pos);
+      records.emplace_back(label, DataSpecUtils::fromString(matcherStr), columnLabel, kind, pos);
       return true;
     }
 
@@ -175,6 +179,10 @@ struct IndexRecordsReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<
         columnLabel = str;
         return true;
       }
+      if (currentKey.compare("matcher") == 0) {
+        matcherStr = str;
+        return true;
+      }
     }
 
     states.push(State::IN_ERROR);
@@ -205,6 +213,8 @@ void writeRecords(rapidjson::Writer<rapidjson::OStreamWrapper>& w, std::vector<o
     w.StartObject();
     w.Key("label");
     w.String(r.label.c_str());
+    w.Key("matcher");
+    w.String(DataSpecUtils::describe(r.matcher).c_str());
     w.Key("column");
     w.String(r.columnLabel.c_str());
     w.Key("kind");

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -58,6 +58,11 @@ int InputRecord::getPos(const char* binding) const
   return -1;
 }
 
+int InputRecord::getPos(ConcreteDataMatcher matcher) const
+{
+  return getPos(mInputsSchema, matcher).index;
+}
+
 InputRecord::InputPos InputRecord::getPos(std::vector<InputRoute> const& schema, ConcreteDataMatcher concrete)
 {
   size_t inputIndex = 0;

--- a/Framework/Core/test/benchmark_EventMixing.cxx
+++ b/Framework/Core/test/benchmark_EventMixing.cxx
@@ -78,7 +78,8 @@ static void BM_EventMixingTraditional(benchmark::State& state)
   auto tableTrack = trackBuilder.finalize();
   o2::aod::StoredTracks tracks{tableTrack};
 
-  ArrowTableSlicingCache atscache({{getLabelFromType<o2::aod::StoredTracks>(), "fIndex" + cutString(getLabelFromType<o2::aod::Collisions>())}});
+  std::string key = "fIndex" + cutString(getLabelFromType<o2::aod::Collisions>());
+  ArrowTableSlicingCache atscache({{getLabelFromType<o2::aod::StoredTracks>(), getMatcherFromTypeForKey<o2::aod::StoredTracks>(key), key}});
   auto s = atscache.updateCacheEntry(0, tableTrack);
   SliceCache cache{&atscache};
 
@@ -171,7 +172,8 @@ static void BM_EventMixingCombinations(benchmark::State& state)
 
   int64_t count = 0;
   int64_t colCount = 0;
-  ArrowTableSlicingCache atscache{{{getLabelFromType<o2::aod::StoredTracks>(), "fIndex" + getLabelFromType<o2::aod::Collisions>()}}};
+  std::string key = "fIndex" + getLabelFromType<o2::aod::Collisions>();
+  ArrowTableSlicingCache atscache{{{getLabelFromType<o2::aod::StoredTracks>(), getMatcherFromTypeForKey<o2::aod::StoredTracks>(key), key}}};
   auto s = atscache.updateCacheEntry(0, tableTrack);
   SliceCache cache{&atscache};
 

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1187,7 +1187,8 @@ TEST_CASE("TestSliceByCached")
   auto refs = w.finalize();
   o2::aod::References r{refs};
 
-  ArrowTableSlicingCache atscache({{o2::soa::getLabelFromType<o2::aod::References>(), "fIndex" + o2::framework::cutString(o2::soa::getLabelFromType<o2::aod::Origints>())}});
+  std::string key = "fIndex" + o2::framework::cutString(o2::soa::getLabelFromType<o2::aod::Origints>());
+  ArrowTableSlicingCache atscache({{o2::soa::getLabelFromType<o2::aod::References>(), o2::soa::getMatcherFromTypeForKey<o2::aod::References>(key), key}});
   auto s = atscache.updateCacheEntry(0, refs);
   SliceCache cache{&atscache};
 
@@ -1238,7 +1239,7 @@ TEST_CASE("TestSliceByCachedMismatched")
   J rr{{refs, refs2}};
 
   auto key = "fIndex" + o2::framework::cutString(o2::soa::getLabelFromType<o2::aod::Origints>()) + "_alt";
-  ArrowTableSlicingCache atscache({{o2::soa::getLabelFromTypeForKey<J>(key), key}});
+  ArrowTableSlicingCache atscache({{o2::soa::getLabelFromTypeForKey<J>(key), o2::soa::getMatcherFromTypeForKey<J>(key), key}});
   auto s = atscache.updateCacheEntry(0, refs2);
   SliceCache cache{&atscache};
 

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -117,7 +117,8 @@ TEST_CASE("GroupSlicerOneAssociated")
   REQUIRE(t.size() == 10 * 20);
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
@@ -191,9 +192,9 @@ TEST_CASE("GroupSlicerSeveralAssociated")
 
   auto tt = std::make_tuple(tx, ty, tz, tu);
   auto key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), key},
-                                 {soa::getLabelFromType<aod::TrksY>(), key},
-                                 {soa::getLabelFromType<aod::TrksZ>(), key}});
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key},
+                                 {soa::getLabelFromType<aod::TrksY>(), soa::getMatcherFromTypeForKey<aod::TrksY>(key), key},
+                                 {soa::getLabelFromType<aod::TrksZ>(), soa::getMatcherFromTypeForKey<aod::TrksZ>(key), key}});
   auto s = slices.updateCacheEntry(0, {trkTableX});
   s = slices.updateCacheEntry(1, {trkTableY});
   s = slices.updateCacheEntry(2, {trkTableZ});
@@ -256,7 +257,8 @@ TEST_CASE("GroupSlicerMismatchedGroups")
   REQUIRE(t.size() == 10 * (20 - 5));
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
@@ -312,7 +314,8 @@ TEST_CASE("GroupSlicerMismatchedUnassignedGroups")
   REQUIRE(t.size() == (30 + 10 * (20 - 5)));
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
@@ -362,7 +365,8 @@ TEST_CASE("GroupSlicerMismatchedFilteredGroups")
   REQUIRE(t.size() == 10 * (20 - 4));
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
@@ -423,7 +427,8 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   REQUIRE(t.size() == 10 * (20 - 4));
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({}, {{soa::getLabelFromType<aod::TrksXU>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({}, {{soa::getLabelFromType<aod::TrksXU>(), soa::getMatcherFromTypeForKey<aod::TrksXU>(key), key}});
   auto s = slices.updateCacheEntryUnsorted(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
@@ -547,8 +552,9 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
   }
   FilteredParts fp{{partsTable}, rows};
   auto associatedTuple = std::make_tuple(fp, t);
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::Parts>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())},
-                                 {soa::getLabelFromType<aod::Things>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::Parts>(), soa::getMatcherFromTypeForKey<aod::Parts>(key), key},
+                                 {soa::getLabelFromType<aod::Things>(), soa::getMatcherFromTypeForKey<aod::Things>(key), key}});
   auto s0 = slices.updateCacheEntry(0, partsTable);
   auto s1 = slices.updateCacheEntry(1, thingsTable);
   o2::framework::GroupSlicer g(e, associatedTuple, slices);
@@ -607,7 +613,8 @@ TEST_CASE("EmptySliceables")
   REQUIRE(t.size() == 0);
 
   auto tt = std::make_tuple(t);
-  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
   o2::framework::GroupSlicer g(e, tt, slices);
 
@@ -679,7 +686,7 @@ TEST_CASE("ArrowDirectSlicing")
 
   std::vector<arrow::Datum> slices;
   std::vector<uint64_t> offsts;
-  auto bk = Entry(soa::getLabelFromType<aod::Events>(), "fID");
+  auto bk = Entry(soa::getLabelFromType<aod::Events>(), soa::getMatcherFromTypeForKey<aod::Events>("fID"), "fID");
   ArrowTableSlicingCache cache({bk});
   auto s = cache.updateCacheEntry(0, {evtTable});
   auto lcache = cache.getCacheFor(bk);
@@ -737,7 +744,7 @@ TEST_CASE("TestSlicingException")
   }
   auto evtTable = builderE.finalize();
 
-  auto bk = Entry(soa::getLabelFromType<aod::Events>(), "fID");
+  auto bk = Entry(soa::getLabelFromType<aod::Events>(), soa::getMatcherFromTypeForKey<aod::Events>("fID"), "fID");
   ArrowTableSlicingCache cache({bk});
 
   try {

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -46,6 +46,10 @@ o2_add_dpl_workflow(analysis-ccdb
                     PUBLIC_LINK_LIBRARIES O2::DataFormatsTOF
                     COMPONENT_NAME TestWorkflows)
 
+o2_add_dpl_workflow(analysis-emb
+                    SOURCES src/o2TestMultisource.cxx
+                    COMPONENT_NAME TestWorkflows)
+
 o2_add_dpl_workflow(two-timers
                   SOURCES src/o2TwoTimers.cxx
                   COMPONENT_NAME TestWorkflows)

--- a/Framework/TestWorkflows/src/o2TestHistograms.cxx
+++ b/Framework/TestWorkflows/src/o2TestHistograms.cxx
@@ -16,8 +16,6 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include <TH2F.h>
-#include <cmath>
-#include <iostream>
 
 using namespace o2;
 using namespace o2::framework;
@@ -72,7 +70,7 @@ struct EtaAndClsHistogramsSimple {
     }
   }
 
-  void process(soa::Filtered<aod::Tracks> const& tracks, aod::FT0s const&, aod::StoredTracksFrom<o2::aod::Hash<"EMB"_h>> const& ortherTracks)
+  void process(soa::Filtered<aod::Tracks> const& tracks, aod::FT0s const&)
   {
     LOGP(info, "Invoking the simple one");
     for (auto& track : tracks) {
@@ -110,7 +108,7 @@ struct EtaAndClsHistogramsIUSimple {
     }
   }
 
-  void process(soa::Filtered<aod::TracksIU> const& tracks, aod::FT0s const&, aod::TracksIUFrom<o2::aod::Hash<"EMB"_h>> const& otherTracks)
+  void process(soa::Filtered<aod::TracksIU> const& tracks, aod::FT0s const&)
   {
     LOGP(info, "Invoking the simple one IU");
     for (auto& track : tracks) {

--- a/Framework/TestWorkflows/src/o2TestMultisource.cxx
+++ b/Framework/TestWorkflows/src/o2TestMultisource.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 ///
 /// \brief Tests that the same tables from different origins are routed correctly.
-///        Required two input files, <name>.root and <name>_EMB.root, that contain
+///        Requires two input files, <name>.root and <name>_EMB.root, that contain
 ///        same number of DFs with the same names.
 /// \author
 /// \since

--- a/Framework/TestWorkflows/src/o2TestMultisource.cxx
+++ b/Framework/TestWorkflows/src/o2TestMultisource.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \brief Tests that the same tables from different origins are routed correctly.
+///        Required two input files, <name>.root and <name>_EMB.root, that contain
+///        same number of DFs with the same names.
+/// \author
+/// \since
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+namespace o2::aod
+{
+O2ORIGIN("EMB");
+template <is_aod_hash T>
+using BCsFrom = BCs_001From<T>;
+using TracksPlus = soa::Join<StoredTracksIU, StoredTracksExtra>;
+template <is_aod_hash T>
+using TracksPlusFrom = soa::Join<StoredTracksIUFrom<T>, StoredTracksExtra_002From<T>>;
+} // namespace o2::aod
+
+struct TestEmbeddingSubscription {
+  void process(aod::BCs const& bcs, aod::BCsFrom<aod::Hash<"EMB"_h>> const& bcse,
+               aod::TracksPlus const& tracks, aod::TracksPlusFrom<aod::Hash<"EMB"_h>> const& trackse)
+  {
+    LOGP(info, "BCs from run {} and {}", bcs.begin().runNumber(), bcse.begin().runNumber());
+    LOGP(info, "Joined tracks: {} and {}", tracks.size(), trackse.size());
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return {adaptAnalysisTask<TestEmbeddingSubscription>(cfgc)};
+}


### PR DESCRIPTION
* update `InputRecord` so that a `ConcreteDataMatcher` can be used to extract entries
* use `ConcreteDataMatcher` instead of binding throughout the Analysis Framework to access AOD+ tables in the input