### PR TITLE
[MCH] filter trackable ROFs before clustering

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/Trackable.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Trackable.h
@@ -38,10 +38,20 @@ bool isTrackable(std::array<int, 10> itemsPerChamber,
 /** Return the number of items per chamber.
  *
  * @tparam T the type of items : implementation exists so far
- * only for mch::Digit (clusters and pre-clusters to come next)
+ * for deIds (int) and mch::Digit
  */
 template <typename T>
 std::array<int, 10> perChamber(gsl::span<const T> items);
+
+/** Return the number of items per chamber.
+ *
+ * @tparam T1 the type of items : implementation exists so far
+ * for mch::PreCluster
+ * @tparam T2 the type of subitems pointed to by items,
+ * e.g. mch::Digit attached to mch::PreCluster
+ */
+template <typename T1, typename T2>
+std::array<int, 10> perChamber(gsl::span<const T1> items, gsl::span<const T2> subitems);
 
 /** Return the number of items per station (1 station==2 chambers). */
 template <typename T>

--- a/Detectors/MUON/MCH/Base/src/Trackable.cxx
+++ b/Detectors/MUON/MCH/Base/src/Trackable.cxx
@@ -10,7 +10,9 @@
 // or submit itself to any jurisdiction.
 
 #include "MCHBase/Trackable.h"
+
 #include "DataFormatsMCH/Digit.h"
+#include "MCHBase/PreCluster.h"
 
 namespace o2::mch
 {
@@ -59,7 +61,27 @@ std::array<int, 10> perChamber(gsl::span<const Digit> digits)
   for (const auto& digit : digits) {
     nofDigits[digit.getDetID() / 100 - 1]++;
   }
+  // do not count isolated digits (at least 2 are required for a cluster)
+  for (auto i = 0; i < 10; ++i) {
+    if (nofDigits[i] == 1) {
+      nofDigits[i] = 0;
+    }
+  }
   return nofDigits;
+}
+
+/** Specialization of perChamber for PreClusters */
+template <>
+std::array<int, 10> perChamber(gsl::span<const PreCluster> preclusters, gsl::span<const Digit> digits)
+{
+  std::array<int, 10> nofPreclusters{};
+  for (const auto& precluster : preclusters) {
+    // only consider preclusters made of at least 2 digits
+    if (precluster.nDigits > 1) {
+      nofPreclusters[digits[precluster.firstDigit].getDetID() / 100 - 1]++;
+    }
+  }
+  return nofPreclusters;
 }
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterizerParam.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterizerParam.h
@@ -37,6 +37,8 @@ struct ClusterizerParam : public o2::conf::ConfigurableParamHelper<ClusterizerPa
 
   bool legacy = true; ///< use original (run2) clustering
 
+  bool onlyTrackable = true; ///< clusterize only ROFs that match the trackable condition @see MCHROFFiltering/TrackableFilter
+
   O2ParamDef(ClusterizerParam, "MCHClustering");
 };
 

--- a/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/TrackableFilter.h
+++ b/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/TrackableFilter.h
@@ -33,7 +33,6 @@ namespace o2::mch
  *
  * @tparam : the type of the items pointed to by the ROFRecords
  */
