### PR TITLE
ALICE3-TRK: fix detector ID assignment to hits

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
@@ -416,15 +416,15 @@ TString GeometryTGeo::getMatrixPath(int index) const
   // build the path
   if (subDetID == 0) { // VD
     if (disk >= 0) {
-      path += Form("%s_%d_%d/", getTRKPetalAssemblyPattern(), petalcase, petalcase + 1);             // PETAL_n
-      path += Form("%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalDiskPattern(), disk); // PETALCASEx_DISKy_1
-      // path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalDiskPattern(), disk, getTRKChipPattern(), disk);   // PETALCASEx_DISKy_TRKChipy_1
+      path += Form("%s_%d_%d/", getTRKPetalAssemblyPattern(), petalcase, petalcase + 1);                                               // PETAL_n
+      path += Form("%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalDiskPattern(), disk);                                   // PETALCASEx_DISKy_1
+      path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalDiskPattern(), disk, getTRKChipPattern(), disk);   // PETALCASEx_DISKy_TRKChipy_1
       path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalDiskPattern(), disk, getTRKSensorPattern(), disk); // PETALCASEx_DISKy_TRKSensory_1
     } else if (layer >= 0) {
       path += Form("%s_%d_%d/", getTRKPetalAssemblyPattern(), petalcase, petalcase + 1);               // PETAL_n
       path += Form("%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalLayerPattern(), layer); // PETALCASEx_LAYERy_1
       // path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalLayerPattern(), layer, getTRKStavePattern(), layer);  // PETALCASEx_LAYERy_TRKStavey_1
-      // path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalLayerPattern(), layer, getTRKChipPattern(), layer);   // PETALCASEx_LAYERy_TRKChipy_1
+      path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalLayerPattern(), layer, getTRKChipPattern(), layer);   // PETALCASEx_LAYERy_TRKChipy_1
       path += Form("%s%d_%s%d_%s%d_1/", getTRKPetalPattern(), petalcase, getTRKPetalLayerPattern(), layer, getTRKSensorPattern(), layer); // PETALCASEx_LAYERy_TRKSensory_1
     }
   } else if (subDetID == 1) {                                               // MLOT
@@ -962,9 +962,9 @@ int GeometryTGeo::extractNumberOfChipsPerPetalVD() const
 
       for (int i = 0; i < subNodes->GetEntriesFast(); i++) {
         auto* subNode = dynamic_cast<TGeoNode*>(subNodes->At(i));
-        if (strstr(subNode->GetName(), getTRKSensorPattern()) != nullptr) {
+        if (strstr(subNode->GetName(), getTRKChipPattern()) != nullptr) {
           numberOfChips++;
-          LOGP(debug, "Found sensor in {}: {}", nodeName, subNode->GetName());
+          LOGP(debug, "Found chip in {}: {}", nodeName, subNode->GetName());
         }
       }
     }

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -266,7 +266,7 @@ void Detector::createGeometry()
   // Alternatives: createIRIS5Geometry(vTRK); createIRIS4aGeometry(vTRK);
 
   o2::trk::clearVDSensorRegistry();
-  o2::trk::createIRISGeometryFullCyl(vTRK);
+  o2::trk::createIRIS4Geometry(vTRK);
 
   // Fill sensor names from registry right after geometry creation
   const auto& regs = o2::trk::vdSensorRegistry();


### PR DESCRIPTION
After the separation of "sensor" and "chip" volumes for the IRIS sensors in the geometry, the detector ID and the path for the transformation matrices were not correctly retrieved anymore. 
This PR fixes the issue by considering the "chip" volume added to the geometry and modifying accordingly the matrix path.