### PR TITLE
[ALICE3] Change 'layoutOL' to 'layoutOT', update ALICE3/README with a config table

### DIFF
--- a/Detectors/Upgrades/ALICE3/README.md
+++ b/Detectors/Upgrades/ALICE3/README.md
@@ -21,7 +21,7 @@ The specific modules for Run 5 are enabled by passing their their IDs to the `-m
 A list of the available DetIDs is reproted in the table below:
 
 | Detector ID | Detector description             |
-|-------------|----------------------------------|
+| ----------- | -------------------------------- |
 | `A3IP`      | Beam pipe                        |
 | `TRK`       | Barrel Tracker                   |
 | `TF3`       | Time Of Flight detectors         |
@@ -49,7 +49,7 @@ export ALICE3_MAGFIELD_MACRO=../ALICE3Field.C
 
 An exampling macro for a custom magnetic field is stored in `Detectors/Upgrades/macros/ALICE3Field.C`.
 
-### Run a simple simulation for run 5
+### Run a simple simulation for ALICE 3
 The simplest command to be run to test the simulation is working is:
 
 ```bash
@@ -61,6 +61,26 @@ To enable a specific set of modules, e.g. the beampipe and the TOFs one can spec
 ```bash
 o2-sim-run5 -n 10 -m A3IP TF3
 ```
+
+#### Specific detector setups
+
+
+
+Configurables for various sub-detectors are presented in the following Table:
+
+| Subsystem          | Available options                                       | Comments                                                         |
+| ------------------ | ------------------------------------------------------- | ---------------------------------------------------------------- |
+| `TRKBase.layoutVD` | `kIRIS4` (default), `kIRISFullCyl`, `kIRIS5`, `kIRIS4a` | [link to definitions](./TRK/base/include/TRKBase/TRKBaseParam.h) |
+| `TRKBase.layoutML` | `kCylinder`, `kTurboStaves` (default), `kStaggered`     |                                                                  |
+| `TRKBase.layoutOT` | `kCylinder`, `kTurboStaves`, `kStaggered` (default)     |                                                                  |
+
+For example, a geometry with fully cylindrical tracker barrel (for all layers in VD, ML and OT) can be obtained by
+```bash
+o2-sim-serial-run5 -n 1 -g pythia8hi -m A3IP TRK FT3 TF3 \
+  --configKeyValues "TRKBase.layoutVD=kIRISFullCyl;TRKBase.layoutML=kCylinder;TRKBase.layoutOL=kCylinder"
+```
+
+
 ### Output of the simulation
 The simulation will produce a `o2sim_Hits<DetID>.root` file with a tree with the hits related to that detector.
 Currently, hits are produced for: `TRK`, `FT3`, and `TF3`.

--- a/Detectors/Upgrades/ALICE3/README.md
+++ b/Detectors/Upgrades/ALICE3/README.md
@@ -64,27 +64,14 @@ o2-sim-run5 -n 10 -m A3IP TF3
 
 #### Specific detector setups
 
-
-
 Configurables for various sub-detectors are presented in the following Table:
 
