### PR TITLE
ALICE3-TRK: added possibility to use a local version of the response file during digitization

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/Specs.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/Specs.h
@@ -131,6 +131,14 @@ constexpr double responseYShift{15.5 * mu};
 constexpr double thickness{45 * mu};
 } // namespace apts
 
+namespace alice3resp /// parameters for the alice3 chip response
+{
+constexpr double pitchX{10.0 * mu};
+constexpr double pitchZ{10.0 * mu};
+constexpr double responseYShift{5 * mu}; /// center of the epitaxial layer
+constexpr double thickness{20 * mu};
+} // namespace alice3resp
+
 } // namespace o2::trk::constants
 
 #endif

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Digitizer.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Digitizer.h
@@ -45,6 +45,7 @@ class Digitizer
   void setDigits(std::vector<o2::itsmft::Digit>* dig) { mDigits = dig; }
   void setMCLabels(o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mclb) { mMCLabels = mclb; }
   void setROFRecords(std::vector<o2::itsmft::ROFRecord>* rec) { mROFRecords = rec; }
+  void setResponseName(const std::string& name) { mRespName = name; }
 
   o2::trk::DigiParams& getParams() { return (o2::trk::DigiParams&)mParams; }
   const o2::trk::DigiParams& getParams() const { return mParams; }
@@ -136,6 +137,8 @@ class Digitizer
   uint32_t mROFrameMax = 0; ///< highest RO frame of current digits
   uint32_t mNewROFrame = 0; ///< ROFrame corresponding to provided time
 
+  bool mIsBeforeFirstRO = false;
+
   uint32_t mEventROFrameMin = 0xffffffff; ///< lowest RO frame for processed events (w/o automatic noise ROFs)
   uint32_t mEventROFrameMax = 0;          ///< highest RO frame forfor processed events (w/o automatic noise ROFs)
 
@@ -144,6 +147,8 @@ class Digitizer
   const o2::trk::ChipSimResponse* mChipSimResp = nullptr;     // simulated response
   const o2::trk::ChipSimResponse* mChipSimRespVD = nullptr;   // simulated response for VD chips
   const o2::trk::ChipSimResponse* mChipSimRespMLOT = nullptr; // simulated response for ML/OT chips
+
+  std::string mRespName; /// APTS or ALICE3, depending on the response to be used
 
   bool mSimRespOrientation{false};   // wether the orientation in the response function is flipped
   float mSimRespVDShift{0.f};        // adjusting the Y-shift in the APTS response function to match sensor local coord.

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/DigiParams.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/DigiParams.cxx
@@ -74,6 +74,9 @@ void DigiParams::print() const
 
 void DigiParams::setAlpSimResponse(const o2::itsmft::AlpideSimResponse* resp)
 {
+  LOG(debug) << "Response function data path: " << resp->getDataPath();
+  LOG(debug) << "Response function info: ";
+  // resp->print();
   if (!resp) {
     LOGP(fatal, "cannot set response function from null");
   }

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Digitizer.cxx
@@ -49,7 +49,7 @@ void Digitizer::init()
     }
   }
 
-  // setting the correct response function (for the moment, for both VD and MLOT the APTS response function is udes)
+  // setting the correct response function (for the moment, for both VD and MLOT the same response function is used)
   mChipSimResp = mParams.getAlpSimResponse();
   mChipSimRespVD = mChipSimResp;   /// for the moment considering the same response
   mChipSimRespMLOT = mChipSimResp; /// for the moment considering the same response
@@ -65,11 +65,24 @@ void Digitizer::init()
   float thicknessVD = 0.0095;                                            // cm --- hardcoded based on geometry currently present
   float thicknessMLOT = o2::trk::SegmentationChip::SiliconThicknessMLOT; // 0.01 cm = 100 um --- based on geometry currently present
 
