### PR TITLE
Increment TPCFastSpaceChargeCorrection class version

### DIFF
--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.h
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.h
@@ -316,7 +316,7 @@ class TPCFastSpaceChargeCorrection : public FlatObject
 
   RowInfo mRowInfos[TPCFastTransformGeo::getMaxNumberOfRows()]; ///< RowInfo array
 
-  ClassDefNV(TPCFastSpaceChargeCorrection, 4);
+  ClassDefNV(TPCFastSpaceChargeCorrection, 5);
 };
 
 /// ====================================================


### PR DESCRIPTION
To avoid:
```
root [0] auto mp = o2::gpu::TPCFastTransform::loadFromFile("o2-gpu-TPCFastTransform_1772563162587.root","ccdb_object")
Warning in <TStreamerInfo::BuildCheck>: 
   The StreamerInfo of class o2::gpu::TPCFastSpaceChargeCorrection read from file o2-gpu-TPCFastTransform_1772563162587.root
   has the same version (=4) as the active class but a different checksum.
   You should update the version to ClassDef(o2::gpu::TPCFastSpaceChargeCorrection,5).
   Do not try to write objects with the current class definition,
   the files will not be readable.

Warning in <TStreamerInfo::CompareContent>: The following data member of
the in-memory layout version 4 of class 'o2::gpu::TPCFastSpaceChargeCorrection' is missing from 
the on-file layout version 4:
   unsigned long mCorrectionDataSize; //
Warning in <TStreamerInfo::CompareContent>: The following data member of
the in-memory layout version 4 of class 'o2::gpu::TPCFastSpaceChargeCorrection' is missing from 
the on-file layout version 4:
   int mClassVersion; //
Warning in <TStreamerInfo::CompareContent>: The following data member of
the in-memory layout version 4 of class 'o2::gpu::TPCFastSpaceChargeCorrection' is missing from 
the on-file layout version 4:
```