### PR TITLE
Filter raw linker flags from GBL_LIBRARIES

### DIFF
--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -288,10 +288,15 @@ if(GBL_FOUND AND NOT TARGET GBL::GBL)
     # As of now, GBL does not provide a cmake target so create a compatibility wrapper
     # also GBL_LIBRARIES contains raw linker flags to ROOT we need to filter out
     set(GBL_LIBRARIES_FILTERED "")
+    set(GBL_LINK_OPTIONS "")
     foreach(_lib IN LISTS GBL_LIBRARIES)
-     if(NOT _lib MATCHES "^-[lL]")
-      list(APPEND GBL_LIBRARIES_FILTERED "${_lib}")
-     endif()
+        if(_lib MATCHES "^-[lL]")
+            continue()
+        elseif(_lib MATCHES "^-")
+            list(APPEND GBL_LINK_OPTIONS "${_lib}")
+        else()
+            list(APPEND GBL_LIBRARIES_FILTERED "${_lib}")
+        endif()
     endforeach()
     add_library(GBL::GBL INTERFACE IMPORTED)
     target_include_directories(GBL::GBL INTERFACE ${GBL_INCLUDE_DIR})
@@ -299,6 +304,7 @@ if(GBL_FOUND AND NOT TARGET GBL::GBL)
         ${GBL_LIBRARIES_FILTERED}
         Eigen3::Eigen
     )
+    target_link_options(GBL::GBL INTERFACE ${GBL_LINK_OPTIONS})
 endif()
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -286,10 +286,17 @@ find_package(GBL)
 set_package_properties(GBL PROPERTIES TYPE REQUIRED)
 if(GBL_FOUND AND NOT TARGET GBL::GBL)
     # As of now, GBL does not provide a cmake target so create a compatibility wrapper
+    # also GBL_LIBRARIES contains raw linker flags to ROOT we need to filter out
+    set(GBL_LIBRARIES_FILTERED "")
+    foreach(_lib IN LISTS GBL_LIBRARIES)
+     if(NOT _lib MATCHES "^-[lL]")
+      list(APPEND GBL_LIBRARIES_FILTERED "${_lib}")
+     endif()
+    endforeach()
     add_library(GBL::GBL INTERFACE IMPORTED)
     target_include_directories(GBL::GBL INTERFACE ${GBL_INCLUDE_DIR})
     target_link_libraries(GBL::GBL INTERFACE
-        ${GBL_LIBRARIES}
+        ${GBL_LIBRARIES_FILTERED}
         Eigen3::Eigen
     )
 endif()


### PR DESCRIPTION
currently GBL exports: /home/fschlepp/alice/sw/ubuntu2404_x86-64/GBL/V03-01-04-4/lib/libGBL.so;-L/local/workspace/DailyBuilds/DailyO2-ubuntu2404/daily-tags.BsAuSDt8F5/ubuntu2404_x86-64/ROOT/v6-36-04-alice9-10/lib;-lCore;-lImt;-lRIO;-lNet;-lHist;-lGraf;-lGraf3d;-lGpad;-lROOTVecOps;-lTree;-lTreePlayer;-lRint;-lPostscript;-lMatrix;-lPhysics;-lMathCore;-lThread;-lROOTNTuple;-lMultiProc;-lROOTDataFrame;-lROOTNTupleUtil;Eigen3::Eigen

which leads to link failures

This removes all the `-l` flags from the library.