### PR TITLE
EventsPerBC calibration task for FT0 (O2-6563)

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/CMakeLists.txt
+++ b/DataFormats/Detectors/FIT/FT0/CMakeLists.txt
@@ -47,4 +47,5 @@ o2_target_root_dictionary(DataFormatsFT0
           include/DataFormatsFT0/GlobalOffsetsCalibrationObject.h
           include/DataFormatsFT0/SpectraInfoObject.h
           include/DataFormatsFT0/SlewingCoef.h
+          include/DataFormatsFT0/EventsPerBc.h
 )

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
@@ -1,0 +1,17 @@
+#ifndef _FT0_EVENTS_PER_BC_CALIB_OBJECT
+#define _FT0_EVENTS_PER_BC_CALIB_OBJECT
+
+#include "CommonConstants/LHCConstants.h"
+#include <Rtypes.h>
+
+namespace o2::ft0
+{
+struct EventsPerBc
+{
+    std::array<double,o2::constants::lhc::LHCMaxBunches> histogram;
+    int16_t amplThresSideA;
+    int16_t amplThresSideC;
+    ClassDefNV(EventsPerBc, 1);
+};
+}
+#endif

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
@@ -6,12 +6,11 @@
 
 namespace o2::ft0
 {
-struct EventsPerBc
-{
-    std::array<double,o2::constants::lhc::LHCMaxBunches> histogram;
-    int16_t amplThresSideA;
-    int16_t amplThresSideC;
-    ClassDefNV(EventsPerBc, 1);
+struct EventsPerBc {
+  std::array<double, o2::constants::lhc::LHCMaxBunches> histogram;
+  int16_t amplThresSideA;
+  int16_t amplThresSideC;
+  ClassDefNV(EventsPerBc, 1);
 };
-}
+} // namespace o2::ft0
 #endif

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #ifndef _FT0_EVENTS_PER_BC_CALIB_OBJECT
 #define _FT0_EVENTS_PER_BC_CALIB_OBJECT
 

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/EventsPerBc.h
@@ -8,8 +8,6 @@ namespace o2::ft0
 {
 struct EventsPerBc {
   std::array<double, o2::constants::lhc::LHCMaxBunches> histogram;
-  int16_t amplThresSideA;
-  int16_t amplThresSideC;
   ClassDefNV(EventsPerBc, 1);
 };
 } // namespace o2::ft0

--- a/DataFormats/Detectors/FIT/FT0/src/DataFormatsFT0LinkDef.h
+++ b/DataFormats/Detectors/FIT/FT0/src/DataFormatsFT0LinkDef.h
@@ -56,4 +56,6 @@
 #pragma link C++ class std::pair < std::vector < double>, std::vector < double>> + ;
 #pragma link C++ class o2::ft0::SlewingCoef + ;
 
+#pragma link C++ class o2::ft0::EventsPerBc + ;
+
 #endif

