### PR TITLE
Rework DCS point classes to have default assign operators

### DIFF
--- a/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
@@ -83,7 +83,7 @@ struct DataPointCompositeObject final {
   /**
          * Copy constructor
          */
-  DataPointCompositeObject(const DataPointCompositeObject& src) noexcept : DataPointCompositeObject(src.id, src.data) {}
+  DataPointCompositeObject(const DataPointCompositeObject& src) noexcept = default;
 
   DataPointCompositeObject& operator=(const DataPointCompositeObject& src) noexcept
   {

--- a/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
@@ -47,7 +47,7 @@ struct DataPointCompositeObject final {
          *
          * @see ADAPRO::ADAPOS::DataPointIdentifier
          */
-  const DataPointIdentifier id;
+  DataPointIdentifier id;
 
   /**
          * The DataPointValue object, which occupies the last 64 bytes of the
@@ -85,13 +85,7 @@ struct DataPointCompositeObject final {
          */
   DataPointCompositeObject(const DataPointCompositeObject& src) noexcept = default;
 
-  DataPointCompositeObject& operator=(const DataPointCompositeObject& src) noexcept
-  {
-    if (&src != this) {
-      memcpy(this, &src, sizeof(DataPointCompositeObject));
-    }
-    return *this;
-  }
+  DataPointCompositeObject& operator=(const DataPointCompositeObject& src) noexcept = default;
 
   /**
          * Bit-by bit equality comparison of DataPointCompositeObjects.

--- a/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
@@ -85,7 +85,7 @@ class DataPointIdentifier final
   /**
    * A copy constructor for DataPointIdentifier.
    */
-  DataPointIdentifier(const DataPointIdentifier& src) noexcept : DataPointIdentifier(src.pt1, src.pt2, src.pt3, src.pt4, src.pt5, src.pt6, src.pt7, src.pt8) {}
+  DataPointIdentifier(const DataPointIdentifier& src) noexcept = default;
 
   DataPointIdentifier& operator=(const DataPointIdentifier& src) noexcept
   {

--- a/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
@@ -41,19 +41,14 @@ namespace dcs
      */
 class DataPointIdentifier final
 {
-  const uint64_t pt1;
-  const uint64_t pt2;
-  const uint64_t pt3;
-  const uint64_t pt4;
-  const uint64_t pt5;
-  const uint64_t pt6;
-  const uint64_t pt7;
-  const uint64_t pt8; // Contains the last 6 chars of alias and the type.
-
-  DataPointIdentifier(
-    const uint64_t pt1, const uint64_t pt2, const uint64_t pt3,
-    const uint64_t pt4, const uint64_t pt5, const uint64_t pt6,
-    const uint64_t pt7, const uint64_t pt8) noexcept : pt1(pt1), pt2(pt2), pt3(pt3), pt4(pt4), pt5(pt5), pt6(pt6), pt7(pt7), pt8(pt8) {}
+  uint64_t pt1;
+  uint64_t pt2;
+  uint64_t pt3;
+  uint64_t pt4;
+  uint64_t pt5;
+  uint64_t pt6;
+  uint64_t pt7;
+  uint64_t pt8; // Contains the last 6 chars of alias and the type.
 
  public:
   /**
@@ -87,13 +82,7 @@ class DataPointIdentifier final
    */
   DataPointIdentifier(const DataPointIdentifier& src) noexcept = default;
 
-  DataPointIdentifier& operator=(const DataPointIdentifier& src) noexcept
-  {
-    if (&src != this) {
-      memcpy(this, &src, sizeof(DataPointIdentifier));
-    }
-    return *this;
-  }
+  DataPointIdentifier& operator=(const DataPointIdentifier& src) noexcept = default;
 
   /**
          * This stati procedure fills the given DataPointIdentifier object with


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AliceO2Group/AliceO2/pull/15240).
* __->__ #15240
* #15239