### PR TITLE
DPL: boost::property_tree::json_parser::write_json no longer adds EoL

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -402,7 +402,6 @@ void DataProcessingDevice::Init()
     if (entry.second.empty() == false) {
       boost::property_tree::json_parser::write_json(ss, entry.second, false);
       str = ss.str();
-      str.pop_back(); // remove EoL
     } else {
       str = entry.second.get_value<std::string>();
     }


### PR DESCRIPTION
Fixes malformed dpl-config.json at the end of processing, as the old code was removing the closing brace.