--- a/Detectors/FIT/FT0/calibration/CMakeLists.txt
+++ b/Detectors/FIT/FT0/calibration/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(FT0Calibration
     O2::Steer
     O2::CCDB
     ROOT::Minuit
+    ROOT::Hist
   )
 
 o2_target_root_dictionary(FT0Calibration

--- a/Detectors/FIT/FT0/calibration/CMakeLists.txt
+++ b/Detectors/FIT/FT0/calibration/CMakeLists.txt
@@ -34,7 +34,7 @@ o2_target_root_dictionary(FT0Calibration
 
 o2_add_executable(ft0-time-offset-calib
   COMPONENT_NAME calibration
-  SOURCES 
+  SOURCES
     workflow/FT0TimeOffsetCalibration-Workflow.cxx
   PUBLIC_LINK_LIBRARIES
     O2::FT0Calibration O2::FITCalibration
@@ -42,7 +42,7 @@ o2_add_executable(ft0-time-offset-calib
 
 o2_add_executable(ft0-time-spectra-processor
   COMPONENT_NAME calibration
-  SOURCES 
+  SOURCES
     workflow/FT0TimeSpectraProcessor-Workflow.cxx
   PUBLIC_LINK_LIBRARIES
     O2::FT0Calibration
@@ -50,11 +50,10 @@ o2_add_executable(ft0-time-spectra-processor
 
 o2_add_executable(ft0-events-per-bc-processor
   COMPONENT_NAME calibration
-  SOURCES 
+  SOURCES
     workflow/FT0EventsPerBcProcessor-Workflow.cxx
   PUBLIC_LINK_LIBRARIES
     O2::FT0Calibration
     O2::Framework
     O2::CCDB
-)
-      
+)     

--- a/Detectors/FIT/FT0/calibration/CMakeLists.txt
+++ b/Detectors/FIT/FT0/calibration/CMakeLists.txt
@@ -56,4 +56,4 @@ o2_add_executable(ft0-events-per-bc-processor
     O2::FT0Calibration
     O2::Framework
     O2::CCDB
-)     
+)

--- a/Detectors/FIT/FT0/calibration/CMakeLists.txt
+++ b/Detectors/FIT/FT0/calibration/CMakeLists.txt
@@ -33,3 +33,10 @@ o2_add_library(FT0Calibration
         PUBLIC_LINK_LIBRARIES
         O2::FT0Calibration
         )
+      o2_add_executable(ft0-events-per-bc-processor
+        COMPONENT_NAME calibration
+        SOURCES workflow/FT0EventsPerBcProcessor-Workflow.cxx
+        PUBLIC_LINK_LIBRARIES
+        O2::FT0Calibration
+      )
+      

--- a/Detectors/FIT/FT0/calibration/CMakeLists.txt
+++ b/Detectors/FIT/FT0/calibration/CMakeLists.txt
@@ -36,6 +36,7 @@ o2_add_library(FT0Calibration
       o2_add_executable(ft0-events-per-bc-processor
         COMPONENT_NAME calibration
         SOURCES workflow/FT0EventsPerBcProcessor-Workflow.cxx
+                src/EventsPerBcCalibrator.cxx
         PUBLIC_LINK_LIBRARIES
         O2::FT0Calibration
       )

--- a/Detectors/FIT/FT0/calibration/CMakeLists.txt
+++ b/Detectors/FIT/FT0/calibration/CMakeLists.txt
@@ -10,34 +10,50 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(FT0Calibration
-        SOURCES
-        src/FT0TimeOffsetSlotContainer.cxx
-        PUBLIC_LINK_LIBRARIES
-         O2::DataFormatsFT0
-         O2::CommonDataFormat
-         O2::DetectorsCalibration
-           )
-       o2_target_root_dictionary(FT0Calibration
-        HEADERS
-        include/FT0Calibration/FT0TimeOffsetSlotContainer.h
-        )
-      o2_add_executable(ft0-time-offset-calib
-        COMPONENT_NAME calibration
-        SOURCES workflow/FT0TimeOffsetCalibration-Workflow.cxx
-        PUBLIC_LINK_LIBRARIES
-        O2::FT0Calibration O2::FITCalibration
-        )
-      o2_add_executable(ft0-time-spectra-processor
-        COMPONENT_NAME calibration
-        SOURCES workflow/FT0TimeSpectraProcessor-Workflow.cxx
-        PUBLIC_LINK_LIBRARIES
-        O2::FT0Calibration
-        )
-      o2_add_executable(ft0-events-per-bc-processor
-        COMPONENT_NAME calibration
-        SOURCES workflow/FT0EventsPerBcProcessor-Workflow.cxx
-                src/EventsPerBcCalibrator.cxx
-        PUBLIC_LINK_LIBRARIES
-        O2::FT0Calibration
-      )
+  SOURCES
+    src/FT0TimeOffsetSlotContainer.cxx
+    src/EventsPerBcCalibrator.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::DetectorsCalibration
+    O2::Framework
+    O2::CommonUtils
+    Microsoft.GSL::GSL
+    O2::DataFormatsFT0
+    O2::CommonDataFormat
+    O2::Steer
+    O2::CCDB
+    ROOT::Minuit
+  )
+
+o2_target_root_dictionary(FT0Calibration
+  HEADERS
+    include/FT0Calibration/FT0TimeOffsetSlotContainer.h
+    include/FT0Calibration/EventsPerBcCalibrator.h
+  )
+
+o2_add_executable(ft0-time-offset-calib
+  COMPONENT_NAME calibration
+  SOURCES 
+    workflow/FT0TimeOffsetCalibration-Workflow.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::FT0Calibration O2::FITCalibration
+  )
+
+o2_add_executable(ft0-time-spectra-processor
+  COMPONENT_NAME calibration
+  SOURCES 
+    workflow/FT0TimeSpectraProcessor-Workflow.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::FT0Calibration
+  )
+
+o2_add_executable(ft0-events-per-bc-processor
+  COMPONENT_NAME calibration
+  SOURCES 
+    workflow/FT0EventsPerBcProcessor-Workflow.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::FT0Calibration
+    O2::Framework
+    O2::CCDB
+)
       

--- a/Detectors/FIT/FT0/calibration/README.md
+++ b/Detectors/FIT/FT0/calibration/README.md
@@ -50,7 +50,7 @@ Receiver example:
 ```
 o2-dpl-raw-proxy --channel-config "name=readout-proxy,type=pull,method=bind,address=tcp://localhost:30453,rateLogging=1,transport=zeromq" --dataspec "A:FT0/DIGITSBC/0" \
 | o2-calibration-ft0-events-per-bc-processor --FT0EventsPerBcProcessor "--slot-len-sec=10 --min-ampl-side-a=0" \
-| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080/ 
+| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080/
 ```
 
 ### CTF Data
@@ -58,5 +58,5 @@ Example:
 ```
 o2-ctf-reader-workflow --ctf-input ctf.root --onlyDet FT0 \
 | o2-calibration-ft0-events-per-bc-processor --FT0EventsPerBcProcessor "--slot-len-sec=10" \
-| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080/ 
+| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080/
 ```

--- a/Detectors/FIT/FT0/calibration/README.md
+++ b/Detectors/FIT/FT0/calibration/README.md
@@ -23,7 +23,7 @@ First, it is important to digitize data with a non-zero run number, orbit, and t
 ```
 o2-sim-digitizer-workflow \
 --onlyDet FT0 \
---configKeyValues="HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=128;HBFUtils.orbitFirstSampled=256;HBFUtils.runNumber=560560;HBFUtils.timestamp=1768464099000"
+--configKeyValues="HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=128;HBFUtils.orbitFirstSampled=256;HBFUtils.runNumber=560560;HBFUtils.startTime=1768464099000"
 ```
 
 To process simulation data, digits must first be converted to RAW format. The `o2-ft0-digi2raw` tool performs this conversion and generates the required configuration file.

--- a/Detectors/FIT/FT0/calibration/README.md
+++ b/Detectors/FIT/FT0/calibration/README.md
@@ -2,7 +2,7 @@
 
 ## Events per BC Calibration
 ### Description
-Generates histograms of **TVX per Bunch Crossing (BC)**. Events can be filtered by applying amplitude thresholds to the **A-side** and **C-side**.
+Generates histograms of **Events per Bunch Crossing (BC)**. Events can be filtered by applying amplitude thresholds to the **A-side** and **C-side**.
 
 ### Command-Line Options
 | Option | Default | Description |

--- a/Detectors/FIT/FT0/calibration/README.md
+++ b/Detectors/FIT/FT0/calibration/README.md
@@ -1,0 +1,55 @@
+# Calibrations
+
+## Events per BC Calibration
+### Description
+Generates histograms of **TVX per Bunch Crossing (BC)**. Events can be filtered by applying amplitude thresholds to the **A-side** and **C-side**.
+
+### Command-Line Options
+| Option | Default | Description |
+| :--- | :--- | :--- |
+| `--slot-len-sec` | `3600` | Duration of each slot in seconds. |
+| `--slot-len-tf` | `0` | Slot length in Time Frames (TFs). |
+| `--one-object-per-run` | — | If set, the workflow creates only one calibration object per run. |
+| `--min-entries-number` | `0` | Minimum number of entries required for a slot to be valid. |
+| `--min-ampl-side-a` | `-2147483648` | Amplitude threshold for Side A events. |
+| `--min-ampl-side-c` | `-2147483648` | Amplitude threshold for Side C events. |
+
+---
+
+## How to Run
+
+### Simulation Data
+To process simulation data, digits must first be converted to RAW format. The `o2-ft0-digi2raw` tool performs this conversion and generates the required configuration file.
+
+Once converted, you can run the calibration either as a single integrated workflow or by spawning as the sender and receiver components separately.
+
+#### Single Workflow Example
+Execute the following command within the simulation directory:
+```
+o2-raw-file-reader-workflow --input-conf FT0raw.cfg --loop -1 \
+| o2-ft0-flp-dpl-workflow --condition-backend=http://localhost:8080 \
+| o2-calibration-ft0-events-per-bc-processor --FT0EventsPerBcProcessor "--slot-len-sec=10" \
+| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080
+```
+
+Sender example (in simulation directory):
+```
+o2-raw-file-reader-workflow --input-conf FT0raw.cfg --loop -1 \
+| o2-ft0-flp-dpl-workflow --condition-backend=http://localhost:8080 \
+| o2-dpl-output-proxy --channel-config "name=downstream,method=connect,address=tcp://localhost:30453,type=push,transport=zeromq" --dataspec "downstream:FT0/DIGITSBC"
+```
+
+Receiver example:
+```
+o2-dpl-raw-proxy --channel-config "name=readout-proxy,type=pull,method=bind,address=tcp://localhost:30453,rateLogging=1,transport=zeromq" --dataspec "A:FT0/DIGITSBC/0" \
+| o2-calibration-ft0-events-per-bc-processor --FT0EventsPerBcProcessor "--slot-len-sec=10 --min-ampl-side-a=0" \
+| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080/ 
+```
+
+### CTF Data
+Example:
+```
+o2-ctf-reader-workflow --ctf-input ctf.root --onlyDet FT0 \
+| o2-calibration-ft0-events-per-bc-processor --FT0EventsPerBcProcessor "--slot-len-sec=10" \
+| o2-calibration-ccdb-populator-workflow --ccdb-path=http://localhost:8080/ 
+```

--- a/Detectors/FIT/FT0/calibration/README.md
+++ b/Detectors/FIT/FT0/calibration/README.md
@@ -19,6 +19,13 @@ Generates histograms of **Events per Bunch Crossing (BC)**. Events can be filter
 ## How to Run
 
 ### Simulation Data
+First, it is important to digitize data with a non-zero run number, orbit, and timestamp. To set these parameters, one can use the `--configKeyValues` option, as shown in the example below.
+```
+o2-sim-digitizer-workflow \
+--onlyDet FT0 \
+--configKeyValues="HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=128;HBFUtils.orbitFirstSampled=256;HBFUtils.runNumber=560560;HBFUtils.timestamp=1768464099000"
+```
+
 To process simulation data, digits must first be converted to RAW format. The `o2-ft0-digi2raw` tool performs this conversion and generates the required configuration file.
 
 Once converted, you can run the calibration either as a single integrated workflow or by spawning as the sender and receiver components separately.

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -3,6 +3,7 @@
 
 #include <bitset>
 #include <array>
+#include <limits>
 #include <TH1F.h>
 
 #include "CommonDataFormat/FlatHisto2D.h"
@@ -11,6 +12,7 @@
 #include "DataFormatsFT0/Digit.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
+#include "CommonDataFormat/TFIDInfo.h"
 #include "TH1F.h"
 #include "Rtypes.h"
 
@@ -18,12 +20,15 @@ namespace o2::ft0
 {
     struct EventsPerBc
     {
-        EventsPerBc() = default;
+        EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC): mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
         
         size_t getEntries() const { return entries; }
         void print() const;
-        void fill(const gsl::span<const o2::ft0::Digit> data);
+        void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
         void merge(const EventsPerBc* prev);
+
+        const int32_t mMinAmplitudeSideA;
+        const int32_t mMinAmplitudeSideC;
 
         std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
         size_t entries{0};
@@ -39,7 +44,7 @@ namespace o2::ft0
         using TFType = o2::calibration::TFType;
 
         public:
-        EventsPerBcCalibrator() = default;
+        EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
         
         bool hasEnoughData(const Slot& slot) const override;
         void initOutput() override;
@@ -50,9 +55,12 @@ namespace o2::ft0
         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
 
         private:
+        const uint32_t mMinNumberOfEntries;
+        const int32_t mMinAmplitudeSideA;
+        const int32_t mMinAmplitudeSideC;
+
         std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
-        uint32_t mMinNumberOfEntries{1000};
 
         ClassDefOverride(EventsPerBcCalibrator, 1);
     };

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -18,53 +18,52 @@
 
 namespace o2::ft0
 {
-    struct EventsPerBc
-    {
-      EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
+struct EventsPerBc {
+  EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
 
-      size_t getEntries() const { return entries; }
-      void print() const;
-      void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
-      void merge(const EventsPerBc* prev);
+  size_t getEntries() const { return entries; }
+  void print() const;
+  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
+  void merge(const EventsPerBc* prev);
 
-      const int32_t mMinAmplitudeSideA;
-      const int32_t mMinAmplitudeSideC;
+  const int32_t mMinAmplitudeSideA;
+  const int32_t mMinAmplitudeSideC;
 
-      std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
-      size_t entries{0};
-      long startTimeStamp{0};
-      long stopTimeStamp{0};
+  std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
+  size_t entries{0};
+  long startTimeStamp{0};
+  long stopTimeStamp{0};
 
-      ClassDefNV(EventsPerBc, 1);
-    };
+  ClassDefNV(EventsPerBc, 1);
+};
 
-    class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBc>
-    {
-        using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBc>;
-        using TFType = o2::calibration::TFType;
-        using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
+class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBc>
+{
+  using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBc>;
+  using TFType = o2::calibration::TFType;
+  using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
 
-       public:
-        EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
+ public:
+  EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
 
-        bool hasEnoughData(const Slot& slot) const override;
-        void initOutput() override;
-        void finalizeSlot(Slot& slot) override;
-        Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
+  bool hasEnoughData(const Slot& slot) const override;
+  void initOutput() override;
+  void finalizeSlot(Slot& slot) override;
+  Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
 
-        const std::vector<EventsHistogram>& getTvxPerBc() { return mTvxPerBcs; }
-        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
+  const std::vector<EventsHistogram>& getTvxPerBc() { return mTvxPerBcs; }
+  std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
 
-       private:
-        const uint32_t mMinNumberOfEntries;
-        const int32_t mMinAmplitudeSideA;
-        const int32_t mMinAmplitudeSideC;
+ private:
+  const uint32_t mMinNumberOfEntries;
+  const int32_t mMinAmplitudeSideA;
+  const int32_t mMinAmplitudeSideC;
 
-        std::vector<EventsHistogram> mTvxPerBcs;
-        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+  std::vector<EventsHistogram> mTvxPerBcs;
+  std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
 
-        ClassDefOverride(EventsPerBcCalibrator, 1);
-    };
-}
+  ClassDefOverride(EventsPerBcCalibrator, 1);
+};
+} // namespace o2::ft0
 
 #endif

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #ifndef O2_FT0TVXPERBCID
 #define O2_FT0TVXPERBCID
 

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -3,10 +3,12 @@
 
 #include <bitset>
 #include <array>
+#include <TH1F.h>
 
 #include "CommonDataFormat/FlatHisto2D.h"
 #include "CommonConstants/LHCConstants.h"
 #include "DataFormatsFT0/SpectraInfoObject.h"
+#include "DataFormatsFT0/Digit.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -41,10 +41,10 @@ namespace o2::ft0
         public:
         EventsPerBcCalibrator() = default;
         
-        bool hasEnoughData(const Slot& slot) const final { return true; }
-        void initOutput() final;
-        void finalizeSlot(Slot& slot) final;
-        Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+        bool hasEnoughData(const Slot& slot) const override;
+        void initOutput() override;
+        void finalizeSlot(Slot& slot) override;
+        Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
 
         const std::vector<std::unique_ptr<TH1F>>& getTvxPerBc() { return mTvxPerBcs; }
         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
@@ -52,6 +52,7 @@ namespace o2::ft0
         private:
         std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+        uint32_t mMinNumberOfEntries{1000};
 
         ClassDefOverride(EventsPerBcCalibrator, 1);
     };

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -9,7 +9,6 @@
 #include "DataFormatsFT0/SpectraInfoObject.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
-#include "DataFormatsFT0/BcEvents.h"
 
 namespace o2::ft0
 {
@@ -34,22 +33,19 @@ namespace o2::ft0
         using TFType = o2::calibration::TFType;
 
         public:
-        EventsPerBcCalibrator()
-        {
-            setUpdateAtTheEndOfRunOnly();
-        }
+        EventsPerBcCalibrator() = default;
         
         bool hasEnoughData(const Slot& slot) const final { return true; }
         void initOutput() final;
         void finalizeSlot(Slot& slot) final;
         Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
 
-        const TH1F* getTvxPerBc() { return mTvxPerBc.get(); }
-        const CcdbObjectInfo* getTvxPerBcCcdbInfo() { return mTvxPerBcInfo.get(); }
+        const std::vector<std::unique_ptr<TH1F>>& getTvxPerBc() { return mTvxPerBcs; }
+        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
 
         private:
-        std::unique_ptr<TH1F> mTvxPerBc;
-        std::unique_ptr<CcdbObjectInfo> mTvxPerBcInfo;
+        std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
+        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
     };
 }
 

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -20,22 +20,22 @@ namespace o2::ft0
 {
     struct EventsPerBc
     {
-        EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC): mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
-        
-        size_t getEntries() const { return entries; }
-        void print() const;
-        void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
-        void merge(const EventsPerBc* prev);
+      EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
 
-        const int32_t mMinAmplitudeSideA;
-        const int32_t mMinAmplitudeSideC;
+      size_t getEntries() const { return entries; }
+      void print() const;
+      void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
+      void merge(const EventsPerBc* prev);
 
-        std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
-        size_t entries{0};
-        long startTimeStamp{0};
-        long stopTimeStamp{0};
+      const int32_t mMinAmplitudeSideA;
+      const int32_t mMinAmplitudeSideC;
 
-        ClassDefNV(EventsPerBc, 1);
+      std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
+      size_t entries{0};
+      long startTimeStamp{0};
+      long stopTimeStamp{0};
+
+      ClassDefNV(EventsPerBc, 1);
     };
 
     class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBc>
@@ -44,25 +44,25 @@ namespace o2::ft0
         using TFType = o2::calibration::TFType;
 
         public:
-        EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
-        
-        bool hasEnoughData(const Slot& slot) const override;
-        void initOutput() override;
-        void finalizeSlot(Slot& slot) override;
-        Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
+         EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
 
-        const std::vector<std::unique_ptr<TH1F>>& getTvxPerBc() { return mTvxPerBcs; }
-        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
+         bool hasEnoughData(const Slot& slot) const override;
+         void initOutput() override;
+         void finalizeSlot(Slot& slot) override;
+         Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
+
+         const std::vector<std::unique_ptr<TH1F>>& getTvxPerBc() { return mTvxPerBcs; }
+         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
 
         private:
-        const uint32_t mMinNumberOfEntries;
-        const int32_t mMinAmplitudeSideA;
-        const int32_t mMinAmplitudeSideC;
+         const uint32_t mMinNumberOfEntries;
+         const int32_t mMinAmplitudeSideA;
+         const int32_t mMinAmplitudeSideC;
 
-        std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
-        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+         std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
+         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
 
-        ClassDefOverride(EventsPerBcCalibrator, 1);
+         ClassDefOverride(EventsPerBcCalibrator, 1);
     };
 }
 

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -19,15 +19,6 @@
 
 namespace o2::ft0
 {
-<<<<<<< HEAD
-struct EventsPerBc {
-  EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
-
-  size_t getEntries() const { return entries; }
-  void print() const;
-  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
-  void merge(const EventsPerBc* prev);
-=======
 struct EventsPerBcContainer {
   EventsPerBcContainer(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
 
@@ -35,7 +26,6 @@ struct EventsPerBcContainer {
   void print() const;
   void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
   void merge(const EventsPerBcContainer* prev);
->>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
   const int32_t mMinAmplitudeSideA;
   const int32_t mMinAmplitudeSideC;
@@ -45,16 +35,6 @@ struct EventsPerBcContainer {
   long startTimeStamp{0};
   long stopTimeStamp{0};
 
-<<<<<<< HEAD
-  ClassDefNV(EventsPerBc, 1);
-};
-
-class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBc>
-{
-  using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBc>;
-  using TFType = o2::calibration::TFType;
-  using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
-=======
   ClassDefNV(EventsPerBcContainer, 1);
 };
 
@@ -63,7 +43,6 @@ class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<
   using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBcContainer>;
   using TFType = o2::calibration::TFType;
   using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
->>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
  public:
   EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
@@ -73,26 +52,16 @@ class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<
   void finalizeSlot(Slot& slot) override;
   Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
 
-<<<<<<< HEAD
-  const std::vector<EventsHistogram>& getTvxPerBc() { return mTvxPerBcs; }
-  std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
-=======
   const std::vector<EventsPerBc>& getTvxPerBc() { return mTvxPerBcs; }
   std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
->>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
  private:
   const uint32_t mMinNumberOfEntries;
   const int32_t mMinAmplitudeSideA;
   const int32_t mMinAmplitudeSideC;
 
-<<<<<<< HEAD
-  std::vector<EventsHistogram> mTvxPerBcs;
-  std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
-=======
   std::vector<EventsPerBc> mTvxPerBcs;
   std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
->>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
   ClassDefOverride(EventsPerBcCalibrator, 1);
 };

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -10,6 +10,7 @@
 #include "CommonConstants/LHCConstants.h"
 #include "DataFormatsFT0/SpectraInfoObject.h"
 #include "DataFormatsFT0/Digit.h"
+#include "DataFormatsFT0/EventsPerBc.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 #include "CommonDataFormat/TFIDInfo.h"
@@ -18,6 +19,7 @@
 
 namespace o2::ft0
 {
+<<<<<<< HEAD
 struct EventsPerBc {
   EventsPerBc(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
 
@@ -25,6 +27,15 @@ struct EventsPerBc {
   void print() const;
   void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
   void merge(const EventsPerBc* prev);
+=======
+struct EventsPerBcContainer {
+  EventsPerBcContainer(int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC) {}
+
+  size_t getEntries() const { return entries; }
+  void print() const;
+  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data);
+  void merge(const EventsPerBcContainer* prev);
+>>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
   const int32_t mMinAmplitudeSideA;
   const int32_t mMinAmplitudeSideC;
@@ -34,6 +45,7 @@ struct EventsPerBc {
   long startTimeStamp{0};
   long stopTimeStamp{0};
 
+<<<<<<< HEAD
   ClassDefNV(EventsPerBc, 1);
 };
 
@@ -42,6 +54,16 @@ class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<
   using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBc>;
   using TFType = o2::calibration::TFType;
   using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
+=======
+  ClassDefNV(EventsPerBcContainer, 1);
+};
+
+class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBcContainer>
+{
+  using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBcContainer>;
+  using TFType = o2::calibration::TFType;
+  using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
+>>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
  public:
   EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
@@ -51,16 +73,26 @@ class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<
   void finalizeSlot(Slot& slot) override;
   Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
 
+<<<<<<< HEAD
   const std::vector<EventsHistogram>& getTvxPerBc() { return mTvxPerBcs; }
   std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
+=======
+  const std::vector<EventsPerBc>& getTvxPerBc() { return mTvxPerBcs; }
+  std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
+>>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
  private:
   const uint32_t mMinNumberOfEntries;
   const int32_t mMinAmplitudeSideA;
   const int32_t mMinAmplitudeSideC;
 
+<<<<<<< HEAD
   std::vector<EventsHistogram> mTvxPerBcs;
   std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+=======
+  std::vector<EventsPerBc> mTvxPerBcs;
+  std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+>>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
   ClassDefOverride(EventsPerBcCalibrator, 1);
 };

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -30,7 +30,7 @@ namespace o2::ft0
       const int32_t mMinAmplitudeSideA;
       const int32_t mMinAmplitudeSideC;
 
-      std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
+      std::array<float, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
       size_t entries{0};
       long startTimeStamp{0};
       long stopTimeStamp{0};

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -27,6 +27,8 @@ namespace o2::ft0
         size_t entries{0};
         long startTimeStamp{0};
         long stopTimeStamp{0};
+
+        ClassDefNV(EventsPerBc, 1);
     };
 
     class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBc>
@@ -48,6 +50,8 @@ namespace o2::ft0
         private:
         std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+
+        ClassDefOverride(EventsPerBcCalibrator, 1);
     };
 }
 

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -30,7 +30,7 @@ namespace o2::ft0
       const int32_t mMinAmplitudeSideA;
       const int32_t mMinAmplitudeSideC;
 
-      std::array<float, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
+      std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
       size_t entries{0};
       long startTimeStamp{0};
       long stopTimeStamp{0};
@@ -42,27 +42,28 @@ namespace o2::ft0
     {
         using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBc>;
         using TFType = o2::calibration::TFType;
+        using EventsHistogram = std::array<double, o2::constants::lhc::LHCMaxBunches>;
 
-        public:
-         EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
+       public:
+        EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC);
 
-         bool hasEnoughData(const Slot& slot) const override;
-         void initOutput() override;
-         void finalizeSlot(Slot& slot) override;
-         Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
+        bool hasEnoughData(const Slot& slot) const override;
+        void initOutput() override;
+        void finalizeSlot(Slot& slot) override;
+        Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) override;
 
-         const std::vector<std::unique_ptr<TH1F>>& getTvxPerBc() { return mTvxPerBcs; }
-         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
+        const std::vector<EventsHistogram>& getTvxPerBc() { return mTvxPerBcs; }
+        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>>& getTvxPerBcCcdbInfo() { return mTvxPerBcInfos; }
 
-        private:
-         const uint32_t mMinNumberOfEntries;
-         const int32_t mMinAmplitudeSideA;
-         const int32_t mMinAmplitudeSideC;
+       private:
+        const uint32_t mMinNumberOfEntries;
+        const int32_t mMinAmplitudeSideA;
+        const int32_t mMinAmplitudeSideC;
 
-         std::vector<std::unique_ptr<TH1F>> mTvxPerBcs;
-         std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
+        std::vector<EventsHistogram> mTvxPerBcs;
+        std::vector<std::unique_ptr<o2::ccdb::CcdbObjectInfo>> mTvxPerBcInfos;
 
-         ClassDefOverride(EventsPerBcCalibrator, 1);
+        ClassDefOverride(EventsPerBcCalibrator, 1);
     };
 }
 

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -11,6 +11,8 @@
 #include "DataFormatsFT0/Digit.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
+#include "TH1F.h"
+#include "Rtypes.h"
 
 namespace o2::ft0
 {

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/EventsPerBcCalibrator.h
@@ -1,0 +1,56 @@
+#ifndef O2_FT0TVXPERBCID
+#define O2_FT0TVXPERBCID
+
+#include <bitset>
+#include <array>
+
+#include "CommonDataFormat/FlatHisto2D.h"
+#include "CommonConstants/LHCConstants.h"
+#include "DataFormatsFT0/SpectraInfoObject.h"
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsFT0/BcEvents.h"
+
+namespace o2::ft0
+{
+    struct EventsPerBc
+    {
+        EventsPerBc() = default;
+        
+        size_t getEntries() const { return entries; }
+        void print() const;
+        void fill(const gsl::span<const o2::ft0::Digit> data);
+        void merge(const EventsPerBc* prev);
+
+        std::array<double, o2::constants::lhc::LHCMaxBunches> mTvx{0.0};
+        size_t entries{0};
+        long startTimeStamp{0};
+        long stopTimeStamp{0};
+    };
+
+    class EventsPerBcCalibrator final : public o2::calibration::TimeSlotCalibration<o2::ft0::EventsPerBc>
+    {
+        using Slot = o2::calibration::TimeSlot<o2::ft0::EventsPerBc>;
+        using TFType = o2::calibration::TFType;
+
+        public:
+        EventsPerBcCalibrator()
+        {
+            setUpdateAtTheEndOfRunOnly();
+        }
+        
+        bool hasEnoughData(const Slot& slot) const final { return true; }
+        void initOutput() final;
+        void finalizeSlot(Slot& slot) final;
+        Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+
+        const TH1F* getTvxPerBc() { return mTvxPerBc.get(); }
+        const CcdbObjectInfo* getTvxPerBcCcdbInfo() { return mTvxPerBcInfo.get(); }
+
+        private:
+        std::unique_ptr<TH1F> mTvxPerBc;
+        std::unique_ptr<CcdbObjectInfo> mTvxPerBcInfo;
+    };
+}
+
+#endif

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -52,7 +52,7 @@ void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
 {
   LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
   o2::ft0::EventsPerBcContainer* data = slot.getContainer();
-  mTvxPerBcs.emplace_back(data->mTvx, mMinAmplitudeSideA, mMinAmplitudeSideC);
+  mTvxPerBcs.emplace_back(data->mTvx);
 
   auto clName = o2::utils::MemFileHelper::getClassName(mTvxPerBcs.back());
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -52,14 +52,14 @@ namespace o2::ft0
     {
         LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
         o2::ft0::EventsPerBc* data = slot.getContainer();
-        mTvxPerBcs.emplace_back(std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
+        mTvxPerBcs.emplace_back(std::make_unique<TH1F>("EventsPerBc", "FT0 Events per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
         for (int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
             mTvxPerBcs.back()->Fill(bin, data->mTvx[bin]);
         }
         auto clName = o2::utils::MemFileHelper::getClassName(*mTvxPerBcs.back());
-        auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+        auto flName = o2::ccdb::CcdbApi::generateFileName(clName) + ".root";
         std::map<std::string, std::string> metaData;
-        mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
+        mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
         LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();
     }
 

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -8,11 +8,14 @@ namespace o2::ft0
         LOG(info) << entries << " entries";
     }
 
-    void EventsPerBc::fill(const gsl::span<const o2::ft0::Digit> data)
+    void EventsPerBc::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data)
     {
         size_t oldEntries = entries;
         for(const auto& digit: data) {
             double isVertex = digit.mTriggers.getVertex();
+            if(digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
+                continue;
+            }
             mTvx[digit.mIntRecord.bc] += isVertex;
             entries += isVertex;
         }
@@ -33,6 +36,14 @@ namespace o2::ft0
         mTvxPerBcInfos.clear();
     }
 
+    
+    EventsPerBcCalibrator::EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC): mMinNumberOfEntries(minNumberOfEntries), mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC)
+    {
+        LOG(info) << "Defined threshold for number of entires per slot: " << mMinNumberOfEntries;
+        LOG(info) << "Defined threshold for side A amplitude for event: " << mMinAmplitudeSideA;
+        LOG(info) << "Defined threshold for side C amplitude for event: " << mMinAmplitudeSideC;
+    }
+
     bool EventsPerBcCalibrator::hasEnoughData(const EventsPerBcCalibrator::Slot& slot) const
     { 
         return slot.getContainer()->entries > mMinNumberOfEntries;
@@ -40,7 +51,7 @@ namespace o2::ft0
 
     void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
     {
-        LOG(info) << "Finializing slot from " << slot.getStartTimeMS()  << " to " << slot.getEndTimeMS();
+        LOG(info) << "Finalizing slot from " << slot.getStartTimeMS()  << " to " << slot.getEndTimeMS();
         o2::ft0::EventsPerBc* data = slot.getContainer();
         mTvxPerBcs.emplace_back(std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
         for(int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
@@ -57,7 +68,7 @@ namespace o2::ft0
     {
         auto& cont = getSlots();
         auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
-        slot.setContainer(std::make_unique<EventsPerBc>());
+        slot.setContainer(std::make_unique<EventsPerBc>(mMinAmplitudeSideA, mMinAmplitudeSideC));
         return slot;
     }
 }

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -1,0 +1,53 @@
+#include "FT0Calibration/EventsPerBcCalibrator.h"
+
+namespace o2::ft0
+{
+    void EventsPerBc::print() const
+    {
+
+    }
+
+    void EventsPerBc::fill(const gsl::span<const o2::ft0::Digit> data)
+    {
+        for(const auto& digit: digits) {
+            double isVertex = digit.mTriggers.isVertex();
+            mTvx[digits.mIntRecord.bc] += isVertex;
+            entries += isVertex;
+        }
+    }
+
+    void EventsPerBc::merge(const EventsPerBc* prev)
+    {
+       for(int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++){
+            mTvx[bc] += prev->mTvx[bc];    
+       }
+       entries += prev->mEntries;
+    }
+
+    void EventsPerBcCalibrator::initOutput() final
+    {
+        mTvxPerBc.reset();
+        mTvxPerBcInfo.reset();
+    }
+
+    void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot) final
+    {
+        o2::ft0::EventsPerBc* data = slot.getContainer();
+        mTvxPerBc = std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1);
+        for(int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
+            tvxsHist->fill(bin, data->mTvx[bin]);
+        }
+        auto clName = o2::utils::MemFileHelper::getClassName(*tvxsHist);
+        auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+        std::map<std::string, std::string> metaData;
+        mTvxPerBcInfo = std::make_unique<CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStarTimeMs(), slot.getEndTimeStampMS());
+    }
+
+    EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend) final
+    {
+        auto& cont = getSlots();
+        auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+        slot.setContainer(std::make_unique<EventsPerBc>());
+        return slot;
+    }
+}

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -4,7 +4,7 @@ namespace o2::ft0
 {
     void EventsPerBc::print() const
     {
-
+        LOG(info) << entries << " entries";
     }
 
     void EventsPerBc::fill(const gsl::span<const o2::ft0::Digit> data)
@@ -26,21 +26,21 @@ namespace o2::ft0
 
     void EventsPerBcCalibrator::initOutput() final
     {
-        mTvxPerBc.reset();
-        mTvxPerBcInfo.reset();
+        mTvxPerBc.clear();
+        mTvxPerBcInfo.clear();
     }
 
     void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot) final
     {
         o2::ft0::EventsPerBc* data = slot.getContainer();
-        mTvxPerBc = std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1);
+        mTvxPerBcs.emplace_back(std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
         for(int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
-            tvxsHist->fill(bin, data->mTvx[bin]);
+            mTvxPerBcs.back()->fill(bin, data->mTvx[bin]);
         }
-        auto clName = o2::utils::MemFileHelper::getClassName(*tvxsHist);
+        auto clName = o2::utils::MemFileHelper::getClassName(*mTvxPerBcs.back());
         auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
         std::map<std::string, std::string> metaData;
-        mTvxPerBcInfo = std::make_unique<CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStarTimeMs(), slot.getEndTimeStampMS());
+        mTvxPerBcInfos.emplace_back(std::make_unique<CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStarTimeMs(), slot.getEndTimeStampMS()));
     }
 
     EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend) final

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -10,11 +10,13 @@ namespace o2::ft0
 
     void EventsPerBc::fill(const gsl::span<const o2::ft0::Digit> data)
     {
+        size_t oldEntries = entries;
         for(const auto& digit: data) {
             double isVertex = digit.mTriggers.getVertex();
             mTvx[digit.mIntRecord.bc] += isVertex;
             entries += isVertex;
         }
+        LOG(debug) << "Container is filled with " << entries - oldEntries << " new VTX events";
     }
 
     void EventsPerBc::merge(const EventsPerBc* prev)
