### PR TITLE
ALICE3-TRK: adapt ordering key for digits to the large number of columns in the VD

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/ChipDigitsContainer.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/ChipDigitsContainer.h
@@ -29,6 +29,12 @@ class ChipDigitsContainer : public o2::itsmft::ChipDigitsContainer
 
   using Segmentation = SegmentationChip;
 
+  /// Get global ordering key made of readout frame, column and row
+  static ULong64_t getOrderingKey(UInt_t roframe, UShort_t row, UShort_t col)
+  {
+    return (static_cast<ULong64_t>(roframe) << (8 * sizeof(UInt_t))) + (static_cast<ULong64_t>(col) << (8 * sizeof(Short_t))) + row;
+  }
+
   ClassDefNV(ChipDigitsContainer, 1);
 };
 


### PR DESCRIPTION
In the VD case, the sensor covers the full z acceptance of the layer, from z=-25 to z=25 cm, for a total of 50000 columns for a single sensor.
When the number of columns exceeded 32768 = 2^15, the function getOrderingKey(...), which uniquely assigns an ID to each digit,  was not working properly anymore.

Issue explained [here](https://indico.cern.ch/event/1642644/?note=367139#14-digitizationclusterization).

The issue is solved with this commit by casting the column variable to 64-bit before the bit-to-bit shift operated in the function. 
This modification is applied only to the TRK class.


