### PR TITLE
Make sure 16 bytes alignment is still enforced

### DIFF
--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -514,8 +514,7 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
     mSectorDataSizeBytes[is] = 0;
     for (int32_t j = 0; j < mGeo.getNumberOfRows(); j++) {
       RowInfo& row = getRowInfo(j);
-      row.dataOffsetBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
-      mSectorDataSizeBytes[is] = row.dataOffsetBytes[is];
+      row.dataOffsetBytes[is] = mSectorDataSizeBytes[is];
       const SplineType& spline = mConstructionScenarios[row.splineScenarioID];
       if (is == 0) {
         const SplineTypeXYZ& splineXYZ = reinterpret_cast<const SplineTypeXYZ&>(spline);

--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -527,8 +527,8 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
         const SplineTypeInvYZ& splineInvYZ = reinterpret_cast<const SplineTypeInvYZ&>(spline);
         mSectorDataSizeBytes[is] += splineInvYZ.getSizeOfParameters();
       }
+      mSectorDataSizeBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
     }
-    mSectorDataSizeBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
     bufferSize += mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
   }
 

--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -509,8 +509,8 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
   size_t bufferSize = scBufferOffsets[0] + scBufferSize;
   size_t correctionDataOffset[3];
   for (int32_t is = 0; is < 3; is++) {
-    correctionDataOffset[is] = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
-    bufferSize = correctionDataOffset[is];
+    bufferSize = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
+    correctionDataOffset[is] = bufferSize;
     mSectorDataSizeBytes[is] = 0;
     for (int32_t j = 0; j < mGeo.getNumberOfRows(); j++) {
       RowInfo& row = getRowInfo(j);

--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -147,6 +147,7 @@ void TPCFastSpaceChargeCorrection::setActualBufferAddress(char* actualFlatBuffer
     }
     size_t bufferSize = scBufferOffset + scBufferSize;
     for (int32_t is = 0; is < 3; is++) {
+      bufferSize = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
       mCorrectionData[is] = reinterpret_cast<char*>(mFlatBufferPtr + bufferSize);
       bufferSize += mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
     }
@@ -255,7 +256,7 @@ void TPCFastSpaceChargeCorrection::setActualBufferAddress(char* actualFlatBuffer
 
   for (int32_t is = 0; is < 3; is++) {
     size_t oldCorrectionDataOffset = alignSize(oldBufferSize, SplineType::getParameterAlignmentBytes());
-    size_t correctionDataOffset = bufferSize;
+    size_t correctionDataOffset = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
     mCorrectionData[is] = reinterpret_cast<char*>(mFlatBufferPtr + correctionDataOffset);
     memmove(mCorrectionData[is], mFlatBufferPtr + oldCorrectionDataOffset, mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors());
     oldBufferSize = oldCorrectionDataOffset + mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
@@ -508,11 +509,13 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
   size_t bufferSize = scBufferOffsets[0] + scBufferSize;
   size_t correctionDataOffset[3];
   for (int32_t is = 0; is < 3; is++) {
-    correctionDataOffset[is] = bufferSize;
+    correctionDataOffset[is] = alignSize(bufferSize, SplineType::getParameterAlignmentBytes());
+    bufferSize = correctionDataOffset[is];
     mSectorDataSizeBytes[is] = 0;
     for (int32_t j = 0; j < mGeo.getNumberOfRows(); j++) {
       RowInfo& row = getRowInfo(j);
-      row.dataOffsetBytes[is] = mSectorDataSizeBytes[is];
+      row.dataOffsetBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
+      mSectorDataSizeBytes[is] = row.dataOffsetBytes[is];
       const SplineType& spline = mConstructionScenarios[row.splineScenarioID];
       if (is == 0) {
         const SplineTypeXYZ& splineXYZ = reinterpret_cast<const SplineTypeXYZ&>(spline);
@@ -525,6 +528,7 @@ void TPCFastSpaceChargeCorrection::finishConstruction()
         mSectorDataSizeBytes[is] += splineInvYZ.getSizeOfParameters();
       }
     }
+    mSectorDataSizeBytes[is] = alignSize(mSectorDataSizeBytes[is], SplineType::getParameterAlignmentBytes());
     bufferSize += mSectorDataSizeBytes[is] * mGeo.getNumberOfSectors();
   }
 

--- a/GPU/TPCFastTransformation/TPCFastTransformPOD.cxx
+++ b/GPU/TPCFastTransformation/TPCFastTransformPOD.cxx
@@ -67,6 +67,7 @@ size_t TPCFastTransformPOD::estimateSize(const TPCFastSpaceChargeCorrection& ori
   }
   // space for splines data
   for (int is = 0; is < 3; is++) {
+    nextDynOffs = FlatObject::alignSize(nextDynOffs, SplineType::getParameterAlignmentBytes());
     nextDynOffs += origCorr.mSectorDataSizeBytes[is] * TPCFastTransformGeo::getNumberOfSectors();
   }
   nextDynOffs = alignOffset(nextDynOffs);
@@ -159,6 +160,7 @@ TPCFastTransformPOD* TPCFastTransformPOD::create(char* buff, size_t buffSize, co
 
   // copy spline data
   for (int is = 0; is < 3; is++) {
+    nextDynOffs = FlatObject::alignSize(nextDynOffs, SplineType::getParameterAlignmentBytes());
     float* data = reinterpret_cast<float*>(buff + nextDynOffs);
     LOGP(debug, "splinID={} start offset {} -> {}", is, nextDynOffs, (void*)data);
 


### PR DESCRIPTION

Unaligned vectorised accesses on aarch64 are not available and result in
verified sporadic crashes in the CI.
