### PR TITLE
ITS: GPU: use mean vertex constraint for gpu processing

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -572,6 +572,9 @@ if [[ $CTFINPUT == 0 && $DIGITINPUT == 0 ]]; then
 fi
 
 has_detector_gpu ITS && GPU_INPUT+=",its-clusters"
+if [[ $BEAMTYPE != "cosmic" && $SYNCMODE != 1 ]]; then
+  has_detector_gpu ITS && GPU_INPUT+=",its-mean-vertex"
+fi
 has_detector_gpu ITS && GPU_OUTPUT+=",its-tracks"
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I noticed that in the Pb-Pb production we did not add the mean vertex constraint to be used.