### PR TITLE
DPL Analysis: Dynamic extraction matchers

### DIFF
--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -240,8 +240,9 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback(ConfigContext const
         // create header
         auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
         auto dh = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
+        bool wasAOD = std::ranges::any_of(route.matcher.metadata, [](ConfigParamSpec const& p){ return p.name.starts_with("aod-origin-replaced"); });
 
-        if (!didir->readTree(outputs, dh, fcnt, ntf, totalSizeCompressed, totalSizeUncompressed)) {
+        if (!didir->readTree(outputs, dh, fcnt, ntf, totalSizeCompressed, totalSizeUncompressed, wasAOD)) {
           if (first) {
             // check if there is a next file to read
             fcnt += device.maxInputTimeslices;
@@ -255,7 +256,7 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback(ConfigContext const
             }
             // get first folder of next file
             ntf = 0;
-            if (!didir->readTree(outputs, dh, fcnt, ntf, totalSizeCompressed, totalSizeUncompressed)) {
+            if (!didir->readTree(outputs, dh, fcnt, ntf, totalSizeCompressed, totalSizeUncompressed, wasAOD)) {
               LOGP(fatal, "Can not retrieve tree for table {}: fileCounter {}, timeFrame {}", concrete.origin.as<std::string>(), fcnt, ntf);
               throw std::runtime_error("Processing is stopped!");
             }

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -240,7 +240,7 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback(ConfigContext const
         // create header
         auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
         auto dh = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
-        bool wasAOD = std::ranges::any_of(route.matcher.metadata, [](ConfigParamSpec const& p){ return p.name.starts_with("aod-origin-replaced"); });
+        bool wasAOD = std::ranges::any_of(route.matcher.metadata, [](ConfigParamSpec const& p) { return p.name.starts_with("aod-origin-replaced"); });
 
         if (!didir->readTree(outputs, dh, fcnt, ntf, totalSizeCompressed, totalSizeUncompressed, wasAOD)) {
           if (first) {

--- a/Framework/AnalysisSupport/src/DataInputDirector.cxx
+++ b/Framework/AnalysisSupport/src/DataInputDirector.cxx
@@ -900,7 +900,7 @@ uint64_t DataInputDirector::getTimeFrameNumber(header::DataHeader dh, int counte
   return didesc->getTimeFrameNumber(counter, numTF, wantedLevel, origin);
 }
 
-bool DataInputDirector::readTree(DataAllocator& outputs, header::DataHeader dh, int counter, int numTF, size_t& totalSizeCompressed, size_t& totalSizeUncompressed)
+bool DataInputDirector::readTree(DataAllocator& outputs, header::DataHeader dh, int counter, int numTF, size_t& totalSizeCompressed, size_t& totalSizeUncompressed, bool wasAOD)
 {
   std::string treename;
 
@@ -913,7 +913,7 @@ bool DataInputDirector::readTree(DataAllocator& outputs, header::DataHeader dh, 
     //  . filename from defaultDataInputDescriptor
     //  . treename from DataHeader
     didesc = mdefaultDataInputDescriptor;
-    treename = aod::datamodel::getTreeName(dh);
+    treename = aod::datamodel::getTreeName(dh, wasAOD);
   }
   std::string origin = dh.dataOrigin.as<std::string>();
 

--- a/Framework/AnalysisSupport/src/DataInputDirector.h
+++ b/Framework/AnalysisSupport/src/DataInputDirector.h
@@ -160,7 +160,7 @@ class DataInputDirector
   int getNumberInputDescriptors() { return mdataInputDescriptors.size(); }
   void createDefaultDataInputDescriptor();
 
-  bool readTree(DataAllocator& outputs, header::DataHeader dh, int counter, int numTF, size_t& totalSizeCompressed, size_t& totalSizeUncompressed);
+  bool readTree(DataAllocator& outputs, header::DataHeader dh, int counter, int numTF, size_t& totalSizeCompressed, size_t& totalSizeUncompressed, bool wasAOD);
   uint64_t getTimeFrameNumber(header::DataHeader dh, int counter, int numTF);
   arrow::dataset::FileSource getFileFolder(header::DataHeader dh, int counter, int numTF);
   int getTimeFramesInFile(header::DataHeader dh, int counter);

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1521,7 +1521,7 @@ consteval static bool relatedBySortedIndex()
 
 namespace o2::framework
 {
-
+/// FIXME: has to track origin to handle the correct arguments
 struct PreslicePolicyBase {
   const std::string binding;
   Entry bindingKey;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1413,7 +1413,7 @@ template <typename... C>
 static constexpr auto hasColumnForKey(framework::pack<C...>, std::string_view key)
 {
   auto caseInsensitiveCompare = [](const std::string_view& str1, const std::string_view& str2) {
-    return std::ranges::equal(
+    return (str1.size() == str2.size()) && std::ranges::equal(
       str1, str2,
       [](char c1, char c2) {
         return std::tolower(static_cast<unsigned char>(c1)) ==

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1413,12 +1413,13 @@ template <typename... C>
 static constexpr auto hasColumnForKey(framework::pack<C...>, std::string_view key)
 {
   auto caseInsensitiveCompare = [](const std::string_view& str1, const std::string_view& str2) {
-    return (str1.size() == str2.size()) && std::ranges::equal(
-      str1, str2,
-      [](char c1, char c2) {
-        return std::tolower(static_cast<unsigned char>(c1)) ==
-               std::tolower(static_cast<unsigned char>(c2));
-      });
+    return (str1.size() == str2.size()) &&
+           std::ranges::equal(
+             str1, str2,
+             [](char c1, char c2) {
+               return std::tolower(static_cast<unsigned char>(c1)) ==
+                      std::tolower(static_cast<unsigned char>(c2));
+             });
   };
   return (caseInsensitiveCompare(C::inherited_t::mLabel, key) || ...);
 }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1723,15 +1723,12 @@ auto doFilteredSliceBy(T const* table, o2::framework::PresliceBase<C, framework:
   return prepareFilteredSlice(table, slice, offset);
 }
 
+std::function<framework::ConcreteDataMatcher(framework::ConcreteDataMatcher&&)> originReplacement(header::DataOrigin newOrigin);
+
 template <soa::is_table T>
 auto doSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m) {
-                                              if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
-                                                m.origin = o;
-                                              }
-                                              return m;
-                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
+  auto localCache = cache.ptr->getCacheFor({"", originReplacement(cache.ptr->newOrigin)(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
                                             node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto t = typename T::self_t({table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count)}, static_cast<uint64_t>(offset));
@@ -1744,12 +1741,7 @@ auto doSliceByCached(T const* table, framework::expressions::BindingNode const& 
 template <soa::is_filtered_table T>
 auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m) {
-                                              if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
-                                                m.origin = o;
-                                              }
-                                              return m;
-                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
+  auto localCache = cache.ptr->getCacheFor({"", originReplacement(cache.ptr->newOrigin)(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
                                             node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto slice = table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count);
@@ -1759,12 +1751,7 @@ auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode
 template <soa::is_table T>
 auto doSliceByCachedUnsorted(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheUnsortedFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m) {
-                                                      if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
-                                                        m.origin = o;
-                                                      }
-                                                      return m;
-                                                    }(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
+  auto localCache = cache.ptr->getCacheUnsortedFor({"", originReplacement(cache.ptr->newOrigin)(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
                                                     node.name});
   if constexpr (soa::is_filtered_table<T>) {
     auto t = typename T::self_t({table->asArrowTable()}, localCache.getSliceFor(value));

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1410,9 +1410,9 @@ static constexpr std::string getLabelFromType()
 }
 
 template <typename... C>
-static constexpr auto hasColumnForKey(framework::pack<C...>, std::string const& key)
+static constexpr auto hasColumnForKey(framework::pack<C...>, std::string_view key)
 {
-  auto caseInsensitiveCompare = [](const std::string_view& str1, const std::string& str2) {
+  auto caseInsensitiveCompare = [](const std::string_view& str1, const std::string_view& str2) {
     return std::ranges::equal(
       str1, str2,
       [](char c1, char c2) {
@@ -1424,43 +1424,31 @@ static constexpr auto hasColumnForKey(framework::pack<C...>, std::string const& 
 }
 
 template <TableRef ref>
-static constexpr std::pair<bool, std::string> hasKey(std::string const& key)
+static constexpr std::pair<bool, std::string> hasKey(std::string_view key)
 {
   return {hasColumnForKey(typename aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::columns{}, key), aod::label<ref>()};
 }
 
 template <TableRef ref>
-static constexpr std::pair<bool, framework::ConcreteDataMatcher> hasKeyM(std::string const& key)
+static constexpr std::pair<bool, framework::ConcreteDataMatcher> hasKeyM(std::string_view key)
 {
   return {hasColumnForKey(typename aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::columns{}, key), aod::matcher<ref>()};
-}
-
-template <typename... C>
-static constexpr auto haveKey(framework::pack<C...>, std::string const& key)
-{
-  return std::vector{hasKey<C>(key)...};
 }
 
 void notFoundColumn(const char* label, const char* key);
 void missingOptionalPreslice(const char* label, const char* key);
 
 template <with_originals T, bool OPT = false>
-static constexpr std::string getLabelFromTypeForKey(std::string const& key)
+static constexpr std::string getLabelFromTypeForKey(std::string_view key)
 {
-  if constexpr (T::originals.size() == 1) {
-    auto locate = hasKey<T::originals[0]>(key);
-    if (locate.first) {
-      return locate.second;
-    }
-  } else {
-    auto locate = [&]<size_t... Is>(std::index_sequence<Is...>) {
-      return std::vector{hasKey<T::originals[Is]>(key)...};
-    }(std::make_index_sequence<T::originals.size()>{});
-    auto it = std::find_if(locate.begin(), locate.end(), [](auto const& x) { return x.first; });
-    if (it != locate.end()) {
-      return it->second;
-    }
+  auto locate = []<size_t... Is>(std::index_sequence<Is...>, std::string_view key) {
+    return std::array{hasKey<T::originals[Is]>(key)...} |
+           std::views::filter([](auto const& x) { return x.first; });
+  }(std::make_index_sequence<T::originals.size()>{}, key);
+  if (!locate.empty()) {
+    return locate.front().second;
   }
+
   if constexpr (!OPT) {
     notFoundColumn(getLabelFromType<std::decay_t<T>>().data(), key.data());
   } else {
@@ -1470,22 +1458,16 @@ static constexpr std::string getLabelFromTypeForKey(std::string const& key)
 }
 
 template <with_originals T, bool OPT = false>
-static constexpr framework::ConcreteDataMatcher getMatcherFromTypeForKey(std::string const& key)
+static constexpr framework::ConcreteDataMatcher getMatcherFromTypeForKey(std::string_view key)
 {
-  if constexpr (T::originals.size() == 1) {
-    auto locate = hasKeyM<T::originals[0]>(key);
-    if (locate.first) {
-      return locate.second;
-    }
-  } else {
-    auto locate = [&]<size_t... Is>(std::index_sequence<Is...>) {
-      return std::vector{hasKeyM<T::originals[Is]>(key)...};
-    }(std::make_index_sequence<T::originals.size()>{});
-    auto it = std::ranges::find_if(locate, [](auto const& x) { return x.first; });
-    if (it != locate.end()) {
-      return it->second;
-    }
+  auto locate = []<size_t... Is>(std::index_sequence<Is...>, std::string_view key) {
+    return std::array{hasKeyM<T::originals[Is]>(key)...} |
+           std::views::filter([](auto const& x) { return x.first; });
+  }(std::make_index_sequence<T::originals.size()>{}, key);
+  if (!locate.empty()) {
+    return locate.front().second;
   }
+
   if constexpr (!OPT) {
     notFoundColumn(getLabelFromType<std::decay_t<T>>().data(), key.data());
   } else {

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1413,13 +1413,12 @@ template <typename... C>
 static constexpr auto hasColumnForKey(framework::pack<C...>, std::string_view key)
 {
   auto caseInsensitiveCompare = [](const std::string_view& str1, const std::string_view& str2) {
-    return (str1.size() == str2.size()) &&
-           std::ranges::equal(
-             str1, str2,
-             [](char c1, char c2) {
-               return std::tolower(static_cast<unsigned char>(c1)) ==
-                      std::tolower(static_cast<unsigned char>(c2));
-             });
+    return std::ranges::equal(
+      str1, str2,
+      [](char c1, char c2) {
+        return std::tolower(static_cast<unsigned char>(c1)) ==
+               std::tolower(static_cast<unsigned char>(c2));
+      });
   };
   return (caseInsensitiveCompare(C::inherited_t::mLabel, key) || ...);
 }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1824,12 +1824,6 @@ consteval auto computeOriginals()
   return o2::soa::mergeOriginals<Ts...>();
 }
 
-// template <size_t N, std::array<TableRef, N> refs>
-// consteval auto commonOrigin()
-// {
-//   return (refs | std::ranges::views::filter([](TableRef const& r) { return (!(r.origin_hash == "DYN"_h || r.origin_hash == "IDX"_h)); })).front().origin_hash;
-// }
-
 /// A Table class which observes an arrow::Table and provides
 /// It is templated on a set of Column / DynamicColumn types.
 template <aod::is_aod_hash L, aod::is_aod_hash D, aod::is_origin_hash O, typename... Ts>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1521,7 +1521,7 @@ consteval static bool relatedBySortedIndex()
 
 namespace o2::framework
 {
-/// FIXME: has to track origin to handle the correct arguments
+/// tracks origin in bindingKey matcher to handle the correct arguments
 struct PreslicePolicyBase {
   const std::string binding;
   Entry bindingKey;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1744,12 +1744,13 @@ auto doFilteredSliceBy(T const* table, o2::framework::PresliceBase<C, framework:
 template <soa::is_table T>
 auto doSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m){
+  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m) {
                                               if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
                                                 m.origin = o;
                                               }
                                               return m;
-                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)), node.name});
+                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
+                                            node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto t = typename T::self_t({table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count)}, static_cast<uint64_t>(offset));
   if (t.tableSize() != 0) {
@@ -1761,12 +1762,13 @@ auto doSliceByCached(T const* table, framework::expressions::BindingNode const& 
 template <soa::is_filtered_table T>
 auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m){
+  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m) {
                                               if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
                                                 m.origin = o;
                                               }
                                               return m;
-                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)), node.name});
+                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
+                                            node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto slice = table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count);
   return prepareFilteredSlice(table, slice, offset);
@@ -1775,12 +1777,13 @@ auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode
 template <soa::is_table T>
 auto doSliceByCachedUnsorted(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheUnsortedFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m){
+  auto localCache = cache.ptr->getCacheUnsortedFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m) {
                                                       if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
                                                         m.origin = o;
                                                       }
                                                       return m;
-                                                    }(o2::soa::getMatcherFromTypeForKey<T>(node.name)), node.name});
+                                                    }(o2::soa::getMatcherFromTypeForKey<T>(node.name)),
+                                                    node.name});
   if constexpr (soa::is_filtered_table<T>) {
     auto t = typename T::self_t({table->asArrowTable()}, localCache.getSliceFor(value));
     if (t.tableSize() != 0) {

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1547,7 +1547,7 @@ struct PreslicePolicyGeneral : public PreslicePolicyBase {
 template <typename T>
 concept is_preslice_policy = std::derived_from<T, PreslicePolicyBase>;
 
-template <typename T, is_preslice_policy Policy, bool OPT = false>
+template <soa::is_table T, is_preslice_policy Policy, bool OPT = false>
 struct PresliceBase : public Policy {
   constexpr static bool optional = OPT;
   using target_t = T;
@@ -1580,13 +1580,13 @@ struct PresliceBase : public Policy {
   }
 };
 
-template <typename T>
+template <soa::is_table T>
 using PresliceUnsorted = PresliceBase<T, PreslicePolicyGeneral, false>;
-template <typename T>
+template <soa::is_table T>
 using PresliceUnsortedOptional = PresliceBase<T, PreslicePolicyGeneral, true>;
-template <typename T>
+template <soa::is_table T>
 using Preslice = PresliceBase<T, PreslicePolicySorted, false>;
-template <typename T>
+template <soa::is_table T>
 using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 
 template <typename T>
@@ -1744,7 +1744,12 @@ auto doFilteredSliceBy(T const* table, o2::framework::PresliceBase<C, framework:
 template <soa::is_table T>
 auto doSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({"", o2::soa::getMatcherFromTypeForKey<T>(node.name), node.name});
+  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m){
+                                              if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
+                                                m.origin = o;
+                                              }
+                                              return m;
+                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)), node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto t = typename T::self_t({table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count)}, static_cast<uint64_t>(offset));
   if (t.tableSize() != 0) {
@@ -1756,7 +1761,12 @@ auto doSliceByCached(T const* table, framework::expressions::BindingNode const& 
 template <soa::is_filtered_table T>
 auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheFor({"", o2::soa::getMatcherFromTypeForKey<T>(node.name), node.name});
+  auto localCache = cache.ptr->getCacheFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m){
+                                              if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
+                                                m.origin = o;
+                                              }
+                                              return m;
+                                            }(o2::soa::getMatcherFromTypeForKey<T>(node.name)), node.name});
   auto [offset, count] = localCache.getSliceFor(value);
   auto slice = table->asArrowTable()->Slice(static_cast<uint64_t>(offset), count);
   return prepareFilteredSlice(table, slice, offset);
@@ -1765,7 +1775,12 @@ auto doFilteredSliceByCached(T const* table, framework::expressions::BindingNode
 template <soa::is_table T>
 auto doSliceByCachedUnsorted(T const* table, framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
 {
-  auto localCache = cache.ptr->getCacheUnsortedFor({"", o2::soa::getMatcherFromTypeForKey<T>(node.name), node.name});
+  auto localCache = cache.ptr->getCacheUnsortedFor({"", [&o = cache.ptr->newOrigin](framework::ConcreteDataMatcher&& m){
+                                                      if ((m.origin == header::DataOrigin{"AOD"}) && (o != header::DataOrigin{"AOD"})) {
+                                                        m.origin = o;
+                                                      }
+                                                      return m;
+                                                    }(o2::soa::getMatcherFromTypeForKey<T>(node.name)), node.name});
   if constexpr (soa::is_filtered_table<T>) {
     auto t = typename T::self_t({table->asArrowTable()}, localCache.getSliceFor(value));
     if (t.tableSize() != 0) {

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1481,7 +1481,7 @@ static constexpr framework::ConcreteDataMatcher getMatcherFromTypeForKey(std::st
     auto locate = [&]<size_t... Is>(std::index_sequence<Is...>) {
       return std::vector{hasKeyM<T::originals[Is]>(key)...};
     }(std::make_index_sequence<T::originals.size()>{});
-    auto it = std::find_if(locate.begin(), locate.end(), [](auto const& x) { return x.first; });
+    auto it = std::ranges::find_if(locate, [](auto const& x) { return x.first; });
     if (it != locate.end()) {
       return it->second;
     }
@@ -4303,7 +4303,7 @@ using SmallGroupsUnfiltered = SmallGroupsBase<T, false>;
 
 template <typename T>
 concept is_smallgroups = requires {
-  []<typename B, bool A>(SmallGroupsBase<B, A>*) {}(std::declval<T*>());
+  []<typename B, bool A>(SmallGroupsBase<B, A>*) {}(std::declval<std::decay_t<T>*>());
 };
 } // namespace o2::soa
 

--- a/Framework/Core/include/Framework/AnalysisDataModelHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisDataModelHelpers.h
@@ -16,6 +16,6 @@
 
 namespace o2::aod::datamodel
 {
-std::string getTreeName(header::DataHeader dh);
+std::string getTreeName(header::DataHeader dh, bool wasAOD);
 } // namespace o2::aod::datamodel
 #endif // O2_FRAMEWORK_ANALYSISDATAMODELHELPERS_H_

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -173,6 +173,9 @@ struct Builder {
 
   std::shared_ptr<arrow::Table> materialize(ProcessingContext& pc);
 };
+
+ConfigParamSpec replaceOrigin(ConfigParamSpec& source, std::string const& originStr);
+ConcreteDataMatcher replaceOrigin(ConcreteDataMatcher& matcher, const header::DataOrigin& newOrigin);
 } // namespace o2::framework
 
 namespace o2::soa
@@ -274,19 +277,23 @@ consteval IndexKind getIndexKind()
 }
 
 template <soa::with_index_pack T>
-inline constexpr auto getIndexMapping()
+inline constexpr auto getIndexMapping(header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
 {
   std::vector<IndexRecord> idx;
   using indices = T::index_pack_t;
   using Key = T::Key;
-  [&idx]<size_t... Is>(std::index_sequence<Is...>) mutable {
+  [&idx, &newOrigin]<size_t... Is>(std::index_sequence<Is...>) mutable {
     constexpr auto refs = T::generateSources();
-    ([&idx]<TableRef ref, typename C>() mutable {
+    ([&idx, &newOrigin]<TableRef ref, typename C>() mutable {
       constexpr auto pos = o2::aod::MetadataTrait<o2::aod::Hash<ref.desc_hash>>::metadata::template getIndexPosToKey<Key>();
+      auto matcher = o2::aod::matcher<ref>();
+      if ((ref.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
+        matcher = replaceOrigin(matcher, newOrigin);
+      }
       if constexpr (pos == -1) {
-        idx.emplace_back(o2::aod::label<ref>(), o2::aod::matcher<ref>(), C::columnLabel(), IndexKind::IdxSelf, pos);
+        idx.emplace_back(o2::aod::label<ref>(), matcher, C::columnLabel(), IndexKind::IdxSelf, pos);
       } else {
-        idx.emplace_back(o2::aod::label<ref>(), o2::aod::matcher<ref>(), C::columnLabel(), getIndexKind<typename C::type>(), pos);
+        idx.emplace_back(o2::aod::label<ref>(), matcher, C::columnLabel(), getIndexKind<typename C::type>(), pos);
       }
     }.template operator()<refs[Is], typename framework::pack_element_t<Is, indices>>(),
      ...);
@@ -381,16 +388,16 @@ constexpr auto getExpressionMetadata() -> std::vector<framework::ConfigParamSpec
 }
 
 template <soa::with_index_pack T>
-constexpr auto getIndexMetadata() -> std::vector<framework::ConfigParamSpec>
+constexpr auto getIndexMetadata(header::DataOrigin newOrigin = header::DataOrigin{"AOD"}) -> std::vector<framework::ConfigParamSpec>
 {
-  auto map = getIndexMapping<T>();
+  auto map = getIndexMapping<T>(newOrigin);
   return {framework::ConfigParamSpec{"index-records", framework::VariantType::String, framework::serializeIndexRecords(map), {"\"\""}},
           {framework::ConfigParamSpec{"index-exclusive", framework::VariantType::Bool, T::exclusive, {"\"\""}}}};
 }
 
 template <typename T>
   requires(!soa::with_index_pack<T>)
-constexpr auto getIndexMetadata() -> std::vector<framework::ConfigParamSpec>
+constexpr auto getIndexMetadata(header::DataOrigin) -> std::vector<framework::ConfigParamSpec>
 {
   return {};
 }
@@ -398,7 +405,7 @@ constexpr auto getIndexMetadata() -> std::vector<framework::ConfigParamSpec>
 } // namespace
 
 template <TableRef R>
-constexpr auto tableRef2InputSpec()
+constexpr auto tableRef2InputSpec(header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
 {
   std::vector<framework::ConfigParamSpec> metadata;
   std::vector<framework::ConfigParamSpec> sources;
@@ -407,24 +414,29 @@ constexpr auto tableRef2InputSpec()
   } else if constexpr (soa::with_sources_generator<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
     sources = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata, o2::aod::Hash<R.origin_hash>>();
   }
+  if ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
+    std::ranges::transform(sources, sources.begin(), [originStr = newOrigin.as<std::string>()](framework::ConfigParamSpec& source){
+      return replaceOrigin(source, originStr);
+    });
+  }
   metadata.insert(metadata.end(), sources.begin(), sources.end());
   auto ccdbURLs = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), ccdbURLs.begin(), ccdbURLs.end());
   auto expressions = getExpressionMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
   metadata.insert(metadata.end(), expressions.begin(), expressions.end());
-  auto indices = getIndexMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
+  auto indices = getIndexMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>(newOrigin);
   metadata.insert(metadata.end(), indices.begin(), indices.end());
   if constexpr (!soa::with_ccdb_urls<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>) {
     metadata.emplace_back(framework::ConfigParamSpec{"schema", framework::VariantType::String, framework::serializeSchema(o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata::getSchema()), {"\"\""}});
   }
 
   return framework::InputSpec{
-    o2::aod::label<R>(),
-    o2::aod::origin<R>(),
-    o2::aod::description(o2::aod::signature<R>()),
-    R.version,
-    framework::Lifetime::Timeframe,
-    metadata};
+                              o2::aod::label<R>(),
+                              ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) ? newOrigin : o2::aod::origin<R>(),
+                              o2::aod::description(o2::aod::signature<R>()),
+                              R.version,
+                              framework::Lifetime::Timeframe,
+                              metadata};
 }
 
 template <TableRef R>

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -483,6 +483,7 @@ struct WritingCursor {
  public:
   using persistent_table_t = decltype([]() { if constexpr (soa::is_iterator<T>) { return typename T::parent_t{nullptr}; } else { return T{nullptr}; } }());
   using cursor_t = decltype(std::declval<TableBuilder>().cursor<persistent_table_t>());
+  OutputSpec outputSpec{soa::tableRef2OutputSpec<persistent_table_t::ref>()};
 
   template <typename... Ts>
   void operator()(Ts&&... args)

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -632,14 +632,14 @@ struct TableTransform {
   using metadata = M;
   constexpr static auto sources = M::template generateSources<o2::aod::Hash<Ref.origin_hash>>();
 
-  OutputSpec outputSpec = updateOutputSpec();
+  OutputSpec outputSpec{soa::tableRef2OutputSpec<Ref>()};
   static OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
   {
     return soa::tableRef2OutputSpec<Ref>(newOrigin);
   }
 
   std::array<InputSpec, sources.size()> requiredInputs = getRequiredInputs();
-  static consteval auto getRequiredInputs(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
+  static constexpr auto getRequiredInputs(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
   {
     return [&newOrigin]<size_t... Is>(std::index_sequence<Is...>) {
       return std::array{soa::tableRef2InputSpec<sources[Is]>(newOrigin)...};
@@ -656,7 +656,7 @@ template <typename T>
 concept is_dynamically_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_configurable_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
 
 template <is_spawnable T>
-constexpr auto transformBase()
+consteval auto transformBase()
 {
   using metadata = typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata;
   return TableTransform<metadata, metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>::ref>{};

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -16,7 +16,6 @@
 #include "Framework/DataAllocator.h"
 #include "Framework/IndexBuilderHelpers.h"
 #include "Framework/InputSpec.h"
-#include "Framework/Output.h"
 #include "Framework/OutputObjHeader.h"
 #include "Framework/OutputRef.h"
 #include "Framework/OutputSpec.h"
@@ -26,6 +25,17 @@
 #include "Framework/Traits.h"
 
 #include <string>
+namespace o2::framework {
+/// Structure to contain mapping between matchers and process functions.
+/// Process function is identified by hash, each matcher has associated
+/// argument position for that process function; single argument can have
+/// many matchers associated due to complicated joins
+struct InputInfo {
+  uint32_t hash;
+  std::vector<std::pair<int, ConcreteDataMatcher>> matchers;
+};
+}
+
 namespace o2::soa
 {
 struct IndexRecord {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -609,6 +609,10 @@ template <soa::is_metadata M, soa::TableRef Ref>
 struct TableTransform {
   using metadata = M;
   constexpr static auto sources = M::template generateSources<o2::aod::Hash<Ref.origin_hash>>();
+  std::vector<InputSpec> requiredInputs = []<size_t... Is>(std::index_sequence<Is...>){
+    return std::vector{soa::tableRef2InputSpec<sources[Is]>()...};
+  }(std::make_index_sequence<sources.size()>());
+  OutputSpec outputSpec = soa::tableRef2OutputSpec<Ref>();
 
   template <soa::TableRef R>
   static auto base_spec()

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -415,7 +415,7 @@ constexpr auto tableRef2InputSpec(header::DataOrigin newOrigin = header::DataOri
     sources = getInputMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata, o2::aod::Hash<R.origin_hash>>();
   }
   if ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
-    std::ranges::transform(sources, sources.begin(), [originStr = newOrigin.as<std::string>()](framework::ConfigParamSpec& source){
+    std::ranges::transform(sources, sources.begin(), [originStr = newOrigin.as<std::string>()](framework::ConfigParamSpec& source) {
       return replaceOrigin(source, originStr);
     });
     metadata.push_back(framework::ConfigParamSpec{"aod-origin-replaced", framework::VariantType::Bool, true, {"\"\""}});
@@ -432,12 +432,12 @@ constexpr auto tableRef2InputSpec(header::DataOrigin newOrigin = header::DataOri
   }
 
   return framework::InputSpec{
-                              o2::aod::label<R>(),
-                              ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) ? newOrigin : o2::aod::origin<R>(),
-                              o2::aod::description(o2::aod::signature<R>()),
-                              R.version,
-                              framework::Lifetime::Timeframe,
-                              metadata};
+    o2::aod::label<R>(),
+    ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) ? newOrigin : o2::aod::origin<R>(),
+    o2::aod::description(o2::aod::signature<R>()),
+    R.version,
+    framework::Lifetime::Timeframe,
+    metadata};
 }
 
 template <TableRef R>
@@ -632,11 +632,10 @@ struct TableTransform {
   std::vector<InputSpec> requiredInputs = getRequiredInputs();
   static std::vector<InputSpec> getRequiredInputs(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
   {
-    return [&newOrigin]<size_t... Is>(std::index_sequence<Is...>){
-        return std::vector{soa::tableRef2InputSpec<sources[Is]>(newOrigin)...};
-      }(std::make_index_sequence<sources.size()>());
+    return [&newOrigin]<size_t... Is>(std::index_sequence<Is...>) {
+      return std::vector{soa::tableRef2InputSpec<sources[Is]>(newOrigin)...};
+    }(std::make_index_sequence<sources.size()>());
   }
-
 };
 
 /// This helper struct allows you to declare extended tables which should be
@@ -653,7 +652,6 @@ constexpr auto transformBase()
   using metadata = typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata;
   return TableTransform<metadata, metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>::ref>{};
 }
-
 
 /// In a multi-origin case the origin is provided by the type
 /// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
@@ -833,7 +831,6 @@ concept is_builds = requires(T t) {
   typename T::Key;
   requires std::same_as<decltype(t.map), std::vector<soa::IndexRecord>>;
 };
-
 
 /// a task with rewritten origin, if running together with a task with the default, will
 /// have a different name and thus its output would be routed separately

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -690,7 +690,7 @@ struct Spawns : decltype(transformBase<T>()) {
 
   std::shared_ptr<typename T::table_t> table = nullptr;
   std::shared_ptr<extension_t> extension = nullptr;
-  static std::array<o2::framework::expressions::Projector, N> projectors = []<typename... C>(framework::pack<C...>)->std::array<expressions::Projector, sizeof...(C)>
+  std::array<o2::framework::expressions::Projector, N> projectors = []<typename... C>(framework::pack<C...>)->std::array<expressions::Projector, sizeof...(C)>
   {
     return {{std::move(C::Projector())...}};
   }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -614,34 +614,6 @@ struct TableTransform {
     return std::vector{soa::tableRef2InputSpec<sources[Is]>()...};
   }(std::make_index_sequence<sources.size()>());
   OutputSpec outputSpec = soa::tableRef2OutputSpec<Ref>();
-
-  template <soa::TableRef R>
-  static auto base_spec()
-  {
-    return soa::tableRef2InputSpec<R>();
-  }
-
-  static auto base_specs()
-  {
-    return []<size_t... Is>(std::index_sequence<Is...>) {
-      return std::array{base_spec<sources[Is]>()...};
-    }(std::make_index_sequence<sources.size()>{});
-  }
-
-  static constexpr auto spec()
-  {
-    return soa::tableRef2OutputSpec<Ref>();
-  }
-
-  static constexpr auto output()
-  {
-    return soa::tableRef2Output<Ref>();
-  }
-
-  static constexpr auto ref()
-  {
-    return soa::tableRef2OutputRef<Ref>();
-  }
 };
 
 /// This helper struct allows you to declare extended tables which should be

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -503,7 +503,7 @@ struct WritingCursor {
   using persistent_table_t = decltype([]() { if constexpr (soa::is_iterator<T>) { return typename T::parent_t{nullptr}; } else { return T{nullptr}; } }());
   using cursor_t = decltype(std::declval<TableBuilder>().cursor<persistent_table_t>());
   OutputSpec outputSpec{soa::tableRef2OutputSpec<persistent_table_t::ref>()};
-  OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
+  static OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
   {
     return soa::tableRef2OutputSpec<persistent_table_t::ref>(newOrigin);
   }
@@ -597,8 +597,9 @@ struct OutputForTable {
   }
 };
 
-/// In a multi-origin case the origin is provided by the type
-/// FIXME: in a rewritten origin case, we need to modify the output designation
+/// For the table-producing category of templates
+/// * In a multi-origin case the origin is provided by the type
+/// * In a rewritten origin case, we need to modify the output designation
 
 /// This helper class allows you to declare things which will be created by a
 /// given analysis task. Notice how the actual cursor is implemented by the
@@ -625,9 +626,6 @@ struct ProducesGroup {
 template <typename T>
 concept is_produces_group = std::derived_from<T, ProducesGroup>;
 
-/// In a multi-origin case the origin is provided by the type
-/// FIXME: In a rewritten origin case, we need to modify the output designation
-
 /// Helper template for table transformations
 template <soa::is_metadata M, soa::TableRef Ref>
 struct TableTransform {
@@ -640,11 +638,11 @@ struct TableTransform {
     return soa::tableRef2OutputSpec<Ref>(newOrigin);
   }
 
-  std::vector<InputSpec> requiredInputs = getRequiredInputs();
-  static std::vector<InputSpec> getRequiredInputs(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
+  std::array<InputSpec, sources.size()> requiredInputs = getRequiredInputs();
+  static consteval auto getRequiredInputs(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
   {
     return [&newOrigin]<size_t... Is>(std::index_sequence<Is...>) {
-      return std::vector{soa::tableRef2InputSpec<sources[Is]>(newOrigin)...};
+      return std::array{soa::tableRef2InputSpec<sources[Is]>(newOrigin)...};
     }(std::make_index_sequence<sources.size()>());
   }
 };
@@ -664,9 +662,10 @@ constexpr auto transformBase()
   return TableTransform<metadata, metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>::ref>{};
 }
 
-/// In a multi-origin case the origin is provided by the type
-/// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
-///        The extraction of the elements needs to be changed in AnalysisManagers using the origin information from the base class
+/// for the automatic table templates
+/// * In a multi-origin case the origin is provided by the type
+/// * In a rewritten origin case the output designation needs to be changed through base class
+/// * The extraction of the elements happens in AnalysisManagers using the origin information from the base class
 template <is_spawnable T>
 struct Spawns : decltype(transformBase<T>()) {
   using spawnable_t = T;
@@ -691,7 +690,7 @@ struct Spawns : decltype(transformBase<T>()) {
 
   std::shared_ptr<typename T::table_t> table = nullptr;
   std::shared_ptr<extension_t> extension = nullptr;
-  std::array<o2::framework::expressions::Projector, N> projectors = []<typename... C>(framework::pack<C...>)->std::array<expressions::Projector, sizeof...(C)>
+  static std::array<o2::framework::expressions::Projector, N> projectors = []<typename... C>(framework::pack<C...>)->std::array<expressions::Projector, sizeof...(C)>
   {
     return {{std::move(C::Projector())...}};
   }
@@ -710,10 +709,6 @@ concept is_spawns = requires(T t) {
   typename T::expression_pack_t;
   requires std::same_as<decltype(t.projector), std::shared_ptr<gandiva::Projector>>;
 };
-
-/// In a multi-origin case the origin is provided by the type
-/// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
-///        The extraction of the elements needs to be changed in AnalysisManagers using the origin information from the base class
 
 /// This helper struct allows you to declare extended tables with dynamically-supplied
 /// expressions to be created by the task
@@ -775,8 +770,7 @@ concept is_defines = requires(T t) {
 
 /// Policy to control index building
 /// Exclusive index: each entry in a row has a valid index
-/// Sparse index: values in a row can be (-1), index table is isomorphic (joinable)
-/// to T1
+/// Sparse index: values in a row can be (-1), index table is isomorphic (joinable) to T1
 struct Exclusive {
 };
 struct Sparse {
@@ -784,15 +778,11 @@ struct Sparse {
 
 /// This helper struct allows you to declare index tables to be created in a task
 template <soa::is_index_table T>
-constexpr auto transformBase()
+consteval auto transformBase()
 {
   using metadata = typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata;
   return TableTransform<metadata, T::ref>{};
 }
-
-/// In a multi-origin case the origin is provided by the type
-/// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
-///        The extraction of the elements needs to be changed in AnalysisManagers using the origin information from the base class
 
 template <soa::is_index_table T>
 struct Builds : decltype(transformBase<T>()) {
@@ -824,7 +814,7 @@ struct Builds : decltype(transformBase<T>()) {
   }
   std::shared_ptr<T> table = nullptr;
 
-  constexpr auto pack()
+  static consteval auto pack()
   {
     return index_pack_t{};
   }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -69,6 +69,7 @@ struct IndexBuilder {
 
 namespace o2::framework
 {
+void wrongOriginReplacement(std::string_view replacement);
 std::shared_ptr<arrow::Table> makeEmptyTableImpl(const char* name, std::shared_ptr<arrow::Schema>& schema);
 
 template <soa::is_table T>

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -429,7 +429,7 @@ constexpr auto tableRef2InputSpec(header::DataOrigin newOrigin = header::DataOri
     std::ranges::transform(sources, sources.begin(), [originStr = newOrigin.as<std::string>()](framework::ConfigParamSpec& source) {
       return replaceOrigin(source, originStr);
     });
-    metadata.push_back(framework::ConfigParamSpec{"aod-origin-replaced", framework::VariantType::Bool, true, {"\"\""}});
+    metadata.emplace_back(framework::ConfigParamSpec{"aod-origin-replaced", framework::VariantType::Bool, true, {"\"\""}});
   }
   metadata.insert(metadata.end(), sources.begin(), sources.end());
   auto ccdbURLs = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -25,7 +25,8 @@
 #include "Framework/Traits.h"
 
 #include <string>
-namespace o2::framework {
+namespace o2::framework
+{
 /// Structure to contain mapping between matchers and process functions.
 /// Process function is identified by hash, each matcher has associated
 /// argument position for that process function; single argument can have
@@ -34,7 +35,7 @@ struct InputInfo {
   uint32_t hash;
   std::vector<std::pair<int, ConcreteDataMatcher>> matchers;
 };
-}
+} // namespace o2::framework
 
 namespace o2::soa
 {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -573,6 +573,9 @@ struct OutputForTable {
   }
 };
 
+/// In a multi-origin case the origin is provided by the type
+/// FIXME: in a rewritten origin case, we need to modify the output designation
+
 /// This helper class allows you to declare things which will be created by a
 /// given analysis task. Notice how the actual cursor is implemented by the
 /// means of the WritingCursor helper class, from which produces actually
@@ -597,6 +600,9 @@ struct ProducesGroup {
 
 template <typename T>
 concept is_produces_group = std::derived_from<T, ProducesGroup>;
+
+/// In a multi-origin case the origin is provided by the type
+/// FIXME: In a rewritten origin case, we need to modify the output designation
 
 /// Helper template for table transformations
 template <soa::is_metadata M, soa::TableRef Ref>
@@ -648,6 +654,10 @@ constexpr auto transformBase()
   return TableTransform<metadata, metadata::template extension_table_t_from<o2::aod::Hash<T::originals[T::originals.size() - 1].origin_hash>>::ref>{};
 }
 
+
+/// In a multi-origin case the origin is provided by the type
+/// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
+///        The extraction of the elements needs to be changed in AnalysisManagers using the origin information from the base class
 template <is_spawnable T>
 struct Spawns : decltype(transformBase<T>()) {
   using spawnable_t = T;
@@ -692,11 +702,14 @@ concept is_spawns = requires(T t) {
   requires std::same_as<decltype(t.projector), std::shared_ptr<gandiva::Projector>>;
 };
 
+/// In a multi-origin case the origin is provided by the type
+/// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
+///        The extraction of the elements needs to be changed in AnalysisManagers using the origin information from the base class
+
 /// This helper struct allows you to declare extended tables with dynamically-supplied
 /// expressions to be created by the task
 /// The actual expressions have to be set in init() for the configurable expression
 /// columns, used to define the table
-
 template <is_dynamically_spawnable T, bool DELAYED = false>
 struct Defines : decltype(transformBase<T>()) {
   static constexpr bool delayed = DELAYED;
@@ -761,13 +774,16 @@ struct Sparse {
 };
 
 /// This helper struct allows you to declare index tables to be created in a task
-
 template <soa::is_index_table T>
 constexpr auto transformBase()
 {
   using metadata = typename aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>::metadata;
   return TableTransform<metadata, T::ref>{};
 }
+
+/// In a multi-origin case the origin is provided by the type
+/// FIXME: In a rewritten origin case the output designation needs to be changed (through base class)
+///        The extraction of the elements needs to be changed in AnalysisManagers using the origin information from the base class
 
 template <soa::is_index_table T>
 struct Builds : decltype(transformBase<T>()) {
@@ -817,6 +833,10 @@ concept is_builds = requires(T t) {
   typename T::Key;
   requires std::same_as<decltype(t.map), std::vector<soa::IndexRecord>>;
 };
+
+
+/// a task with rewritten origin, if running together with a task with the default, will
+/// have a different name and thus its output would be routed separately
 
 /// This helper class allows you to declare things which will be created by a
 /// given analysis task. Currently wrapped objects are limited to be TNamed
@@ -958,6 +978,13 @@ auto getTableFromFilter(soa::is_not_filtered_table auto const& table, soa::Selec
 
 void initializePartitionCaches(std::set<uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter);
 
+/// Partition ties directly to the argument type
+/// in a case with several origins in subscriptions it will get the correct input, as the type contains the origin
+/// in a case with rewritten origin the type stays the same, so the association stays correct
+/// FIXME: currently partition has to rerun the selection each time the invokeProcess is called
+///        the real reason is to provide grouped parts for the process functions that request it
+///        better solution would be to "slice" the selection, as is already done in GroupSlicer
+///        for the same purpose, instead of reapplying the filtering
 template <typename T>
 struct Partition {
   using content_t = T;

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -452,6 +452,9 @@ constexpr auto tableRef2OutputSpec(header::DataOrigin newOrigin = header::DataOr
   } else if constexpr (soa::with_index_pack<md>) {
     metadata.emplace_back("index-records", framework::VariantType::Bool, true, framework::ConfigParamSpec::HelpString{"\"\""});
   }
+  if ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
+    metadata.push_back(framework::ConfigParamSpec{"aod-origin-replaced", framework::VariantType::Bool, true, {"\"\""}});
+  }
   return framework::OutputSpec{
     framework::OutputLabel{o2::aod::label<R>()},
     ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) ? newOrigin : o2::aod::origin<R>(),
@@ -459,15 +462,6 @@ constexpr auto tableRef2OutputSpec(header::DataOrigin newOrigin = header::DataOr
     R.version,
     framework::Lifetime::Timeframe,
     metadata};
-}
-
-template <TableRef R>
-constexpr auto tableRef2Output()
-{
-  return framework::Output{
-    o2::aod::origin<R>(),
-    o2::aod::description(o2::aod::signature<R>()),
-    R.version};
 }
 
 template <TableRef R>
@@ -498,9 +492,9 @@ struct WritingCursor {
   using persistent_table_t = decltype([]() { if constexpr (soa::is_iterator<T>) { return typename T::parent_t{nullptr}; } else { return T{nullptr}; } }());
   using cursor_t = decltype(std::declval<TableBuilder>().cursor<persistent_table_t>());
   OutputSpec outputSpec{soa::tableRef2OutputSpec<persistent_table_t::ref>()};
-  OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin)
+  OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
   {
-    outputSpec = soa::tableRef2OutputSpec<persistent_table_t::ref>(newOrigin);
+    return soa::tableRef2OutputSpec<persistent_table_t::ref>(newOrigin);
   }
 
   template <typename... Ts>

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -418,6 +418,7 @@ constexpr auto tableRef2InputSpec(header::DataOrigin newOrigin = header::DataOri
     std::ranges::transform(sources, sources.begin(), [originStr = newOrigin.as<std::string>()](framework::ConfigParamSpec& source){
       return replaceOrigin(source, originStr);
     });
+    metadata.push_back(framework::ConfigParamSpec{"aod-origin-replaced", framework::VariantType::Bool, true, {"\"\""}});
   }
   metadata.insert(metadata.end(), sources.begin(), sources.end());
   auto ccdbURLs = getCCDBMetadata<typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata>();
@@ -440,7 +441,7 @@ constexpr auto tableRef2InputSpec(header::DataOrigin newOrigin = header::DataOri
 }
 
 template <TableRef R>
-constexpr auto tableRef2OutputSpec()
+constexpr auto tableRef2OutputSpec(header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
 {
   std::vector<framework::ConfigParamSpec> metadata;
   using md = typename o2::aod::MetadataTrait<o2::aod::Hash<R.desc_hash>>::metadata;
@@ -453,7 +454,7 @@ constexpr auto tableRef2OutputSpec()
   }
   return framework::OutputSpec{
     framework::OutputLabel{o2::aod::label<R>()},
-    o2::aod::origin<R>(),
+    ((R.origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) ? newOrigin : o2::aod::origin<R>(),
     o2::aod::description(o2::aod::signature<R>()),
     R.version,
     framework::Lifetime::Timeframe,
@@ -497,6 +498,10 @@ struct WritingCursor {
   using persistent_table_t = decltype([]() { if constexpr (soa::is_iterator<T>) { return typename T::parent_t{nullptr}; } else { return T{nullptr}; } }());
   using cursor_t = decltype(std::declval<TableBuilder>().cursor<persistent_table_t>());
   OutputSpec outputSpec{soa::tableRef2OutputSpec<persistent_table_t::ref>()};
+  OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin)
+  {
+    outputSpec = soa::tableRef2OutputSpec<persistent_table_t::ref>(newOrigin);
+  }
 
   template <typename... Ts>
   void operator()(Ts&&... args)
@@ -623,10 +628,21 @@ template <soa::is_metadata M, soa::TableRef Ref>
 struct TableTransform {
   using metadata = M;
   constexpr static auto sources = M::template generateSources<o2::aod::Hash<Ref.origin_hash>>();
-  std::vector<InputSpec> requiredInputs = []<size_t... Is>(std::index_sequence<Is...>){
-    return std::vector{soa::tableRef2InputSpec<sources[Is]>()...};
-  }(std::make_index_sequence<sources.size()>());
-  OutputSpec outputSpec = soa::tableRef2OutputSpec<Ref>();
+
+  OutputSpec outputSpec = updateOutputSpec();
+  static OutputSpec updateOutputSpec(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
+  {
+    return soa::tableRef2OutputSpec<Ref>(newOrigin);
+  }
+
+  std::vector<InputSpec> requiredInputs = getRequiredInputs();
+  static std::vector<InputSpec> getRequiredInputs(header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
+  {
+    return [&newOrigin]<size_t... Is>(std::index_sequence<Is...>){
+        return std::vector{soa::tableRef2InputSpec<sources[Is]>(newOrigin)...};
+      }(std::make_index_sequence<sources.size()>());
+  }
+
 };
 
 /// This helper struct allows you to declare extended tables which should be

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -193,7 +193,7 @@ bool updateOutputSpec(T& entity, header::DataOrigin newOrigin = header::DataOrig
 template <is_produces_group T>
 bool updateOutputSpec(T& producesGroup, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
 {
-  homogeneous_apply_refs<true>([&newOrigin](auto& produces){ return updateOutputSpec(produces, newOrigin); }, producesGroup);
+  homogeneous_apply_refs<true>([&newOrigin](auto& produces) { return updateOutputSpec(produces, newOrigin); }, producesGroup);
 }
 
 template <typename C>
@@ -312,7 +312,7 @@ template <is_spawns T>
 bool prepareOutput(ProcessingContext& context, T& spawns)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables( framework::extractTablesFromRecord(context.inputs(), spawns.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ) );
+  auto originalTable = soa::ArrowHelpers::joinTables(framework::extractTablesFromRecord(context.inputs(), spawns.requiredInputs | std::views::transform([](auto const& input) { return DataSpecUtils::asConcreteDataMatcher(input); })));
   if (originalTable->num_rows() == 0) {
     originalTable = makeEmptyTable("EMPTY", typename metadata::base_table_t::persistent_columns_t{});
   }
@@ -330,7 +330,7 @@ bool prepareOutput(ProcessingContext& context, T& spawns)
 template <is_builds T>
 bool prepareOutput(ProcessingContext& context, T& builds)
 {
-  return builds.build(framework::extractTablesFromRecord(context.inputs(), builds.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ));
+  return builds.build(framework::extractTablesFromRecord(context.inputs(), builds.requiredInputs | std::views::transform([](auto const& input) { return DataSpecUtils::asConcreteDataMatcher(input); })));
 }
 
 template <is_defines T>
@@ -338,7 +338,7 @@ bool prepareOutput(ProcessingContext& context, T& defines)
   requires(T::delayed == false)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables( framework::extractTablesFromRecord(context.inputs(), defines.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ) );
+  auto originalTable = soa::ArrowHelpers::joinTables(framework::extractTablesFromRecord(context.inputs(), defines.requiredInputs | std::views::transform([](auto const& input) { return DataSpecUtils::asConcreteDataMatcher(input); })));
   if (originalTable->num_rows() == 0) {
     originalTable = makeEmptyTable("EMPTY", typename metadata::base_table_t::persistent_columns_t{});
   }
@@ -370,7 +370,7 @@ bool prepareDelayedOutput(ProcessingContext& context, T& defines)
     defines.recompile();
   }
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::ref.desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables( framework::extractTablesFromRecord(context.inputs(), defines.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ) );
+  auto originalTable = soa::ArrowHelpers::joinTables(framework::extractTablesFromRecord(context.inputs(), defines.requiredInputs | std::views::transform([](auto const& input) { return DataSpecUtils::asConcreteDataMatcher(input); })));
   if (originalTable->num_rows() == 0) {
     originalTable = makeEmptyTable<metadata::base_table_t::ref>();
   }
@@ -622,7 +622,7 @@ bool replaceOrigin(T& preslice, header::DataOrigin const& newOrigin = header::Da
 template <is_preslice_group T>
 bool replaceOrigin(T& presliceGroup, header::DataOrigin const& newOrigin)
 {
-  homogeneous_apply_refs<true>([&newOrigin](auto& preslice){ return replaceOrigin(preslice, newOrigin); }, presliceGroup);
+  homogeneous_apply_refs<true>([&newOrigin](auto& preslice) { return replaceOrigin(preslice, newOrigin); }, presliceGroup);
   return true;
 }
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -190,6 +190,12 @@ bool updateOutputSpec(T& entity, header::DataOrigin newOrigin = header::DataOrig
   return true;
 }
 
+template <is_produces_group T>
+bool updateOutputSpec(T& producesGroup, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+{
+  homogeneous_apply_refs<true>([&newOrigin](auto& produces){ return updateOutputSpec(produces, newOrigin); }, producesGroup);
+}
+
 template <typename C>
 bool newDataframeCondition(InputRecord&, C&)
 {
@@ -604,9 +610,9 @@ bool replaceOrigin(T&, header::DataOrigin const&)
 }
 
 template <is_preslice T>
-bool replaceOrigin(T& preslice, header::DataOrigin const& newOrigin)
+bool replaceOrigin(T& preslice, header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
 {
-  if ((T::target_t::originals[0].origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
+  if ((T::target_t::binding_origin == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
     preslice.bindingKey.matcher = framework::replaceOrigin(preslice.bindingKey.matcher, newOrigin);
     return true;
   }

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -134,8 +134,19 @@ bool appendCondition(std::vector<InputSpec>& inputs, C& conditionGroup)
 }
 
 /// Table auto-creation handling
+
 template <typename T>
-bool requestInputs(std::vector<InputSpec>&, T const&)
+concept with_required_inputs = requires(T t) { t.getRequiredInputs(); };
+
+template <typename T>
+  requires(!with_required_inputs<T>)
+bool requestInputs(std::vector<InputSpec>&, T&, header::DataOrigin)
+{
+  return false;
+}
+
+template <typename T>
+bool updateOutputSpec(T&, header::DataOrigin)
 {
   return false;
 }
@@ -158,16 +169,24 @@ const char* controlOption()
   return "control:define";
 }
 
-template <typename T>
-concept with_required_inputs = requires(T t) { t.requiredInputs.size(); };
-
 template <with_required_inputs T>
-bool requestInputs(std::vector<InputSpec>& inputs, T const& entity)
+bool requestInputs(std::vector<InputSpec>& inputs, T& entity, header::DataOrigin const& newOrigin = header::DataOrigin{"AOD"})
 {
+  entity.requiredInputs = entity.getRequiredInputs(newOrigin);
   for (auto base_spec : entity.requiredInputs) {
     base_spec.metadata.push_back(ConfigParamSpec{std::string{controlOption<T>()}, VariantType::Bool, true, {"\"\""}});
     DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
   }
+  return true;
+}
+
+template <typename T>
+concept with_updateable_output = requires(T t) { t.updateOutputSpec(); };
+
+template <with_updateable_output T>
+bool updateOutputSpec(T& entity, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+{
+  entity.outputSpec = entity.updateOutputSpec(newOrigin);
   return true;
 }
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -200,9 +200,9 @@ constexpr bool appendOutput(std::vector<OutputSpec>&, T&, uint32_t)
 }
 
 template <is_produces T>
-constexpr bool appendOutput(std::vector<OutputSpec>& outputs, T&, uint32_t)
+constexpr bool appendOutput(std::vector<OutputSpec>& outputs, T& produces, uint32_t)
 {
-  outputs.emplace_back(soa::tableRef2OutputSpec<T::persistent_table_t::ref>());
+  outputs.emplace_back(produces.outputSpec);
   return true;
 }
 
@@ -272,8 +272,8 @@ bool prepareOutput(ProcessingContext&, T&)
 template <is_produces T>
 bool prepareOutput(ProcessingContext& context, T& produces)
 {
-  /// FIXME: use matcher instead of an OutputRef
-  produces.resetCursor(std::move(context.outputs().make<TableBuilder>(soa::tableRef2OutputRef<T::persistent_table_t::ref>())));
+  auto matcher = DataSpecUtils::asConcreteDataMatcher(produces.outputSpec);
+  produces.resetCursor(std::move(context.outputs().make<TableBuilder>(Output{matcher.origin, matcher.description, matcher.subSpec})));
   return true;
 }
 
@@ -306,7 +306,6 @@ bool prepareOutput(ProcessingContext& context, T& spawns)
 template <is_builds T>
 bool prepareOutput(ProcessingContext& context, T& builds)
 {
-  using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::buildable_t::ref.desc_hash>>::metadata;
   return builds.build(framework::extractTablesFromRecord(context.inputs(), builds.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ));
 }
 

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -194,6 +194,7 @@ template <is_produces_group T>
 bool updateOutputSpec(T& producesGroup, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
 {
   homogeneous_apply_refs<true>([&newOrigin](auto& produces) { return updateOutputSpec(produces, newOrigin); }, producesGroup);
+  return true;
 }
 
 template <typename C>

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -579,6 +579,30 @@ static void setGroupedCombination(C& comb, TG& grouping, std::tuple<Ts...>& asso
 /// Preslice handling
 template <typename T>
   requires(!is_preslice<T> && !is_preslice_group<T>)
+bool replaceOrigin(T&, header::DataOrigin const&)
+{
+  return false;
+}
+
+template <is_preslice T>
+bool replaceOrigin(T& preslice, header::DataOrigin const& newOrigin)
+{
+  if ((T::target_t::originals[0].origin_hash == "AOD"_h) && (newOrigin != header::DataOrigin{"AOD"})) {
+    preslice.bindingKey.matcher = framework::replaceOrigin(preslice.bindingKey.matcher, newOrigin);
+    return true;
+  }
+  return false;
+}
+
+template <is_preslice_group T>
+bool replaceOrigin(T& presliceGroup, header::DataOrigin const& newOrigin)
+{
+  homogeneous_apply_refs<true>([&newOrigin](auto& preslice){ return replaceOrigin(preslice, newOrigin); }, presliceGroup);
+  return true;
+}
+
+template <typename T>
+  requires(!is_preslice<T> && !is_preslice_group<T>)
 bool registerCache(T&, Cache&, Cache&)
 {
   return false;

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -41,6 +41,17 @@ static inline auto extractOriginals(ProcessingContext& pc)
     return {pc.inputs().get<TableConsumer>(o2::aod::matcher<refs[Is]>())->asArrowTable()...};
   }(std::make_index_sequence<refs.size()>());
 }
+
+template <std::ranges::input_range R>
+static auto extractTablesFromRecord(InputRecord& record, R matchers)
+{
+  std::vector<std::shared_ptr<arrow::Table>> tables;
+  std::ranges::transform(matchers, std::back_inserter(tables), [&record](auto const& m) {
+    return record.get<TableConsumer>(m)->asArrowTable();
+  });
+  return tables;
+}
+
 } // namespace
 
 namespace analysis_task_parsers
@@ -222,7 +233,7 @@ template <typename T>
   requires(is_spawns<T> || is_builds<T> || is_defines<T>)
 bool appendOutput(std::vector<OutputSpec>& outputs, T& entity, uint32_t)
 {
-  outputs.emplace_back(entity.spec());
+  outputs.emplace_back(entity.outputSpec);
   return true;
 }
 
@@ -277,7 +288,7 @@ template <is_spawns T>
 bool prepareOutput(ProcessingContext& context, T& spawns)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::N, metadata::template generateSources<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].origin_hash>>()>(context), std::span{metadata::base_table_t::originalLabels});
+  auto originalTable = soa::ArrowHelpers::joinTables( framework::extractTablesFromRecord(context.inputs(), spawns.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ) );
   if (originalTable->num_rows() == 0) {
     originalTable = makeEmptyTable("EMPTY", typename metadata::base_table_t::persistent_columns_t{});
   }
@@ -296,7 +307,7 @@ template <is_builds T>
 bool prepareOutput(ProcessingContext& context, T& builds)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::buildable_t::ref.desc_hash>>::metadata;
-  return builds.build(extractOriginals<metadata::N, metadata::template generateSources<o2::aod::Hash<T::buildable_t::ref.origin_hash>>()>(context));
+  return builds.build(framework::extractTablesFromRecord(context.inputs(), builds.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ));
 }
 
 template <is_defines T>
@@ -304,7 +315,7 @@ bool prepareOutput(ProcessingContext& context, T& defines)
   requires(T::delayed == false)
 {
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::N, metadata::template generateSources<o2::aod::Hash<T::spawnable_t::originals[T::spawnable_t::originals.size() - 1].origin_hash>>()>(context), std::span{metadata::base_table_t::originalLabels});
+  auto originalTable = soa::ArrowHelpers::joinTables( framework::extractTablesFromRecord(context.inputs(), defines.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ) );
   if (originalTable->num_rows() == 0) {
     originalTable = makeEmptyTable("EMPTY", typename metadata::base_table_t::persistent_columns_t{});
   }
@@ -336,7 +347,7 @@ bool prepareDelayedOutput(ProcessingContext& context, T& defines)
     defines.recompile();
   }
   using metadata = o2::aod::MetadataTrait<o2::aod::Hash<T::spawnable_t::ref.desc_hash>>::metadata;
-  auto originalTable = soa::ArrowHelpers::joinTables(extractOriginals<metadata::sources.size(), metadata::sources>(context), std::span{metadata::base_table_t::originalLabels});
+  auto originalTable = soa::ArrowHelpers::joinTables( framework::extractTablesFromRecord(context.inputs(), defines.requiredInputs | std::views::transform([](auto const& input){ return DataSpecUtils::asConcreteDataMatcher(input); }) ) );
   if (originalTable->num_rows() == 0) {
     originalTable = makeEmptyTable<metadata::base_table_t::ref>();
   }

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -261,6 +261,7 @@ bool prepareOutput(ProcessingContext&, T&)
 template <is_produces T>
 bool prepareOutput(ProcessingContext& context, T& produces)
 {
+  /// FIXME: use matcher instead of an OutputRef
   produces.resetCursor(std::move(context.outputs().make<TableBuilder>(soa::tableRef2OutputRef<T::persistent_table_t::ref>())));
   return true;
 }

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -159,13 +159,12 @@ const char* controlOption()
 }
 
 template <typename T>
-concept with_base_table = requires { T::base_specs(); };
+concept with_required_inputs = requires(T t) { t.requiredInputs.size(); };
 
-template <with_base_table T>
-bool requestInputs(std::vector<InputSpec>& inputs, T const& /*entity*/)
+template <with_required_inputs T>
+bool requestInputs(std::vector<InputSpec>& inputs, T const& entity)
 {
-  auto base_specs = T::base_specs();
-  for (auto base_spec : base_specs) {
+  for (auto base_spec : entity.requiredInputs) {
     base_spec.metadata.push_back(ConfigParamSpec{std::string{controlOption<T>()}, VariantType::Bool, true, {"\"\""}});
     DataSpecUtils::updateInputList(inputs, std::forward<InputSpec>(base_spec));
   }
@@ -388,21 +387,24 @@ bool finalizeOutput(ProcessingContext& context, T& producesGroup)
 template <is_spawns T>
 bool finalizeOutput(ProcessingContext& context, T& spawns)
 {
-  context.outputs().adopt(spawns.output(), spawns.asArrowTable());
+  auto matcher = DataSpecUtils::asConcreteDataMatcher(spawns.outputSpec);
+  context.outputs().adopt(Output{matcher.origin, matcher.description, matcher.subSpec}, spawns.asArrowTable());
   return true;
 }
 
 template <is_builds T>
 bool finalizeOutput(ProcessingContext& context, T& builds)
 {
-  context.outputs().adopt(builds.output(), builds.asArrowTable());
+  auto matcher = DataSpecUtils::asConcreteDataMatcher(builds.outputSpec);
+  context.outputs().adopt(Output{matcher.origin, matcher.description, matcher.subSpec}, builds.asArrowTable());
   return true;
 }
 
 template <is_defines T>
 bool finalizeOutput(ProcessingContext& context, T& defines)
 {
-  context.outputs().adopt(defines.output(), defines.asArrowTable());
+  auto matcher = DataSpecUtils::asConcreteDataMatcher(defines.outputSpec);
+  context.outputs().adopt(Output{matcher.origin, matcher.description, matcher.subSpec}, defines.asArrowTable());
   return true;
 }
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -97,6 +97,9 @@ struct AnalysisDataProcessorBuilder {
   static void addOriginalRef(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
   {
     auto spec = soa::tableRef2InputSpec<R>(newOrigin);
+    if (R.origin_hash != "AOD"_h) {
+      spec.metadata.emplace_back(ConfigParamSpec{"aod-origin-replaced", VariantType::Bool, true, {"\"\""}});
+    }
     spec.metadata.emplace_back(ConfigParamSpec{std::string{"control:"} + name, VariantType::Bool, value, {"\"\""}});
     auto matcher = DataSpecUtils::asConcreteDataMatcher(spec);
     DataSpecUtils::updateInputList(inputs, std::move(spec));

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -526,6 +526,18 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<ExpressionInfo> expressionInfos;
   std::vector<InputInfo> inputInfos;
 
+  std::string replacementOrigin;
+  header::DataOrigin newOrigin{"AOD"};
+  if (ctx.options().hasOption("aod-origin-replace")) {
+    replacementOrigin = ctx.options().get<std::string>("aod-origin-replace");
+    if (replacementOrigin.size() > 4UL) {
+      wrongOriginReplacement(replacementOrigin);
+    }
+  }
+  if (!replacementOrigin.empty()) {
+    newOrigin.runtimeInit(replacementOrigin.c_str(), std::min(replacementOrigin.size(), 4UL));
+  }
+
   constexpr const int numElements = nested_brace_constructible_size<false, std::decay_t<T>>() / 10;
 
   /// make sure options and configurables are set before expression infos are created

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -235,16 +235,6 @@ struct AnalysisDataProcessorBuilder {
   {
   }
 
-  template <soa::TableRef R>
-  static auto extractTableFromRecord(InputRecord& record)
-  {
-    auto table = record.get<TableConsumer>(o2::aod::matcher<R>())->asArrowTable();
-    if (table->num_rows() == 0) {
-      table = makeEmptyTable<R>();
-    }
-    return table;
-  }
-
   template <std::ranges::input_range R>
   static auto extractTablesFromRecord(InputRecord& record, R matchers)
   {
@@ -293,7 +283,8 @@ struct AnalysisDataProcessorBuilder {
   template <soa::is_table_or_iterator T, int AI>
   static auto extract(InputRecord& record, std::vector<InputInfo> iInfos, std::vector<ExpressionInfo>& infos, size_t phash)
   {
-    auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers | std::views::filter([](auto const& pair) { return pair.first == AI; });
+    auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers
+                    | std::views::filter([](auto const& pair) { return pair.first == AI; });
     if constexpr (soa::is_filtered<T>) {
       return extractFilteredFromRecord<T>(record, matchers, *std::ranges::find_if(infos, [&phash](ExpressionInfo const& i) { return (i.processHash == phash && i.argumentIndex == AI); }));
     } else {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -148,12 +148,6 @@ struct AnalysisDataProcessorBuilder {
     }.template operator()<A::originals.size(), std::decay_t<A>::originals>(std::make_index_sequence<std::decay_t<A>::originals.size()>());
   }
 
-  // template <soa::is_iterator A>
-  // static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash, header::DataOrigin&& newOrigin = header::DataOrigin{"AOD"})
-  // {
-  //   addInput<typename std::decay_t<A>::parent_t>(name, value, inputs, iInfos, ai, hash, newOrigin);
-  // }
-
   /// helper to append the inputs and expression information for normalized arguments
   template <soa::is_table... As>
   static void addInputsAndExpressions(uint32_t hash, const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos, header::DataOrigin&& newOrigin = header::DataOrigin{"AOD"})

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -594,14 +594,6 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   // replace origins in Preslice declarations
   homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element){ return analysis_task_parsers::replaceOrigin(element, newOrigin); }, *task.get());
 
-  /// FIXME: In order to replace origins consistently, there are following things that need to be touched
-  /// 1. inputs and outputs, including their metadata - done
-  /// 2. inputInfos, that contain matchers for extracting arguments of process functions - done in the 1st step
-  /// 3. bindingKeys/bindingKeysUnsorted, that contain matchers to extract tables used to calculate slicing - preslices are update, bks are updated
-  /// 4. Produces/Spawns/Defines/Builds contain matchers for required inputs and created outputs that need to be modified - same
-  ///
-  /// 3a. GroupSlicer has to use runtime list of extractions
-
   auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos, newOrigin, newOriginStr](InitContext& ic) mutable {
     Cache bindingsKeys;
     Cache bindingsKeysUnsorted;

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -69,15 +69,6 @@ concept is_enumeration = is_enumeration_v<std::decay_t<T>>;
 template <typename T>
 concept is_table_iterator_or_enumeration = soa::is_table_or_iterator<T> || is_enumeration<T>;
 
-/// Structure to contain mapping between matchers and process functions.
-/// Process function is identified by hash, each matcher has associated
-/// argument position for that process function; single argument can have
-/// many matchers associated due to complicated joins
-struct InputInfo {
-  uint32_t hash;
-  std::vector<std::pair<int, ConcreteDataMatcher>> matchers;
-};
-
 // Helper struct which builds a DataProcessorSpec from
 // the contents of an AnalysisTask...
 namespace
@@ -268,16 +259,16 @@ struct AnalysisDataProcessorBuilder {
     }
   }
 
-  template <is_enumeration T, int AI>
-  static auto extract(InputRecord&, std::vector<InputInfo>, std::vector<ExpressionInfo>&, size_t)
+  template <is_enumeration T, int AI, std::ranges::input_range R>
+  static auto extract(InputRecord&, R, std::vector<ExpressionInfo>&, size_t)
   {
     return T{};
   }
 
-  template <soa::is_table_or_iterator T, int AI>
-  static auto extract(InputRecord& record, std::vector<InputInfo> iInfos, std::vector<ExpressionInfo>& infos, size_t phash)
+  template <soa::is_table_or_iterator T, int AI, std::ranges::input_range R>
+  static auto extract(InputRecord& record, R matchers, std::vector<ExpressionInfo>& infos, size_t phash)
   {
-    auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers | std::views::filter([](auto const& pair) { return pair.first == AI; });
+    // auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers | std::views::filter([](auto const& pair) { return pair.first == AI; });
     if constexpr (soa::is_filtered<T>) {
       return extractFilteredFromRecord<T>(record, matchers, *std::ranges::find_if(infos, [&phash](ExpressionInfo const& i) { return (i.processHash == phash && i.argumentIndex == AI); }));
     } else {
@@ -285,21 +276,20 @@ struct AnalysisDataProcessorBuilder {
     }
   }
 
-  template <typename C, is_table_iterator_or_enumeration Grouping, soa::is_table... Args>
-  static auto bindGroupingTable(InputRecord& record, std::vector<InputInfo> iInfos, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
+  template <std::ranges::input_range R, typename C, is_table_iterator_or_enumeration Grouping, soa::is_table... Args>
+  static auto bindGroupingTable(InputRecord& record, R matchers, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
     requires(!std::same_as<Grouping, void>)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(Grouping, Args...)>();
-    return extract<std::decay_t<Grouping>, 0>(record, iInfos, infos, hash);
+    return extract<std::decay_t<Grouping>, 0>(record, matchers | std::views::filter([](auto const& pair) { return pair.first == 0; }), infos, hash);
   }
 
-  template <typename C, is_table_iterator_or_enumeration Grouping, soa::is_table... Args>
-  static auto bindAssociatedTables(InputRecord& record, std::vector<InputInfo> iInfos, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
+  template <std::ranges::input_range R, typename C, is_table_iterator_or_enumeration Grouping, soa::is_table... Args>
+  static auto bindAssociatedTables(InputRecord& record, R matchers, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
     requires(!std::same_as<Grouping, void> && sizeof...(Args) > 0)
   {
-    constexpr auto p = pack<Args...>{};
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(Grouping, Args...)>();
-    return std::make_tuple(extract<std::decay_t<Args>, has_type_at_v<Args>(p) + 1>(record, iInfos, infos, hash)...);
+    return std::make_tuple(extract<std::decay_t<Args>, has_type_at_v<Args>(pack<Args...>{}) + 1>(record, matchers | std::views::filter([](auto const& pair) { return pair.first == has_type_at_v<Args>(pack<Args...>{}) + 1; }), infos, hash)...);
   }
 
   template <soa::is_table... As>
@@ -308,11 +298,11 @@ struct AnalysisDataProcessorBuilder {
     (std::get<As>(dest).bindInternalIndicesTo(&std::get<As>(src)), ...);
   }
 
-  template <typename Task, is_table_iterator_or_enumeration Grouping, soa::is_table... Associated>
-  static void invokeProcess(Task& task, InputRecord& inputs, std::vector<InputInfo> iInfos, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+  template <typename Task, is_table_iterator_or_enumeration Grouping, std::ranges::input_range R, soa::is_table... Associated>
+  static void invokeProcess(Task& task, InputRecord& inputs, R matchers, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
   {
     using G = std::decay_t<Grouping>;
-    auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, iInfos, processingFunction, infos);
+    auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, matchers, processingFunction, infos);
 
     constexpr const int numElements = nested_brace_constructible_size<false, std::decay_t<Task>>() / 10;
 
@@ -341,7 +331,7 @@ struct AnalysisDataProcessorBuilder {
       }
     } else {
       // multiple arguments to process
-      auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, iInfos, processingFunction, infos);
+      auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, matchers, processingFunction, infos);
       // pre-bind self indices
       std::apply(
         [&task](auto&... t) mutable {
@@ -381,7 +371,7 @@ struct AnalysisDataProcessorBuilder {
                                                 task);
       overwriteInternalIndices(associatedTables, associatedTables);
       if constexpr (soa::is_iterator<G>) {
-        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, newOrigin);
+        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, matchers, newOrigin);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
           overwriteInternalIndices(associatedSlices, associatedTables);
@@ -674,14 +664,18 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       }
       // execute process()
       if constexpr (requires { &T::process; }) {
-        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), inputInfos, &T::process, expressionInfos, slices, newOrigin);
+        constexpr auto phash = o2::framework::TypeIdHelpers::uniqueId<decltype(&T::process)>();
+        auto matchers = std::ranges::find_if(inputInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers;
+        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), matchers, &T::process, expressionInfos, slices, newOrigin);
       }
       // execute optional process()
       homogeneous_apply_refs_sized<numElements>(
         [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOrigin](auto& x) {
           if constexpr (is_process_configurable<decltype(x)>) {
             if (x.value == true) {
-              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), inputInfos, x.process, expressionInfos, slices, newOrigin);
+              constexpr auto phash = o2::framework::TypeIdHelpers::uniqueId<decltype(x.process)>();
+              auto matchers = std::ranges::find_if(inputInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers;
+              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), matchers, x.process, expressionInfos, slices, newOrigin);
               return true;
             }
             return false;

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -574,6 +574,12 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());
   homogeneous_apply_refs_sized<numElements>([&requiredServices](auto& element) { return analysis_task_parsers::addService(requiredServices, element); }, *task.get());
 
+  /// FIXME: In order to replace origins consistently, there are following things that need to be touched
+  /// 1. inputs and outputs, including their metadata
+  /// 2. inputInfos, that contain matchers for extracting arguments of process functions
+  /// 3. bindingKeys/bindingKeysUnsorted, that contain matchers to extract tables used to calculate slicing (created in init)
+  /// 4. Produces/Spawns/Defines/Builds contain matchers for required inputs and created outputs that need to be modified
+
   auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos](InitContext& ic) mutable {
     Cache bindingsKeys;
     Cache bindingsKeysUnsorted;

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -277,8 +277,7 @@ struct AnalysisDataProcessorBuilder {
   template <soa::is_table_or_iterator T, int AI>
   static auto extract(InputRecord& record, std::vector<InputInfo> iInfos, std::vector<ExpressionInfo>& infos, size_t phash)
   {
-    auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers
-                    | std::views::filter([](auto const& pair) { return pair.first == AI; });
+    auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers | std::views::filter([](auto const& pair) { return pair.first == AI; });
     if constexpr (soa::is_filtered<T>) {
       return extractFilteredFromRecord<T>(record, matchers, *std::ranges::find_if(infos, [&phash](ExpressionInfo const& i) { return (i.processHash == phash && i.argumentIndex == AI); }));
     } else {
@@ -563,7 +562,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   }
 
   // update OutputSpecs in output declarations
-  homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element){ return analysis_task_parsers::updateOutputSpec(element, newOrigin); }, *task.get());
+  homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element) { return analysis_task_parsers::updateOutputSpec(element, newOrigin); }, *task.get());
 
   // Auto-register default ccdb: path options from subscribed timestamped-table inputs.
   // This allows tasks to accept --ccdb:fXxx overrides without requiring an explicit
@@ -586,7 +585,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   homogeneous_apply_refs_sized<numElements>([&requiredServices](auto& element) { return analysis_task_parsers::addService(requiredServices, element); }, *task.get());
 
   // replace origins in Preslice declarations
-  homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element){ return analysis_task_parsers::replaceOrigin(element, newOrigin); }, *task.get());
+  homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element) { return analysis_task_parsers::replaceOrigin(element, newOrigin); }, *task.get());
 
   auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos, newOrigin, newOriginStr](InitContext& ic) mutable {
     Cache bindingsKeys;
@@ -635,13 +634,13 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       *task.get());
 
     /// replace origin in slicing caches
-    std::ranges::transform(bindingsKeys, bindingsKeys.begin(), [&newOrigin](Entry& entry){
+    std::ranges::transform(bindingsKeys, bindingsKeys.begin(), [&newOrigin](Entry& entry) {
       if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
         entry.matcher = replaceOrigin(entry.matcher, newOrigin);
       }
       return entry;
     });
-    std::ranges::transform(bindingsKeysUnsorted, bindingsKeysUnsorted.begin(), [&newOrigin](Entry& entry){
+    std::ranges::transform(bindingsKeysUnsorted, bindingsKeysUnsorted.begin(), [&newOrigin](Entry& entry) {
       if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
         entry.matcher = replaceOrigin(entry.matcher, newOrigin);
       }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -558,8 +558,8 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   // request base tables for spawnable extended tables and indices to be built
   // this checks for duplications
-  homogeneous_apply_refs_sized<numElements>([&inputs](auto& element) {
-    return analysis_task_parsers::requestInputs(inputs, element);
+  homogeneous_apply_refs_sized<numElements>([&inputs, &newOrigin](auto& element) {
+    return analysis_task_parsers::requestInputs(inputs, element, newOrigin);
   },
                                             *task.get());
 
@@ -567,6 +567,9 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   if (inputs.empty() == true) {
     LOG(warn) << "Task " << name_str << " has no inputs";
   }
+
+  // update OutputSpecs in output declarations
+  homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element){ return analysis_task_parsers::updateOutputSpec(element, newOrigin); }, *task.get());
 
   // Auto-register default ccdb: path options from subscribed timestamped-table inputs.
   // This allows tasks to accept --ccdb:fXxx overrides without requiring an explicit
@@ -579,8 +582,10 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     }
   }
 
+  // append outputs
   homogeneous_apply_refs_sized<numElements>([&outputs, &hash](auto& element) { return analysis_task_parsers::appendOutput(outputs, element, hash); }, *task.get());
 
+  // request services
   auto requiredServices = CommonServices::defaultServices();
   auto arrowServices = CommonServices::arrowServices();
   requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -316,7 +316,7 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename Task, is_table_iterator_or_enumeration Grouping, soa::is_table... Associated>
-  static void invokeProcess(Task& task, InputRecord& inputs, std::vector<InputInfo> iInfos, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, std::string const& newOriginStr)
+  static void invokeProcess(Task& task, InputRecord& inputs, std::vector<InputInfo> iInfos, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
   {
     using G = std::decay_t<Grouping>;
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, iInfos, processingFunction, infos);
@@ -388,7 +388,7 @@ struct AnalysisDataProcessorBuilder {
                                                 task);
       overwriteInternalIndices(associatedTables, associatedTables);
       if constexpr (soa::is_iterator<G>) {
-        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, newOriginStr);
+        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, newOrigin);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
           overwriteInternalIndices(associatedSlices, associatedTables);
@@ -664,8 +664,9 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
     ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
     ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));
+    ic.services().get<ArrowTableSlicingCacheDef>().setOrigin(newOrigin);
 
-    return [task, expressionInfos, inputInfos, newOriginStr](ProcessingContext& pc) mutable {
+    return [task, expressionInfos, inputInfos, newOrigin](ProcessingContext& pc) mutable {
       // load the ccdb object from their cache
       homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::newDataframeCondition(pc.inputs(), element); }, *task.get());
       // reset partitions once per dataframe
@@ -688,14 +689,14 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       }
       // execute process()
       if constexpr (requires { &T::process; }) {
-        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), inputInfos, &T::process, expressionInfos, slices, newOriginStr);
+        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), inputInfos, &T::process, expressionInfos, slices, newOrigin);
       }
       // execute optional process()
       homogeneous_apply_refs_sized<numElements>(
-        [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOriginStr](auto& x) {
+        [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOrigin](auto& x) {
           if constexpr (is_process_configurable<decltype(x)>) {
             if (x.value == true) {
-              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), inputInfos, x.process, expressionInfos, slices, newOriginStr);
+              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), inputInfos, x.process, expressionInfos, slices, newOrigin);
               return true;
             }
             return false;

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -69,6 +69,15 @@ concept is_enumeration = is_enumeration_v<std::decay_t<T>>;
 template <typename T>
 concept is_table_iterator_or_enumeration = soa::is_table_or_iterator<T> || is_enumeration<T>;
 
+/// Structure to contain mapping between matchers and process functions.
+/// Process function is identified by hash, each matcher has associated
+/// argument position for that process function; single argument can have
+/// many matchers associated due to complicated joins
+struct InputInfo {
+  uint32_t hash;
+  std::vector<std::pair<int, ConcreteDataMatcher>> matchers;
+};
+
 // Helper struct which builds a DataProcessorSpec from
 // the contents of an AnalysisTask...
 namespace
@@ -94,11 +103,20 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <soa::TableRef R>
-  static void addOriginalRef(const char* name, bool value, std::vector<InputSpec>& inputs)
+  static void addOriginalRef(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash)
   {
     auto spec = soa::tableRef2InputSpec<R>();
     spec.metadata.emplace_back(ConfigParamSpec{std::string{"control:"} + name, VariantType::Bool, value, {"\"\""}});
     DataSpecUtils::updateInputList(inputs, std::move(spec));
+    auto matcher = DataSpecUtils::asConcreteDataMatcher(spec);
+    auto locate = std::ranges::find_if(iInfos, [&hash](auto const& info) { return info.hash == hash; });
+    if (locate == iInfos.end()) {
+      iInfos.emplace_back(hash, std::vector{std::pair{ai, matcher}});
+    } else {
+      if (std::ranges::none_of(locate->matchers, [&ai, &matcher](auto const& match) { return (match.first == ai) && (match.second == matcher); })) {
+        locate->matchers.emplace_back(std::pair{ai, matcher});
+      }
+    }
   }
 
   /// helpers to append expression information for a single argument
@@ -123,43 +141,43 @@ struct AnalysisDataProcessorBuilder {
 
   /// helpers to append InputSpec for a single argument
   template <soa::is_table A>
-  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs)
+  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash)
   {
-    [&name, &value, &inputs]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) mutable {
-      (addOriginalRef<refs[Is]>(name, value, inputs), ...);
+    [&name, &value, &inputs, &iInfos, &ai, &hash]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) mutable {
+      (addOriginalRef<refs[Is]>(name, value, inputs, iInfos, ai, hash), ...);
     }.template operator()<A::originals.size(), std::decay_t<A>::originals>(std::make_index_sequence<std::decay_t<A>::originals.size()>());
   }
 
   template <soa::is_iterator A>
-  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs)
+  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash)
   {
-    addInput<typename std::decay_t<A>::parent_t>(name, value, inputs);
+    addInput<typename std::decay_t<A>::parent_t>(name, value, inputs, iInfos, ai, hash);
   }
 
   /// helper to append the inputs and expression information for normalized arguments
   template <soa::is_table... As>
-  static void addInputsAndExpressions(uint32_t hash, const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
+  static void addInputsAndExpressions(uint32_t hash, const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos)
   {
     int ai = -1;
-    ([&ai, &hash, &eInfos, &name, &value, &inputs]() mutable {
+    ([&ai, &hash, &eInfos, &name, &value, &inputs, &iInfos]() mutable {
       ++ai;
       using T = std::decay_t<As>;
       addExpression<T>(ai, hash, eInfos);
-      addInput<T>(name, value, inputs);
+      addInput<T>(name, value, inputs, iInfos, ai, hash);
     }(),
      ...);
   }
 
   /// helper to parse the process arguments
   template <typename T>
-  inline static bool requestInputsFromArgs(T&, std::string const&, std::vector<InputSpec>&, std::vector<ExpressionInfo>&)
+  inline static bool requestInputsFromArgs(T&, std::string const&, std::vector<InputSpec>&, std::vector<ExpressionInfo>&, std::vector<InputInfo>&)
   {
     return false;
   }
   template <is_process_configurable T>
-  inline static bool requestInputsFromArgs(T& pc, std::string const& name, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eis)
+  inline static bool requestInputsFromArgs(T& pc, std::string const& name, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eis, std::vector<InputInfo>& iifs)
   {
-    AnalysisDataProcessorBuilder::inputsFromArgs(pc.process, (name + "/" + pc.name).c_str(), pc.value, inputs, eis);
+    AnalysisDataProcessorBuilder::inputsFromArgs(pc.process, (name + "/" + pc.name).c_str(), pc.value, inputs, eis, iifs);
     return true;
   }
   template <typename T>
@@ -175,7 +193,7 @@ struct AnalysisDataProcessorBuilder {
   }
   /// 1. enumeration (must be the only argument)
   template <typename C, is_enumeration A>
-  static void inputsFromArgs(void (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&) //, Cache&, Cache&)
+  static void inputsFromArgs(void (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&, std::vector<InputInfo>&)
   {
     std::vector<ConfigParamSpec> inputMetadata;
     // FIXME: for the moment we do not support begin, end and step.
@@ -184,20 +202,20 @@ struct AnalysisDataProcessorBuilder {
 
   /// 2. 1st argument is an iterator
   template <typename C, soa::is_iterator A, soa::is_table... Args>
-  static void inputsFromArgs(void (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos) //, Cache& bk, Cache& bku)
+  static void inputsFromArgs(void (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos)
     requires(std::is_lvalue_reference_v<A> && (std::is_lvalue_reference_v<Args> && ...))
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(A, Args...)>();
-    addInputsAndExpressions<typename std::decay_t<A>::parent_t, Args...>(hash, name, value, inputs, eInfos);
+    addInputsAndExpressions<typename std::decay_t<A>::parent_t, Args...>(hash, name, value, inputs, eInfos, iInfos);
   }
 
   /// 3. generic case
   template <typename C, soa::is_table... Args>
-  static void inputsFromArgs(void (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos) //, Cache&, Cache&)
+  static void inputsFromArgs(void (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos)
     requires(std::is_lvalue_reference_v<Args> && ...)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(Args...)>();
-    addInputsAndExpressions<Args...>(hash, name, value, inputs, eInfos);
+    addInputsAndExpressions<Args...>(hash, name, value, inputs, eInfos, iInfos);
   }
 
   /// 1. enumeration (no grouping)
@@ -227,28 +245,32 @@ struct AnalysisDataProcessorBuilder {
     return table;
   }
 
-  template <soa::is_table T>
-  static auto extractFromRecord(InputRecord& record)
+  template <std::ranges::input_range R>
+  static auto extractTablesFromRecord(InputRecord& record, R matchers)
   {
-    return T { [&record]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) { return std::vector{extractTableFromRecord<refs[Is]>(record)...}; }.template operator()<T::originals.size(), T::originals>(std::make_index_sequence<T::originals.size()>()) };
+    std::vector<std::shared_ptr<arrow::Table>> tables;
+    std::ranges::transform(matchers, std::back_inserter(tables), [&record](auto const& m) {
+      return record.get<TableConsumer>(m.second)->asArrowTable();
+    });
+    return tables;
   }
 
-  template <soa::is_iterator T>
-  static auto extractFromRecord(InputRecord& record)
+  template <soa::is_table T, std::ranges::input_range R>
+  static auto extractFromRecord(InputRecord& record, R matchers)
   {
-    return typename T::parent_t { [&record]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) { return std::vector{extractTableFromRecord<refs[Is]>(record)...}; }.template operator()<T::parent_t::originals.size(), T::parent_t::originals>(std::make_index_sequence<T::parent_t::originals.size()>()) };
+    return T{extractTablesFromRecord(record, matchers)};
   }
 
-  template <soa::is_filtered T>
-  static auto extractFilteredFromRecord(InputRecord& record, ExpressionInfo& info)
+  template <soa::is_iterator T, std::ranges::input_range R>
+  static auto extractFromRecord(InputRecord& record, R matchers)
   {
-    std::shared_ptr<arrow::Table> table = nullptr;
-    auto joiner = [&record]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) { return std::vector{extractTableFromRecord<refs[Is]>(record)...}; };
-    if constexpr (soa::is_iterator<T>) {
-      table = o2::soa::ArrowHelpers::joinTables(joiner.template operator()<T::parent_t::originals.size(), T::parent_t::originals>(std::make_index_sequence<T::parent_t::originals.size()>()), std::span{T::parent_t::originalLabels});
-    } else {
-      table = o2::soa::ArrowHelpers::joinTables(joiner.template operator()<T::originals.size(), T::originals>(std::make_index_sequence<T::originals.size()>()), std::span{T::originalLabels});
-    }
+    return typename T::parent_t{extractTablesFromRecord(record, matchers)};
+  }
+
+  template <soa::is_filtered T, std::ranges::input_range R>
+  static auto extractFilteredFromRecord(InputRecord& record, R matchers, ExpressionInfo& info)
+  {
+    std::shared_ptr<arrow::Table> table = soa::ArrowHelpers::joinTables(extractTablesFromRecord(record, matchers));
     expressions::updateFilterInfo(info, table);
     if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
       if (info.selection == nullptr) {
@@ -263,46 +285,37 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <is_enumeration T, int AI>
-  static auto extract(InputRecord&, std::vector<ExpressionInfo>&, size_t)
+  static auto extract(InputRecord&, std::vector<InputInfo>, std::vector<ExpressionInfo>&, size_t)
   {
     return T{};
   }
 
-  template <soa::is_iterator T, int AI>
-  static auto extract(InputRecord& record, std::vector<ExpressionInfo>& infos, size_t phash)
+  template <soa::is_table_or_iterator T, int AI>
+  static auto extract(InputRecord& record, std::vector<InputInfo> iInfos, std::vector<ExpressionInfo>& infos, size_t phash)
   {
-    if constexpr (std::same_as<typename T::policy_t, soa::FilteredIndexPolicy>) {
-      return extractFilteredFromRecord<T>(record, *std::find_if(infos.begin(), infos.end(), [&phash](ExpressionInfo const& i) { return (i.processHash == phash && i.argumentIndex == AI); }));
+    auto matchers = std::ranges::find_if(iInfos, [&phash](auto const& info) { return info.hash == phash; })->matchers | std::views::filter([](auto const& pair) { return pair.first == AI; });
+    if constexpr (soa::is_filtered<T>) {
+      return extractFilteredFromRecord<T>(record, matchers, *std::ranges::find_if(infos, [&phash](ExpressionInfo const& i) { return (i.processHash == phash && i.argumentIndex == AI); }));
     } else {
-      return extractFromRecord<T>(record);
-    }
-  }
-
-  template <soa::is_table T, int AI>
-  static auto extract(InputRecord& record, std::vector<ExpressionInfo>& infos, size_t phash)
-  {
-    if constexpr (soa::is_filtered_table<T>) {
-      return extractFilteredFromRecord<T>(record, *std::find_if(infos.begin(), infos.end(), [&phash](ExpressionInfo const& i) { return (i.processHash == phash && i.argumentIndex == AI); }));
-    } else {
-      return extractFromRecord<T>(record);
+      return extractFromRecord<T>(record, matchers);
     }
   }
 
   template <typename C, is_table_iterator_or_enumeration Grouping, soa::is_table... Args>
-  static auto bindGroupingTable(InputRecord& record, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
+  static auto bindGroupingTable(InputRecord& record, std::vector<InputInfo> iInfos, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
     requires(!std::same_as<Grouping, void>)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(Grouping, Args...)>();
-    return extract<std::decay_t<Grouping>, 0>(record, infos, hash);
+    return extract<std::decay_t<Grouping>, 0>(record, iInfos, infos, hash);
   }
 
   template <typename C, is_table_iterator_or_enumeration Grouping, soa::is_table... Args>
-  static auto bindAssociatedTables(InputRecord& record, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
+  static auto bindAssociatedTables(InputRecord& record, std::vector<InputInfo> iInfos, void (C::*)(Grouping, Args...), std::vector<ExpressionInfo>& infos)
     requires(!std::same_as<Grouping, void> && sizeof...(Args) > 0)
   {
     constexpr auto p = pack<Args...>{};
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(Grouping, Args...)>();
-    return std::make_tuple(extract<std::decay_t<Args>, has_type_at_v<Args>(p) + 1>(record, infos, hash)...);
+    return std::make_tuple(extract<std::decay_t<Args>, has_type_at_v<Args>(p) + 1>(record, iInfos, infos, hash)...);
   }
 
   template <soa::is_table... As>
@@ -312,10 +325,10 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename Task, is_table_iterator_or_enumeration Grouping, soa::is_table... Associated>
-  static void invokeProcess(Task& task, InputRecord& inputs, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices)
+  static void invokeProcess(Task& task, InputRecord& inputs, std::vector<InputInfo> iInfos, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices)
   {
     using G = std::decay_t<Grouping>;
-    auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, processingFunction, infos);
+    auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, iInfos, processingFunction, infos);
 
     constexpr const int numElements = nested_brace_constructible_size<false, std::decay_t<Task>>() / 10;
 
@@ -340,15 +353,11 @@ struct AnalysisDataProcessorBuilder {
           std::invoke(processingFunction, task, *element);
         }
       } else {
-        static_assert(soa::is_table<G> || is_enumeration<G>,
-                      "Single argument of process() should be a table-like or an iterator");
         std::invoke(processingFunction, task, groupingTable);
       }
     } else {
       // multiple arguments to process
-      static_assert(((soa::is_iterator<std::decay_t<Associated>> == false) && ...),
-                    "Associated arguments of process() should not be iterators");
-      auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, processingFunction, infos);
+      auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, iInfos, processingFunction, infos);
       // pre-bind self indices
       std::apply(
         [&task](auto&... t) mutable {
@@ -387,7 +396,7 @@ struct AnalysisDataProcessorBuilder {
       },
                                                 task);
       overwriteInternalIndices(associatedTables, associatedTables);
-      if constexpr (soa::is_iterator<std::decay_t<G>>) {
+      if constexpr (soa::is_iterator<G>) {
         auto slicer = GroupSlicer(groupingTable, associatedTables, slices);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
@@ -405,7 +414,9 @@ struct AnalysisDataProcessorBuilder {
           },
                                                     task);
 
-          invokeProcessWithArgs(task, processingFunction, slice.groupingElement(), associatedSlices);
+          [](Task& task, void (Task::*processingFunction)(Grouping, Associated...), Grouping g, std::tuple<std::decay_t<Associated>...>& at) {
+            std::invoke(processingFunction, task, g, std::get<std::decay_t<Associated>>(at)...);
+          }(task, processingFunction, slice.groupingElement(), associatedSlices);
         }
       } else {
         // bind partitions and grouping table
@@ -415,15 +426,11 @@ struct AnalysisDataProcessorBuilder {
         },
                                                   task);
 
-        invokeProcessWithArgs(task, processingFunction, groupingTable, associatedTables);
+        [](Task& task, void (Task::*processingFunction)(Grouping, Associated...), Grouping g, std::tuple<std::decay_t<Associated>...>& at) {
+          std::invoke(processingFunction, task, g, std::get<std::decay_t<Associated>>(at)...);
+        }(task, processingFunction, groupingTable, associatedTables);
       }
     }
-  }
-
-  template <typename C, typename T, is_table_iterator_or_enumeration G, soa::is_table... A>
-  static void invokeProcessWithArgs(C& task, T processingFunction, G g, std::tuple<A...>& at)
-  {
-    std::invoke(processingFunction, task, g, std::get<A>(at)...);
   }
 };
 } // namespace
@@ -502,7 +509,6 @@ auto getTaskNameSetProcesses(std::string& outputName, A... args)
   outputName = type_to_task_name(type_name_str);
   return task;
 }
-
 } // namespace
 
 /// Adaptor to make an AlgorithmSpec from a o2::framework::Task
@@ -527,6 +533,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<InputSpec> inputs;
   std::vector<ConfigParamSpec> options;
   std::vector<ExpressionInfo> expressionInfos;
+  std::vector<InputInfo> inputInfos;
 
   constexpr const int numElements = nested_brace_constructible_size<false, std::decay_t<T>>() / 10;
 
@@ -537,12 +544,12 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   /// parse process functions defined by corresponding configurables
   if constexpr (requires { &T::process; }) {
-    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos);
+    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos, inputInfos);
   }
   homogeneous_apply_refs_sized<numElements>(
-    [name = name_str, &expressionInfos, &inputs](auto& x) mutable {
+    [name = name_str, &expressionInfos, &inputs, &inputInfos](auto& x) mutable {
       // this pushes (argumentIndex, processHash, schemaPtr, nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
-      return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos);
+      return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos, inputInfos);
     },
     *task.get());
 
@@ -576,7 +583,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());
   homogeneous_apply_refs_sized<numElements>([&requiredServices](auto& element) { return analysis_task_parsers::addService(requiredServices, element); }, *task.get());
 
-  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos](InitContext& ic) mutable {
+  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos](InitContext& ic) mutable {
     Cache bindingsKeys;
     Cache bindingsKeysUnsorted;
     // add preslice declarations to slicing cache definition
@@ -625,7 +632,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
     ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));
 
-    return [task, expressionInfos](ProcessingContext& pc) mutable {
+    return [task, expressionInfos, inputInfos](ProcessingContext& pc) mutable {
       // load the ccdb object from their cache
       homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::newDataframeCondition(pc.inputs(), element); }, *task.get());
       // reset partitions once per dataframe
@@ -633,7 +640,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       // reset selections for the next dataframe
       std::ranges::for_each(expressionInfos, [](auto& info) { info.resetSelection = true; });
       // reset pre-slice for the next dataframe
-      auto slices = pc.services().get<ArrowTableSlicingCache>();
+      auto& slices = pc.services().get<ArrowTableSlicingCache>();
       homogeneous_apply_refs_sized<numElements>([&slices](auto& element) {
         return analysis_task_parsers::updateSliceInfo(element, slices);
       },
@@ -648,14 +655,14 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       }
       // execute process()
       if constexpr (requires { &T::process; }) {
-        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), &T::process, expressionInfos, slices);
+        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), inputInfos, &T::process, expressionInfos, slices);
       }
       // execute optional process()
       homogeneous_apply_refs_sized<numElements>(
-        [&pc, &expressionInfos, &task, &slices](auto& x) {
+        [&pc, &expressionInfos, &task, &slices, &inputInfos](auto& x) {
           if constexpr (is_process_configurable<decltype(x)>) {
             if (x.value == true) {
-              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), x.process, expressionInfos, slices);
+              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), inputInfos, x.process, expressionInfos, slices);
               return true;
             }
             return false;

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -371,7 +371,7 @@ struct AnalysisDataProcessorBuilder {
                                                 task);
       overwriteInternalIndices(associatedTables, associatedTables);
       if constexpr (soa::is_iterator<G>) {
-        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, matchers, newOrigin);
+        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, newOrigin);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
           overwriteInternalIndices(associatedSlices, associatedTables);

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -103,12 +103,12 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <soa::TableRef R>
-  static void addOriginalRef(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash)
+  static void addOriginalRef(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
   {
-    auto spec = soa::tableRef2InputSpec<R>();
+    auto spec = soa::tableRef2InputSpec<R>(newOrigin);
     spec.metadata.emplace_back(ConfigParamSpec{std::string{"control:"} + name, VariantType::Bool, value, {"\"\""}});
-    DataSpecUtils::updateInputList(inputs, std::move(spec));
     auto matcher = DataSpecUtils::asConcreteDataMatcher(spec);
+    DataSpecUtils::updateInputList(inputs, std::move(spec));
     auto locate = std::ranges::find_if(iInfos, [&hash](auto const& info) { return info.hash == hash; });
     if (locate == iInfos.end()) {
       iInfos.emplace_back(hash, std::vector{std::pair{ai, matcher}});
@@ -141,43 +141,43 @@ struct AnalysisDataProcessorBuilder {
 
   /// helpers to append InputSpec for a single argument
   template <soa::is_table A>
-  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash)
+  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash, header::DataOrigin&& newOrigin = header::DataOrigin{"AOD"})
   {
-    [&name, &value, &inputs, &iInfos, &ai, &hash]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) mutable {
-      (addOriginalRef<refs[Is]>(name, value, inputs, iInfos, ai, hash), ...);
+    [&name, &value, &inputs, &iInfos, &ai, &hash, newOrigin = std::move(newOrigin)]<size_t N, std::array<soa::TableRef, N> refs, size_t... Is>(std::index_sequence<Is...>) mutable {
+      (addOriginalRef<refs[Is]>(name, value, inputs, iInfos, ai, hash, newOrigin), ...);
     }.template operator()<A::originals.size(), std::decay_t<A>::originals>(std::make_index_sequence<std::decay_t<A>::originals.size()>());
   }
 
-  template <soa::is_iterator A>
-  static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash)
-  {
-    addInput<typename std::decay_t<A>::parent_t>(name, value, inputs, iInfos, ai, hash);
-  }
+  // template <soa::is_iterator A>
+  // static void addInput(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<InputInfo>& iInfos, int ai, uint32_t hash, header::DataOrigin&& newOrigin = header::DataOrigin{"AOD"})
+  // {
+  //   addInput<typename std::decay_t<A>::parent_t>(name, value, inputs, iInfos, ai, hash, newOrigin);
+  // }
 
   /// helper to append the inputs and expression information for normalized arguments
   template <soa::is_table... As>
-  static void addInputsAndExpressions(uint32_t hash, const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos)
+  static void addInputsAndExpressions(uint32_t hash, const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos, header::DataOrigin&& newOrigin = header::DataOrigin{"AOD"})
   {
     int ai = -1;
-    ([&ai, &hash, &eInfos, &name, &value, &inputs, &iInfos]() mutable {
+    ([&ai, &hash, &eInfos, &name, &value, &inputs, &iInfos, newOrigin]() mutable {
       ++ai;
       using T = std::decay_t<As>;
       addExpression<T>(ai, hash, eInfos);
-      addInput<T>(name, value, inputs, iInfos, ai, hash);
+      addInput<T>(name, value, inputs, iInfos, ai, hash, std::move(newOrigin));
     }(),
      ...);
   }
 
   /// helper to parse the process arguments
   template <typename T>
-  inline static bool requestInputsFromArgs(T&, std::string const&, std::vector<InputSpec>&, std::vector<ExpressionInfo>&, std::vector<InputInfo>&)
+  inline static bool requestInputsFromArgs(T&, std::string const&, std::vector<InputSpec>&, std::vector<ExpressionInfo>&, std::vector<InputInfo>&, header::DataOrigin)
   {
     return false;
   }
   template <is_process_configurable T>
-  inline static bool requestInputsFromArgs(T& pc, std::string const& name, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eis, std::vector<InputInfo>& iifs)
+  inline static bool requestInputsFromArgs(T& pc, std::string const& name, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eis, std::vector<InputInfo>& iifs, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
   {
-    AnalysisDataProcessorBuilder::inputsFromArgs(pc.process, (name + "/" + pc.name).c_str(), pc.value, inputs, eis, iifs);
+    AnalysisDataProcessorBuilder::inputsFromArgs(pc.process, (name + "/" + pc.name).c_str(), pc.value, inputs, eis, iifs, newOrigin);
     return true;
   }
   template <typename T>
@@ -193,7 +193,7 @@ struct AnalysisDataProcessorBuilder {
   }
   /// 1. enumeration (must be the only argument)
   template <typename C, is_enumeration A>
-  static void inputsFromArgs(void (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&, std::vector<InputInfo>&)
+  static void inputsFromArgs(void (C::*)(A), const char* /*name*/, bool /*value*/, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>&, std::vector<InputInfo>&, header::DataOrigin)
   {
     std::vector<ConfigParamSpec> inputMetadata;
     // FIXME: for the moment we do not support begin, end and step.
@@ -202,20 +202,20 @@ struct AnalysisDataProcessorBuilder {
 
   /// 2. 1st argument is an iterator
   template <typename C, soa::is_iterator A, soa::is_table... Args>
-  static void inputsFromArgs(void (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos)
+  static void inputsFromArgs(void (C::*)(A, Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
     requires(std::is_lvalue_reference_v<A> && (std::is_lvalue_reference_v<Args> && ...))
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(A, Args...)>();
-    addInputsAndExpressions<typename std::decay_t<A>::parent_t, Args...>(hash, name, value, inputs, eInfos, iInfos);
+    addInputsAndExpressions<typename std::decay_t<A>::parent_t, Args...>(hash, name, value, inputs, eInfos, iInfos, std::move(newOrigin));
   }
 
   /// 3. generic case
   template <typename C, soa::is_table... Args>
-  static void inputsFromArgs(void (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos)
+  static void inputsFromArgs(void (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<InputInfo>& iInfos, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
     requires(std::is_lvalue_reference_v<Args> && ...)
   {
     constexpr auto hash = o2::framework::TypeIdHelpers::uniqueId<void (C::*)(Args...)>();
-    addInputsAndExpressions<Args...>(hash, name, value, inputs, eInfos, iInfos);
+    addInputsAndExpressions<Args...>(hash, name, value, inputs, eInfos, iInfos, std::move(newOrigin));
   }
 
   /// 1. enumeration (no grouping)
@@ -316,7 +316,7 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename Task, is_table_iterator_or_enumeration Grouping, soa::is_table... Associated>
-  static void invokeProcess(Task& task, InputRecord& inputs, std::vector<InputInfo> iInfos, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices)
+  static void invokeProcess(Task& task, InputRecord& inputs, std::vector<InputInfo> iInfos, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, std::string const& newOriginStr)
   {
     using G = std::decay_t<Grouping>;
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, iInfos, processingFunction, infos);
@@ -388,7 +388,7 @@ struct AnalysisDataProcessorBuilder {
                                                 task);
       overwriteInternalIndices(associatedTables, associatedTables);
       if constexpr (soa::is_iterator<G>) {
-        auto slicer = GroupSlicer(groupingTable, associatedTables, slices);
+        auto slicer = GroupSlicer(groupingTable, associatedTables, slices, newOriginStr);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
           overwriteInternalIndices(associatedSlices, associatedTables);
@@ -526,16 +526,16 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<ExpressionInfo> expressionInfos;
   std::vector<InputInfo> inputInfos;
 
-  std::string replacementOrigin;
+  std::string newOriginStr;
   header::DataOrigin newOrigin{"AOD"};
   if (ctx.options().hasOption("aod-origin-replace")) {
-    replacementOrigin = ctx.options().get<std::string>("aod-origin-replace");
-    if (replacementOrigin.size() > 4UL) {
-      wrongOriginReplacement(replacementOrigin);
+    newOriginStr = ctx.options().get<std::string>("aod-origin-replace");
+    if (newOriginStr.size() > 4UL) {
+      wrongOriginReplacement(newOriginStr);
     }
   }
-  if (!replacementOrigin.empty()) {
-    newOrigin.runtimeInit(replacementOrigin.c_str(), std::min(replacementOrigin.size(), 4UL));
+  if (!newOriginStr.empty()) {
+    newOrigin.runtimeInit(newOriginStr.c_str(), std::min(newOriginStr.size(), 4UL));
   }
 
   constexpr const int numElements = nested_brace_constructible_size<false, std::decay_t<T>>() / 10;
@@ -547,12 +547,12 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   /// parse process functions defined by corresponding configurables
   if constexpr (requires { &T::process; }) {
-    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos, inputInfos);
+    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos, inputInfos, newOrigin);
   }
   homogeneous_apply_refs_sized<numElements>(
-    [name = name_str, &expressionInfos, &inputs, &inputInfos](auto& x) mutable {
+    [name = name_str, &expressionInfos, &inputs, &inputInfos, &newOrigin](auto& x) mutable {
       // this pushes (argumentIndex, processHash, schemaPtr, nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
-      return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos, inputInfos);
+      return AnalysisDataProcessorBuilder::requestInputsFromArgs(x, name, inputs, expressionInfos, inputInfos, newOrigin);
     },
     *task.get());
 
@@ -586,13 +586,18 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());
   homogeneous_apply_refs_sized<numElements>([&requiredServices](auto& element) { return analysis_task_parsers::addService(requiredServices, element); }, *task.get());
 
-  /// FIXME: In order to replace origins consistently, there are following things that need to be touched
-  /// 1. inputs and outputs, including their metadata
-  /// 2. inputInfos, that contain matchers for extracting arguments of process functions
-  /// 3. bindingKeys/bindingKeysUnsorted, that contain matchers to extract tables used to calculate slicing (created in init)
-  /// 4. Produces/Spawns/Defines/Builds contain matchers for required inputs and created outputs that need to be modified
+  // replace origins in Preslice declarations
+  homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element){ return analysis_task_parsers::replaceOrigin(element, newOrigin); }, *task.get());
 
-  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos](InitContext& ic) mutable {
+  /// FIXME: In order to replace origins consistently, there are following things that need to be touched
+  /// 1. inputs and outputs, including their metadata - done
+  /// 2. inputInfos, that contain matchers for extracting arguments of process functions - done in the 1st step
+  /// 3. bindingKeys/bindingKeysUnsorted, that contain matchers to extract tables used to calculate slicing - preslices are update, bks are updated
+  /// 4. Produces/Spawns/Defines/Builds contain matchers for required inputs and created outputs that need to be modified - same
+  ///
+  /// 3a. GroupSlicer has to use runtime list of extractions
+
+  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos, newOrigin, newOriginStr](InitContext& ic) mutable {
     Cache bindingsKeys;
     Cache bindingsKeysUnsorted;
     // add preslice declarations to slicing cache definition
@@ -638,10 +643,24 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       },
       *task.get());
 
+    /// replace origin in slicing caches
+    std::ranges::transform(bindingsKeys, bindingsKeys.begin(), [&newOrigin](Entry& entry){
+      if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
+        entry.matcher = replaceOrigin(entry.matcher, newOrigin);
+      }
+      return entry;
+    });
+    std::ranges::transform(bindingsKeysUnsorted, bindingsKeysUnsorted.begin(), [&newOrigin](Entry& entry){
+      if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
+        entry.matcher = replaceOrigin(entry.matcher, newOrigin);
+      }
+      return entry;
+    });
+
     ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
     ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));
 
-    return [task, expressionInfos, inputInfos](ProcessingContext& pc) mutable {
+    return [task, expressionInfos, inputInfos, newOriginStr](ProcessingContext& pc) mutable {
       // load the ccdb object from their cache
       homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::newDataframeCondition(pc.inputs(), element); }, *task.get());
       // reset partitions once per dataframe
@@ -664,14 +683,14 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       }
       // execute process()
       if constexpr (requires { &T::process; }) {
-        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), inputInfos, &T::process, expressionInfos, slices);
+        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), inputInfos, &T::process, expressionInfos, slices, newOriginStr);
       }
       // execute optional process()
       homogeneous_apply_refs_sized<numElements>(
-        [&pc, &expressionInfos, &task, &slices, &inputInfos](auto& x) {
+        [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOriginStr](auto& x) {
           if constexpr (is_process_configurable<decltype(x)>) {
             if (x.value == true) {
-              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), inputInfos, x.process, expressionInfos, slices);
+              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), inputInfos, x.process, expressionInfos, slices, newOriginStr);
               return true;
             }
             return false;

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -64,9 +64,14 @@ struct ArrowTableSlicingCacheDef {
   constexpr static ServiceKind service_kind = ServiceKind::Global;
   Cache bindingsKeys;
   Cache bindingsKeysUnsorted;
+  header::DataOrigin newOrigin = header::DataOrigin{"AOD"};
 
   void setCaches(Cache&& bsks);
   void setCachesUnsorted(Cache&& bsks);
+  void setOrigin(header::DataOrigin newOrigin_ = header::DataOrigin{"AOD"})
+  {
+    newOrigin = newOrigin_;
+  }
 };
 
 struct ArrowTableSlicingCache {
@@ -80,7 +85,9 @@ struct ArrowTableSlicingCache {
   std::vector<std::vector<int>> valuesUnsorted;
   std::vector<ListVector> groups;
 
-  ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted = {});
+  header::DataOrigin newOrigin = header::DataOrigin{"AOD"};
+
+  ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted = {}, header::DataOrigin newOrigin_ = header::DataOrigin{"AOD"});
 
   // set caching information externally
   void setCaches(Cache&& bsks, Cache&& bsksUnsorted = {});

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -35,12 +35,12 @@ auto getMatcherFor(std::string const& columnName, o2::header::DataOrigin newOrig
 
 namespace o2::framework
 {
-template <typename G, std::ranges::input_range R, typename... A>
+template <typename G, typename... A>
 struct GroupSlicer {
   using grouping_t = std::decay_t<G>;
-  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, R matchers, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
     : max{gt.size()},
-      mBegin{GroupSlicerIterator(gt, at, slices, matchers, newOrigin)}
+      mBegin{GroupSlicerIterator(gt, at, slices, newOrigin)}
   {
   }
 
@@ -95,15 +95,14 @@ struct GroupSlicer {
       starts[index] = selections[index]->begin();
     }
 
-    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, R matchers_, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
       : mIndexColumnName{std::string("fIndex") + o2::framework::cutString(o2::soa::getLabelFromType<G>())},
         mGt{&gt},
         mAt{&at},
         mGroupingElement{gt.begin()},
         position{0},
         mSlices{&slices},
-        replacementOrigin{newOrigin},
-        matchers{matchers_}
+        replacementOrigin{newOrigin}
     {
       if constexpr (soa::is_filtered_table<std::decay_t<G>>) {
         groupSelection = mGt->getSelectedRows();
@@ -281,7 +280,6 @@ struct GroupSlicer {
     std::array<SliceInfoUnsortedPtr, sizeof...(A)> sliceInfosUnsorted;
     ArrowTableSlicingCache* mSlices;
     header::DataOrigin replacementOrigin;
-    R matchers;
   };
 
   GroupSlicerIterator& begin()

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -20,7 +20,8 @@
 #include <arrow/util/key_value_metadata.h>
 #include <type_traits>
 #include <string>
-namespace {
+namespace
+{
 template <typename T>
 auto getMatcherFor(std::string const& columnName, o2::header::DataOrigin newOrigin = o2::header::DataOrigin{"AOD"})
 {
@@ -30,8 +31,7 @@ auto getMatcherFor(std::string const& columnName, o2::header::DataOrigin newOrig
   }
   return matcher;
 }
-}
-
+} // namespace
 
 namespace o2::framework
 {
@@ -113,7 +113,7 @@ struct GroupSlicer {
       /// to grouping table
       /// extract selections from filtered associated tables
 
-      [this]<size_t... Is>(std::tuple<A...>& at, std::index_sequence<Is...>){
+      [this]<size_t... Is>(std::tuple<A...>& at, std::index_sequence<Is...>) {
         (splittingFunction(std::get<Is>(at)), ...);
         (extractingFunction(std::get<Is>(at)), ...);
       }(*mAt, std::make_index_sequence<sizeof...(A)>());

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -26,9 +26,9 @@ namespace o2::framework
 template <typename G, typename... A>
 struct GroupSlicer {
   using grouping_t = std::decay_t<G>;
-  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, std::string const& newOriginStr = "AOD")
+  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
     : max{gt.size()},
-      mBegin{GroupSlicerIterator(gt, at, slices, newOriginStr)}
+      mBegin{GroupSlicerIterator(gt, at, slices, newOrigin)}
   {
   }
 
@@ -87,15 +87,15 @@ struct GroupSlicer {
       starts[index] = selections[index]->begin();
     }
 
-    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, std::string const& newOriginStr = "AOD")
+    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
       : mIndexColumnName{std::string("fIndex") + o2::framework::cutString(o2::soa::getLabelFromType<G>())},
         mGt{&gt},
         mAt{&at},
         mGroupingElement{gt.begin()},
         position{0},
-        mSlices{&slices}
+        mSlices{&slices},
+        replacementOrigin{newOrigin}
     {
-      replacementOrigin.runtimeInit(newOriginStr.c_str(), newOriginStr.size());
       if constexpr (soa::is_filtered_table<std::decay_t<G>>) {
         groupSelection = mGt->getSelectedRows();
       }

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -55,12 +55,11 @@ struct GroupSlicer {
     auto splittingFunction(T&& table)
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
-      auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
       auto matcher = o2::soa::getMatcherFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
       if ((matcher.origin == header::DataOrigin{"AOD"}) && (replacementOrigin != header::DataOrigin{"AOD"})) {
         matcher = framework::replaceOrigin(matcher, replacementOrigin);
       }
-      auto bk = Entry(binding, matcher, mIndexColumnName);
+      auto bk = Entry("", matcher, mIndexColumnName);
       if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
         if (table.size() == 0) {
           return;

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -14,6 +14,7 @@
 
 #include "Framework/Pack.h"
 #include "Framework/ASoA.h"
+#include "Framework/AnalysisHelpers.h"
 
 #include <arrow/util/config.h>
 #include <arrow/util/key_value_metadata.h>
@@ -25,9 +26,9 @@ namespace o2::framework
 template <typename G, typename... A>
 struct GroupSlicer {
   using grouping_t = std::decay_t<G>;
-  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices)
+  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, std::string const& newOriginStr = "AOD")
     : max{gt.size()},
-      mBegin{GroupSlicerIterator(gt, at, slices)}
+      mBegin{GroupSlicerIterator(gt, at, slices, newOriginStr)}
   {
   }
 
@@ -55,7 +56,11 @@ struct GroupSlicer {
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
-      auto bk = Entry(binding, o2::soa::getMatcherFromTypeForKey<std::decay_t<T>>(mIndexColumnName), mIndexColumnName);
+      auto matcher = o2::soa::getMatcherFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
+      if ((matcher.origin == header::DataOrigin{"AOD"}) && (replacementOrigin != header::DataOrigin{"AOD"})) {
+        matcher = framework::replaceOrigin(matcher, replacementOrigin);
+      }
+      auto bk = Entry(binding, matcher, mIndexColumnName);
       if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
         if (table.size() == 0) {
           return;
@@ -82,7 +87,7 @@ struct GroupSlicer {
       starts[index] = selections[index]->begin();
     }
 
-    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices)
+    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, std::string const& newOriginStr = "AOD")
       : mIndexColumnName{std::string("fIndex") + o2::framework::cutString(o2::soa::getLabelFromType<G>())},
         mGt{&gt},
         mAt{&at},
@@ -90,6 +95,7 @@ struct GroupSlicer {
         position{0},
         mSlices{&slices}
     {
+      replacementOrigin.runtimeInit(newOriginStr.c_str(), newOriginStr.size());
       if constexpr (soa::is_filtered_table<std::decay_t<G>>) {
         groupSelection = mGt->getSelectedRows();
       }
@@ -271,6 +277,7 @@ struct GroupSlicer {
     std::array<SliceInfoPtr, sizeof...(A)> sliceInfos;
     std::array<SliceInfoUnsortedPtr, sizeof...(A)> sliceInfosUnsorted;
     ArrowTableSlicingCache* mSlices;
+    header::DataOrigin replacementOrigin;
   };
 
   GroupSlicerIterator& begin()

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -20,15 +20,27 @@
 #include <arrow/util/key_value_metadata.h>
 #include <type_traits>
 #include <string>
+namespace {
+template <typename T>
+auto getMatcherFor(std::string const& columnName, o2::header::DataOrigin newOrigin = o2::header::DataOrigin{"AOD"})
+{
+  auto matcher = o2::soa::getMatcherFromTypeForKey<std::decay_t<T>>(columnName);
+  if ((matcher.origin == o2::header::DataOrigin{"AOD"}) && (newOrigin != o2::header::DataOrigin{"AOD"})) {
+    matcher = o2::framework::replaceOrigin(matcher, newOrigin);
+  }
+  return matcher;
+}
+}
+
 
 namespace o2::framework
 {
-template <typename G, typename... A>
+template <typename G, std::ranges::input_range R, typename... A>
 struct GroupSlicer {
   using grouping_t = std::decay_t<G>;
-  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, R matchers, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
     : max{gt.size()},
-      mBegin{GroupSlicerIterator(gt, at, slices, newOrigin)}
+      mBegin{GroupSlicerIterator(gt, at, slices, matchers, newOrigin)}
   {
   }
 
@@ -50,27 +62,24 @@ struct GroupSlicer {
     {
     }
 
-    template <typename T>
+    template <soa::is_table T>
+      requires(o2::soa::relatedByIndex<std::decay_t<G>, std::decay_t<T>>() && !soa::is_smallgroups<T>)
+    auto splittingFunction(T&& table)
+    {
+      if (table.size() == 0) {
+        return;
+      }
+      sliceInfos[framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{})] = mSlices->getCacheFor(Entry("", getMatcherFor<T>(mIndexColumnName, replacementOrigin), mIndexColumnName));
+    }
+
+    template <soa::is_smallgroups T>
       requires(o2::soa::relatedByIndex<std::decay_t<G>, std::decay_t<T>>())
     auto splittingFunction(T&& table)
     {
-      constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
-      auto matcher = o2::soa::getMatcherFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
-      if ((matcher.origin == header::DataOrigin{"AOD"}) && (replacementOrigin != header::DataOrigin{"AOD"})) {
-        matcher = framework::replaceOrigin(matcher, replacementOrigin);
+      if (table.tableSize() == 0) {
+        return;
       }
-      auto bk = Entry("", matcher, mIndexColumnName);
-      if constexpr (!o2::soa::is_smallgroups<std::decay_t<T>>) {
-        if (table.size() == 0) {
-          return;
-        }
-        sliceInfos[index] = mSlices->getCacheFor(bk);
-      } else {
-        if (table.tableSize() == 0) {
-          return;
-        }
-        sliceInfosUnsorted[index] = mSlices->getCacheUnsortedFor(bk);
-      }
+      sliceInfosUnsorted[framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{})] = mSlices->getCacheUnsortedFor(Entry("", getMatcherFor<T>(mIndexColumnName, replacementOrigin), mIndexColumnName));
     }
 
     template <typename T>
@@ -86,14 +95,15 @@ struct GroupSlicer {
       starts[index] = selections[index]->begin();
     }
 
-    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices, R matchers_, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
       : mIndexColumnName{std::string("fIndex") + o2::framework::cutString(o2::soa::getLabelFromType<G>())},
         mGt{&gt},
         mAt{&at},
         mGroupingElement{gt.begin()},
         position{0},
         mSlices{&slices},
-        replacementOrigin{newOrigin}
+        replacementOrigin{newOrigin},
+        matchers{matchers_}
     {
       if constexpr (soa::is_filtered_table<std::decay_t<G>>) {
         groupSelection = mGt->getSelectedRows();
@@ -101,18 +111,12 @@ struct GroupSlicer {
 
       /// prepare slices and offsets for all associated tables that have index
       /// to grouping table
-      ///
-      std::apply(
-        [&](auto&&... x) -> void {
-          (splittingFunction(x), ...);
-        },
-        at);
       /// extract selections from filtered associated tables
-      std::apply(
-        [&](auto&&... x) -> void {
-          (extractingFunction(x), ...);
-        },
-        at);
+
+      [this]<size_t... Is>(std::tuple<A...>& at, std::index_sequence<Is...>){
+        (splittingFunction(std::get<Is>(at)), ...);
+        (extractingFunction(std::get<Is>(at)), ...);
+      }(*mAt, std::make_index_sequence<sizeof...(A)>());
     }
 
     GroupSlicerIterator& operator++()
@@ -277,6 +281,7 @@ struct GroupSlicer {
     std::array<SliceInfoUnsortedPtr, sizeof...(A)> sliceInfosUnsorted;
     ArrowTableSlicingCache* mSlices;
     header::DataOrigin replacementOrigin;
+    R matchers;
   };
 
   GroupSlicerIterator& begin()

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -548,7 +548,7 @@ class InputRecord
     auto pos = getPos(matcher);
     if (pos < 0) {
       auto msg = describeAvailableInputs();
-      throw runtime_error_f("InputRecord::get: no input with binding %s found. %s", DataSpecUtils::describe(matcher).c_str(), msg.c_str());
+      throw runtime_error_f("InputRecord::get: no input %s found. %s", DataSpecUtils::describe(matcher).c_str(), msg.c_str());
     }
     return getByPos(pos, part);
   }

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -529,7 +529,7 @@ class InputRecord
     auto pos = getPos(matcher);
     if (pos < 0) {
       auto msg = describeAvailableInputs();
-      throw runtime_error_f("InputRecord::get: no input with binding %s found. %s", DataSpecUtils::describe(matcher).c_str(), msg.c_str());
+      throw runtime_error_f("InputRecord::get: no input %s found. %s", DataSpecUtils::describe(matcher).c_str(), msg.c_str());
     }
     return getByPos(pos, part);
   }

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -259,6 +259,16 @@ void* extractCCDBPayload(char* payload, size_t size, TClass const* cl, const cha
   return result;
 }
 
+std::function<framework::ConcreteDataMatcher(framework::ConcreteDataMatcher&&)> originReplacement(header::DataOrigin newOrigin)
+{
+  return [newOrigin](framework::ConcreteDataMatcher&& m) {
+    if ((m.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
+      m.origin = newOrigin;
+    }
+    return m;
+  };
+}
+
 } // namespace o2::soa
 
 namespace o2::framework

--- a/Framework/Core/src/AnalysisDataModelHelpers.cxx
+++ b/Framework/Core/src/AnalysisDataModelHelpers.cxx
@@ -42,7 +42,7 @@ std::string getTreeName(header::DataHeader dh, bool wasAOD)
 
   // exceptions from this
   auto origin = std::string(dh.dataOrigin.str);
-  if (origin == "AOD" && description == "MCCOLLISLABEL") {
+  if ((origin == "AOD" || wasAOD) && description == "MCCOLLISLABEL") {
     treeName = "O2mccollisionlabel";
   }
 

--- a/Framework/Core/src/AnalysisDataModelHelpers.cxx
+++ b/Framework/Core/src/AnalysisDataModelHelpers.cxx
@@ -12,8 +12,6 @@
 #include "Framework/AnalysisDataModelHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisSupportHelpers.h"
-#include "Framework/StringHelpers.h"
-#include "Framework/Logger.h"
 
 std::string str_tolower(std::string s)
 {
@@ -25,7 +23,7 @@ std::string str_tolower(std::string s)
 
 namespace o2::aod::datamodel
 {
-std::string getTreeName(header::DataHeader dh)
+std::string getTreeName(header::DataHeader dh, bool wasAOD)
 {
   auto description = std::string(dh.dataDescription.str);
   auto iver = (float)dh.subSpecification;
@@ -38,11 +36,8 @@ std::string getTreeName(header::DataHeader dh)
   }
 
   // add prefix according to origin
-  for (auto possibleOrigin : framework::AODOrigins) {
-    if (dh.dataOrigin == possibleOrigin) {
+  if (wasAOD || std::ranges::any_of(framework::AODOrigins, [&o = dh.dataOrigin](header::DataOrigin const& origin){ return o == origin;  })) {
       treeName = "O2" + treeName;
-      break;
-    }
   }
 
   // exceptions from this

--- a/Framework/Core/src/AnalysisDataModelHelpers.cxx
+++ b/Framework/Core/src/AnalysisDataModelHelpers.cxx
@@ -36,8 +36,8 @@ std::string getTreeName(header::DataHeader dh, bool wasAOD)
   }
 
   // add prefix according to origin
-  if (wasAOD || std::ranges::any_of(framework::AODOrigins, [&o = dh.dataOrigin](header::DataOrigin const& origin){ return o == origin;  })) {
-      treeName = "O2" + treeName;
+  if (wasAOD || std::ranges::any_of(framework::AODOrigins, [&o = dh.dataOrigin](header::DataOrigin const& origin) { return o == origin; })) {
+    treeName = "O2" + treeName;
   }
 
   // exceptions from this

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/AnalysisHelpers.h"
+#include <regex>
 #include "Framework/ExpressionHelpers.h"
 #include "ExpressionJSONHelpers.h"
 #include "IndexJSONHelpers.h"
@@ -82,6 +83,20 @@ namespace o2::framework
 void wrongOriginReplacement(std::string_view replacement)
 {
   throw framework::runtime_error_f("Provided origin replacement string is longer than 4 symbols: %s", replacement.data());
+}
+
+ConfigParamSpec replaceOrigin(ConfigParamSpec& source, std::string const& originStr)
+{
+  if (!source.name.starts_with("input:")) {
+    return source;
+  }
+  source.defaultValue = std::regex_replace(source.defaultValue.get<std::string>(), std::regex{"/AOD/"}, "/" + originStr + "/");
+  return source;
+}
+
+ConcreteDataMatcher replaceOrigin(ConcreteDataMatcher& matcher, header::DataOrigin const& newOrigin)
+{
+  return ConcreteDataMatcher{newOrigin, matcher.description, matcher.subSpec};
 }
 
 std::shared_ptr<arrow::Table> makeEmptyTableImpl(const char* name, std::shared_ptr<arrow::Schema>& schema)

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -79,6 +79,11 @@ std::shared_ptr<arrow::Table> IndexBuilder::materialize(std::vector<framework::I
 
 namespace o2::framework
 {
+void wrongOriginReplacement(std::string_view replacement)
+{
+  throw framework::runtime_error_f("Provided origin replacement string is longer than 4 symbols: %s", replacement.data());
+}
+
 std::shared_ptr<arrow::Table> makeEmptyTableImpl(const char* name, std::shared_ptr<arrow::Schema>& schema)
 {
   schema = schema->WithMetadata(std::make_shared<arrow::KeyValueMetadata>(std::vector{std::string{"label"}}, std::vector{std::string{name}}));

--- a/Framework/Core/src/AnalysisSupportHelpers.cxx
+++ b/Framework/Core/src/AnalysisSupportHelpers.cxx
@@ -175,9 +175,7 @@ void AnalysisSupportHelpers::addMissingOutputsToBuilder(std::vector<InputSpec> c
   // FIXME: until we have a single list of pairs
   additionalInputs |
     std::ranges::views::filter([](InputSpec const& input) {
-      return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p) {
-               return p.name.starts_with("aod-origin-replaced");
-             });
+      return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, checks::has_params_with_name_starting("aod-origin-replaced"));
     }) |
     std::ranges::views::filter([](InputSpec const& input) {
       return std::ranges::none_of(input.metadata, [](ConfigParamSpec const& p) { return (p.name.compare("projectors") == 0) || (p.name.compare("index-records") == 0); });

--- a/Framework/Core/src/AnalysisSupportHelpers.cxx
+++ b/Framework/Core/src/AnalysisSupportHelpers.cxx
@@ -174,7 +174,11 @@ void AnalysisSupportHelpers::addMissingOutputsToBuilder(std::vector<InputSpec> c
   additionalInputs | sinks::update_input_list{publisher.inputs}; // update publisher inputs
   // FIXME: until we have a single list of pairs
   additionalInputs |
-    views::partial_match_filter(AODOrigins) |
+    std::ranges::views::filter([](InputSpec const& input){
+      return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p){
+               return p.name.starts_with("aod-origin-replaced");
+             });
+    }) |
     std::ranges::views::filter([](InputSpec const& input) {
       return std::ranges::none_of(input.metadata, [](ConfigParamSpec const& p) { return (p.name.compare("projectors") == 0) || (p.name.compare("index-records") == 0); });
     }) |

--- a/Framework/Core/src/AnalysisSupportHelpers.cxx
+++ b/Framework/Core/src/AnalysisSupportHelpers.cxx
@@ -174,8 +174,8 @@ void AnalysisSupportHelpers::addMissingOutputsToBuilder(std::vector<InputSpec> c
   additionalInputs | sinks::update_input_list{publisher.inputs}; // update publisher inputs
   // FIXME: until we have a single list of pairs
   additionalInputs |
-    std::ranges::views::filter([](InputSpec const& input){
-      return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p){
+    std::ranges::views::filter([](InputSpec const& input) {
+      return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p) {
                return p.name.starts_with("aod-origin-replaced");
              });
     }) |

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -773,7 +773,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
     .configure = CommonServices::noConfiguration(),
     .preProcessing = [](ProcessingContext& pc, void* service_ptr) {
       auto* service = static_cast<ArrowTableSlicingCache*>(service_ptr);
-      auto& caches = service->bindingsKeys;
+      auto const& caches = service->bindingsKeys;
       for (auto i = 0u; i < caches.size(); ++i) {
         if (caches[i].enabled && pc.inputs().getPos(caches[i].binding.c_str()) >= 0) {
           auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].matcher)->asArrowTable());
@@ -782,7 +782,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
           }
         }
       }
-      auto& unsortedCaches = service->bindingsKeysUnsorted;
+      auto const& unsortedCaches = service->bindingsKeysUnsorted;
       for (auto i = 0u; i < unsortedCaches.size(); ++i) {
         if (unsortedCaches[i].enabled && pc.inputs().getPos(unsortedCaches[i].binding.c_str()) >= 0) {
           auto status = service->updateCacheEntryUnsorted(i, pc.inputs().get<TableConsumer>(unsortedCaches[i].matcher)->asArrowTable());

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -711,8 +711,8 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
         // update currently requested AODs
         for (auto& d : workflow) {
           d.inputs |
-            std::ranges::views::filter([](InputSpec const& input){
-              return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p){
+            std::ranges::views::filter([](InputSpec const& input) {
+              return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p) {
                        return p.name.starts_with("aod-origin-replaced");
                      });
             }) |

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -769,7 +769,8 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
     .uniqueId = CommonServices::simpleServiceId<ArrowTableSlicingCache>(),
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions&) { return ServiceHandle{TypeIdHelpers::uniqueId<ArrowTableSlicingCache>(),
                                                                                                          new ArrowTableSlicingCache(Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeys},
-                                                                                                                                    Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeysUnsorted}),
+                                                                                                                                    Cache{services.get<ArrowTableSlicingCacheDef>().bindingsKeysUnsorted},
+                                                                                                                                    services.get<ArrowTableSlicingCacheDef>().newOrigin),
                                                                                                          ServiceKind::Stream, typeid(ArrowTableSlicingCache).name()}; },
     .configure = CommonServices::noConfiguration(),
     .preProcessing = [](ProcessingContext& pc, void* service_ptr) {

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -711,7 +711,11 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
         // update currently requested AODs
         for (auto& d : workflow) {
           d.inputs |
-            views::partial_match_filter(AODOrigins) |
+            std::ranges::views::filter([](InputSpec const& input){
+              return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p){
+                       return p.name.starts_with("aod-origin-replaced");
+                     });
+            }) |
             sinks::update_input_list{dec.requestedAODs};
         }
 

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -712,9 +712,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
         for (auto& d : workflow) {
           d.inputs |
             std::ranges::views::filter([](InputSpec const& input) {
-              return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, [](ConfigParamSpec const& p) {
-                       return p.name.starts_with("aod-origin-replaced");
-                     });
+              return DataSpecUtils::partialMatch(input, AODOrigins) || std::ranges::any_of(input.metadata, checks::has_params_with_name_starting("aod-origin-replaced"));
             }) |
             sinks::update_input_list{dec.requestedAODs};
         }

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -11,6 +11,7 @@
 
 #include "Framework/ArrowTableSlicingCache.h"
 #include "Framework/RuntimeError.h"
+#include "Framework/DataSpecUtils.h"
 
 #include <arrow/compute/api_aggregate.h>
 #include <arrow/compute/kernel.h>
@@ -78,9 +79,10 @@ void ArrowTableSlicingCacheDef::setCachesUnsorted(Cache&& bsks)
   bindingsKeysUnsorted = bsks;
 }
 
-ArrowTableSlicingCache::ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted)
+ArrowTableSlicingCache::ArrowTableSlicingCache(Cache&& bsks, Cache&& bsksUnsorted, header::DataOrigin newOrigin_)
   : bindingsKeys{bsks},
-    bindingsKeysUnsorted{bsksUnsorted}
+    bindingsKeysUnsorted{bsksUnsorted},
+    newOrigin{newOrigin_}
 {
   offsets.resize(bindingsKeys.size());
   sizes.resize(bindingsKeys.size());
@@ -112,7 +114,7 @@ arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<
   }
   auto& [b, m, k, e] = bindingsKeys[pos];
   if (!e) {
-    throw runtime_error_f("Disabled cache %s/%s update requested", b.c_str(), k.c_str());
+    throw runtime_error_f("Disabled cache (%s) %s/%s update requested", DataSpecUtils::describe(m).c_str(), b.c_str(), k.c_str());
   }
   validateOrder(bindingsKeys[pos], table);
 
@@ -205,7 +207,7 @@ std::pair<int, bool> ArrowTableSlicingCache::getCachePos(const Entry& bindingKey
   if (pos != -1) {
     return {pos, false};
   }
-  throw runtime_error_f("%s/%s not found neither in sorted or unsorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
+  throw runtime_error_f("(%s) %s/%s not found neither in sorted or unsorted cache", DataSpecUtils::describe(bindingKey.matcher).c_str(), bindingKey.binding.c_str(), bindingKey.key.c_str());
 }
 
 int ArrowTableSlicingCache::getCachePosSortedFor(Entry const& bindingKey) const
@@ -242,10 +244,10 @@ SliceInfoUnsortedPtr ArrowTableSlicingCache::getCacheUnsortedFor(const Entry& bi
 {
   auto [p, s] = getCachePos(bindingKey);
   if (s) {
-    throw runtime_error_f("%s/%s is found in sorted cache", bindingKey.binding.c_str(), bindingKey.key.c_str());
+    throw runtime_error_f("(%s) %s/%s is found in sorted cache", DataSpecUtils::describe(bindingKey.matcher).c_str(), bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
   if (!bindingsKeysUnsorted[p].enabled) {
-    throw runtime_error_f("Disabled unsorted cache %s/%s is requested", bindingKey.binding.c_str(), bindingKey.key.c_str());
+    throw runtime_error_f("Disabled unsorted cache (%s) %s/%s is requested", DataSpecUtils::describe(bindingKey.matcher).c_str(), bindingKey.binding.c_str(), bindingKey.key.c_str());
   }
 
   return getCacheUnsortedForPos(p);

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1596,53 +1596,71 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
         }
       };
 
-      for (const auto varit : varmap) {
+      for (const auto& varit : varmap) {
         // find the option belonging to key, add if the option has been parsed
         // and is not defaulted
         const auto* description = odesc.find_nothrow(varit.first, false);
-        if (description && varmap.count(varit.first)) {
-          // check the semantics of the value
-          auto semantic = description->semantic();
-          const char* optarg = "";
-          if (semantic) {
-            // the value semantics allows different properties like
-            // multitoken, zero_token and composing
-            // currently only the simple case is supported
-            assert(semantic->min_tokens() <= 1);
-            // assert(semantic->max_tokens() && semantic->min_tokens());
-            if (semantic->min_tokens() > 0) {
-              std::string stringRep;
-              if (auto v = boost::any_cast<std::string>(&varit.second.value())) {
-                stringRep = *v;
-              } else if (auto v = boost::any_cast<EarlyForwardPolicy>(&varit.second.value())) {
-                std::stringstream tmp;
-                tmp << *v;
-                stringRep = fmt::format("{}", tmp.str());
-              }
-              if (varit.first == "channel-config") {
-                // FIXME: the parameter to channel-config can be a list of configurations separated
-                // by semicolon. The individual configurations will be separated and added individually.
-                // The device arguments can then contaoin multiple channel-config entries, but only
-                // one for the last configuration is added to control.options
-                processRawChannelConfig(stringRep);
-                optarg = tmpArgs.back().c_str();
-              } else {
-                std::string key(fmt::format("--{}", varit.first));
-                if (stringRep.length() == 0) {
-                  // in order to identify options without parameter we add a string
-                  // with one blank for the 'blank' parameter, it is filtered out
-                  // further down and a zero-length string is added to argument list
-                  stringRep = " ";
-                }
-                updateDeviceArguments(key, stringRep);
-                optarg = uniqueDeviceArgs[key].c_str();
-              }
-            } else if (semantic->min_tokens() == 0 && varit.second.as<bool>()) {
-              updateDeviceArguments(fmt::format("--{}", varit.first), "");
-            }
-          }
-          control.options.insert(std::make_pair(varit.first, optarg));
+        if (description == nullptr || varmap.count(varit.first) == 0) {
+          continue;
         }
+
+        if (varit.second.defaulted()) {
+          continue;
+        }
+
+        // check the semantics of the value
+        auto semantic = description->semantic();
+        const char* optarg = "";
+        if (!semantic) {
+          control.options.insert(std::make_pair(varit.first, optarg));
+          continue;
+        }
+
+        if (semantic->min_tokens() == 0 && varit.second.as<bool>()) {
+          updateDeviceArguments(fmt::format("--{}", varit.first), "");
+          control.options.insert(std::make_pair(varit.first, optarg));
+          continue;
+        }
+
+        // the value semantics allows different properties like
+        // multitoken, zero_token and composing
+        // currently only the simple case is supported
+        assert(semantic->min_tokens() <= 1);
+        // assert(semantic->max_tokens() && semantic->min_tokens());
+        if (semantic->min_tokens() == 0) {
+          control.options.insert(std::make_pair(varit.first, optarg));
+          continue;
+        }
+
+        if (semantic->min_tokens() > 0) {
+          std::string stringRep;
+          if (auto v = boost::any_cast<std::string>(&varit.second.value())) {
+            stringRep = *v;
+          } else if (auto v = boost::any_cast<EarlyForwardPolicy>(&varit.second.value())) {
+            std::stringstream tmp;
+            tmp << *v;
+            stringRep = fmt::format("{}", tmp.str());
+          }
+          if (varit.first == "channel-config") {
+            // FIXME: the parameter to channel-config can be a list of configurations separated
+            // by semicolon. The individual configurations will be separated and added individually.
+            // The device arguments can then contaoin multiple channel-config entries, but only
+            // one for the last configuration is added to control.options
+            processRawChannelConfig(stringRep);
+            optarg = tmpArgs.back().c_str();
+          } else {
+            std::string key(fmt::format("--{}", varit.first));
+            if (stringRep.length() == 0) {
+              // in order to identify options without parameter we add a string
+              // with one blank for the 'blank' parameter, it is filtered out
+              // further down and a zero-length string is added to argument list
+              stringRep = " ";
+            }
+            updateDeviceArguments(key, stringRep);
+            optarg = uniqueDeviceArgs[key].c_str();
+          }
+        }
+        control.options.insert(std::make_pair(varit.first, optarg));
       }
     };
 
@@ -1653,11 +1671,11 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
 
     // Add the channel configuration
     for (auto& channel : spec.outputChannels) {
-      tmpArgs.emplace_back(std::string("--channel-config"));
+      tmpArgs.emplace_back("--channel-config");
       tmpArgs.emplace_back(outputChannel2String(channel));
     }
     for (auto& channel : spec.inputChannels) {
-      tmpArgs.emplace_back(std::string("--channel-config"));
+      tmpArgs.emplace_back("--channel-config");
       tmpArgs.emplace_back(inputChannel2String(channel));
     }
 

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1604,10 +1604,6 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
           continue;
         }
 
-        if (varit.second.defaulted()) {
-          continue;
-        }
-
         // check the semantics of the value
         auto semantic = description->semantic();
         const char* optarg = "";

--- a/Framework/Core/src/WorkflowCustomizationHelpers.cxx
+++ b/Framework/Core/src/WorkflowCustomizationHelpers.cxx
@@ -67,6 +67,8 @@ std::vector<ConfigParamSpec> WorkflowCustomizationHelpers::requiredWorkflowOptio
            {"aod-writer-resmode", VariantType::String, "RECREATE", {"Creation mode of the result files: NEW, CREATE, RECREATE, UPDATE"}},
            {"aod-writer-ntfmerge", VariantType::Int, -1, {"Number of time frames to merge into one file"}},
            {"aod-writer-keep", VariantType::String, "", {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION:treename:col1/col2/..:filename"}},
+           // options to manipulate origins
+           {"aod-origin-replace", VariantType::String, "", {"Replace AOD origin with the string provided"}},
 
            {"fairmq-rate-logging", VariantType::Int, 0, {"Rate logging for FairMQ channels"}},
            {"fairmq-recv-buffer-size", VariantType::Int, 4, {"recvBufferSize option for FairMQ channels"}},

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -282,8 +282,12 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       bool hasProjectors = false;
       bool hasIndexRecords = false;
       bool hasCCDBURLs = false;
+      bool wasAOD = false;
       // all three options are exclusive
       for (auto const& p : input.metadata) {
+        if (p.name.starts_with("aod-origin-replaced")) {
+          wasAOD = true;
+        }
         if (p.name.compare("projectors") == 0) {
           hasProjectors = true;
           break;
@@ -342,7 +346,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
         DataSpecUtils::updateInputList(dec.requestedIDXs, InputSpec{input});
       } else if (hasCCDBURLs) {
         DataSpecUtils::updateInputList(dec.requestedTIMs, InputSpec{input});
-      } else if (DataSpecUtils::partialMatch(input, AODOrigins)) {
+      } else if (DataSpecUtils::partialMatch(input, AODOrigins) || wasAOD) {
         DataSpecUtils::updateInputList(dec.requestedAODs, InputSpec{input});
       }
     }
@@ -353,8 +357,12 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       bool hasProjectors = false;
       bool hasIndexRecords = false;
       bool hasCCDBURLs = false;
+      bool wasAOD = false;
       // all three options are exclusive
       for (auto const& p : output.metadata) {
+        if (p.name.starts_with("aod-origin-replaced")) {
+          wasAOD = true;
+        }
         if (p.name.compare("projectors") == 0) {
           hasProjectors = true;
           break;
@@ -374,7 +382,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
         dec.providedTIMs.emplace_back(output);
       } else if (hasIndexRecords) {
         dec.providedIDXs.emplace_back(output);
-      } else if (DataSpecUtils::partialMatch(output, AODOrigins)) {
+      } else if (DataSpecUtils::partialMatch(output, AODOrigins) || wasAOD) {
         dec.providedAODs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
         dec.providedOutputObjHist.emplace_back(output);

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -121,7 +121,7 @@ TEST_CASE("GroupSlicerOneAssociated")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   auto count = 0;
   for (auto& slice : g) {
@@ -199,7 +199,7 @@ TEST_CASE("GroupSlicerSeveralAssociated")
   auto s = slices.updateCacheEntry(0, {trkTableX});
   s = slices.updateCacheEntry(1, {trkTableY});
   s = slices.updateCacheEntry(2, {trkTableZ});
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   auto count = 0;
   for (auto& slice : g) {
@@ -261,7 +261,7 @@ TEST_CASE("GroupSlicerMismatchedGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   for (auto& slice : g) {
     auto as = slice.associatedTables();
@@ -318,7 +318,7 @@ TEST_CASE("GroupSlicerMismatchedUnassignedGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   auto count = 0;
   for (auto& slice : g) {
@@ -369,7 +369,7 @@ TEST_CASE("GroupSlicerMismatchedFilteredGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   auto count = 0;
 
@@ -431,7 +431,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({}, {{soa::getLabelFromType<aod::TrksXU>(), soa::getMatcherFromTypeForKey<aod::TrksXU>(key), key}});
   auto s = slices.updateCacheEntryUnsorted(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
 
@@ -454,7 +454,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   std::vector<int64_t> sele;
   soa::SmallGroups<aod::TrksXU> te{{trkTableE}, std::move(sele)};
   auto tte = std::make_tuple(te);
-  o2::framework::GroupSlicer ge(e, tte, slices, Matchers{});
+  o2::framework::GroupSlicer ge(e, tte, slices);
 
   count = 0;
   for (auto& slice : ge) {
@@ -468,7 +468,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
 
   soa::SmallGroupsUnfiltered<aod::TrksXU> tu{{trkTable}, std::vector<int64_t>{}};
   auto ttu = std::make_tuple(tu);
-  o2::framework::GroupSlicer gu(e, ttu, slices, Matchers{});
+  o2::framework::GroupSlicer gu(e, ttu, slices);
 
   count = 0;
   for (auto& slice : gu) {
@@ -558,7 +558,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
                                  {soa::getLabelFromType<aod::Things>(), soa::getMatcherFromTypeForKey<aod::Things>(key), key}});
   auto s0 = slices.updateCacheEntry(0, partsTable);
   auto s1 = slices.updateCacheEntry(1, thingsTable);
-  o2::framework::GroupSlicer g(e, associatedTuple, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, associatedTuple, slices);
 
   overwriteInternalIndices(associatedTuple, associatedTuple);
 
@@ -617,7 +617,7 @@ TEST_CASE("EmptySliceables")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
   for (auto& slice : g) {

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -15,7 +15,6 @@
 #include "Framework/GroupSlicer.h"
 #include "Framework/ArrowTableSlicingCache.h"
 #include <arrow/util/config.h>
-#include <iostream>
 
 #include <catch_amalgamated.hpp>
 
@@ -94,6 +93,8 @@ TEST_CASE("RelatedByIndex")
   CHECK(soa::relatedByIndex<aod::Collision, aod::Tracks>() == true);
 }
 
+using Matchers = std::vector<std::pair<int, ConcreteDataMatcher>>;
+
 TEST_CASE("GroupSlicerOneAssociated")
 {
   TableBuilder builderE;
@@ -120,7 +121,7 @@ TEST_CASE("GroupSlicerOneAssociated")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   auto count = 0;
   for (auto& slice : g) {
@@ -198,7 +199,7 @@ TEST_CASE("GroupSlicerSeveralAssociated")
   auto s = slices.updateCacheEntry(0, {trkTableX});
   s = slices.updateCacheEntry(1, {trkTableY});
   s = slices.updateCacheEntry(2, {trkTableZ});
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   auto count = 0;
   for (auto& slice : g) {
@@ -260,7 +261,7 @@ TEST_CASE("GroupSlicerMismatchedGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   for (auto& slice : g) {
     auto as = slice.associatedTables();
@@ -317,7 +318,7 @@ TEST_CASE("GroupSlicerMismatchedUnassignedGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   auto count = 0;
   for (auto& slice : g) {
@@ -368,7 +369,7 @@ TEST_CASE("GroupSlicerMismatchedFilteredGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   auto count = 0;
 
@@ -430,7 +431,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({}, {{soa::getLabelFromType<aod::TrksXU>(), soa::getMatcherFromTypeForKey<aod::TrksXU>(key), key}});
   auto s = slices.updateCacheEntryUnsorted(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   unsigned int count = 0;
 
@@ -453,7 +454,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   std::vector<int64_t> sele;
   soa::SmallGroups<aod::TrksXU> te{{trkTableE}, std::move(sele)};
   auto tte = std::make_tuple(te);
-  o2::framework::GroupSlicer ge(e, tte, slices);
+  o2::framework::GroupSlicer ge(e, tte, slices, Matchers{});
 
   count = 0;
   for (auto& slice : ge) {
@@ -467,7 +468,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
 
   soa::SmallGroupsUnfiltered<aod::TrksXU> tu{{trkTable}, std::vector<int64_t>{}};
   auto ttu = std::make_tuple(tu);
-  o2::framework::GroupSlicer gu(e, ttu, slices);
+  o2::framework::GroupSlicer gu(e, ttu, slices, Matchers{});
 
   count = 0;
   for (auto& slice : gu) {
@@ -557,7 +558,7 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroupsWithSelfIndex")
                                  {soa::getLabelFromType<aod::Things>(), soa::getMatcherFromTypeForKey<aod::Things>(key), key}});
   auto s0 = slices.updateCacheEntry(0, partsTable);
   auto s1 = slices.updateCacheEntry(1, thingsTable);
-  o2::framework::GroupSlicer g(e, associatedTuple, slices);
+  o2::framework::GroupSlicer g(e, associatedTuple, slices, Matchers{});
 
   overwriteInternalIndices(associatedTuple, associatedTuple);
 
@@ -616,7 +617,7 @@ TEST_CASE("EmptySliceables")
   std::string key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
   ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), soa::getMatcherFromTypeForKey<aod::TrksX>(key), key}});
   auto s = slices.updateCacheEntry(0, trkTable);
-  o2::framework::GroupSlicer g(e, tt, slices);
+  o2::framework::GroupSlicer g(e, tt, slices, Matchers{});
 
   unsigned int count = 0;
   for (auto& slice : g) {

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -93,8 +93,6 @@ TEST_CASE("RelatedByIndex")
   CHECK(soa::relatedByIndex<aod::Collision, aod::Tracks>() == true);
 }
 
-using Matchers = std::vector<std::pair<int, ConcreteDataMatcher>>;
-
 TEST_CASE("GroupSlicerOneAssociated")
 {
   TableBuilder builderE;


### PR DESCRIPTION
* Rework workflow option handling (supersedes #15320)
* Add `--aod-origin-replace <newOrigin>` workflow option, that is used in `adaptAnalysisTask` to replace all of the default origins (i.e. AOD) with the new origin - both in inputs (including implicit) and outputs
* Rework the input extraction, grouping and handling of Spawns/Defines/Builds to account for origin replacement
* Track the origin replacement using InputSpec/OutputSpec metadata for correct handling by the reader
* Update the grouping errors to use the actual matcher in the error message
* Restrict Preslice to only accept tables and not iterators as its template argument (O2Physics PR https://github.com/AliceO2Group/O2Physics/pull/16258)

Using the provided option, the common support tasks, like event selection and track propagation, can be duplicated in the workflow to process separate origin chains.