### PR TITLE
ITS: do not query GRPECS anymore

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -125,9 +125,6 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
 
   std::uint32_t roFrame = 0;
 
-  bool continuous = o2::base::GRPGeomHelper::instance().getGRPECS()->isDetContinuousReadOut(o2::detectors::DetID::ITS);
-  LOG(info) << "ITSTracker RO: continuous=" << continuous;
-
   if (mOverrideBeamEstimation) {
     mTimeFrame->setBeamPosition(mMeanVertex->getX(),
                                 mMeanVertex->getY(),

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -102,7 +102,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, bool useGeom, int trgType, Tracking
   inputs.emplace_back("itscldict", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary"));
   inputs.emplace_back("itsalppar", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam"));
   auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                                                                        // orbitResetTime
-                                                              true,                                                                         // GRPECS=true
+                                                              false,                                                                        // GRPECS=false
                                                               false,                                                                        // GRPLHCIF
                                                               true,                                                                         // GRPMagField
                                                               true,                                                                         // askMatLUT

--- a/Detectors/ITSMFT/common/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClustererSpec.cxx
@@ -210,7 +210,7 @@ void ClustererDPL<N>::updateTimeDependentParams(ProcessingContext& pc)
     pc.inputs().get<TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
     pc.inputs().get<o2::itsmft::DPLAlpideParam<N>*>("alppar");
     pc.inputs().get<o2::itsmft::ClustererParam<N>*>("cluspar");
-    mClusterer->setContinuousReadOut(o2::base::GRPGeomHelper::instance().getGRPECS()->isDetContinuousReadOut(N));
+    mClusterer->setContinuousReadOut(true);
     // settings for the fired pixel overflow masking
     const auto& alpParams = o2::itsmft::DPLAlpideParam<N>::Instance();
     const auto& clParams = o2::itsmft::ClustererParam<N>::Instance();
@@ -292,7 +292,7 @@ DataProcessorSpec getClustererSpec(bool useMC)
   inputs.emplace_back("cluspar", Origin, "CLUSPARAM", 0, Lifetime::Condition, ccdbParamSpec(Origin.as<std::string>() + "/Config/ClustererParam"));
   inputs.emplace_back("alppar", Origin, "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec(Origin.as<std::string>() + "/Config/AlpideParam"));
   auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
-                                                              true,                           // GRPECS=true
+                                                              false,                          // GRPECS=false
                                                               false,                          // GRPLHCIF
                                                               false,                          // GRPMagField
                                                               false,                          // askMatLUT


### PR DESCRIPTION
ITS(&MFT) are always in continuous mode, there is no point in querying GRPECS anymore. 