### PR TITLE
CAD->TGeo: Add first support for material mapping

### DIFF
--- a/scripts/geometry/O2_CADtoTGeo.py
+++ b/scripts/geometry/O2_CADtoTGeo.py
@@ -4,6 +4,14 @@ A Python script, doing a deep STEP/XCAF -> ROOT TGeo conversion.
 For now, all CAD solids are simply meshed. The ROOT geometry is build as a C++ ROOT macro
 and facet data is stored in binary form to keep disc space minimal.
 
+NEW (03/2026):
+  - Optional material/medium emission from a BOM (bill of materials) CSV file.
+    The CSV is expected to contain lines like:
+      CAD, Mechanical/Part, <PartNumber>, <Rev>, <Name>, <Mass>, <Material>, ...
+  - If both a part mass and a CAD volume are available, an effective density is computed
+    and used in the emitted TGeoMaterial. Otherwise a reasonable default density is used
+    for a few common materials, or 1.0 g/cm^3 as fallback.
+
 Generates (into --output-folder):
   - geom.C (small ROOT macro)
   - facets_<VOLNAME>_<LID>.bin for each leaf logical volume (float32 triangles)
@@ -28,15 +36,21 @@ Units:
 
 Author:
   - Sandro Wenzel, CERN (02/2026)
+  - Material/BOM integration patch (03/2026)
 """
 
 import warnings
 warnings.filterwarnings("ignore", message=".*all to deprecated function.*", category=DeprecationWarning)
 
 import argparse
+import csv
+import json
+import math
 import re
 import struct
+from dataclasses import dataclass
 from pathlib import Path as _Path
+from typing import Dict, List, Optional, Tuple
 
 from OCC.Core.Bnd import Bnd_Box
 from OCC.Core.BRepBndLib import brepbndlib
@@ -54,6 +68,14 @@ from OCC.Core.IFSelect import IFSelect_RetDone
 from OCC.Core.TDF import TDF_Label, TDF_LabelSequence, TDF_Tool
 from OCC.Core.TCollection import TCollection_AsciiString
 from OCC.Core.gp import gp_Trsf
+
+# volume properties for density calcs (may not be present in older pythonOCC builds)
+try:
+    from OCC.Core.GProp import GProp_GProps
+    from OCC.Core.BRepGProp import brepgprop_VolumeProperties
+    _HAS_VOLPROPS = True
+except Exception:
+    _HAS_VOLPROPS = False
 
 
 # -------------------------------
@@ -222,6 +244,30 @@ def triangulate_CAD_solid(my_solid, meshparam, scale_to_cm: float = 1.0):
 
 
 # -------------------------------
+# Volume helpers (for density)
+# -------------------------------
+
+def volume_cm3_of_shape(shape, scale_to_cm: float) -> float:
+    """Compute CAD solid volume in cm^3 (using STEP->cm scale)."""
+    if _HAS_VOLPROPS:
+        try:
+            props = GProp_GProps()
+            brepgprop_VolumeProperties(shape, props)
+            # volume returned in STEP length units^3
+            v = float(props.Mass())
+            return v * (scale_to_cm ** 3)
+        except Exception:
+            pass
+
+    # Fallback: bounding-box volume (rough but always defined)
+    box = Bnd_Box()
+    brepbndlib.Add(shape, box)
+    xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
+    dx, dy, dz = (xmax - xmin) * scale_to_cm, (ymax - ymin) * scale_to_cm, (zmax - zmin) * scale_to_cm
+    return max(dx, 0.0) * max(dy, 0.0) * max(dz, 0.0)
+
+
+# -------------------------------
 # Naming helpers
 # -------------------------------
 
@@ -254,6 +300,472 @@ def write_facets_bin(path: _Path, triangles):
                 float(b[0]), float(b[1]), float(b[2]),
                 float(c[0]), float(c[1]), float(c[2]),
             ))
+
+
+# -------------------------------
+# BOM / material mapping
+# -------------------------------
+
+@dataclass(frozen=True)
+class BomEntry:
+    part_number: str
+    revision: str
+    name: str
+    mass_value: float  # as in CSV
+    material: str
+
+    @property
+    def part_number_key(self) -> str:
+        return (self.part_number or "").strip()
+
+    @property
+    def name_key(self) -> str:
+        return (self.name or "").strip()
+
+
+def _to_float(s: str) -> Optional[float]:
+    try:
+        if s is None:
+            return None
+        s = str(s).strip()
+        if not s:
+            return None
+        return float(s)
+    except Exception:
+        return None
+
+
+def read_bom_csv(csv_path: str) -> List[BomEntry]:
+    """
+    Reads a BOM CSV in the format provided by design team.
+
+    We look for rows whose first column is 'CAD' and second is 'Mechanical/Part'.
+    Columns (0-based):
+      0 CAD
+      1 type
+      2 part number
+      3 revision
+      4 name/description
+      5 mass
+      6 material
+    """
+    entries: List[BomEntry] = []
+    with open(csv_path, newline="", encoding="utf-8", errors="ignore") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row:
+                continue
+            if len(row) < 7:
+                continue
+            if row[0].strip() != "CAD":
+                continue
+            if row[1].strip() != "Mechanical/Part":
+                continue
+
+            part_no = (row[2] or "").strip()
+            rev = (row[3] or "").strip()
+            name = (row[4] or "").strip()
+            mass = _to_float(row[5])
+            mat = (row[6] or "").strip()
+
+            if not (part_no or name):
+                continue
+            if mass is None:
+                mass = float("nan")
+            if not mat:
+                mat = "Default"
+
+            entries.append(BomEntry(part_no, rev, name, float(mass), mat))
+    return entries
+
+
+
+def normalize_material_name(mat: str) -> str:
+    """
+    Normalizes a BOM material string for matching / caching.
+
+    Note: We keep the *original* string for ROOT object names; this is only used
+    internally for robust matching and dictionary keys.
+    """
+    mat = (mat or "Default").strip()
+    mat = re.sub(r"\s+", " ", mat)
+    return mat
+
+
+def _norm_tokens(s: str) -> List[str]:
+    s = (s or "").lower()
+    # common grade/format noise
+    s = re.sub(r"\(.*?\)", " ", s)
+    s = s.replace("en aw", " ")
+    s = s.replace("en-aw", " ")
+    s = s.replace("en", " ")
+    s = s.replace("aw", " ")
+    s = s.replace("_", " ").replace("-", " ")
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    if not s:
+        return []
+    toks = s.split(" ")
+
+    # small synonym normalization
+    syn = {
+        "alu": "al",
+        "aluminium": "aluminum",
+        "silicium": "silicon",
+        "inox": "stainless",
+        "ss": "stainless",
+        "cu": "copper",
+        "fe": "iron",
+        "ptfe": "teflon",
+        "ti": "titanium",
+        "be": "beryllium",
+    }
+
+    # Expand common element symbols to names and vice-versa so that e.g. "G4_Si" can match "silicon".
+    elem_alias = {
+        "h": "hydrogen", "he": "helium", "c": "carbon", "n": "nitrogen", "o": "oxygen",
+        "al": "aluminum", "si": "silicon", "fe": "iron", "cu": "copper", "be": "beryllium",
+        "mg": "magnesium", "mn": "manganese", "cr": "chromium", "ni": "nickel", "zn": "zinc",
+        "ti": "titanium", "w": "tungsten", "pb": "lead", "sn": "tin",
+    }
+    name_to_sym = {v: k for k, v in elem_alias.items()}
+
+    out: List[str] = []
+    for t in toks:
+        t2 = syn.get(t, t)
+        out.append(t2)
+        if t2 in elem_alias:
+            out.append(elem_alias[t2])
+        if t2 in name_to_sym:
+            out.append(name_to_sym[t2])
+
+    # de-dup while preserving order
+    seen = set()
+    out2: List[str] = []
+    for t in out:
+        if t and t not in seen:
+            seen.add(t)
+            out2.append(t)
+    return out2
+
+
+def _density_score(rho_part: Optional[float], rho_ref: Optional[float]) -> float:
+    if rho_part is None or rho_ref is None or not (rho_part > 0.0) or not (rho_ref > 0.0):
+        return 0.0
+    # symmetric score in log-space; 1.0 is perfect match
+    d = abs(math.log(rho_ref / rho_part))
+    return 1.0 / (1.0 + d)
+
+
+def _token_score(tokens_a: List[str], tokens_b: List[str]) -> float:
+    if not tokens_a or not tokens_b:
+        return 0.0
+    sa = set(tokens_a)
+    sb = set(tokens_b)
+    inter = len(sa & sb)
+    union = len(sa | sb)
+    if union == 0:
+        return 0.0
+    return inter / union
+
+
+def load_g4_nist_db(json_path: str) -> Dict[str, dict]:
+    """
+    Loads a JSON dump created by the 'nist_export_all' tool.
+    Returns a dict: nist_name -> material record.
+    """
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    mats = data.get("materials", {})
+    if not isinstance(mats, dict) or not mats:
+        raise RuntimeError(f"G4 NIST DB JSON seems empty or malformed: {json_path}")
+    return mats
+
+# Minimal periodic table for parsing custom alloys not present in NIST.
+# Values: Z (atomic number), A (g/mol)
+_ELEMENT_TABLE = {
+    "H": (1, 1.00794),
+    "C": (6, 12.0107),
+    "N": (7, 14.0067),
+    "O": (8, 15.9994),
+    "Al": (13, 26.9815385),
+    "Si": (14, 28.0855),
+    "Fe": (26, 55.845),
+    "Cu": (29, 63.546),
+    "Be": (4, 9.0121831),
+    "Mg": (12, 24.305),
+    "Mn": (25, 54.938044),
+    "Cr": (24, 51.9961),
+    "Ni": (28, 58.6934),
+    "Zn": (30, 65.38),
+    "Ti": (22, 47.867),
+    "W": (74, 183.84),
+    "Pb": (82, 207.2),
+    "Sn": (50, 118.71),
+}
+
+
+@dataclass
+class ResolvedMaterial:
+    bom_name: str
+    nist_name: Optional[str]          # e.g. "G4_Al"
+    score: float
+    rho_used_g_cm3: Optional[float]   # density used in ROOT definition
+    radlen_cm: Optional[float]
+    intlen_cm: Optional[float]
+    elements: Optional[List[dict]]    # list of {symbol,Z,A_g_mol,mass_fraction}
+    note: str                         # for comments in geom.C (warnings/FIXME)
+
+@dataclass
+class MatMatchConfig:
+    # Minimum combined score to accept a match.
+    min_score: float = 0.35
+    # If (best - second_best) < ambiguity_delta, treat as ambiguous/unresolved.
+    ambiguity_delta: float = 0.05
+    # Weights for the combined score = w_token * token_score + w_density * density_score
+    w_token: float = 0.75
+    w_density: float = 0.25
+    # Optional hard filter on density proximity (in log-space). If <=0, disabled.
+    # Example: max_log_density_diff=0.8 means accept within exp(0.8)~2.2x in either direction.
+    max_log_density_diff: float = 0.0
+    # Penalize compound matches (oxide/dioxide/carbide/...) when BOM doesn't mention those tokens.
+    compound_penalty: float = 0.25
+
+
+def resolve_bom_material(
+    bom_material: str,
+    rho_part_g_cm3: Optional[float],
+    g4db: Optional[Dict[str, dict]],
+    cfg: MatMatchConfig,
+) -> ResolvedMaterial:
+    """
+    Resolves an arbitrary BOM material string to a Geant4 NIST material name using:
+      - exact key match (BOM already uses e.g. "G4_Al")
+      - token overlap scoring on names
+      - density proximity scoring (if rho_part_g_cm3 available)
+
+    If unresolved/ambiguous, tries to parse element symbols from the BOM string (e.g. "Cu Be")
+    and emits a placeholder mixture (equal mass fractions) annotated with FIXME.
+    """
+    raw_bom_material = (bom_material or "").strip()
+    bom_material = normalize_material_name(bom_material)
+
+    if not g4db:
+        return ResolvedMaterial(
+            bom_name=bom_material,
+            nist_name=None,
+            score=0.0,
+            rho_used_g_cm3=rho_part_g_cm3,
+            radlen_cm=None,
+            intlen_cm=None,
+            elements=None,
+            note="FIXME: No Geant4 NIST DB provided; using dummy material.",
+        )
+
+    # Trivial: BOM already provides an exact Geant4 material key
+    if bom_material in g4db:
+        rec = g4db[bom_material]
+        rho_ref = rec.get("density_g_cm3")
+        # Use NIST density for emission; CAD-derived density is used only for matching.
+        rho_used = rho_ref
+
+        rad = rec.get("radlen_cm")
+        itl = rec.get("intlen_cm")
+
+        return ResolvedMaterial(
+            bom_name=bom_material,
+            nist_name=bom_material,
+            score=1.0,
+            rho_used_g_cm3=rho_used,
+            radlen_cm=rad,
+            intlen_cm=itl,
+            elements=rec.get("elements", []),
+            note="Resolved by exact Geant4 NIST name from BOM.",
+        )
+
+    bom_toks = _norm_tokens(bom_material)
+    if not bom_toks:
+        return ResolvedMaterial(
+            bom_name=bom_material,
+            nist_name=None,
+            score=0.0,
+            rho_used_g_cm3=rho_part_g_cm3,
+            radlen_cm=None,
+            intlen_cm=None,
+            elements=None,
+            note="FIXME: Empty/unknown BOM material string; using dummy material.",
+        )
+
+    def _build_custom_from_elements(note_prefix: str) -> Optional[ResolvedMaterial]:
+        s = raw_bom_material
+        if not s:
+            return None
+
+        symbols = set(re.findall(r"\b([A-Z][a-z]?)\b", s))
+        name_to_symbol = {
+            "aluminum": "Al", "aluminium": "Al", "silicon": "Si", "iron": "Fe", "copper": "Cu",
+            "beryllium": "Be", "magnesium": "Mg", "manganese": "Mn", "chromium": "Cr", "nickel": "Ni",
+            "zinc": "Zn", "titanium": "Ti", "tungsten": "W", "lead": "Pb", "tin": "Sn",
+        }
+        for t in bom_toks:
+            if t in name_to_symbol:
+                symbols.add(name_to_symbol[t])
+
+        symbols = [sym for sym in sorted(symbols) if sym in _ELEMENT_TABLE]
+        if not symbols:
+            return None
+
+        frac = 1.0 / float(len(symbols))
+        elems: List[dict] = []
+        for sym in symbols:
+            Z, A = _ELEMENT_TABLE[sym]
+            elems.append({"symbol": sym, "Z": Z, "A_g_mol": A, "mass_fraction": frac})
+
+        return ResolvedMaterial(
+            bom_name=bom_material,
+            nist_name=None,
+            score=0.0,
+            rho_used_g_cm3=rho_part_g_cm3,
+            radlen_cm=None,
+            intlen_cm=None,
+            elements=elems,
+            note=f"FIXME: {note_prefix} No suitable Geant4 NIST material. Emitting placeholder mixture from parsed elements {symbols} with equal mass fractions; please adjust fractions/material.",
+        )
+
+    best = (None, -1.0, 0.0, 0.0)   # (nist_name, score, dens_score, token_score)
+    second = (None, -1.0, 0.0, 0.0)
+
+    bom_has_compound = any(t in bom_toks for t in (
+        "oxide", "dioxide", "carbide", "nitride", "fluoride", "chloride",
+        "sulfate", "phosphate", "glass", "dioxyde"
+    ))
+
+    for nist_name, rec in g4db.items():
+        nist_toks = _norm_tokens(nist_name)
+        ts = _token_score(bom_toks, nist_toks)
+        if ts <= 0.0:
+            continue
+
+        ds = _density_score(rho_part_g_cm3, rec.get("density_g_cm3"))
+
+        # Optional hard density filter
+        if cfg.max_log_density_diff and cfg.max_log_density_diff > 0.0 and rho_part_g_cm3 and rec.get("density_g_cm3"):
+            try:
+                if abs(math.log(float(rec.get("density_g_cm3")) / float(rho_part_g_cm3))) > cfg.max_log_density_diff:
+                    continue
+            except Exception:
+                pass
+
+        nist_has_compound = any(t in nist_toks for t in (
+            "oxide", "dioxide", "carbide", "nitride", "fluoride", "chloride",
+            "sulfate", "phosphate", "glass", "dioxyde"
+        ))
+        compound_pen = cfg.compound_penalty if (nist_has_compound and not bom_has_compound) else 0.0
+
+        score = cfg.w_token * ts + cfg.w_density * ds - compound_pen
+
+        if score > best[1]:
+            second = best
+            best = (nist_name, score, ds, ts)
+        elif score > second[1]:
+            second = (nist_name, score, ds, ts)
+
+    nist_best, score_best, ds_best, ts_best = best
+    nist_second, score_second, _, _ = second
+
+    if nist_best is None or score_best < cfg.min_score:
+        custom = _build_custom_from_elements("Could not resolve with enough confidence.")
+        if custom is not None:
+            return custom
+        return ResolvedMaterial(
+            bom_name=bom_material,
+            nist_name=None,
+            score=float(score_best if score_best > 0 else 0.0),
+            rho_used_g_cm3=rho_part_g_cm3,
+            radlen_cm=None,
+            intlen_cm=None,
+            elements=None,
+            note="FIXME: Could not resolve BOM material to a Geant4 NIST material with enough confidence; using dummy material.",
+        )
+
+    if score_second > 0 and (score_best - score_second) < cfg.ambiguity_delta:
+        custom = _build_custom_from_elements(
+            f"Ambiguous material match (best '{nist_best}' score={score_best:.3f}, second '{nist_second}' score={score_second:.3f})."
+        )
+        if custom is not None:
+            return custom
+        return ResolvedMaterial(
+            bom_name=bom_material,
+            nist_name=None,
+            score=float(score_best),
+            rho_used_g_cm3=rho_part_g_cm3,
+            radlen_cm=None,
+            intlen_cm=None,
+            elements=None,
+            note=f"FIXME: Ambiguous material match (best '{nist_best}' score={score_best:.3f}, second '{nist_second}' score={score_second:.3f}); using dummy material.",
+        )
+
+    rec = g4db[nist_best]
+    rho_ref = rec.get("density_g_cm3")
+    # Use NIST density for emission; CAD-derived density is used only for matching.
+    rho_used = rho_ref
+
+    rad = rec.get("radlen_cm")
+    itl = rec.get("intlen_cm")
+
+    return ResolvedMaterial(
+        bom_name=bom_material,
+        nist_name=nist_best,
+        score=float(score_best),
+        rho_used_g_cm3=rho_used,
+        radlen_cm=rad,
+        intlen_cm=itl,
+        elements=rec.get("elements", []),
+        note=f"Resolved to '{nist_best}' (token={ts_best:.3f}, density={ds_best:.3f}, score={score_best:.3f}).",
+    )
+
+
+def build_volume_to_material_map(
+    bom_entries: List[BomEntry],
+    def_names: Dict[str, str],
+) -> Dict[str, BomEntry]:
+    """
+    Builds a mapping def_lid -> BomEntry by matching the XCAF display name to:
+      - exact part_number match
+      - exact description/name match
+      - substring match on part_number within the XCAF name
+
+    This is heuristic; if nothing matches we keep no assignment for that volume.
+    """
+    # lookup tables
+    by_part: Dict[str, BomEntry] = {}
+    by_name: Dict[str, BomEntry] = {}
+    for e in bom_entries:
+        if e.part_number_key:
+            by_part[e.part_number_key] = e
+        if e.name_key and e.name_key not in by_name:
+            by_name[e.name_key] = e
+
+    out: Dict[str, BomEntry] = {}
+    for lid, disp in def_names.items():
+        key = (disp or "").strip()
+        if not key:
+            continue
+
+        # 1) exact part number
+        if key in by_part:
+            out[lid] = by_part[key]
+            continue
+        # 2) exact name/description
+        if key in by_name:
+            out[lid] = by_name[key]
+            continue
+        # 3) substring match on any part number
+        for pn, e in by_part.items():
+            if pn and pn in key:
+                out[lid] = e
+                break
+    return out
 
 
 # -------------------------------
@@ -306,27 +818,100 @@ static void LoadFacets(const std::string& file, TGeoTessellated* solid, bool che
 """
 
 