-| Subsystem          | Available options                                       | Comments                                                         |
-| ------------------ | ------------------------------------------------------- | ---------------------------------------------------------------- |
-| `TRKBase.layoutVD` | `kIRIS4` (default), `kIRISFullCyl`, `kIRIS5`, `kIRIS4a` | [link to definitions](./TRK/base/include/TRKBase/TRKBaseParam.h) |
-| `TRKBase.layoutML` | `kCylinder`, `kTurboStaves` (default), `kStaggered`     |                                                                  |
-| `TRKBase.layoutOT` | `kCylinder`, `kTurboStaves`, `kStaggered` (default)     |                                                                  |
-
-For example, a geometry with fully cylindrical tracker barrel (for all layers in VD, ML and OT) can be obtained by
-```bash
-o2-sim-serial-run5 -n 1 -g pythia8hi -m A3IP TRK FT3 TF3 \
-  --configKeyValues "TRKBase.layoutVD=kIRISFullCyl;TRKBase.layoutML=kCylinder;TRKBase.layoutOL=kCylinder"
-```
-
+| Available options | Link to options                                                |
+| ----------------- | -------------------------------------------------------------- |
+| TKR               | [Link to TRK options](./TRK/README.md#specific-detector-setup) |
 
 ### Output of the simulation
 The simulation will produce a `o2sim_Hits<DetID>.root` file with a tree with the hits related to that detector.
-Currently, hits are produced for: `TRK`, `FT3`, and `TF3`.
-More detectors will be included.
 
 ## Reconstruction
 WIP

--- a/Detectors/Upgrades/ALICE3/TRK/README.md
+++ b/Detectors/Upgrades/ALICE3/TRK/README.md
@@ -6,5 +6,23 @@
 
 This is top page for the TRK detector documentation.
 
+
+## Specific detector setup
+
+
+Configurables for various sub-detectors are presented in the following Table:
+
+| Subsystem          | Available options                                       | Comments                                                         |
+| ------------------ | ------------------------------------------------------- | ---------------------------------------------------------------- |
+| `TRKBase.layoutVD` | `kIRIS4` (default), `kIRISFullCyl`, `kIRIS5`, `kIRIS4a` | [link to definitions](./base/include/TRKBase/TRKBaseParam.h) |
+| `TRKBase.layoutML` | `kCylinder`, `kTurboStaves` (default), `kStaggered`     |                                                                  |
+| `TRKBase.layoutOT` | `kCylinder`, `kTurboStaves`, `kStaggered` (default)     |                                                                  |
+
+For example, a geometry with fully cylindrical tracker barrel (for all layers in VD, ML and OT) can be obtained by
+```bash
+o2-sim-serial-run5 -n 1 -g pythia8hi -m A3IP TRK FT3 TF3 \
+  --configKeyValues "TRKBase.layoutVD=kIRISFullCyl;TRKBase.layoutML=kCylinder;TRKBase.layoutOL=kCylinder"
+```
+
 <!-- doxy
 /doxy -->

--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/GeometryTGeo.h
@@ -223,7 +223,7 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   std::vector<float> mCacheRefAlphaMLOT; /// cache for sensor ref alpha ML and OT
 
   eLayout mLayoutML; // Type of segmentation for the middle layers
-  eLayout mLayoutOL; // Type of segmentation for the outer layers
+  eLayout mLayoutOT; // Type of segmentation for the outer layers
 
  private:
   static std::unique_ptr<o2::trk::GeometryTGeo> sInstance;

--- a/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
+++ b/Detectors/Upgrades/ALICE3/TRK/base/include/TRKBase/TRKBaseParam.h
@@ -46,11 +46,11 @@ struct TRKBaseParam : public o2::conf::ConfigurableParamHelper<TRKBaseParam> {
   eOverallGeom overallGeom = kDefaultRadii; // Overall geometry option, to be used in Detector::buildTRKMiddleOuterLayers
 
   eLayout layoutML = kTurboStaves; // Type of segmentation for the middle layers
-  eLayout layoutOL = kStaggered;   // Type of segmentation for the outer layers
+  eLayout layoutOT = kStaggered;   // Type of segmentation for the outer layers
   eVDLayout layoutVD = kIRIS4;     // VD detector layout design
 
   eLayout getLayoutML() const { return layoutML; }
-  eLayout getLayoutOL() const { return layoutOL; }
+  eLayout getLayoutOT() const { return layoutOT; }
   eVDLayout getLayoutVD() const { return layoutVD; }
 
   O2ParamDef(TRKBaseParam, "TRKBase");

--- a/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/base/src/GeometryTGeo.cxx
@@ -77,9 +77,9 @@ void GeometryTGeo::Build(int loadTrans)
   }
 
   mLayoutML = o2::trk::TRKBaseParam::Instance().getLayoutML();
-  mLayoutOL = o2::trk::TRKBaseParam::Instance().getLayoutOL();
+  mLayoutOT = o2::trk::TRKBaseParam::Instance().getLayoutOT();
 
-  LOG(debug) << "Layout ML: " << mLayoutML << ", Layout OL: " << mLayoutOL;
+  LOG(debug) << "Layout ML: " << mLayoutML << ", Layout OL: " << mLayoutOT;
 
   mNumberOfLayersMLOT = extractNumberOfLayersMLOT();
   mNumberOfPetalsVD = extractNumberOfPetalsVD();
@@ -405,7 +405,7 @@ TString GeometryTGeo::getMatrixPath(int index) const
   // handling cylindrical configuration for ML and/or OT
   // needed bercause of the different numbering scheme in the geometry for the cylindrical case wrt the staggered and turbo ones
   if (subDetID == 1) {
-    if ((layer < 4 && mLayoutML == eLayout::kCylinder) || (layer > 3 && mLayoutOL == eLayout::kCylinder)) {
+    if ((layer < 4 && mLayoutML == eLayout::kCylinder) || (layer > 3 && mLayoutOT == eLayout::kCylinder)) {
       stave = 1;
       mod = 1;
       chip = 1;

--- a/Detectors/Upgrades/ALICE3/TRK/macros/test/run_test.sh
+++ b/Detectors/Upgrades/ALICE3/TRK/macros/test/run_test.sh
@@ -2,7 +2,7 @@
 nEvents=10
 
 # Simulating
-o2-sim-serial-run5 -n $nEvents -g pythia8hi -m TRK --configKeyValues "TRKBase.layoutML=kTurboStaves;TRKBase.layoutOL=kStaggered;">& sim_TRK.log
+o2-sim-serial-run5 -n $nEvents -g pythia8hi -m TRK --configKeyValues "TRKBase.layoutML=kTurboStaves;TRKBase.layoutOT=kStaggered;">& sim_TRK.log
 
 # Digitizing
 o2-sim-digitizer-workflow -b >& digiTRK.log

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -146,10 +146,10 @@ void Detector::buildTRKMiddleOuterLayers()
   mLayers[3].setLayout(trkPars.layoutML);
 
   // Outer tracker
-  mLayers[4].setLayout(trkPars.layoutOL);
-  mLayers[5].setLayout(trkPars.layoutOL);
-  mLayers[6].setLayout(trkPars.layoutOL);
-  mLayers[7].setLayout(trkPars.layoutOL);
+  mLayers[4].setLayout(trkPars.layoutOT);
+  mLayers[5].setLayout(trkPars.layoutOT);
+  mLayers[6].setLayout(trkPars.layoutOT);
+  mLayers[7].setLayout(trkPars.layoutOT);
 }
 
 void Detector::configFromFile(std::string fileName)

--- a/Detectors/Upgrades/ALICE3/TRK/workflow/README.md
+++ b/Detectors/Upgrades/ALICE3/TRK/workflow/README.md
@@ -98,7 +98,7 @@ Note that the `trackingparams` field can contain multiple sets of parameters for
 First, generate simulation data:
 
 ```bash
-o2-sim-serial-run5 -n 200 -g pythia8hi -m TRK --configKeyValues "Diamond.width[0]=0.01;Diamond.width[1]=0.01;Diamond.width[2]=5;TRKBase.layoutML=kTurboStaves;TRKBase.layoutOL=kStaggered;"
+o2-sim-serial-run5 -n 200 -g pythia8hi -m TRK --configKeyValues "Diamond.width[0]=0.01;Diamond.width[1]=0.01;Diamond.width[2]=5;TRKBase.layoutML=kTurboStaves;TRKBase.layoutOT=kStaggered;"
 ```
 
 This produces, among other files:


### PR DESCRIPTION
- TRK: change naming 'layoutOL' to 'layoutOT', for consistency (since we use "Outer Tracker" elsewhere)
- update of ALICE3/README: a table with configurables for geometry of sub-detectors is added (more info to be given)
