### PR TITLE
Replace `std::format` with `fmt::format`

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROFLookupTables.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROFLookupTables.h
@@ -96,7 +96,7 @@ struct LayerTiming {
 #ifndef GPUCA_GPUCODE
   GPUh() std::string asString() const
   {
-    return std::format("NROFsPerTF {:4} ROFLength {:4} ({:4} per Orbit) ROFDelay {:4} ROFBias {:4} ROFAddTimeErr {:4}", mNROFsTF, mROFLength, (o2::constants::lhc::LHCMaxBunches / mROFLength), mROFDelay, mROFBias, mROFAddTimeErr);
+    return fmt::format("NROFsPerTF {:4} ROFLength {:4} ({:4} per Orbit) ROFDelay {:4} ROFBias {:4} ROFAddTimeErr {:4}", mNROFsTF, mROFLength, (o2::constants::lhc::LHCMaxBunches / mROFLength), mROFDelay, mROFBias, mROFAddTimeErr);
   }
 
   GPUh() void print() const


### PR DESCRIPTION
#15188 breaks compilation with the latest Xcode 26.4, `std::format` fails with non constant expression call to a consteval function. `fmt::format` is functionally identical and works with Xcode.