### PR TITLE
ALICE3-TRK: add noise to the digitization process

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/ChipDigitsContainer.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/ChipDigitsContainer.h
@@ -35,6 +35,10 @@ class ChipDigitsContainer : public o2::itsmft::ChipDigitsContainer
     return (static_cast<ULong64_t>(roframe) << (8 * sizeof(UInt_t))) + (static_cast<ULong64_t>(col) << (8 * sizeof(Short_t))) + row;
   }
 
+  /// Adds noise digits, deleted the one using the itsmft::DigiParams interface
+  void addNoise(UInt_t rofMin, UInt_t rofMax, const o2::itsmft::DigiParams* params, int maxRows = o2::itsmft::SegmentationAlpide::NRows, int maxCols = o2::itsmft::SegmentationAlpide::NCols) = delete;
+  void addNoise(UInt_t rofMin, UInt_t rofMax, const o2::trk::DigiParams* params, int subDetID, int layer);
+
   ClassDefNV(ChipDigitsContainer, 1);
 };
 

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DPLDigitizerParam.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DPLDigitizerParam.h
@@ -54,7 +54,7 @@ struct DPLDigitizerParam : public o2::conf::ConfigurableParamHelper<DPLDigitizer
  private:
   static constexpr float DEFNoisePerPixel()
   {
-    return N == o2::detectors::DetID::TRK ? 1e-8 : 1e-8; // ITS/MFT values here!!
+    return N == o2::detectors::DetID::TRK ? 1e-7 : 1e-8; // ITS/MFT values here!!
   }
 
   static constexpr std::string_view ParamName[2] = {"TRKDigitizerParam", "FT3DigitizerParam"};

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DigiParams.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/DigiParams.h
@@ -103,7 +103,7 @@ class DigiParams
  private:
   static constexpr double infTime = 1e99;
   bool mIsContinuous = false;            ///< flag for continuous simulation
-  float mNoisePerPixel = 1.e-8;          ///< ALPIDE Noise per chip
+  float mNoisePerPixel = 1.e-7;          ///< Noise per chip
   int mROFrameLengthInBC = 0;            ///< ROF length in BC for continuos mode
   float mROFrameLength = 0;              ///< length of RO frame in ns
   float mStrobeDelay = 0.;               ///< strobe start (in ns) wrt ROF start

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/ChipDigitsContainer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/ChipDigitsContainer.cxx
@@ -29,7 +29,7 @@ void ChipDigitsContainer::addNoise(UInt_t rofMin, UInt_t rofMax, const o2::trk::
   int maxCols = 0;
 
   // TODO: set different noise and threshold for VD and MLOT
-  if (subDetID == 0) { // VD
+  if (subDetID == 0) {                                   // VD
     maxRows = constants::VD::petal::layer::nRows[layer]; // TODO: get the layer from the geometry
     maxCols = constants::VD::petal::layer::nCols;
     mean = params->getNoisePerPixel() * maxRows * maxCols;

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/ChipDigitsContainer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/ChipDigitsContainer.cxx
@@ -15,3 +15,50 @@ using namespace o2::trk;
 
 ChipDigitsContainer::ChipDigitsContainer(UShort_t idx)
   : o2::itsmft::ChipDigitsContainer(idx) {}
+
+//______________________________________________________________________
+void ChipDigitsContainer::addNoise(UInt_t rofMin, UInt_t rofMax, const o2::trk::DigiParams* params, int subDetID, int layer)
+{
+  UInt_t row = 0;
+  UInt_t col = 0;
+  Int_t nhits = 0;
+  constexpr float ns2sec = 1e-9;
+  float mean = 0.f;
+  int nel = 0;
+  int maxRows = 0;
+  int maxCols = 0;
+
+  // TODO: set different noise and threshold for VD and MLOT
+  if (subDetID == 0) { // VD
+    maxRows = constants::VD::petal::layer::nRows[layer]; // TODO: get the layer from the geometry
+    maxCols = constants::VD::petal::layer::nCols;
+    mean = params->getNoisePerPixel() * maxRows * maxCols;
+    nel = static_cast<int>(params->getChargeThreshold() * 1.1);
+  } else { // ML/OT
+    maxRows = constants::moduleMLOT::chip::nRows;
+    maxCols = constants::moduleMLOT::chip::nCols;
+    mean = params->getNoisePerPixel() * maxRows * maxCols;
+    nel = static_cast<int>(params->getChargeThreshold() * 1.1);
+  }
+
+  LOG(debug) << "Adding noise for chip " << mChipIndex << " with mean " << mean << " and charge " << nel;
+
+  for (UInt_t rof = rofMin; rof <= rofMax; rof++) {
+    nhits = gRandom->Poisson(mean);
+    for (Int_t i = 0; i < nhits; ++i) {
+      row = gRandom->Integer(maxRows);
+      col = gRandom->Integer(maxCols);
+      LOG(debug) << "Generated noise hit at ROF " << rof << ", row " << row << ", col " << col;
+      if (mNoiseMap && mNoiseMap->isNoisy(mChipIndex, row, col)) {
+        continue;
+      }
+      if (mDeadChanMap && mDeadChanMap->isNoisy(mChipIndex, row, col)) {
+        continue;
+      }
+      auto key = getOrderingKey(rof, row, col);
+      if (!findDigit(key)) {
+        addDigit(key, rof, row, col, nel, o2::MCCompLabel(true));
+      }
+    }
+  }
+}

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Digitizer.cxx
@@ -215,7 +215,7 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
       if (chip.isDisabled()) {
         continue;
       }
-      // chip.addNoise(mROFrameMin, mROFrameMin, &mParams);  /// TODO: add noise
+      chip.addNoise(mROFrameMin, mROFrameMin, &mParams, mGeometry->getSubDetID(chip.getChipIndex()), mGeometry->getLayer(chip.getChipIndex())); /// TODO: add noise
       auto& buffer = chip.getPreDigits();
       if (buffer.empty()) {
         continue;


### PR DESCRIPTION
The code to add noise has been adapted from the ones for ITS2 and ITS3.
The noise (FHR) is set at a level of 1e-7 both for VD and ML/OT at the moment.
The value  1e-7 has been chosen following the current ITS2 noise trend. It has to be adjusted once more detailed studies are done for the ALICE3 chips.