-def emit_materials_cpp() -> str:
-    return """  // Default material/medium (placeholder; can be replaced later)
-  TGeoMaterial *mat_Default = new TGeoMaterial("Default", 0., 0., 0.);
-  TGeoMedium   *med_Default = new TGeoMedium("Default", 1, mat_Default);
-"""
+def emit_materials_cpp(
+    used_materials: Dict[str, ResolvedMaterial],
+    # key: BOM material string as used in CSV after normalization
+) -> Tuple[str, Dict[str, str]]:
+    """
+    Emits C++ code defining TGeoMaterial/TGeoMixture + TGeoMedium for all used materials.
+
+    - If a material resolved to a Geant4 NIST entry, emit a physically correct mixture
+      (element mass fractions) and set RadLen/IntLen (from Geant4) when available.
+    - If unresolved/ambiguous, emit a dummy material and annotate with FIXME comments.
+    """
+    cpp: List[str] = []
+    cpp.append("  // Default material/medium (placeholder; can be replaced later)")
+    cpp.append("  TGeoMaterial *mat_Default = new TGeoMaterial(\"Default\", 0., 0., 0.);")
+    cpp.append("  TGeoMedium   *med_Default = new TGeoMedium(\"Default\", 1, mat_Default);")
+    cpp.append("")
+
+    emitted_el: Dict[str, str] = {}
+
+    def _emit_element(el: dict) -> str:
+        sym = el.get("symbol", "X")
+        Z = int(el.get("Z", 0))
+        A = float(el.get("A_g_mol", 0.0))
+        if sym in emitted_el:
+            return emitted_el[sym]
+        safe = sanitize_cpp_name(sym)
+        var = f"el_{safe}"
+        cpp.append(f"  TGeoElement *{var} = new TGeoElement(\"{sym}\", \"{sym}\", {Z}, {A:.10g});")
+        emitted_el[sym] = var
+        return var
+
+    medium_var: Dict[str, str] = {"Default": "med_Default"}
+    next_id = 2
+
+    for bom_mat in sorted(used_materials.keys(), key=lambda s: s.lower()):
+        rm = used_materials[bom_mat]
+        safe = sanitize_cpp_name(bom_mat)
+        base = safe
+        k = 2
+        while f"med_{safe}" in medium_var.values():
+            safe = f"{base}_{k}"
+            k += 1
+
+        rho = rm.rho_used_g_cm3 if (rm.rho_used_g_cm3 and rm.rho_used_g_cm3 > 0.0) else 0.0
+
+        cpp.append(f"  // BOM material: {rm.bom_name}")
+        cpp.append(f"  // {rm.note}")
+
+        if rm.elements:
+            elems = rm.elements
+            if len(elems) == 1 and abs(float(elems[0].get('mass_fraction', 1.0)) - 1.0) < 1e-6:
+                el = elems[0]
+                A = float(el.get("A_g_mol", 0.0))
+                Z = float(el.get("Z", 0))
+                cpp.append(f"  TGeoMaterial *mat_{safe} = new TGeoMaterial(\"{bom_mat}\", {A:.10g}, {Z:.10g}, {rho:.10g});")
+            else:
+                cpp.append(f"  TGeoMixture  *mat_{safe} = new TGeoMixture(\"{bom_mat}\", {len(elems)}, {rho:.10g});")
+                for el in elems:
+                    elvar = _emit_element(el)
+                    w = float(el.get("mass_fraction", 0.0))
+                    cpp.append(f"  mat_{safe}->AddElement({elvar}, {w:.10g});")
+
+            if rm.radlen_cm is not None and rm.intlen_cm is not None:
+                cpp.append(f"  mat_{safe}->SetRadLen({float(rm.radlen_cm):.10g}, {float(rm.intlen_cm):.10g});")
+            elif rm.radlen_cm is not None:
+                cpp.append(f"  mat_{safe}->SetRadLen({float(rm.radlen_cm):.10g});")
+        else:
+            cpp.append("  // FIXME: Unresolved material. Replace with a proper TGeoMaterial/TGeoMixture.")
+            cpp.append(f"  TGeoMaterial *mat_{safe} = new TGeoMaterial(\"{bom_mat}\", 0., 0., {rho:.10g});")
+
+        cpp.append(f"  TGeoMedium   *med_{safe} = new TGeoMedium(\"{bom_mat}\", {next_id}, mat_{safe});")
+        cpp.append("")
+        medium_var[bom_mat] = f"med_{safe}"
+        next_id += 1
+
+    return "\n".join(cpp), medium_var
 
 
-def emit_tessellated_cpp(lid: str, vol_display_name: str, facet_abspath: str, ntriangles: int) -> str:
+
+
+def emit_tessellated_cpp(lid: str, vol_display_name: str, facet_abspath: str, ntriangles: int, medium_var: str) -> str:
     safe = sanitize_cpp_name(lid)
     shape_name = vol_display_name if vol_display_name else lid
 
     if ntriangles <= 0:
         out = []
         out.append(f'  TGeoBBox *solid_{safe} = new TGeoBBox("{shape_name}", 0.001, 0.001, 0.001);')
-        out.append(f'  TGeoVolume *vol_{safe} = new TGeoVolume("{shape_name}", solid_{safe}, med_Default);')
+        out.append(f'  TGeoVolume *vol_{safe} = new TGeoVolume("{shape_name}", solid_{safe}, {medium_var});')
         return "\n".join(out)
 
     out = []
     out.append(f'  TGeoTessellated *solid_{safe} = new TGeoTessellated("{shape_name}", {ntriangles});')
     out.append(f'  LoadFacets("{facet_abspath}", solid_{safe}, check);')
-    out.append(f'  TGeoVolume *vol_{safe} = new TGeoVolume("{shape_name}", solid_{safe}, med_Default);')
+    out.append(f'  TGeoVolume *vol_{safe} = new TGeoVolume("{shape_name}", solid_{safe}, {medium_var});')
     return "\n".join(out)
 
 
@@ -340,12 +925,13 @@ def emit_assembly_cpp(lid: str, asm_display_name: str) -> str:
 # Definition graph extraction
 # -------------------------------
 
-logical_volumes = {}     # def_lid -> triangles
-def_names = {}           # def_lid -> human display name (may be "")
-assemblies = set()       # def_lid
-placements = []          # (parent_def_lid, child_def_lid, gp_Trsf local)
-top_defs = set()         # top definition lids
-visited_defs = set()     # expanded defs
+logical_volumes: Dict[str, list] = {}     # def_lid -> triangles
+def_names: Dict[str, str] = {}           # def_lid -> human display name (may be "")
+def_volumes_cm3: Dict[str, float] = {}   # def_lid -> volume in cm^3 (leaf only)
+assemblies = set()                       # def_lid
+placements = []                          # (parent_def_lid, child_def_lid, gp_Trsf local)
+top_defs = set()                         # top definition lids
+visited_defs = set()                     # expanded defs
 
 
 def cpp_var_for_def(lid: str) -> str:
@@ -393,6 +979,13 @@ def expand_definition(def_label: TDF_Label, shape_tool, meshparam=None, scale_to
     if shape_tool.IsSimpleShape(def_label):
         if def_lid not in logical_volumes:
             shape = shape_tool.GetShape(def_label)
+
+            # store volume (for density estimation)
+            try:
+                def_volumes_cm3[def_lid] = volume_cm3_of_shape(shape, scale_to_cm=scale_to_cm)
+            except Exception:
+                def_volumes_cm3[def_lid] = 0.0
+
             do_meshing = (meshparam is not None) and meshparam.get("do_meshing", None) is True
             logical_volumes[def_lid] = triangulate_CAD_solid(shape, meshparam=meshparam, scale_to_cm=scale_to_cm) if do_meshing else triangulate_asbbox(shape, scale_to_cm=scale_to_cm)
         return
@@ -401,9 +994,10 @@ def expand_definition(def_label: TDF_Label, shape_tool, meshparam=None, scale_to
 
 
 def extract_graph(step_path: str, meshparam=None, scale_to_cm: float = 1.0):
-    global logical_volumes, def_names, assemblies, placements, top_defs, visited_defs
+    global logical_volumes, def_names, def_volumes_cm3, assemblies, placements, top_defs, visited_defs
     logical_volumes = {}
     def_names = {}
+    def_volumes_cm3 = {}
     assemblies = set()
     placements = []
     top_defs = set()
@@ -439,7 +1033,52 @@ def emit_placement_cpp(parent_def: str, child_def: str, trsf: gp_Trsf, copy_no: 
     return trsf_to_tgeo(trsf, tr_name, scale_to_cm) + f"  {parent_cpp}->AddNode({child_cpp}, {copy_no}, {tr_name});\n"
 
 
-def emit_root_macro(step_path: str, out_folder: _Path, meshparam=None, step_unit: str = "auto"):
+
+def _compute_density_g_cm3(
+    volume_cm3: float,
+    mass_value: float,
+    mass_unit: str,
+) -> Tuple[Optional[float], str]:
+    """
+    Computes an effective part density from (mass, CAD volume).
+
+    Returns (rho_g_cm3 or None, comment). If rho is None, caller should fall back
+    to the Geant4 NIST density (if resolved) or to a dummy density.
+    """
+    if not volume_cm3 or volume_cm3 <= 0:
+        return None, "no CAD volume available for density"
+
+    if (mass_value is None) or (isinstance(mass_value, float) and math.isnan(mass_value)):
+        return None, "no BOM mass available for density"
+
+    mass_g = float(mass_value)
+    mu = (mass_unit or "kg").lower()
+    if mu == "kg":
+        mass_g *= 1000.0
+    elif mu == "g":
+        pass
+    else:
+        # unknown unit: assume kg
+        mass_g *= 1000.0
+
+    rho = mass_g / float(volume_cm3)
+    # Guard against obvious unit/volume issues
+    if not (0.01 < rho < 50.0):
+        return None, f"computed density {rho:.3g} g/cm3 rejected (unit mismatch?)"
+
+    return rho, "density from BOM mass and CAD volume"
+
+
+def emit_root_macro(
+    step_path: str,
+    out_folder: _Path,
+    meshparam=None,
+    step_unit: str = "auto",
+    materials_csv: Optional[str] = None,
+    bom_mass_unit: str = "kg",
+    g4_nist_json: Optional[str] = None,
+    mat_cfg: Optional[MatMatchConfig] = None,
+):
     if (step_unit or "auto").lower() == "auto":
         detected = detect_step_length_unit(step_path)
         scale_to_cm = step_unit_scale_to_cm(detected)
@@ -453,6 +1092,28 @@ def emit_root_macro(step_path: str, out_folder: _Path, meshparam=None, step_unit
     out_folder = out_folder.expanduser().resolve()
     out_folder.mkdir(parents=True, exist_ok=True)
 
+
+    # --- Geant4 NIST material DB (optional but recommended) ---
+    g4db: Optional[Dict[str, dict]] = None
+    if g4_nist_json:
+        g4db = load_g4_nist_db(g4_nist_json)
+        print(f"Loaded Geant4 NIST DB with {len(g4db)} materials from: {g4_nist_json}")
+    else:
+        print("No --g4-nist-json provided: unresolved materials will fall back to dummy ROOT materials.")
+    mat_cfg = mat_cfg or MatMatchConfig()
+
+
+    # --- BOM: map volumes to materials (heuristic) ---
+    lid_to_bom: Dict[str, BomEntry] = {}
+    if materials_csv:
+        bom_entries = read_bom_csv(materials_csv)
+        lid_to_bom = build_volume_to_material_map(bom_entries, def_names)
+        print(f"Loaded {len(bom_entries)} BOM entries from: {materials_csv}")
+        print(f"Matched {len(lid_to_bom)} CAD logical volumes to BOM entries (by name/part-number heuristics)")
+    else:
+        print("No --materials-csv provided: emitting Default medium for all logical volumes")
+
+    # --- facet files ---
     facet_files = {}  # def_lid -> absolute path string
     for lid, tris in logical_volumes.items():
         disp = def_names.get(lid, "")
@@ -463,16 +1124,63 @@ def emit_root_macro(step_path: str, out_folder: _Path, meshparam=None, step_unit
         write_facets_bin(fpath, tris)
         facet_files[lid] = str(fpath).replace("\\", "\\\\")  # C++ string literal safety
 
-    cpp = []
+    # --- which materials do we need to emit? ---
+    
+    # --- materials: collect unique BOM material strings actually used by leaf volumes ---
+    # We resolve each unique BOM string to a Geant4 NIST material using string + density scoring.
+    used_materials: Dict[str, ResolvedMaterial] = {}
+
+    # Precompute one representative part density per BOM material (first good value wins)
+    mat_to_rho: Dict[str, Optional[float]] = {}
+    mat_to_rho_note: Dict[str, str] = {}
+
+    for lid in logical_volumes.keys():
+        if lid not in lid_to_bom:
+            continue
+        bom = lid_to_bom[lid]
+        mat_name = normalize_material_name(bom.material)
+
+        if mat_name not in mat_to_rho:
+            rho_part, rho_note = _compute_density_g_cm3(
+                def_volumes_cm3.get(lid, 0.0),
+                bom.mass_value,
+                bom_mass_unit,
+            )
+            mat_to_rho[mat_name] = rho_part
+            mat_to_rho_note[mat_name] = rho_note
+
+    for mat_name in sorted(mat_to_rho.keys(), key=lambda s: s.lower()):
+        rho_part = mat_to_rho.get(mat_name)
+        rm = resolve_bom_material(mat_name, rho_part, g4db, mat_cfg)
+
+        # Fold density provenance into the note for geom.C comments
+        rm.note = f"{rm.note} (density: {mat_to_rho_note.get(mat_name, 'n/a')})"
+
+        if rm.nist_name is None:
+            print(f"WARNING: Unresolved/ambiguous material '{mat_name}'. See FIXME in generated geom.C.")
+
+        used_materials[mat_name] = rm
+
+    materials_cpp, medium_var_map = emit_materials_cpp(used_materials)
+
+    # --- emit C++ macro ---
+    cpp: List[str] = []
     cpp.append(emit_cpp_prelude())
 
     cpp.append("TGeoVolume* build(bool check=true) {")
     cpp.append('  if (!gGeoManager) { throw std::runtime_error("gGeoManager is null. Call build_and_export() or create a TGeoManager first."); }')
-    cpp.append(emit_materials_cpp())
+    cpp.append(materials_cpp)
 
     for lid in logical_volumes.keys():
         ntriangles = len(logical_volumes[lid])
-        cpp.append(emit_tessellated_cpp(lid, def_names.get(lid, ""), facet_files[lid], ntriangles))
+
+        # choose medium for this volume
+        med = "med_Default"
+        if lid in lid_to_bom:
+            mat_name = normalize_material_name(lid_to_bom[lid].material)
+            med = medium_var_map.get(mat_name, "med_Default")
+
+        cpp.append(emit_tessellated_cpp(lid, def_names.get(lid, ""), facet_files[lid], ntriangles, med))
 
     for lid in sorted(assemblies):
         cpp.append(emit_assembly_cpp(lid, def_names.get(lid, "")))
@@ -527,7 +1235,7 @@ def traverse_print(label, shape_tool, depth=0):
     indent = "  " * depth
     name = label.GetLabelName()
     entry = label_entry(label)
-    print(f"{indent}- {name}  =>[{entry}]")
+    print(f"{indent}- {name}  =>[{entry}]") 
 
     if shape_tool.IsReference(label):
         ref_label = TDF_Label()
@@ -569,7 +1277,21 @@ def main():
     ap.add_argument("--mesh", action="store_true", help="Use full BRepMesh triangulation instead of bounding boxes")
     ap.add_argument("--print-tree", action="store_true", help="Just prints the geometry tree")
     ap.add_argument("--mesh-prec", default=0.1, help="meshing precision. lower --> slower")
-    ap.add_argument("--step-unit", default="auto", choices=["auto", "mm", "cm", "m", "in", "ft"], help="STEP length unit override (default: auto-detect)")
+    ap.add_argument("--step-unit", default="auto", choices=["auto", "mm", "cm", "m", "in", "ft"], help="STEP length unit override (default: auto-detect); TGeo expects cm")
+
+    # NEW: BOM / material support
+    ap.add_argument("--materials-csv", default=None, help="BOM CSV file providing material + mass per part (optional)")
+    ap.add_argument("--bom-mass-unit", default="kg", choices=["kg", "g"], help="Unit of the BOM mass column (default: kg)")
+    ap.add_argument("--g4-nist-json", default=None, help="Path to Geant4 NIST DB JSON dump (from nist_export_all). Enables TGeoMixture emission + RadLen/IntLen.")
+
+
+    # Material matching scoring knobs (only used if --g4-nist-json is provided)
+    ap.add_argument("--mat-min-score", type=float, default=0.35, help="Minimum combined score to accept a G4 NIST material match (default: 0.35)")
+    ap.add_argument("--mat-ambiguity-delta", type=float, default=0.05, help="If best-second < delta, treat match as ambiguous/unresolved (default: 0.05)")
+    ap.add_argument("--mat-w-token", type=float, default=0.75, help="Weight for token/name similarity score (default: 0.75)")
+    ap.add_argument("--mat-w-density", type=float, default=0.25, help="Weight for density proximity score (default: 0.25)")
+    ap.add_argument("--mat-max-log-density-diff", type=float, default=0.0, help="Optional hard density filter in log-space (0 disables). Example 0.8 ~ within 2.2x (default: 0.0)")
+    ap.add_argument("--mat-compound-penalty", type=float, default=0.25, help="Penalty for matching to oxides/carbides/etc. when BOM doesn't mention them (default: 0.25)")
 
     args = ap.parse_args()
 
@@ -584,11 +1306,30 @@ def main():
 
     meshparam = {"do_meshing": args.mesh, "lin_defl": args.mesh_prec, "ang_defl": args.mesh_prec}
 
+
+    mat_cfg = MatMatchConfig(
+    min_score=args.mat_min_score,
+    ambiguity_delta=args.mat_ambiguity_delta,
+    w_token=args.mat_w_token,
+    w_density=args.mat_w_density,
+    max_log_density_diff=args.mat_max_log_density_diff,
+    compound_penalty=args.mat_compound_penalty,
+    )
+
     out_folder = out_folder.expanduser().resolve()
     out_folder.mkdir(parents=True, exist_ok=True)
 
     out_macro = (out_folder / _Path(args.out).name).resolve()
-    code = emit_root_macro(step_path, out_folder, meshparam=meshparam, step_unit=args.step_unit)
+    code = emit_root_macro(
+        step_path,
+        out_folder,
+        meshparam=meshparam,
+        step_unit=args.step_unit,
+        materials_csv=args.materials_csv,
+        bom_mass_unit=args.bom_mass_unit,
+        g4_nist_json=args.g4_nist_json,
+        mat_cfg=mat_cfg,
+    )
     out_macro.write_text(code)
 
     print(f"Wrote ROOT macro: {out_macro}")

--- a/scripts/geometry/g4_nist_database/G4_NIST_DB.json
+++ b/scripts/geometry/g4_nist_database/G4_NIST_DB.json
@@ -1,0 +1,7160 @@
+{
+  "schema": "g4_nist_export_v1",
+  "count_requested": 309,
+  "materials": {
+    "G4_1,2-DICHLOROBENZENE": {
+      "name": "G4_1,2-DICHLOROBENZENE",
+      "density_g_cm3": 1.3048000000,
+      "radlen_cm": 20.7489144362,
+      "intlen_cm": 69.0775200428,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4902297089
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0274267115
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.4823435796
+        }
+      ]
+    },
+    "G4_1,2-DICHLOROETHANE": {
+      "name": "G4_1,2-DICHLOROETHANE",
+      "density_g_cm3": 1.2351000000,
+      "radlen_cm": 18.6131823209,
+      "intlen_cm": 77.6700314494,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2427431829
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0407420059
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.7165148112
+        }
+      ]
+    },
+    "G4_A-150_TISSUE": {
+      "name": "G4_A-150_TISSUE",
+      "density_g_cm3": 1.1270000000,
+      "radlen_cm": 37.1439852154,
+      "intlen_cm": 63.7486912428,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1013268987
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7755002245
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0350569649
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0523159477
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.0174219826
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.0183779816
+        }
+      ]
+    },
+    "G4_ACETONE": {
+      "name": "G4_ACETONE",
+      "density_g_cm3": 0.7899000000,
+      "radlen_cm": 52.2534185395,
+      "intlen_cm": 91.4814595809,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6203973505
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1041274661
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2754751834
+        }
+      ]
+    },
+    "G4_ACETYLENE": {
+      "name": "G4_ACETYLENE",
+      "density_g_cm3": 0.0010967000,
+      "radlen_cm": 39930.0227629710,
+      "intlen_cm": 66449.2307704659,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9225773293
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0774226707
+        }
+      ]
+    },
+    "G4_ADENINE": {
+      "name": "G4_ADENINE",
+      "density_g_cm3": 1.3500000000,
+      "radlen_cm": 30.0581586935,
+      "intlen_cm": 58.0823779196,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4444232424
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0372959895
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.5182807681
+        }
+      ]
+    },
+    "G4_ADIPOSE_TISSUE_ICRP": {
+      "name": "G4_ADIPOSE_TISSUE_ICRP",
+      "density_g_cm3": 0.9500000000,
+      "radlen_cm": 43.3949297995,
+      "intlen_cm": 75.2919618730,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1140000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5980000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0070000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2780000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0010000000
+        }
+      ]
+    },
+    "G4_AIR": {
+      "name": "G4_AIR",
+      "density_g_cm3": 0.0012047900,
+      "radlen_cm": 30392.0700501740,
+      "intlen_cm": 71009.5012707064,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0001240001
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.7552677553
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2317812318
+        },
+        {
+          "symbol": "Ar",
+          "Z": 18,
+          "A_g_mol": 39.9476933511,
+          "mass_fraction": 0.0128270128
+        }
+      ]
+    },
+    "G4_ALANINE": {
+      "name": "G4_ALANINE",
+      "density_g_cm3": 1.4200000000,
+      "radlen_cm": 27.7725516260,
+      "intlen_cm": 53.1723594099,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4044321096
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0791931803
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1572145382
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3591601720
+        }
+      ]
+    },
+    "G4_ALUMINUM_OXIDE": {
+      "name": "G4_ALUMINUM_OXIDE",
+      "density_g_cm3": 3.9700000000,
+      "radlen_cm": 7.0377543639,
+      "intlen_cm": 24.2683456290,
+      "elements": [
+        {
+          "symbol": "Al",
+          "Z": 13,
+          "A_g_mol": 26.9815000000,
+          "mass_fraction": 0.5292504916
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4707495084
+        }
+      ]
+    },
+    "G4_AMBER": {
+      "name": "G4_AMBER",
+      "density_g_cm3": 1.1000000000,
+      "radlen_cm": 39.1372915409,
+      "intlen_cm": 64.6512140234,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1059301059
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7889737890
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1050961051
+        }
+      ]
+    },
+    "G4_AMMONIA": {
+      "name": "G4_AMMONIA",
+      "density_g_cm3": 0.0008260190,
+      "radlen_cm": 49481.0183957974,
+      "intlen_cm": 81682.0756970836,
+      "elements": [
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.8224476051
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1775523949
+        }
+      ]
+    },
+    "G4_ANILINE": {
+      "name": "G4_ANILINE",
+      "density_g_cm3": 1.0235000000,
+      "radlen_cm": 41.9603888047,
+      "intlen_cm": 71.8321544827,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7738313735
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0757632320
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1504053945
+        }
+      ]
+    },
+    "G4_ANTHRACENE": {
+      "name": "G4_ANTHRACENE",
+      "density_g_cm3": 1.2830000000,
+      "radlen_cm": 33.8977543296,
+      "intlen_cm": 58.2256880136,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9434470990
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0565529010
+        }
+      ]
+    },
+    "G4_Ac": {
+      "name": "G4_Ac",
+      "density_g_cm3": 10.0700000000,
+      "radlen_cm": 0.6015581907,
+      "intlen_cm": 21.2030538527,
+      "elements": [
+        {
+          "symbol": "Ac",
+          "Z": 89,
+          "A_g_mol": 227.0280000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ag": {
+      "name": "G4_Ag",
+      "density_g_cm3": 10.5000000000,
+      "radlen_cm": 0.8542919107,
+      "intlen_cm": 15.8675527542,
+      "elements": [
+        {
+          "symbol": "Ag",
+          "Z": 47,
+          "A_g_mol": 107.8682200000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Al": {
+      "name": "G4_Al",
+      "density_g_cm3": 2.6990000000,
+      "radlen_cm": 8.8963176127,
+      "intlen_cm": 38.8944132871,
+      "elements": [
+        {
+          "symbol": "Al",
+          "Z": 13,
+          "A_g_mol": 26.9815000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Am": {
+      "name": "G4_Am",
+      "density_g_cm3": 13.6700000000,
+      "radlen_cm": 0.4243095287,
+      "intlen_cm": 15.9785730103,
+      "elements": [
+        {
+          "symbol": "Am",
+          "Z": 95,
+          "A_g_mol": 243.0610000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ar": {
+      "name": "G4_Ar",
+      "density_g_cm3": 0.0016620100,
+      "radlen_cm": 11762.1436719519,
+      "intlen_cm": 71988.8135208583,
+      "elements": [
+        {
+          "symbol": "Ar",
+          "Z": 18,
+          "A_g_mol": 39.9476933511,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_As": {
+      "name": "G4_As",
+      "density_g_cm3": 5.7300000000,
+      "radlen_cm": 2.0837957777,
+      "intlen_cm": 25.7503105909,
+      "elements": [
+        {
+          "symbol": "As",
+          "Z": 33,
+          "A_g_mol": 74.9216000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_At": {
+      "name": "G4_At",
+      "density_g_cm3": 9.3200000000,
+      "radlen_cm": 0.6507992580,
+      "intlen_cm": 22.3211364933,
+      "elements": [
+        {
+          "symbol": "At",
+          "Z": 85,
+          "A_g_mol": 209.9870000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Au": {
+      "name": "G4_Au",
+      "density_g_cm3": 19.3200000000,
+      "radlen_cm": 0.3344364418,
+      "intlen_cm": 10.5404409730,
+      "elements": [
+        {
+          "symbol": "Au",
+          "Z": 79,
+          "A_g_mol": 196.9670000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_B": {
+      "name": "G4_B",
+      "density_g_cm3": 2.3700000000,
+      "radlen_cm": 22.2307454494,
+      "intlen_cm": 32.6544150557,
+      "elements": [
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_B-100_BONE": {
+      "name": "G4_B-100_BONE",
+      "density_g_cm3": 1.4500000000,
+      "radlen_cm": 22.1470650946,
+      "intlen_cm": 55.3715324980,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0654709345
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5369444631
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0214999785
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0320849679
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.1674108326
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.1765888234
+        }
+      ]
+    },
+    "G4_BAKELITE": {
+      "name": "G4_BAKELITE",
+      "density_g_cm3": 1.2500000000,
+      "radlen_cm": 33.3909731372,
+      "intlen_cm": 60.5624222030,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0574410000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7745910000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1679680000
+        }
+      ]
+    },
+    "G4_BARIUM_FLUORIDE": {
+      "name": "G4_BARIUM_FLUORIDE",
+      "density_g_cm3": 4.8900000000,
+      "radlen_cm": 2.0272211742,
+      "intlen_cm": 30.7133072542,
+      "elements": [
+        {
+          "symbol": "Ba",
+          "Z": 56,
+          "A_g_mol": 137.3267993000,
+          "mass_fraction": 0.7832761810
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.2167238190
+        }
+      ]
+    },
+    "G4_BARIUM_SULFATE": {
+      "name": "G4_BARIUM_SULFATE",
+      "density_g_cm3": 4.5000000000,
+      "radlen_cm": 2.5872675325,
+      "intlen_cm": 29.2271363557,
+      "elements": [
+        {
+          "symbol": "Ba",
+          "Z": 56,
+          "A_g_mol": 137.3267993000,
+          "mass_fraction": 0.5883993303
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.1373925574
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2742081123
+        }
+      ]
+    },
+    "G4_BENZENE": {
+      "name": "G4_BENZENE",
+      "density_g_cm3": 0.8786500000,
+      "radlen_cm": 49.8392488069,
+      "intlen_cm": 82.9395907198,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9225773293
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0774226707
+        }
+      ]
+    },
+    "G4_BERYLLIUM_OXIDE": {
+      "name": "G4_BERYLLIUM_OXIDE",
+      "density_g_cm3": 3.0100000000,
+      "radlen_cm": 13.7223989677,
+      "intlen_cm": 27.2312420821,
+      "elements": [
+        {
+          "symbol": "Be",
+          "Z": 4,
+          "A_g_mol": 9.0121800000,
+          "mass_fraction": 0.3603204378
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6396795622
+        }
+      ]
+    },
+    "G4_BGO": {
+      "name": "G4_BGO",
+      "density_g_cm3": 7.1300000000,
+      "radlen_cm": 1.1180299951,
+      "intlen_cm": 22.7101337225,
+      "elements": [
+        {
+          "symbol": "Bi",
+          "Z": 83,
+          "A_g_mol": 208.9800000000,
+          "mass_fraction": 0.6710168961
+        },
+        {
+          "symbol": "Ge",
+          "Z": 32,
+          "A_g_mol": 72.6127869100,
+          "mass_fraction": 0.1748650836
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1541180203
+        }
+      ]
+    },
+    "G4_BLOOD_ICRP": {
+      "name": "G4_BLOOD_ICRP",
+      "density_g_cm3": 1.0600000000,
+      "radlen_cm": 34.4916255606,
+      "intlen_cm": 71.4008796952,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1020000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1100000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0330000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7450000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.0010000000
+        }
+      ]
+    },
+    "G4_BONE_COMPACT_ICRU": {
+      "name": "G4_BONE_COMPACT_ICRU",
+      "density_g_cm3": 1.8500000000,
+      "radlen_cm": 16.4792529255,
+      "intlen_cm": 44.4244163422,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0640000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2780000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0270000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4100000000
+        },
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0700000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.1470000000
+        }
+      ]
+    },
+    "G4_BONE_CORTICAL_ICRP": {
+      "name": "G4_BONE_CORTICAL_ICRP",
+      "density_g_cm3": 1.9200000000,
+      "radlen_cm": 14.0594998747,
+      "intlen_cm": 46.4710446539,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0340000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1550000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0420000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4350000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.1030000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.2250000000
+        }
+      ]
+    },
+    "G4_BORON_CARBIDE": {
+      "name": "G4_BORON_CARBIDE",
+      "density_g_cm3": 2.5200000000,
+      "radlen_cm": 19.8956330875,
+      "intlen_cm": 30.9425465737,
+      "elements": [
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 0.7826299987
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2173700013
+        }
+      ]
+    },
+    "G4_BORON_OXIDE": {
+      "name": "G4_BORON_OXIDE",
+      "density_g_cm3": 1.8120000000,
+      "radlen_cm": 21.2007815469,
+      "intlen_cm": 46.6495645684,
+      "elements": [
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 0.3105712358
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6894287642
+        }
+      ]
+    },
+    "G4_BRAIN_ICRP": {
+      "name": "G4_BRAIN_ICRP",
+      "density_g_cm3": 1.0400000000,
+      "radlen_cm": 35.4025933979,
+      "intlen_cm": 72.1555402096,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1070000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1450000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0220000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7120000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0040000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0030000000
+        }
+      ]
+    },
+    "G4_BRASS": {
+      "name": "G4_BRASS",
+      "density_g_cm3": 8.5200000000,
+      "radlen_cm": 1.3674058172,
+      "intlen_cm": 16.9476882148,
+      "elements": [
+        {
+          "symbol": "Cu",
+          "Z": 29,
+          "A_g_mol": 63.5456450600,
+          "mass_fraction": 0.5751304341
+        },
+        {
+          "symbol": "Zn",
+          "Z": 30,
+          "A_g_mol": 65.3955232900,
+          "mass_fraction": 0.3341218915
+        },
+        {
+          "symbol": "Pb",
+          "Z": 82,
+          "A_g_mol": 207.2170000000,
+          "mass_fraction": 0.0907476744
+        }
+      ]
+    },
+    "G4_BRONZE": {
+      "name": "G4_BRONZE",
+      "density_g_cm3": 8.8200000000,
+      "radlen_cm": 1.3674305230,
+      "intlen_cm": 16.1768594449,
+      "elements": [
+        {
+          "symbol": "Cu",
+          "Z": 29,
+          "A_g_mol": 63.5456450600,
+          "mass_fraction": 0.8493676870
+        },
+        {
+          "symbol": "Zn",
+          "Z": 30,
+          "A_g_mol": 65.3955232900,
+          "mass_fraction": 0.0883914919
+        },
+        {
+          "symbol": "Pb",
+          "Z": 82,
+          "A_g_mol": 207.2170000000,
+          "mass_fraction": 0.0622408211
+        }
+      ]
+    },
+    "G4_BUTANE": {
+      "name": "G4_BUTANE",
+      "density_g_cm3": 0.0024934300,
+      "radlen_cm": 18139.0227601157,
+      "intlen_cm": 26268.9556216470,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8265829410
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1734170590
+        }
+      ]
+    },
+    "G4_Ba": {
+      "name": "G4_Ba",
+      "density_g_cm3": 3.5000000000,
+      "radlen_cm": 2.3733248313,
+      "intlen_cm": 51.5923290927,
+      "elements": [
+        {
+          "symbol": "Ba",
+          "Z": 56,
+          "A_g_mol": 137.3267993000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Be": {
+      "name": "G4_Be",
+      "density_g_cm3": 1.8480000000,
+      "radlen_cm": 35.2759751356,
+      "intlen_cm": 39.4132938630,
+      "elements": [
+        {
+          "symbol": "Be",
+          "Z": 4,
+          "A_g_mol": 9.0121800000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Bi": {
+      "name": "G4_Bi",
+      "density_g_cm3": 9.7470000000,
+      "radlen_cm": 0.6453882442,
+      "intlen_cm": 21.3091121330,
+      "elements": [
+        {
+          "symbol": "Bi",
+          "Z": 83,
+          "A_g_mol": 208.9800000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Bk": {
+      "name": "G4_Bk",
+      "density_g_cm3": 14.0000000000,
+      "radlen_cm": 0.4064786913,
+      "intlen_cm": 15.6872462983,
+      "elements": [
+        {
+          "symbol": "Bk",
+          "Z": 97,
+          "A_g_mol": 247.0700000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Br": {
+      "name": "G4_Br",
+      "density_g_cm3": 0.0070721000,
+      "radlen_cm": 1615.1154699324,
+      "intlen_cm": 21316.1276450533,
+      "elements": [
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_C": {
+      "name": "G4_C",
+      "density_g_cm3": 2.0000000000,
+      "radlen_cm": 21.3485184336,
+      "intlen_cm": 40.0769468390,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_C-552": {
+      "name": "G4_C-552",
+      "density_g_cm3": 1.7600000000,
+      "radlen_cm": 21.3755217174,
+      "intlen_cm": 47.2178616072,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0246800247
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5016105016
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0045270045
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.4652094652
+        },
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 0.0039730040
+        }
+      ]
+    },
+    "G4_CADMIUM_TELLURIDE": {
+      "name": "G4_CADMIUM_TELLURIDE",
+      "density_g_cm3": 6.2000000000,
+      "radlen_cm": 1.4363029675,
+      "intlen_cm": 27.8572965803,
+      "elements": [
+        {
+          "symbol": "Cd",
+          "Z": 48,
+          "A_g_mol": 112.4114464000,
+          "mass_fraction": 0.4683531856
+        },
+        {
+          "symbol": "Te",
+          "Z": 52,
+          "A_g_mol": 127.6028203000,
+          "mass_fraction": 0.5316468144
+        }
+      ]
+    },
+    "G4_CADMIUM_TUNGSTATE": {
+      "name": "G4_CADMIUM_TUNGSTATE",
+      "density_g_cm3": 7.9000000000,
+      "radlen_cm": 1.0975367504,
+      "intlen_cm": 19.6990488848,
+      "elements": [
+        {
+          "symbol": "Cd",
+          "Z": 48,
+          "A_g_mol": 112.4114464000,
+          "mass_fraction": 0.3120367899
+        },
+        {
+          "symbol": "W",
+          "Z": 74,
+          "A_g_mol": 183.8416100000,
+          "mass_fraction": 0.5103158768
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1776473334
+        }
+      ]
+    },
+    "G4_CALCIUM_CARBONATE": {
+      "name": "G4_CALCIUM_CARBONATE",
+      "density_g_cm3": 2.8000000000,
+      "radlen_cm": 8.5806303005,
+      "intlen_cm": 34.7483442364,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.4004321837
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1200030341
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4795647823
+        }
+      ]
+    },
+    "G4_CALCIUM_FLUORIDE": {
+      "name": "G4_CALCIUM_FLUORIDE",
+      "density_g_cm3": 3.1800000000,
+      "radlen_cm": 6.7515445571,
+      "intlen_cm": 33.1126825134,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.5133284414
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.4866715586
+        }
+      ]
+    },
+    "G4_CALCIUM_OXIDE": {
+      "name": "G4_CALCIUM_OXIDE",
+      "density_g_cm3": 3.3000000000,
+      "radlen_cm": 5.7605472772,
+      "intlen_cm": 32.9311668963,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.7146910499
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2853089501
+        }
+      ]
+    },
+    "G4_CALCIUM_SULFATE": {
+      "name": "G4_CALCIUM_SULFATE",
+      "density_g_cm3": 2.9600000000,
+      "radlen_cm": 7.6700891493,
+      "intlen_cm": 34.1039310668,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.2943846699
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.2355348323
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4700804977
+        }
+      ]
+    },
+    "G4_CALCIUM_TUNGSTATE": {
+      "name": "G4_CALCIUM_TUNGSTATE",
+      "density_g_cm3": 6.0620000000,
+      "radlen_cm": 1.5061183605,
+      "intlen_cm": 23.9389476671,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.1391998505
+        },
+        {
+          "symbol": "W",
+          "Z": 74,
+          "A_g_mol": 183.8416100000,
+          "mass_fraction": 0.6385224915
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2222776580
+        }
+      ]
+    },
+    "G4_CARBON_DIOXIDE": {
+      "name": "G4_CARBON_DIOXIDE",
+      "density_g_cm3": 0.0018421200,
+      "radlen_cm": 19648.6261057218,
+      "intlen_cm": 46600.4101036886,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2729122504
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7270877496
+        }
+      ]
+    },
+    "G4_CARBON_TETRACHLORIDE": {
+      "name": "G4_CARBON_TETRACHLORIDE",
+      "density_g_cm3": 1.5940000000,
+      "radlen_cm": 12.6353035438,
+      "intlen_cm": 69.7653934353,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0780825377
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.9219174623
+        }
+      ]
+    },
+    "G4_CELLULOSE_BUTYRATE": {
+      "name": "G4_CELLULOSE_BUTYRATE",
+      "density_g_cm3": 1.2000000000,
+      "radlen_cm": 33.1272771295,
+      "intlen_cm": 63.5368792659,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0671250000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5454030000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3874720000
+        }
+      ]
+    },
+    "G4_CELLULOSE_CELLOPHANE": {
+      "name": "G4_CELLULOSE_CELLOPHANE",
+      "density_g_cm3": 1.4200000000,
+      "radlen_cm": 27.2894013482,
+      "intlen_cm": 54.5257863934,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4444558564
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0621645440
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4933795996
+        }
+      ]
+    },
+    "G4_CELLULOSE_NITRATE": {
+      "name": "G4_CELLULOSE_NITRATE",
+      "density_g_cm3": 1.4900000000,
+      "radlen_cm": 24.9514919127,
+      "intlen_cm": 54.9526743102,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0292160000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2712960000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1212760000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5782120000
+        }
+      ]
+    },
+    "G4_CERIC_SULFATE": {
+      "name": "G4_CERIC_SULFATE",
+      "density_g_cm3": 1.0300000000,
+      "radlen_cm": 34.3245544164,
+      "intlen_cm": 73.8457863342,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1075960000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0008000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.8749760000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0146270000
+        },
+        {
+          "symbol": "Ce",
+          "Z": 58,
+          "A_g_mol": 140.1153107700,
+          "mass_fraction": 0.0020010000
+        }
+      ]
+    },
+    "G4_CESIUM_FLUORIDE": {
+      "name": "G4_CESIUM_FLUORIDE",
+      "density_g_cm3": 4.1150000000,
+      "radlen_cm": 2.2265267957,
+      "intlen_cm": 38.9591822729,
+      "elements": [
+        {
+          "symbol": "Cs",
+          "Z": 55,
+          "A_g_mol": 132.9050000000,
+          "mass_fraction": 0.8749310417
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.1250689583
+        }
+      ]
+    },
+    "G4_CESIUM_IODIDE": {
+      "name": "G4_CESIUM_IODIDE",
+      "density_g_cm3": 4.5100000000,
+      "radlen_cm": 1.8602879809,
+      "intlen_cm": 39.3059850354,
+      "elements": [
+        {
+          "symbol": "Cs",
+          "Z": 55,
+          "A_g_mol": 132.9050000000,
+          "mass_fraction": 0.5115488686
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.4884511314
+        }
+      ]
+    },
+    "G4_CHLOROBENZENE": {
+      "name": "G4_CHLOROBENZENE",
+      "density_g_cm3": 1.1058000000,
+      "radlen_cm": 28.2213601504,
+      "intlen_cm": 75.3196655676,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6402499469
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0447748021
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.3149752510
+        }
+      ]
+    },
+    "G4_CHLOROFORM": {
+      "name": "G4_CHLOROFORM",
+      "density_g_cm3": 1.4832000000,
+      "radlen_cm": 13.8426852338,
+      "intlen_cm": 72.9258168862,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1006123208
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0084433839
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.8909442953
+        }
+      ]
+    },
+    "G4_CONCRETE": {
+      "name": "G4_CONCRETE",
+      "density_g_cm3": 2.3000000000,
+      "radlen_cm": 11.5527147841,
+      "intlen_cm": 41.2115550512,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0100000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5291070000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0160000000
+        },
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Al",
+          "Z": 13,
+          "A_g_mol": 26.9815000000,
+          "mass_fraction": 0.0338720000
+        },
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 0.3370210000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0130000000
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.0440000000
+        },
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.0140000000
+        }
+      ]
+    },
+    "G4_CR39": {
+      "name": "G4_CR39",
+      "density_g_cm3": 1.3200000000,
+      "radlen_cm": 29.9630720578,
+      "intlen_cm": 57.9349397872,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0661505040
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5255046077
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4083448883
+        }
+      ]
+    },
+    "G4_CYCLOHEXANE": {
+      "name": "G4_CYCLOHEXANE",
+      "density_g_cm3": 0.7790000000,
+      "radlen_cm": 57.4759804747,
+      "intlen_cm": 86.7995841505,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8562817123
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1437182877
+        }
+      ]
+    },
+    "G4_CYTOSINE": {
+      "name": "G4_CYTOSINE",
+      "density_g_cm3": 1.3000000000,
+      "radlen_cm": 30.7578506265,
+      "intlen_cm": 60.0651401038,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0453609120
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4324206194
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.3782125956
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1440058730
+        }
+      ]
+    },
+    "G4_Ca": {
+      "name": "G4_Ca",
+      "density_g_cm3": 1.5500000000,
+      "radlen_cm": 10.4151095198,
+      "intlen_cm": 77.2749101845,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cd": {
+      "name": "G4_Cd",
+      "density_g_cm3": 8.6500000000,
+      "radlen_cm": 1.0399387577,
+      "intlen_cm": 19.5278973588,
+      "elements": [
+        {
+          "symbol": "Cd",
+          "Z": 48,
+          "A_g_mol": 112.4114464000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ce": {
+      "name": "G4_Ce",
+      "density_g_cm3": 6.6570000000,
+      "radlen_cm": 1.1950616986,
+      "intlen_cm": 27.3076746781,
+      "elements": [
+        {
+          "symbol": "Ce",
+          "Z": 58,
+          "A_g_mol": 140.1153107700,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cf": {
+      "name": "G4_Cf",
+      "density_g_cm3": 10.0000000000,
+      "radlen_cm": 0.5683275438,
+      "intlen_cm": 22.0803245446,
+      "elements": [
+        {
+          "symbol": "Cf",
+          "Z": 98,
+          "A_g_mol": 251.0800000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cl": {
+      "name": "G4_Cl",
+      "density_g_cm3": 0.0029947300,
+      "radlen_cm": 6437.3408608729,
+      "intlen_cm": 38393.6729355327,
+      "elements": [
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cm": {
+      "name": "G4_Cm",
+      "density_g_cm3": 13.5100000000,
+      "radlen_cm": 0.4287060756,
+      "intlen_cm": 16.2562137806,
+      "elements": [
+        {
+          "symbol": "Cm",
+          "Z": 96,
+          "A_g_mol": 247.0700000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Co": {
+      "name": "G4_Co",
+      "density_g_cm3": 8.9000000000,
+      "radlen_cm": 1.5300516989,
+      "intlen_cm": 15.3037576765,
+      "elements": [
+        {
+          "symbol": "Co",
+          "Z": 27,
+          "A_g_mol": 58.9332000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cr": {
+      "name": "G4_Cr",
+      "density_g_cm3": 7.1800000000,
+      "radlen_cm": 2.0814040144,
+      "intlen_cm": 18.1942423649,
+      "elements": [
+        {
+          "symbol": "Cr",
+          "Z": 24,
+          "A_g_mol": 51.9961301370,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cs": {
+      "name": "G4_Cs",
+      "density_g_cm3": 1.8730000000,
+      "radlen_cm": 4.4342020259,
+      "intlen_cm": 95.3624518046,
+      "elements": [
+        {
+          "symbol": "Cs",
+          "Z": 55,
+          "A_g_mol": 132.9050000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Cu": {
+      "name": "G4_Cu",
+      "density_g_cm3": 8.9600000000,
+      "radlen_cm": 1.4355780238,
+      "intlen_cm": 15.5879379043,
+      "elements": [
+        {
+          "symbol": "Cu",
+          "Z": 29,
+          "A_g_mol": 63.5456450600,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_DACRON": {
+      "name": "G4_DACRON",
+      "density_g_cm3": 1.4000000000,
+      "radlen_cm": 28.5364043256,
+      "intlen_cm": 55.9231513594,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6250108323
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0419607171
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3330284506
+        }
+      ]
+    },
+    "G4_DEOXYRIBOSE": {
+      "name": "G4_DEOXYRIBOSE",
+      "density_g_cm3": 1.5000000000,
+      "radlen_cm": 26.0277793263,
+      "intlen_cm": 50.7245404788,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0751461910
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4477252695
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4771285395
+        }
+      ]
+    },
+    "G4_DICHLORODIETHYL_ETHER": {
+      "name": "G4_DICHLORODIETHYL_ETHER",
+      "density_g_cm3": 1.2199000000,
+      "radlen_cm": 21.7159252335,
+      "intlen_cm": 72.0157030853,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3359387920
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0563839532
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1118752364
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.4958020185
+        }
+      ]
+    },
+    "G4_DIETHYL_ETHER": {
+      "name": "G4_DIETHYL_ETHER",
+      "density_g_cm3": 0.7137800000,
+      "radlen_cm": 59.2587073492,
+      "intlen_cm": 97.1612602951,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6481626481
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1359844906
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2158528613
+        }
+      ]
+    },
+    "G4_DIMETHYL_SULFOXIDE": {
+      "name": "G4_DIMETHYL_SULFOXIDE",
+      "density_g_cm3": 1.1014000000,
+      "radlen_cm": 25.6056153635,
+      "intlen_cm": 75.2873092978,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3074369871
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0774003171
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2047669780
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.4103957178
+        }
+      ]
+    },
+    "G4_DNA_ADENINE": {
+      "name": "G4_DNA_ADENINE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 40.4701354302,
+      "intlen_cm": 79.1489834113,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0300610227
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4477631967
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.5221757806
+        }
+      ]
+    },
+    "G4_DNA_CYTOSINE": {
+      "name": "G4_DNA_CYTOSINE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 39.8517602235,
+      "intlen_cm": 78.9747286021,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0366209616
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4363795341
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.3816752229
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1453242814
+        }
+      ]
+    },
+    "G4_DNA_DEOXYRIBOSE": {
+      "name": "G4_DNA_DEOXYRIBOSE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 41.8531490771,
+      "intlen_cm": 73.4025938940,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0848959119
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7225923706
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1925117175
+        }
+      ]
+    },
+    "G4_DNA_GUANINE": {
+      "name": "G4_DNA_GUANINE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 39.6999832548,
+      "intlen_cm": 80.0236241154,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0268571707
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4000413663
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.4665231851
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1065782779
+        }
+      ]
+    },
+    "G4_DNA_PHOSPHATE": {
+      "name": "G4_DNA_PHOSPHATE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 28.5212126943,
+      "intlen_cm": 94.2697781537,
+      "elements": [
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.3261383165
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6738616835
+        }
+      ]
+    },
+    "G4_DNA_THYMINE": {
+      "name": "G4_DNA_THYMINE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 39.6095818095,
+      "intlen_cm": 78.7777563069,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0402835649
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4800235304
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.2239189496
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2557739551
+        }
+      ]
+    },
+    "G4_DNA_URACIL": {
+      "name": "G4_DNA_URACIL",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 39.0409633092,
+      "intlen_cm": 80.4546879807,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0272222464
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4325111686
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.2521945291
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2880720559
+        }
+      ]
+    },
+    "G4_Dy": {
+      "name": "G4_Dy",
+      "density_g_cm3": 8.5500000000,
+      "radlen_cm": 0.8561401252,
+      "intlen_cm": 22.3383201875,
+      "elements": [
+        {
+          "symbol": "Dy",
+          "Z": 66,
+          "A_g_mol": 162.4971100000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_ETHANE": {
+      "name": "G4_ETHANE",
+      "density_g_cm3": 0.0012532400,
+      "radlen_cm": 36434.2860647397,
+      "intlen_cm": 50781.0189376312,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7988752227
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.2011247773
+        }
+      ]
+    },
+    "G4_ETHYLENE": {
+      "name": "G4_ETHYLENE",
+      "density_g_cm3": 0.0011749700,
+      "radlen_cm": 38106.3250889615,
+      "intlen_cm": 57547.7467962794,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8562817123
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1437182877
+        }
+      ]
+    },
+    "G4_ETHYL_ALCOHOL": {
+      "name": "G4_ETHYL_ALCOHOL",
+      "density_g_cm3": 0.7893000000,
+      "radlen_cm": 51.8429704156,
+      "intlen_cm": 89.2594985493,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5214293661
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1312750254
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3472956085
+        }
+      ]
+    },
+    "G4_ETHYL_CELLULOSE": {
+      "name": "G4_ETHYL_CELLULOSE",
+      "density_g_cm3": 1.1300000000,
+      "radlen_cm": 35.9450301822,
+      "intlen_cm": 65.2831880981,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0900270000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5851820000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3247910000
+        }
+      ]
+    },
+    "G4_EYE_LENS_ICRP": {
+      "name": "G4_EYE_LENS_ICRP",
+      "density_g_cm3": 1.0700000000,
+      "radlen_cm": 34.9413412839,
+      "intlen_cm": 70.6360062417,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0960000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1950000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0570000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6460000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0010000000
+        }
+      ]
+    },
+    "G4_Er": {
+      "name": "G4_Er",
+      "density_g_cm3": 9.0660000000,
+      "radlen_cm": 0.7880939310,
+      "intlen_cm": 21.2705940900,
+      "elements": [
+        {
+          "symbol": "Er",
+          "Z": 68,
+          "A_g_mol": 167.2560232000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Eu": {
+      "name": "G4_Eu",
+      "density_g_cm3": 5.2430000000,
+      "radlen_cm": 1.4186770984,
+      "intlen_cm": 35.6234054321,
+      "elements": [
+        {
+          "symbol": "Eu",
+          "Z": 63,
+          "A_g_mol": 151.9643219000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_F": {
+      "name": "G4_F",
+      "density_g_cm3": 0.0015802900,
+      "radlen_cm": 20838.1744350084,
+      "intlen_cm": 59097.6615288435,
+      "elements": [
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_FERRIC_OXIDE": {
+      "name": "G4_FERRIC_OXIDE",
+      "density_g_cm3": 5.2000000000,
+      "radlen_cm": 3.2418173343,
+      "intlen_cm": 22.2675201920,
+      "elements": [
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.6994260486
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3005739514
+        }
+      ]
+    },
+    "G4_FERROBORIDE": {
+      "name": "G4_FERROBORIDE",
+      "density_g_cm3": 7.1500000000,
+      "radlen_cm": 2.1983578257,
+      "intlen_cm": 16.7331909572,
+      "elements": [
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.8378091129
+        },
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 0.1621908871
+        }
+      ]
+    },
+    "G4_FERROUS_OXIDE": {
+      "name": "G4_FERROUS_OXIDE",
+      "density_g_cm3": 5.7000000000,
+      "radlen_cm": 2.7992227484,
+      "intlen_cm": 21.0475937407,
+      "elements": [
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.7773052893
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2226947107
+        }
+      ]
+    },
+    "G4_FERROUS_SULFATE": {
+      "name": "G4_FERROUS_SULFATE",
+      "density_g_cm3": 1.0240000000,
+      "radlen_cm": 34.8125553802,
+      "intlen_cm": 74.1303341800,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1082590000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0000270000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.8786360000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0000220000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0129680000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0000340000
+        },
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.0000540000
+        }
+      ]
+    },
+    "G4_FREON-12": {
+      "name": "G4_FREON-12",
+      "density_g_cm3": 1.1200000000,
+      "radlen_cm": 21.1136459442,
+      "intlen_cm": 92.0056500582,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0993350000
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.3142470000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.5864180000
+        }
+      ]
+    },
+    "G4_FREON-12B2": {
+      "name": "G4_FREON-12B2",
+      "density_g_cm3": 1.8000000000,
+      "radlen_cm": 7.5563082797,
+      "intlen_cm": 72.0960738549,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0572450000
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.1810960000
+        },
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 0.7616590000
+        }
+      ]
+    },
+    "G4_FREON-13": {
+      "name": "G4_FREON-13",
+      "density_g_cm3": 0.9500000000,
+      "radlen_cm": 28.5519879814,
+      "intlen_cm": 102.9101489011,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1149828850
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.5456214544
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.3393956606
+        }
+      ]
+    },
+    "G4_FREON-13B1": {
+      "name": "G4_FREON-13B1",
+      "density_g_cm3": 1.5000000000,
+      "radlen_cm": 11.0211416256,
+      "intlen_cm": 76.9456788799,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0806579862
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.3827507249
+        },
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 0.5365912889
+        }
+      ]
+    },
+    "G4_FREON-13I1": {
+      "name": "G4_FREON-13I1",
+      "density_g_cm3": 1.8000000000,
+      "radlen_cm": 6.4111664137,
+      "intlen_cm": 73.4578642805,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0613090000
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.2909240000
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.6477670000
+        }
+      ]
+    },
+    "G4_Fe": {
+      "name": "G4_Fe",
+      "density_g_cm3": 7.8740000000,
+      "radlen_cm": 1.7574934651,
+      "intlen_cm": 16.9903002759,
+      "elements": [
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Fr": {
+      "name": "G4_Fr",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 6.1882573776,
+      "intlen_cm": 212.2508067736,
+      "elements": [
+        {
+          "symbol": "Fr",
+          "Z": 87,
+          "A_g_mol": 223.0200000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_GADOLINIUM_OXYSULFIDE": {
+      "name": "G4_GADOLINIUM_OXYSULFIDE",
+      "density_g_cm3": 7.4400000000,
+      "radlen_cm": 1.1407035079,
+      "intlen_cm": 21.9702398250,
+      "elements": [
+        {
+          "symbol": "Gd",
+          "Z": 64,
+          "A_g_mol": 157.2521250000,
+          "mass_fraction": 0.8307709545
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0845255913
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0847034542
+        }
+      ]
+    },
+    "G4_GALLIUM_ARSENIDE": {
+      "name": "G4_GALLIUM_ARSENIDE",
+      "density_g_cm3": 5.3100000000,
+      "radlen_cm": 2.2959768793,
+      "intlen_cm": 27.4658727793,
+      "elements": [
+        {
+          "symbol": "Ga",
+          "Z": 31,
+          "A_g_mol": 69.7230809720,
+          "mass_fraction": 0.4820300374
+        },
+        {
+          "symbol": "As",
+          "Z": 33,
+          "A_g_mol": 74.9216000000,
+          "mass_fraction": 0.5179699626
+        }
+      ]
+    },
+    "G4_GEL_PHOTO_EMULSION": {
+      "name": "G4_GEL_PHOTO_EMULSION",
+      "density_g_cm3": 1.2914000000,
+      "radlen_cm": 30.2058086009,
+      "intlen_cm": 58.4748172458,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0811800000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4160600000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1112400000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3806400000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0108800000
+        }
+      ]
+    },
+    "G4_GLASS_LEAD": {
+      "name": "G4_GLASS_LEAD",
+      "density_g_cm3": 6.2200000000,
+      "radlen_cm": 1.2655477423,
+      "intlen_cm": 25.7388388952,
+      "elements": [
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1564530000
+        },
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 0.0808660000
+        },
+        {
+          "symbol": "Ti",
+          "Z": 22,
+          "A_g_mol": 47.8667173300,
+          "mass_fraction": 0.0080920000
+        },
+        {
+          "symbol": "As",
+          "Z": 33,
+          "A_g_mol": 74.9216000000,
+          "mass_fraction": 0.0026510000
+        },
+        {
+          "symbol": "Pb",
+          "Z": 82,
+          "A_g_mol": 207.2170000000,
+          "mass_fraction": 0.7519380000
+        }
+      ]
+    },
+    "G4_GLASS_PLATE": {
+      "name": "G4_GLASS_PLATE",
+      "density_g_cm3": 2.4000000000,
+      "radlen_cm": 10.6921640656,
+      "intlen_cm": 40.6857797379,
+      "elements": [
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4598004598
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0964410964
+        },
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 0.3365533366
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.1072051072
+        }
+      ]
+    },
+    "G4_GLUTAMINE": {
+      "name": "G4_GLUTAMINE",
+      "density_g_cm3": 1.4600000000,
+      "radlen_cm": 27.0121584298,
+      "intlen_cm": 52.3124063449,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4109190507
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0689686368
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1916834413
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3284288712
+        }
+      ]
+    },
+    "G4_GLYCEROL": {
+      "name": "G4_GLYCEROL",
+      "density_g_cm3": 1.2613000000,
+      "radlen_cm": 30.7600170394,
+      "intlen_cm": 59.6449295333,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3912550846
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0875576500
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5211872654
+        }
+      ]
+    },
+    "G4_GRAPHITE": {
+      "name": "G4_GRAPHITE",
+      "density_g_cm3": 2.2100000000,
+      "radlen_cm": 19.3199261842,
+      "intlen_cm": 36.2687301711,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_GRAPHITE_POROUS": {
+      "name": "G4_GRAPHITE_POROUS",
+      "density_g_cm3": 1.7000000000,
+      "radlen_cm": 25.1159040395,
+      "intlen_cm": 47.1493492224,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_GUANINE": {
+      "name": "G4_GUANINE",
+      "density_g_cm3": 1.5800000000,
+      "radlen_cm": 25.1887769514,
+      "intlen_cm": 50.2170220603,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3973732857
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0333475581
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.4634117033
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1058674529
+        }
+      ]
+    },
+    "G4_GYPSUM": {
+      "name": "G4_GYPSUM",
+      "density_g_cm3": 2.3200000000,
+      "radlen_cm": 10.6092208180,
+      "intlen_cm": 40.6273547785,
+      "elements": [
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.2327786930
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.1862443803
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5575598954
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0234170314
+        }
+      ]
+    },
+    "G4_Ga": {
+      "name": "G4_Ga",
+      "density_g_cm3": 5.9040000000,
+      "radlen_cm": 2.1127975858,
+      "intlen_cm": 24.3994809094,
+      "elements": [
+        {
+          "symbol": "Ga",
+          "Z": 31,
+          "A_g_mol": 69.7230809720,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Galactic": {
+      "name": "G4_Galactic",
+      "density_g_cm3": 0.0000000000,
+      "radlen_cm": 630435090422683690204135424.0000000000,
+      "intlen_cm": 350000028082484913811488768.0000000000,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Gd": {
+      "name": "G4_Gd",
+      "density_g_cm3": 7.9004000000,
+      "radlen_cm": 0.9472083827,
+      "intlen_cm": 23.9121066950,
+      "elements": [
+        {
+          "symbol": "Gd",
+          "Z": 64,
+          "A_g_mol": 157.2521250000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ge": {
+      "name": "G4_Ge",
+      "density_g_cm3": 5.3230000000,
+      "radlen_cm": 2.3012998808,
+      "intlen_cm": 27.4314847558,
+      "elements": [
+        {
+          "symbol": "Ge",
+          "Z": 32,
+          "A_g_mol": 72.6127869100,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_H": {
+      "name": "G4_H",
+      "density_g_cm3": 0.0000837480,
+      "radlen_cm": 752776.2936699188,
+      "intlen_cm": 417920.4614826443,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_He": {
+      "name": "G4_He",
+      "density_g_cm3": 0.0001663220,
+      "radlen_cm": 567113.1420929121,
+      "intlen_cm": 334118.5985088379,
+      "elements": [
+        {
+          "symbol": "He",
+          "Z": 2,
+          "A_g_mol": 4.0026425851,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Hf": {
+      "name": "G4_Hf",
+      "density_g_cm3": 13.3100000000,
+      "radlen_cm": 0.5177172521,
+      "intlen_cm": 14.8055339056,
+      "elements": [
+        {
+          "symbol": "Hf",
+          "Z": 72,
+          "A_g_mol": 178.4851746000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Hg": {
+      "name": "G4_Hg",
+      "density_g_cm3": 13.5460000000,
+      "radlen_cm": 0.4752411427,
+      "intlen_cm": 15.1251608352,
+      "elements": [
+        {
+          "symbol": "Hg",
+          "Z": 80,
+          "A_g_mol": 200.5991002000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ho": {
+      "name": "G4_Ho",
+      "density_g_cm3": 8.7950000000,
+      "radlen_cm": 0.8224469594,
+      "intlen_cm": 21.8238878765,
+      "elements": [
+        {
+          "symbol": "Ho",
+          "Z": 67,
+          "A_g_mol": 164.9300000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_I": {
+      "name": "G4_I",
+      "density_g_cm3": 4.9300000000,
+      "radlen_cm": 1.7201640735,
+      "intlen_cm": 35.6762827299,
+      "elements": [
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_In": {
+      "name": "G4_In",
+      "density_g_cm3": 7.3100000000,
+      "radlen_cm": 1.2105450732,
+      "intlen_cm": 23.2713161873,
+      "elements": [
+        {
+          "symbol": "In",
+          "Z": 49,
+          "A_g_mol": 114.8182000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ir": {
+      "name": "G4_Ir",
+      "density_g_cm3": 22.4200000000,
+      "radlen_cm": 0.2941415950,
+      "intlen_cm": 9.0093994089,
+      "elements": [
+        {
+          "symbol": "Ir",
+          "Z": 77,
+          "A_g_mol": 192.2162540000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_K": {
+      "name": "G4_K",
+      "density_g_cm3": 0.8620000000,
+      "radlen_cm": 20.0870675609,
+      "intlen_cm": 137.8097927497,
+      "elements": [
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_KAPTON": {
+      "name": "G4_KAPTON",
+      "density_g_cm3": 1.4200000000,
+      "radlen_cm": 28.5747754063,
+      "intlen_cm": 55.8169092105,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6911278143
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0263633782
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0732713202
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2092374873
+        }
+      ]
+    },
+    "G4_KEVLAR": {
+      "name": "G4_KEVLAR",
+      "density_g_cm3": 1.4400000000,
+      "radlen_cm": 28.6728455313,
+      "intlen_cm": 53.7041703894,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7057961409
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0423074270
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1343120694
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1175843627
+        }
+      ]
+    },
+    "G4_Kr": {
+      "name": "G4_Kr",
+      "density_g_cm3": 0.0034783200,
+      "radlen_cm": 3269.4392743928,
+      "intlen_cm": 44033.0436533239,
+      "elements": [
+        {
+          "symbol": "Kr",
+          "Z": 36,
+          "A_g_mol": 83.7993175100,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_LANTHANUM_OXYBROMIDE": {
+      "name": "G4_LANTHANUM_OXYBROMIDE",
+      "density_g_cm3": 6.2800000000,
+      "radlen_cm": 1.5241532522,
+      "intlen_cm": 25.3014351184,
+      "elements": [
+        {
+          "symbol": "La",
+          "Z": 57,
+          "A_g_mol": 138.9051009000,
+          "mass_fraction": 0.5915688472
+        },
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 0.3402929715
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0681381812
+        }
+      ]
+    },
+    "G4_LANTHANUM_OXYSULFIDE": {
+      "name": "G4_LANTHANUM_OXYSULFIDE",
+      "density_g_cm3": 5.8600000000,
+      "radlen_cm": 1.5889258344,
+      "intlen_cm": 26.7145523078,
+      "elements": [
+        {
+          "symbol": "La",
+          "Z": 57,
+          "A_g_mol": 138.9051009000,
+          "mass_fraction": 0.8126073070
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0935978698
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0937948232
+        }
+      ]
+    },
+    "G4_LEAD_OXIDE": {
+      "name": "G4_LEAD_OXIDE",
+      "density_g_cm3": 9.5300000000,
+      "radlen_cm": 0.7098556946,
+      "intlen_cm": 19.8173808964,
+      "elements": [
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0716820000
+        },
+        {
+          "symbol": "Pb",
+          "Z": 82,
+          "A_g_mol": 207.2170000000,
+          "mass_fraction": 0.9283180000
+        }
+      ]
+    },
+    "G4_LITHIUM_AMIDE": {
+      "name": "G4_LITHIUM_AMIDE",
+      "density_g_cm3": 1.1780000000,
+      "radlen_cm": 40.2298585529,
+      "intlen_cm": 59.5078880837,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.3022309285
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.6099796156
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0877894559
+        }
+      ]
+    },
+    "G4_LITHIUM_CARBONATE": {
+      "name": "G4_LITHIUM_CARBONATE",
+      "density_g_cm3": 2.1100000000,
+      "radlen_cm": 18.9197918579,
+      "intlen_cm": 38.8235211926,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.1878503065
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1625511321
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6495985614
+        }
+      ]
+    },
+    "G4_LITHIUM_FLUORIDE": {
+      "name": "G4_LITHIUM_FLUORIDE",
+      "density_g_cm3": 2.6350000000,
+      "radlen_cm": 14.8973607769,
+      "intlen_cm": 32.0247499094,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.2675579189
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.7324420811
+        }
+      ]
+    },
+    "G4_LITHIUM_HYDRIDE": {
+      "name": "G4_LITHIUM_HYDRIDE",
+      "density_g_cm3": 0.8200000000,
+      "radlen_cm": 97.0850620364,
+      "intlen_cm": 73.0132624194,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.8731826806
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1268173194
+        }
+      ]
+    },
+    "G4_LITHIUM_IODIDE": {
+      "name": "G4_LITHIUM_IODIDE",
+      "density_g_cm3": 3.4940000000,
+      "radlen_cm": 2.5456045592,
+      "intlen_cm": 46.4058302608,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.0518516443
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.9481483557
+        }
+      ]
+    },
+    "G4_LITHIUM_OXIDE": {
+      "name": "G4_LITHIUM_OXIDE",
+      "density_g_cm3": 2.0130000000,
+      "radlen_cm": 23.3753863602,
+      "intlen_cm": 38.1260963105,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.4645354330
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5354645670
+        }
+      ]
+    },
+    "G4_LITHIUM_TETRABORATE": {
+      "name": "G4_LITHIUM_TETRABORATE",
+      "density_g_cm3": 2.4400000000,
+      "radlen_cm": 16.2719894171,
+      "intlen_cm": 34.0334121576,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 0.0820723599
+        },
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 0.2557006868
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6622269533
+        }
+      ]
+    },
+    "G4_LUCITE": {
+      "name": "G4_LUCITE",
+      "density_g_cm3": 1.1900000000,
+      "radlen_cm": 34.0748652335,
+      "intlen_cm": 62.6704780225,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0805380000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5998480000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3196140000
+        }
+      ]
+    },
+    "G4_LUNG_ICRP": {
+      "name": "G4_LUNG_ICRP",
+      "density_g_cm3": 1.0400000000,
+      "radlen_cm": 35.0156133645,
+      "intlen_cm": 72.6726342239,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1050000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0830000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0230000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7790000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0020000000
+        }
+      ]
+    },
+    "G4_La": {
+      "name": "G4_La",
+      "density_g_cm3": 6.1540000000,
+      "radlen_cm": 1.3223836276,
+      "intlen_cm": 29.4543867747,
+      "elements": [
+        {
+          "symbol": "La",
+          "Z": 57,
+          "A_g_mol": 138.9051009000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Li": {
+      "name": "G4_Li",
+      "density_g_cm3": 0.5340000000,
+      "radlen_cm": 154.9972904774,
+      "intlen_cm": 125.0203388568,
+      "elements": [
+        {
+          "symbol": "Li",
+          "Z": 3,
+          "A_g_mol": 6.9400332080,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Lu": {
+      "name": "G4_Lu",
+      "density_g_cm3": 9.8400000000,
+      "radlen_cm": 0.7036514007,
+      "intlen_cm": 19.8941317320,
+      "elements": [
+        {
+          "symbol": "Lu",
+          "Z": 71,
+          "A_g_mol": 174.9669518000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_M3_WAX": {
+      "name": "G4_M3_WAX",
+      "density_g_cm3": 1.0500000000,
+      "radlen_cm": 37.4523271935,
+      "intlen_cm": 68.7782440198,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1143181143
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6558236558
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0921830922
+        },
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.1347921348
+        },
+        {
+          "symbol": "Ca",
+          "Z": 20,
+          "A_g_mol": 40.0780316410,
+          "mass_fraction": 0.0028830029
+        }
+      ]
+    },
+    "G4_MAGNESIUM_CARBONATE": {
+      "name": "G4_MAGNESIUM_CARBONATE",
+      "density_g_cm3": 2.9580000000,
+      "radlen_cm": 10.7392076017,
+      "intlen_cm": 30.5238324080,
+      "elements": [
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.2882681150
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1424525855
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5692792995
+        }
+      ]
+    },
+    "G4_MAGNESIUM_FLUORIDE": {
+      "name": "G4_MAGNESIUM_FLUORIDE",
+      "density_g_cm3": 3.0000000000,
+      "radlen_cm": 9.7736131065,
+      "intlen_cm": 32.1181946756,
+      "elements": [
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.3901172937
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.6098827063
+        }
+      ]
+    },
+    "G4_MAGNESIUM_OXIDE": {
+      "name": "G4_MAGNESIUM_OXIDE",
+      "density_g_cm3": 3.5800000000,
+      "radlen_cm": 7.8275822876,
+      "intlen_cm": 26.7323051305,
+      "elements": [
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.6030361955
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3969638045
+        }
+      ]
+    },
+    "G4_MAGNESIUM_TETRABORATE": {
+      "name": "G4_MAGNESIUM_TETRABORATE",
+      "density_g_cm3": 2.5300000000,
+      "radlen_cm": 14.0171151884,
+      "intlen_cm": 34.3098315005,
+      "elements": [
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.1353701908
+        },
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 0.2408538825
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6237759267
+        }
+      ]
+    },
+    "G4_MERCURIC_IODIDE": {
+      "name": "G4_MERCURIC_IODIDE",
+      "density_g_cm3": 6.3600000000,
+      "radlen_cm": 1.1695626925,
+      "intlen_cm": 29.4979745172,
+      "elements": [
+        {
+          "symbol": "Hg",
+          "Z": 80,
+          "A_g_mol": 200.5991002000,
+          "mass_fraction": 0.4414523895
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.5585476105
+        }
+      ]
+    },
+    "G4_METHANE": {
+      "name": "G4_METHANE",
+      "density_g_cm3": 0.0006671510,
+      "radlen_cm": 69648.1895684307,
+      "intlen_cm": 90727.2666787782,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7486823647
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.2513176353
+        }
+      ]
+    },
+    "G4_METHANOL": {
+      "name": "G4_METHANOL",
+      "density_g_cm3": 0.7914000000,
+      "radlen_cm": 49.8277776201,
+      "intlen_cm": 90.6875121309,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3748448189
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1258278783
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4993273028
+        }
+      ]
+    },
+    "G4_MIX_D_WAX": {
+      "name": "G4_MIX_D_WAX",
+      "density_g_cm3": 0.9900000000,
+      "radlen_cm": 42.4388764028,
+      "intlen_cm": 70.0170389774,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1340400000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7779600000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0350200000
+        },
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.0385940000
+        },
+        {
+          "symbol": "Ti",
+          "Z": 22,
+          "A_g_mol": 47.8667173300,
+          "mass_fraction": 0.0143860000
+        }
+      ]
+    },
+    "G4_MS20_TISSUE": {
+      "name": "G4_MS20_TISSUE",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 38.2901787990,
+      "intlen_cm": 75.6659085615,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0811920000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5834420000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0177980000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1863810000
+        },
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 0.1302870000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0009000000
+        }
+      ]
+    },
+    "G4_MUSCLE_SKELETAL_ICRP": {
+      "name": "G4_MUSCLE_SKELETAL_ICRP",
+      "density_g_cm3": 1.0500000000,
+      "radlen_cm": 35.0573564270,
+      "intlen_cm": 71.8808850701,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1020000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1430000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0340000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7100000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0040000000
+        }
+      ]
+    },
+    "G4_MUSCLE_STRIATED_ICRU": {
+      "name": "G4_MUSCLE_STRIATED_ICRU",
+      "density_g_cm3": 1.0400000000,
+      "radlen_cm": 35.2882455673,
+      "intlen_cm": 72.6659485329,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1021021021
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1231231231
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0350350350
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7297297297
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010010010
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0020020020
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0040040040
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0030030030
+        }
+      ]
+    },
+    "G4_MUSCLE_WITHOUT_SUCROSE": {
+      "name": "G4_MUSCLE_WITHOUT_SUCROSE",
+      "density_g_cm3": 1.0700000000,
+      "radlen_cm": 34.5507134115,
+      "intlen_cm": 70.5306459594,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1019690000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1200580000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0354510000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7425220000
+        }
+      ]
+    },
+    "G4_MUSCLE_WITH_SUCROSE": {
+      "name": "G4_MUSCLE_WITH_SUCROSE",
+      "density_g_cm3": 1.1100000000,
+      "radlen_cm": 33.5030358691,
+      "intlen_cm": 68.1084691034,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0982340982
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1562141562
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0354510355
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7101007101
+        }
+      ]
+    },
+    "G4_MYLAR": {
+      "name": "G4_MYLAR",
+      "density_g_cm3": 1.4000000000,
+      "radlen_cm": 28.5364043256,
+      "intlen_cm": 55.9231513594,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6250108323
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0419607171
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3330284506
+        }
+      ]
+    },
+    "G4_Mg": {
+      "name": "G4_Mg",
+      "density_g_cm3": 1.7400000000,
+      "radlen_cm": 14.3859171086,
+      "intlen_cm": 58.2663034870,
+      "elements": [
+        {
+          "symbol": "Mg",
+          "Z": 12,
+          "A_g_mol": 24.3050157600,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Mn": {
+      "name": "G4_Mn",
+      "density_g_cm3": 7.4400000000,
+      "radlen_cm": 1.9677221865,
+      "intlen_cm": 17.8835098670,
+      "elements": [
+        {
+          "symbol": "Mn",
+          "Z": 25,
+          "A_g_mol": 54.9380000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Mo": {
+      "name": "G4_Mo",
+      "density_g_cm3": 10.2200000000,
+      "radlen_cm": 0.9591074077,
+      "intlen_cm": 15.6772760730,
+      "elements": [
+        {
+          "symbol": "Mo",
+          "Z": 42,
+          "A_g_mol": 95.9312864600,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_N": {
+      "name": "G4_N",
+      "density_g_cm3": 0.0011652000,
+      "radlen_cm": 32602.2350168044,
+      "intlen_cm": 72406.9506998844,
+      "elements": [
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_N,N-DIMETHYL_FORMAMIDE": {
+      "name": "G4_N,N-DIMETHYL_FORMAMIDE",
+      "density_g_cm3": 0.9487000000,
+      "radlen_cm": 42.9986906208,
+      "intlen_cm": 77.1577428431,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4929574510
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0965276183
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1916269163
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2188880144
+        }
+      ]
+    },
+    "G4_N-BUTYL_ALCOHOL": {
+      "name": "G4_N-BUTYL_ALCOHOL",
+      "density_g_cm3": 0.8098000000,
+      "radlen_cm": 52.2322550404,
+      "intlen_cm": 85.6406080185,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6481626481
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1359844906
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2158528613
+        }
+      ]
+    },
+    "G4_N-HEPTANE": {
+      "name": "G4_N-HEPTANE",
+      "density_g_cm3": 0.6837600000,
+      "radlen_cm": 65.8657382833,
+      "intlen_cm": 97.0698845209,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8390549213
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1609450787
+        }
+      ]
+    },
+    "G4_N-HEXANE": {
+      "name": "G4_N-HEXANE",
+      "density_g_cm3": 0.6603000000,
+      "radlen_cm": 68.2710686267,
+      "intlen_cm": 100.2185093356,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8362509531
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1637490469
+        }
+      ]
+    },
+    "G4_N-PENTANE": {
+      "name": "G4_N-PENTANE",
+      "density_g_cm3": 0.6262000000,
+      "radlen_cm": 72.0844513772,
+      "intlen_cm": 105.2394466274,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8323567353
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1676432647
+        }
+      ]
+    },
+    "G4_N-PROPYL_ALCOHOL": {
+      "name": "G4_N-PROPYL_ALCOHOL",
+      "density_g_cm3": 0.8035000000,
+      "radlen_cm": 51.9709503464,
+      "intlen_cm": 86.8320985664,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5995862193
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1341793689
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2662344118
+        }
+      ]
+    },
+    "G4_NAPHTHALENE": {
+      "name": "G4_NAPHTHALENE",
+      "density_g_cm3": 1.1450000000,
+      "radlen_cm": 38.0628209006,
+      "intlen_cm": 64.7481877565,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9370876957
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0629123043
+        }
+      ]
+    },
+    "G4_NEOPRENE": {
+      "name": "G4_NEOPRENE",
+      "density_g_cm3": 1.2300000000,
+      "radlen_cm": 23.6452775257,
+      "intlen_cm": 68.4404103466,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5426421718
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0569231500
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.4004346781
+        }
+      ]
+    },
+    "G4_NITROBENZENE": {
+      "name": "G4_NITROBENZENE",
+      "density_g_cm3": 1.1986700000,
+      "radlen_cm": 33.4429484913,
+      "intlen_cm": 65.3377994376,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5853676418
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0409367005
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1137747242
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2599209335
+        }
+      ]
+    },
+    "G4_NITROUS_OXIDE": {
+      "name": "G4_NITROUS_OXIDE",
+      "density_g_cm3": 0.0018309400,
+      "radlen_cm": 19953.4404326249,
+      "intlen_cm": 46817.4565215888,
+      "elements": [
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.6364843009
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3635156991
+        }
+      ]
+    },
+    "G4_NYLON-11_RILSAN": {
+      "name": "G4_NYLON-11_RILSAN",
+      "density_g_cm3": 1.4250000000,
+      "radlen_cm": 30.1506780146,
+      "intlen_cm": 49.4620432566,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1154758845
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7208182792
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0764169236
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0872889127
+        }
+      ]
+    },
+    "G4_NYLON-6-10": {
+      "name": "G4_NYLON-6-10",
+      "density_g_cm3": 1.1400000000,
+      "radlen_cm": 37.2399939034,
+      "intlen_cm": 62.6184623928,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1070620000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6804490000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0991890000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1133000000
+        }
+      ]
+    },
+    "G4_NYLON-6-6": {
+      "name": "G4_NYLON-6-6",
+      "density_g_cm3": 1.1400000000,
+      "radlen_cm": 36.7677016597,
+      "intlen_cm": 63.4952151640,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6368481720
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0979811903
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1237807148
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1413899228
+        }
+      ]
+    },
+    "G4_NYLON-8062": {
+      "name": "G4_NYLON-8062",
+      "density_g_cm3": 1.0800000000,
+      "radlen_cm": 38.9258725316,
+      "intlen_cm": 66.5604267341,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1035091035
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6484156484
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0995360995
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1485391485
+        }
+      ]
+    },
+    "G4_Na": {
+      "name": "G4_Na",
+      "density_g_cm3": 0.9710000000,
+      "radlen_cm": 28.5646359402,
+      "intlen_cm": 102.4929311883,
+      "elements": [
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Nb": {
+      "name": "G4_Nb",
+      "density_g_cm3": 8.5700000000,
+      "radlen_cm": 1.1578315182,
+      "intlen_cm": 18.4970498911,
+      "elements": [
+        {
+          "symbol": "Nb",
+          "Z": 41,
+          "A_g_mol": 92.9064000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Nd": {
+      "name": "G4_Nd",
+      "density_g_cm3": 6.9000000000,
+      "radlen_cm": 1.1166740406,
+      "intlen_cm": 26.6017647572,
+      "elements": [
+        {
+          "symbol": "Nd",
+          "Z": 60,
+          "A_g_mol": 144.2362360000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ne": {
+      "name": "G4_Ne",
+      "density_g_cm3": 0.0008385050,
+      "radlen_cm": 34504.7957012515,
+      "intlen_cm": 113641.3080885588,
+      "elements": [
+        {
+          "symbol": "Ne",
+          "Z": 10,
+          "A_g_mol": 20.1800112800,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ni": {
+      "name": "G4_Ni",
+      "density_g_cm3": 8.9020000000,
+      "radlen_cm": 1.4242208745,
+      "intlen_cm": 15.2795322887,
+      "elements": [
+        {
+          "symbol": "Ni",
+          "Z": 28,
+          "A_g_mol": 58.6933251009,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Np": {
+      "name": "G4_Np",
+      "density_g_cm3": 20.2500000000,
+      "radlen_cm": 0.2896763497,
+      "intlen_cm": 10.6968313874,
+      "elements": [
+        {
+          "symbol": "Np",
+          "Z": 93,
+          "A_g_mol": 237.0480000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_O": {
+      "name": "G4_O",
+      "density_g_cm3": 0.0013315100,
+      "radlen_cm": 25713.7634595345,
+      "intlen_cm": 66235.5975584616,
+      "elements": [
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_OCTADECANOL": {
+      "name": "G4_OCTADECANOL",
+      "density_g_cm3": 0.8120000000,
+      "radlen_cm": 54.2695775063,
+      "intlen_cm": 83.8467764328,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1415990478
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7992522572
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0591486950
+        }
+      ]
+    },
+    "G4_OCTANE": {
+      "name": "G4_OCTANE",
+      "density_g_cm3": 0.7026000000,
+      "radlen_cm": 64.0534438285,
+      "intlen_cm": 94.6809469695,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8411702684
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1588297316
+        }
+      ]
+    },
+    "G4_Os": {
+      "name": "G4_Os",
+      "density_g_cm3": 22.5700000000,
+      "radlen_cm": 0.2958609866,
+      "intlen_cm": 8.9185046979,
+      "elements": [
+        {
+          "symbol": "Os",
+          "Z": 76,
+          "A_g_mol": 190.2245546000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_P": {
+      "name": "G4_P",
+      "density_g_cm3": 2.2000000000,
+      "radlen_cm": 9.6387902637,
+      "intlen_cm": 49.9624310154,
+      "elements": [
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_PARAFFIN": {
+      "name": "G4_PARAFFIN",
+      "density_g_cm3": 0.9300000000,
+      "radlen_cm": 48.2237383379,
+      "intlen_cm": 72.3210868975,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8513873152
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1486126848
+        }
+      ]
+    },
+    "G4_PHOSPHORIC_ACID": {
+      "name": "G4_PHOSPHORIC_ACID",
+      "density_g_cm3": 1.8700000000,
+      "radlen_cm": 15.5141283621,
+      "intlen_cm": 47.9082638597,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0308568456
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.3160747168
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6530684376
+        }
+      ]
+    },
+    "G4_PHOTO_EMULSION": {
+      "name": "G4_PHOTO_EMULSION",
+      "density_g_cm3": 3.8150000000,
+      "radlen_cm": 2.9706503474,
+      "intlen_cm": 35.0478714990,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0141000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0722610000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0193200000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.0661010000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0018900000
+        },
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 0.3491030000
+        },
+        {
+          "symbol": "Ag",
+          "Z": 47,
+          "A_g_mol": 107.8682200000,
+          "mass_fraction": 0.4741050000
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.0031200000
+        }
+      ]
+    },
+    "G4_PLASTIC_SC_VINYLTOLUENE": {
+      "name": "G4_PLASTIC_SC_VINYLTOLUENE",
+      "density_g_cm3": 1.0320000000,
+      "radlen_cm": 42.5441996486,
+      "intlen_cm": 69.9693874192,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9147085318
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0852914682
+        }
+      ]
+    },
+    "G4_PLEXIGLASS": {
+      "name": "G4_PLEXIGLASS",
+      "density_g_cm3": 1.1900000000,
+      "radlen_cm": 34.0748806544,
+      "intlen_cm": 62.6702055110,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5998410709
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0805418407
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3196170884
+        }
+      ]
+    },
+    "G4_PLUTONIUM_DIOXIDE": {
+      "name": "G4_PLUTONIUM_DIOXIDE",
+      "density_g_cm3": 11.4600000000,
+      "radlen_cm": 0.5723242927,
+      "intlen_cm": 16.2912350677,
+      "elements": [
+        {
+          "symbol": "Pu",
+          "Z": 94,
+          "A_g_mol": 244.0640000000,
+          "mass_fraction": 0.8840887543
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1159112457
+        }
+      ]
+    },
+    "G4_POLYACRYLONITRILE": {
+      "name": "G4_POLYACRYLONITRILE",
+      "density_g_cm3": 1.1700000000,
+      "radlen_cm": 35.9776646539,
+      "intlen_cm": 64.6096169435,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6790483898
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0569857271
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.2639658832
+        }
+      ]
+    },
+    "G4_POLYCARBONATE": {
+      "name": "G4_POLYCARBONATE",
+      "density_g_cm3": 1.2000000000,
+      "radlen_cm": 34.5873361608,
+      "intlen_cm": 63.3495193368,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7557453702
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0554943691
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1887602607
+        }
+      ]
+    },
+    "G4_POLYCHLOROSTYRENE": {
+      "name": "G4_POLYCHLOROSTYRENE",
+      "density_g_cm3": 1.3000000000,
+      "radlen_cm": 25.3754585368,
+      "intlen_cm": 62.3930757123,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6932901610
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0509082842
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.2558015548
+        }
+      ]
+    },
+    "G4_POLYETHYLENE": {
+      "name": "G4_POLYETHYLENE",
+      "density_g_cm3": 0.9400000000,
+      "radlen_cm": 47.6316902019,
+      "intlen_cm": 71.9328468651,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8562817123
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1437182877
+        }
+      ]
+    },
+    "G4_POLYOXYMETHYLENE": {
+      "name": "G4_POLYOXYMETHYLENE",
+      "density_g_cm3": 1.4250000000,
+      "radlen_cm": 26.9940588984,
+      "intlen_cm": 54.1869646318,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4000110924
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0671378455
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5328510621
+        }
+      ]
+    },
+    "G4_POLYPROPYLENE": {
+      "name": "G4_POLYPROPYLENE",
+      "density_g_cm3": 0.9000000000,
+      "radlen_cm": 49.7486542109,
+      "intlen_cm": 75.1298622814,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8562817123
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1437182877
+        }
+      ]
+    },
+    "G4_POLYSTYRENE": {
+      "name": "G4_POLYSTYRENE",
+      "density_g_cm3": 1.0600000000,
+      "radlen_cm": 41.3125056266,
+      "intlen_cm": 68.7498786660,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9225773293
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0774226707
+        }
+      ]
+    },
+    "G4_POLYTRIFLUOROCHLOROETHYLENE": {
+      "name": "G4_POLYTRIFLUOROCHLOROETHYLENE",
+      "density_g_cm3": 2.1000000000,
+      "radlen_cm": 13.4211774188,
+      "intlen_cm": 45.5231505449,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2062473447
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.4893583661
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.3043942892
+        }
+      ]
+    },
+    "G4_POLYVINYLIDENE_CHLORIDE": {
+      "name": "G4_POLYVINYLIDENE_CHLORIDE",
+      "density_g_cm3": 1.7000000000,
+      "radlen_cm": 13.3466912811,
+      "intlen_cm": 58.5490734291,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2477909327
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0207946100
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.7314144572
+        }
+      ]
+    },
+    "G4_POLYVINYLIDENE_FLUORIDE": {
+      "name": "G4_POLYVINYLIDENE_FLUORIDE",
+      "density_g_cm3": 1.7600000000,
+      "radlen_cm": 20.8089540539,
+      "intlen_cm": 47.6128231526,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3751353170
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0314813482
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.5933833348
+        }
+      ]
+    },
+    "G4_POLYVINYL_ACETATE": {
+      "name": "G4_POLYVINYL_ACETATE",
+      "density_g_cm3": 1.1900000000,
+      "radlen_cm": 33.5589610921,
+      "intlen_cm": 63.7392761655,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5580589687
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0702484460
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3716925853
+        }
+      ]
+    },
+    "G4_POLYVINYL_ALCOHOL": {
+      "name": "G4_POLYVINYL_ALCOHOL",
+      "density_g_cm3": 1.3000000000,
+      "radlen_cm": 30.9791700346,
+      "intlen_cm": 56.8283796029,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5452903684
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0915215132
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3631881183
+        }
+      ]
+    },
+    "G4_POLYVINYL_BUTYRAL": {
+      "name": "G4_POLYVINYL_BUTYRAL",
+      "density_g_cm3": 1.1200000000,
+      "radlen_cm": 37.2445284119,
+      "intlen_cm": 64.6185702523,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6757292578
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0992375747
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2250331675
+        }
+      ]
+    },
+    "G4_POLYVINYL_CHLORIDE": {
+      "name": "G4_POLYVINYL_CHLORIDE",
+      "density_g_cm3": 1.3000000000,
+      "radlen_cm": 19.6259713893,
+      "intlen_cm": 69.2301257138,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3843566728
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0483828062
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.5672605210
+        }
+      ]
+    },
+    "G4_POLYVINYL_PYRROLIDONE": {
+      "name": "G4_POLYVINYL_PYRROLIDONE",
+      "density_g_cm3": 1.2500000000,
+      "radlen_cm": 33.3295432994,
+      "intlen_cm": 59.0516806099,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.6483992503
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0816204778
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1260258351
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1439544368
+        }
+      ]
+    },
+    "G4_POTASSIUM_IODIDE": {
+      "name": "G4_POTASSIUM_IODIDE",
+      "density_g_cm3": 3.1300000000,
+      "radlen_cm": 3.0794662292,
+      "intlen_cm": 50.4789672731,
+      "elements": [
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.2355286329
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.7644713671
+        }
+      ]
+    },
+    "G4_POTASSIUM_OXIDE": {
+      "name": "G4_POTASSIUM_OXIDE",
+      "density_g_cm3": 2.3200000000,
+      "radlen_cm": 8.1473889734,
+      "intlen_cm": 48.3539578260,
+      "elements": [
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.8301478368
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1698521632
+        }
+      ]
+    },
+    "G4_PROPANE": {
+      "name": "G4_PROPANE",
+      "density_g_cm3": 0.0018793900,
+      "radlen_cm": 24143.4343892002,
+      "intlen_cm": 34507.9467355684,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8171359205
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1828640795
+        }
+      ]
+    },
+    "G4_PYRIDINE": {
+      "name": "G4_PYRIDINE",
+      "density_g_cm3": 0.9819000000,
+      "radlen_cm": 43.4238519327,
+      "intlen_cm": 76.0528817127,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.7592106765
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0637129445
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1770763790
+        }
+      ]
+    },
+    "G4_Pa": {
+      "name": "G4_Pa",
+      "density_g_cm3": 15.3700000000,
+      "radlen_cm": 0.3860695338,
+      "intlen_cm": 13.9729283036,
+      "elements": [
+        {
+          "symbol": "Pa",
+          "Z": 91,
+          "A_g_mol": 231.0360000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Pb": {
+      "name": "G4_Pb",
+      "density_g_cm3": 11.3500000000,
+      "radlen_cm": 0.5612532628,
+      "intlen_cm": 18.2479470310,
+      "elements": [
+        {
+          "symbol": "Pb",
+          "Z": 82,
+          "A_g_mol": 207.2170000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_PbWO4": {
+      "name": "G4_PbWO4",
+      "density_g_cm3": 8.2800000000,
+      "radlen_cm": 0.8924531919,
+      "intlen_cm": 20.7397427149,
+      "elements": [
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1406366195
+        },
+        {
+          "symbol": "Pb",
+          "Z": 82,
+          "A_g_mol": 207.2170000000,
+          "mass_fraction": 0.4553657612
+        },
+        {
+          "symbol": "W",
+          "Z": 74,
+          "A_g_mol": 183.8416100000,
+          "mass_fraction": 0.4039976193
+        }
+      ]
+    },
+    "G4_Pd": {
+      "name": "G4_Pd",
+      "density_g_cm3": 12.0200000000,
+      "radlen_cm": 0.7657167657,
+      "intlen_cm": 13.7984874589,
+      "elements": [
+        {
+          "symbol": "Pd",
+          "Z": 46,
+          "A_g_mol": 106.4151876000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Pm": {
+      "name": "G4_Pm",
+      "density_g_cm3": 7.2200000000,
+      "radlen_cm": 1.0408459865,
+      "intlen_cm": 25.4624387556,
+      "elements": [
+        {
+          "symbol": "Pm",
+          "Z": 61,
+          "A_g_mol": 144.9130000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Po": {
+      "name": "G4_Po",
+      "density_g_cm3": 9.3200000000,
+      "radlen_cm": 0.6610916001,
+      "intlen_cm": 22.2854698005,
+      "elements": [
+        {
+          "symbol": "Po",
+          "Z": 84,
+          "A_g_mol": 208.9820000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Pr": {
+      "name": "G4_Pr",
+      "density_g_cm3": 6.7100000000,
+      "radlen_cm": 1.1562026576,
+      "intlen_cm": 27.1429747446,
+      "elements": [
+        {
+          "symbol": "Pr",
+          "Z": 59,
+          "A_g_mol": 140.9080000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Pt": {
+      "name": "G4_Pt",
+      "density_g_cm3": 21.4500000000,
+      "radlen_cm": 0.3050532706,
+      "intlen_cm": 9.4633205278,
+      "elements": [
+        {
+          "symbol": "Pt",
+          "Z": 78,
+          "A_g_mol": 195.0780035700,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Pu": {
+      "name": "G4_Pu",
+      "density_g_cm3": 19.8400000000,
+      "radlen_cm": 0.2989048704,
+      "intlen_cm": 11.0245529144,
+      "elements": [
+        {
+          "symbol": "Pu",
+          "Z": 94,
+          "A_g_mol": 244.0640000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Pyrex_Glass": {
+      "name": "G4_Pyrex_Glass",
+      "density_g_cm3": 2.2300000000,
+      "radlen_cm": 12.6325375693,
+      "intlen_cm": 42.2910635276,
+      "elements": [
+        {
+          "symbol": "B",
+          "Z": 5,
+          "A_g_mol": 10.8110164000,
+          "mass_fraction": 0.0400639199
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5395609209
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0281909436
+        },
+        {
+          "symbol": "Al",
+          "Z": 13,
+          "A_g_mol": 26.9815000000,
+          "mass_fraction": 0.0116439767
+        },
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 0.3772192456
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0033209934
+        }
+      ]
+    },
+    "G4_RUBBER_BUTYL": {
+      "name": "G4_RUBBER_BUTYL",
+      "density_g_cm3": 0.9200000000,
+      "radlen_cm": 48.6670416944,
+      "intlen_cm": 73.4971873425,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1437110000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8562890000
+        }
+      ]
+    },
+    "G4_RUBBER_NATURAL": {
+      "name": "G4_RUBBER_NATURAL",
+      "density_g_cm3": 0.9200000000,
+      "radlen_cm": 48.2532262024,
+      "intlen_cm": 75.5816000621,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1183710000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8816290000
+        }
+      ]
+    },
+    "G4_RUBBER_NEOPRENE": {
+      "name": "G4_RUBBER_NEOPRENE",
+      "density_g_cm3": 1.2300000000,
+      "radlen_cm": 23.6452744201,
+      "intlen_cm": 68.4406876941,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0569200000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5426460000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.4004340000
+        }
+      ]
+    },
+    "G4_Ra": {
+      "name": "G4_Ra",
+      "density_g_cm3": 5.0000000000,
+      "radlen_cm": 1.2298658749,
+      "intlen_cm": 42.6399710179,
+      "elements": [
+        {
+          "symbol": "Ra",
+          "Z": 88,
+          "A_g_mol": 226.0250000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Rb": {
+      "name": "G4_Rb",
+      "density_g_cm3": 1.5320000000,
+      "radlen_cm": 7.1977407506,
+      "intlen_cm": 100.6336626726,
+      "elements": [
+        {
+          "symbol": "Rb",
+          "Z": 37,
+          "A_g_mol": 85.4676764200,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Re": {
+      "name": "G4_Re",
+      "density_g_cm3": 21.0200000000,
+      "radlen_cm": 0.3182831922,
+      "intlen_cm": 9.5082503276,
+      "elements": [
+        {
+          "symbol": "Re",
+          "Z": 75,
+          "A_g_mol": 186.2068780000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Rh": {
+      "name": "G4_Rh",
+      "density_g_cm3": 12.4100000000,
+      "radlen_cm": 0.7466192395,
+      "intlen_cm": 13.2162992461,
+      "elements": [
+        {
+          "symbol": "Rh",
+          "Z": 45,
+          "A_g_mol": 102.9060000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Rn": {
+      "name": "G4_Rn",
+      "density_g_cm3": 0.0090066200,
+      "radlen_cm": 697.7766671691,
+      "intlen_cm": 23530.7426900032,
+      "elements": [
+        {
+          "symbol": "Rn",
+          "Z": 86,
+          "A_g_mol": 222.0180000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ru": {
+      "name": "G4_Ru",
+      "density_g_cm3": 12.4100000000,
+      "radlen_cm": 0.7640666774,
+      "intlen_cm": 13.1370029745,
+      "elements": [
+        {
+          "symbol": "Ru",
+          "Z": 44,
+          "A_g_mol": 101.0648187900,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_S": {
+      "name": "G4_S",
+      "density_g_cm3": 2.0000000000,
+      "radlen_cm": 9.7482931365,
+      "intlen_cm": 55.5972779233,
+      "elements": [
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_SILICON_DIOXIDE": {
+      "name": "G4_SILICON_DIOXIDE",
+      "density_g_cm3": 2.3200000000,
+      "radlen_cm": 11.6577276645,
+      "intlen_cm": 41.3174239290,
+      "elements": [
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 0.4674338418
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5325661582
+        }
+      ]
+    },
+    "G4_SILVER_BROMIDE": {
+      "name": "G4_SILVER_BROMIDE",
+      "density_g_cm3": 6.4730000000,
+      "radlen_cm": 1.5250930816,
+      "intlen_cm": 24.6362003753,
+      "elements": [
+        {
+          "symbol": "Ag",
+          "Z": 47,
+          "A_g_mol": 107.8682200000,
+          "mass_fraction": 0.5744646322
+        },
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 0.4255353678
+        }
+      ]
+    },
+    "G4_SILVER_CHLORIDE": {
+      "name": "G4_SILVER_CHLORIDE",
+      "density_g_cm3": 5.5600000000,
+      "radlen_cm": 1.8592358479,
+      "intlen_cm": 26.9699324435,
+      "elements": [
+        {
+          "symbol": "Ag",
+          "Z": 47,
+          "A_g_mol": 107.8682200000,
+          "mass_fraction": 0.7526348232
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.2473651768
+        }
+      ]
+    },
+    "G4_SILVER_HALIDES": {
+      "name": "G4_SILVER_HALIDES",
+      "density_g_cm3": 6.4700000000,
+      "radlen_cm": 1.5245239630,
+      "intlen_cm": 24.6583577333,
+      "elements": [
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 0.4228950000
+        },
+        {
+          "symbol": "Ag",
+          "Z": 47,
+          "A_g_mol": 107.8682200000,
+          "mass_fraction": 0.5737480000
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.0033570000
+        }
+      ]
+    },
+    "G4_SILVER_IODIDE": {
+      "name": "G4_SILVER_IODIDE",
+      "density_g_cm3": 6.0100000000,
+      "radlen_cm": 1.4473505292,
+      "intlen_cm": 28.5353855145,
+      "elements": [
+        {
+          "symbol": "Ag",
+          "Z": 47,
+          "A_g_mol": 107.8682200000,
+          "mass_fraction": 0.4594590450
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.5405409550
+        }
+      ]
+    },
+    "G4_SKIN_ICRP": {
+      "name": "G4_SKIN_ICRP",
+      "density_g_cm3": 1.0900000000,
+      "radlen_cm": 34.3047957676,
+      "intlen_cm": 69.0045449724,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1000000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2040000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0420000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6450000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0010000000
+        }
+      ]
+    },
+    "G4_SODIUM_CARBONATE": {
+      "name": "G4_SODIUM_CARBONATE",
+      "density_g_cm3": 2.5320000000,
+      "radlen_cm": 12.5293001203,
+      "intlen_cm": 36.2077642513,
+      "elements": [
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.4338168452
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1133211199
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4528620349
+        }
+      ]
+    },
+    "G4_SODIUM_IODIDE": {
+      "name": "G4_SODIUM_IODIDE",
+      "density_g_cm3": 3.6670000000,
+      "radlen_cm": 2.5882212769,
+      "intlen_cm": 42.9136935370,
+      "elements": [
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.1533739221
+        },
+        {
+          "symbol": "I",
+          "Z": 53,
+          "A_g_mol": 126.9040000000,
+          "mass_fraction": 0.8466260779
+        }
+      ]
+    },
+    "G4_SODIUM_MONOXIDE": {
+      "name": "G4_SODIUM_MONOXIDE",
+      "density_g_cm3": 2.2700000000,
+      "radlen_cm": 12.8484696099,
+      "intlen_cm": 42.4347669192,
+      "elements": [
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.7418578408
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2581421592
+        }
+      ]
+    },
+    "G4_SODIUM_NITRATE": {
+      "name": "G4_SODIUM_NITRATE",
+      "density_g_cm3": 2.2610000000,
+      "radlen_cm": 14.4612324186,
+      "intlen_cm": 39.9375053268,
+      "elements": [
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.2704849729
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1647957147
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5647193123
+        }
+      ]
+    },
+    "G4_STAINLESS-STEEL": {
+      "name": "G4_STAINLESS-STEEL",
+      "density_g_cm3": 8.0000000000,
+      "radlen_cm": 1.7380670645,
+      "intlen_cm": 16.6780570974,
+      "elements": [
+        {
+          "symbol": "Fe",
+          "Z": 26,
+          "A_g_mol": 55.8451107980,
+          "mass_fraction": 0.7462128746
+        },
+        {
+          "symbol": "Cr",
+          "Z": 24,
+          "A_g_mol": 51.9961301370,
+          "mass_fraction": 0.1690010443
+        },
+        {
+          "symbol": "Ni",
+          "Z": 28,
+          "A_g_mol": 58.6933251009,
+          "mass_fraction": 0.0847860811
+        }
+      ]
+    },
+    "G4_STILBENE": {
+      "name": "G4_STILBENE",
+      "density_g_cm3": 0.9707000000,
+      "radlen_cm": 44.9595141781,
+      "intlen_cm": 75.9942943910,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9328955096
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0671044904
+        }
+      ]
+    },
+    "G4_SUCROSE": {
+      "name": "G4_SUCROSE",
+      "density_g_cm3": 1.5805000000,
+      "radlen_cm": 24.4231162245,
+      "intlen_cm": 48.9185997692,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4210638981
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0647820686
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.5141540333
+        }
+      ]
+    },
+    "G4_Sb": {
+      "name": "G4_Sb",
+      "density_g_cm3": 6.6910000000,
+      "radlen_cm": 1.3040127628,
+      "intlen_cm": 25.9265676022,
+      "elements": [
+        {
+          "symbol": "Sb",
+          "Z": 51,
+          "A_g_mol": 121.7598000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Sc": {
+      "name": "G4_Sc",
+      "density_g_cm3": 2.9890000000,
+      "radlen_cm": 5.5354470594,
+      "intlen_cm": 41.6361977932,
+      "elements": [
+        {
+          "symbol": "Sc",
+          "Z": 21,
+          "A_g_mol": 44.9559000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Se": {
+      "name": "G4_Se",
+      "density_g_cm3": 4.5000000000,
+      "radlen_cm": 2.6462517652,
+      "intlen_cm": 33.3674841789,
+      "elements": [
+        {
+          "symbol": "Se",
+          "Z": 34,
+          "A_g_mol": 78.9593734300,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Si": {
+      "name": "G4_Si",
+      "density_g_cm3": 2.3300000000,
+      "radlen_cm": 9.3660702922,
+      "intlen_cm": 45.6603073704,
+      "elements": [
+        {
+          "symbol": "Si",
+          "Z": 14,
+          "A_g_mol": 28.0853614555,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Sm": {
+      "name": "G4_Sm",
+      "density_g_cm3": 7.4600000000,
+      "radlen_cm": 1.0152448223,
+      "intlen_cm": 24.9485982224,
+      "elements": [
+        {
+          "symbol": "Sm",
+          "Z": 62,
+          "A_g_mol": 150.3663619000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Sn": {
+      "name": "G4_Sn",
+      "density_g_cm3": 7.3100000000,
+      "radlen_cm": 1.2063713058,
+      "intlen_cm": 23.5313378422,
+      "elements": [
+        {
+          "symbol": "Sn",
+          "Z": 50,
+          "A_g_mol": 118.7101218000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Sr": {
+      "name": "G4_Sr",
+      "density_g_cm3": 2.5400000000,
+      "radlen_cm": 4.2369989713,
+      "intlen_cm": 61.2016634807,
+      "elements": [
+        {
+          "symbol": "Sr",
+          "Z": 38,
+          "A_g_mol": 87.6166395000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_TEFLON": {
+      "name": "G4_TEFLON",
+      "density_g_cm3": 2.2000000000,
+      "radlen_cm": 15.8385014262,
+      "intlen_cm": 40.8310561331,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2401785261
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.7598214739
+        }
+      ]
+    },
+    "G4_TERPHENYL": {
+      "name": "G4_TERPHENYL",
+      "density_g_cm3": 1.2400000000,
+      "radlen_cm": 35.1277340003,
+      "intlen_cm": 59.9049067935,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9387281833
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0612718167
+        }
+      ]
+    },
+    "G4_TESTIS_ICRP": {
+      "name": "G4_TESTIS_ICRP",
+      "density_g_cm3": 1.0400000000,
+      "radlen_cm": 35.1692276422,
+      "intlen_cm": 72.4725513802,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1060000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0990000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0200000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7660000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0020000000
+        }
+      ]
+    },
+    "G4_TETRACHLOROETHYLENE": {
+      "name": "G4_TETRACHLOROETHYLENE",
+      "density_g_cm3": 1.6250000000,
+      "radlen_cm": 12.8873634663,
+      "intlen_cm": 66.5667035399,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1448544708
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.8551455292
+        }
+      ]
+    },
+    "G4_THALLIUM_CHLORIDE": {
+      "name": "G4_THALLIUM_CHLORIDE",
+      "density_g_cm3": 7.0040000000,
+      "radlen_cm": 1.0166713986,
+      "intlen_cm": 26.3467114309,
+      "elements": [
+        {
+          "symbol": "Tl",
+          "Z": 81,
+          "A_g_mol": 204.3829295200,
+          "mass_fraction": 0.8521796274
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.1478203726
+        }
+      ]
+    },
+    "G4_THYMINE": {
+      "name": "G4_THYMINE",
+      "density_g_cm3": 1.4800000000,
+      "radlen_cm": 26.8429768410,
+      "intlen_cm": 52.7013719035,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0479539269
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4761870282
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.2221293174
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2537297275
+        }
+      ]
+    },
+    "G4_TISSUE-METHANE": {
+      "name": "G4_TISSUE-METHANE",
+      "density_g_cm3": 0.0010640900,
+      "radlen_cm": 37431.0260905174,
+      "intlen_cm": 68943.1775981619,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1018690000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4561790000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0351720000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4067800000
+        }
+      ]
+    },
+    "G4_TISSUE-PROPANE": {
+      "name": "G4_TISSUE-PROPANE",
+      "density_g_cm3": 0.0018262800,
+      "radlen_cm": 22400.6777976263,
+      "intlen_cm": 39755.8870930692,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1026720000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5689400000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0350220000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2933660000
+        }
+      ]
+    },
+    "G4_TISSUE_SOFT_ICRP": {
+      "name": "G4_TISSUE_SOFT_ICRP",
+      "density_g_cm3": 1.0300000000,
+      "radlen_cm": 36.6945920182,
+      "intlen_cm": 72.2954858829,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1050000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2560000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0270000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.6020000000
+        },
+        {
+          "symbol": "Na",
+          "Z": 11,
+          "A_g_mol": 22.9898000000,
+          "mass_fraction": 0.0010000000
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "S",
+          "Z": 16,
+          "A_g_mol": 32.0661142600,
+          "mass_fraction": 0.0030000000
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.0020000000
+        },
+        {
+          "symbol": "K",
+          "Z": 19,
+          "A_g_mol": 39.0982931613,
+          "mass_fraction": 0.0020000000
+        }
+      ]
+    },
+    "G4_TISSUE_SOFT_ICRU-4": {
+      "name": "G4_TISSUE_SOFT_ICRU-4",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 36.8431452797,
+      "intlen_cm": 75.6496725291,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1010000000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1110000000
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.0260000000
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.7620000000
+        }
+      ]
+    },
+    "G4_TITANIUM_DIOXIDE": {
+      "name": "G4_TITANIUM_DIOXIDE",
+      "density_g_cm3": 4.2600000000,
+      "radlen_cm": 4.8120066363,
+      "intlen_cm": 25.3523138121,
+      "elements": [
+        {
+          "symbol": "Ti",
+          "Z": 22,
+          "A_g_mol": 47.8667173300,
+          "mass_fraction": 0.5993416236
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.4006583764
+        }
+      ]
+    },
+    "G4_TOLUENE": {
+      "name": "G4_TOLUENE",
+      "density_g_cm3": 0.8669000000,
+      "radlen_cm": 50.6840912009,
+      "intlen_cm": 83.0802585391,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9124848982
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0875151018
+        }
+      ]
+    },
+    "G4_TRICHLOROETHYLENE": {
+      "name": "G4_TRICHLOROETHYLENE",
+      "density_g_cm3": 1.4600000000,
+      "radlen_cm": 14.7632677276,
+      "intlen_cm": 71.7912794212,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1828297192
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0076715332
+        },
+        {
+          "symbol": "Cl",
+          "Z": 17,
+          "A_g_mol": 35.4525734000,
+          "mass_fraction": 0.8094987477
+        }
+      ]
+    },
+    "G4_TRIETHYL_PHOSPHATE": {
+      "name": "G4_TRIETHYL_PHOSPHATE",
+      "density_g_cm3": 1.0700000000,
+      "radlen_cm": 32.3802005558,
+      "intlen_cm": 72.7982710675,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.3956216481
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0830014017
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.3513359494
+        },
+        {
+          "symbol": "P",
+          "Z": 15,
+          "A_g_mol": 30.9738000000,
+          "mass_fraction": 0.1700410008
+        }
+      ]
+    },
+    "G4_TUNGSTEN_HEXAFLUORIDE": {
+      "name": "G4_TUNGSTEN_HEXAFLUORIDE",
+      "density_g_cm3": 2.4000000000,
+      "radlen_cm": 4.0495275513,
+      "intlen_cm": 57.8720027568,
+      "elements": [
+        {
+          "symbol": "W",
+          "Z": 74,
+          "A_g_mol": 183.8416100000,
+          "mass_fraction": 0.6172661226
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.3827338774
+        }
+      ]
+    },
+    "G4_Ta": {
+      "name": "G4_Ta",
+      "density_g_cm3": 16.6540000000,
+      "radlen_cm": 0.4093920370,
+      "intlen_cm": 11.8868655868,
+      "elements": [
+        {
+          "symbol": "Ta",
+          "Z": 73,
+          "A_g_mol": 180.9478798800,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Tb": {
+      "name": "G4_Tb",
+      "density_g_cm3": 8.2290000000,
+      "radlen_cm": 0.8939773235,
+      "intlen_cm": 23.0383704280,
+      "elements": [
+        {
+          "symbol": "Tb",
+          "Z": 65,
+          "A_g_mol": 158.9250000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Tc": {
+      "name": "G4_Tc",
+      "density_g_cm3": 11.5000000000,
+      "radlen_cm": 0.8331486453,
+      "intlen_cm": 14.0273332814,
+      "elements": [
+        {
+          "symbol": "Tc",
+          "Z": 43,
+          "A_g_mol": 97.9072000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Te": {
+      "name": "G4_Te",
+      "density_g_cm3": 6.2400000000,
+      "radlen_cm": 1.4145736790,
+      "intlen_cm": 28.2381937661,
+      "elements": [
+        {
+          "symbol": "Te",
+          "Z": 52,
+          "A_g_mol": 127.6028203000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Th": {
+      "name": "G4_Th",
+      "density_g_cm3": 11.7200000000,
+      "radlen_cm": 0.5182303174,
+      "intlen_cm": 18.3510184568,
+      "elements": [
+        {
+          "symbol": "Th",
+          "Z": 90,
+          "A_g_mol": 232.0380000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Ti": {
+      "name": "G4_Ti",
+      "density_g_cm3": 4.5400000000,
+      "radlen_cm": 3.5601976931,
+      "intlen_cm": 27.9913240031,
+      "elements": [
+        {
+          "symbol": "Ti",
+          "Z": 22,
+          "A_g_mol": 47.8667173300,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Tl": {
+      "name": "G4_Tl",
+      "density_g_cm3": 11.7200000000,
+      "radlen_cm": 0.5476649213,
+      "intlen_cm": 17.5909248845,
+      "elements": [
+        {
+          "symbol": "Tl",
+          "Z": 81,
+          "A_g_mol": 204.3829295200,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Tm": {
+      "name": "G4_Tm",
+      "density_g_cm3": 9.3210000000,
+      "radlen_cm": 0.7544283053,
+      "intlen_cm": 20.7576376405,
+      "elements": [
+        {
+          "symbol": "Tm",
+          "Z": 69,
+          "A_g_mol": 168.9340000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_U": {
+      "name": "G4_U",
+      "density_g_cm3": 18.9500000000,
+      "radlen_cm": 0.3166296193,
+      "intlen_cm": 11.4463995326,
+      "elements": [
+        {
+          "symbol": "U",
+          "Z": 92,
+          "A_g_mol": 238.0291290500,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_URACIL": {
+      "name": "G4_URACIL",
+      "density_g_cm3": 1.3200000000,
+      "radlen_cm": 29.6780964598,
+      "intlen_cm": 60.2469223893,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0359699343
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.4286218190
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.2499266740
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2854815727
+        }
+      ]
+    },
+    "G4_URANIUM_DICARBIDE": {
+      "name": "G4_URANIUM_DICARBIDE",
+      "density_g_cm3": 11.2800000000,
+      "radlen_cm": 0.5774187445,
+      "intlen_cm": 16.6288137602,
+      "elements": [
+        {
+          "symbol": "U",
+          "Z": 92,
+          "A_g_mol": 238.0291290500,
+          "mass_fraction": 0.9083326938
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0916673062
+        }
+      ]
+    },
+    "G4_URANIUM_MONOCARBIDE": {
+      "name": "G4_URANIUM_MONOCARBIDE",
+      "density_g_cm3": 13.6300000000,
+      "radlen_cm": 0.4591719671,
+      "intlen_cm": 14.7086462814,
+      "elements": [
+        {
+          "symbol": "U",
+          "Z": 92,
+          "A_g_mol": 238.0291290500,
+          "mass_fraction": 0.9519647143
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.0480352857
+        }
+      ]
+    },
+    "G4_URANIUM_OXIDE": {
+      "name": "G4_URANIUM_OXIDE",
+      "density_g_cm3": 10.9600000000,
+      "radlen_cm": 0.6067585859,
+      "intlen_cm": 16.8728319003,
+      "elements": [
+        {
+          "symbol": "U",
+          "Z": 92,
+          "A_g_mol": 238.0291290500,
+          "mass_fraction": 0.8814982465
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.1185017535
+        }
+      ]
+    },
+    "G4_UREA": {
+      "name": "G4_UREA",
+      "density_g_cm3": 1.3230000000,
+      "radlen_cm": 29.2864284039,
+      "intlen_cm": 58.3095550771,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.1999941860
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0671340321
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.4664613838
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2664103982
+        }
+      ]
+    },
+    "G4_V": {
+      "name": "G4_V",
+      "density_g_cm3": 6.1100000000,
+      "radlen_cm": 2.5928540732,
+      "intlen_cm": 21.2349284162,
+      "elements": [
+        {
+          "symbol": "V",
+          "Z": 23,
+          "A_g_mol": 50.9415080000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_VALINE": {
+      "name": "G4_VALINE",
+      "density_g_cm3": 1.2300000000,
+      "radlen_cm": 33.0046908252,
+      "intlen_cm": 59.7177245788,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.5126370904
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0946450872
+        },
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 0.1195661791
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.2731516433
+        }
+      ]
+    },
+    "G4_VITON": {
+      "name": "G4_VITON",
+      "density_g_cm3": 1.8000000000,
+      "radlen_cm": 19.6436366979,
+      "intlen_cm": 48.8530589173,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0094170000
+        },
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.2805550000
+        },
+        {
+          "symbol": "F",
+          "Z": 9,
+          "A_g_mol": 18.9984000000,
+          "mass_fraction": 0.7100280000
+        }
+      ]
+    },
+    "G4_W": {
+      "name": "G4_W",
+      "density_g_cm3": 19.3000000000,
+      "radlen_cm": 0.3504180177,
+      "intlen_cm": 10.3115837893,
+      "elements": [
+        {
+          "symbol": "W",
+          "Z": 74,
+          "A_g_mol": 183.8416100000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_WATER": {
+      "name": "G4_WATER",
+      "density_g_cm3": 1.0000000000,
+      "radlen_cm": 36.0829774640,
+      "intlen_cm": 75.3747894121,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1118984778
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.8881015222
+        }
+      ]
+    },
+    "G4_WATER_VAPOR": {
+      "name": "G4_WATER_VAPOR",
+      "density_g_cm3": 0.0007561820,
+      "radlen_cm": 47717.3186666997,
+      "intlen_cm": 99678.1058159553,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1118984778
+        },
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 0.8881015222
+        }
+      ]
+    },
+    "G4_XYLENE": {
+      "name": "G4_XYLENE",
+      "density_g_cm3": 0.8700000000,
+      "radlen_cm": 50.6283508279,
+      "intlen_cm": 82.0777032085,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.9050593022
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.0949406978
+        }
+      ]
+    },
+    "G4_Xe": {
+      "name": "G4_Xe",
+      "density_g_cm3": 0.0054853600,
+      "radlen_cm": 1546.2047849966,
+      "intlen_cm": 32429.6946749956,
+      "elements": [
+        {
+          "symbol": "Xe",
+          "Z": 54,
+          "A_g_mol": 131.2924485000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Y": {
+      "name": "G4_Y",
+      "density_g_cm3": 4.4690000000,
+      "radlen_cm": 2.3294263573,
+      "intlen_cm": 34.9543386305,
+      "elements": [
+        {
+          "symbol": "Y",
+          "Z": 39,
+          "A_g_mol": 88.9058000000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Yb": {
+      "name": "G4_Yb",
+      "density_g_cm3": 6.7300000000,
+      "radlen_cm": 1.0433231211,
+      "intlen_cm": 28.9800996269,
+      "elements": [
+        {
+          "symbol": "Yb",
+          "Z": 70,
+          "A_g_mol": 173.0376377000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Zn": {
+      "name": "G4_Zn",
+      "density_g_cm3": 7.1330000000,
+      "radlen_cm": 1.7428596191,
+      "intlen_cm": 19.7687190024,
+      "elements": [
+        {
+          "symbol": "Zn",
+          "Z": 30,
+          "A_g_mol": 65.3955232900,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_Zr": {
+      "name": "G4_Zr",
+      "density_g_cm3": 6.5060000000,
+      "radlen_cm": 1.5670742707,
+      "intlen_cm": 24.2171559753,
+      "elements": [
+        {
+          "symbol": "Zr",
+          "Z": 40,
+          "A_g_mol": 91.2236313100,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lAr": {
+      "name": "G4_lAr",
+      "density_g_cm3": 1.3960000000,
+      "radlen_cm": 14.0034386850,
+      "intlen_cm": 85.7063953867,
+      "elements": [
+        {
+          "symbol": "Ar",
+          "Z": 18,
+          "A_g_mol": 39.9476933511,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lBr": {
+      "name": "G4_lBr",
+      "density_g_cm3": 3.1028000000,
+      "radlen_cm": 3.6812743699,
+      "intlen_cm": 48.5850800305,
+      "elements": [
+        {
+          "symbol": "Br",
+          "Z": 35,
+          "A_g_mol": 79.9035138000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lH2": {
+      "name": "G4_lH2",
+      "density_g_cm3": 0.0708000000,
+      "radlen_cm": 890.4450429699,
+      "intlen_cm": 494.3503221504,
+      "elements": [
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lKr": {
+      "name": "G4_lKr",
+      "density_g_cm3": 2.4180000000,
+      "radlen_cm": 4.7031249036,
+      "intlen_cm": 63.3420249794,
+      "elements": [
+        {
+          "symbol": "Kr",
+          "Z": 36,
+          "A_g_mol": 83.7993175100,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lN2": {
+      "name": "G4_lN2",
+      "density_g_cm3": 0.8070000000,
+      "radlen_cm": 47.0732642399,
+      "intlen_cm": 104.5459466611,
+      "elements": [
+        {
+          "symbol": "N",
+          "Z": 7,
+          "A_g_mol": 14.0067689600,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lO2": {
+      "name": "G4_lO2",
+      "density_g_cm3": 1.1410000000,
+      "radlen_cm": 30.0071281192,
+      "intlen_cm": 77.2947944830,
+      "elements": [
+        {
+          "symbol": "O",
+          "Z": 8,
+          "A_g_mol": 15.9993904110,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    },
+    "G4_lPROPANE": {
+      "name": "G4_lPROPANE",
+      "density_g_cm3": 0.4300000000,
+      "radlen_cm": 105.5230910621,
+      "intlen_cm": 150.8230000357,
+      "elements": [
+        {
+          "symbol": "C",
+          "Z": 6,
+          "A_g_mol": 12.0107363800,
+          "mass_fraction": 0.8171359205
+        },
+        {
+          "symbol": "H",
+          "Z": 1,
+          "A_g_mol": 1.0079407527,
+          "mass_fraction": 0.1828640795
+        }
+      ]
+    },
+    "G4_lXe": {
+      "name": "G4_lXe",
+      "density_g_cm3": 2.9530000000,
+      "radlen_cm": 2.8721604739,
+      "intlen_cm": 60.2399424255,
+      "elements": [
+        {
+          "symbol": "Xe",
+          "Z": 54,
+          "A_g_mol": 131.2924485000,
+          "mass_fraction": 1.0000000000
+        }
+      ]
+    }
+  },
+  "count_built_ok": 309,
+  "count_built_fail": 0
+}

--- a/scripts/geometry/g4_nist_database/compile.sh
+++ b/scripts/geometry/g4_nist_database/compile.sh
@@ -1,0 +1,11 @@
+echo "Compiling using geant4-config..."
+
+g++ -std=c++20 nist_export_all.cxx \
+    $(geant4-config --cflags) \
+    $(geant4-config --libs) \
+    -O2 -o nist_export_all
+
+echo ""
+echo "Build complete."
+echo "Run with:"
+echo "  ./nist_export_all nist_db_all.json"

--- a/scripts/geometry/g4_nist_database/nist_export_all.cxx
+++ b/scripts/geometry/g4_nist_database/nist_export_all.cxx
@@ -1,0 +1,136 @@
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// Geant4
+#include "G4NistManager.hh"
+#include "G4Material.hh"
+#include "G4Element.hh"
+#include "G4SystemOfUnits.hh"
+
+static std::string json_escape(const std::string& s)
+{
+  std::string out;
+  out.reserve(s.size() + 8);
+  for (char c : s) {
+    switch (c) {
+      case '\\':
+        out += "\\\\";
+        break;
+      case '"':
+        out += "\\\"";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        out += c;
+        break;
+    }
+  }
+  return out;
+}
+
+int main(int argc, char** argv)
+{
+  if (argc < 2) {
+    std::cerr << "Usage:\n  " << argv[0] << " out.json\n";
+    return 2;
+  }
+
+  const std::string out_json = argv[1];
+
+  auto* nist = G4NistManager::Instance();
+
+  // This returns all known NIST material names.
+  std::vector<G4String> names = nist->GetNistMaterialNames();
+  std::sort(names.begin(), names.end());
+
+  std::ofstream out(out_json);
+  if (!out) {
+    std::cerr << "Cannot write: " << out_json << "\n";
+    return 2;
+  }
+
+  out << std::fixed << std::setprecision(10);
+  out << "{\n"
+      << "  \"schema\": \"g4_nist_export_v1\",\n"
+      << "  \"count_requested\": " << names.size() << ",\n"
+      << "  \"materials\": {\n";
+
+  bool first_mat = true;
+  size_t built_ok = 0;
+  size_t built_fail = 0;
+
+  for (const auto& g4name : names) {
+    // Build the material (some may fail depending on Geant4 build/config).
+    G4Material* mat = nist->FindOrBuildMaterial(g4name, /*warning=*/false, /*isotopes=*/false);
+    if (!mat) {
+      ++built_fail;
+      continue;
+    }
+    ++built_ok;
+
+    const std::string name = g4name; // convert G4String -> std::string
+
+    // Export in convenient units
+    const double density_g_cm3 = mat->GetDensity() / (g / cm3);
+    const double radlen_cm = mat->GetRadlen() / cm;
+    const double intlen_cm = mat->GetNuclearInterLength() / cm;
+
+    const size_t ne = mat->GetNumberOfElements();
+    const auto* elems = mat->GetElementVector();
+    const auto* fracs = mat->GetFractionVector(); // mass fractions (nullptr for some edge cases)
+
+    if (!first_mat)
+      out << ",\n";
+    first_mat = false;
+
+    out << "    \"" << json_escape(name) << "\": {\n";
+    out << "      \"name\": \"" << json_escape(name) << "\",\n";
+    out << "      \"density_g_cm3\": " << density_g_cm3 << ",\n";
+    out << "      \"radlen_cm\": " << radlen_cm << ",\n";
+    out << "      \"intlen_cm\": " << intlen_cm << ",\n";
+    out << "      \"elements\": [\n";
+
+    for (size_t i = 0; i < ne; ++i) {
+      const G4Element* el = (*elems)[i];
+      const int Z = static_cast<int>(el->GetZ());
+      const double A_g_mol = el->GetA() / (g / mole);
+      const double w = fracs ? fracs[i] : 0.0;
+
+      out << "        {"
+          << "\"symbol\": \"" << json_escape(el->GetSymbol()) << "\", "
+          << "\"Z\": " << Z << ", "
+          << "\"A_g_mol\": " << A_g_mol << ", "
+          << "\"mass_fraction\": " << w
+          << "}";
+
+      if (i + 1 != ne)
+        out << ",";
+      out << "\n";
+    }
+
+    out << "      ]\n";
+    out << "    }";
+  }
+
+  out << "\n  },\n"
+      << "  \"count_built_ok\": " << built_ok << ",\n"
+      << "  \"count_built_fail\": " << built_fail << "\n"
+      << "}\n";
+
+  std::cerr << "Wrote: " << out_json << "\n"
+            << "NIST names: " << names.size() << ", built ok: " << built_ok
+            << ", failed: " << built_fail << "\n";
+  return 0;
+}

--- a/scripts/geometry/simulating_CAD_modules.md
+++ b/scripts/geometry/simulating_CAD_modules.md
@@ -6,7 +6,8 @@ These are a few notes related to the inclusion of external (CAD-described) detec
 
 In principle, such integration is now possible and requires the following steps:
 
-1. The CAD geometry needs to be exported to STEP format and must contain only the final geometry (no artificial eta-cut elements). Ideally, the geometry should be fully hierarchical with proper solid reuse. The solids should retain their proper surface representation for detailed analysis.
+1. The CAD geometry needs to be exported to STEP format and must contain only the final geometry (no artificial eta-cut elements). Ideally, the geometry should be fully hierarchical with proper solid reuse. The solids should retain their proper surface representation for detailed analysis. Materials can be treated by providing a CSV file that map STEP part names to a material name. The conversion code will do it's best to find a corresponding material definition from a G4 NIST database JSON file (which can be expanded by users with custom definitions).
+
 
 2. A tool `O2-CADtoTGeo.py` is provided to convert the STEP geometry into TGeo format. The tool is part of AliceO2 and is based on Python bindings (OCC) for OpenCascade. The tool can be used as follows:
 
@@ -17,7 +18,14 @@ In principle, such integration is now possible and requires the following steps:
 
     This will create a ROOT macro file `geom.C` containing the geometry description in ROOT format, as well as several binary files describing the TGeo solids. The `geom.C` file can either be used directly in ROOT to inspect the geometry or be provided to ALICE-O2 for inclusion in the geometry.
 
-3. Introduction of materials/media in the file `geom.C`. Currently, the file `geom.C` needs to be patched or edited to properly include `TGeoMaterial`/`TGeoMedium` definitions and connect them to the relevant `TGeoVolume` objects. At present, every solid has the same dummy material attached, which is not realistic. It may be a good idea to create a new file `geom_withMaterials.C`, which differs from `geom.C` by the addition of these material definitions.
+    When materials are included the conversion process looks like this
+    ```bash
+    python O2-CADtoTGeo.py STEP_FILE --output-folder my_detector -o geom.C --mesh \
+                           --mesh-prec 0.2                                        \
+                           --materials-csv MATERIALS.csv                          \ --g4-nist-json ../g4_nist_database/G4_NIST_DB.json 
+    ```
+
+3. Inspection of the created geom.C file and possible manual editing/fixing of the code, in particular materials and medium objects.
 
 4. Once the conversion is complete, the module can be inserted into the O2 geometry via the `ExternalModule` class. To do so, follow this pattern in `build_geometry.C`:
 


### PR DESCRIPTION
The present commit adds support to complement
the geometry created from CAD STEP files with materials.

For now the script can process materials mentioned in a CSV
file, where each line maps the CAD part name to a material string.

An example is this
```
,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
CAD,Mechanical/Part,ST1782525_01,AA.04,FIRST PART,1.51881,St. Steel EN 1.4306 (304L)
,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
CAD,Mechanical/Part,ST2487461_01,AA.04,SECOND PART,2.344,Alu EN AW-5083 (H116)
,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
CAD,Mechanical/Part,ST2487721_01,AA.02,THIRD PART,0.313133,Carbon Fiber
```
where `ST2487721_01` are the part names referenced in the STEP file.

The conversion script will read the material names (e.g., Alu EN AW-5083 (H116)) and attempt a mapping to known materials in the Geant4 NIST database of materials based on string matching as well as material density.

The user should check the emitted materials in the resulting geometry file (geom.C) and possibly edit/correct the code. Another possibility would be to fix the CSV file from the start and only reference Geant4 NIST names.

The commit also contains a small utility to extract a JSON G4 NIST database from the Geant4 engine. The resulting JSON file `G4_NIST_DB.json` is also part of the commit and can be extended by the user with further definitions.

A complete conversion example, including materials would like this:
```bash
python3 O2_CADtoTGeo.py STEPFILE.stp --mesh [--mesh-prec 1.2]    \
         --out-path tgeo_geometry_output_folder -o geom.C        \
	 --materials-csv MATERIALS.csv                           \
	 --g4-nist-json G4_NIST_DB.json
```

Code generated with help of a code assistant.