-  mSimRespVDScaleX = o2::trk::constants::apts::pitchX / o2::trk::SegmentationChip::PitchRowVD;
-  mSimRespVDScaleZ = o2::trk::constants::apts::pitchZ / o2::trk::SegmentationChip::PitchColVD;
-  mSimRespVDShift = mChipSimRespVD->getDepthMax(); // the curved, rescaled, sensors have a width from 0 to -45. Must add 10 um (= max depth) to match the APTS response.
-  mSimRespMLOTScaleX = o2::trk::constants::apts::pitchX / o2::trk::SegmentationChip::PitchRowMLOT;
-  mSimRespMLOTScaleZ = o2::trk::constants::apts::pitchZ / o2::trk::SegmentationChip::PitchColMLOT;
+  LOG(info) << "Using response name: " << mRespName;
+
+  if (mRespName == "APTS") { // default
+    mSimRespVDScaleX = o2::trk::constants::apts::pitchX / o2::trk::SegmentationChip::PitchRowVD;
+    mSimRespVDScaleZ = o2::trk::constants::apts::pitchZ / o2::trk::SegmentationChip::PitchColVD;
+    mSimRespVDShift = mChipSimRespVD->getDepthMax(); // the curved, rescaled, sensors have a width from 0 to -45. Must add ~10 um (= max depth) to match the APTS response.
+    mSimRespMLOTScaleX = o2::trk::constants::apts::pitchX / o2::trk::SegmentationChip::PitchRowMLOT;
+    mSimRespMLOTScaleZ = o2::trk::constants::apts::pitchZ / o2::trk::SegmentationChip::PitchColMLOT;
+  } else if (mRespName == "ALICE3") {
+    mSimRespVDScaleX = o2::trk::constants::alice3resp::pitchX / o2::trk::SegmentationChip::PitchRowVD;
+    mSimRespVDScaleZ = o2::trk::constants::alice3resp::pitchZ / o2::trk::SegmentationChip::PitchColVD;
+    mSimRespVDShift = mChipSimRespVD->getDepthMax(); // the curved, rescaled, sensors have a width from 0 to -95 um. Must align the start of epi layer with the response function.
+    mSimRespMLOTScaleX = o2::trk::constants::alice3resp::pitchX / o2::trk::SegmentationChip::PitchRowMLOT;
+    mSimRespMLOTScaleZ = o2::trk::constants::alice3resp::pitchZ / o2::trk::SegmentationChip::PitchColMLOT;
+  } else {
+    LOG(fatal) << "Unknown response name: " << mRespName;
+  }
+
   mSimRespMLOTShift = mChipSimRespMLOT->getDepthMax() - thicknessMLOT / 2.f; // the shift should be done considering the rescaling done to adapt to the wrong silicon thickness. TODO: remove the scaling factor for the depth when the silicon thickness match the simulated response
   mSimRespOrientation = false;
 

--- a/Steer/DigitizerWorkflow/src/TRKDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TRKDigitizerSpec.cxx
@@ -34,6 +34,7 @@
 #include <TChain.h>
 #include <TStopwatch.h>
 
+#include <memory>
 #include <string>
 
 using namespace o2::framework;
@@ -68,6 +69,7 @@ class TRKDPLDigitizerTask : BaseDPLDigitizer
   void initDigitizerTask(framework::InitContext& ic) override
   {
     mDisableQED = ic.options().get<bool>("disable-qed");
+    mLocalRespFile = ic.options().get<std::string>("local-response-file");
   }
 
   void run(framework::ProcessingContext& pc)
@@ -200,6 +202,15 @@ class TRKDPLDigitizerTask : BaseDPLDigitizer
     mFinished = true;
   }
 
+  void setLocalResponseFunction()
+  {
+    std::unique_ptr<TFile> file(TFile::Open(mLocalRespFile.data(), "READ"));
+    if (!file) {
+      LOG(fatal) << "Cannot open response file " << mLocalRespFile;
+    }
+    mDigitizer.getParams().setAlpSimResponse((const o2::itsmft::AlpideSimResponse*)file->Get("response1"));
+  }
+
   void updateTimeDependentParams(ProcessingContext& pc)
   {
     static bool initOnce{false};
@@ -267,7 +278,15 @@ class TRKDPLDigitizerTask : BaseDPLDigitizer
     // }
     if (matcher == ConcreteDataMatcher(mOrigin, "APTSRESP", 0)) {
       LOG(info) << mID.getName() << " loaded APTSResponseData";
-      mDigitizer.getParams().setAlpSimResponse((const o2::itsmft::AlpideSimResponse*)obj);
+      if (mLocalRespFile.empty()) {
+        LOG(info) << "Using CCDB/APTS response file";
+        mDigitizer.getParams().setAlpSimResponse((const o2::itsmft::AlpideSimResponse*)obj);
+        mDigitizer.setResponseName("APTS");
+      } else {
+        LOG(info) << "Response function will be loaded from local file: " << mLocalRespFile;
+        setLocalResponseFunction();
+        mDigitizer.setResponseName("ALICE3");
+      }
     }
   }
 
@@ -275,6 +294,7 @@ class TRKDPLDigitizerTask : BaseDPLDigitizer
   bool mWithMCTruth{true};
   bool mFinished{false};
   bool mDisableQED{false};
+  std::string mLocalRespFile{""};
   const o2::detectors::DetID mID{o2::detectors::DetID::TRK};
   const o2::header::DataOrigin mOrigin{o2::header::gDataOriginTRK};
   o2::trk::Digitizer mDigitizer{};
@@ -307,7 +327,9 @@ DataProcessorSpec getTRKDigitizerSpec(int channel, bool mctruth)
   return DataProcessorSpec{detStr + "Digitizer",
                            inputs, makeOutChannels(detOrig, mctruth),
                            AlgorithmSpec{adaptFromTask<TRKDPLDigitizerTask>(mctruth)},
-                           Options{{"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}}}};
+                           Options{
+                             {"disable-qed", o2::framework::VariantType::Bool, false, {"disable QED handling"}},
+                             {"local-response-file", o2::framework::VariantType::String, "", {"use response file saved locally at this path/filename"}}}};
 }
 
 } // namespace o2::trk


### PR DESCRIPTION
Added the possibility to use a version of the response file locally stored when performing digitization. 
To be used during digitization studies.
Usage: 
o2-sim-digitizer-workflow --local-response-file "path_to_file/ResponseData.root" 
If the  --local-response-file argument is not set, the response is retrieved from CCDB (as set with PR #14902)