### PR TITLE
ALICE3-TRK: partial fix to issue #14959

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/GeometryTGeo.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <DetectorsCommonDataFormats/DetMatrixCache.h>
 #include "DetectorsCommonDataFormats/DetID.h"
+#include "TRKBase/TRKBaseParam.h"
 
 namespace o2
 {
@@ -220,6 +221,9 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   std::vector<int> sensorsMLOT;
   std::vector<float> mCacheRefXMLOT;     /// cache for X of ML and OT
   std::vector<float> mCacheRefAlphaMLOT; /// cache for sensor ref alpha ML and OT
+
+  eLayout mLayoutML; // Type of segmentation for the middle layers
+  eLayout mLayoutOL; // Type of segmentation for the outer layers
 
  private:
   static std::unique_ptr<o2::trk::GeometryTGeo> sInstance;

--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
@@ -41,6 +41,9 @@ struct TRKBaseParam : public o2::conf::ConfigurableParamHelper<TRKBaseParam> {
   eLayout layoutML = kCylinder; // Type of segmentation for the middle layers
   eLayout layoutOL = kCylinder; // Type of segmentation for the outer layers
 
+  eLayout getLayoutML() const { return layoutML; }
+  eLayout getLayoutOL() const { return layoutOL; }
+
   O2ParamDef(TRKBaseParam, "TRKBase");
 };
 

--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
@@ -38,8 +38,8 @@ struct TRKBaseParam : public o2::conf::ConfigurableParamHelper<TRKBaseParam> {
 
   eOverallGeom overallGeom = kDefaultRadii; // Overall geometry option, to be used in Detector::buildTRKMiddleOuterLayers
 
-  eLayout layoutML = kCylinder; // Type of segmentation for the middle layers
-  eLayout layoutOL = kCylinder; // Type of segmentation for the outer layers
+  eLayout layoutML = kTurboStaves; // Type of segmentation for the middle layers
+  eLayout layoutOL = kStaggered;   // Type of segmentation for the outer layers
 
   eLayout getLayoutML() const { return layoutML; }
   eLayout getLayoutOL() const { return layoutOL; }

--- a/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
@@ -76,6 +76,11 @@ void GeometryTGeo::Build(int loadTrans)
     LOGP(fatal, "Geometry is not loaded");
   }
 
+  mLayoutML = o2::trk::TRKBaseParam::Instance().getLayoutML();
+  mLayoutOL = o2::trk::TRKBaseParam::Instance().getLayoutOL();
+
+  LOG(debug) << "Layout ML: " << mLayoutML << ", Layout OL: " << mLayoutOL;
+
   mNumberOfLayersMLOT = extractNumberOfLayersMLOT();
   mNumberOfPetalsVD = extractNumberOfPetalsVD();
   mNumberOfActivePartsVD = extractNumberOfActivePartsVD();
@@ -398,6 +403,17 @@ TString GeometryTGeo::getMatrixPath(int index) const
   // TString path = "/cave_1/barrel_1/TRKV_2/TRKLayer0_1/TRKStave0_1/TRKChip0_1/TRKSensor0_1/"; /// dummy path, to be used for tests
   TString path = Form("/cave_1/barrel_1/%s_2/", GeometryTGeo::getTRKVolPattern());
 
+  // handling cylindrical configuration for ML and/or OT
+  // needed bercause of the different numbering scheme in the geometry for the cylindrical case wrt the staggered and turbo ones
+  if (subDetID == 1) {
+    if ((layer < 4 && mLayoutML == eLayout::kCylinder) || (layer > 3 && mLayoutOL == eLayout::kCylinder)) {
+      stave = 1;
+      mod = 1;
+      chip = 1;
+    }
+  }
+
+  // build the path
   if (subDetID == 0) { // VD
     if (disk >= 0) {
       path += Form("%s_%d_%d/", getTRKPetalAssemblyPattern(), petalcase, petalcase + 1);             // PETAL_n


### PR DESCRIPTION
Fixing part of issue #14959, for the TRK module part.
* The getMatrixPath() method now handles the creation of the path for cylindrical geometry in ML and/or OT. Note: the cylindrical geometry is developed up to the step of the simulation. From the digitization step on, however, it is not maintained/handled, since this geometry is deprecated and not foreseen to be used as it is. If needed, the digitization step can be implemented after some modification of the geometry (e.g. addition of gaps, subdivision of the single layers, ...).
* Now the default configuration in simulation is kTurboStaves for ML, and kStaggered for OT. To use the kCylinder configuration, add it to the configKeyValues.