### PR TITLE
DPL: keep code checker happy

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -170,7 +170,7 @@ bool newDataframeCondition(InputRecord&, C&)
 template <is_condition C>
 bool newDataframeCondition(InputRecord& record, C& condition)
 {
-  condition.instance = (typename C::type*)record.get<typename C::type*>(condition.path).get();
+  condition.instance = (typename C::type*)record.get<typename C::type*>(condition.path).release();
   return true;
 }
 


### PR DESCRIPTION

The code checker complains about the unique_ptr going out of scope.

However this is a false positive because such unique_ptr has a custom
deletion policy to mimick the behavior of an observer_ptr.

In order to keep the code checker happy, we use release, so that the bare
pointer is returned without any complain. Given the custom deleter, the semantic
is actually the same.
