### PR TITLE
ITS: fix zero field seeding

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
@@ -143,8 +143,9 @@ GPUdii() o2::track::TrackParCov buildTrackSeed(const Cluster& cluster1,
 
   float snp, q2pt, q2pt2;
   if (o2::gpu::CAMath::Abs(bz) < 0.01f) {
-    const float tgp = o2::gpu::CAMath::ATan2(y3 - y1, x3 - x1);
-    snp = sign * tgp / o2::gpu::CAMath::Sqrt(1.f + tgp * tgp);
+    const float dx = x3 - x1;
+    const float dy = y3 - y1;
+    snp = sign * dy / o2::gpu::CAMath::Hypot(dx, dy);
     q2pt = sign / track::kMostProbablePt;
     q2pt2 = 1.f;
   } else {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -1278,8 +1278,9 @@ track::TrackParCov TrackerTraits<nLayers>::buildTrackSeed(const Cluster& cluster
 
   float snp, q2pt, q2pt2;
   if (mIsZeroField) {
-    const float tgp = o2::gpu::CAMath::ATan2(y3 - y1, x3 - x1);
-    snp = sign * tgp / o2::gpu::CAMath::Sqrt(1.f + tgp * tgp);
+    const float dx = x3 - x1;
+    const float dy = y3 - y1;
+    snp = sign * dy / o2::gpu::CAMath::Hypot(dx, dy);
     q2pt = sign / track::kMostProbablePt;
     q2pt2 = 1.f;
   } else {


### PR DESCRIPTION
The previous code only worked by coincidence and with the introduction of the reseeding the math we use was totally off for reverse direction.