### PR TITLE
Fix type mismatch

### DIFF
--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -501,7 +501,7 @@ void GeneratorHepMC::updateHeader(o2::dataformats::MCEventHeader* eventHeader)
                               hiInfo->Nwounded_N_collisions);
     eventHeader->putInfo<int>(Key::nCollNWoundedNwounded,
                               hiInfo->Nwounded_Nwounded_collisions);
-    eventHeader->putInfo<float>(Key::planeAngle, hiInfo->event_plane_angle);
+    eventHeader->putInfo<double>(Key::planeAngle, hiInfo->event_plane_angle);
     eventHeader->putInfo<float>(Key::sigmaInelNN, hiInfo->sigma_inel_NN);
     eventHeader->putInfo<float>(Key::centrality, hiInfo->centrality);
     eventHeader->putInfo<int>(Key::nSpecProjectileProton, hiInfo->Nspec_proj_p);


### PR DESCRIPTION
When getting the info in the AODMcProducerHelpers.cxx the variable value was not correctly fetched due to a type mismatch. This simple modification sets it correctly. It doesn't apply to other values (for now) because the fallback values of getEventInfo are constants (aside from the planeAngle where header.GetRotZ() is used).