### PR TITLE
Fix and improve TPC Loopers implementation

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -17,10 +17,6 @@
 #include "FairGenerator.h"
 #include "TParticle.h"
 #include "Generators/Trigger.h"
-#ifdef GENERATORS_WITH_TPCLOOPERS
-#include "Generators/TPCLoopers.h"
-#include "Generators/TPCLoopersParam.h"
-#endif
 #include <functional>
 #include <vector>
 #include <unordered_map>
@@ -37,6 +33,8 @@ namespace o2
 {
 namespace eventgen
 {
+
+class GenTPCLoopers; // Forward declaration
 
 /*****************************************************************/
 /*****************************************************************/
@@ -60,7 +58,7 @@ class Generator : public FairGenerator
   /** constructor **/
   Generator(const Char_t* name, const Char_t* title = "ALICEo2 Generator");
   /** destructor **/
-  ~Generator() override = default;
+  ~Generator() override;
 
   /** Initialize the generator if needed **/
   Bool_t Init() override;
@@ -169,9 +167,9 @@ class Generator : public FairGenerator
   // global static information about (upper limit of) number of events to be generated
   static unsigned int gTotalNEvents;
 
-#ifdef GENERATORS_WITH_TPCLOOPERS
   // Loopers generator instance
-  std::unique_ptr<o2::eventgen::GenTPCLoopers> mTPCLoopersGen = nullptr;
+  o2::eventgen::GenTPCLoopers* mTPCLoopersGen = nullptr;
+#ifdef GENERATORS_WITH_TPCLOOPERS
   bool initTPCLoopersGen();
 #endif
 

--- a/Generators/include/Generators/TPCLoopers.h
+++ b/Generators/include/Generators/TPCLoopers.h
@@ -16,14 +16,12 @@
 
 #ifdef GENERATORS_WITH_TPCLOOPERS
 #include <onnxruntime_cxx_api.h>
-#endif
 #include <vector>
 #include <rapidjson/document.h>
 #include "TRandom3.h"
 #include <SimulationDataFormat/DigitizationContext.h>
 #include "TParticle.h"
 
-#ifdef GENERATORS_WITH_TPCLOOPERS
 // Static Ort::Env instance for multiple onnx model loading
 extern Ort::Env global_env;
 

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -27,6 +27,10 @@
 #include "TGrid.h"
 #include "CCDB/BasicCCDBManager.h"
 #include <filesystem>
+#ifdef GENERATORS_WITH_TPCLOOPERS
+#include "Generators/TPCLoopers.h"
+#include "Generators/TPCLoopersParam.h"
+#endif
 
 namespace o2
 {
@@ -90,6 +94,19 @@ Generator::Generator(const Char_t* name, const Char_t* title) : FairGenerator(na
     }
   } else {
     LOG(info) << "Loopers fast generator turned OFF with veto flag.";
+  }
+#endif
+}
+
+/*****************************************************************/
+
+Generator::~Generator()
+{
+  /** destructor **/
+#ifdef GENERATORS_WITH_TPCLOOPERS
+  if (mTPCLoopersGen) {
+    delete mTPCLoopersGen;
+    mTPCLoopersGen = nullptr;
   }
 #endif
 }
@@ -171,7 +188,7 @@ bool Generator::initTPCLoopersGen()
   nclxrate = isAlien[2] || isCCDB[2] ? local_names[2] : nclxrate;
   try {
     // Create the TPC loopers generator with the provided parameters
-    mTPCLoopersGen = std::make_unique<o2::eventgen::GenTPCLoopers>(model_pairs, model_compton, poisson, gauss, scaler_pair, scaler_compton);
+    mTPCLoopersGen = new o2::eventgen::GenTPCLoopers(model_pairs, model_compton, poisson, gauss, scaler_pair, scaler_compton);
     const auto& intrate = loopersParam.intrate;
     // Configure the generator with flat gas loopers defined per orbit with clusters/track info
     // If intrate is negative (default), automatic IR from collisioncontext.root will be used
@@ -188,7 +205,9 @@ bool Generator::initTPCLoopersGen()
     LOG(info) << "TPC Loopers generator initialized successfully";
   } catch (const std::exception& e) {
     LOG(error) << "Failed to initialize TPC Loopers generator: " << e.what();
-    mTPCLoopersGen.reset();
+    delete mTPCLoopersGen;
+    mTPCLoopersGen = nullptr;
+    return kFALSE;
   }
   return kTRUE;
 }


### PR DESCRIPTION
- Moved the TPCLoopers inclusion to Generator.cxx
- Made forward declaration for GenTPCLoopers
- Switched to normal pointer instead of unique_ptr (destroyed in Generator destructor) ==> moved outside ifdef scope, this was the main cause of the segmentation issue when using the external generators, such as https://github.com/AliceO2Group/O2DPG/pull/2256
