### PR TITLE
DPL Analysis: remove special origins and add `From<>` version for auto-generated tables

### DIFF
--- a/Framework/AnalysisSupport/src/AODWriterHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODWriterHelpers.cxx
@@ -21,7 +21,6 @@
 #include "Framework/TableConsumer.h"
 #include "Framework/DataOutputDirector.h"
 #include "Framework/TableTreeHelpers.h"
-#include "Framework/Monitoring.h"
 #include "Framework/Signpost.h"
 
 #include <Monitoring/Monitoring.h>
@@ -32,8 +31,6 @@
 #include <TMap.h>
 #include <TObjString.h>
 #include <arrow/table.h>
-#include <chrono>
-#include <ios>
 
 O2_DECLARE_DYNAMIC_LOG(histogram_registry);
 
@@ -157,7 +154,7 @@ AlgorithmSpec AODWriterHelpers::getOutputTTreeWriter(ConfigContext const& ctx)
         }
 
         // skip non-AOD refs
-        if (!DataSpecUtils::partialMatch(*ref.spec, writableAODOrigins)) {
+        if (!DataSpecUtils::partialMatch(*ref.spec, AODOrigins)) {
           continue;
         }
         startTime = DataRefUtils::getHeader<DataProcessingHeader*>(ref)->startTime;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -395,6 +395,20 @@ static constexpr auto sourceSpec()
 {
   return fmt::format("{}/{}/{}/{}", label<R>(), origin_str<R>(), description_str(signature<R>()), R.version);
 }
+
+/// Replace origins in the TableRef array
+template <size_t N, std::array<soa::TableRef, N> ar, o2::aod::is_origin_hash O>
+consteval auto replaceOrigin()
+{
+  std::array<soa::TableRef, N> res;
+  for (auto i = 0U; i < N; ++i) {
+    res[i].label_hash = ar[i].label_hash;
+    res[i].desc_hash = ar[i].desc_hash;
+    res[i].origin_hash = O::hash;
+    res[i].version = ar[i].version;
+  }
+  return res;
+}
 } // namespace o2::aod
 
 namespace o2::soa
@@ -1312,13 +1326,18 @@ concept with_sources = requires {
 };
 
 template <typename T>
+concept with_sources_generator = requires(T t) {
+  t.template generateSources<o2::aod::Hash<"AOD"_h>>();
+};
+
+template <typename T>
 concept with_ccdb_urls = requires {
   T::ccdb_urls.size();
 };
 
 template <typename T>
 concept with_base_table = requires {
-  typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::base_table_t;
+  typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata::base_table_t;
 };
 
 template <typename T>
@@ -1384,9 +1403,10 @@ static constexpr std::string getLabelFromType()
   return getLabelForTable<typename std::decay_t<T>::first_t>();
 }
 template <soa::with_base_table T>
+  requires(!soa::is_iterator<T>)
 static constexpr std::string getLabelFromType()
 {
-  return getLabelForTable<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata::base_table_t>();
+  return getLabelForTable<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata::base_table_t>();
 }
 
 template <typename... C>
@@ -1811,17 +1831,17 @@ consteval auto computeOriginals()
 }
 
 template <TableRef ref, typename... Ts>
-  requires((sizeof...(Ts) > 0) && (!o2::soa::is_column<Ts> || ...))
+  requires((sizeof...(Ts) > 0) && (!(o2::soa::is_column<Ts> && ...)))
 consteval auto computeOriginals()
 {
   return o2::soa::mergeOriginals<Ts...>();
 }
 
-template <size_t N, std::array<TableRef, N> refs>
-consteval auto commonOrigin()
-{
-  return (refs | std::ranges::views::filter([](TableRef const& r) { return (!(r.origin_hash == "DYN"_h || r.origin_hash == "IDX"_h)); })).front().origin_hash;
-}
+// template <size_t N, std::array<TableRef, N> refs>
+// consteval auto commonOrigin()
+// {
+//   return (refs | std::ranges::views::filter([](TableRef const& r) { return (!(r.origin_hash == "DYN"_h || r.origin_hash == "IDX"_h)); })).front().origin_hash;
+// }
 
 /// A Table class which observes an arrow::Table and provides
 /// It is templated on a set of Column / DynamicColumn types.
@@ -1837,7 +1857,8 @@ class Table
   static constexpr const auto originalLabels = []<size_t N, std::array<TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) {
     return std::array<const char*, N>{o2::aod::label<refs[Is]>()...};
   }.template operator()<originals.size(), originals>(std::make_index_sequence<originals.size()>());
-  static constexpr const uint32_t binding_origin = commonOrigin<originals.size(), originals>();
+  static constexpr const uint32_t binding_origin = originals[0].origin_hash; // commonOrigin<originals.size(), originals>();
+  static constexpr header::DataOrigin binding_origin_ = o2::aod::Hash<binding_origin>::origin;
 
   template <size_t N, std::array<TableRef, N> bindings>
     requires(ref.origin_hash == "CONC"_h)
@@ -1850,10 +1871,10 @@ class Table
     requires(ref.origin_hash == "JOIN"_h)
   static consteval auto isIndexTargetOf()
   {
-    return std::ranges::find_if(self_t::originals,
-                                [](TableRef const& r) {
-                                  return std::ranges::find(bindings, r) != bindings.end();
-                                }) != self_t::originals.end();
+    return std::ranges::any_of(self_t::originals,
+                               [](TableRef const& r) {
+                                 return std::ranges::any_of(bindings, [&r](TableRef const& b) { return b == r; });
+                               });
   }
 
   template <size_t N, std::array<TableRef, N> bindings>
@@ -1866,7 +1887,7 @@ class Table
   template <TableRef r>
   static consteval bool hasOriginal()
   {
-    return std::find_if(originals.begin(), originals.end(), [](TableRef const& o) { return o.desc_hash == r.desc_hash; }) != originals.end();
+    return std::ranges::any_of(originals, [](TableRef const& o) { return o.desc_hash == r.desc_hash; });
   }
 
   using columns_t = decltype(getColumns<ref, Ts...>());
@@ -2389,9 +2410,9 @@ namespace o2::aod
 O2ORIGIN("AOD");
 O2ORIGIN("AOD1");
 O2ORIGIN("AOD2");
-O2ORIGIN("DYN");
-O2ORIGIN("IDX");
-O2ORIGIN("ATIM");
+// O2ORIGIN("DYN");
+// O2ORIGIN("IDX");
+// O2ORIGIN("ATIM");
 O2ORIGIN("JOIN");
 O2HASH("JOIN/0");
 O2ORIGIN("CONC");
@@ -3273,85 +3294,113 @@ consteval auto getIndexTargets()
 #define DECLARE_SOA_TABLE_STAGED(_BaseName_, _Desc_, ...) \
   DECLARE_SOA_TABLE_STAGED_VERSIONED(_BaseName_, _Desc_, 0, __VA_ARGS__);
 
-#define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Label_, _OriginalTable_, _Origin_, _Desc_, _Version_, ...)                     \
+#define DECLARE_SOA_EXTENDED_TABLE_NG(_Name_, _OriginalTable_, _Desc_, _Version_, ...)                                          \
   O2HASH(_Desc_ "/" #_Version_);                                                                                                \
+  O2HASH(#_Name_ "Extension");                                                                                                  \
   template <typename O>                                                                                                         \
-  using _Name_##ExtensionFrom = soa::Table<o2::aod::Hash<_Label_ ""_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O>;          \
-  using _Name_##Extension = _Name_##ExtensionFrom<o2::aod::Hash<_Origin_ ""_h>>;                                                \
-  template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                          \
-  struct _Name_##ExtensionMetadataFrom : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                \
+  using _Name_##ExtensionFrom = soa::Table<o2::aod::Hash<#_Name_ "Extension"_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O>; \
+  using _Name_##Extension = _Name_##ExtensionFrom<o2::aod::Hash<"AOD"_h>>;                                                      \
+  struct _Name_##ExtensionMetadata : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                    \
     using base_table_t = _OriginalTable_;                                                                                       \
-    using extension_table_t = _Name_##ExtensionFrom<O>;                                                                         \
+    template <o2::aod::is_origin_hash O>                                                                                        \
+    using extension_table_t_from = _Name_##ExtensionFrom<O>;                                                                    \
+    using extension_table_t = _Name_##Extension;                                                                                \
     using expression_pack_t = framework::pack<__VA_ARGS__>;                                                                     \
-    static constexpr auto sources = _OriginalTable_::originals;                                                                 \
+    static constexpr auto N = _OriginalTable_::originals.size();                                                                \
+    template <o2::aod::is_origin_hash O = o2::aod::Hash<"AOD"_h>>                                                               \
+    static consteval auto generateSources()                                                                                     \
+    {                                                                                                                           \
+      return _OriginalTable_##From<O>::originals;                                                                               \
+    }                                                                                                                           \
   };                                                                                                                            \
-  using _Name_##ExtensionMetadata = _Name_##ExtensionMetadataFrom<o2::aod::Hash<_Origin_ ""_h>>;                                \
   template <>                                                                                                                   \
   struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                             \
     using metadata = _Name_##ExtensionMetadata;                                                                                 \
   };                                                                                                                            \
   template <typename O>                                                                                                         \
-  using _Name_##From = o2::soa::JoinFull<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, _OriginalTable_, _Name_##ExtensionFrom<O>>; \
-  using _Name_ = _Name_##From<o2::aod::Hash<_Origin_ ""_h>>;
+  using _Name_##From = o2::soa::Join<_OriginalTable_##From<O>, _Name_##ExtensionFrom<O>>;                                       \
+  using _Name_ = _Name_##From<o2::aod::Hash<"AOD"_h>>;
 
 #define DECLARE_SOA_EXTENDED_TABLE(_Name_, _Table_, _Description_, _Version_, ...) \
