### PR TITLE
ALICE 3 feat: Configurable VD design, set def to IRIS 4, remove IRIS disks

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
@@ -31,6 +31,13 @@ enum eLayout {
   kStaggered,
 };
 
+enum eVDLayout {
+  kIRIS4 = 0,
+  kIRISFullCyl,
+  kIRIS5,
+  kIRIS4a,
+};
+
 struct TRKBaseParam : public o2::conf::ConfigurableParamHelper<TRKBaseParam> {
   std::string configFile = "";
   float serviceTubeX0 = 0.02f; // X0 Al2O3
@@ -40,9 +47,11 @@ struct TRKBaseParam : public o2::conf::ConfigurableParamHelper<TRKBaseParam> {
 
   eLayout layoutML = kTurboStaves; // Type of segmentation for the middle layers
   eLayout layoutOL = kStaggered;   // Type of segmentation for the outer layers
+  eVDLayout layoutVD = kIRIS4;     // VD detector layout design
 
   eLayout getLayoutML() const { return layoutML; }
   eLayout getLayoutOL() const { return layoutOL; }
+  eVDLayout getLayoutVD() const { return layoutVD; }
 
   O2ParamDef(TRKBaseParam, "TRKBase");
 };

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -261,12 +261,32 @@ void Detector::createGeometry()
   mServices.createServices(vTRK);
 
   // Build the VD using the petal builder
-  // Choose the VD design (here: IRIS4 by default).
-  // You can wire this to a parameter in TRKBaseParam if desired.
-  // Alternatives: createIRIS5Geometry(vTRK); createIRIS4aGeometry(vTRK);
+  // Choose the VD design based on TRKBaseParam.layoutVD
+  auto& trkPars = TRKBaseParam::Instance();
 
   o2::trk::clearVDSensorRegistry();
-  o2::trk::createIRISGeometryFullCyl(vTRK);
+
+  switch (trkPars.layoutVD) {
+    case kIRIS4:
+      LOG(info) << "Building VD with IRIS4 layout";
+      o2::trk::createIRIS4Geometry(vTRK);
+      break;
+    case kIRISFullCyl:
+      LOG(info) << "Building VD with IRIS fully cylindrical layout";
+      o2::trk::createIRISGeometryFullCyl(vTRK);
+      break;
+    case kIRIS5:
+      LOG(info) << "Building VD with IRIS5 layout";
+      o2::trk::createIRIS5Geometry(vTRK);
+      break;
+    case kIRIS4a:
+      LOG(info) << "Building VD with IRIS4a layout";
+      o2::trk::createIRIS4aGeometry(vTRK);
+      break;
+    default:
+      LOG(fatal) << "Unknown VD layout option: " << static_cast<int>(trkPars.layoutVD);
+      break;
+  }
 
   // Fill sensor names from registry right after geometry creation
   const auto& regs = o2::trk::vdSensorRegistry();

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/VDGeometryBuilder.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/VDGeometryBuilder.cxx
@@ -749,7 +749,7 @@ static TGeoVolume* buildPetalAssembly(int nPetals,
                 /*fullCylindricalRadialWalls=*/fullCylinders);
 
   addBarrelLayers(petalAsm, nPetals, petalID, rectangularL0, fullCylinders);
-  addDisks(petalAsm, nPetals, petalID, fullCylinders);
+  // addDisks(petalAsm, nPetals, petalID, fullCylinders); // disks removed according to the v3b layout
 
   addColdPlate(petalAsm, nPetals, petalID, /*fullCylinders=*/false);
   addIRISServiceModulesSegmented(petalAsm, nPetals);


### PR DESCRIPTION
## ALICE 3 feat: Configurable VD design, set default to IRIS 4, remove IRIS disks

Adds `layoutVD` parameter to select VD detector design at runtime, following the same pattern as `layoutML` and `layoutOL`. Default changed from IRIS Full Cylinder to IRIS4. IRIS disks geometry removed.

### Changes
- Added `eVDLayout` enum with options: `kIRIS4` (default), `kIRISFullCyl`, `kIRIS5`, `kIRIS4a`,
- Added `layoutVD` member to `TRKBaseParam` struct with default value `kIRIS4`
- Modified `Detector.cxx` to use switch statement based on `layoutVD` parameter instead of hardcoded geometry
- Removed IRIS disks from the petal builder 

### Example usage
```bash
o2-sim-serial-run5 -n 1 -g pythia8hi -m A3IP TRK FT3 TF3 \
  --configKeyValues "TRKBase.layoutVD=kIRIS4"