@@ -31,8 +33,14 @@ namespace o2::ft0
         mTvxPerBcInfos.clear();
     }
 
+    bool EventsPerBcCalibrator::hasEnoughData(const EventsPerBcCalibrator::Slot& slot) const
+    { 
+        return slot.getContainer()->entries > mMinNumberOfEntries;
+    }
+
     void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
     {
+        LOG(info) << "Finializing slot from " << slot.getStartTimeMS()  << " to " << slot.getEndTimeMS();
         o2::ft0::EventsPerBc* data = slot.getContainer();
         mTvxPerBcs.emplace_back(std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
         for(int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
@@ -42,6 +50,7 @@ namespace o2::ft0
         auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
         std::map<std::string, std::string> metaData;
         mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
+        LOG(info) << "Created new calibration object. Current number of objects: " << mTvxPerBcs.size();
     }
 
     EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -13,8 +13,8 @@ namespace o2::ft0
         size_t oldEntries = entries;
         for(const auto& digit: data) {
             double isVertex = digit.mTriggers.getVertex();
-            if(digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
-                continue;
+            if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
+              continue;
             }
             mTvx[digit.mIntRecord.bc] += isVertex;
             entries += isVertex;
@@ -36,12 +36,11 @@ namespace o2::ft0
         mTvxPerBcInfos.clear();
     }
 
-    
-    EventsPerBcCalibrator::EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC): mMinNumberOfEntries(minNumberOfEntries), mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC)
+    EventsPerBcCalibrator::EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinNumberOfEntries(minNumberOfEntries), mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC)
     {
-        LOG(info) << "Defined threshold for number of entires per slot: " << mMinNumberOfEntries;
-        LOG(info) << "Defined threshold for side A amplitude for event: " << mMinAmplitudeSideA;
-        LOG(info) << "Defined threshold for side C amplitude for event: " << mMinAmplitudeSideC;
+      LOG(info) << "Defined threshold for number of entires per slot: " << mMinNumberOfEntries;
+      LOG(info) << "Defined threshold for side A amplitude for event: " << mMinAmplitudeSideA;
+      LOG(info) << "Defined threshold for side C amplitude for event: " << mMinAmplitudeSideC;
     }
 
     bool EventsPerBcCalibrator::hasEnoughData(const EventsPerBcCalibrator::Slot& slot) const
