### PR TITLE
Correctly handle errors in merging histograms with kAverage

### DIFF
--- a/Utilities/Mergers/src/MergerAlgorithm.cxx
+++ b/Utilities/Mergers/src/MergerAlgorithm.cxx
@@ -111,7 +111,7 @@ Long64_t mergeDefault(TObject* const target, TObject* const other)
       // Merge() does not support averages, we have to use Add()
       // this will break if collection.size != 1
       if (auto otherTH1 = dynamic_cast<TH1*>(otherCollection.First())) {
-        errorCode = targetTH1->Add(otherTH1);
+        errorCode = targetTH1->Add(otherTH1) == kFALSE ? -1 : 0;
       }
     } else {
       // Add() does not support histograms with labels, thus we resort to Merge() by default


### PR DESCRIPTION
As pointed out by Felix Schlepper, TH1::Add reports errors differently than Merge, see https://root.cern.ch/doc/master/classTH1.html#a6e3008f571628f0c9d17d754c8b88730

Fixes QC-1341.