### PR TITLE
Fix sign of the tgL in ITS seeding

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackHelpers.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackHelpers.h
@@ -80,8 +80,7 @@ GPUdi() o2::track::TrackParCov buildTrackSeed(const Cluster& cluster1,
     q2pt = sign * crv / (bz * o2::constants::math::B2C);
     q2pt2 = crv * crv;
   }
-  const float tgl = 0.5f * (math_utils::computeTanDipAngle(x1, y1, x2, y2, cluster1.zCoordinate, cluster2.zCoordinate) +
-                            math_utils::computeTanDipAngle(x2, y2, x3, y3, cluster2.zCoordinate, tf3.positionTrackingFrame[1]));
+  const float tgl = -0.5f * sign * (math_utils::computeTanDipAngle(x1, y1, x2, y2, cluster1.zCoordinate, cluster2.zCoordinate) + math_utils::computeTanDipAngle(x2, y2, x3, y3, cluster2.zCoordinate, tf3.positionTrackingFrame[1]));
   const float sg2q2pt = o2::track::kC1Pt2max * o2::gpu::CAMath::Clamp(q2pt2, 0.0005f, 1.0f);
   return {x3, tf3.alphaTrackingFrame, {y3, tf3.positionTrackingFrame[1], snp, tgl, q2pt}, {tf3.covarianceTrackingFrame[0], tf3.covarianceTrackingFrame[1], tf3.covarianceTrackingFrame[2], 0.f, 0.f, o2::track::kCSnp2max, 0.f, 0.f, 0.f, o2::track::kCTgl2max, 0.f, 0.f, 0.f, 0.f, sg2q2pt}};
 }


### PR DESCRIPTION
@f3sch The tgl sign indeed must be inverted, currently it always flips from seeding to cell fit.
```
 [3651609:its-tracker]: seed: X:+3.8122e+00 Alp:-1.075e+00 Par: +9.7989e-01 +1.1784e+00 +2.6474e-01 -8.9826e-01 -2.8998e+00 |Q|:1 Pion
[3651609:its-tracker]: fit:: X:+2.1876e+00 Alp:-1.069e+00 Par: +5.2618e-01 -3.3599e-01 +2.5181e-01 +8.9755e-01 -2.8725e+00 |Q|:1 Pion
```
We did not see a particular effect since the direct seeding with the wrong sign (inward clusters fit) is used only at cell building (no linRef used). And for the seeding in the reverse order, the tgL sign was correct by accident.