### PR TITLE
ITS: Implement early return for missing cluster data

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -160,6 +160,11 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
   auto& allVerticesLabels = mIsMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "VERTICESMCTR", 0}) : dummyMCLabVerts;
   auto& allVerticesPurities = mIsMC ? pc.outputs().make<std::vector<float>>(Output{"ITS", "VERTICESMCPUR", 0}) : dummyMCPurVerts;
 
+  if (!hasClusters) { 
+    // skip processing if no data is received entirely but still create empty output so consumers do not wait
+    return;
+  }
+
   if (mOverrideBeamEstimation) {
     mTimeFrame->setBeamPosition(mMeanVertex->getX(),
                                 mMeanVertex->getY(),

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -160,7 +160,7 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
   auto& allVerticesLabels = mIsMC ? pc.outputs().make<std::vector<o2::MCCompLabel>>(Output{"ITS", "VERTICESMCTR", 0}) : dummyMCLabVerts;
   auto& allVerticesPurities = mIsMC ? pc.outputs().make<std::vector<float>>(Output{"ITS", "VERTICESMCPUR", 0}) : dummyMCPurVerts;
 
-  if (!hasClusters) { 
+  if (!hasClusters) {
     // skip processing if no data is received entirely but still create empty output so consumers do not wait
     return;
   }


### PR DESCRIPTION
@ehellbar  this fixes the crash you observe running:
```bash
o2-ctf-reader-workflow --max-tf 10 $GLOSET --ans-version 1.0 --ctf-dict none --delay 0 --loop 0 --ctf-input o2_ctf_run00554701_orbit0029026560_tf0000000001_epn315.root --onlyDet ITS,TPC --pipeline tpc-entropy-decoder:1  --configKeyValues "keyval.input_dir=$PWD;keyval.output_dir=/dev/null;;" | \
o2-gpu-reco-workflow $GLOSET --gpu-reconstruction "--severity info" --input-type=compressed-clusters-flat --disable-mc --output-type tracks,clusters,send-clusters-per-sector  --disable-ctp-lumi-request --pipeline gpu-reconstruction:${TPC_PIPELINES:-1} --configKeyValues "keyval.input_dir=$PWD;keyval.output_dir=/dev/null;;GPU_global.deviceType=CPU;GPU_proc.debugLevel=0;GPU_proc.tpcInputWithClusterRejection=1;GPU_proc.ompThreads=-1;GPU_proc.deviceNum=-2;" | \
o2-its-reco-workflow $GLOSET --trackerCA  --tracking-mode async --disable-mc --clusters-from-upstream  --pipeline its-tracker:${ITS_PIPELINES:-1},its-clusterer:${ITS_PIPELINES:-1}  --configKeyValues "keyval.input_dir=$PWD;keyval.output_dir=/dev/null;;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.phiCut=0.2;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;;;;ITSClustererParam.maxBCDiffToMaskBias=-1;MFTClustererParam.maxBCDiffToMaskBias=-1" | \
o2-dpl-run $GLOSET  --run -b | tee out_ITS-pipes${ITS_PIPELINES:-1}_ccdb-fetchers${NCCDB}_TPC${TPC_PIPELINES:-1}.log
```

The underlying reason why it crashes is that since the staggering PR the ITS tracking code requires that upstream producers at least provide the correct assumed time-structure, e.g., ROFs. In the this specific case we take the clusters directly from the CTFs, e.g., skipping re-clusterization where we make sure that ROFs are correct. If there is no ITS data recorded in the TF then the ROF vector is empty and you trigger this exception:
```
[40876:its-tracker]: [13:00:24][FATAL] Received inconsistent number of rofs on layer:-1 expected:576 received:0
```

Now if there is no data to consume be-it no clusters / no rofs the processing is entirely skipped. One could also have made the ctf-reader ensure 'correct' ROF output but I think it is better this way, maybe...