### PR TITLE
Fix GPU b-field initialization

### DIFF
--- a/GPU/GPUTracking/Interface/GPUO2InterfaceUtils.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceUtils.cxx
@@ -142,3 +142,9 @@ uint32_t GPUO2InterfaceUtils::getTpcMaxTimeBinFromNHbf(uint32_t nHbf)
 {
   return (nHbf * o2::constants::lhc::LHCMaxBunches + 2 * o2::tpc::constants::LHCBCPERTIMEBIN - 2) / o2::tpc::constants::LHCBCPERTIMEBIN;
 }
+
+float GPUO2InterfaceUtils::getNominalGPUBzFromCurrent(float l3curr)
+{
+  float al3curr = CAMath::Abs(l3curr);
+  return (CAMath::Abs(al3curr - 12000) < CAMath::Abs(al3curr - 30000) ? (2.04487f / 12000.f) : (5.00668f / 30000.f)) * l3curr;
+}

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceUtils.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceUtils.h
@@ -53,8 +53,9 @@ class GPUO2InterfaceUtils
   template <class T>
   static float getNominalGPUBz(T& src)
   {
-    return (5.00668f / 30000.f) * src.getL3Current();
+    return getNominalGPUBzFromCurrent(src.getL3Current());
   }
+  static float getNominalGPUBzFromCurrent(float l3curr);
   static std::unique_ptr<GPUParam> getFullParam(float solenoidBz, uint32_t nHbfPerTf = 0, std::unique_ptr<GPUO2InterfaceConfiguration>* pConfiguration = nullptr, std::unique_ptr<GPUSettingsO2>* pO2Settings = nullptr, bool* autoMaxTimeBin = nullptr);
   static std::shared_ptr<GPUParam> getFullParamShared(float solenoidBz, uint32_t nHbfPerTf = 0, std::unique_ptr<GPUO2InterfaceConfiguration>* pConfiguration = nullptr, std::unique_ptr<GPUSettingsO2>* pO2Settings = nullptr, bool* autoMaxTimeBin = nullptr); // Return owning pointer
   static void paramUseExternalOccupancyMap(GPUParam* param, uint32_t nHbfPerTf, const uint32_t* occupancymap, int32_t occupancyMapSize);


### PR DESCRIPTION
The 12kA L3 field should be scaled wrt its own nominal rather than 30kA nominal Bz. Keep the old scaling for backward compatibility.

Don't merge until TPC CTF decoding with field Bz from the CTF itself is not ready, as this PR will crash low-field data decoding.

Example of difference:

```
// original field for -12kA:
auto f2 = o2::field::MagneticField::createFieldMap(-12000, -6000);
f2->GetBz(120, 120, -20)
(double) -2.0522978

// old gpu field initialized with -12kA:
fld.GetFieldBz(120, 120, -20)/0.000299792458f
(float) -2.00946f
// -> 2.1% difference

// field with this PR initialized with -12kA 
fld.GetFieldBz(120, 120, -20)/0.000299792458f
(float) -2.05180f
// -> 0.024% difference
```