### PR TITLE
AODProducer option to store all mft covariances

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -249,6 +249,7 @@ class AODProducerWorkflowDPL : public Task
   bool mThinTracks{false};
   bool mPropTracks{false};
   bool mPropMuons{false};
+  bool mStoreAllMFTCov{false};
   float mTrackQCKeepGlobalTracks{false};
   float mTrackQCRetainOnlydEdx{false};
   float mTrackQCFraction{0.00};
@@ -547,8 +548,8 @@ class AODProducerWorkflowDPL : public Task
   template <typename TRDsExtraCursorType>
   void addToTRDsExtra(const o2::globaltracking::RecoContainer& recoData, TRDsExtraCursorType& trdExtraCursor, const GIndex& trkIdx, int trkTableIdx);
 
-  template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>
-  void addToMFTTracksTable(mftTracksCursorType& mftTracksCursor, AmbigMFTTracksCursorType& ambigMFTTracksCursor,
+  template <typename mftTracksCursorType, typename mftTracksCovCursorType, typename AmbigMFTTracksCursorType>
+  void addToMFTTracksTable(mftTracksCursorType& mftTracksCursor, mftTracksCovCursorType& mftTracksCovCursor, AmbigMFTTracksCursorType& ambigMFTTracksCursor,
                            GIndex trackID, const o2::globaltracking::RecoContainer& data, int collisionID,
                            std::uint64_t collisionBC, const std::map<uint64_t, int>& bcsMap);
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -507,8 +507,8 @@ void AODProducerWorkflowDPL::addToTRDsExtra(const o2::globaltracking::RecoContai
   trdExtraCursor(trkTableIdx, q0s, q1s, q2s, q0sCor, q1sCor, q2sCor, ttgls, tphis);
 }
 
-template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>
-void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksCursor, AmbigMFTTracksCursorType& ambigMFTTracksCursor,
+template <typename mftTracksCursorType, typename mftTracksCovCursorType, typename AmbigMFTTracksCursorType>
+void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksCursor, mftTracksCovCursorType& mftTracksCovCursor, AmbigMFTTracksCursorType& ambigMFTTracksCursor,
                                                  GIndex trackID, const o2::globaltracking::RecoContainer& data, int collisionID,
                                                  std::uint64_t collisionBC, const std::map<uint64_t, int>& bcsMap)
 {
@@ -543,6 +543,30 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
                   truncateFloatFraction(track.getTrackChi2(), mTrackChi2),
                   truncateFloatFraction(trackTime, mTrackTime),
                   truncateFloatFraction(trackTimeRes, mTrackTimeError));
+  if (mStoreAllMFTCov) {
+    float sX = TMath::Sqrt(track.getSigma2X());
+    float sY = TMath::Sqrt(track.getSigma2Y());
+    float sPhi = TMath::Sqrt(track.getSigma2Phi());
+    float sTgl = TMath::Sqrt(track.getSigma2Tanl());
+    float sQ2Pt = TMath::Sqrt(track.getSigma2InvQPt());
+
+    mftTracksCovCursor(mTableTrMFTID,
+                       truncateFloatFraction(sX, mTrackCovDiag),
+                       truncateFloatFraction(sY, mTrackCovDiag),
+                       truncateFloatFraction(sPhi, mTrackCovDiag),
+                       truncateFloatFraction(sTgl, mTrackCovDiag),
+                       truncateFloatFraction(sQ2Pt, mTrackCovDiag),
+                       (Char_t)(128. * track.getCovariances()(0, 1) / (sX * sY)),
+                       (Char_t)(128. * track.getCovariances()(0, 2) / (sPhi * sX)),
+                       (Char_t)(128. * track.getCovariances()(1, 2) / (sPhi * sY)),
+                       (Char_t)(128. * track.getCovariances()(0, 3) / (sTgl * sX)),
+                       (Char_t)(128. * track.getCovariances()(1, 3) / (sTgl * sY)),
+                       (Char_t)(128. * track.getCovariances()(2, 3) / (sTgl * sPhi)),
+                       (Char_t)(128. * track.getCovariances()(0, 4) / (sQ2Pt * sX)),
+                       (Char_t)(128. * track.getCovariances()(1, 4) / (sQ2Pt * sY)),
+                       (Char_t)(128. * track.getCovariances()(2, 4) / (sQ2Pt * sPhi)),
+                       (Char_t)(128. * track.getCovariances()(3, 4) / (sQ2Pt * sTgl)));
+  }
   if (needBCSlice) {
     ambigMFTTracksCursor(mTableTrMFTID, bcSlice);
   }
