### PR TITLE
Switch option from external to hybrid

### DIFF
--- a/Generators/include/Generators/GeneratorHybridParam.h
+++ b/Generators/include/Generators/GeneratorHybridParam.h
@@ -29,9 +29,10 @@ namespace eventgen
  **/
 
 struct GeneratorHybridParam : public o2::conf::ConfigurableParamHelper<GeneratorHybridParam> {
-  std::string configFile = ""; // JSON configuration file for the generators
-  bool randomize = false;      // randomize the order of the generators, if not generator using fractions
-  int num_workers = 1;         // number of threads available for asyn/parallel event generation
+  std::string configFile = "";    // JSON configuration file for the generators
+  bool randomize = false;         // randomize the order of the generators, if not generator using fractions
+  int num_workers = 1;            // number of threads available for asyn/parallel event generation
+  bool switchExtToHybrid = false; // force external generator to be executed as hybrid mode, useful for Hyperloop MCGEN
   O2ParamDef(GeneratorHybridParam, "GeneratorHybrid");
 };
 

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -93,6 +93,12 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
 
   o2::O2DatabasePDG::addALICEParticles(TDatabasePDG::Instance());
   auto genconfig = conf.getGenerator();
+#if defined(GENERATORS_WITH_PYTHIA8) && defined(GENERATORS_WITH_HEPMC3)
+  if (GeneratorHybridParam::Instance().switchExtToHybrid && (genconfig.compare("external") == 0 || genconfig.compare("extgen") == 0)) {
+    LOG(info) << "Switching external generator to hybrid mode";
+    genconfig = "hybrid";
+  }
+#endif
   LOG(info) << "** Generator to use: '" << genconfig << "'";
   if (genconfig.compare("boxgen") == 0) {
     // a simple "box" generator configurable via BoxGunparam

--- a/run/SimExamples/ExternalToHybrid/GeneratorHyperloopHybrid.ini
+++ b/run/SimExamples/ExternalToHybrid/GeneratorHyperloopHybrid.ini
@@ -1,0 +1,3 @@
+[GeneratorHybrid]
+configFile = ${O2_ROOT}/examples/ExternalToHybrid/sequential.json
+switchExtToHybrid = true

--- a/run/SimExamples/ExternalToHybrid/GeneratorHyperloopHybridCocktail.ini
+++ b/run/SimExamples/ExternalToHybrid/GeneratorHyperloopHybridCocktail.ini
@@ -1,0 +1,3 @@
+[GeneratorHybrid]
+configFile = ${O2_ROOT}/examples/ExternalToHybrid/cocktail.json
+switchExtToHybrid = true

--- a/run/SimExamples/ExternalToHybrid/README.md
+++ b/run/SimExamples/ExternalToHybrid/README.md
@@ -1,0 +1,45 @@
+<!-- doxy
+\page refrunSimExamplesExternalToHybrid Example ExternalToHybrid
+/doxy -->
+
+This example demonstrates how to bypass the Hyperloop limitations when using external generators by switching the configuration to hybrid mode, using the new `GeneratorHybrid.switchExtToHybrid` parameter (set to false by default).
+
+This solution works only with updated O2sim versions containing the `switchExtToHybrid` option.
+
+# Configuration Files
+
+Two example configuration files are provided, each pointing to different hybrid JSON files:
+
+- **GeneratorHyperloopHybridCocktail.ini** → Creates a cocktail mixing two Pythia8 based generators and a boxgen instance
+- **GeneratorHyperloopHybrid.ini** → Defines sequential generation of boxgen and EPOS4 events called with an external generator
+
+# Script Description
+
+## rundpl.sh
+
+This script demonstrates event generation using the DPL framework, launching it with the external generator in hybrid mode.
+
+### Available Flags
+
+- **-i, --ini CONFIG** → Specifies the configuration ini file (default: `GeneratorHyperloopHybridCocktail.ini`)
+- **-n, --nevents EVENTS** → Sets the number of events to generate (default: 5)
+- **-h, --help** → Prints usage instructions and o2-sim-dpl-eventgen help
+- **--** → Passes remaining command line arguments to o2-sim-dpl-eventgen
+
+### Usage Examples
+
+Run with default settings (5 events using cocktail configuration):
+```bash
+./rundpl.sh
+```
+
+Generate 10 events using the sequential configuration:
+```bash
+./rundpl.sh -n 10 -i ${O2_ROOT}/examples/ExternalToHybrid/GeneratorHyperloopHybrid.ini
+```
+
+# Requirements
+
+- O2sim version with `switchExtToHybrid` support
+- O2_ROOT and O2DPG_MC_CONFIG_ROOT environment variable must be loaded (possibly via O2sim directly)
+- Appropriate external generator configurations (e.g., EPOS4) must be available

--- a/run/SimExamples/ExternalToHybrid/cocktail.json
+++ b/run/SimExamples/ExternalToHybrid/cocktail.json
@@ -1,0 +1,49 @@
+{
+  "generators": [
+    {
+      "cocktail": [
+        {
+          "name": "pythia8",
+          "config": {
+            "config": "${O2_ROOT}/share/Generators/egconfig/pythia8_inel.cfg",
+            "hooksFileName": "",
+            "hooksFuncName": "",
+            "includePartonEvent": false,
+            "particleFilter": "",
+            "verbose": 0
+          }
+        },
+        {
+          "name": "external",
+          "config": {
+            "fileName": "",
+            "funcName": "",
+            "iniFile": "${O2DPG_MC_CONFIG_ROOT}/MC/config/ALICE3/ini/pythia8_pp_13tev.ini"
+          }
+        },
+        {
+          "name": "boxgen",
+          "config": {
+            "pdg": 443,
+            "number": 10,
+            "eta": [
+              -0.8,
+              0.8
+            ],
+            "prange": [
+              0.1,
+              5
+            ],
+            "phirange": [
+              0,
+              360
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "fractions": [
+    1
+  ]
+}

--- a/run/SimExamples/ExternalToHybrid/rundpl.sh
+++ b/run/SimExamples/ExternalToHybrid/rundpl.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# This is a simple example script to bypass the Hyperloop limitations in using
+# external generators only, by switching the generator to the hybrid mode
+
+# This script works only with updated O2sim version containing the switchExtToHybrid option
+
+[ ! "${O2_ROOT}" ] && echo "Error: This needs O2 loaded" && exit 2
+[ ! "${O2DPG_MC_CONFIG_ROOT}" ] && echo "Error: This needs O2DPG loaded" && exit 2
+
+NEV=5
+# Two example ini configurations are provided pointing to different hybrid JSON files
+# One creates a cocktail based on Pythia8, while the other generates sequentially EPOS4 and boxgen events
+ini="${O2_ROOT}/examples/ExternalToHybrid/GeneratorHyperloopHybridCocktail.ini"
+
+usage()
+{
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+
+  -i,--ini     INI         Configuration ini file ($ini)
+  -n,--nevents EVENTS      Number of events ($nev)
+  -h,--help                Print these instructions
+  --                       Rest of command line sent to o2-sim
+
+COMMAND must be quoted if it contains spaces or other special
+characters
+
+Below follows the help output of o2-sim-dpl-eventgen
+
+EOF
+}
+
+if [ "$#" -lt 2 ]; then
+    echo "Running with default values"
+fi
+
+while test $# -gt 0 ; do
+    case $1 in
+        -i|--ini)     ini="$2" ; shift ;;
+        -n|--nevents) NEV=$2 ; shift ;;
+        -h|--help) usage; o2-sim-dpl-eventgen --help full ; exit 0 ;;
+        --)           shift ; break ;;
+        *) echo "Unknown option '$1', did you forget '--'?" >/dev/stderr
+           exit 3
+           ;;
+    esac
+    shift
+done
+
+# Starting the dpl-eventgen simulation
+o2-sim-dpl-eventgen -b --generator external --nEvents $NEV --configFile $ini

--- a/run/SimExamples/ExternalToHybrid/sequential.json
+++ b/run/SimExamples/ExternalToHybrid/sequential.json
@@ -1,0 +1,35 @@
+{
+  "generators": [
+    {
+      "name": "boxgen",
+      "config": {
+        "pdg": 443,
+        "number": 10,
+        "eta": [
+          -0.8,
+          0.8
+        ],
+        "prange": [
+          0.1,
+          5
+        ],
+        "phirange": [
+          0,
+          360
+        ]
+      }
+    },
+    {
+      "name": "external",
+      "config": {
+        "fileName": "",
+        "funcName": "",
+        "iniFile": "${O2DPG_MC_CONFIG_ROOT}/MC/config/examples/ini/GeneratorEPOS4_pp13TeV.ini"
+      }
+    }
+  ],
+  "fractions": [
+    1,
+    1
+  ]
+}


### PR DESCRIPTION
Hyperloop MCGEN simulations are automatically set to use the `external` generator, making them difficult to configure in some cases. This development bypasses the block by switching the mode to hybrid in case a parameter is set. An example is provided for clarity. For Hyperloop usage purpose ini files in O2DPG will have to be created anyway, but they will contain only the Hybrid parameters, while the test macros will need only the External() function. 