### PR TITLE
Protect time-slice calibration from stray TFs

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/TFIDInfo.h
+++ b/DataFormats/common/include/CommonDataFormat/TFIDInfo.h
@@ -29,6 +29,7 @@ struct TFIDInfo { // helper info to patch DataHeader
   uint32_t runNumber = -1U;
   uint32_t startTime = -1U; // same as timeslot
   uint64_t creation = -1UL;
+  bool discard = false;
 
   bool isDummy() { return tfCounter == -1U; }
   void fill(uint32_t firstTForbit_, uint32_t tfCounter_, uint32_t runNumber_, uint32_t startTime_, uint64_t creation_)
@@ -38,9 +39,10 @@ struct TFIDInfo { // helper info to patch DataHeader
     runNumber = runNumber_;
     startTime = startTime_;
     creation = creation_;
+    discard = (firstTForbit < tfCounter) || firstTForbit == -1U || creation == -1;
   }
 
-  ClassDefNV(TFIDInfo, 2);
+  ClassDefNV(TFIDInfo, 3);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/Base/src/TFIDInfoHelper.cxx
+++ b/Detectors/Base/src/TFIDInfoHelper.cxx
@@ -23,15 +23,9 @@ void o2::base::TFIDInfoHelper::fillTFIDInfo(ProcessingContext& pc, o2::dataforma
 {
   const auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
   static int errCount = 0;
-  if (tinfo.firstTForbit == -1U || tinfo.creation == -1) {
-    if (errCount++ < 5) {
-      LOGP(warn, "Ignoring dummy input with orbit {} and creation time {} in fillTFIDInfo", tinfo.firstTForbit, tinfo.creation);
-    }
-    return;
+  ti.fill(tinfo.firstTForbit, tinfo.tfCounter, tinfo.runNumber, tinfo.timeslice, tinfo.creation);
+  if (ti.discard && errCount++ < 5) {
+    LOGP(warn, "Bad input with orbit {}, TFcounter {} and creation time {} in fillTFIDInfo", tinfo.firstTForbit, tinfo.tfCounter, tinfo.creation);
   }
-  ti.firstTForbit = tinfo.firstTForbit;
-  ti.tfCounter = tinfo.tfCounter;
-  ti.runNumber = tinfo.runNumber;
-  ti.startTime = tinfo.timeslice;
-  ti.creation = tinfo.creation;
+  return;
 }

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -281,6 +281,15 @@ template <typename Container>
 template <typename... DATA>
 bool TimeSlotCalibration<Container>::process(const DATA&... data)
 {
+  if (mCurrentTFInfo.discard) {
+    LOGP(warn, "Ignoring TF with discard flag on: Orbit {}, TFcounter {}, Run:{}, StartTime:{} CreationTime {}, ",
+         mCurrentTFInfo.firstTForbit,
+         mCurrentTFInfo.tfCounter,
+         mCurrentTFInfo.runNumber,
+         mCurrentTFInfo.startTime,
+         mCurrentTFInfo.creation);
+    return false; // ignore bad TF
+  }
   static bool firstCall = true;
   if (firstCall) {
     firstCall = false;

--- a/Detectors/PHOS/calib/src/PHOSEnergyCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSEnergyCalibDevice.cxx
@@ -133,6 +133,7 @@ void PHOSEnergyCalibDevice::run(o2::framework::ProcessingContext& pc)
       LOG(warning) << "LHCPeriod is not available, using current month " << mLHCPeriod;
     }
   }
+  o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
   mCalibrator->process(tfcounter, clusters, cluelements, cluTR, mOutputDigits);
 
   fillOutputTree();

--- a/Detectors/PHOS/calib/src/PHOSL1phaseCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSL1phaseCalibDevice.cxx
@@ -30,7 +30,7 @@ void PHOSL1phaseCalibDevice::init(o2::framework::InitContext& ic)
 
 void PHOSL1phaseCalibDevice::run(o2::framework::ProcessingContext& pc)
 {
-
+  o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   auto crTime = pc.services().get<o2::framework::TimingInfo>().creation;
   if (mRunStartTime == 0 || crTime < mRunStartTime) {

--- a/Detectors/PHOS/calib/src/PHOSRunbyrunCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSRunbyrunCalibDevice.cxx
@@ -54,6 +54,7 @@ void PHOSRunbyrunCalibDevice::run(o2::framework::ProcessingContext& pc)
   auto tfcounter = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("clusters").header)->tfCounter;
   auto clusters = pc.inputs().get<gsl::span<Cluster>>("clusters");
   auto cluTR = pc.inputs().get<gsl::span<TriggerRecord>>("cluTR");
+  o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
   LOG(detail) << "Processing TF with " << clusters.size() << " clusters and " << cluTR.size() << " TriggerRecords";
   mCalibrator->process(tfcounter, clusters, cluTR);
 }

--- a/Detectors/PHOS/calib/src/PHOSTurnonCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSTurnonCalibDevice.cxx
@@ -49,7 +49,7 @@ void PHOSTurnonCalibDevice::run(o2::framework::ProcessingContext& pc)
   auto cellTR = pc.inputs().get<gsl::span<TriggerRecord>>("cellTriggerRecords");
   auto clusters = pc.inputs().get<gsl::span<Cluster>>("clusters");
   auto cluTR = pc.inputs().get<gsl::span<TriggerRecord>>("clusterTriggerRecords");
-
+  o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
   LOG(detail) << "[PHOSTurnonCalibDevice - run]  Received " << cells.size() << " cells and " << clusters.size() << " clusters, running calibration";
 
   mCalibrator->process(tfcounter, cells, cellTR, clusters, cluTR);


### PR DESCRIPTION
The TFs with bogus orbit, creation time or orbit<tfCounter will be discared when filling calibration slots.