@@ -51,17 +50,17 @@ namespace o2::ft0
 
     void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
     {
-        LOG(info) << "Finalizing slot from " << slot.getStartTimeMS()  << " to " << slot.getEndTimeMS();
+        LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
         o2::ft0::EventsPerBc* data = slot.getContainer();
         mTvxPerBcs.emplace_back(std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
-        for(int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
+        for (int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
             mTvxPerBcs.back()->Fill(bin, data->mTvx[bin]);
         }
         auto clName = o2::utils::MemFileHelper::getClassName(*mTvxPerBcs.back());
         auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
         std::map<std::string, std::string> metaData;
         mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
-        LOG(info) << "Created new calibration object. Current number of objects: " << mTvxPerBcs.size();
+        LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << TvxPerBcInfos.back()->getEndValidityTimestamp() << ""
     }
 
     EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -3,70 +3,70 @@
 
 namespace o2::ft0
 {
-    void EventsPerBc::print() const
-    {
-        LOG(info) << entries << " entries";
-    }
-
-    void EventsPerBc::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data)
-    {
-        size_t oldEntries = entries;
-        for(const auto& digit: data) {
-          double isVertex = digit.mTriggers.getVertex();
-          if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
-            continue;
-          }
-            mTvx[digit.mIntRecord.bc] += isVertex;
-            entries += isVertex;
-        }
-        LOG(debug) << "Container is filled with " << entries - oldEntries << " new events";
-    }
-
-    void EventsPerBc::merge(const EventsPerBc* prev)
-    {
-       for(int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++){
-            mTvx[bc] += prev->mTvx[bc];    
-       }
-       entries += prev->entries;
-    }
-
-    void EventsPerBcCalibrator::initOutput()
-    {
-        mTvxPerBcs.clear();
-        mTvxPerBcInfos.clear();
-    }
-
-    EventsPerBcCalibrator::EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinNumberOfEntries(minNumberOfEntries), mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC)
-    {
-      LOG(info) << "Defined threshold for number of entires per slot: " << mMinNumberOfEntries;
-      LOG(info) << "Defined threshold for side A amplitude for event: " << mMinAmplitudeSideA;
-      LOG(info) << "Defined threshold for side C amplitude for event: " << mMinAmplitudeSideC;
-    }
-
-    bool EventsPerBcCalibrator::hasEnoughData(const EventsPerBcCalibrator::Slot& slot) const
-    { 
-        return slot.getContainer()->entries > mMinNumberOfEntries;
-    }
-
-    void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
-    {
-        LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
-        o2::ft0::EventsPerBc* data = slot.getContainer();
-        mTvxPerBcs.emplace_back(std::move(data->mTvx));
-
-        auto clName = o2::utils::MemFileHelper::getClassName(mTvxPerBcs.back());
-        auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-
-        std::map<std::string, std::string> metaData;
-        mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
-        LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();
-    }
-
-    EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
-    {
-        auto& cont = getSlots();
-        auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
-        slot.setContainer(std::make_unique<EventsPerBc>(mMinAmplitudeSideA, mMinAmplitudeSideC));
-        return slot;
-    }
+void EventsPerBc::print() const
+{
+  LOG(info) << entries << " entries";
 }
