### PR TITLE
Fix ITS seeding for B=0

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
@@ -146,7 +146,7 @@ GPUdii() o2::track::TrackParCov buildTrackSeed(const Cluster& cluster1,
     const float dx = x3 - x1;
     const float dy = y3 - y1;
     snp = sign * dy / o2::gpu::CAMath::Hypot(dx, dy);
-    q2pt = sign / track::kMostProbablePt;
+    q2pt = 1.f / track::kMostProbablePt;
     q2pt2 = 1.f;
   } else {
     const float crv = math_utils::computeCurvature(x3, y3, x2, y2, x1, y1);

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -1281,7 +1281,7 @@ track::TrackParCov TrackerTraits<nLayers>::buildTrackSeed(const Cluster& cluster
     const float dx = x3 - x1;
     const float dy = y3 - y1;
     snp = sign * dy / o2::gpu::CAMath::Hypot(dx, dy);
-    q2pt = sign / track::kMostProbablePt;
+    q2pt = 1.f / track::kMostProbablePt;
     q2pt2 = 1.f;
   } else {
     const float crv = math_utils::computeCurvature(x3, y3, x2, y2, x1, y1);


### PR DESCRIPTION
The convention is to assign to q/pT = 1/mostProbablePt(=0.6) in case of B=0

Due to the sign inversion the ITS/TPC matching for B=0 was failing.

<img width="995" height="851" alt="image" src="https://github.com/user-attachments/assets/d48d8e29-1223-44d1-8f50-00ee81132cbe" />
