### PR TITLE
Avoid premature loop termination in the ITS vertexer

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -370,7 +370,7 @@ void VertexerTraits<nLayers>::computeVertices(const int iteration)
           std::array<float, 3> tmpVertex{mTimeFrame->getTrackletClusters(rofId).back().getVertex()};
           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
             mTimeFrame->getTrackletClusters(rofId).pop_back();
-            break;
+            continue;
           }
           usedTracklets[line1] = true;
           usedTracklets[line2] = true;


### PR DESCRIPTION
The efficiency for the low-multiplicity ITS vertex seeds hence the ITS tracking significantly increases, the test is done on single CTF (o2_ctf_run00550369_orbit0158120896_tf0002865985_epn093.root) of LHC24af/550369

ITS seeding vertices "contributors":
<img width="1023" height="938" alt="itsVtNCont" src="https://github.com/user-attachments/assets/32a3ef1d-b0ff-4b67-a9ef-818b1ad45888" />

Global PV contributors:
<img width="1023" height="938" alt="itsNcl" src="https://github.com/user-attachments/assets/7bd4b850-a1c8-4f6f-9283-ffc9b81f96b8" />

ITS tracks NClusters:
<img width="974" height="894" alt="pvNCont" src="https://github.com/user-attachments/assets/038a9fc8-bc5c-4e08-8816-796e805b679e" />

K0 yield (with global prongs only):
<img width="1350" height="1123" alt="K0s" src="https://github.com/user-attachments/assets/b628ab9a-8a5e-4683-9ad6-a37417c424ff" />
