### PR TITLE
ALICE3-TRK: fix y-axis orientation in the sensor local coordinate system, keeping the geometry unchanged

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKLayer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKLayer.cxx
@@ -137,17 +137,17 @@ TGeoVolume* TRKLayer::createChip(std::string type)
     metalVol = createMetalStack("flat");
 
     TGeoCombiTrans* transSens = new TGeoCombiTrans();
-    transSens->SetTranslation(-mDeadzoneWidth / 2, -(mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
+    transSens->SetTranslation(-mDeadzoneWidth / 2, (mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
     LOGP(debug, "Inserting {} in {} ", sensVol->GetName(), chipVol->GetName());
     chipVol->AddNode(sensVol, 1, transSens);
 
     TGeoCombiTrans* transDead = new TGeoCombiTrans();
-    transDead->SetTranslation((mChipWidth - mDeadzoneWidth) / 2, -(mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
+    transDead->SetTranslation((mChipWidth - mDeadzoneWidth) / 2, (mChipThickness - mSensorThickness) / 2, 0); // TO BE CHECKED !!!
     LOGP(debug, "Inserting {} in {} ", deadVol->GetName(), chipVol->GetName());
     chipVol->AddNode(deadVol, 1, transDead);
 
     TGeoCombiTrans* transMetal = new TGeoCombiTrans();
-    transMetal->SetTranslation(0, mSensorThickness / 2, 0); // TO BE CHECKED !!!
+    transMetal->SetTranslation(0, -(mSensorThickness) / 2, 0); // TO BE CHECKED !!!
     LOGP(debug, "Inserting {} in {} ", metalVol->GetName(), chipVol->GetName());
     chipVol->AddNode(metalVol, 1, transMetal);
   } else {
@@ -374,7 +374,7 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
       // Put the staves in the correct position and orientation
       TGeoCombiTrans* trans = new TGeoCombiTrans();
       double theta = 360. * iStave / nStaves;
-      TGeoRotation* rot = new TGeoRotation("rot", theta - 90 + 4, 0, 0);
+      TGeoRotation* rot = new TGeoRotation("rot", theta + 90 + 4, 0, 0);
       trans->SetRotation(rot);
       trans->SetTranslation(mInnerRadius * std::cos(2. * TMath::Pi() * iStave / nStaves), mInnerRadius * std::sin(2 * TMath::Pi() * iStave / nStaves), 0);
 
@@ -408,7 +408,7 @@ void TRKLayer::createLayer(TGeoVolume* motherVolume)
       // Put the staves in the correct position and orientation
       TGeoCombiTrans* trans = new TGeoCombiTrans();
       double theta = 360. * iStave / nStaves;
-      TGeoRotation* rot = new TGeoRotation("rot", theta - 90, 0, 0);
+      TGeoRotation* rot = new TGeoRotation("rot", theta + 90, 0, 0);
       trans->SetRotation(rot);
       trans->SetTranslation(mInnerRadius * std::cos(2. * TMath::Pi() * iStave / nStaves), mInnerRadius * std::sin(2 * TMath::Pi() * iStave / nStaves), 0);
 


### PR DESCRIPTION
This change modifies the method with which sensor and metal subvolumes are positioned within the ML/OT chips.
- Before this change, their relative orientation was set with a rotation of the stave after their creation and positioning inside the module and stave.
- Now, the rotation introduced with [PR#15043](https://github.com/AliceO2Group/AliceO2/pull/15043) has been reversed, and a shift has been applied to the elements to adjust their relative orientation in space.
This change does not alter the geometry, but ensures that the orientation of the chip's local reference system has the y-axis oriented toward the interaction point. This is the convention used in the digitization and reconstruction processes.
Everything else remains unchanged.