### PR TITLE
DPL: ensure dummy sink is added with correct rate limiting configuration

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -627,12 +627,15 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     // Use the new dummy sink when the AOD reader is there
     O2_SIGNPOST_ID_GENERATE(sid, workflow_helpers);
     if (tfnsource != workflow.end()) {
-      O2_SIGNPOST_EVENT_EMIT(workflow_helpers, sid, "injectServiceDevices", "Injecting scheduled dummy sink");
-      // if there is a tfnsource, make sure the sink gets TFN/TFF
       DataSpecUtils::updateInputList(ignored, InputSpec{"tfn", "TFN", "TFNumber", 0, Lifetime::Sporadic});
       DataSpecUtils::updateInputList(ignored, InputSpec{"tff", "TFF", "TFFilename", 0, Lifetime::Sporadic});
+    }
+
+    if (tfnsource != workflow.end() && !tfnsource->name.starts_with("aod-producer-workflow")) { // any tfnsource except the aod-producer should use scheduled sink
+      O2_SIGNPOST_EVENT_EMIT(workflow_helpers, sid, "injectServiceDevices", "Injecting scheduled dummy sink");
+      // if there is a tfnsource, make sure the sink gets TFN/TFF
       extraSpecs.push_back(CommonDataProcessors::getScheduledDummySink(ignored));
-    } else {
+    } else { // if there is no tfn source or if that source is aod-producer-workflow, out-of-band channel is used to propagate the number of consumed timeframes
       O2_SIGNPOST_EVENT_EMIT(workflow_helpers, sid, "injectServiceDevices", "Injecting rate limited dummy sink");
       std::string rateLimitingChannelConfigOutput;
       if (rateLimitingIPCID != -1) {


### PR DESCRIPTION
* If there is a TFN/TFF source, sink has to catch these messages to be at the topology end
* If the TFN/TFF source is aod-producer, the rate limiting config should be with out-of-band channel instead of scheduler

@ktf @shahor02 this fixes the issue with async workflow not seeing the consumed timeframes and maintains normal behavior for analysis and OTF-sim workflows