-  O2HASH(#_Name_ "Extension");                                                     \
-  DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, #_Name_ "Extension", _Table_, "DYN", _Description_, _Version_, __VA_ARGS__)
+  DECLARE_SOA_EXTENDED_TABLE_NG(_Name_, _Table_, _Description_, _Version_, __VA_ARGS__)
 
 #define DECLARE_SOA_EXTENDED_TABLE_USER(_Name_, _Table_, _Description_, ...) \
-  O2HASH(#_Name_ "Extension");                                               \
-  DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, #_Name_ "Extension", _Table_, "AOD", "EX" _Description_, 0, __VA_ARGS__)
+  DECLARE_SOA_EXTENDED_TABLE_NG(_Name_, _Table_, "EX" _Description_, 0, __VA_ARGS__)
 
-#define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_FULL(_Name_, _Label_, _OriginalTable_, _Origin_, _Desc_, _Version_, ...)           \
-  O2HASH(_Desc_ "/" #_Version_);                                                                                                   \
-  template <typename O>                                                                                                            \
-  using _Name_##CfgExtensionFrom = soa::Table<o2::aod::Hash<_Label_ ""_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O>;          \
-  using _Name_##CfgExtension = _Name_##CfgExtensionFrom<o2::aod::Hash<_Origin_ ""_h>>;                                             \
-  template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                             \
-  struct _Name_##CfgExtensionMetadataFrom : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                \
-    using base_table_t = _OriginalTable_;                                                                                          \
-    using extension_table_t = _Name_##CfgExtensionFrom<O>;                                                                         \
-    using placeholders_pack_t = framework::pack<__VA_ARGS__>;                                                                      \
-    using configurable_t = std::true_type;                                                                                         \
-    static constexpr auto sources = _OriginalTable_::originals;                                                                    \
-  };                                                                                                                               \
-  using _Name_##CfgExtensionMetadata = _Name_##CfgExtensionMetadataFrom<o2::aod::Hash<_Origin_ ""_h>>;                             \
-  template <>                                                                                                                      \
-  struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                \
-    using metadata = _Name_##CfgExtensionMetadata;                                                                                 \
-  };                                                                                                                               \
-  template <typename O>                                                                                                            \
-  using _Name_##From = o2::soa::JoinFull<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, _OriginalTable_, _Name_##CfgExtensionFrom<O>>; \
-  using _Name_ = _Name_##From<o2::aod::Hash<_Origin_ ""_h>>;
+#define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_NG(_Name_, _OriginalTable_, _Desc_, _Version_, ...)                                   \
+  O2HASH(_Desc_ "/" #_Version_);                                                                                                      \
+  O2HASH(#_Name_ "CfgExtension");                                                                                                     \
+  template <typename O>                                                                                                               \
+  using _Name_##CfgExtensionFrom = soa::Table<o2::aod::Hash<#_Name_ "CfgExtension"_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O>; \
+  using _Name_##CfgExtension = _Name_##CfgExtensionFrom<o2::aod::Hash<"AOD"_h>>;                                                      \
+  struct _Name_##CfgExtensionMetadata : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                       \
+    using base_table_t = _OriginalTable_;                                                                                             \
+    template <o2::aod::is_origin_hash O>                                                                                              \
+    using extension_table_t_from = _Name_##CfgExtensionFrom<O>;                                                                       \
+    using extension_table_t = _Name_##CfgExtension;                                                                                   \
+    using placeholders_pack_t = framework::pack<__VA_ARGS__>;                                                                         \
+    using configurable_t = std::true_type;                                                                                            \
+    static constexpr auto N = _OriginalTable_::originals.size();                                                                      \
+    template <o2::aod::is_origin_hash O = o2::aod::Hash<"AOD"_h>>                                                                     \
+    static consteval auto generateSources()                                                                                           \
+    {                                                                                                                                 \
+      return _OriginalTable_##From<O>::originals;                                                                                     \
+    }                                                                                                                                 \
+  };                                                                                                                                  \
+  template <>                                                                                                                         \
+  struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                   \
+    using metadata = _Name_##CfgExtensionMetadata;                                                                                    \
+  };                                                                                                                                  \
+  template <typename O>                                                                                                               \
+  using _Name_##From = o2::soa::Join<_OriginalTable_##From<O>, _Name_##CfgExtensionFrom<O>>;                                          \
+  using _Name_ = _Name_##From<o2::aod::Hash<"AOD"_h>>;
 
-#define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE(_Name_, _Table_, _Description_, ...) \
-  O2HASH(#_Name_ "CfgExtension");                                                    \
-  DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_FULL(_Name_, #_Name_ "CfgExtension", _Table_, "AOD", "EX" _Description_, 0, __VA_ARGS__)
+#define DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE(_Name_, _OriginalTable_, _Description_, ...) \
+  DECLARE_SOA_CONFIGURABLE_EXTENDED_TABLE_NG(_Name_, _OriginalTable_, "EX" _Description_, 0, __VA_ARGS__)
 
-#define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Version_, _Desc_, _Exclusive_, ...)                                                              \
-  O2HASH(#_Name_);                                                                                                                                              \
-  O2HASH(_Desc_ "/" #_Version_);                                                                                                                                \
-  template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                                                          \
-  struct _Name_##MetadataFrom : o2::aod::TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, soa::Index<>, __VA_ARGS__> {                                  \
-    static constexpr bool exclusive = _Exclusive_;                                                                                                              \
-    using Key = _Key_;                                                                                                                                          \
-    using index_pack_t = framework::pack<__VA_ARGS__>;                                                                                                          \
-    static constexpr const auto sources = []<typename... Cs>(framework::pack<Cs...>) {                                                                          \
-      constexpr auto a = o2::soa::mergeOriginals<typename Cs::binding_t...>();                                                                                  \
-      return o2::aod::filterForKey<a.size(), a, Key>();                                                                                                         \
-    }(framework::pack<__VA_ARGS__>{});                                                                                                                          \
-    static_assert(sources.size() - Key::originals.size() + 1 == framework::pack_size(index_pack_t{}), "One of the referred tables does not have index to Key"); \
-  };                                                                                                                                                            \
-  using _Name_##Metadata = _Name_##MetadataFrom<o2::aod::Hash<_Origin_ ""_h>>;                                                                                  \
-                                                                                                                                                                \
-  template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                                                          \
-  using _Name_##From = o2::soa::IndexTable<o2::aod::Hash<#_Name_ ""_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O, _Key_, __VA_ARGS__>;                      \
-  using _Name_ = _Name_##From<o2::aod::Hash<_Origin_ ""_h>>;                                                                                                    \
-                                                                                                                                                                \
-  template <>                                                                                                                                                   \
-  struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                                             \
-    using metadata = _Name_##Metadata;                                                                                                                          \
-  };
+#define DECLARE_SOA_INDEX_TABLE_NG(_Name_, _Key_, _Version_, _Desc_, _Exclusive_, ...)                                                              \
+  O2HASH(#_Name_);                                                                                                                                  \
+  O2HASH(_Desc_ "/" #_Version_);                                                                                                                    \
+  struct _Name_##Metadata : o2::aod::TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, soa::Index<>, __VA_ARGS__> {                          \
+    static constexpr bool exclusive = _Exclusive_;                                                                                                  \
+    template <o2::aod::is_origin_hash O>                                                                                                            \
+    using KeyFrom = _Key_##From<O>;                                                                                                                 \
+    using Key = _Key_;                                                                                                                              \
+    using index_pack_t = framework::pack<__VA_ARGS__>;                                                                                              \
+    template <o2::aod::is_origin_hash O = o2::aod::Hash<"AOD"_h>>                                                                                   \
+    static consteval auto generateSources()                                                                                                         \
+    {                                                                                                                                               \
+      return []<soa::is_index_column... Cs>(framework::pack<Cs...>) {                                                                               \
+        constexpr auto first = o2::soa::mergeOriginals<typename Cs::binding_t...>();                                                                \
+        constexpr auto second = o2::aod::filterForKey<first.size(), first, Key>();                                                                  \
+        return o2::aod::replaceOrigin<second.size(), second, O>();                                                                                  \
+      }(framework::pack<__VA_ARGS__>{});                                                                                                            \
+    }                                                                                                                                               \
+    static constexpr auto N = []<typename... Cs>(framework::pack<Cs...>) {                                                                          \
+      constexpr auto a = o2::soa::mergeOriginals<typename Cs::binding_t...>();                                                                      \
+      return o2::aod::filterForKey<a.size(), a, Key>();                                                                                             \
+    }(framework::pack<__VA_ARGS__>{})                                                                                                               \
+                                .size();                                                                                                            \
+  };                                                                                                                                                \
+  template <>                                                                                                                                       \
+  struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                                 \
+    using metadata = _Name_##Metadata;                                                                                                              \
+  };                                                                                                                                                \
+  template <o2::aod::is_origin_hash O>                                                                                                              \
+  using _Name_##From = o2::soa::IndexTable<o2::aod::Hash<#_Name_ ""_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O, _Key_##From<O>, __VA_ARGS__>; \
+  using _Name_ = _Name_##From<o2::aod::Hash<"AOD"_h>>;
+
+#define DECLARE_SOA_INDEX_TABLE(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_NG(_Name_, _Key_, 0, _Description_, false, __VA_ARGS__)
+
+#define DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_NG(_Name_, _Key_, 0, _Description_, true, __VA_ARGS__)
+
+#define DECLARE_SOA_INDEX_TABLE_USER(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_NG(_Name_, _Key_, 0, _Description_, false, __VA_ARGS__)
+
+#define DECLARE_SOA_INDEX_TABLE_EXCLUSIVE_USER(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_NG(_Name_, _Key_, 0, _Description_, true, __VA_ARGS__)
 
 // Declare were each row is associated to a timestamp column of an _TimestampSource_
 // table.
@@ -3363,9 +3412,10 @@ consteval auto getIndexTargets()
   template <typename O>                                                                                                             \
   using _Name_##TimestampFrom = soa::Table<o2::aod::Hash<_Label_ ""_h>, o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, O>;              \
   using _Name_##Timestamp = _Name_##TimestampFrom<o2::aod::Hash<_Origin_ ""_h>>;                                                    \
-  template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                              \
-  struct _Name_##TimestampMetadataFrom : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                    \
-    using base_table_t = _TimestampSource_;                                                                                         \
+  struct _Name_##TimestampMetadata : TableMetadata<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, __VA_ARGS__> {                        \
+    template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                            \
+    using base_table_t = _TimestampSource_##From<O>;                                                                                \
+    template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                            \
     using extension_table_t = _Name_##TimestampFrom<O>;                                                                             \
     static constexpr const auto ccdb_urls = []<typename... Cs>(framework::pack<Cs...>) {                                            \
       return std::array<std::string_view, sizeof...(Cs)>{Cs::query...};                                                             \
@@ -3373,49 +3423,37 @@ consteval auto getIndexTargets()
     static constexpr const auto ccdb_bindings = []<typename... Cs>(framework::pack<Cs...>) {                                        \
       return std::array<std::string_view, sizeof...(Cs)>{Cs::mLabel...};                                                            \
     }(framework::pack<__VA_ARGS__>{});                                                                                              \
-    static constexpr auto sources = _TimestampSource_::originals;                                                                   \
+    template <typename O = o2::aod::Hash<_Origin_ ""_h>>                                                                            \
+    static constexpr auto sources = _TimestampSource_##From<O>::originals;                                                          \
     static constexpr auto timestamp_column_label = _TimestampColumn_::mLabel;                                                       \
     /*static constexpr auto timestampColumn = _TimestampColumn_;*/                                                                  \
   };                                                                                                                                \
-  using _Name_##TimestampMetadata = _Name_##TimestampMetadataFrom<o2::aod::Hash<_Origin_ ""_h>>;                                    \
   template <>                                                                                                                       \
   struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                 \
     using metadata = _Name_##TimestampMetadata;                                                                                     \
   };                                                                                                                                \
   template <typename O>                                                                                                             \
-  using _Name_##From = o2::soa::JoinFull<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>, _TimestampSource_, _Name_##TimestampFrom<O>>;   \
+  using _Name_##From = o2::soa::Join<_TimestampSource_, _Name_##TimestampFrom<O>>;                                                  \
   using _Name_ = _Name_##From<o2::aod::Hash<_Origin_ ""_h>>;
 
 #define DECLARE_SOA_TIMESTAMPED_TABLE(_Name_, _TimestampSource_, _TimestampColumn_, _Version_, _Desc_, ...) \
   O2HASH(#_Name_ "Timestamped");                                                                            \
-  DECLARE_SOA_TIMESTAMPED_TABLE_FULL(_Name_, #_Name_ "Timestamped", _TimestampSource_, _TimestampColumn_, "ATIM", _Version_, _Desc_, __VA_ARGS__)
-
-#define DECLARE_SOA_INDEX_TABLE(_Name_, _Key_, _Description_, ...) \
-  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "IDX", 0, _Description_, false, __VA_ARGS__)
-
-#define DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(_Name_, _Key_, _Description_, ...) \
-  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "IDX", 0, _Description_, true, __VA_ARGS__)
-
-#define DECLARE_SOA_INDEX_TABLE_USER(_Name_, _Key_, _Description_, ...) \
-  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "AOD", 0, _Description_, false, __VA_ARGS__)
-
-#define DECLARE_SOA_INDEX_TABLE_EXCLUSIVE_USER(_Name_, _Key_, _Description_, ...) \
-  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "AOD", 0, _Description_, true, __VA_ARGS__)
+  DECLARE_SOA_TIMESTAMPED_TABLE_FULL(_Name_, #_Name_ "Timestamped", _TimestampSource_, _TimestampColumn_, "AOD", _Version_, _Desc_, __VA_ARGS__)
 
 namespace o2::soa
 {
-template <typename D, typename... Ts>
-struct JoinFull : Table<o2::aod::Hash<"JOIN"_h>, D, o2::aod::Hash<"JOIN"_h>, Ts...> {
-  using base = Table<o2::aod::Hash<"JOIN"_h>, D, o2::aod::Hash<"JOIN"_h>, Ts...>;
+template <typename... Ts>
+struct Join : Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Ts...> {
+  using base = Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Ts...>;
 
-  JoinFull(std::shared_ptr<arrow::Table>&& table, uint64_t offset = 0)
+  Join(std::shared_ptr<arrow::Table>&& table, uint64_t offset = 0)
     : base{std::move(table), offset}
   {
     if (this->tableSize() != 0) {
       bindInternalIndicesTo(this);
     }
   }
-  JoinFull(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
+  Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
     : base{ArrowHelpers::joinTables(std::move(tables), std::span{base::originalLabels}), offset}
   {
     if (this->tableSize() != 0) {
@@ -3425,6 +3463,7 @@ struct JoinFull : Table<o2::aod::Hash<"JOIN"_h>, D, o2::aod::Hash<"JOIN"_h>, Ts.
   using base::bindExternalIndices;
   using base::bindInternalIndicesTo;
   static constexpr const uint32_t binding_origin = base::binding_origin;
+  static constexpr const header::DataOrigin binding_origin_ = base::binding_origin_;
 
   template <typename... TA>
   void bindExternalIndices(TA*... current)
@@ -3437,7 +3476,7 @@ struct JoinFull : Table<o2::aod::Hash<"JOIN"_h>, D, o2::aod::Hash<"JOIN"_h>, Ts.
      ...);
   }
 
-  using self_t = JoinFull<D, Ts...>;
+  using self_t = Join<Ts...>;
   using table_t = base;
   static constexpr const auto originals = base::originals;
   static constexpr const auto originalLabels = base::originalLabels;
@@ -3501,12 +3540,11 @@ struct JoinFull : Table<o2::aod::Hash<"JOIN"_h>, D, o2::aod::Hash<"JOIN"_h>, Ts.
   template <typename T>
   static consteval bool contains()
   {
-    return std::find_if(originals.begin(), originals.end(), [](TableRef const& ref) { return ref.desc_hash == T::ref.desc_hash; }) != originals.end();
+    return []<size_t... Is>(std::index_sequence<Is...>) {
+      return (std::ranges::any_of(originals, [](TableRef const& ref) { return ref.desc_hash == T::originals[Is].desc_hash; }) && ...);
+    }(std::make_index_sequence<T::originals.size()>());
   }
 };
-
-template <typename... Ts>
-using Join = JoinFull<o2::aod::Hash<"JOIN/0"_h>, Ts...>;
 
 template <typename... Ts>
 constexpr auto join(Ts const&... t)
@@ -3515,7 +3553,7 @@ constexpr auto join(Ts const&... t)
 }
 
 template <typename T>
-concept is_join = framework::specialization_of_template<JoinFull, T>;
+concept is_join = framework::specialization_of_template<Join, T>;
 
 template <typename T>
 constexpr bool is_soa_join_v = is_join<T>;
@@ -3566,6 +3604,7 @@ class FilteredBase : public T
   using table_t = typename T::table_t;
   using T::originals;
   static constexpr const uint32_t binding_origin = T::binding_origin;
+  static constexpr const header::DataOrigin binding_origin_ = T::binding_origin_;
   template <typename... TA>
   void bindExternalIndices(TA*... current)
   {
@@ -4181,6 +4220,7 @@ struct IndexTable : Table<L, D, O> {
   using rest_t = framework::pack<typename Ts::binding_t...>;
 
   static constexpr const uint32_t binding_origin = Key::binding_origin;
+  static constexpr const header::DataOrigin binding_origin_ = Key::binding_origin_;
 
   template <typename... TA>
   void bindExternalIndices(TA*... current)

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -51,6 +51,8 @@ DECLARE_SOA_TABLE(BCFlags, "AOD", "BCFLAG", //! flag for tagging UPCs, joinable 
                   bc::Flags);
 
 using BCs = BCs_001; // current version
+template <aod::is_origin_hash O>
+using BCsFrom = BCs_001From<O>;
 using BC = BCs::iterator;
 
 namespace timestamp
@@ -66,7 +68,7 @@ using BCsWithTimestamps = soa::Join<aod::BCs, aod::Timestamps>;
 
 namespace soa
 {
-extern template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::BCs, aod::Timestamps>;
+extern template struct Join<aod::BCs, aod::Timestamps>;
 }
 namespace aod
 {
@@ -514,11 +516,11 @@ DECLARE_SOA_TABLE_FULL(StoredTracksIU, "Tracks_IU", "AOD", "TRACK_IU", //! On di
                        track::Sign<track::Signed1Pt>,
                        o2::soa::Marker<2>);
 
-DECLARE_SOA_EXTENDED_TABLE(TracksIU, StoredTracksIU, "EXTRACK_IU", 0, //! Track parameters at inner most update (e.g. ITS) as it comes from the tracking
-                           aod::track::Pt,
-                           aod::track::P,
-                           aod::track::Eta,
-                           aod::track::Phi);
+DECLARE_SOA_EXTENDED_TABLE_NG(TracksIU, StoredTracksIU, "EXTRACK_IU", 0, //! Track parameters at inner most update (e.g. ITS) as it comes from the tracking
+                              aod::track::Pt,
+                              aod::track::P,
+                              aod::track::Eta,
+                              aod::track::Phi);
 
 DECLARE_SOA_TABLE_FULL(StoredTracksCov, "TracksCov", "AOD", "TRACKCOV", //! On disk version of the TracksCov table at collision vertex
                        track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,
@@ -680,9 +682,9 @@ using Run2TrackExtra = Run2TrackExtras::iterator;
 } // namespace aod
 namespace soa
 {
-extern template struct soa::JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Tracks, aod::TracksExtra>;
-extern template struct soa::JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Tracks, aod::TracksCov, aod::TracksExtra>;
-extern template struct soa::JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::TracksExtension, aod::StoredTracks>;
+extern template struct soa::Join<aod::Tracks, aod::TracksExtra>;
+extern template struct soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra>;
+extern template struct soa::Join<aod::TracksExtension, aod::StoredTracks>;
 } // namespace soa
 namespace aod
 {
@@ -926,6 +928,8 @@ using MFTTracks = MFTTracks_001;
 using StoredMFTTracks = StoredMFTTracks_001;
 
 using MFTTrack = MFTTracks::iterator;
+template <aod::is_origin_hash O>
+using MFTTracksFrom = MFTTracks_001From<O>;
 
 namespace fwdtrack // Index to MFTtrack column must be defined after table definition.
 {
@@ -1005,7 +1009,7 @@ using MFTTrackCovFwd = MFTTracksCov::iterator;
 } // namespace aod
 namespace soa
 {
-extern template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::FwdTracks, aod::FwdTracksCov>;
+extern template struct Join<aod::FwdTracks, aod::FwdTracksCov>;
 }
 namespace aod
 {
@@ -2026,6 +2030,8 @@ DECLARE_SOA_EXTENDED_TABLE(McParticles_001, StoredMcParticles_001, "EXMCPARTICLE
 using StoredMcParticles = StoredMcParticles_001;
 using McParticles = McParticles_001;
 using McParticle = McParticles::iterator;
+template <aod::is_origin_hash O>
+using McParticlesFrom = McParticles_001From<O>;
 } // namespace aod
 namespace soa
 {
@@ -2191,11 +2197,11 @@ DECLARE_SOA_INDEX_COLUMN(FDD, fdd);                    //!
 // First entry: Collision
 #define INDEX_LIST_RUN2 indices::CollisionId, indices::ZdcId, indices::BCId, indices::FT0Id, indices::FV0AId, indices::FV0CId, indices::FDDId
 DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(Run2MatchedExclusive, BCs, "MA_RN2_EX", INDEX_LIST_RUN2); //!
-DECLARE_SOA_INDEX_TABLE(Run2MatchedSparse, BCs, "MA_RN2_SP", INDEX_LIST_RUN2);              //!
+DECLARE_SOA_INDEX_TABLE(Run2MatchedSparse, BCs_001, "MA_RN2_SP", INDEX_LIST_RUN2);          //!
 
 #define INDEX_LIST_RUN3 indices::CollisionId, indices::ZdcId, indices::BCId, indices::FT0Id, indices::FV0AId, indices::FDDId
 DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(Run3MatchedExclusive, BCs, "MA_RN3_EX", INDEX_LIST_RUN3); //!
-DECLARE_SOA_INDEX_TABLE(Run3MatchedSparse, BCs, "MA_RN3_SP", INDEX_LIST_RUN3);              //!
+DECLARE_SOA_INDEX_TABLE(Run3MatchedSparse, BCs_001, "MA_RN3_SP", INDEX_LIST_RUN3);          //!
 
 // First entry: BC
 DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(MatchedBCCollisionsExclusive, BCs, "MA_BCCOL_EX", //!
@@ -2225,8 +2231,8 @@ DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksIU, aod::McTrackLabels);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::Collisions, aod::McCollisionLabels);
 // Joins with collisions (only for sparse ones)
 // NOTE: index table needs to be always last argument
-extern template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Collisions, aod::Run2MatchedSparse>;
-extern template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Collisions, aod::Run3MatchedSparse>;
+extern template struct Join<aod::Collisions, aod::Run2MatchedSparse>;
+extern template struct Join<aod::Collisions, aod::Run3MatchedSparse>;
 } // namespace soa
 namespace aod
 {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -79,6 +79,7 @@ auto makeEmptyTable(const char* name)
 }
 
 template <soa::TableRef R>
+  requires(soa::not_void<typename aod::MetadataTrait<aod::Hash<R.desc_hash>>::metadata>)
 auto makeEmptyTable()
 {
   auto schema = std::make_shared<arrow::Schema>(soa::createFieldsFromColumns(typename aod::MetadataTrait<aod::Hash<R.desc_hash>>::metadata::persistent_columns_t{}));
@@ -93,6 +94,7 @@ auto makeEmptyTable(const char* name, framework::pack<Cs...> p)
 }
 
 template <aod::is_aod_hash D>
+  requires(soa::not_void<typename aod::MetadataTrait<D>::metadata>)
 auto makeEmptyTable(const char* name)
 {
   auto schema = std::make_shared<arrow::Schema>(soa::createFieldsFromColumns(typename aod::MetadataTrait<D>::metadata::persistent_columns_t{}));
@@ -216,6 +218,26 @@ inline constexpr auto getSourceSchemas()
   }.template operator()<T::sources.size(), T::sources>();
 }
 
+template <soa::with_sources_generator T, aod::is_origin_hash O = o2::aod::Hash<"AOD"_h>>
+inline constexpr auto getSources()
+{
+  return []<size_t N, std::array<soa::TableRef, N> refs>() {
+    return []<size_t... Is>(std::index_sequence<Is...>) {
+      return std::vector{soa::tableRef2ConfigParamSpec<refs[Is]>()...};
+    }(std::make_index_sequence<N>());
+  }.template operator()<T::N, T::template generateSources<O>()>();
+}
+
+template <soa::with_sources_generator T, aod::is_origin_hash O = o2::aod::Hash<"AOD"_h>>
+inline constexpr auto getSourceSchemas()
+{
+  return []<size_t N, std::array<soa::TableRef, N> refs>() {
+    return []<size_t... Is>(std::index_sequence<Is...>) {
+      return std::vector{soa::tableRef2Schema<refs[Is]>()...};
+    }(std::make_index_sequence<N>());
+  }.template operator()<T::N, T::template generateSources<O>()>();
+}
+
 template <soa::with_ccdb_urls T>
 inline constexpr auto getCCDBUrls()
 {
@@ -257,7 +279,7 @@ inline constexpr auto getIndexMapping()
   using indices = T::index_pack_t;
   using Key = T::Key;
   [&idx]<size_t... Is>(std::index_sequence<Is...>) mutable {
-    constexpr auto refs = T::sources;
+    constexpr auto refs = T::generateSources();
     ([&idx]<TableRef ref, typename C>() mutable {
       constexpr auto pos = o2::aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::template getIndexPosToKey<Key>();
       if constexpr (pos == -1) {
@@ -270,6 +292,26 @@ inline constexpr auto getIndexMapping()
   }(std::make_index_sequence<framework::pack_size(indices{})>());
   ;
   return idx;
+}
+
+template <soa::with_sources_generator T, aod::is_origin_hash O = o2::aod::Hash<"AOD"_h>>
+constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
+{
+  std::vector<framework::ConfigParamSpec> inputMetadata;
+
+  auto inputSources = getSources<T, O>();
+  std::sort(inputSources.begin(), inputSources.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name < b.name; });
+  auto last = std::unique(inputSources.begin(), inputSources.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name == b.name; });
+  inputSources.erase(last, inputSources.end());
+  inputMetadata.insert(inputMetadata.end(), inputSources.begin(), inputSources.end());
+
+  auto inputSchemas = getSourceSchemas<T, O>();
+  std::sort(inputSchemas.begin(), inputSchemas.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name < b.name; });
+  last = std::unique(inputSchemas.begin(), inputSchemas.end(), [](framework::ConfigParamSpec const& a, framework::ConfigParamSpec const& b) { return a.name == b.name; });
+  inputSchemas.erase(last, inputSchemas.end());
+  inputMetadata.insert(inputMetadata.end(), inputSchemas.begin(), inputSchemas.end());
+
+  return inputMetadata;
 }
 
 template <soa::with_sources T>
@@ -293,7 +335,7 @@ constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
 }
 
 template <typename T>
-  requires(!soa::with_sources<T>)
+  requires(!(soa::with_sources<T> || soa::with_sources_generator<T>))
 constexpr auto getInputMetadata() -> std::vector<framework::ConfigParamSpec>
 {
   return {};
@@ -358,7 +400,12 @@ template <TableRef R>
 constexpr auto tableRef2InputSpec()
 {
   std::vector<framework::ConfigParamSpec> metadata;
-  auto sources = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  std::vector<framework::ConfigParamSpec> sources;
+  if constexpr (soa::with_sources<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
+    sources = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  } else if constexpr (soa::with_sources_generator<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
+    sources = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata, o2::aod::Hash<R.origin_hash>>();
+  }
   metadata.insert(metadata.end(), sources.begin(), sources.end());
   auto ccdbURLs = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), ccdbURLs.begin(), ccdbURLs.end());
@@ -555,7 +602,7 @@ concept is_produces_group = std::derived_from<T, ProducesGroup>;
 template <soa::is_metadata M, soa::TableRef Ref>
 struct TableTransform {
   using metadata = M;
-  constexpr static auto sources = M::sources;
+  constexpr static auto sources = M::template generateSources<o2::aod::Hash<Ref.origin_hash>>();
 
   template <soa::TableRef R>
   static auto base_spec()
@@ -589,23 +636,23 @@ struct TableTransform {
 /// This helper struct allows you to declare extended tables which should be
 /// created by the task (as opposed to those pre-defined by data model)
 template <typename T>
-concept is_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> && soa::has_extension<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata>;
+concept is_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
 
 template <typename T>
-concept is_dynamically_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> && soa::has_configurable_extension<typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata>;
+concept is_dynamically_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_configurable_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
 
 template <is_spawnable T>
 constexpr auto transformBase()
 {
-  using metadata = typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata;
-  return TableTransform<metadata, metadata::extension_table_t::ref>{};
+  using metadata = typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata;
+  return TableTransform<metadata, metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>::ref>{};
 }
 
 template <is_spawnable T>
 struct Spawns : decltype(transformBase<T>()) {
   using spawnable_t = T;
   using metadata = decltype(transformBase<T>())::metadata;
-  using extension_t = typename metadata::extension_table_t;
+  using extension_t = typename metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>;
   using expression_pack_t = typename metadata::expression_pack_t;
   static constexpr size_t N = framework::pack_size(expression_pack_t{});
 
@@ -655,7 +702,7 @@ struct Defines : decltype(transformBase<T>()) {
   static constexpr bool delayed = DELAYED;
   using spawnable_t = T;
   using metadata = decltype(transformBase<T>())::metadata;
-  using extension_t = typename metadata::extension_table_t;
+  using extension_t = typename metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>;
   using placeholders_pack_t = typename metadata::placeholders_pack_t;
   static constexpr size_t N = framework::pack_size(placeholders_pack_t{});
 

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -358,14 +358,14 @@ template <TableRef R>
 constexpr auto tableRef2InputSpec()
 {
   std::vector<framework::ConfigParamSpec> metadata;
-  auto m = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
-  metadata.insert(metadata.end(), m.begin(), m.end());
-  auto ccdbMetadata = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
-  metadata.insert(metadata.end(), ccdbMetadata.begin(), ccdbMetadata.end());
-  auto p = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
-  metadata.insert(metadata.end(), p.begin(), p.end());
-  auto idx = getIndexMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
-  metadata.insert(metadata.end(), idx.begin(), idx.end());
+  auto sources = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  metadata.insert(metadata.end(), sources.begin(), sources.end());
+  auto ccdbURLs = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  metadata.insert(metadata.end(), ccdbURLs.begin(), ccdbURLs.end());
+  auto expressions = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  metadata.insert(metadata.end(), expressions.begin(), expressions.end());
+  auto indices = getIndexMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  metadata.insert(metadata.end(), indices.begin(), indices.end());
   if constexpr (!soa::with_ccdb_urls<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
     metadata.emplace_back(framework::ConfigParamSpec{"schema", framework::VariantType::String, framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()), {"\"\""}});
   }
@@ -382,11 +382,22 @@ constexpr auto tableRef2InputSpec()
 template <TableRef R>
 constexpr auto tableRef2OutputSpec()
 {
+  std::vector<framework::ConfigParamSpec> metadata;
+  using md = typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata;
+  if constexpr (soa::with_ccdb_urls<md>) {
+    metadata.emplace_back("ccdb:", framework::VariantType::Bool, true, framework::ConfigParamSpec::HelpString{"\"\""});
+  } else if constexpr (soa::with_expression_pack<md>) {
+    metadata.emplace_back("projectors", framework::VariantType::Bool, true, framework::ConfigParamSpec::HelpString{"\"\""});
+  } else if constexpr (soa::with_index_pack<md>) {
+    metadata.emplace_back("index-records", framework::VariantType::Bool, true, framework::ConfigParamSpec::HelpString{"\"\""});
+  }
   return framework::OutputSpec{
     framework::OutputLabel{o2::aod::label<R>()},
     o2::aod::origin<R>(),
     o2::aod::description(o2::aod::signature<R>()),
-    R.version};
+    R.version,
+    framework::Lifetime::Timeframe,
+    metadata};
 }
 
 template <TableRef R>
@@ -504,14 +515,14 @@ struct OutputForTable {
   using table_t = decltype(typeWithRef<T>());
   using metadata = aod::MetadataTrait<o2::aod::Hash<table_t::ref.desc_hash>>::metadata;
 
-  static OutputSpec const spec()
+  static constexpr auto spec()
   {
-    return OutputSpec{OutputLabel{aod::label<table_t::ref>()}, o2::aod::origin<table_t::ref>(), o2::aod::description(o2::aod::signature<table_t::ref>()), table_t::ref.version};
+    return soa::tableRef2OutputSpec<table_t::ref>();
   }
 
-  static OutputRef ref()
+  static constexpr auto ref()
   {
-    return OutputRef{aod::label<table_t::ref>(), table_t::ref.version};
+    return soa::tableRef2OutputRef<table_t::ref>();
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -275,10 +275,10 @@ bool prepareOutput(ProcessingContext& context, T& producesGroup)
 template <is_spawns T>
 bool prepareOutput(ProcessingContext& context, T& spawns)
 {
-  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::ref.desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::sources.size(), metadata::sources>(context), std::span{metadata::base_table_t::originalLabels});
+  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].desc_hash>>::metadata;
+  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::N, metadata::template generateSources<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].origin_hash>>()>(context), std::span{metadata::base_table_t::originalLabels});
   if (originalTable->num_rows() == 0) {
-    originalTable = makeEmptyTable<metadata::base_table_t::ref>();
+    originalTable = makeEmptyTable("EMPTY", typename metadata::base_table_t::persistent_columns_t{});
   }
   using D = o2::aod::Hash<metadata::extension_table_t::ref.desc_hash>;
 
@@ -295,17 +295,17 @@ template <is_builds T>
 bool prepareOutput(ProcessingContext& context, T& builds)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::buildable_t::ref.desc_hash>>::metadata;
-  return builds.build(extractOriginals<metadata::sources.size(), metadata::sources>(context));
+  return builds.build(extractOriginals<metadata::N, metadata::template generateSources<o2::aod::Hash<T::buildable_t::ref.origin_hash>>()>(context));
 }
 
 template <is_defines T>
 bool prepareOutput(ProcessingContext& context, T& defines)
   requires(T::delayed == false)
 {
-  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::ref.desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::sources.size(), metadata::sources>(context), std::span{metadata::base_table_t::originalLabels});
+  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].desc_hash>>::metadata;
+  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::N, metadata::template generateSources<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].origin_hash>>()>(context), std::span{metadata::base_table_t::originalLabels});
   if (originalTable->num_rows() == 0) {
-    originalTable = makeEmptyTable<metadata::base_table_t::ref>();
+    originalTable = makeEmptyTable("EMPTY", typename metadata::base_table_t::persistent_columns_t{});
   }
   if (defines.inputSchema == nullptr) {
     defines.inputSchema = originalTable->schema();

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -183,20 +183,20 @@ bool newDataframeCondition(InputRecord& record, C& conditionGroup)
 
 /// Outputs handling
 template <typename T>
-bool appendOutput(std::vector<OutputSpec>&, T&, uint32_t)
+constexpr bool appendOutput(std::vector<OutputSpec>&, T&, uint32_t)
 {
   return false;
 }
 
 template <is_produces T>
-bool appendOutput(std::vector<OutputSpec>& outputs, T&, uint32_t)
+constexpr bool appendOutput(std::vector<OutputSpec>& outputs, T&, uint32_t)
 {
-  outputs.emplace_back(OutputForTable<typename T::persistent_table_t>::spec());
+  outputs.emplace_back(soa::tableRef2OutputSpec<T::persistent_table_t::ref>());
   return true;
 }
 
 template <is_produces_group T>
-bool appendOutput(std::vector<OutputSpec>& outputs, T& producesGroup, uint32_t hash)
+constexpr bool appendOutput(std::vector<OutputSpec>& outputs, T& producesGroup, uint32_t hash)
 {
   homogeneous_apply_refs<true>([&outputs, hash](auto& produces) { return appendOutput(outputs, produces, hash); }, producesGroup);
   return true;
@@ -261,7 +261,7 @@ bool prepareOutput(ProcessingContext&, T&)
 template <is_produces T>
 bool prepareOutput(ProcessingContext& context, T& produces)
 {
-  produces.resetCursor(std::move(context.outputs().make<TableBuilder>(OutputForTable<typename T::persistent_table_t>::ref())));
+  produces.resetCursor(std::move(context.outputs().make<TableBuilder>(soa::tableRef2OutputRef<T::persistent_table_t::ref>())));
   return true;
 }
 

--- a/Framework/Core/include/Framework/AnalysisSupportHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisSupportHelpers.h
@@ -21,11 +21,11 @@
 namespace o2::framework
 {
 static constexpr std::array<header::DataOrigin, 4> AODOrigins{header::DataOrigin{"AOD"}, header::DataOrigin{"AOD1"}, header::DataOrigin{"AOD2"}, header::DataOrigin{"EMB"}};
-static constexpr std::array<header::DataOrigin, 6> extendedAODOrigins{header::DataOrigin{"AOD"}, header::DataOrigin{"AOD1"}, header::DataOrigin{"AOD2"}, header::DataOrigin{"DYN"}, header::DataOrigin{"AMD"}, header::DataOrigin{"EMB"}};
-static constexpr std::array<header::DataOrigin, 4> writableAODOrigins{header::DataOrigin{"AOD"}, header::DataOrigin{"AOD1"}, header::DataOrigin{"AOD2"}, header::DataOrigin{"DYN"}};
+// static constexpr std::array<header::DataOrigin, 6> extendedAODOrigins{header::DataOrigin{"AOD"}, header::DataOrigin{"AOD1"}, header::DataOrigin{"AOD2"}, header::DataOrigin{"EMB"}};
+// static constexpr std::array<header::DataOrigin, 4> writableAODOrigins{header::DataOrigin{"AOD"}, header::DataOrigin{"AOD1"}, header::DataOrigin{"AOD2"}, header::DataOrigin{"EMB"}};
 
 class DataOutputDirector;
-class ConfigContext;
+struct ConfigContext;
 
 // Helper class to be moved in the AnalysisSupport plugin at some point
 struct AnalysisSupportHelpers {

--- a/Framework/Core/include/Framework/DanglingEdgesContext.h
+++ b/Framework/Core/include/Framework/DanglingEdgesContext.h
@@ -33,15 +33,24 @@ struct OutputObjectInfo {
 // been requested and for which we will need to inject
 // some source device.
 struct DanglingEdgesContext {
+  // generic AOD tables
   std::vector<InputSpec> requestedAODs;
   std::vector<OutputSpec> providedAODs;
+  // extension tables
   std::vector<InputSpec> requestedDYNs;
   std::vector<OutputSpec> providedDYNs;
+  // index tables
   std::vector<InputSpec> requestedIDXs;
+  std::vector<OutputSpec> providedIDXs;
+  // ccdb tables
   std::vector<OutputSpec> providedTIMs;
   std::vector<InputSpec> requestedTIMs;
+  // output objects
   std::vector<OutputSpec> providedOutputObjHist;
+  // inputs for the extension spawner
   std::vector<InputSpec> spawnerInputs;
+  // inputs for the index builder
+  std::vector<InputSpec> builderInputs;
 
   // These are the timestamped tables which are required to
   // inject the the CCDB objecs.

--- a/Framework/Core/include/Framework/DataSpecViews.h
+++ b/Framework/Core/include/Framework/DataSpecViews.h
@@ -14,8 +14,31 @@
 #include "Framework/DataSpecUtils.h"
 #include <ranges>
 
+namespace o2::framework::checks
+{
+static auto has_params_with_name(std::string&& name)
+{
+  return [name](ConfigParamSpec const& p) { return p.name.compare(name) == 0; };
+}
+
+static auto has_params_with_name_starting(std::string&& name)
+{
+  return [name](ConfigParamSpec const& p) { return p.name.starts_with(name); };
+}
+} // namespace o2::framework::checks
+
 namespace o2::framework::views
 {
+static auto filter_with_params_by_name(std::string&& name)
+{
+  return std::views::filter([name = std::move(name)](auto const& spec) mutable { return std::ranges::any_of(spec.metadata, checks::has_params_with_name(std::move(name))); });
+}
+
+static auto filter_with_params_by_name_starting(std::string&& name)
+{
+  return std::views::filter([name = std::move(name)](auto const& spec) mutable { return std::ranges::any_of(spec.metadata, checks::has_params_with_name_starting(std::move(name))); });
+}
+
 static auto partial_match_filter(auto what)
 {
   return std::views::filter([what](auto const& t) -> bool { return DataSpecUtils::partialMatch(t, what); });

--- a/Framework/Core/src/AnalysisDataModel.cxx
+++ b/Framework/Core/src/AnalysisDataModel.cxx
@@ -12,12 +12,12 @@
 
 namespace o2::soa
 {
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::BCs, aod::Timestamps>;
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Tracks, aod::TracksExtra>;
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Tracks, aod::TracksCov, aod::TracksExtra>;
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::FwdTracks, aod::FwdTracksCov>;
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Collisions, aod::Run2MatchedSparse>;
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::Collisions, aod::Run3MatchedSparse>;
+template struct Join<aod::BCs, aod::Timestamps>;
+template struct Join<aod::Tracks, aod::TracksExtra>;
+template struct Join<aod::Tracks, aod::TracksCov, aod::TracksExtra>;
+template struct Join<aod::FwdTracks, aod::FwdTracksCov>;
+template struct Join<aod::Collisions, aod::Run2MatchedSparse>;
+template struct Join<aod::Collisions, aod::Run3MatchedSparse>;
 
-template struct JoinFull<o2::aod::Hash<"JOIN/0"_h>, aod::TracksExtension, aod::StoredTracks>;
+template struct Join<aod::TracksExtension, aod::StoredTracks>;
 } // namespace o2::soa

--- a/Framework/Core/src/AnalysisSupportHelpers.cxx
+++ b/Framework/Core/src/AnalysisSupportHelpers.cxx
@@ -175,9 +175,14 @@ void AnalysisSupportHelpers::addMissingOutputsToBuilder(std::vector<InputSpec> c
   // FIXME: until we have a single list of pairs
   additionalInputs |
     views::partial_match_filter(AODOrigins) |
+    std::ranges::views::filter([](InputSpec const& input) {
+      return std::ranges::none_of(input.metadata, [](ConfigParamSpec const& p) { return (p.name.compare("projectors") == 0) || (p.name.compare("index-records") == 0); });
+    }) |
     sinks::update_input_list{requestedAODs}; // update requestedAODs
   additionalInputs |
-    views::partial_match_filter(header::DataOrigin{"DYN"}) |
+    std::ranges::views::filter([](InputSpec const& input) {
+      return std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p) { return p.name.compare("projectors") == 0; });
+    }) |
     sinks::update_input_list{requestedDYNs}; // update requestedDYNs
 }
 

--- a/Framework/Core/src/AnalysisSupportHelpers.cxx
+++ b/Framework/Core/src/AnalysisSupportHelpers.cxx
@@ -102,7 +102,7 @@ std::shared_ptr<DataOutputDirector> AnalysisSupportHelpers::getDataOutputDirecto
         // use the dangling outputs
         std::vector<InputSpec> danglingOutputs;
         for (auto ii = 0u; ii < OutputsInputs.size(); ii++) {
-          if (DataSpecUtils::partialMatch(OutputsInputs[ii], writableAODOrigins) && isDangling[ii]) {
+          if (DataSpecUtils::partialMatch(OutputsInputs[ii], AODOrigins) && isDangling[ii]) {
             danglingOutputs.emplace_back(OutputsInputs[ii]);
           }
         }

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -50,7 +50,6 @@ O2_DECLARE_DYNAMIC_LOG(rate_limiting);
 
 namespace o2::framework
 {
-
 class EndOfStreamContext;
 class ProcessingContext;
 
@@ -578,45 +577,80 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        } },
     .adjustTopology = [](WorkflowSpecNode& node, ConfigContext const& ctx) {
       auto& workflow = node.specs;
-      auto spawner = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-spawner"); });
-      auto analysisCCDB = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-ccdb"); });
-      auto builder = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-index-builder"); });
-      auto writer = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-writer"); });
       auto& dec = ctx.services().get<DanglingEdgesContext>();
       dec.requestedAODs.clear();
       dec.requestedDYNs.clear();
-      dec.providedDYNs.clear();
-      dec.providedTIMs.clear();
-      dec.requestedTIMs.clear();
 
       auto inputSpecLessThan = [](InputSpec const& lhs, InputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
       auto outputSpecLessThan = [](OutputSpec const& lhs, OutputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
 
+      auto builder = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-index-builder"); });
       if (builder != workflow.end()) {
         // collect currently requested IDXs
         dec.requestedIDXs.clear();
+        dec.providedIDXs.clear();
         for (auto& d : workflow | views::exclude_by_name(builder->name)) {
           d.inputs |
-            views::partial_match_filter(header::DataOrigin{"IDX"}) |
+            views::filter_with_params_by_name("index-records") |
             sinks::update_input_list{dec.requestedIDXs};
+          d.outputs |
+            views::filter_with_params_by_name("index-records") |
+            sinks::update_output_list{dec.providedIDXs};
         }
+        std::ranges::sort(dec.requestedIDXs, inputSpecLessThan);
+        std::ranges::sort(dec.providedIDXs, outputSpecLessThan);
+        dec.builderInputs.clear();
+        dec.requestedIDXs |
+          views::filter_not_matching(dec.providedIDXs) |
+          sinks::append_to{dec.builderInputs};
         // recreate inputs and outputs
         builder->inputs.clear();
         builder->outputs.clear();
-
-        // load real AlgorithmSpec before deployment
-        builder->algorithm = PluginManager::loadAlgorithmFromPlugin("O2FrameworkOnDemandTablesSupport", "IndexTableBuilder", ctx);
-        AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.requestedIDXs, dec.requestedAODs, dec.requestedDYNs, *builder);
+        AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.builderInputs, dec.requestedAODs, dec.requestedDYNs, *builder);
+        if (!builder->inputs.empty()) {
+          // load real AlgorithmSpec before deployment
+          builder->algorithm = PluginManager::loadAlgorithmFromPlugin("O2FrameworkOnDemandTablesSupport", "IndexTableBuilder", ctx);
+        }
       }
 
+      auto analysisCCDB = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-ccdb"); });
+      if (analysisCCDB != workflow.end()) {
+        dec.requestedTIMs.clear();
+        dec.providedTIMs.clear();
+        for (auto& d : workflow | views::exclude_by_name(analysisCCDB->name)) {
+          d.inputs |
+            views::filter_with_params_by_name_starting("ccdb:") |
+            sinks::update_input_list{dec.requestedTIMs};
+          d.outputs |
+            views::filter_with_params_by_name_starting("ccdb:") |
+            sinks::append_to{dec.providedTIMs};
+        }
+        std::ranges::sort(dec.requestedTIMs, inputSpecLessThan);
+        std::ranges::sort(dec.providedTIMs, outputSpecLessThan);
+        // Use ranges::to<std::vector<>> in C++23...
+        dec.analysisCCDBInputs.clear();
+        dec.requestedTIMs |
+          views::filter_not_matching(dec.providedTIMs) |
+          sinks::append_to{dec.analysisCCDBInputs};
+
+        // recreate inputs and outputs
+        analysisCCDB->outputs.clear();
+        analysisCCDB->inputs.clear();
+        AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.analysisCCDBInputs, dec.requestedAODs, dec.requestedDYNs, *analysisCCDB);
+        // load real AlgorithmSpec before deployment
+        analysisCCDB->algorithm = PluginManager::loadAlgorithmFromPlugin("O2FrameworkCCDBSupport", "AnalysisCCDBFetcherPlugin", ctx);
+      }
+
+      auto spawner = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-spawner"); });
       if (spawner != workflow.end()) {
+        dec.providedDYNs.clear();
         // collect currently requested DYNs
         for (auto& d : workflow | views::exclude_by_name(spawner->name)) {
           d.inputs |
-            views::partial_match_filter(header::DataOrigin{"DYN"}) |
+            views::filter_with_params_by_name("projectors") |
             sinks::update_input_list{dec.requestedDYNs};
           d.outputs |
-            views::partial_match_filter(header::DataOrigin{"DYN"}) |
+            views::filter_with_params_by_name("projectors") |
             sinks::append_to{dec.providedDYNs};
         }
         std::ranges::sort(dec.requestedDYNs, inputSpecLessThan);
@@ -628,32 +662,14 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
         // recreate inputs and outputs
         spawner->outputs.clear();
         spawner->inputs.clear();
-
-        // load real AlgorithmSpec before deployment
-        spawner->algorithm = PluginManager::loadAlgorithmFromPlugin("O2FrameworkOnDemandTablesSupport", "ExtendedTableSpawner", ctx);
         AnalysisSupportHelpers::addMissingOutputsToSpawner({}, dec.spawnerInputs, dec.requestedAODs, *spawner);
-      }
-
-      if (analysisCCDB != workflow.end()) {
-        for (auto& d : workflow | views::exclude_by_name(analysisCCDB->name)) {
-          d.inputs | views::partial_match_filter(header::DataOrigin{"ATIM"}) | sinks::update_input_list{dec.requestedTIMs};
-          d.outputs | views::partial_match_filter(header::DataOrigin{"ATIM"}) | sinks::append_to{dec.providedTIMs};
+        if (!spawner->inputs.empty()) {
+          // load real AlgorithmSpec before deployment
+          spawner->algorithm = PluginManager::loadAlgorithmFromPlugin("O2FrameworkOnDemandTablesSupport", "ExtendedTableSpawner", ctx);
         }
-        std::ranges::sort(dec.requestedTIMs, inputSpecLessThan);
-        std::ranges::sort(dec.providedTIMs, outputSpecLessThan);
-        // Use ranges::to<std::vector<>> in C++23...
-        dec.analysisCCDBInputs.clear();
-        dec.requestedTIMs | views::filter_not_matching(dec.providedTIMs) | sinks::append_to{dec.analysisCCDBInputs};
-
-        // recreate inputs and outputs
-        analysisCCDB->outputs.clear();
-        analysisCCDB->inputs.clear();
-        // load real AlgorithmSpec before deployment
-        // FIXME how can I make the lookup depend on DYN tables as well??
-        analysisCCDB->algorithm = PluginManager::loadAlgorithmFromPlugin("O2FrameworkCCDBSupport", "AnalysisCCDBFetcherPlugin", ctx);
-        AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.analysisCCDBInputs, dec.requestedAODs, dec.requestedDYNs, *analysisCCDB);
       }
 
+      auto writer = std::ranges::find_if(workflow, [](DataProcessorSpec const& spec) { return spec.name.starts_with("internal-dpl-aod-writer"); });
       if (writer != workflow.end()) {
         workflow.erase(writer);
       }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -234,8 +234,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   ctx.services().registerService(ServiceRegistryHelpers::handleForService<DanglingEdgesContext>(new DanglingEdgesContext));
   auto& dec = ctx.services().get<DanglingEdgesContext>();
 
-  std::vector<OutputSpec> DYNs;
-
   std::vector<InputSpec> requestedCCDBs;
   std::vector<OutputSpec> providedCCDBs;
 
@@ -369,9 +367,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
           hasCCDBURLs = true;
           break;
         }
-      }
-      if (DataSpecUtils::partialMatch(output, header::DataOrigin{"DYN"})) {
-        DYNs.emplace_back(output);
       }
       if (hasProjectors) {
         dec.providedDYNs.emplace_back(output);
@@ -592,7 +587,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       continue;
     }
     // AODs are skipped in any case.
-    if (DataSpecUtils::partialMatch(dec.outputsInputs[ii], extendedAODOrigins)) {
+    if (DataSpecUtils::partialMatch(dec.outputsInputs[ii], AODOrigins)) {
       continue;
     }
     redirectedOutputsInputs.emplace_back(dec.outputsInputs[ii]);
@@ -727,7 +722,7 @@ void WorkflowHelpers::injectAODWriter(WorkflowSpec& workflow, ConfigContext cons
   // select outputs of type AOD which need to be saved
   dec.outputsInputsAOD.clear();
   for (auto ii = 0u; ii < dec.outputsInputs.size(); ii++) {
-    if (DataSpecUtils::partialMatch(dec.outputsInputs[ii], extendedAODOrigins)) {
+    if (DataSpecUtils::partialMatch(dec.outputsInputs[ii], AODOrigins)) {
       auto ds = dod->getDataOutputDescriptors(dec.outputsInputs[ii]);
       if (ds.size() > 0 || dec.isDangling[ii]) {
         dec.outputsInputsAOD.emplace_back(dec.outputsInputs[ii]);
@@ -855,10 +850,8 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
       if (forwards.empty()) {
         errorDueToMissingOutputFor(consumer, input);
       }
-      availableOutputsInfo.erase(std::remove_if(availableOutputsInfo.begin(), availableOutputsInfo.end(), [](auto& info) { return info.enabled == false; }), availableOutputsInfo.end());
-      for (auto& forward : forwards) {
-        availableOutputsInfo.push_back(forward);
-      }
+      availableOutputsInfo.erase(std::remove_if(availableOutputsInfo.begin(), availableOutputsInfo.end(), [](auto const& info) { return info.enabled == false; }), availableOutputsInfo.end());
+      std::ranges::copy(forwards, std::back_inserter(availableOutputsInfo));
     }
     O2_SIGNPOST_END(workflow_helpers, sid, "input matching", "");
   }
@@ -937,14 +930,14 @@ WorkflowParsingState WorkflowHelpers::verifyWorkflow(const o2::framework::Workfl
     return WorkflowParsingState::Empty;
   }
   std::set<std::string> validNames;
-  std::vector<OutputSpec> availableOutputs;
-  std::vector<InputSpec> requiredInputs;
+  // std::vector<OutputSpec> availableOutputs;
+  // std::vector<InputSpec> requiredInputs;
 
   // An index many to one index to go from a given input to the
   // associated spec
-  std::map<size_t, size_t> inputToSpec;
+  // std::map<size_t, size_t> inputToSpec;
   // A one to one index to go from a given output to the Spec emitting it
-  std::map<size_t, size_t> outputToSpec;
+  // std::map<size_t, size_t> outputToSpec;
 
   std::ostringstream ss;
 
@@ -1125,14 +1118,14 @@ void WorkflowHelpers::validateEdges(WorkflowSpec const& workflow,
   // Get the input lifetime and the output lifetime.
   // Output lifetime must be Timeframe if the input lifetime is Timeframe.
   bool hasErrors = false;
-  for (auto& edge : edges) {
+  for (auto const& edge : edges) {
     DataProcessorSpec const& producer = workflow[edge.producer];
     DataProcessorSpec const& consumer = workflow[edge.consumer];
     DataProcessorPoliciesInfo const& producerPolicies = policies[edge.producer];
     DataProcessorPoliciesInfo const& consumerPolicies = policies[edge.consumer];
     OutputSpec const& output = outputs[edge.outputGlobalIndex];
     InputSpec const& input = consumer.inputs[edge.consumerInputIndex];
-    for (auto& validator : defaultValidators) {
+    for (auto const& validator : defaultValidators) {
       hasErrors |= !validator(errors, producer, output, producerPolicies, consumer, input, consumerPolicies);
     }
   }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -234,6 +234,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   ctx.services().registerService(ServiceRegistryHelpers::handleForService<DanglingEdgesContext>(new DanglingEdgesContext));
   auto& dec = ctx.services().get<DanglingEdgesContext>();
 
+  std::vector<OutputSpec> DYNs;
+
   std::vector<InputSpec> requestedCCDBs;
   std::vector<OutputSpec> providedCCDBs;
 
@@ -279,6 +281,24 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     bool hasConditionOption = false;
     for (size_t ii = 0; ii < processor.inputs.size(); ++ii) {
       auto& input = processor.inputs[ii];
+      bool hasProjectors = false;
+      bool hasIndexRecords = false;
+      bool hasCCDBURLs = false;
+      // all three options are exclusive
+      for (auto const& p : input.metadata) {
+        if (p.name.compare("projectors") == 0) {
+          hasProjectors = true;
+          break;
+        }
+        if (p.name.compare("index-records") == 0) {
+          hasIndexRecords = true;
+          break;
+        }
+        if (p.name.starts_with("ccdb:")) {
+          hasCCDBURLs = true;
+          break;
+        }
+      }
       switch (input.lifetime) {
         case Lifetime::Timer: {
           auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
@@ -318,29 +338,49 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
         case Lifetime::Optional:
           break;
       }
-      if (DataSpecUtils::partialMatch(input, AODOrigins)) {
-        DataSpecUtils::updateInputList(dec.requestedAODs, InputSpec{input});
-      }
-      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"DYN"})) {
+      if (hasProjectors) {
         DataSpecUtils::updateInputList(dec.requestedDYNs, InputSpec{input});
-      }
-      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"IDX"})) {
+      } else if (hasIndexRecords) {
         DataSpecUtils::updateInputList(dec.requestedIDXs, InputSpec{input});
-      }
-      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"ATIM"})) {
+      } else if (hasCCDBURLs) {
         DataSpecUtils::updateInputList(dec.requestedTIMs, InputSpec{input});
+      } else if (DataSpecUtils::partialMatch(input, AODOrigins)) {
+        DataSpecUtils::updateInputList(dec.requestedAODs, InputSpec{input});
       }
     }
 
     std::ranges::stable_sort(timer.outputs, [](OutputSpec const& a, OutputSpec const& b) { return *DataSpecUtils::getOptionalSubSpec(a) < *DataSpecUtils::getOptionalSubSpec(b); });
 
     for (auto& output : processor.outputs) {
-      if (DataSpecUtils::partialMatch(output, AODOrigins)) {
-        dec.providedAODs.emplace_back(output);
-      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"DYN"})) {
+      bool hasProjectors = false;
+      bool hasIndexRecords = false;
+      bool hasCCDBURLs = false;
+      // all three options are exclusive
+      for (auto const& p : output.metadata) {
+        if (p.name.compare("projectors") == 0) {
+          hasProjectors = true;
+          break;
+        }
+        if (p.name.compare("index-records") == 0) {
+          hasIndexRecords = true;
+          break;
+        }
+        if (p.name.starts_with("ccdb:")) {
+          hasCCDBURLs = true;
+          break;
+        }
+      }
+      if (DataSpecUtils::partialMatch(output, header::DataOrigin{"DYN"})) {
+        DYNs.emplace_back(output);
+      }
+      if (hasProjectors) {
         dec.providedDYNs.emplace_back(output);
-      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATIM"})) {
+      } else if (hasCCDBURLs) {
         dec.providedTIMs.emplace_back(output);
+      } else if (hasIndexRecords) {
+        dec.providedIDXs.emplace_back(output);
+      } else if (DataSpecUtils::partialMatch(output, AODOrigins)) {
+        dec.providedAODs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
         dec.providedOutputObjHist.emplace_back(output);
         auto it = std::ranges::find_if(dec.outObjHistMap, [&](auto&& x) { return x.id == hash; });
@@ -350,6 +390,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
           it->bindings.push_back(output.binding.value);
         }
       }
+
       if (output.lifetime == Lifetime::Condition) {
         providedCCDBs.push_back(output);
       }
@@ -358,10 +399,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   auto inputSpecLessThan = [](InputSpec const& lhs, InputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
   auto outputSpecLessThan = [](OutputSpec const& lhs, OutputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
-  std::ranges::sort(dec.requestedDYNs, inputSpecLessThan);
-  std::ranges::sort(dec.requestedTIMs, inputSpecLessThan);
-  std::ranges::sort(dec.providedDYNs, outputSpecLessThan);
-  std::ranges::sort(dec.providedTIMs, outputSpecLessThan);
 
   DataProcessorSpec indexBuilder{
     "internal-dpl-aod-index-builder",
@@ -369,14 +406,18 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {},
     AlgorithmSpec::dummyAlgorithm(), // real algorithm will be set in adjustTopology
     {}};
-  AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.requestedIDXs, dec.requestedAODs, dec.requestedDYNs, indexBuilder);
+  std::ranges::sort(dec.requestedIDXs, inputSpecLessThan);
+  std::ranges::sort(dec.providedIDXs, outputSpecLessThan);
+  dec.requestedIDXs | views::filter_not_matching(dec.providedIDXs) | sinks::append_to{dec.builderInputs};
+  AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.builderInputs, dec.requestedAODs, dec.requestedDYNs, indexBuilder);
 
+  std::ranges::sort(dec.requestedTIMs, inputSpecLessThan);
+  std::ranges::sort(dec.providedTIMs, outputSpecLessThan);
   dec.requestedTIMs | views::filter_not_matching(dec.providedTIMs) | sinks::append_to{dec.analysisCCDBInputs};
-  DeploymentMode deploymentMode = DefaultsHelpers::deploymentMode();
-  if (deploymentMode != DeploymentMode::OnlineDDS && deploymentMode != DeploymentMode::OnlineECS) {
-    AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.analysisCCDBInputs, dec.requestedAODs, dec.requestedTIMs, analysisCCDBBackend);
-  }
+  AnalysisSupportHelpers::addMissingOutputsToBuilder(dec.analysisCCDBInputs, dec.requestedAODs, dec.requestedDYNs, analysisCCDBBackend);
 
+  std::ranges::sort(dec.requestedDYNs, inputSpecLessThan);
+  std::ranges::sort(dec.providedDYNs, outputSpecLessThan);
   dec.requestedDYNs | views::filter_not_matching(dec.providedDYNs) | sinks::append_to{dec.spawnerInputs};
 
   DataProcessorSpec aodSpawner{
@@ -386,6 +427,9 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     AlgorithmSpec::dummyAlgorithm(), // real algorithm will be set in adjustTopology
     {}};
   AnalysisSupportHelpers::addMissingOutputsToSpawner({}, dec.spawnerInputs, dec.requestedAODs, aodSpawner);
+
+  std::ranges::sort(dec.requestedAODs, inputSpecLessThan);
+  std::ranges::sort(dec.providedAODs, outputSpecLessThan);
   AnalysisSupportHelpers::addMissingOutputsToReader(dec.providedAODs, dec.requestedAODs, aodReader);
 
   std::ranges::sort(requestedCCDBs, inputSpecLessThan);
@@ -407,6 +451,14 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   if (indexBuilder.outputs.empty() == false) {
     extraSpecs.push_back(indexBuilder);
+  }
+
+  // add the Analysys CCDB backend which reads CCDB objects using a provided table
+  DeploymentMode deploymentMode = DefaultsHelpers::deploymentMode();
+  if (deploymentMode != DeploymentMode::OnlineDDS && deploymentMode != DeploymentMode::OnlineECS) {
+    if (analysisCCDBBackend.outputs.empty() == false) {
+      extraSpecs.push_back(analysisCCDBBackend);
+    }
   }
 
   // add the reader
@@ -509,11 +561,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   } else if (requiresDISTSUBTIMEFRAME && enumCandidate != -1) {
     // add DSTF/ccdb source to the enumeration-driven source explicitly if it is required in the workflow
     DataSpecUtils::updateOutputList(workflow[enumCandidate].outputs, OutputSpec{{"ccdb-diststf"}, dstf, Lifetime::Timeframe});
-  }
-
-  // add the Analysys CCDB backend which reads CCDB objects using a provided table
-  if (analysisCCDBBackend.outputs.empty() == false) {
-    extraSpecs.push_back(analysisCCDBBackend);
   }
 
   // add the timer

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1685,15 +1685,15 @@ int runStateMachine(DataProcessorSpecs const& workflow,
               continue;
             }
             // ignore devices with no metadata in inputs
-            auto hasMetadata = std::any_of(device.inputs.begin(), device.inputs.end(), [](InputSpec const& spec) {
+            auto hasMetadata = std::ranges::any_of(device.inputs, [](InputSpec const& spec) {
               return spec.metadata.empty() == false;
             });
             if (!hasMetadata) {
               continue;
             }
             // ignore devices with no control options
-            auto hasControls = std::any_of(device.inputs.begin(), device.inputs.end(), [](InputSpec const& spec) {
-              return std::any_of(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& param) {
+            auto hasControls = std::ranges::any_of(device.inputs, [](InputSpec const& spec) {
+              return std::ranges::any_of(spec.metadata, [](ConfigParamSpec const& param) {
                 return param.type == VariantType::Bool && param.name.find("control:") != std::string::npos;
               });
             });

--- a/Framework/Core/test/test_Concepts.cxx
+++ b/Framework/Core/test/test_Concepts.cxx
@@ -87,7 +87,7 @@ TEST_CASE("IdentificationConcepts")
 
   REQUIRE(with_originals<o2::aod::Collisions>);
 
-  REQUIRE(with_sources<o2::aod::MetadataTrait<o2::aod::Hash<"MA_RN3_SP/0"_h>>::metadata>);
+  REQUIRE(with_sources_generator<o2::aod::MetadataTrait<o2::aod::Hash<"MA_RN3_SP/0"_h>>::metadata>);
 
   REQUIRE(with_base_table<o2::aod::Tracks>);
 

--- a/Framework/Core/test/test_IndexBuilder.cxx
+++ b/Framework/Core/test/test_IndexBuilder.cxx
@@ -108,7 +108,7 @@ TEST_CASE("TestIndexBuilder")
   auto t5 = IndexBuilder::materialize(builders1, {t1, t2, t3, t4}, map, schema1, true);
   // auto t5 = IndexBuilder::materialize({t1, t2, t3, t4}, map, schema1, true);
   REQUIRE(t5->num_rows() == 4);
-  IDXs idxt{t5};
+  IDXsFrom<o2::aod::Hash<"TST"_h>> idxt{t5};
   idxt.bindExternalIndices(&st1, &st2, &st3, &st4);
   for (auto& row : idxt) {
     REQUIRE(row.distance().pointId() == row.pointId());
@@ -121,7 +121,7 @@ TEST_CASE("TestIndexBuilder")
   std::vector<o2::framework::IndexColumnBuilder> builders2;
   auto t6 = IndexBuilder::materialize(builders2, {t2, t1, t3, t4}, map, schema2, false);
   REQUIRE(t6->num_rows() == st2.size());
-  IDX2s idxs{t6};
+  IDX2sFrom<o2::aod::Hash<"TST"_h>> idxs{t6};
   std::array<int, 7> fs{0, 1, 2, -1, -1, 4, -1};
   std::array<int, 7> cs{0, 1, 2, -1, 5, 6, -1};
   idxs.bindExternalIndices(&st1, &st2, &st3, &st4);
@@ -222,7 +222,7 @@ TEST_CASE("AdvancedIndexTables")
   std::vector<o2::framework::IndexColumnBuilder> builders3;
   auto t3 = IndexBuilder::materialize(builders3, {t1, t2, tc}, map, schema3, false);
   REQUIRE(t3->num_rows() == st1.size());
-  IDX3s idxs{t3};
+  IDX3sFrom<o2::aod::Hash<"TST"_h>> idxs{t3};
   idxs.bindExternalIndices(&st1, &st2, &st3);
   count = 0;
   for (auto const& row : idxs) {

--- a/Framework/TestWorkflows/src/o2TestMultisource.cxx
+++ b/Framework/TestWorkflows/src/o2TestMultisource.cxx
@@ -25,8 +25,6 @@ using namespace o2::framework::expressions;
 namespace o2::aod
 {
 O2ORIGIN("EMB");
-template <is_aod_hash T>
-using BCsFrom = BCs_001From<T>;
 using TracksPlus = soa::Join<StoredTracksIU, StoredTracksExtra>;
 template <is_aod_hash T>
 using TracksPlusFrom = soa::Join<StoredTracksIUFrom<T>, StoredTracksExtra_002From<T>>;
@@ -34,9 +32,9 @@ using TracksPlusFrom = soa::Join<StoredTracksIUFrom<T>, StoredTracksExtra_002Fro
 
 struct TestEmbeddingSubscription {
   void process(aod::BCs const& bcs, aod::BCsFrom<aod::Hash<"EMB"_h>> const& bcse,
-               aod::TracksPlus const& tracks, aod::TracksPlusFrom<aod::Hash<"EMB"_h>> const& trackse)
+               aod::TracksIU const& tracks, aod::TracksIUFrom<aod::Hash<"EMB"_h>> const& trackse)
   {
-    LOGP(info, "BCs from run {} and {}", bcs.begin().runNumber(), bcse.begin().runNumber());
+    LOGP(info, "BCs from run {} ({}) and {} ({})", bcs.begin().runNumber(), bcs.size(), bcse.begin().runNumber(), bcse.size());
     LOGP(info, "Joined tracks: {} and {}", tracks.size(), trackse.size());
   }
 };


### PR DESCRIPTION
* Remove DYN, IDX and ATIM special origins in favor of metadata
* Rework extended, index and timestamped tables declarations to add `From<>` versions; now these tables can transparently adapt to multiple sources, i.e. `TracksIUFrom<o2::aod::Hash<"EMB"_h>>` (extended table) would be automatically and correctly constructed from `StoredTracksIUFrom<o2::aod::Hash<"EMB"_h>>`
* The `_USER` versions of the declaration macros are left for compatibility with the current O2Physics, but are now simply aliases for the general macros
* The `Join` template is simplified
* Preparations to remove origin from `TableRef` so that origin can be easily replaced for an arbitrary task