### PR TITLE
Update omp detection for macOS

### DIFF
--- a/dependencies/FindOpenMPMacOS.cmake
+++ b/dependencies/FindOpenMPMacOS.cmake
@@ -1,3 +1,14 @@
+# Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
 find_library(OpenMP_LIBRARY
     NAMES omp libomp
     HINTS

--- a/dependencies/FindOpenMPMacOS.cmake
+++ b/dependencies/FindOpenMPMacOS.cmake
@@ -13,18 +13,14 @@ find_library(OpenMP_LIBRARY
     NAMES omp libomp
     HINTS
         /opt/homebrew/opt/libomp/lib
-        /opt/homebrew/lib
         /usr/local/opt/libomp/lib
-        /usr/local/lib
 )
 
 find_path(OpenMP_INCLUDE_DIR
     NAMES omp.h
     HINTS
         /opt/homebrew/opt/libomp/include
-        /opt/homebrew/include
         /usr/local/opt/libomp/include
-        /usr/local/include
 )
 
 mark_as_advanced(OpenMP_LIBRARY OpenMP_INCLUDE_DIR)

--- a/dependencies/FindOpenMPMacOS.cmake
+++ b/dependencies/FindOpenMPMacOS.cmake
@@ -1,28 +1,46 @@
 find_library(OpenMP_LIBRARY
-    NAMES omp
+    NAMES omp libomp
+    HINTS
+        /opt/homebrew/opt/libomp/lib
+        /opt/homebrew/lib
+        /usr/local/opt/libomp/lib
+        /usr/local/lib
 )
 
 find_path(OpenMP_INCLUDE_DIR
-    omp.h
+    NAMES omp.h
+    HINTS
+        /opt/homebrew/opt/libomp/include
+        /opt/homebrew/include
+        /usr/local/opt/libomp/include
+        /usr/local/include
 )
 
 mark_as_advanced(OpenMP_LIBRARY OpenMP_INCLUDE_DIR)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OpenMP DEFAULT_MSG
-    OpenMP_LIBRARY OpenMP_INCLUDE_DIR)
+find_package_handle_standard_args(
+    OpenMPMacOS
+    DEFAULT_MSG
+    OpenMP_LIBRARY OpenMP_INCLUDE_DIR
+)
 
-if (OpenMP_FOUND)
+if (OpenMPMacOS_FOUND)
     set(OpenMP_LIBRARIES ${OpenMP_LIBRARY})
     set(OpenMP_INCLUDE_DIRS ${OpenMP_INCLUDE_DIR})
-    set(OpenMP_COMPILE_OPTIONS -Xpreprocessor -fopenmp)
 
-    set(OpenMP_CXX_FOUND True)
-    set(OpenMPMacOS_FOUND True)
-    add_library(OpenMP::OpenMP_CXX SHARED IMPORTED)
+    set(OpenMP_CXX_FOUND TRUE)
+    set(OpenMP_FOUND TRUE)
+
+    add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
     set_target_properties(OpenMP::OpenMP_CXX PROPERTIES
-        IMPORTED_LOCATION ${OpenMP_LIBRARIES}
         INTERFACE_INCLUDE_DIRECTORIES "${OpenMP_INCLUDE_DIRS}"
-        INTERFACE_COMPILE_OPTIONS "${OpenMP_COMPILE_OPTIONS}"
+        INTERFACE_COMPILE_OPTIONS "-Xclang;-fopenmp"
+        INTERFACE_LINK_LIBRARIES "${OpenMP_LIBRARIES}"
+    )
+    message(STATUS
+        "Found OpenMP (macOS workaround): "
+        "library=${OpenMP_LIBRARY}, "
+        "include=${OpenMP_INCLUDE_DIR}"
     )
 endif()


### PR DESCRIPTION
Updated OpenMP detection for macOS with hints to brew/usr library paths and set required compile flags. This correctly picks it up at least on my system.