### PR TITLE
fix wrong long_to_int converstion in TOF readout window indexing

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -96,7 +96,7 @@ class WindowFiller
   }
 
   std::vector<uint8_t>& getPatterns() { return mPatterns; }
-  void addPattern(const uint32_t val, int icrate, int orbit, int bc) { mCratePatterns.emplace_back(val, icrate, orbit * 3 + (bc + 100) / Geo::BC_IN_WINDOW); }
+  void addPattern(const uint32_t val, int icrate, int orbit, int bc) { mCratePatterns.emplace_back(val, icrate, ((unsigned long)orbit) * 3 + (bc + 100) / Geo::BC_IN_WINDOW); }
   void addCrateHeaderData(unsigned long orbit, int crate, int32_t bc, uint32_t eventCounter);
   Diagnostic& getDiagnosticFrequency() { return mDiagnosticFrequency; }
 

--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -194,9 +194,9 @@ void WindowFiller::fillOutputContainer(std::vector<Digit>& digits)
     int npatterns = 0;
 
     // check if patterns are in the current row
-    unsigned int initrow = mFirstIR.orbit * Geo::NWINDOW_IN_ORBIT;
+    unsigned long initrow = ((unsigned long)mFirstIR.orbit) * Geo::NWINDOW_IN_ORBIT;
     for (std::vector<PatternData>::reverse_iterator it = mCratePatterns.rbegin(); it != mCratePatterns.rend(); ++it) {
-      unsigned int irow = it->row;
+      unsigned long irow = it->row;
       // printf("pattern row=%ld (%u - %u) current=%ld\n",irow - initrow,irow,initrow,mReadoutWindowCurrent);
 
       if (irow - initrow > mReadoutWindowCurrent) {


### PR DESCRIPTION
Dear @ehellbar ,
I fixed two lines with bad conversion from long to int.
Indeed, even if orbit is "int", when multiplying by 3 it can get "long".
Thanks for spotting the problem.
Cheers,
Francesco