### PR TITLE
DPL: use better criterion to add arrow support service

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -3010,8 +3010,8 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
   ServiceSpecs driverServices = ServiceSpecHelpers::filterDisabled(CommonDriverServices::defaultServices(), driverServicesOverride);
   // We insert the hash for the internal devices.
   WorkflowHelpers::injectServiceDevices(physicalWorkflow, configContext);
-  auto reader = std::find_if(physicalWorkflow.begin(), physicalWorkflow.end(), [](DataProcessorSpec& spec) { return spec.name == "internal-dpl-aod-reader"; });
-  if (reader != physicalWorkflow.end()) {
+  auto& dec = configContext.services().get<DanglingEdgesContext>();
+  if (!(dec.requestedAODs.empty() && dec.requestedDYNs.empty() && dec.requestedIDXs.empty() && dec.requestedTIMs.empty())) {
     driverServices.push_back(ArrowSupport::arrowBackendSpec());
   }
   for (auto& service : driverServices) {


### PR DESCRIPTION
Delayed loading of algorithms for internal devices is done through ArrowSupport service, which may be not added in some special cases. Thus instead of checking for the presence of the aod-reader, it is better to check if the workflow is dealing with any analysis-level inputs, like AOD, DYN, IDX or ATIM, which will cover these special cases. 