### PR TITLE
path for LHCphase ccdb configurable

### DIFF
--- a/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
@@ -99,6 +99,8 @@ class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2:
 
   void setCalibTOFapi(CalibTOFapi* api) { mCalibTOFapi = api; }
   CalibTOFapi* getCalibTOFapi() const { return mCalibTOFapi; }
+  const char* getPath() const { return mPath.Data(); }
+  void setPath(const char* path) { mPath = path; }
 
  private:
   int mMinEntries = 0;
@@ -107,6 +109,7 @@ class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2:
   CalibTOFapi* mCalibTOFapi = nullptr;
   CcdbObjectInfoVector mInfoVector; // vector of CCDB Infos , each element is filled with the CCDB description of the accompanying LHCPhase
   LHCphaseVector mLHCphaseVector;   // vector of LhcPhase, each element is filled in "process" when we finalize one slot (multiple can be finalized during the same "process", which is why we have a vector. Each element is to be considered the output of the device, and will go to the CCDB
+  TString mPath = "TOF/Calib/LHCphaseSync";
 
 #ifdef DEBUGGING
   int mNslot = 0;

--- a/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
@@ -158,7 +158,7 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
   l.setStartValidity(starting);
   l.setEndValidity(stopping);
 
-  mInfoVector.emplace_back("TOF/Calib/LHCphase", clName, flName, md, starting, stopping);
+  mInfoVector.emplace_back(mPath.Data(), clName, flName, md, starting, stopping);
   mLHCphaseVector.emplace_back(l);
 
   slot.print();

--- a/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
@@ -53,7 +53,10 @@ class LHCClockCalibDevice : public o2::framework::Task
     int nb = std::max(500, ic.options().get<int>("nbins"));
     auto slotL = ic.options().get<uint32_t>("tf-per-slot");
     auto delay = ic.options().get<uint32_t>("max-delay");
+    std::string path = ic.options().get<std::string>("output-path");
+
     mCalibrator = std::make_unique<o2::tof::LHCClockCalibrator>(minEnt, nb);
+    mCalibrator->setPath(path.data());
     mCalibrator->setSlotLength(slotL);
     mCalibrator->setMaxSlotsDelay(delay);
 
@@ -216,6 +219,7 @@ DataProcessorSpec getLHCClockCalibDeviceSpec(bool useCCDB)
     AlgorithmSpec{adaptFromTask<device>(ccdbRequest, useCCDB)},
     Options{
       {"tf-per-slot", VariantType::UInt32, 5u, {"number of TFs per calibration time slot"}},
+      {"output-path", VariantType::String, "TOF/Calib/LHCphaseSync", {"path to ccdb output"}},
       {"max-delay", VariantType::UInt32, 3u, {"number of slots in past to consider"}},
       {"min-entries", VariantType::Int, 500, {"minimum number of entries to fit single time slot"}},
       {"nbins", VariantType::Int, 4000, {"number of bins for "}}}};


### PR DESCRIPTION
path TOF/Calib/LHCphaseSync, now set as default for sync calibrations