@@ -579,10 +603,13 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
     int nToReserve = end - start; // + last index for a given table
     if (src == GIndex::Source::MFT) {
       mftTracksCursor.reserve(nToReserve + mftTracksCursor.lastIndex());
+      if (mStoreAllMFTCov) {
+        mftTracksCovCursor.reserve(nToReserve + mftTracksCovCursor.lastIndex());
+      }
     } else if (src == GIndex::Source::MCH || src == GIndex::Source::MFTMCH || src == GIndex::Source::MCHMID) {
       fwdTracksCursor.reserve(nToReserve + fwdTracksCursor.lastIndex());
       fwdTracksCovCursor.reserve(nToReserve + fwdTracksCovCursor.lastIndex());
-      if (src == GIndex::Source::MFTMCH) {
+      if (!mStoreAllMFTCov && src == GIndex::Source::MFTMCH) {
         mftTracksCovCursor.reserve(nToReserve + mftTracksCovCursor.lastIndex());
       }
     } else {
@@ -597,7 +624,7 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
           if (trackIndex.isAmbiguous() && mGIDToTableMFTID.find(trackIndex) != mGIDToTableMFTID.end()) { // was it already stored ?
             continue;
           }
-          addToMFTTracksTable(mftTracksCursor, ambigMFTTracksCursor, trackIndex, data, collisionID, collisionBC, bcsMap);
+          addToMFTTracksTable(mftTracksCursor, mftTracksCovCursor, ambigMFTTracksCursor, trackIndex, data, collisionID, collisionBC, bcsMap);
           mGIDToTableMFTID.emplace(trackIndex, mTableTrMFTID);
           mTableTrMFTID++;
         } else if (src == GIndex::Source::MCH || src == GIndex::Source::MFTMCH || src == GIndex::Source::MCHMID) { // FwdTracks tracks are treated separately since they are stored in a different table
@@ -929,22 +956,24 @@ void AODProducerWorkflowDPL::addToFwdTracksTable(FwdTracksCursorType& fwdTracksC
     float sX = TMath::Sqrt(mfttrack.getSigma2X()), sY = TMath::Sqrt(mfttrack.getSigma2Y()), sPhi = TMath::Sqrt(mfttrack.getSigma2Phi()),
           sTgl = TMath::Sqrt(mfttrack.getSigma2Tanl()), sQ2Pt = TMath::Sqrt(mfttrack.getSigma2InvQPt());
 
-    mftTracksCovCursor(fwdInfo.matchmfttrackid,
-                       truncateFloatFraction(sX, mTrackCovDiag),
-                       truncateFloatFraction(sY, mTrackCovDiag),
-                       truncateFloatFraction(sPhi, mTrackCovDiag),
-                       truncateFloatFraction(sTgl, mTrackCovDiag),
-                       truncateFloatFraction(sQ2Pt, mTrackCovDiag),
-                       (Char_t)(128. * mfttrack.getCovariances()(0, 1) / (sX * sY)),
-                       (Char_t)(128. * mfttrack.getCovariances()(0, 2) / (sPhi * sX)),
-                       (Char_t)(128. * mfttrack.getCovariances()(1, 2) / (sPhi * sY)),
-                       (Char_t)(128. * mfttrack.getCovariances()(0, 3) / (sTgl * sX)),
-                       (Char_t)(128. * mfttrack.getCovariances()(1, 3) / (sTgl * sY)),
-                       (Char_t)(128. * mfttrack.getCovariances()(2, 3) / (sTgl * sPhi)),
-                       (Char_t)(128. * mfttrack.getCovariances()(0, 4) / (sQ2Pt * sX)),
-                       (Char_t)(128. * mfttrack.getCovariances()(1, 4) / (sQ2Pt * sY)),
-                       (Char_t)(128. * mfttrack.getCovariances()(2, 4) / (sQ2Pt * sPhi)),
-                       (Char_t)(128. * mfttrack.getCovariances()(3, 4) / (sQ2Pt * sTgl)));
+    if (!mStoreAllMFTCov) {
+      mftTracksCovCursor(fwdInfo.matchmfttrackid,
+                         truncateFloatFraction(sX, mTrackCovDiag),
+                         truncateFloatFraction(sY, mTrackCovDiag),
+                         truncateFloatFraction(sPhi, mTrackCovDiag),
+                         truncateFloatFraction(sTgl, mTrackCovDiag),
+                         truncateFloatFraction(sQ2Pt, mTrackCovDiag),
+                         (Char_t)(128. * mfttrack.getCovariances()(0, 1) / (sX * sY)),
+                         (Char_t)(128. * mfttrack.getCovariances()(0, 2) / (sPhi * sX)),
+                         (Char_t)(128. * mfttrack.getCovariances()(1, 2) / (sPhi * sY)),
+                         (Char_t)(128. * mfttrack.getCovariances()(0, 3) / (sTgl * sX)),
+                         (Char_t)(128. * mfttrack.getCovariances()(1, 3) / (sTgl * sY)),
+                         (Char_t)(128. * mfttrack.getCovariances()(2, 3) / (sTgl * sPhi)),
+                         (Char_t)(128. * mfttrack.getCovariances()(0, 4) / (sQ2Pt * sX)),
+                         (Char_t)(128. * mfttrack.getCovariances()(1, 4) / (sQ2Pt * sY)),
+                         (Char_t)(128. * mfttrack.getCovariances()(2, 4) / (sQ2Pt * sPhi)),
+                         (Char_t)(128. * mfttrack.getCovariances()(3, 4) / (sQ2Pt * sTgl)));
+    }
   }
 
   std::uint64_t bcOfTimeRef;
@@ -1830,6 +1859,7 @@ void AODProducerWorkflowDPL::init(InitContext& ic)
   mPropTracks = ic.options().get<bool>("propagate-tracks");
   mMaxPropXiu = ic.options().get<float>("propagate-tracks-max-xiu");
   mPropMuons = ic.options().get<bool>("propagate-muons");
+  mStoreAllMFTCov = ic.options().get<bool>("store-all-mft-cov");
   if (auto s = ic.options().get<std::string>("with-streamers"); !s.empty()) {
     mStreamerFlags.set(s);
     if (mStreamerFlags) {
@@ -3524,6 +3554,7 @@ DataProcessorSpec getAODProducerWorkflowSpec(GID::mask_t src, bool enableSV, boo
       ConfigParamSpec{"propagate-tracks-max-xiu", VariantType::Float, 5.0f, {"Propagate tracks to IP if X_IU smaller than this value (and if propagate tracks enabled)"}},
       ConfigParamSpec{"hepmc-update", VariantType::String, "always", {"When to update HepMC Aux tables: always - force update, never - never update, all - if all keys are present, any - when any key is present (not valid yet)"}},
       ConfigParamSpec{"propagate-muons", VariantType::Bool, false, {"Propagate muons to IP"}},
+      ConfigParamSpec{"store-all-mft-cov", VariantType::Bool, false, {"Store covariance matrices for all MFT tracks"}},
       ConfigParamSpec{"thin-tracks", VariantType::Bool, false, {"Produce thinned track tables"}},
       ConfigParamSpec{"trackqc-keepglobaltracks", VariantType::Bool, false, {"Always keep TrackQA for global tracks"}},
       ConfigParamSpec{"trackqc-retainonlydedx", VariantType::Bool, false, {"Keep only dEdx information, zero out everything else"}},


### PR DESCRIPTION
@aferrero2707 Adding an option (false by default) to store all MFT covariances in AO2D instead of just ones related to MFT-Muon matching candidates. Intended for matching studies in Pb-Pb in specific productions. 