+
+void EventsPerBc::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data)
+{
+  size_t oldEntries = entries;
+  for (const auto& digit : data) {
+    double isVertex = digit.mTriggers.getVertex();
+    if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
+      continue;
+    }
+    mTvx[digit.mIntRecord.bc] += isVertex;
+    entries += isVertex;
+  }
+  LOG(debug) << "Container is filled with " << entries - oldEntries << " new events";
+}
+
+void EventsPerBc::merge(const EventsPerBc* prev)
+{
+  for (int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++) {
+    mTvx[bc] += prev->mTvx[bc];
+  }
+  entries += prev->entries;
+}
+
+void EventsPerBcCalibrator::initOutput()
+{
+  mTvxPerBcs.clear();
+  mTvxPerBcInfos.clear();
+}
+
+EventsPerBcCalibrator::EventsPerBcCalibrator(uint32_t minNumberOfEntries, int32_t minAmplitudeSideA, int32_t minAmplitudeSideC) : mMinNumberOfEntries(minNumberOfEntries), mMinAmplitudeSideA(minAmplitudeSideA), mMinAmplitudeSideC(minAmplitudeSideC)
+{
+  LOG(info) << "Defined threshold for number of entires per slot: " << mMinNumberOfEntries;
+  LOG(info) << "Defined threshold for side A amplitude for event: " << mMinAmplitudeSideA;
+  LOG(info) << "Defined threshold for side C amplitude for event: " << mMinAmplitudeSideC;
+}
+
+bool EventsPerBcCalibrator::hasEnoughData(const EventsPerBcCalibrator::Slot& slot) const
+{
+  return slot.getContainer()->entries > mMinNumberOfEntries;
+}
+
+void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
+{
+  LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
+  o2::ft0::EventsPerBc* data = slot.getContainer();
+  mTvxPerBcs.emplace_back(std::move(data->mTvx));
+
+  auto clName = o2::utils::MemFileHelper::getClassName(mTvxPerBcs.back());
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+
+  std::map<std::string, std::string> metaData;
+  mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
+  LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();
+}
+
+EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+  auto& cont = getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  slot.setContainer(std::make_unique<EventsPerBc>(mMinAmplitudeSideA, mMinAmplitudeSideC));
+  return slot;
+}
+} // namespace o2::ft0

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -23,7 +23,7 @@ void EventsPerBcContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::
 {
   size_t oldEntries = entries;
   for (const auto& digit : data) {
-    if (digit.mTriggers.getVertex() && digit.mTriggers.getAmplA() >= mMinAmplitudeSideA &&  digit.mTriggers.getAmplC() >= mMinAmplitudeSideC) {
+    if (digit.mTriggers.getVertex() && digit.mTriggers.getAmplA() >= mMinAmplitudeSideA && digit.mTriggers.getAmplC() >= mMinAmplitudeSideC) {
       mTvx[digit.mIntRecord.bc]++;
       entries++;
     }

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -12,14 +12,14 @@ namespace o2::ft0
     {
         size_t oldEntries = entries;
         for(const auto& digit: data) {
-            double isVertex = digit.mTriggers.getVertex();
+            float isVertex = digit.mTriggers.getVertex();
             if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
               continue;
             }
             mTvx[digit.mIntRecord.bc] += isVertex;
             entries += isVertex;
         }
-        LOG(debug) << "Container is filled with " << entries - oldEntries << " new VTX events";
+        LOG(debug) << "Container is filled with " << entries - oldEntries << " new events";
     }
 
     void EventsPerBc::merge(const EventsPerBc* prev)

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -3,12 +3,12 @@
 
 namespace o2::ft0
 {
-void EventsPerBc::print() const
+void EventsPerBcContainer::print() const
 {
   LOG(info) << entries << " entries";
 }
 
-void EventsPerBc::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data)
+void EventsPerBcContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const o2::ft0::Digit> data)
 {
   size_t oldEntries = entries;
   for (const auto& digit : data) {
@@ -22,7 +22,7 @@ void EventsPerBc::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<cons
   LOG(debug) << "Container is filled with " << entries - oldEntries << " new events";
 }
 
-void EventsPerBc::merge(const EventsPerBc* prev)
+void EventsPerBcContainer::merge(const EventsPerBcContainer* prev)
 {
   for (int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++) {
     mTvx[bc] += prev->mTvx[bc];
@@ -51,14 +51,14 @@ bool EventsPerBcCalibrator::hasEnoughData(const EventsPerBcCalibrator::Slot& slo
 void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
 {
   LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
-  o2::ft0::EventsPerBc* data = slot.getContainer();
-  mTvxPerBcs.emplace_back(std::move(data->mTvx));
+  o2::ft0::EventsPerBcContainer* data = slot.getContainer();
+  mTvxPerBcs.emplace_back(data->mTvx, mMinAmplitudeSideA, mMinAmplitudeSideC);
 
   auto clName = o2::utils::MemFileHelper::getClassName(mTvxPerBcs.back());
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
 
   std::map<std::string, std::string> metaData;
-  mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
+  mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBcContainer", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
   LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();
 }
 
@@ -66,7 +66,7 @@ EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, T
 {
   auto& cont = getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
-  slot.setContainer(std::make_unique<EventsPerBc>(mMinAmplitudeSideA, mMinAmplitudeSideC));
+  slot.setContainer(std::make_unique<EventsPerBcContainer>(mMinAmplitudeSideA, mMinAmplitudeSideC));
   return slot;
 }
 } // namespace o2::ft0

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #include "FT0Calibration/EventsPerBcCalibrator.h"
 #include "CommonUtils/MemFileHelper.h"
 

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -60,7 +60,7 @@ namespace o2::ft0
         auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
         std::map<std::string, std::string> metaData;
         mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
-        LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << TvxPerBcInfos.back()->getEndValidityTimestamp() << ""
+        LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();
     }
 
     EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -23,12 +23,10 @@ void EventsPerBcContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::
 {
   size_t oldEntries = entries;
   for (const auto& digit : data) {
-    double isVertex = digit.mTriggers.getVertex();
-    if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
-      continue;
+    if (digit.mTriggers.getVertex() && digit.mTriggers.getAmplA() >= mMinAmplitudeSideA &&  digit.mTriggers.getAmplC() >= mMinAmplitudeSideC) {
+      mTvx[digit.mIntRecord.bc]++;
+      entries++;
     }
-    mTvx[digit.mIntRecord.bc] += isVertex;
-    entries += isVertex;
   }
   LOG(debug) << "Container is filled with " << entries - oldEntries << " new events";
 }
@@ -69,7 +67,7 @@ void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
 
   std::map<std::string, std::string> metaData;
-  mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBcContainer", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
+  mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
   LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();
 }
 

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -1,4 +1,5 @@
 #include "FT0Calibration/EventsPerBcCalibrator.h"
+#include "CommonUtils/MemFileHelper.h"
 
 namespace o2::ft0
 {
@@ -9,9 +10,9 @@ namespace o2::ft0
 
     void EventsPerBc::fill(const gsl::span<const o2::ft0::Digit> data)
     {
-        for(const auto& digit: digits) {
-            double isVertex = digit.mTriggers.isVertex();
-            mTvx[digits.mIntRecord.bc] += isVertex;
+        for(const auto& digit: data) {
+            double isVertex = digit.mTriggers.getVertex();
+            mTvx[digit.mIntRecord.bc] += isVertex;
             entries += isVertex;
         }
     }
@@ -21,29 +22,29 @@ namespace o2::ft0
        for(int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++){
             mTvx[bc] += prev->mTvx[bc];    
        }
-       entries += prev->mEntries;
+       entries += prev->entries;
     }
 
-    void EventsPerBcCalibrator::initOutput() final
+    void EventsPerBcCalibrator::initOutput()
     {
-        mTvxPerBc.clear();
-        mTvxPerBcInfo.clear();
+        mTvxPerBcs.clear();
+        mTvxPerBcInfos.clear();
     }
 
-    void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot) final
+    void EventsPerBcCalibrator::finalizeSlot(EventsPerBcCalibrator::Slot& slot)
     {
         o2::ft0::EventsPerBc* data = slot.getContainer();
         mTvxPerBcs.emplace_back(std::make_unique<TH1F>("TvxPerBc", "FT0 TVX per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
         for(int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
-            mTvxPerBcs.back()->fill(bin, data->mTvx[bin]);
+            mTvxPerBcs.back()->Fill(bin, data->mTvx[bin]);
         }
         auto clName = o2::utils::MemFileHelper::getClassName(*mTvxPerBcs.back());
         auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
         std::map<std::string, std::string> metaData;
-        mTvxPerBcInfos.emplace_back(std::make_unique<CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStarTimeMs(), slot.getEndTimeStampMS()));
+        mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/TvxPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
     }
 
-    EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend) final
+    EventsPerBcCalibrator::Slot& EventsPerBcCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
     {
         auto& cont = getSlots();
         auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);

--- a/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
+++ b/Detectors/FIT/FT0/calibration/src/EventsPerBcCalibrator.cxx
@@ -12,10 +12,10 @@ namespace o2::ft0
     {
         size_t oldEntries = entries;
         for(const auto& digit: data) {
-            float isVertex = digit.mTriggers.getVertex();
-            if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
-              continue;
-            }
+          double isVertex = digit.mTriggers.getVertex();
+          if (digit.mTriggers.getAmplA() < mMinAmplitudeSideA || digit.mTriggers.getAmplC() < mMinAmplitudeSideC) {
+            continue;
+          }
             mTvx[digit.mIntRecord.bc] += isVertex;
             entries += isVertex;
         }
@@ -52,12 +52,11 @@ namespace o2::ft0
     {
         LOG(info) << "Finalizing slot from " << slot.getStartTimeMS() << " to " << slot.getEndTimeMS();
         o2::ft0::EventsPerBc* data = slot.getContainer();
-        mTvxPerBcs.emplace_back(std::make_unique<TH1F>("EventsPerBc", "FT0 Events per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1));
-        for (int bin = 0; bin < o2::constants::lhc::LHCMaxBunches; bin++) {
-            mTvxPerBcs.back()->Fill(bin, data->mTvx[bin]);
-        }
-        auto clName = o2::utils::MemFileHelper::getClassName(*mTvxPerBcs.back());
-        auto flName = o2::ccdb::CcdbApi::generateFileName(clName) + ".root";
+        mTvxPerBcs.emplace_back(std::move(data->mTvx));
+
+        auto clName = o2::utils::MemFileHelper::getClassName(mTvxPerBcs.back());
+        auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+
         std::map<std::string, std::string> metaData;
         mTvxPerBcInfos.emplace_back(std::make_unique<o2::ccdb::CcdbObjectInfo>("FT0/Calib/EventsPerBc", clName, flName, metaData, slot.getStartTimeMS(), slot.getEndTimeMS()));
         LOG(info) << "Created object valid from " << mTvxPerBcInfos.back()->getStartValidityTimestamp() << " to " << mTvxPerBcInfos.back()->getEndValidityTimestamp();

--- a/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
+++ b/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
@@ -19,6 +19,6 @@
 #pragma link C++ class o2::ft0::EventsPerBcCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0TimeOffsetSlotContainer>;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0TimeOffsetSlotContainer>;
-#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::EventsPerBc> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::EventsPerBc> + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::EventsPerBcContainer> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::EventsPerBcContainer> + ;
 #endif

--- a/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
+++ b/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::ft0::FT0TimeOffsetSlotContainer + ;
+#pragma link C++ class o2::calibration::EventsPerBcCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0TimeOffsetSlotContainer>;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0TimeOffsetSlotContainer>;
 

--- a/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
+++ b/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
@@ -16,8 +16,9 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::ft0::FT0TimeOffsetSlotContainer + ;
-#pragma link C++ class o2::calibration::EventsPerBcCalibrator + ;
+#pragma link C++ class o2::ft0::EventsPerBcCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0TimeOffsetSlotContainer>;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0TimeOffsetSlotContainer>;
-
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::EventsPerBc> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::EventsPerBc> + ;
 #endif

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #include "FT0EventsPerBcSpec.h"
 #include "Framework/Lifetime.h"
 #include <limits>

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -10,19 +10,17 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
     outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
     outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Sporadic);
     DataProcessorSpec dataProcessorSpec{
-        "FT0EventsPerBcProcessor",
-        inputs,
-        outputs,
-        AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>()),
-        Options{
-            {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
-            {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
-            {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
-            {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
-            {"min-ampl-side-a", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side A events"}},
-            {"min-ampl-side-c", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side C events"}}
-        }
-    };
+      "FT0EventsPerBcProcessor",
+      inputs,
+      outputs,
+      AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>()),
+      Options{
+        {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
+        {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
+        {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
+        {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
+        {"min-ampl-side-a", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side A events"}},
+        {"min-ampl-side-c", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side C events"}}}};
 
     WorkflowSpec workflow;
     workflow.emplace_back(dataProcessorSpec);

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -5,64 +5,98 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/Task.h"
+#include "DetectorsCalibration/Utils.h"
 
 #include "DataFormatsFT0/Digit.h"
-#include "DataFormatsFT0/BcEvents.h"
 #include "FT0Calibration/EventsPerBcCalibrator.h"
 
-namespace o2::ft0
+
+namespace o2::calibration
 {
     class FT0EventsPerBcProcessor final : public o2::framework::Task
     {
+        public:
         void init(o2::framework::InitContext& ic) final
         {
-            mCalibrator = std::make_unique<EventsPerBcCalibrator>();
+            mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>();
+            if(ic.options().hasOption("slot-len-sec")) {
+                mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
+            }
+            if(ic.options().hasOption("one-object-per-run")) {
+                mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
+            }
+
+            if(mOneObjectPerRun) {
+                mCalibrator->setUpdateAtTheEndOfRunOnly();
+            } else {
+                mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
+            }
         }
 
-        void run(o2::framework::ProcessContext& pc) final
+        void run(o2::framework::ProcessingContext& pc) final
         {
             auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
             mCalibrator->process(digits);
+            if(mOneObjectPerRun == false) {
+                sendOutput(pc.outputs());
+            }
         }
 
         void endOfStream(o2::framework::EndOfStreamContext& ec) final 
         {
-            mCalibrator->chekSlotToFinalize();
+            mCalibrator->checkSlotsToFinalize();
             sendOutput(ec.outputs());
             mCalibrator->initOutput();    
         }
 
-        void sendOutput(DataAllocator& output)
+        void sendOutput(o2::framework::DataAllocator& output)
         {
-            TH1F* tvxHist = mCalibrator->getTvxPerBc();
-            CcdbObjectInfo* info = mCalibrator->getTvxPerBcCcdbInfo();
-            auto image = o2::ccdb::CcdbApi::createObjectImage(tvxHist, info);
-            LOG(info) << "Sending object to CCDB";
-            output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EVENTS_PER_BC_INFO", 0}, *image.get());
-            output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EVENTS_PER_BC_INFO", 0}, info);
+            using o2::framework::Output;
+
+            const auto& tvxHists = mCalibrator->getTvxPerBc();
+            auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
+            for(int idx = 0; idx < tvxHists.size(); idx++){
+                auto& info =  infos[idx];
+                const auto& payload = tvxHists[idx];
+
+                auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
+                LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
+                    << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
+                output.snapshot(Output(o2::calibration::Utils::gDataOriginCDBPayload, "EVENTS_PER_BC_INFO", 0), *image.get());
+                output.snapshot(Output(o2::calibration::Utils::gDataOriginCDBWrapper, "EVENTS_PER_BC_INFO", 0), *info.get());
+            }
         }
 
         private:
-        std::unique_ptr<EventsPerBcCalibrator> mCalibrator;
+        std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
+        bool mOneObjectPerRun;
+        uint32_t mSlotLenSec;
     };
 }
 
-WorkflowSpec defineDataProcessing(ConfigContext& const & cfgc)
+namespace o2::framework
+{
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
     using namespace o2::framework;
+    using o2::calibration::FT0EventsPerBcProcessor;
     std::vector<InputSpec> inputs;
     inputs.emplace_back("digits", "FT0", "DIGITSBC");
     std::vector<OutputSpec> outputs;
-    outputs.emplace_back("eventsPerBcInfo", "FT0", "EVENTS_PER_BC_INFO")
+    outputs.emplace_back("eventsPerBcInfo", "FT0", "EVENTS_PER_BC_INFO");
     DataProcessorSpec dataProcessorSpec{
         "FT0EventsPerBcProcessor",
         inputs,
         outputs,
-        AlgorithmSpec(adaptFromTask<o2::ft0::FT0EventsPerBcProcessor>()),
-        Options{}
+        AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>()),
+        Options{
+            {"slot-len-sec", VariantType::UInt32, 3600u, "Time lenght of slot in seconds"},
+            {"one-object-per-run", VariantType::Bool, false, "If true, then one calibration object is created per run"}
+        }
     };
 
     WorkflowSpec workflow;
     workflow.emplace_back(dataProcessorSpec);
     return workflow;
+}
 }

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -1,17 +1,28 @@
 #include "FT0EventsPerBcSpec.h"
 #include <limits>
+
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
+<<<<<<< HEAD
   using namespace o2::framework;
   using o2::calibration::FT0EventsPerBcProcessor;
   std::vector<InputSpec> inputs;
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
                                                                 false,                          // GRPECS=true
+=======
+  using namespace o2::framework;
+  using o2::calibration::FT0EventsPerBcProcessor;
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("digits", "FT0", "DIGITSBC", Lifetime::Timeframe);
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,  // orbitResetTime
+                                                                false, // GRPECS=true
+>>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
                                                                 false,                          // GRPLHCIF
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
+<<<<<<< HEAD
   inputs.emplace_back("digits", "FT0", "DIGITSBC");
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
@@ -28,6 +39,23 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
       {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
       {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
       {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
+=======
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Timeframe);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Timeframe);
+  DataProcessorSpec dataProcessorSpec{
+    "FT0EventsPerBcProcessor",
+    inputs,
+    outputs,
+    AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>(ccdbRequest)),
+    Options{
+      {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
+      {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
+      {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
+      {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
+      {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
+      {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
+>>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
   WorkflowSpec workflow;
   workflow.emplace_back(dataProcessorSpec);

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -8,8 +8,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   using o2::calibration::FT0EventsPerBcProcessor;
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "FT0", "DIGITSBC", Lifetime::Timeframe);
-  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,  // orbitResetTime
-                                                                false, // GRPECS=true
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                                false,                          // GRPECS=true
                                                                 false,                          // GRPLHCIF
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -1,0 +1,68 @@
+#include "Framework/runDataProcessing.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include <Framework/ConfigContext.h>
+#include "Framework/DeviceSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+
+#include "DataFormatsFT0/Digit.h"
+#include "DataFormatsFT0/BcEvents.h"
+#include "FT0Calibration/EventsPerBcCalibrator.h"
+
+namespace o2::ft0
+{
+    class FT0EventsPerBcProcessor final : public o2::framework::Task
+    {
+        void init(o2::framework::InitContext& ic) final
+        {
+            mCalibrator = std::make_unique<EventsPerBcCalibrator>();
+        }
+
+        void run(o2::framework::ProcessContext& pc) final
+        {
+            auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
+            mCalibrator->process(digits);
+        }
+
+        void endOfStream(o2::framework::EndOfStreamContext& ec) final 
+        {
+            mCalibrator->chekSlotToFinalize();
+            sendOutput(ec.outputs());
+            mCalibrator->initOutput();    
+        }
+
+        void sendOutput(DataAllocator& output)
+        {
+            TH1F* tvxHist = mCalibrator->getTvxPerBc();
+            CcdbObjectInfo* info = mCalibrator->getTvxPerBcCcdbInfo();
+            auto image = o2::ccdb::CcdbApi::createObjectImage(tvxHist, info);
+            LOG(info) << "Sending object to CCDB";
+            output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EVENTS_PER_BC_INFO", 0}, *image.get());
+            output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EVENTS_PER_BC_INFO", 0}, info);
+        }
+
+        private:
+        std::unique_ptr<EventsPerBcCalibrator> mCalibrator;
+    };
+}
+
+WorkflowSpec defineDataProcessing(ConfigContext& const & cfgc)
+{
+    using namespace o2::framework;
+    std::vector<InputSpec> inputs;
+    inputs.emplace_back("digits", "FT0", "DIGITSBC");
+    std::vector<OutputSpec> outputs;
+    outputs.emplace_back("eventsPerBcInfo", "FT0", "EVENTS_PER_BC_INFO")
+    DataProcessorSpec dataProcessorSpec{
+        "FT0EventsPerBcProcessor",
+        inputs,
+        outputs,
+        AlgorithmSpec(adaptFromTask<o2::ft0::FT0EventsPerBcProcessor>()),
+        Options{}
+    };
+
+    WorkflowSpec workflow;
+    workflow.emplace_back(dataProcessorSpec);
+    return workflow;
+}

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -36,9 +36,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
     AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>(ccdbRequest)),
     Options{
       {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
-      {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
       {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
-      {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
+      {"min-entries-number", VariantType::UInt32, 5000, {"Minimum number of entries required for a slot to be valid"}},
       {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
       {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
 

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -1,102 +1,24 @@
-#include "Framework/runDataProcessing.h"
-#include "CommonUtils/ConfigurableParam.h"
-#include "Framework/ConfigParamSpec.h"
-#include <Framework/ConfigContext.h>
-#include "Framework/DeviceSpec.h"
-#include "Framework/WorkflowSpec.h"
-#include "Framework/Task.h"
-#include "DetectorsCalibration/Utils.h"
-
-#include "DataFormatsFT0/Digit.h"
-#include "FT0Calibration/EventsPerBcCalibrator.h"
-
-
-namespace o2::calibration
-{
-    class FT0EventsPerBcProcessor final : public o2::framework::Task
-    {
-        public:
-        void init(o2::framework::InitContext& ic) final
-        {
-            mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>();
-            if(ic.options().hasOption("slot-len-sec")) {
-                mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
-            }
-            if(ic.options().hasOption("one-object-per-run")) {
-                mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
-            }
-
-            if(mOneObjectPerRun) {
-                mCalibrator->setUpdateAtTheEndOfRunOnly();
-            } else {
-                mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
-            }
-        }
-
-        void run(o2::framework::ProcessingContext& pc) final
-        {
-            auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
-            mCalibrator->process(digits);
-            if(mOneObjectPerRun == false) {
-                sendOutput(pc.outputs());
-            }
-        }
-
-        void endOfStream(o2::framework::EndOfStreamContext& ec) final 
-        {
-            mCalibrator->checkSlotsToFinalize();
-            sendOutput(ec.outputs());
-            mCalibrator->initOutput();    
-        }
-
-        void sendOutput(o2::framework::DataAllocator& output)
-        {
-            using o2::framework::Output;
-
-            const auto& tvxHists = mCalibrator->getTvxPerBc();
-            auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
-            for(int idx = 0; idx < tvxHists.size(); idx++){
-                auto& info =  infos[idx];
-                const auto& payload = tvxHists[idx];
-
-                auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
-                LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
-                    << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
-                output.snapshot(Output(o2::calibration::Utils::gDataOriginCDBPayload, "EVENTS_PER_BC_INFO", 0), *image.get());
-                output.snapshot(Output(o2::calibration::Utils::gDataOriginCDBWrapper, "EVENTS_PER_BC_INFO", 0), *info.get());
-            }
-        }
-
-        private:
-        std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
-        bool mOneObjectPerRun;
-        uint32_t mSlotLenSec;
-    };
-}
-
-namespace o2::framework
-{
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+#include "FT0EventsPerBcSpec.h"
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
     using namespace o2::framework;
     using o2::calibration::FT0EventsPerBcProcessor;
     std::vector<InputSpec> inputs;
     inputs.emplace_back("digits", "FT0", "DIGITSBC");
     std::vector<OutputSpec> outputs;
-    outputs.emplace_back("eventsPerBcInfo", "FT0", "EVENTS_PER_BC_INFO");
+    outputs.emplace_back(ConcreteDataTypeMatcher{"FT0", "EventsPerBc"}, Lifetime::Sporadic);
     DataProcessorSpec dataProcessorSpec{
         "FT0EventsPerBcProcessor",
         inputs,
         outputs,
         AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>()),
         Options{
-            {"slot-len-sec", VariantType::UInt32, 3600u, "Time lenght of slot in seconds"},
-            {"one-object-per-run", VariantType::Bool, false, "If true, then one calibration object is created per run"}
+            {"slot-len-sec", VariantType::UInt32, 3600u, {"Time lenght of slot in seconds"}},
+            {"one-object-per-run", VariantType::Bool, false, {"If true, then one calibration object is created per run"}}
         }
     };
 
     WorkflowSpec workflow;
     workflow.emplace_back(dataProcessorSpec);
     return workflow;
-}
 }

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -26,8 +26,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
         {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
         {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
         {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
-        {"min-ampl-side-a", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side A events"}},
-        {"min-ampl-side-c", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side C events"}}}};
+        {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
+        {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
 
     WorkflowSpec workflow;
     workflow.emplace_back(dataProcessorSpec);

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -1,45 +1,20 @@
 #include "FT0EventsPerBcSpec.h"
+#include "Framework/Lifetime.h"
 #include <limits>
 
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-<<<<<<< HEAD
-  using namespace o2::framework;
-  using o2::calibration::FT0EventsPerBcProcessor;
-  std::vector<InputSpec> inputs;
-  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
-                                                                false,                          // GRPECS=true
-=======
   using namespace o2::framework;
   using o2::calibration::FT0EventsPerBcProcessor;
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "FT0", "DIGITSBC", Lifetime::Timeframe);
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,  // orbitResetTime
                                                                 false, // GRPECS=true
->>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
                                                                 false,                          // GRPLHCIF
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
-<<<<<<< HEAD
-  inputs.emplace_back("digits", "FT0", "DIGITSBC");
-  std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Sporadic);
-  DataProcessorSpec dataProcessorSpec{
-    "FT0EventsPerBcProcessor",
-    inputs,
-    outputs,
-    AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>(ccdbRequest)),
-    Options{
-      {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
-      {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
-      {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
-      {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
-      {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
-      {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
-=======
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Timeframe);
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Timeframe);
@@ -55,7 +30,6 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
       {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
       {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
       {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
->>>>>>> b9ec63cd4d (Created CCDB object class for EvetnsPerBC calibration)
 
   WorkflowSpec workflow;
   workflow.emplace_back(dataProcessorSpec);

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -1,4 +1,5 @@
 #include "FT0EventsPerBcSpec.h"
+#include <limits>
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
     using namespace o2::framework;
@@ -14,8 +15,12 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
         outputs,
         AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>()),
         Options{
-            {"slot-len-sec", VariantType::UInt32, 3600u, {"Time lenght of slot in seconds"}},
-            {"one-object-per-run", VariantType::Bool, false, {"If true, then one calibration object is created per run"}}
+            {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
+            {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
+            {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
+            {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
+            {"min-ampl-side-a", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side A events"}},
+            {"min-ampl-side-c", VariantType::Int, std::numeric_limits<int32_t>::min(), {"Amplitude threshold for Side C events"}}
         }
     };
 

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -5,6 +5,13 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
     using namespace o2::framework;
     using o2::calibration::FT0EventsPerBcProcessor;
     std::vector<InputSpec> inputs;
+    auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                                false,                           // GRPECS=true
+                                                                false,                          // GRPLHCIF
+                                                                false,                          // GRPMagField
+                                                                false,                          // askMatLUT
+                                                                o2::base::GRPGeomRequest::None, // geometry
+                                                                inputs);
     inputs.emplace_back("digits", "FT0", "DIGITSBC");
     std::vector<OutputSpec> outputs;
     outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
@@ -13,7 +20,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
       "FT0EventsPerBcProcessor",
       inputs,
       outputs,
-      AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>()),
+      AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>(ccdbRequest)),
       Options{
         {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
         {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -2,34 +2,34 @@
 #include <limits>
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-    using namespace o2::framework;
-    using o2::calibration::FT0EventsPerBcProcessor;
-    std::vector<InputSpec> inputs;
-    auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
-                                                                false,                           // GRPECS=true
+  using namespace o2::framework;
+  using o2::calibration::FT0EventsPerBcProcessor;
+  std::vector<InputSpec> inputs;
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                                false,                          // GRPECS=true
                                                                 false,                          // GRPLHCIF
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
-    inputs.emplace_back("digits", "FT0", "DIGITSBC");
-    std::vector<OutputSpec> outputs;
-    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
-    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Sporadic);
-    DataProcessorSpec dataProcessorSpec{
-      "FT0EventsPerBcProcessor",
-      inputs,
-      outputs,
-      AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>(ccdbRequest)),
-      Options{
-        {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
-        {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
-        {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
-        {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
-        {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
-        {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
+  inputs.emplace_back("digits", "FT0", "DIGITSBC");
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Sporadic);
+  DataProcessorSpec dataProcessorSpec{
+    "FT0EventsPerBcProcessor",
+    inputs,
+    outputs,
+    AlgorithmSpec(adaptFromTask<FT0EventsPerBcProcessor>(ccdbRequest)),
+    Options{
+      {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
+      {"slot-len-tf", VariantType::UInt32, 0u, {"Slot length in Time Frames (TFs)"}},
+      {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
+      {"min-entries-number", VariantType::UInt32, 0u, {"Minimum number of entries required for a slot to be valid"}},
+      {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
+      {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
 
-    WorkflowSpec workflow;
-    workflow.emplace_back(dataProcessorSpec);
-    return workflow;
+  WorkflowSpec workflow;
+  workflow.emplace_back(dataProcessorSpec);
+  return workflow;
 }

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -6,7 +6,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
     std::vector<InputSpec> inputs;
     inputs.emplace_back("digits", "FT0", "DIGITSBC");
     std::vector<OutputSpec> outputs;
-    outputs.emplace_back(ConcreteDataTypeMatcher{"FT0", "EventsPerBc"}, Lifetime::Sporadic);
+    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc"}, Lifetime::Sporadic);
+    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc"}, Lifetime::Sporadic);
     DataProcessorSpec dataProcessorSpec{
         "FT0EventsPerBcProcessor",
         inputs,

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcProcessor-Workflow.cxx
@@ -37,7 +37,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
     Options{
       {"slot-len-sec", VariantType::UInt32, 3600u, {"Duration of each slot in seconds"}},
       {"one-object-per-run", VariantType::Bool, false, {"If set, workflow creates only one calibration object per run"}},
-      {"min-entries-number", VariantType::UInt32, 5000, {"Minimum number of entries required for a slot to be valid"}},
+      {"min-entries-number", VariantType::UInt32, 5000u, {"Minimum number of entries required for a slot to be valid"}},
       {"min-ampl-side-a", VariantType::Int, 0, {"Amplitude threshold for Side A events"}},
       {"min-ampl-side-c", VariantType::Int, 0, {"Amplitude threshold for Side C events"}}}};
 

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -10,6 +10,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/Task.h"
 #include "DetectorsCalibration/Utils.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 #include "DataFormatsFT0/Digit.h"
 #include "FT0Calibration/EventsPerBcCalibrator.h"
@@ -20,10 +21,11 @@ namespace o2::calibration
     class FT0EventsPerBcProcessor final : public o2::framework::Task
     {
         public:
-        FT0EventsPerBcProcessor() = default;
+        FT0EventsPerBcProcessor(std::shared_ptr<o2::base::GRPGeomRequest> request): mCCDBRequest(request) {}
         
         void init(o2::framework::InitContext& ic) final
         {
+          o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
           if (ic.options().hasOption("slot-len-sec")) {
             mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
           }
@@ -59,8 +61,14 @@ namespace o2::calibration
           }
         }
 
+        void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+        {
+          o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+        }
+
         void run(o2::framework::ProcessingContext& pc) final
         {
+            o2::base::GRPGeomHelper::instance().checkUpdates(pc);
             auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
             o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
             if(digits.size() == 0) {
@@ -102,6 +110,7 @@ namespace o2::calibration
         }
 
         private:
+        std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
         std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
         bool mOneObjectPerRun;
         uint32_t mSlotLenSec;

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -24,24 +24,45 @@ namespace o2::calibration
         
         void init(o2::framework::InitContext& ic) final
         {
-            mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>();
             if(ic.options().hasOption("slot-len-sec")) {
                 mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
             }
             if(ic.options().hasOption("one-object-per-run")) {
                 mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
             }
+            if(ic.options().hasOption("slot-len-tf")) {
+                mSlotLen = ic.options().get<o2::calibration::TFType>("slot-len-tf");
+            }
+            if(ic.options().hasOption("min-entries-number")) {
+                mMinNumberOfEntries = ic.options().get<uint32_t>("min-entries-number");
+            }
+            if(ic.options().hasOption("min-ampl-side-a")) {
+                mMinAmplitudeSideA = ic.options().get<int32_t>("min-ampl-side-a");
+            }
+            if(ic.options().hasOption("min-ampl-side-c")) {
+                mMinAmplitudeSideC = ic.options().get<int32_t>("min-ampl-side-c");
+            }
+
+            mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>(mMinNumberOfEntries, mMinAmplitudeSideA, mMinAmplitudeSideC);
 
             if(mOneObjectPerRun) {
+                LOG(info) << "Only one object will be created at the end of run";
                 mCalibrator->setUpdateAtTheEndOfRunOnly();
-            } else {
+            } 
+            if (mOneObjectPerRun == false && mSlotLen == 0){
+                LOG(info) << "Defined slot interval to " << mSlotLenSec << " seconds";
                 mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
+            } 
+            if (mOneObjectPerRun == false && mSlotLen != 0) {
+                LOG(info) << "Defined slot interval to " << mSlotLen << " TFS";
+                mCalibrator->setSlotLength(mSlotLen);
             }
         }
 
         void run(o2::framework::ProcessingContext& pc) final
         {
             auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
+            o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
             if(digits.size() == 0) {
                 return;
             }
@@ -51,8 +72,9 @@ namespace o2::calibration
             }
         }
 
-        void endOfStream(o2::framework::EndOfStreamContext& ec) final 
+        void endOfStream(o2::framework::EndOfStreamContext& ec) final
         {
+            LOG(info) << "Received end-of-stream, checking for slot to finalize...";
             mCalibrator->checkSlotsToFinalize();
             sendOutput(ec.outputs());
             mCalibrator->initOutput();    
@@ -63,7 +85,7 @@ namespace o2::calibration
             using o2::framework::Output;
             const auto& tvxHists = mCalibrator->getTvxPerBc();
             auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
-            for(int idx = 0; idx < tvxHists.size(); idx++){
+            for(unsigned int idx = 0; idx < tvxHists.size(); idx++){
                 auto& info =  infos[idx];
                 const auto& payload = tvxHists[idx];
 
@@ -83,6 +105,10 @@ namespace o2::calibration
         std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
         bool mOneObjectPerRun;
         uint32_t mSlotLenSec;
+        o2::calibration::TFType mSlotLen;
+        uint32_t mMinNumberOfEntries;
+        int32_t mMinAmplitudeSideA;
+        int32_t mMinAmplitudeSideC;
     };
 }
 #endif

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -1,3 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 
 #ifndef O2_CALIBRATION_FT0_EVENTS_PER_BC_CALIBRATOR_H
 #define O2_CALIBRATION_FT0_EVENTS_PER_BC_CALIBRATOR_H

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -42,6 +42,9 @@ namespace o2::calibration
         void run(o2::framework::ProcessingContext& pc) final
         {
             auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
+            if(digits.size() == 0) {
+                return;
+            }
             mCalibrator->process(digits);
             if(mOneObjectPerRun == false) {
                 sendOutput(pc.outputs());
@@ -58,7 +61,6 @@ namespace o2::calibration
         void sendOutput(o2::framework::DataAllocator& output)
         {
             using o2::framework::Output;
-
             const auto& tvxHists = mCalibrator->getTvxPerBc();
             auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
             for(int idx = 0; idx < tvxHists.size(); idx++){
@@ -68,8 +70,8 @@ namespace o2::calibration
                 auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
                 LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
                     << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
-                output.snapshot(Output{o2::header::gDataOriginFT0, "EventsPerBc", idx}, *image.get());
-                output.snapshot(Output{o2::header::gDataOriginFT0, "EventsPerBc", idx}, *info.get());
+                output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc", idx}, *image.get());
+                output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc", idx}, *info.get());
             }
 
             if(tvxHists.size()) {

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -15,109 +15,108 @@
 #include "DataFormatsFT0/Digit.h"
 #include "FT0Calibration/EventsPerBcCalibrator.h"
 
-
 namespace o2::calibration
 {
-    class FT0EventsPerBcProcessor final : public o2::framework::Task
-    {
-        public:
-        FT0EventsPerBcProcessor(std::shared_ptr<o2::base::GRPGeomRequest> request): mCCDBRequest(request) {}
-        
-        void init(o2::framework::InitContext& ic) final
-        {
-          o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
-          if (ic.options().hasOption("slot-len-sec")) {
-            mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
-          }
-          if (ic.options().hasOption("one-object-per-run")) {
-            mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
-          }
-          if (ic.options().hasOption("slot-len-tf")) {
-            mSlotLen = ic.options().get<o2::calibration::TFType>("slot-len-tf");
-          }
-          if (ic.options().hasOption("min-entries-number")) {
-            mMinNumberOfEntries = ic.options().get<uint32_t>("min-entries-number");
-          }
-          if (ic.options().hasOption("min-ampl-side-a")) {
-            mMinAmplitudeSideA = ic.options().get<int32_t>("min-ampl-side-a");
-          }
-          if (ic.options().hasOption("min-ampl-side-c")) {
-            mMinAmplitudeSideC = ic.options().get<int32_t>("min-ampl-side-c");
-          }
+class FT0EventsPerBcProcessor final : public o2::framework::Task
+{
+ public:
+  FT0EventsPerBcProcessor(std::shared_ptr<o2::base::GRPGeomRequest> request) : mCCDBRequest(request) {}
 
-          mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>(mMinNumberOfEntries, mMinAmplitudeSideA, mMinAmplitudeSideC);
+  void init(o2::framework::InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    if (ic.options().hasOption("slot-len-sec")) {
+      mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
+    }
+    if (ic.options().hasOption("one-object-per-run")) {
+      mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
+    }
+    if (ic.options().hasOption("slot-len-tf")) {
+      mSlotLen = ic.options().get<o2::calibration::TFType>("slot-len-tf");
+    }
+    if (ic.options().hasOption("min-entries-number")) {
+      mMinNumberOfEntries = ic.options().get<uint32_t>("min-entries-number");
+    }
+    if (ic.options().hasOption("min-ampl-side-a")) {
+      mMinAmplitudeSideA = ic.options().get<int32_t>("min-ampl-side-a");
+    }
+    if (ic.options().hasOption("min-ampl-side-c")) {
+      mMinAmplitudeSideC = ic.options().get<int32_t>("min-ampl-side-c");
+    }
 
-          if (mOneObjectPerRun) {
-            LOG(info) << "Only one object will be created at the end of run";
-            mCalibrator->setUpdateAtTheEndOfRunOnly();
-          }
-          if (mOneObjectPerRun == false && mSlotLen == 0) {
-            LOG(info) << "Defined slot interval to " << mSlotLenSec << " seconds";
-            mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
-          }
-          if (mOneObjectPerRun == false && mSlotLen != 0) {
-            LOG(info) << "Defined slot interval to " << mSlotLen << " TFS";
-            mCalibrator->setSlotLength(mSlotLen);
-          }
-        }
+    mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>(mMinNumberOfEntries, mMinAmplitudeSideA, mMinAmplitudeSideC);
 
-        void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
-        {
-          o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
-        }
+    if (mOneObjectPerRun) {
+      LOG(info) << "Only one object will be created at the end of run";
+      mCalibrator->setUpdateAtTheEndOfRunOnly();
+    }
+    if (mOneObjectPerRun == false && mSlotLen == 0) {
+      LOG(info) << "Defined slot interval to " << mSlotLenSec << " seconds";
+      mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
+    }
+    if (mOneObjectPerRun == false && mSlotLen != 0) {
+      LOG(info) << "Defined slot interval to " << mSlotLen << " TFS";
+      mCalibrator->setSlotLength(mSlotLen);
+    }
+  }
 
-        void run(o2::framework::ProcessingContext& pc) final
-        {
-            o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-            auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
-            o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
-            if(digits.size() == 0) {
-                return;
-            }
-            mCalibrator->process(digits);
-            if(mOneObjectPerRun == false) {
-                sendOutput(pc.outputs());
-            }
-        }
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+  {
+    o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+  }
 
-        void endOfStream(o2::framework::EndOfStreamContext& ec) final
-        {
-          LOG(info) << "Received end-of-stream, checking for slot to finalize...";
-          mCalibrator->checkSlotsToFinalize();
-          sendOutput(ec.outputs());
-          mCalibrator->initOutput();
-        }
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+    auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
+    o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
+    if (digits.size() == 0) {
+      return;
+    }
+    mCalibrator->process(digits);
+    if (mOneObjectPerRun == false) {
+      sendOutput(pc.outputs());
+    }
+  }
 
-        void sendOutput(o2::framework::DataAllocator& output)
-        {
-            using o2::framework::Output;
-            const auto& tvxHists = mCalibrator->getTvxPerBc();
-            auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
-            for (unsigned int idx = 0; idx < tvxHists.size(); idx++) {
-              auto& info = infos[idx];
-              const auto& payload = tvxHists[idx];
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOG(info) << "Received end-of-stream, checking for slot to finalize...";
+    mCalibrator->checkSlotsToFinalize();
+    sendOutput(ec.outputs());
+    mCalibrator->initOutput();
+  }
 
-              auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, info.get());
-              LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
-                        << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
-              output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc", idx}, *image.get());
-              output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc", idx}, *info.get());
-            }
+  void sendOutput(o2::framework::DataAllocator& output)
+  {
+    using o2::framework::Output;
+    const auto& tvxHists = mCalibrator->getTvxPerBc();
+    auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
+    for (unsigned int idx = 0; idx < tvxHists.size(); idx++) {
+      auto& info = infos[idx];
+      const auto& payload = tvxHists[idx];
 
-            if(tvxHists.size()) {
-                mCalibrator->initOutput();
-            }
-        }
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, info.get());
+      LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
+                << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc", idx}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc", idx}, *info.get());
+    }
 
-        private:
-        std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
-        std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
-        bool mOneObjectPerRun;
-        uint32_t mSlotLenSec;
-        o2::calibration::TFType mSlotLen;
-        uint32_t mMinNumberOfEntries;
-        int32_t mMinAmplitudeSideA;
-        int32_t mMinAmplitudeSideC;
-    };
-}
+    if (tvxHists.size()) {
+      mCalibrator->initOutput();
+    }
+  }
+
+ private:
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
+  bool mOneObjectPerRun;
+  uint32_t mSlotLenSec;
+  o2::calibration::TFType mSlotLen;
+  uint32_t mMinNumberOfEntries;
+  int32_t mMinAmplitudeSideA;
+  int32_t mMinAmplitudeSideC;
+};
+} // namespace o2::calibration
 #endif

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -41,9 +41,6 @@ class FT0EventsPerBcProcessor final : public o2::framework::Task
     if (ic.options().hasOption("one-object-per-run")) {
       mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
     }
-    if (ic.options().hasOption("slot-len-tf")) {
-      mSlotLen = ic.options().get<o2::calibration::TFType>("slot-len-tf");
-    }
     if (ic.options().hasOption("min-entries-number")) {
       mMinNumberOfEntries = ic.options().get<uint32_t>("min-entries-number");
     }
@@ -60,13 +57,9 @@ class FT0EventsPerBcProcessor final : public o2::framework::Task
       LOG(info) << "Only one object will be created at the end of run";
       mCalibrator->setUpdateAtTheEndOfRunOnly();
     }
-    if (mOneObjectPerRun == false && mSlotLen == 0) {
+    if (mOneObjectPerRun == false) {
       LOG(info) << "Defined slot interval to " << mSlotLenSec << " seconds";
       mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
-    }
-    if (mOneObjectPerRun == false && mSlotLen != 0) {
-      LOG(info) << "Defined slot interval to " << mSlotLen << " TFS";
-      mCalibrator->setSlotLength(mSlotLen);
     }
   }
 
@@ -123,7 +116,6 @@ class FT0EventsPerBcProcessor final : public o2::framework::Task
   std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
   bool mOneObjectPerRun;
   uint32_t mSlotLenSec;
-  o2::calibration::TFType mSlotLen;
   uint32_t mMinNumberOfEntries;
   int32_t mMinAmplitudeSideA;
   int32_t mMinAmplitudeSideC;

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -24,39 +24,39 @@ namespace o2::calibration
         
         void init(o2::framework::InitContext& ic) final
         {
-            if(ic.options().hasOption("slot-len-sec")) {
-                mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
-            }
-            if(ic.options().hasOption("one-object-per-run")) {
-                mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
-            }
-            if(ic.options().hasOption("slot-len-tf")) {
-                mSlotLen = ic.options().get<o2::calibration::TFType>("slot-len-tf");
-            }
-            if(ic.options().hasOption("min-entries-number")) {
-                mMinNumberOfEntries = ic.options().get<uint32_t>("min-entries-number");
-            }
-            if(ic.options().hasOption("min-ampl-side-a")) {
-                mMinAmplitudeSideA = ic.options().get<int32_t>("min-ampl-side-a");
-            }
-            if(ic.options().hasOption("min-ampl-side-c")) {
-                mMinAmplitudeSideC = ic.options().get<int32_t>("min-ampl-side-c");
-            }
+          if (ic.options().hasOption("slot-len-sec")) {
+            mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
+          }
+          if (ic.options().hasOption("one-object-per-run")) {
+            mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
+          }
+          if (ic.options().hasOption("slot-len-tf")) {
+            mSlotLen = ic.options().get<o2::calibration::TFType>("slot-len-tf");
+          }
+          if (ic.options().hasOption("min-entries-number")) {
+            mMinNumberOfEntries = ic.options().get<uint32_t>("min-entries-number");
+          }
+          if (ic.options().hasOption("min-ampl-side-a")) {
+            mMinAmplitudeSideA = ic.options().get<int32_t>("min-ampl-side-a");
+          }
+          if (ic.options().hasOption("min-ampl-side-c")) {
+            mMinAmplitudeSideC = ic.options().get<int32_t>("min-ampl-side-c");
+          }
 
-            mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>(mMinNumberOfEntries, mMinAmplitudeSideA, mMinAmplitudeSideC);
+          mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>(mMinNumberOfEntries, mMinAmplitudeSideA, mMinAmplitudeSideC);
 
-            if(mOneObjectPerRun) {
-                LOG(info) << "Only one object will be created at the end of run";
-                mCalibrator->setUpdateAtTheEndOfRunOnly();
-            } 
-            if (mOneObjectPerRun == false && mSlotLen == 0){
-                LOG(info) << "Defined slot interval to " << mSlotLenSec << " seconds";
-                mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
-            } 
-            if (mOneObjectPerRun == false && mSlotLen != 0) {
-                LOG(info) << "Defined slot interval to " << mSlotLen << " TFS";
-                mCalibrator->setSlotLength(mSlotLen);
-            }
+          if (mOneObjectPerRun) {
+            LOG(info) << "Only one object will be created at the end of run";
+            mCalibrator->setUpdateAtTheEndOfRunOnly();
+          }
+          if (mOneObjectPerRun == false && mSlotLen == 0) {
+            LOG(info) << "Defined slot interval to " << mSlotLenSec << " seconds";
+            mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
+          }
+          if (mOneObjectPerRun == false && mSlotLen != 0) {
+            LOG(info) << "Defined slot interval to " << mSlotLen << " TFS";
+            mCalibrator->setSlotLength(mSlotLen);
+          }
         }
 
         void run(o2::framework::ProcessingContext& pc) final
@@ -74,10 +74,10 @@ namespace o2::calibration
 
         void endOfStream(o2::framework::EndOfStreamContext& ec) final
         {
-            LOG(info) << "Received end-of-stream, checking for slot to finalize...";
-            mCalibrator->checkSlotsToFinalize();
-            sendOutput(ec.outputs());
-            mCalibrator->initOutput();    
+          LOG(info) << "Received end-of-stream, checking for slot to finalize...";
+          mCalibrator->checkSlotsToFinalize();
+          sendOutput(ec.outputs());
+          mCalibrator->initOutput();
         }
 
         void sendOutput(o2::framework::DataAllocator& output)
@@ -85,15 +85,15 @@ namespace o2::calibration
             using o2::framework::Output;
             const auto& tvxHists = mCalibrator->getTvxPerBc();
             auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
-            for(unsigned int idx = 0; idx < tvxHists.size(); idx++){
-                auto& info =  infos[idx];
-                const auto& payload = tvxHists[idx];
+            for (unsigned int idx = 0; idx < tvxHists.size(); idx++) {
+              auto& info = infos[idx];
+              const auto& payload = tvxHists[idx];
 
-                auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
-                LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
-                    << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
-                output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc", idx}, *image.get());
-                output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc", idx}, *info.get());
+              auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
+              LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
+                        << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
+              output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc", idx}, *image.get());
+              output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "EventsPerBc", idx}, *info.get());
             }
 
             if(tvxHists.size()) {

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -1,0 +1,86 @@
+
+#ifndef O2_CALIBRATION_FT0_EVENTS_PER_BC_CALIBRATOR_H
+#define O2_CALIBRATION_FT0_EVENTS_PER_BC_CALIBRATOR_H
+
+#include "Framework/runDataProcessing.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include <Framework/ConfigContext.h>
+#include "Framework/DeviceSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "DetectorsCalibration/Utils.h"
+
+#include "DataFormatsFT0/Digit.h"
+#include "FT0Calibration/EventsPerBcCalibrator.h"
+
+
+namespace o2::calibration
+{
+    class FT0EventsPerBcProcessor final : public o2::framework::Task
+    {
+        public:
+        FT0EventsPerBcProcessor() = default;
+        
+        void init(o2::framework::InitContext& ic) final
+        {
+            mCalibrator = std::make_unique<o2::ft0::EventsPerBcCalibrator>();
+            if(ic.options().hasOption("slot-len-sec")) {
+                mSlotLenSec = ic.options().get<uint32_t>("slot-len-sec");
+            }
+            if(ic.options().hasOption("one-object-per-run")) {
+                mOneObjectPerRun = ic.options().get<bool>("one-object-per-run");
+            }
+
+            if(mOneObjectPerRun) {
+                mCalibrator->setUpdateAtTheEndOfRunOnly();
+            } else {
+                mCalibrator->setSlotLengthInSeconds(mSlotLenSec);
+            }
+        }
+
+        void run(o2::framework::ProcessingContext& pc) final
+        {
+            auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
+            mCalibrator->process(digits);
+            if(mOneObjectPerRun == false) {
+                sendOutput(pc.outputs());
+            }
+        }
+
+        void endOfStream(o2::framework::EndOfStreamContext& ec) final 
+        {
+            mCalibrator->checkSlotsToFinalize();
+            sendOutput(ec.outputs());
+            mCalibrator->initOutput();    
+        }
+
+        void sendOutput(o2::framework::DataAllocator& output)
+        {
+            using o2::framework::Output;
+
+            const auto& tvxHists = mCalibrator->getTvxPerBc();
+            auto& infos = mCalibrator->getTvxPerBcCcdbInfo();
+            for(int idx = 0; idx < tvxHists.size(); idx++){
+                auto& info =  infos[idx];
+                const auto& payload = tvxHists[idx];
+
+                auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
+                LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
+                    << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
+                output.snapshot(Output{o2::header::gDataOriginFT0, "EventsPerBc", idx}, *image.get());
+                output.snapshot(Output{o2::header::gDataOriginFT0, "EventsPerBc", idx}, *info.get());
+            }
+
+            if(tvxHists.size()) {
+                mCalibrator->initOutput();
+            }
+        }
+
+        private:
+        std::unique_ptr<o2::ft0::EventsPerBcCalibrator> mCalibrator;
+        bool mOneObjectPerRun;
+        uint32_t mSlotLenSec;
+    };
+}
+#endif

--- a/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
+++ b/Detectors/FIT/FT0/calibration/workflow/FT0EventsPerBcSpec.h
@@ -97,7 +97,7 @@ namespace o2::calibration
               auto& info = infos[idx];
               const auto& payload = tvxHists[idx];
 
-              auto image = o2::ccdb::CcdbApi::createObjectImage(payload.get(), info.get());
+              auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, info.get());
               LOG(info) << "Sending object " << info->getPath() << "/" << info->getFileName() << " of size " << image->size()
                         << " bytes, valid for " << info->getStartValidityTimestamp() << " : " << info->getEndValidityTimestamp();
               output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "EventsPerBc", idx}, *image.get());

--- a/Detectors/FIT/FT0/macros/CMakeLists.txt
+++ b/Detectors/FIT/FT0/macros/CMakeLists.txt
@@ -12,3 +12,7 @@ o2_add_test_root_macro(FT0Misaligner.C
                        PUBLIC_LINK_LIBRARIES O2::CCDB
                        O2::FT0Simulation
                        LABELS ft0)
+                       
+o2_add_test_root_macro(FT0readEventsPerBc.C
+                       PUBLIC_LINK_LIBRARIES O2::CCDB
+                       LABELS ft0)

--- a/Detectors/FIT/FT0/macros/CMakeLists.txt
+++ b/Detectors/FIT/FT0/macros/CMakeLists.txt
@@ -15,5 +15,7 @@ o2_add_test_root_macro(FT0Misaligner.C
                        LABELS ft0)
 
 o2_add_test_root_macro(FT0readEventsPerBc.C
-                       PUBLIC_LINK_LIBRARIES O2::CCDB
+                       PUBLIC_LINK_LIBRARIES
+                       O2::CCDB
+                       O2::DataFormatsFT0
                        LABELS ft0)

--- a/Detectors/FIT/FT0/macros/CMakeLists.txt
+++ b/Detectors/FIT/FT0/macros/CMakeLists.txt
@@ -1,12 +1,13 @@
-# Copyright CERN and copyright holders of ALICE O2. This software is distributed
-# under the terms of the GNU General Public License v3 (GPL Version 3), copied
-# verbatim in the file "COPYING".
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-# See http://alice-o2.web.cern.ch/license for full licensing information.
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 o2_add_test_root_macro(FT0Misaligner.C
                        PUBLIC_LINK_LIBRARIES O2::CCDB

--- a/Detectors/FIT/FT0/macros/CMakeLists.txt
+++ b/Detectors/FIT/FT0/macros/CMakeLists.txt
@@ -12,7 +12,7 @@ o2_add_test_root_macro(FT0Misaligner.C
                        PUBLIC_LINK_LIBRARIES O2::CCDB
                        O2::FT0Simulation
                        LABELS ft0)
-                       
+
 o2_add_test_root_macro(FT0readEventsPerBc.C
                        PUBLIC_LINK_LIBRARIES O2::CCDB
                        LABELS ft0)

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <iostream>
 #include <array>

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -33,7 +33,7 @@ void FT0readEventsPerBc(std::string ccdbUrl, long timestamp)
   }
 
   hist = std::make_unique<TH1F>("eventsPerBcHist", "Events per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1);
-  for (int idx = 0; idx < LhcOrbits; idx++) {
+  for (int idx = 0; idx < o2::constants::lhc::LHCMaxBunches; idx++) {
     hist->Fill(idx, (*events)[idx]);
   }
   canvas = std::make_unique<TCanvas>();

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -8,7 +8,6 @@
 #include "CommonConstants/LHCConstants.h"
 #endif
 
-
 std::unique_ptr<TH1F> hist;
 std::unique_ptr<TCanvas> canvas;
 

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -1,14 +1,13 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-
 #include <iostream>
 #include <array>
 #include "CCDB/CcdbApi.h"
 #include "TH1F.h"
-#endif
-
+#include "DataFormatsFT0/EventsPerBc.h"
 #include "Framework/Logger.h"
 #include "CommonConstants/LHCConstants.h"
-#include "DataFormatsFT0/EventsPerBc.h"
+#endif
+
 
 std::unique_ptr<TH1F> hist;
 std::unique_ptr<TCanvas> canvas;

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -12,12 +12,14 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <iostream>
 #include <array>
+#endif
+
 #include "CCDB/CcdbApi.h"
+#include "CCDB/CCDBTimeStampUtils.h"
 #include "TH1F.h"
 #include "DataFormatsFT0/EventsPerBc.h"
 #include "Framework/Logger.h"
 #include "CommonConstants/LHCConstants.h"
-#endif
 
 std::unique_ptr<TH1F> hist;
 std::unique_ptr<TCanvas> canvas;
@@ -33,7 +35,7 @@ void FT0readEventsPerBc(std::string ccdbUrl, long timestamp)
     timestamp = o2::ccdb::getCurrentTimestamp();
   }
 
-  EventsArray* events = ccdbApi.retrieveFromTFileAny<o2::ft0::EventsPerBc>(ccdbPath, metadata, timestamp);
+  std::unique_ptr<o2::ft0::EventsPerBc> events(ccdbApi.retrieveFromTFileAny<o2::ft0::EventsPerBc>(ccdbPath, metadata, timestamp));
 
   if (!events) {
     LOGP(fatal, "EventsPerBc object not found in {}/{} for timestamp {}.", ccdbUrl, ccdbPath, timestamp);

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -1,0 +1,42 @@
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include <iostream>
+#include <array>
+#include "CCDB/CcdbApi.h"
+#include "TH1F.h"
+#endif
+
+#include "Framework/Logger.h"
+#include "CommonConstants/LHCConstants.h"
+
+using EventsArray = std::array<double, o2::constants::lhc::LHCMaxBunches>;
+std::unique_ptr<TH1F> hist;
+std::unique_ptr<TCanvas> canvas;
+
+void FT0readEventsPerBc(std::string ccdbUrl, long timestamp)
+{
+  o2::ccdb::CcdbApi ccdbApi;
+  ccdbApi.init(ccdbUrl);
+  const std::string ccdbPath = "FT0/Calib/EventsPerBc";
+  std::map<std::string, std::string> metadata;
+
+  if (timestamp < 0) {
+    timestamp = o2::ccdb::getCurrentTimestamp();
+  }
+
+  EventsArray* events = ccdbApi.retrieveFromTFileAny<EventsArray>(ccdbPath, metadata, timestamp);
+
+  if (!events) {
+    LOGP(fatal, "EventsPerBc object not found in {}/{} for timestamp {}.", ccdbUrl, ccdbPath, timestamp);
+    return;
+  }
+
+  hist = std::make_unique<TH1F>("eventsPerBcHist", "Events per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1);
+  for (int idx = 0; idx < LhcOrbits; idx++) {
+    hist->Fill(idx, (*events)[idx]);
+  }
+  canvas = std::make_unique<TCanvas>();
+  hist->Draw();
+  canvas->Draw();
+}

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -1,4 +1,3 @@
-
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 
 #include <iostream>

--- a/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
+++ b/Detectors/FIT/FT0/macros/FT0readEventsPerBc.C
@@ -8,8 +8,8 @@
 
 #include "Framework/Logger.h"
 #include "CommonConstants/LHCConstants.h"
+#include "DataFormatsFT0/EventsPerBc.h"
 
-using EventsArray = std::array<double, o2::constants::lhc::LHCMaxBunches>;
 std::unique_ptr<TH1F> hist;
 std::unique_ptr<TCanvas> canvas;
 
@@ -24,7 +24,7 @@ void FT0readEventsPerBc(std::string ccdbUrl, long timestamp)
     timestamp = o2::ccdb::getCurrentTimestamp();
   }
 
-  EventsArray* events = ccdbApi.retrieveFromTFileAny<EventsArray>(ccdbPath, metadata, timestamp);
+  EventsArray* events = ccdbApi.retrieveFromTFileAny<o2::ft0::EventsPerBc>(ccdbPath, metadata, timestamp);
 
   if (!events) {
     LOGP(fatal, "EventsPerBc object not found in {}/{} for timestamp {}.", ccdbUrl, ccdbPath, timestamp);
@@ -33,7 +33,7 @@ void FT0readEventsPerBc(std::string ccdbUrl, long timestamp)
 
   hist = std::make_unique<TH1F>("eventsPerBcHist", "Events per BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1);
   for (int idx = 0; idx < o2::constants::lhc::LHCMaxBunches; idx++) {
-    hist->Fill(idx, (*events)[idx]);
+    hist->Fill(idx, events->histogram[idx]);
   }
   canvas = std::make_unique<TCanvas>();
   hist->Draw();


### PR DESCRIPTION
Implements the EventsPerBC calibration task for FT0, which generates a histogram of VTX events above a defined amplitude threshold plotted against the BC.