### PR TITLE
Option to write only ROFRecord to ITS/MFT clusters file:

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterWorkflow.h
@@ -23,7 +23,7 @@ namespace its
 
 namespace cluster_writer_workflow
 {
-framework::WorkflowSpec getWorkflow(bool useMC, bool doStag);
+framework::WorkflowSpec getWorkflow(bool useMC, bool doStag, bool clusterROFOnly = false);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -27,7 +27,7 @@ namespace reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC, bool doStag, TrackingMode::Type trmode, const bool overrideBeamPosition = false,
-                                    bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool useGeom = false, int useTrig = 0,
+                                    bool upstreamDigits = false, bool upstreamClusters = false, bool clrofOnly = false, bool disableRootOutput = false, bool useGeom = false, int useTrig = 0,
                                     bool useGPUWF = false, o2::gpu::gpudatatypes::DeviceType dType = o2::gpu::gpudatatypes::DeviceType::CPU);
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterWorkflow.cxx
@@ -22,11 +22,11 @@ namespace its
 namespace cluster_writer_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool doStag)
+framework::WorkflowSpec getWorkflow(bool useMC, bool doStag, bool clusterROFOnly)
 {
   framework::WorkflowSpec specs;
 
-  specs.emplace_back(o2::itsmft::getITSClusterWriterSpec(useMC, doStag));
+  specs.emplace_back(o2::itsmft::getITSClusterWriterSpec(useMC, doStag, clusterROFOnly));
 
   return specs;
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -32,6 +32,7 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool doStag,
                                     const bool overrideBeamPosition,
                                     bool upstreamDigits,
                                     bool upstreamClusters,
+                                    bool clrofOnly,
                                     bool disableRootOutput,
                                     bool useGeom,
                                     int useTrig,
@@ -45,8 +46,8 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool doStag,
   if (!upstreamClusters) {
     specs.emplace_back(o2::itsmft::getITSClustererSpec(useMC, doStag));
   }
-  if (!disableRootOutput) {
-    specs.emplace_back(o2::itsmft::getITSClusterWriterSpec(useMC, doStag));
+  if (!disableRootOutput || clrofOnly) {
+    specs.emplace_back(o2::itsmft::getITSClusterWriterSpec(useMC, doStag, clrofOnly));
   }
   if ((trmode != TrackingMode::Off) && (TrackerParamConfig::Instance().trackingMode != TrackingMode::Off)) {
     if (useGPUWF) {

--- a/Detectors/ITSMFT/ITS/workflow/src/its-cluster-writer-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-cluster-writer-workflow.cxx
@@ -30,6 +30,13 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
       o2::framework::VariantType::Bool,
       false,
       {"disable MC propagation even if available"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "cluster-rof-branch-only",
+      o2::framework::VariantType::Bool,
+      false,
+      {"writer will store only ClustersROF brunch"}});
+
   o2::itsmft::DPLAlpideParamInitializer::addITSConfigOption(workflowOptions);
 }
 
@@ -39,5 +46,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto doStag = o2::itsmft::DPLAlpideParamInitializer::isITSStaggeringEnabled(configcontext);
-  return std::move(o2::its::cluster_writer_workflow::getWorkflow(useMC, doStag));
+  auto clrofOnly = configcontext.options().get<bool>("cluster-rof-branch-only");
+  return std::move(o2::its::cluster_writer_workflow::getWorkflow(useMC, doStag, clrofOnly));
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -50,7 +50,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"use-full-geometry", o2::framework::VariantType::Bool, false, {"use full geometry instead of the light-weight ITS part"}},
     {"use-gpu-workflow", o2::framework::VariantType::Bool, false, {"use GPU workflow (default: false)"}},
-    {"gpu-device", o2::framework::VariantType::Int, 1, {"use gpu device: CPU=1,CUDA=2,HIP=3 (default: CPU)"}}};
+    {"gpu-device", o2::framework::VariantType::Int, 1, {"use gpu device: CPU=1,CUDA=2,HIP=3 (default: CPU)"}},
+    {"cluster-rof-branch-only", o2::framework::VariantType::Bool, false, {"writer will store only ClustersROF brunch"}}};
   o2::itsmft::DPLAlpideParamInitializer::addITSConfigOption(options);
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -75,6 +76,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto useGeom = configcontext.options().get<bool>("use-full-geometry");
   auto doStag = o2::itsmft::DPLAlpideParamInitializer::isITSStaggeringEnabled(configcontext);
+  auto clrofOnly = configcontext.options().get<bool>("cluster-rof-branch-only");
   if (configcontext.options().get<bool>("disable-tracking")) {
     trmode = "off";
   }
@@ -97,6 +99,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     beamPosOVerride,
     extDigits,
     extClusters,