-
 template <typename T>
 ROFFilter
   createTrackableFilter(gsl::span<const T> items,
@@ -42,6 +41,33 @@ ROFFilter
 {
   return [items, requestStation, moreCandidates](const ROFRecord& rof) {
     std::array<int, 10> nofItemsPerChamber = perChamber(items.subspan(rof.getFirstIdx(), rof.getNEntries()));
+    return isTrackable(nofItemsPerChamber, requestStation, moreCandidates);
+  };
+}
+
+/** Returns a ROFRecord filter that selects ROFs that are trackable.
+ *
+ * The returned filter is a function that takes a ROFRecord and returns
+ * a boolean.
+ *
+ * @param items : the items "pointed to" by the ROFRecords (preclusters, ...)
+ * @param subitems : the subitems "pointed to" by the items (digits, ...)
+ *
+ * @param requestStation : @ref isTrackable
+ * @param moreCandidates : @ref isTrackable
+ *
+ * @tparam T1 : the type of the items pointed to by the ROFRecords
+ * @tparam T2 : the type of the subitems pointed to by the items
+ */
+template <typename T1, typename T2>
+ROFFilter
+  createTrackableFilter(gsl::span<const T1> items,
+                        gsl::span<const T2> subitems,
+                        std::array<bool, 5> requestStation = {true, true, true, true, true},
+                        bool moreCandidates = false)
+{
+  return [items, subitems, requestStation, moreCandidates](const ROFRecord& rof) {
+    std::array<int, 10> nofItemsPerChamber = perChamber(items.subspan(rof.getFirstIdx(), rof.getNEntries()), subitems);
     return isTrackable(nofItemsPerChamber, requestStation, moreCandidates);
   };
 }

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_add_library(MCHWorkflow
                    O2::MCHPreClustering
                    O2::MCHRawCommon
                    O2::MCHRawDecoder
+                   O2::MCHROFFiltering
                    ROOT::TreePlayer
                )
 

--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -35,13 +35,16 @@
 #include "Framework/Logger.h"
 
 #include "CommonUtils/ConfigurableParam.h"
-#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/Cluster.h"
 #include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/ROFRecord.h"
 #include "MCHBase/Error.h"
 #include "MCHBase/ErrorMap.h"
 #include "MCHBase/PreCluster.h"
-#include "DataFormatsMCH/Cluster.h"
+#include "MCHBase/TrackerParam.h"
 #include "MCHClustering/ClusterFinderOriginal.h"
+#include "MCHClustering/ClusterizerParam.h"
+#include "MCHROFFiltering/TrackableFilter.h"
 
 namespace o2
 {
@@ -94,10 +97,34 @@ class ClusterFinderOriginalTask
     auto& clusters = pc.outputs().make<std::vector<Cluster>>(OutputRef{"clusters"});
     auto& usedDigits = pc.outputs().make<std::vector<Digit>>(OutputRef{"clusterdigits"});
 
+    // create the trackable ROF filtering if needed
+    ROFFilter trackable{};
+    if (ClusterizerParam::Instance().onlyTrackable) {
+      const auto& trackerParam = TrackerParam::Instance();
+      std::array<bool, 5> requestStation{
+        trackerParam.requestStation[0],
+        trackerParam.requestStation[1],
+        trackerParam.requestStation[2],
+        trackerParam.requestStation[3],
+        trackerParam.requestStation[4]};
+      trackable = createTrackableFilter(preClusters, digits, requestStation, trackerParam.moreCandidates);
+    }
+
     clusterROFs.reserve(preClusterROFs.size());
     auto& errorMap = mClusterFinder.getErrorMap();
     errorMap.clear();
+    int nFilteredRofs = 0;
+    int nFilteredPreClusters = 0;
     for (const auto& preClusterROF : preClusterROFs) {
+
+      // filter out non-trackable ROFs if requested
+      if (ClusterizerParam::Instance().onlyTrackable && !trackable(preClusterROF)) {
+        // create an empty cluster ROF
+        clusterROFs.emplace_back(preClusterROF.getBCData(), clusters.size(), 0, preClusterROF.getBCWidth());
+        continue;
+      }
+      ++nFilteredRofs;
+      nFilteredPreClusters += preClusterROF.getNEntries();
 
       // prepare to clusterize the current ROF
       auto clusterOffset = clusters.size();
@@ -137,8 +164,8 @@ class ClusterFinderOriginalTask
     });
     mErrorMap.add(errorMap);
 
-    LOGP(info, "Found {:4d} clusters from {:4d} preclusters in {:2d} ROFs",
-         clusters.size(), preClusters.size(), preClusterROFs.size());
+    LOGP(info, "Found {:4d} clusters from {:4d} preclusters (out of {:4d}) in {:2d} filtered ROFs (out of {:2d})",
+         clusters.size(), nFilteredPreClusters, preClusters.size(), nFilteredRofs, preClusterROFs.size());
   }
 
  private:


### PR DESCRIPTION
Do not run the clustering on ROF that do not contain enough pre-clusters on enough chambers to potentially reconstruct a track afterward.

Do not consider in this filtering the pre-clusters made of only 1 digit since they are skipped in the clustering.

Also modify the trackable ROF filtering based on digits at the end of the time clustering to require at least 2 digits (instead of 1) on enough chambers, in order to filter out as much ROF as possible from the beginning.

This reduces the number of reconstructed ROF by ~30% in pp (~23% in PbPb) and speed-up the clustering as well as reduces the number of reconstructed clusters by ~12% in pp (~8% in PbPb). It also slightly speed-up the tracking in pp by ~2%.
