### PR TITLE
fix include in one TOF macro

### DIFF
--- a/Detectors/TOF/prototyping/checkDRMobj_tof.C
+++ b/Detectors/TOF/prototyping/checkDRMobj_tof.C
@@ -12,6 +12,7 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "TFile.h"
 #include "TH2F.h"
+#include "TCanvas.h"
 #include "TOFBase/CalibTOFapi.h"
 #endif
 


### PR DESCRIPTION
Dear @vkucera ,
this is to fix a missing header.
Thanks for spotting it.