### PR TITLE
TPC: time gain calibration optimizations

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
@@ -115,6 +115,9 @@ class CalibdEdxCorrection
   /// Single fit parameters averaged over all sectors for a stack type
   float getMeanEntries(const GEMstack stack, ChargeType charge) const;
 
+  /// set all corrections to 1, used for default initialization and to reset corrections
+  void setUnity();
+
 #endif
 
  private:

--- a/DataFormats/Detectors/TPC/src/CalibdEdxCorrection.cxx
+++ b/DataFormats/Detectors/TPC/src/CalibdEdxCorrection.cxx
@@ -168,3 +168,16 @@ float CalibdEdxCorrection::getMeanEntries(const GEMstack stack, ChargeType charg
 
   return mean / (SECTORSPERSIDE * SIDES);
 }
+
+void CalibdEdxCorrection::setUnity()
+{
+  for (int i = 0; i < FitSize; ++i) {
+    for (int j = 0; j < ParamSize; ++j) {
+      mParams[i][j] = 0.f;
+    }
+    mParams[i][0] = 1.f; // constant term = 1
+    mChi2[i] = 0.f;
+    mEntries[i] = 0;
+  }
+  mDims = 0;
+}

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibdEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibdEdx.h
@@ -129,7 +129,9 @@ class CalibdEdx
   /// Compute MIP position from dEdx histograms and save result in the correction container.
   /// To retrieve the correction call `CalibdEdx::getCalib()`
   /// \param useGausFits make gaussian fits of dEdx vs tgl instead of fitting the mean dEdx
-  void finalize(const bool useGausFits = true);
+  /// \param averageSectors If true, the correction is averaged over all sectors.
+  /// In this case, no mean-sector scaling is applied when statistics are low.
+  void finalize(const bool useGausFits = true, const bool averageSectors = false);
 
   /// Return calib data histogram
   const Hist& getHist() const { return mHist; }

--- a/Detectors/TPC/calibration/src/CalibdEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalibdEdx.cxx
@@ -351,7 +351,7 @@ auto ProjectBoostHistoXFastAllSectors(const Hist& hist, std::vector<int>& bin_in
 
       // access the bin content specified by bin_indices
       const float counts = hist.at(bin_indices);
-      float dEdx = hist.axis(ax::dEdx).value(i);
+      float dEdx = hist.axis(ax::dEdx).bin(i).center();
 
       // scale the dedx to the mean
       if (stackMean != nullptr) {
@@ -532,7 +532,7 @@ void CalibdEdx::fitHistGaus(TLinearFitter& fitter, CalibdEdxCorrection& corr, co
   LOGP(info, "Calibration fits took: {}", time.count());
 }
 
-void CalibdEdx::finalize(const bool useGausFits)
+void CalibdEdx::finalize(const bool useGausFits, const bool averageSectors)
 {
   const float entries = minStackEntries();
   mCalib.clear();
@@ -565,10 +565,15 @@ void CalibdEdx::finalize(const bool useGausFits)
     // get mean of each GEM stack
     CalibdEdxCorrection meanCorr{};
     meanCorr.setDims(0);
-    TLinearFitter meanFitter(0);
-    meanFitter.SetFormula("1");
-    // get the mean dEdx for each stack
-    fitHist(mHist, meanCorr, meanFitter, mFitCut, mFitLowCutFactor, mFitPasses);
+    if (averageSectors) {
+      // set mean dEdx per stack to unity
+      meanCorr.setUnity();
+    } else {
+      // get the mean dEdx for each stack
+      TLinearFitter meanFitter(0);
+      meanFitter.SetFormula("1");
+      fitHist(mHist, meanCorr, meanFitter, mFitCut, mFitLowCutFactor, mFitPasses, nullptr, mDebugOutputStreamer.get());
+    }
     if (!useGausFits) {
       // get higher dimension corrections with projected sectors
       fitHist(mHist, mCalib, fitter, mFitCut, mFitLowCutFactor, mFitPasses, &meanCorr, mDebugOutputStreamer.get());


### PR DESCRIPTION
- bug fix: using bin centre of the dE/dx instead of lower bin edge
- add option to not perform per sector scaling (needed for MC)