### PR TITLE
DPL: allow non-owning TFileFileSystem

### DIFF
--- a/Framework/AnalysisSupport/src/DataInputDirector.cxx
+++ b/Framework/AnalysisSupport/src/DataInputDirector.cxx
@@ -314,7 +314,9 @@ void DataInputDescriptor::printFileOpening()
     monitoringInfo += fmt::format(",se={},open_time={:.1f}", alienFile->GetSE(), alienFile->GetElapsed());
   }
 #endif
-  mContext.monitoring->send(o2::monitoring::Metric{monitoringInfo, "aod-file-open-info"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
+  if (mContext.monitoring) {
+    mContext.monitoring->send(o2::monitoring::Metric{monitoringInfo, "aod-file-open-info"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
+  }
   LOGP(info, "Opening file: {}", monitoringInfo);
 }
 
@@ -335,7 +337,9 @@ void DataInputDescriptor::printFileStatistics()
     monitoringInfo += fmt::format(",se={},open_time={:.1f}", alienFile->GetSE(), alienFile->GetElapsed());
   }
 #endif
-  mContext.monitoring->send(o2::monitoring::Metric{monitoringInfo, "aod-file-read-info"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
+  if (mContext.monitoring) {
+    mContext.monitoring->send(o2::monitoring::Metric{monitoringInfo, "aod-file-read-info"}.addTag(o2::monitoring::tags::Key::Subsystem, o2::monitoring::tags::Value::DPL));
+  }
   LOGP(info, "Read info: {}", monitoringInfo);
 }
 

--- a/Framework/Core/include/Framework/RootArrowFilesystem.h
+++ b/Framework/Core/include/Framework/RootArrowFilesystem.h
@@ -146,7 +146,7 @@ class TFileFileSystem : public VirtualRootFileSystemBase
  public:
   arrow::Result<arrow::fs::FileInfo> GetFileInfo(const std::string& path) override;
 
-  TFileFileSystem(TDirectoryFile* f, size_t readahead, RootObjectReadingFactory&);
+  TFileFileSystem(TDirectoryFile* f, size_t readahead, RootObjectReadingFactory&, bool ownsFile = true);
 
   ~TFileFileSystem() override;
 
@@ -172,6 +172,7 @@ class TFileFileSystem : public VirtualRootFileSystemBase
  private:
   TDirectoryFile* mFile;
   RootObjectReadingFactory& mObjectFactory;
+  bool mOwnsFile = true;
 };
 
 class TBufferFileFS : public VirtualRootFileSystemBase

--- a/Framework/Core/src/RootArrowFilesystem.cxx
+++ b/Framework/Core/src/RootArrowFilesystem.cxx
@@ -34,18 +34,21 @@ namespace o2::framework
 {
 using arrow::Status;
 
-TFileFileSystem::TFileFileSystem(TDirectoryFile* f, size_t readahead, RootObjectReadingFactory& factory)
+TFileFileSystem::TFileFileSystem(TDirectoryFile* f, size_t readahead, RootObjectReadingFactory& factory, bool ownsFile)
   : VirtualRootFileSystemBase(),
     mFile(f),
-    mObjectFactory(factory)
+    mObjectFactory(factory),
+    mOwnsFile(ownsFile)
 {
   ((TFile*)mFile)->SetReadaheadSize(50 * 1024 * 1024);
 }
 
 TFileFileSystem::~TFileFileSystem()
 {
-  mFile->Close();
-  delete mFile;
+  if (mOwnsFile) {
+    mFile->Close();
+    delete mFile;
+  }
 }
 
 std::shared_ptr<RootObjectHandler> TFileFileSystem::GetObjectHandler(arrow::dataset::FileSource source)


### PR DESCRIPTION

Given this filesystem is really a virtual entity, it makes
sense to allow for actual ownership of the TFile elsewhere.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/15179).
* #15163
* __->__ #15179 (2 commits)