### PR TITLE
DPL: Better detection for injected workflows

### DIFF
--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -680,8 +680,12 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
           workflow.erase(reader);
         } else {
           // load reader algorithm before deployment
-          auto mctracks2aod = std::find_if(workflow.begin(), workflow.end(), [](auto const& x) { return x.name == "mctracks-to-aod"; });
-          if (mctracks2aod == workflow.end()) { // add normal reader algorithm only if no on-the-fly generator is injected
+          auto tfnsource = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) {
+            return std::ranges::any_of(spec.outputs, [](OutputSpec const& output) {
+              return DataSpecUtils::match(output, "TFN", "TFNumber", 0);
+            });
+          });
+          if (tfnsource == workflow.end()) { // add normal reader algorithm only if no on-the-fly generator is injected
             reader->algorithm = CommonDataProcessors::wrapWithTimesliceConsumption(PluginManager::loadAlgorithmFromPlugin("O2FrameworkAnalysisSupport", "ROOTFileReader", ctx));
           } // otherwise the algorithm was set in injectServiceDevices
         }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -411,13 +411,17 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   // add the reader
   if (aodReader.outputs.empty() == false) {
-    auto mctracks2aod = std::ranges::find_if(workflow, [](auto const& x) { return x.name == "mctracks-to-aod"; });
-    if (mctracks2aod == workflow.end()) {
+    auto tfnsource = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) {
+      return std::ranges::any_of(spec.outputs, [](OutputSpec const& output) {
+        return DataSpecUtils::match(output, "TFN", "TFNumber", 0);
+      });
+    });
+    if (tfnsource == workflow.end()) {
       // add normal reader
       aodReader.outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
       aodReader.outputs.emplace_back(OutputSpec{"TFF", "TFFilename"});
     } else {
-      // AODs are being injected on-the-fly, add error-handler reader
+      // AODs are being injected the tfnsource is the entry point, add error-handler reader
       aodReader.algorithm = AlgorithmSpec{
         adaptStateful(
           [](DeviceSpec const& spec) {
@@ -698,6 +702,11 @@ void WorkflowHelpers::injectAODWriter(WorkflowSpec& workflow, ConfigContext cons
 
     auto it = std::find_if(dec.outputsInputs.begin(), dec.outputsInputs.end(), [](InputSpec const& spec) -> bool {
       return DataSpecUtils::partialMatch(spec, o2::header::DataOrigin("TFN"));
+    });
+    dec.isDangling[std::distance(dec.outputsInputs.begin(), it)] = false;
+
+    it = std::find_if(dec.outputsInputs.begin(), dec.outputsInputs.end(), [](InputSpec const& spec) -> bool {
+      return DataSpecUtils::partialMatch(spec, o2::header::DataOrigin("TFF"));
     });
     dec.isDangling[std::distance(dec.outputsInputs.begin(), it)] = false;
   }

--- a/run/o2sim_hepmc_publisher.cxx
+++ b/run/o2sim_hepmc_publisher.cxx
@@ -37,7 +37,9 @@ struct O2simHepmcPublisher {
   int tfCounter = 0;
   std::shared_ptr<HepMC3::Reader> hepMCReader;
   bool eos = false;
-  std::vector<o2::MCTrack> mcTracks;
+
+  std::vector<o2::pmr::vector<o2::MCTrack>*> mctracks_vector;
+  std::vector<o2::dataformats::MCEventHeader*> mcheader_vector;
 
   void init(o2::framework::InitContext& /*ic*/)
   {
@@ -50,13 +52,19 @@ struct O2simHepmcPublisher {
       LOGP(fatal, "Cannot open HEPMC kine file {}", (std::string)hepmcFileName);
     }
     // allocate the memory upfront to prevent reallocations later
-    mcTracks.reserve(1e3 * aggregate);
+    mctracks_vector.reserve(aggregate);
+    mcheader_vector.reserve(aggregate);
   }
 
   void run(o2::framework::ProcessingContext& pc)
   {
     HepMC3::GenEvent event;
-    for (auto i = 0; i < (int)aggregate; ++i) {
+    auto batch = maxEvents > 0 ? std::min((int)aggregate, (int)maxEvents - eventCounter) : (int)aggregate;
+    for (auto i = 0; i < batch; ++i) {
+      mctracks_vector.push_back(&pc.outputs().make<o2::pmr::vector<o2::MCTrack>>(Output{"MC", "MCTRACKS", 0}));
+      auto& mctracks = mctracks_vector.back();
+      mcheader_vector.push_back(&pc.outputs().make<o2::dataformats::MCEventHeader>(Output{"MC", "MCHEADER", 0}));
+      auto& mcheader = mcheader_vector.back();
       // read next entry
       hepMCReader->read_event(event);
       if (hepMCReader->failed()) {
@@ -66,61 +74,60 @@ struct O2simHepmcPublisher {
       }
 
       // create O2 MCHeader and MCtracks vector out of HEPMC event
-      o2::dataformats::MCEventHeader mcHeader;
-      mcHeader.SetEventID(event.event_number());
-      mcHeader.SetVertex(event.event_pos().px(), event.event_pos().py(), event.event_pos().pz());
+      mcheader->SetEventID(event.event_number());
+      mcheader->SetVertex(event.event_pos().px(), event.event_pos().py(), event.event_pos().pz());
       auto xsecInfo = event.cross_section();
       if (xsecInfo != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::acceptedEvents, (uint64_t)xsecInfo->get_accepted_events());
-        mcHeader.putInfo(MCInfoKeys::attemptedEvents, (uint64_t)xsecInfo->get_attempted_events());
-        mcHeader.putInfo(MCInfoKeys::xSection, (float)xsecInfo->xsec());
-        mcHeader.putInfo(MCInfoKeys::xSectionError, (float)xsecInfo->xsec_err());
+        mcheader->putInfo(MCInfoKeys::acceptedEvents, (uint64_t)xsecInfo->get_accepted_events());
+        mcheader->putInfo(MCInfoKeys::attemptedEvents, (uint64_t)xsecInfo->get_attempted_events());
+        mcheader->putInfo(MCInfoKeys::xSection, (float)xsecInfo->xsec());
+        mcheader->putInfo(MCInfoKeys::xSectionError, (float)xsecInfo->xsec_err());
       }
       auto scale = event.attribute<HepMC3::DoubleAttribute>(MCInfoKeys::eventScale);
       if (scale != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::eventScale, (float)scale->value());
+        mcheader->putInfo(MCInfoKeys::eventScale, (float)scale->value());
       }
       auto nMPI = event.attribute<HepMC3::IntAttribute>(MCInfoKeys::mpi);
       if (nMPI != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::mpi, nMPI->value());
+        mcheader->putInfo(MCInfoKeys::mpi, nMPI->value());
       }
       auto sid = event.attribute<HepMC3::IntAttribute>(MCInfoKeys::processCode);
       auto scode = event.attribute<HepMC3::IntAttribute>(MCInfoKeys::processID); // default pythia8 hepmc3 interface uses signal_process_id
       if (sid != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::processCode, sid->value());
+        mcheader->putInfo(MCInfoKeys::processCode, sid->value());
       } else if (scode != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::processCode, scode->value());
+        mcheader->putInfo(MCInfoKeys::processCode, scode->value());
       }
       auto pdfInfo = event.pdf_info();
       if (pdfInfo != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::pdfParton1Id, pdfInfo->parton_id[0]);
-        mcHeader.putInfo(MCInfoKeys::pdfParton2Id, pdfInfo->parton_id[1]);
-        mcHeader.putInfo(MCInfoKeys::pdfCode1, pdfInfo->pdf_id[0]);
-        mcHeader.putInfo(MCInfoKeys::pdfCode2, pdfInfo->pdf_id[1]);
-        mcHeader.putInfo(MCInfoKeys::pdfX1, (float)pdfInfo->x[0]);
-        mcHeader.putInfo(MCInfoKeys::pdfX2, (float)pdfInfo->x[1]);
-        mcHeader.putInfo(MCInfoKeys::pdfScale, (float)pdfInfo->scale);
-        mcHeader.putInfo(MCInfoKeys::pdfXF1, (float)pdfInfo->xf[0]);
-        mcHeader.putInfo(MCInfoKeys::pdfXF2, (float)pdfInfo->xf[1]);
+        mcheader->putInfo(MCInfoKeys::pdfParton1Id, pdfInfo->parton_id[0]);
+        mcheader->putInfo(MCInfoKeys::pdfParton2Id, pdfInfo->parton_id[1]);
+        mcheader->putInfo(MCInfoKeys::pdfCode1, pdfInfo->pdf_id[0]);
+        mcheader->putInfo(MCInfoKeys::pdfCode2, pdfInfo->pdf_id[1]);
+        mcheader->putInfo(MCInfoKeys::pdfX1, (float)pdfInfo->x[0]);
+        mcheader->putInfo(MCInfoKeys::pdfX2, (float)pdfInfo->x[1]);
+        mcheader->putInfo(MCInfoKeys::pdfScale, (float)pdfInfo->scale);
+        mcheader->putInfo(MCInfoKeys::pdfXF1, (float)pdfInfo->xf[0]);
+        mcheader->putInfo(MCInfoKeys::pdfXF2, (float)pdfInfo->xf[1]);
       }
       auto heavyIon = event.heavy_ion();
       if (heavyIon != nullptr) {
-        mcHeader.putInfo(MCInfoKeys::nCollHard, heavyIon->Ncoll_hard);
-        mcHeader.putInfo(MCInfoKeys::nPartProjectile, heavyIon->Npart_proj);
-        mcHeader.putInfo(MCInfoKeys::nPartTarget, heavyIon->Npart_targ);
-        mcHeader.putInfo(MCInfoKeys::nColl, heavyIon->Ncoll);
-        mcHeader.putInfo(MCInfoKeys::nCollNNWounded, heavyIon->N_Nwounded_collisions);
-        mcHeader.putInfo(MCInfoKeys::nCollNWoundedN, heavyIon->Nwounded_N_collisions);
-        mcHeader.putInfo(MCInfoKeys::nCollNWoundedNwounded, heavyIon->Nwounded_Nwounded_collisions);
-        mcHeader.putInfo(MCInfoKeys::nSpecProjectileNeutron, heavyIon->Nspec_proj_n);
-        mcHeader.putInfo(MCInfoKeys::nSpecProjectileProton, heavyIon->Nspec_proj_p);
-        mcHeader.putInfo(MCInfoKeys::nSpecTargetNeutron, heavyIon->Nspec_targ_n);
-        mcHeader.putInfo(MCInfoKeys::nSpecTargetProton, heavyIon->Nspec_targ_p);
-        mcHeader.putInfo(MCInfoKeys::impactParameter, (float)heavyIon->impact_parameter);
-        mcHeader.putInfo(MCInfoKeys::planeAngle, (float)heavyIon->event_plane_angle);
-        mcHeader.putInfo("eccentricity", (float)heavyIon->eccentricity);
-        mcHeader.putInfo(MCInfoKeys::sigmaInelNN, (float)heavyIon->sigma_inel_NN);
-        mcHeader.putInfo(MCInfoKeys::centrality, (float)heavyIon->centrality);
+        mcheader->putInfo(MCInfoKeys::nCollHard, heavyIon->Ncoll_hard);
+        mcheader->putInfo(MCInfoKeys::nPartProjectile, heavyIon->Npart_proj);
+        mcheader->putInfo(MCInfoKeys::nPartTarget, heavyIon->Npart_targ);
+        mcheader->putInfo(MCInfoKeys::nColl, heavyIon->Ncoll);
+        mcheader->putInfo(MCInfoKeys::nCollNNWounded, heavyIon->N_Nwounded_collisions);
+        mcheader->putInfo(MCInfoKeys::nCollNWoundedN, heavyIon->Nwounded_N_collisions);
+        mcheader->putInfo(MCInfoKeys::nCollNWoundedNwounded, heavyIon->Nwounded_Nwounded_collisions);
+        mcheader->putInfo(MCInfoKeys::nSpecProjectileNeutron, heavyIon->Nspec_proj_n);
+        mcheader->putInfo(MCInfoKeys::nSpecProjectileProton, heavyIon->Nspec_proj_p);
+        mcheader->putInfo(MCInfoKeys::nSpecTargetNeutron, heavyIon->Nspec_targ_n);
+        mcheader->putInfo(MCInfoKeys::nSpecTargetProton, heavyIon->Nspec_targ_p);
+        mcheader->putInfo(MCInfoKeys::impactParameter, (float)heavyIon->impact_parameter);
+        mcheader->putInfo(MCInfoKeys::planeAngle, (float)heavyIon->event_plane_angle);
+        mcheader->putInfo("eccentricity", (float)heavyIon->eccentricity);
+        mcheader->putInfo(MCInfoKeys::sigmaInelNN, (float)heavyIon->sigma_inel_NN);
+        mcheader->putInfo(MCInfoKeys::centrality, (float)heavyIon->centrality);
       }
 
       auto particles = event.particles();
@@ -131,7 +138,7 @@ struct O2simHepmcPublisher {
         auto has_children = children.size() > 0;
         auto p = particle->momentum();
         auto v = particle->production_vertex();
-        mcTracks.emplace_back(
+        mctracks->emplace_back(
           particle->pid(),
           has_parents ? parents.front()->id() : -1, has_parents ? parents.back()->id() : -1,
           has_children ? children.front()->id() : -1, has_children ? children.back()->id() : -1,
@@ -139,18 +146,13 @@ struct O2simHepmcPublisher {
           v->position().x(), v->position().y(), v->position().z(),
           v->position().t(), 0);
       }
-
-      // add to the message
-      pc.outputs().snapshot(Output{"MC", "MCHEADER", 0}, mcHeader);
-      pc.outputs().snapshot(Output{"MC", "MCTRACKS", 0}, mcTracks);
-      mcTracks.clear();
       ++eventCounter;
     }
 
     // report number of TFs injected for the rate limiter to work
     ++tfCounter;
     pc.services().get<o2::monitoring::Monitoring>().send(o2::monitoring::Metric{(uint64_t)tfCounter, "df-sent"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
-    if (eos || (maxEvents > 0 && eventCounter == maxEvents)) {
+    if (eos || (maxEvents > 0 && eventCounter >= maxEvents)) {
       pc.services().get<ControlService>().endOfStream();
       pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     }

--- a/run/o2sim_kine_publisher.cxx
+++ b/run/o2sim_kine_publisher.cxx
@@ -40,7 +40,8 @@ struct O2simKinePublisher {
 
   void run(o2::framework::ProcessingContext& pc)
   {
-    for (auto i = 0; i < std::min((int)aggregate, nEvents - eventCounter); ++i) {
+    auto batch = std::min((int)aggregate, nEvents - eventCounter);
+    for (auto i = 0; i < batch; ++i) {
       auto mcevent = mcKinReader->getMCEventHeader(0, eventCounter);
       auto mctracks = mcKinReader->getTracks(0, eventCounter);
       pc.outputs().snapshot(Output{"MC", "MCHEADER", 0}, mcevent);

--- a/run/o2sim_mctracks_to_aod.cxx
+++ b/run/o2sim_mctracks_to_aod.cxx
@@ -70,7 +70,7 @@ struct MctracksToAod {
   /** Run the conversion */
   void run(o2::framework::ProcessingContext& pc)
   {
-    LOG(debug) << "=== Running extended MC AOD exporter ===";
+    LOG(detail) << "=== Running extended MC AOD exporter ===";
     using namespace o2::aodmchelpers;
     using McHeader = o2::dataformats::MCEventHeader;
     using McTrack = o2::MCTrack;
@@ -94,13 +94,13 @@ struct MctracksToAod {
     // TODO: include BC simulation
     auto bcCounter = 0UL;
     size_t offset = 0;
-    LOG(debug) << "--- Loop over " << nParts << " parts ---";
+    LOG(detail) << "--- Loop over " << nParts << " parts ---";
     for (auto i = 0U; i < nParts; ++i) {
       auto record = mSampler.generateCollisionTime();
       auto header = pc.inputs().get<McHeader*>("mcheader", i);
       auto tracks = pc.inputs().get<McTracks>("mctracks", i);
 
-      LOG(debug) << "Updating collision table";
+      LOG(detail) << "Updating collision table";
       auto genID = updateMCCollisions(mCollisions.cursor,
                                       bcCounter,
                                       record.timeInBCNS * 1.e-3,
@@ -108,12 +108,12 @@ struct MctracksToAod {
                                       0,
                                       i);
 
-      LOG(debug) << "Updating HepMC tables";
+      LOG(detail) << "Updating HepMC tables";
       updateHepMCXSection(mXSections.cursor, bcCounter, genID, *header);
       updateHepMCPdfInfo(mPdfInfos.cursor, bcCounter, genID, *header);
       updateHepMCHeavyIon(mHeavyIons.cursor, bcCounter, genID, *header);
 
-      LOG(debug) << "Updating particles table";
+      LOG(detail) << "Updating particles table";
       TrackToIndex preselect;
       offset = updateParticles(mParticles.cursor,
                                bcCounter,
@@ -123,7 +123,7 @@ struct MctracksToAod {
                                (bool)filt,
                                false);
 
-      LOG(debug) << "Increment BC counter";
+      LOG(detail) << "Increment BC counter";
       bcCounter++;
     }
 


### PR DESCRIPTION
* Use the presence of the source of `TFN/TFNumber` and `TFF/TFFilename` messages as a criterion of disabling the AOD reader, instead of the mctracks-to-aod converter. 
* Improve hepmc-publisher to reduce memory copying. 
* Fix the loop modifying the loop condition for kine- and hepmc-publisher (as already done for dpl-eventgen).