### PR TITLE
Parse and pass SOR to o2-steer-colcontexttool in FST

### DIFF
--- a/Detectors/Calibration/testMacros/getRunParameters.cxx
+++ b/Detectors/Calibration/testMacros/getRunParameters.cxx
@@ -53,6 +53,18 @@ void writeDurationToFile(long duration)
   fclose(fptr);
 }
 
+void writeSORToFile(long sor)
+{
+
+  FILE* fptr = fopen("SOR.txt", "w");
+  if (fptr == nullptr) {
+    LOGP(fatal, "ERROR: Could not open file to write SOR!");
+    return;
+  }
+  fprintf(fptr, "%ld", sor);
+  fclose(fptr);
+}
+
 void writeBFieldToFile(float b)
 {
 
@@ -165,6 +177,7 @@ int main(int argc, char* argv[])
       ir = -1.f;
       writeIRtoFile(ir);
       writeDurationToFile(run_O2duration);
+      writeSORToFile(tsSOR);
       return 0;
     }
   }
@@ -204,6 +217,7 @@ int main(int argc, char* argv[])
   }
   writeIRtoFile(ir);
   writeDurationToFile(duration);
+  writeSORToFile(tsSOR);
 
   return 0;
 }

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -81,6 +81,10 @@ fi
 
 [[ "$FIRSTSAMPLEDORBIT" -lt "$RUNFIRSTORBIT" ]] && FIRSTSAMPLEDORBIT=$RUNFIRSTORBIT
 
+# get run start time
+taskwrapper run_params.log o2-calibration-get-run-parameters -r $RUNNUMBER
+runStartTime=`cat SOR.txt`
+
 # allow skipping
 JOBUTILS_SKIPDONE=ON
 # potentially enable memory monitoring (independent on whether DPL or not)
@@ -162,6 +166,7 @@ taskwrapper collcontext.log o2-steer-colcontexttool \
   --maxCollsPerTF ${NEvents} \
   --orbitsEarly ${OrbitsBeforeTf} \
   --bcPatternFile ccdb \
+  --timestamp ${runStartTime} \
   ${QEDSPEC}
 
 # Include collision system for TPC loopers generation


### PR DESCRIPTION
The o2-steer-colcontexttool was using timestamp -1 (i.e. now) therefore the FST is generating the context with the mean-vertex available at givin moment. If this happen to be the default meanvertex with sigmaX,Y of 0.5 cm, the generated data is not reconstructable in the ITS since the reconstruction will use the meanvertx with small sigma corresponding to the selected run number.