### PR TITLE
Improve Vertex handling in MCEventHeader

### DIFF
--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -144,7 +144,11 @@ class GeneratorFromEventPool : public o2::eventgen::Generator
 
   void updateHeader(o2::dataformats::MCEventHeader* eventHeader) override
   {
+    // Copy current vertex position from the event header
+    const double xyz[3] = {eventHeader->GetX(), eventHeader->GetY(), eventHeader->GetZ()};
     mO2KineGenerator->updateHeader(eventHeader);
+    // Event pool uses vertex position from current simulation, only extKinO2 takes the one from the file instead
+    eventHeader->SetVertex(xyz[0], xyz[1], xyz[2]);
   }
 
   // determine the collection of available files

--- a/Generators/include/Generators/GeneratorHybrid.h
+++ b/Generators/include/Generators/GeneratorHybrid.h
@@ -76,7 +76,7 @@ class GeneratorHybrid : public Generator
   ~GeneratorHybrid();
   o2::eventgen::Generator* currentgen = nullptr;
   std::vector<std::shared_ptr<o2::eventgen::Generator>> gens;
-  const std::vector<std::string> generatorNames = {"extkinO2", "evtpool", "boxgen", "external", "hepmc", "pythia8", "pythia8pp", "pythia8hi", "pythia8hf", "pythia8powheg"};
+  const std::vector<std::string> generatorNames = {"evtpool", "boxgen", "external", "hepmc", "pythia8", "pythia8pp", "pythia8hi", "pythia8hf", "pythia8powheg"};
   std::vector<std::string> mInputGens;
   std::vector<std::string> mGens;
   std::vector<std::string> mConfigs;
@@ -120,6 +120,7 @@ class GeneratorHybrid : public Generator
   bool mIsInitialized = false;
 
   o2::dataformats::MCEventHeader mMCEventHeader; // to capture event headers
+  int mHeaderGeneratorIndex = -1;                // index of the generator that updated the header in current event
 
   enum class GenMode {
     kSeq,

--- a/Generators/src/GeneratorHybrid.cxx
+++ b/Generators/src/GeneratorHybrid.cxx
@@ -96,10 +96,6 @@ GeneratorHybrid::GeneratorHybrid(const std::string& inputgens)
         }
         mConfsPythia8.push_back(mConfigs[index]);
         mGens.push_back(gen);
-      } else if (gen.compare("extkinO2") == 0) {
-        int confO2KineIndex = std::stoi(mConfigs[index].substr(9));
-        gens.push_back(std::make_shared<o2::eventgen::GeneratorFromO2Kine>(*mO2KineGenConfigs[confO2KineIndex]));
-        mGens.push_back(gen);
       } else if (gen.compare("evtpool") == 0) {
         int confEvtPoolIndex = std::stoi(mConfigs[index].substr(8));
         gens.push_back(std::make_shared<o2::eventgen::GeneratorFromEventPool>(mEventPoolConfigs[confEvtPoolIndex]));
@@ -417,10 +413,12 @@ bool GeneratorHybrid::importParticles()
 
   // Clear particles and event header
   mParticles.clear();
-  mMCEventHeader.clearInfo();
+  // event header of underlying generator must be fully reset
+  // this is important when using event pools where the full header information is forwarded from the generator
+  // otherwise some events might have mixed header information from different generators
+  mMCEventHeader.Reset();
   if (mCocktailMode) {
     // in cocktail mode we need to merge the particles from the different generators
-    bool baseGen = true; // first generator of the cocktail is used as reference to update the event header information
     for (auto subIndex : subGenIndex) {
       LOG(info) << "Importing particles for task " << subIndex;
       auto subParticles = gens[subIndex]->getParticles();
@@ -442,9 +440,10 @@ bool GeneratorHybrid::importParticles()
       }
 
       mParticles.insert(mParticles.end(), subParticles.begin(), subParticles.end());
-      if (baseGen) {
+      // first generator of the cocktail is used as reference to update the event header information
+      if (mHeaderGeneratorIndex == -1) {
         gens[subIndex]->updateHeader(&mMCEventHeader);
-        baseGen = false;
+        mHeaderGeneratorIndex = subIndex; // store index of generator updating the header
       }
       mInputTaskQueue.push(subIndex);
       mTasksStarted++;
@@ -467,6 +466,7 @@ bool GeneratorHybrid::importParticles()
 
     // fetch the event Header information from the underlying generator
     gens[genIndex]->updateHeader(&mMCEventHeader);
+    mHeaderGeneratorIndex = genIndex; // store index of generator updating the header
     mInputTaskQueue.push(genIndex);
     mTasksStarted++;
   }
@@ -484,6 +484,10 @@ bool GeneratorHybrid::importParticles()
 void GeneratorHybrid::updateHeader(o2::dataformats::MCEventHeader* eventHeader)
 {
   if (eventHeader) {
+    // Overwrite current vertex information to the underlying generator header,
+    // otherwise the info will be dropped when copying the FairMCEventHeader part of the header
+    mMCEventHeader.SetVertex(eventHeader->GetX(), eventHeader->GetY(), eventHeader->GetZ());
+    mHeaderGeneratorIndex = -1; // reset header generator index for next event
     // Forward the base class fields from FairMCEventHeader
     static_cast<FairMCEventHeader&>(*eventHeader) = static_cast<FairMCEventHeader&>(mMCEventHeader);
     // Copy the key-value store info
@@ -518,11 +522,6 @@ Bool_t GeneratorHybrid::confSetter(const auto& gen)
       auto pythia8Config = TBufferJSON::FromJSON<o2::eventgen::Pythia8GenConfig>(jsonValueToString(pythia8conf).c_str());
       mPythia8GenConfigs.push_back(std::move(pythia8Config));
       mConfigs.push_back("pythia8_" + std::to_string(mPythia8GenConfigs.size() - 1));
-    } else if (name == "extkinO2") {
-      const auto& o2kineconf = gen["config"];
-      auto o2kineConfig = TBufferJSON::FromJSON<o2::eventgen::O2KineGenConfig>(jsonValueToString(o2kineconf).c_str());
-      mO2KineGenConfigs.push_back(std::move(o2kineConfig));
-      mConfigs.push_back("extkinO2_" + std::to_string(mO2KineGenConfigs.size() - 1));
     } else if (name == "evtpool") {
       const auto& o2kineconf = gen["config"];
       auto poolConfig = TBufferJSON::FromJSON<o2::eventgen::EventPoolGenConfig>(jsonValueToString(o2kineconf).c_str());
@@ -546,7 +545,7 @@ Bool_t GeneratorHybrid::confSetter(const auto& gen)
       mConfigs.push_back("");
     }
   } else {
-    if (name == "boxgen" || name == "pythia8" || name == "extkinO2" || name == "external" || name == "hepmc") {
+    if (name == "boxgen" || name == "pythia8" || name == "external" || name == "hepmc") {
       LOG(fatal) << "No configuration provided for generator " << name;
       return false;
     } else {


### PR DESCRIPTION
A full reset of the underlying generator header in hybrid was needed, otherwise when using event-pools together with other generators some info where kept from one event to the other (no hard reset on base FairMCEventHeader class info).  The extKinO2 generator has been disabled in hybrid mode due to vertex inconsistencies issues. 