+    clrofOnly,
     disableRootOutput,
     useGeom,
     trType,

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/RecoWorkflow.h
@@ -29,6 +29,7 @@ framework::WorkflowSpec getWorkflow(
   bool useGeom,
   bool upstreamDigits,
   bool upstreamClusters,
+  bool clrofOnly,
   bool disableRootOutput,
   bool runAssessment,
   bool processGen,

--- a/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
@@ -36,6 +36,7 @@ framework::WorkflowSpec getWorkflow(
   bool useGeom,
   bool upstreamDigits,
   bool upstreamClusters,
+  bool clrofOnly,
   bool disableRootOutput,
   bool runAssessment,
   bool processGen,
@@ -55,8 +56,8 @@ framework::WorkflowSpec getWorkflow(
   if (!upstreamClusters) {
     specs.emplace_back(o2::itsmft::getMFTClustererSpec(useMC, doStag));
   }
-  if (!disableRootOutput) {
-    specs.emplace_back(o2::itsmft::getMFTClusterWriterSpec(useMC, doStag));
+  if (!disableRootOutput || clrofOnly) {
+    specs.emplace_back(o2::itsmft::getMFTClusterWriterSpec(useMC, doStag, clrofOnly));
   }
 
   if (runTracking) {

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-cluster-writer-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-cluster-writer-workflow.cxx
@@ -24,8 +24,8 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(
-    ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
+  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
+  workflowOptions.push_back(ConfigParamSpec{"cluster-rof-branch-only", o2::framework::VariantType::Bool, false, {"writer will store only ClustersROF brunch"}});
   o2::itsmft::DPLAlpideParamInitializer::addMFTConfigOption(workflowOptions);
 }
 
@@ -35,7 +35,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto doStag = o2::itsmft::DPLAlpideParamInitializer::isMFTStaggeringEnabled(configcontext);
+  auto clrofOnly = configcontext.options().get<bool>("cluster-rof-branch-only");
   WorkflowSpec specs;
-  specs.emplace_back(o2::itsmft::getMFTClusterWriterSpec(useMC, doStag));
+  specs.emplace_back(o2::itsmft::getMFTClusterWriterSpec(useMC, doStag, clrofOnly));
   return specs;
 }

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
@@ -44,7 +44,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"nThreads", VariantType::Int, 1, {"Number of threads"}},
     {"use-full-geometry", o2::framework::VariantType::Bool, false, {"use full geometry instead of the light-weight MFT part"}},
-    {"run-tracks2records", o2::framework::VariantType::Bool, false, {"run MFT alignment tracks to records workflow"}}};
+    {"run-tracks2records", o2::framework::VariantType::Bool, false, {"run MFT alignment tracks to records workflow"}},
+    {"cluster-rof-branch-only", o2::framework::VariantType::Bool, false, {"writer will store only ClustersROF brunch"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   o2::itsmft::DPLAlpideParamInitializer::addMFTConfigOption(options);
   std::swap(workflowOptions, options);
@@ -70,6 +71,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto runTracks2Records = configcontext.options().get<bool>("run-tracks2records");
   auto useGeom = configcontext.options().get<bool>("use-full-geometry");
   auto doStag = o2::itsmft::DPLAlpideParamInitializer::isMFTStaggeringEnabled(configcontext);
+  auto clrofOnly = configcontext.options().get<bool>("cluster-rof-branch-only");
 
   auto wf = o2::mft::reco_workflow::getWorkflow(
     useMC,
@@ -77,6 +79,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     useGeom,
     extDigits,
     extClusters,
+    clrofOnly,
     disableRootOutput,
     runAssessment,
     processGen,

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterWriterSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterWriterSpec.h
@@ -20,9 +20,9 @@ namespace o2::itsmft
 {
 
 template <int N>
-framework::DataProcessorSpec getClusterWriterSpec(bool useMC, bool doStag);
-framework::DataProcessorSpec getITSClusterWriterSpec(bool useMC, bool doStag);
-framework::DataProcessorSpec getMFTClusterWriterSpec(bool useMC, bool doStag);
+framework::DataProcessorSpec getClusterWriterSpec(bool useMC, bool doStag, bool clusterROFOnly = false);
+framework::DataProcessorSpec getITSClusterWriterSpec(bool useMC, bool doStag, bool clusterROFOnly = false);
+framework::DataProcessorSpec getMFTClusterWriterSpec(bool useMC, bool doStag, bool clusterROFOnly = false);
 
 } // namespace o2::itsmft
 

--- a/Detectors/ITSMFT/common/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClusterWriterSpec.cxx
@@ -41,7 +41,7 @@ using ROFRecLblT = std::vector<o2::itsmft::MC2ROFRecord>;
 using namespace o2::header;
 
 template <int N>
-DataProcessorSpec getClusterWriterSpec(bool useMC, bool doStag)
+DataProcessorSpec getClusterWriterSpec(bool useMC, bool doStag, bool clusterROFOnly)
 {
   static constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
   const int nLayers = (doStag) ? DPLAlpideParam<N>::getNLayers() : 1;
@@ -82,6 +82,18 @@ DataProcessorSpec getClusterWriterSpec(bool useMC, bool doStag)
     vecInpSpecLbl.emplace_back(getName("labels", iLayer), Origin, "CLUSTERSMCTR", iLayer);
   }
 
+  if (clusterROFOnly) {
+    return MakeRootTreeWriterSpec(std::format("{}-cluster-writer", detNameLC).c_str(),
+                                  (o2::detectors::DetID::ITS == N) ? "o2clus_its.root" : "mftclusters.root",
+                                  MakeRootTreeWriterSpec::TreeAttributes{.name = "o2sim", .title = std::format("Tree with {} cluster ROFs only", detName)},
+                                  BranchDefinition<ROFrameRType>{vecInpSpecROF,
+                                                                 (detName + "ClustersROF").c_str(), "cluster-rof-branch",
+                                                                 nLayers,
+                                                                 logger,
+                                                                 getIndex,
+                                                                 getName})();
+  }
+
   return MakeRootTreeWriterSpec(std::format("{}-cluster-writer", detNameLC).c_str(),
                                 (o2::detectors::DetID::ITS == N) ? "o2clus_its.root" : "mftclusters.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{.name = "o2sim", .title = std::format("Tree with {} clusters", detName)},
@@ -114,7 +126,7 @@ DataProcessorSpec getClusterWriterSpec(bool useMC, bool doStag)
                                                              getName})();
 }
 
-framework::DataProcessorSpec getITSClusterWriterSpec(bool useMC, bool doStag) { return getClusterWriterSpec<o2::detectors::DetID::ITS>(useMC, doStag); }
-framework::DataProcessorSpec getMFTClusterWriterSpec(bool useMC, bool doStag) { return getClusterWriterSpec<o2::detectors::DetID::MFT>(useMC, doStag); }
+framework::DataProcessorSpec getITSClusterWriterSpec(bool useMC, bool doStag, bool clusterROFOnly) { return getClusterWriterSpec<o2::detectors::DetID::ITS>(useMC, doStag, clusterROFOnly); }
+framework::DataProcessorSpec getMFTClusterWriterSpec(bool useMC, bool doStag, bool clusterROFOnly) { return getClusterWriterSpec<o2::detectors::DetID::MFT>(useMC, doStag, clusterROFOnly); }
 
 } // namespace o2::itsmft

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -468,7 +468,7 @@ if [[ -n $INPUT_DETECTOR_LIST ]]; then
     if [[ $NTIMEFRAMES == -1 ]]; then NTIMEFRAMES_CMD= ; else NTIMEFRAMES_CMD="--max-tf $NTIMEFRAMES"; fi
     CTF_EMC_SUBSPEC=
     ( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && has_detector EMC && CTF_EMC_SUBSPEC="--emcal-decoded-subspec 1"
-    add_W o2-ctf-reader-workflow "$RANS_OPT --delay $TFDELAY --loop $TFLOOP $NTIMEFRAMES_CMD $ITS_STAGGERED $MFT_STAGGERED --ctf-input ${CTFName} ${INPUT_FILE_COPY_CMD+--copy-cmd} ${INPUT_FILE_COPY_CMD:-} --onlyDet $INPUT_DETECTOR_LIST $CTF_EMC_SUBSPEC ${TIMEFRAME_SHM_LIMIT+--timeframes-shm-limit} ${TIMEFRAME_SHM_LIMIT:-} --pipeline $(get_N tpc-entropy-decoder TPC REST 1 TPCENTDEC)"
+    add_W o2-ctf-reader-workflow "$RANS_OPT --delay $TFDELAY --loop $TFLOOP $NTIMEFRAMES_CMD $ITS_STAGGERED $MFT_STAGGERED --ctf-input ${CTFName} ${INPUT_FILE_COPY_CMD+--copy-cmd} ${INPUT_FILE_COPY_CMD:-} --onlyDet $INPUT_DETECTOR_LIST $CTF_EMC_SUBSPEC ${TIMEFRAME_SHM_LIMIT+--timeframes-shm-limit} ${TIMEFRAME_SHM_LIMIT:-} --pipeline $(get_N tpc-entropy-decoder TPC REST 1 TPCENTDEC),$(get_N its-entropy-decoder ITS REST 1 ITSENTDEC)"
   elif [[ $RAWTFINPUT == 1 ]]; then
     TFName=`ls -t $RAWINPUTDIR/o2_*.tf 2> /dev/null | head -n1`
     [[ -z $TFName && $WORKFLOWMODE == "print" ]] && TFName='$TFName'


### PR DESCRIPTION
With --cluster-rof-branch-only passed to the ITS or MFT reco workflows the cluster writing will be activated (even if --disable-root-output was globally passed to the workflows) and only the ROFRecords branch will be stored.

Option to scale the ITS entropy decoding with N_ITSENTDEC or MULTIPLICITY_PROCESS_its_entropy_decoder env. var.