### PR TITLE
FT0: fix return type mismatch in ChannelData getters (int16_t)

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/ChannelData.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/ChannelData.h
@@ -76,8 +76,8 @@ struct ChannelData {
   void print() const;
   void printLog() const;
   [[nodiscard]] uint8_t getChannelID() const { return ChId; }
-  [[nodiscard]] uint16_t getTime() const { return CFDTime; }
-  [[nodiscard]] uint16_t getAmp() const { return QTCAmpl; }
+  [[nodiscard]] int16_t getTime() const { return CFDTime; }
+  [[nodiscard]] int16_t getAmp() const { return QTCAmpl; }
 
   bool operator==(ChannelData const& other) const
   {

--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/ChannelData.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/ChannelData.h
@@ -76,8 +76,8 @@ struct ChannelData {
   void print() const;
   void printLog() const;
   [[nodiscard]] uint8_t getChannelID() const { return ChId; }
-  [[nodiscard]] uint16_t getTime() const { return CFDTime; }
-  [[nodiscard]] uint16_t getAmp() const { return QTCAmpl; }
+  [[nodiscard]] int16_t getTime() const { return CFDTime; }
+  [[nodiscard]] int16_t getAmp() const { return QTCAmpl; }
 
   bool operator==(ChannelData const& other) const
   {


### PR DESCRIPTION
This PR fixes a type inconsistency in `ChannelData` getters.

The internal data members:
- `CFDTime` (int16_t)
- `QTCAmpl` (int16_t)

were already stored as `int16_t`, but the getters returned a different type.
This change updates:
- `getTime()`
- `getAmp()`

to return `int16_t`, ensuring consistency with the underlying data.