### PR TITLE
C++ standard fobids specializations of `is_trivially_copyable`

### DIFF
--- a/Common/MathUtils/include/MathUtils/Cartesian.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian.h
@@ -284,25 +284,15 @@ GPUdi() SMatrix<T, D1, D1, MatRepSym<T, D1>> Similarity(const SMatrix<T, D1, D2,
 #if (!defined(GPUCA_STANDALONE) || !defined(DGPUCA_NO_ROOT)) && !defined(GPUCA_GPUCODE) && !defined(GPUCOMMONRTYPES_H_ACTIVE)
 std::ostream& operator<<(std::ostream& os, const o2::math_utils::Rotation2Df_t& t);
 std::ostream& operator<<(std::ostream& os, const o2::math_utils::Rotation2Dd_t& t);
-
-namespace std
+namespace o2::framework
 {
-
-/// Defining Point3D explicitly as trivially copyable
-///
-/// std::is_trivially_copyable<ROOT::Math::Cartesian3D<T>> fails because the class
-/// implements a copy constructor, although it does not much more than the default copy
-/// constructor. We need Point3D to fulfill the condition in order to make types
-/// inheriting from it or using it as member can be safely detected as messageable.
-///
-/// We believe that Point3D is messageable and explicitly specialize the type trait.
-/// There is a unit test for checking trivial copy
-/// This is a workaround, we will also make suggestions to fix the cause in ROOT itself
-/// TODO: delete once it is fixed in ROOT
 template <typename T>
-struct is_trivially_copyable<o2::math_utils::Point3D<T>> : std::true_type {
+struct is_forced_trivially_copyable;
+
+template <typename T>
+struct is_forced_trivially_copyable<o2::math_utils::Point3D<T>> : std::true_type {
 };
-} // namespace std
+} // namespace o2::framework
 #endif // Disable for GPU
 
 #endif

--- a/Common/MathUtils/test/testCartesian.cxx
+++ b/Common/MathUtils/test/testCartesian.cxx
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(Cartesian_test)
 BOOST_AUTO_TEST_CASE(Point3D_messageable)
 {
   using ElementType = math_utils::Point3D<int>;
-  static_assert(std::is_trivially_copyable<ElementType>::value == true);
+  static_assert(o2::framework::is_forced_trivially_copyable<ElementType>::value == true);
   std::vector<ElementType> pts(10);
   auto makeElement = [](int idx) {
     return ElementType{idx, idx + 10, idx + 20};

--- a/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
@@ -28,9 +28,7 @@
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DeliveryType.h"
 
-namespace o2
-{
-namespace dcs
+namespace o2::dcs
 {
 /**
      * DataPointCompositeObject is a composition of a DataPointIdentifier and a
@@ -291,26 +289,6 @@ struct DataPointCompositeObject final {
 template <typename T>
 T getValue(const DataPointCompositeObject& dpcom);
 
-} // namespace dcs
-
-/// Defining DataPointCompositeObject explicitly as messageable
-namespace framework
-{
-template <typename T>
-struct is_messageable;
-template <>
-struct is_messageable<o2::dcs::DataPointCompositeObject> : std::true_type {
-};
-} // namespace framework
-
-} // namespace o2
-
-/// Defining DataPointCompositeObject explicitly as copiable
-namespace std
-{
-template <>
-struct is_trivially_copyable<o2::dcs::DataPointCompositeObject> : std::true_type {
-};
-} // namespace std
+} // namespace o2::dcs
 
 #endif /* O2_DCS_DATAPOINT_COMPOSITE_OBJECT_H */

--- a/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
@@ -31,9 +31,7 @@
 #include "DetectorsDCS/GenericFunctions.h"
 #include "DetectorsDCS/DeliveryType.h"
 
-namespace o2
-{
-namespace dcs
+namespace o2::dcs
 {
 /**
      * DataPointIdentifier object is responsible for storing the alias and type
@@ -208,19 +206,7 @@ struct DPIDHash {
     return dpid.hash_code();
   }
 };
-} // namespace dcs
-
-/// Defining DataPointIdentifier explicitly as messageable
-namespace framework
-{
-template <typename T>
-struct is_messageable;
-template <>
-struct is_messageable<o2::dcs::DataPointIdentifier> : std::true_type {
-};
-} // namespace framework
-
-} // namespace o2
+} // namespace o2::dcs
 
 // specailized std::hash
 namespace std
@@ -232,11 +218,6 @@ struct hash<o2::dcs::DataPointIdentifier> {
     return std::hash<uint64_t>{}(dpid.hash_code());
   }
 };
-
-template <>
-struct is_trivially_copyable<o2::dcs::DataPointIdentifier> : std::true_type {
-};
-
 } // namespace std
 
 #endif /* O2_DCS_DATAPOINT_IDENTIFIER_H */

--- a/Detectors/DCS/test/testDataPointTypes.cxx
+++ b/Detectors/DCS/test/testDataPointTypes.cxx
@@ -17,8 +17,6 @@
 #include <boost/test/unit_test.hpp>
 #include "DetectorsDCS/DataPointCompositeObject.h"
 #include "Framework/TypeTraits.h"
-#include <vector>
-#include <list>
 #include <gsl/gsl>
 #include <boost/mpl/list.hpp>
 
@@ -26,7 +24,7 @@ typedef boost::mpl::list<o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue, 
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(DataPointCompositeObjectTypeTraits, T, testTypes)
 {
-  BOOST_CHECK_EQUAL(std::is_trivially_copyable<T>::value, true);
+  BOOST_CHECK_EQUAL(std::is_trivially_copyable_v<T>, true);
   BOOST_CHECK_EQUAL(std::is_polymorphic<T>::value, false);
   BOOST_CHECK_EQUAL(std::is_pointer<T>::value, false);
   BOOST_CHECK_EQUAL(o2::framework::is_forced_non_messageable<T>::value, false);

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -38,13 +38,18 @@ struct is_forced_non_messageable<
   typename std::enable_if<std::is_same<typename T::non_messageable, MarkAsNonMessageable>::value>::type> : public std::true_type {
 };
 
+template <typename T>
+struct is_forced_trivially_copyable : std::false_type {
+};
+
 // TODO: extend this to exclude structs with pointer data members
 // see e.g. https://stackoverflow.com/questions/32880990/how-to-check-if-class-has-pointers-in-c14
 template <typename T>
-struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value && //
-                                           !std::is_polymorphic<T>::value &&     //
-                                           !std::is_pointer<T>::value &&         //
-                                           !is_forced_non_messageable<T>::value, //
+struct is_messageable : std::conditional<(std::is_trivially_copyable<T>::value ||               //
+                                          framework::is_forced_trivially_copyable<T>::value) && //
+                                           !std::is_polymorphic<T>::value &&                    //
+                                           !std::is_pointer<T>::value &&                        //
+                                           !is_forced_non_messageable<T>::value,                //
                                          std::true_type,
                                          std::false_type>::type {
 };


### PR DESCRIPTION
* Introduce `is_forced_trivially_copyable`
* Use it in the definition of `is_messageable`
Update: with #15240 in place the workaround is only needed for the Point3D