### PR TITLE
Ft3 tiling bugfixing & module feature update

### DIFF
--- a/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
+++ b/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
@@ -40,9 +40,11 @@ struct FT3BaseParam : public o2::conf::ConfigurableParamHelper<FT3BaseParam> {
   Float_t etaOut = 1.5;
   Float_t Layerx2X0 = 0.01;
 
-  // override values from FT3ModuleConstants, inner and outer
-  bool cutStavesOnNominalRadius_inner = true;
-  bool cutStavesOnNominalRadius_outer = true;
+  // define tolerance allowed for staves to go outside nominal radii
+  double staveTolMLInner = 0.;
+  double staveTolMLOuter = 0.;
+  double staveTolOTInner = 0.;
+  double staveTolOTOuter = 0.;
 
   // What to place over x=0 line in case of full outer-outer stave: Gap or Sensor
   bool placeSensorInMiddleOfStave = false;

--- a/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
+++ b/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
@@ -46,8 +46,8 @@ struct FT3BaseParam : public o2::conf::ConfigurableParamHelper<FT3BaseParam> {
   double staveTolOTInner = 0.;
   double staveTolOTOuter = 0.;
 
-  // What to place over x=0 line in case of full outer-outer stave: Gap or Sensor
-  bool placeSensorInMiddleOfStave = false;
+  // What to place over x=0 line in case of full outer-outer stave: Gap or Module
+  bool placeSensorStackInMiddleOfStave = false;
 
   // Draw reference circles at inner and outer radius of stave layer, for visualisation
   bool drawReferenceCircles = false;

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3Module.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3Module.h
@@ -81,26 +81,26 @@ class FT3Module
     std::pair<double, double>& absAllowedYRange,
     double x_mid, double y_mid, double z_stave_shift_forward);
   void addDetectorVolume(
-    TGeoVolume* motherVolume, std::string volumeName, int color, unsigned* volume_count,
+    TGeoVolume* motherVolume, std::string volumeName, int color, unsigned volume_count,
     double x_mid, double y_mid, double z_mid,
     double x_half_length, double y_half_length, double z_half_length);
 
   void add2x1GlueVolume(
     TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-    unsigned* volume_count, double x_mid, double y_mid, double z_mid,
+    unsigned volume_count, double x_mid, double y_mid, double z_mid,
     std::string element_glued_to);
 
   void add2x1CopperVolume(
     TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-    unsigned* volume_count, double x_mid, double y_mid, double z_mid);
+    unsigned volume_count, double x_mid, double y_mid, double z_mid);
 
   void add2x1KaptonVolume(
     TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-    unsigned* volume_count, double x_mid, double y_mid, double z_mid);
+    unsigned volume_count, double x_mid, double y_mid, double z_mid);
 
   void addSingleSensorVolume(
     TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-    unsigned* volume_count, double active_x_mid, double y_mid, double z_mid, bool isLeft);
+    unsigned volume_count, double active_x_mid, double y_mid, double z_mid, bool isLeft);
 };
 
 #endif // FT3MODULE_H

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3ModuleConstants.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3ModuleConstants.h
@@ -153,7 +153,7 @@ const std::vector<double> x_midpoints = {
   38.25, 42.75, 47.25, 51.75, 56.25, 60.75, 65.25               // R
 };
 const double x_midpoint_spacing = 4.5; // assume constant for now
-const double maxToleranceInner = 0.; // default not allowed inwards
+const double maxToleranceInner = 0.;   // default not allowed inwards
 const double maxToleranceOuter = 3.4;  // leave 1mm for layer air encapsulation
 const std::vector<bool> staveOnFront =
   {
@@ -180,8 +180,8 @@ const std::vector<double> x_midpoints = {
   2.25, 6.75, 11.25, 15.75, 20.25, 24.75, 29.25, 33.75          // R
 };
 const double x_midpoint_spacing = 4.5;
-const double maxToleranceInner = 0.; // default not allowed inwards
-const double maxToleranceOuter = 3.4;  // leave 1mm for layer air encapsulation
+const double maxToleranceInner = 0.;  // default not allowed inwards
+const double maxToleranceOuter = 3.4; // leave 1mm for layer air encapsulation
 const std::vector<bool> staveOnFront =
   {
     1, 0, 1, 0, 1, 0, 1, 0, // L

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3ModuleConstants.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3ModuleConstants.h
@@ -23,7 +23,7 @@
 namespace o2::ft3::ModuleConstants
 {
 /* CURRENT STATUS:
- * 25x32mm sensors, 2mm inactive on one side
+ * 25x29mm sensors, 2mm inactive on one side
  * Most granular layout is 2x1 sensors, where the one on the right has the inactive region
  * on the right, and the one on the left has the inactive region on the left.
  * When stacking 2x1 modules, there is a 0.2mm gap between them. By default, we assume this
@@ -35,7 +35,7 @@ namespace o2::ft3::ModuleConstants
  * | |        |        | |
  * | |        |        | |
  * | |        |        | |
- * | |        |        | |  32mm sensor height
+ * | |        |        | |  29mm sensor height
  * | |        |        | |
  * | |        |        | |
  * ------------------------
@@ -105,8 +105,9 @@ const int CuColor = kOrange;
 const int kaptonColor = kYellow;
 const int carbonFiberColor = kGray + 1;
 
-// Struct for stave position configuration (varies between IT/OT)
+// Struct for stave position configuration (varies between ML/OT)
 struct StaveConfig {
+  const unsigned isML; // whether this config is for ML or OT
   /*
    * Constants for staves are written for both positive
    * and negative x even though they are just mirrored now,
@@ -123,7 +124,10 @@ struct StaveConfig {
   // lengths of staves, their midpoint, and their face
   const std::vector<double>& y_lengths;
   const std::vector<double>& x_midpoints;
-  double x_midpoint_spacing;
+  const double x_midpoint_spacing;
+  // whether staves can be placed outside of nominal radii
+  const double maxToleranceInner;
+  const double maxToleranceOuter;
   // which side of the disc do we place the stave?
   // kSegmentedStave: staggering staves in z (see z_offsetStave)
   // accessed via stave index, NOT stave ID
@@ -149,6 +153,8 @@ const std::vector<double> x_midpoints = {
   38.25, 42.75, 47.25, 51.75, 56.25, 60.75, 65.25               // R
 };
 const double x_midpoint_spacing = 4.5; // assume constant for now
+const double maxToleranceInner = 0.; // default not allowed inwards
+const double maxToleranceOuter = 3.4;  // leave 1mm for layer air encapsulation
 const std::vector<bool> staveOnFront =
   {
     1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, // L
@@ -174,6 +180,8 @@ const std::vector<double> x_midpoints = {
   2.25, 6.75, 11.25, 15.75, 20.25, 24.75, 29.25, 33.75          // R
 };
 const double x_midpoint_spacing = 4.5;
+const double maxToleranceInner = 0.; // default not allowed inwards
+const double maxToleranceOuter = 3.4;  // leave 1mm for layer air encapsulation
 const std::vector<bool> staveOnFront =
   {
     1, 0, 1, 0, 1, 0, 1, 0, // L
@@ -186,17 +194,23 @@ inline StaveConfig getStaveConfig(bool isInnerDisk)
 {
   if (isInnerDisk) {
     return StaveConfig{
+      true, // isML
       ML_StavePositions::staveID_to_y_midpoint,
       ML_StavePositions::y_lengths,
       ML_StavePositions::x_midpoints,
       ML_StavePositions::x_midpoint_spacing,
+      ML_StavePositions::maxToleranceInner,
+      ML_StavePositions::maxToleranceOuter,
       ML_StavePositions::staveOnFront};
   } else {
     return StaveConfig{
+      false, // isML
       OT_StavePositions::staveID_to_y_midpoint,
       OT_StavePositions::y_lengths,
       OT_StavePositions::x_midpoints,
       OT_StavePositions::x_midpoint_spacing,
+      OT_StavePositions::maxToleranceInner,
+      OT_StavePositions::maxToleranceOuter,
       OT_StavePositions::staveOnFront};
   }
 }

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
@@ -630,9 +630,9 @@ void Detector::defineSensitiveVolumes()
       std::string sig2 = "FT3Sensor_front_" + std::to_string(iLayer) + "_" + std::to_string(direction);
       std::string sig3 = "FT3Sensor_back_" + std::to_string(iLayer) + "_" + std::to_string(direction);
 
-      // 3. SegmentedStave (format: FT3Sensor_<layer>_<dir>_...)
+      // 3. SegmentedStave (format: FT3Sensor_<dir>_<layer>_...)
       // Add the trailing underscore to avoid confusing it with sig1
-      std::string sig4 = "FT3Sensor_" + std::to_string(iLayer) + "_" + std::to_string(direction) + "_";
+      std::string sig4 = "FT3Sensor_" + std::to_string(direction) + "_" + std::to_string(iLayer) + "_";
 
       // Iterate over all existing volumes to find matches
       for (int i = 0; i < nVolumes; ++i) {

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -233,17 +233,21 @@ void FT3Layer::createReferenceCircles(TGeoVolume* motherVolume, const std::strin
   // create reference circles at the inner and outer radius of the layer, for visualization purposes
   TGeoTube* innerCircle = new TGeoTube(mInnerRadius - 0.1, mInnerRadius + 0.1, 0.01);
   TGeoTube* outerCircle = new TGeoTube(mOuterRadius - 0.1, mOuterRadius + 0.1, 0.01);
+  TGeoTube* outerCircleEdge = new TGeoTube(mOuterRadius + 3.3, mOuterRadius + 3.5, 0.01);
 
   TGeoVolume* innerCircleVol = new TGeoVolume((mLayerName + "_InnerCircle").c_str(), innerCircle, gGeoManager->GetMedium("FT3_AIR$"));
   TGeoVolume* outerCircleVol = new TGeoVolume((mLayerName + "_OuterCircle").c_str(), outerCircle, gGeoManager->GetMedium("FT3_AIR$"));
+  TGeoVolume* outerCircleEdgeVol = new TGeoVolume((mLayerName + "_OuterCircleEdge").c_str(), outerCircleEdge, gGeoManager->GetMedium("FT3_AIR$"));
 
   innerCircleVol->SetLineColor(kRed);
   outerCircleVol->SetLineColor(kBlue);
+  outerCircleEdgeVol->SetLineColor(kBlack);
 
   double z_position = mDirection ? 0.5 : -0.5;
 
   motherVolume->AddNode(innerCircleVol, 1, new TGeoTranslation(0, 0, z_position));
   motherVolume->AddNode(outerCircleVol, 1, new TGeoTranslation(0, 0, z_position));
+  motherVolume->AddNode(outerCircleEdgeVol, 1, new TGeoTranslation(0, 0, z_position));
 }
 
 void FT3Layer::createLayer(TGeoVolume* motherVolume)

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -463,8 +463,8 @@ void FT3Layer::createLayer(TGeoVolume* motherVolume)
 
     // shift stave volumes into layer volume, since nominal z_{stave face} = 0
     double z_local_offset = z_layer_thickness / 2.0;
-     // ensure staves fully encapsulated in the layer volume,
-     // but don't cross out of max nominal radii of 38.5cm & 71.5cm respectively (3.5cm tolerance)
+    // ensure staves fully encapsulated in the layer volume,
+    // but don't cross out of max nominal radii of 38.5cm & 71.5cm respectively (3.5cm tolerance)
     TGeoTube* layer = new TGeoTube(mInnerRadius - 0.2, mOuterRadius + 3.49, z_layer_thickness / 2);
     layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -459,7 +459,9 @@ void FT3Layer::createLayer(TGeoVolume* motherVolume)
 
     // shift stave volumes into layer volume, since nominal z_{stave face} = 0
     double z_local_offset = z_layer_thickness / 2.0;
-    TGeoTube* layer = new TGeoTube(mInnerRadius - 0.2, mOuterRadius + 2.5, z_layer_thickness / 2); // margins to ensure staves are fully encapsulated in the layer volume
+     // ensure staves fully encapsulated in the layer volume,
+     // but don't cross out of max nominal radii of 38.5cm & 71.5cm respectively (3.5cm tolerance)
+    TGeoTube* layer = new TGeoTube(mInnerRadius - 0.2, mOuterRadius + 3.49, z_layer_thickness / 2);
     layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
 
     if (ft3Params.drawReferenceCircles) {

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -459,8 +459,8 @@ void FT3Layer::createLayer(TGeoVolume* motherVolume)
 
     // shift stave volumes into layer volume, since nominal z_{stave face} = 0
     double z_local_offset = z_layer_thickness / 2.0;
-     // ensure staves fully encapsulated in the layer volume,
-     // but don't cross out of max nominal radii of 38.5cm & 71.5cm respectively (3.5cm tolerance)
+    // ensure staves fully encapsulated in the layer volume,
+    // but don't cross out of max nominal radii of 38.5cm & 71.5cm respectively (3.5cm tolerance)
     TGeoTube* layer = new TGeoTube(mInnerRadius - 0.2, mOuterRadius + 3.49, z_layer_thickness / 2);
     layerVol = new TGeoVolume(mLayerName.c_str(), layer, medAir);
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
@@ -143,11 +143,10 @@ std::pair<double, double> calculate_y_range(
  * Rin: the inner radius of the layer
  * x_left: the x position of the left edge of the sensor to be placed
  * kSensorStack: the number of sensors to be stacked on top of each other
- * tolerance: the tolerance to be subtracted from the maximum y position to avoid
- *            placing sensors too close to the edge. If this is negative, it effectively
- *            means that you can place sensors beyond the nominal disc edge
- * y_start: the y positions to start placing sensors,
- *          for positive and negative y respectively
+ * y_ranges: the y positions to start and end placing sensors,
+ *           for positive and negative y respectively
+ * absAllowedYRange: the absolute y range allowed for placing sensors,
+ *                   used to cut placement if they go past allowed tolerances
  */
 void FT3Module::fill_stave(PosNegPositionTypes& y_positions, double Rin, double Rout,
                            double x_left, unsigned kSensorStack, PositionRangeType y_ranges,
@@ -550,6 +549,13 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
   unsigned volume_count = 0; // give each subvolume a unique ID
   // stave triangle cross sections are the same for every stave (direction based)
   std::array<std::array<double, 3>, 4> staveTriangles = buildStaveTriangle(direction);
+  // declare vector with number of 2xn sensor stacks (modules) -- only used for logging
+  // each entry is a vector, where each entry is the number of modules of that stack height
+  std::vector<std::vector<unsigned>> nSensorStackCountPerStave(
+    staveConfig.x_midpoints.size(),
+    std::vector<unsigned>(Constants::kSensorsPerStack.size(), 0)
+  );
+  std::vector<unsigned> nSensorStackTotal(Constants::kSensorsPerStack.size(), 0);
   for (unsigned i_stave = 0; i_stave < staveConfig.x_midpoints.size(); i_stave++) {
     y_positionsPosNeg.emplace_back(PosNegPositionTypes{PositionTypes{}, PositionTypes{}});
     const int staveID = Constants::staveIdxToID(i_stave, staveConfig.x_midpoints.size());
@@ -559,16 +565,21 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     // default positive and negative starting points has a gap around x-axis for symmetry
     double stave_half_length = staveConfig.y_lengths[i_stave] / 2;
     PositionRangeType y_ranges;
-    if (ft3Params.placeSensorInMiddleOfStave) {
+    if (ft3Params.placeSensorStackInMiddleOfStave) {
       /*
-       * We want a sensor to cross over the x-axis for coverage at y=0
+       * We want a sensor stack to cross over the x-axis for coverage at y=0
        * N.B. not necessarily exactly mirrored, only if stack gap is the same
-       * as the gap between sensors in a stack.
+       * as the gap between sensors in a stack. Since we start filling with the
+       * first value in the kSensorsPerStack vector, we offset the first position
+       * by half of that.
+       *
+       * NOTE: TODO: in case the stave is too short to fit one full stack over the middle,
+       * then we will not be able to place anything since the bottom right/left point of
+       * the module will already be outside of acceptable bounds -- killing further placement.
        */
-      y_ranges = {{-Constants::sensor2x1_height / 2,
-                   stave_half_length},
-                  {-Constants::sensor2x1_height / 2 - Constants::stackGap,
-                   -stave_half_length}};
+      double stackHeight = Constants::getStackHeight(Constants::kSensorsPerStack[0]);
+      y_ranges = {{-stackHeight / 2, stave_half_length},
+                  {-stackHeight / 2 - Constants::stackGap, -stave_half_length}};
     } else {
       /*
        * Otherwise have a gap around y=0, so sensors are not placed there.
@@ -658,11 +669,35 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
 
     // now add the sensor positions on the stave
     for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
+      unsigned nModulesCurr = y_positionsPosNeg.back().first.size()
+                            + y_positionsPosNeg.back().second.size();
       fill_stave(y_positionsPosNeg.back(), Rin, Rout, x_left,
                  Constants::kSensorsPerStack[i_kSens], y_ranges,
                  absAllowedYRange);
+      unsigned nModulesAdded = y_positionsPosNeg.back().first.size()
+                             + y_positionsPosNeg.back().second.size()
+                             - nModulesCurr;
+      nSensorStackCountPerStave[i_stave][i_kSens] = nModulesAdded;
+      nSensorStackTotal[i_kSens] += nModulesAdded;
     }
+    std::string moduleDebugStr = "Module size counts for layer " + std::to_string(layerNumber)
+                             + " in direction " + std::to_string(direction) + ":\n";
+    for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
+      moduleDebugStr += "\t" + std::to_string(nSensorStackCountPerStave[i_stave][i_kSens])
+                     + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens])
+                     + " sensors stacked\n";
+    }
+    LOG(debug) << moduleDebugStr;
   }
+  std::string totalModuleInfoStr =
+    "Total module size counts for layer " + std::to_string(layerNumber) +
+    " in direction " + std::to_string(direction) + ":\n";
+  for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
+    totalModuleInfoStr += "\t" + std::to_string(nSensorStackTotal[i_kSens])
+                        + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens])
+                        + " sensors stacked\n";
+  }
+  LOG(info) << totalModuleInfoStr;
 
   // Create volumes for the sensors and the support materials on top of the stave
   for (unsigned i_stave = 0; i_stave < staveConfig.x_midpoints.size(); i_stave++) {

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
@@ -550,7 +550,6 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
   unsigned volume_count = 0; // give each subvolume a unique ID
   // stave triangle cross sections are the same for every stave (direction based)
   std::array<std::array<double, 3>, 4> staveTriangles = buildStaveTriangle(direction);
-  // Create the stave volumes and fill the y positions where to put sensors on the stave
   for (unsigned i_stave = 0; i_stave < staveConfig.x_midpoints.size(); i_stave++) {
     y_positionsPosNeg.emplace_back(PosNegPositionTypes{PositionTypes{}, PositionTypes{}});
     const int staveID = Constants::staveIdxToID(i_stave, staveConfig.x_midpoints.size());
@@ -588,23 +587,29 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     }
 
     // Define tolerances for cutting staves and placing sensors
-    double tolerance_inner = -1000; // large negative number to allow given numbers
-    double tolerance_outer = -1000;
-    // cut staves on nominal inner radius if specified
-    if (ft3Params.cutStavesOnNominalRadius_inner) {
-      tolerance_inner = 0.;
+    double tolerance_inner, tolerance_outer;
+    if (staveConfig.isML) {
+      tolerance_inner = ft3Params.staveTolMLInner;
+      tolerance_outer = ft3Params.staveTolMLOuter;
+    } else {
+      tolerance_inner = ft3Params.staveTolOTInner;
+      tolerance_outer = ft3Params.staveTolOTOuter;
     }
-    if (ft3Params.cutStavesOnNominalRadius_outer) {
-      tolerance_outer = 0.;
+    // cut staves on nominal inner radius if specified
+    if (tolerance_inner > staveConfig.maxToleranceInner) {
+      tolerance_inner = staveConfig.maxToleranceInner;
+    }
+    if (tolerance_outer > staveConfig.maxToleranceOuter) {
+      tolerance_outer = staveConfig.maxToleranceOuter;
     }
 
     /*
-     * There are three cases in which we want to mirror the stave around the x-axis,
+     * There are two cases in which we want to mirror the stave around the x-axis,
      * which correspond to the stave not going fully from + to - Rout in y.
      *
-     * (1) The inner tolerance is 0 (or positive)
+     * (1) The inner tolerance is 0 (or negative)
      *    a) AND either x_left or x_right lies within the inner radius
-     * (2) The inner tolerance is large (allow stave placement as wished)
+     * (2) The inner tolerance is large enough to allow stave placement as wished
      *    a) AND the given stave midpoint is above the inner radius
      */
     double x_left = staveConfig.x_midpoints[i_stave] - Constants::sensor2x1_width / 2;
@@ -618,8 +623,8 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
      * that there is no lower limit. The upper limit must however be larger than 0,
      * if it is not, then skip this stave and give a warning.
      */
-    absAllowedYRange.first += tolerance_inner;
-    absAllowedYRange.second -= tolerance_outer;
+    absAllowedYRange.first -= tolerance_inner;
+    absAllowedYRange.second += tolerance_outer;
 
     if (absAllowedYRange.first < 0) {
       absAllowedYRange.first = 0;
@@ -637,6 +642,8 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     std::string stave_volume_name =
       "Stave_" + std::to_string(i_stave) + "_" + std::to_string(layerNumber) +
       "_" + std::to_string(direction);
+
+    // Create the stave volumes and fill the y positions where to put sensors on the stave
     addStaveVolume(
       motherVolume, stave_volume_name, direction, &volume_count,
       staveConfig.y_lengths[i_stave], staveTriangles, absAllowedYRange,

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
@@ -395,9 +395,7 @@ void FT3Module::add2x1GlueVolume(
   unsigned volume_count, double x_mid, double y_mid, double z_mid,
   std::string element_glued_to)
 {
-  std::string glue_name = "FT3glue_" + element_glued_to + "_"
-                        + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_"
-                        + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
+  std::string glue_name = "FT3glue_" + element_glued_to + "_" + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_" + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
   addDetectorVolume(
     motherVolume, glue_name, Constants::glueColor, volume_count,
     x_mid, y_mid, z_mid,
@@ -412,9 +410,7 @@ void FT3Module::add2x1CopperVolume(
   TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
   unsigned volume_count, double x_mid, double y_mid, double z_mid)
 {
-  std::string copper_name = "FT3Copper_" + std::to_string(direction) + "_"
-                          + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
-                          + "_" + std::to_string(volume_count);
+  std::string copper_name = "FT3Copper_" + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_" + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
   addDetectorVolume(
     motherVolume, copper_name, Constants::CuColor, volume_count,
     x_mid, y_mid, z_mid,
@@ -429,9 +425,7 @@ void FT3Module::add2x1KaptonVolume(
   TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
   unsigned volume_count, double x_mid, double y_mid, double z_mid)
 {
-  std::string kapton_name = "FT3Kapton_" + std::to_string(direction) + "_"
-                          + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
-                          + "_" + std::to_string(volume_count);
+  std::string kapton_name = "FT3Kapton_" + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_" + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
   addDetectorVolume(
     motherVolume, kapton_name, Constants::kaptonColor, volume_count,
     x_mid, y_mid, z_mid,
@@ -464,9 +458,7 @@ void FT3Module::addSingleSensorVolume(
   TGeoVolume* sensor;
   TGeoManager* geoManager = gGeoManager;
   // ACTIVE AREA
-  std::string sensor_name = "FT3Sensor_" + std::to_string(direction) + "_"
-                          + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
-                          + "_" + std::to_string(volume_count);
+  std::string sensor_name = "FT3Sensor_" + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_" + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
   sensor = geoManager->MakeBox(sensor_name.c_str(), siliconMed, Constants::active_width / 2,
                                Constants::single_sensor_height / 2, Constants::siliconThickness / 2);
   sensor->SetLineColor(Constants::SiColor);
@@ -483,9 +475,7 @@ void FT3Module::addSingleSensorVolume(
   // INACTIVE STRIP ON LEFT OR RIGHT
   double inactive_x_mid = isLeft ? (active_x_mid - Constants::active_width / 2 - Constants::inactive_width / 2)
                                  : (active_x_mid + Constants::active_width / 2 + Constants::inactive_width / 2);
-  std::string sensor_inactive_name = "FT3Sensor_Inactive_" + std::to_string(direction) + "_"
-                                   + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
-                                   + "_" + std::to_string(volume_count);
+  std::string sensor_inactive_name = "FT3Sensor_Inactive_" + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_" + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
   sensor = geoManager->MakeBox(sensor_inactive_name.c_str(), siliconMed, Constants::inactive_width / 2,
                                Constants::single_sensor_height / 2, Constants::siliconThickness / 2);
   sensor->SetLineColor(Constants::SiInactiveColor);
@@ -560,8 +550,7 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
   // each entry is a vector, where each entry is the number of modules of that stack height
   std::vector<std::vector<unsigned>> nSensorStackCountPerStave(
     staveConfig.x_midpoints.size(),
-    std::vector<unsigned>(Constants::kSensorsPerStack.size(), 0)
-  );
+    std::vector<unsigned>(Constants::kSensorsPerStack.size(), 0));
   std::vector<unsigned> nSensorStackTotal(Constants::kSensorsPerStack.size(), 0);
   unsigned staveVolumeCount = 0;
   for (unsigned i_stave = 0; i_stave < staveConfig.x_midpoints.size(); i_stave++) {
@@ -677,23 +666,17 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
 
     // now add the sensor positions on the stave
     for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
-      unsigned nModulesCurr = y_positionsPosNeg.back().first.size()
-                            + y_positionsPosNeg.back().second.size();
+      unsigned nModulesCurr = y_positionsPosNeg.back().first.size() + y_positionsPosNeg.back().second.size();
       fill_stave(y_positionsPosNeg.back(), Rin, Rout, x_left,
                  Constants::kSensorsPerStack[i_kSens], y_ranges,
                  absAllowedYRange);
-      unsigned nModulesAdded = y_positionsPosNeg.back().first.size()
-                             + y_positionsPosNeg.back().second.size()
-                             - nModulesCurr;
+      unsigned nModulesAdded = y_positionsPosNeg.back().first.size() + y_positionsPosNeg.back().second.size() - nModulesCurr;
       nSensorStackCountPerStave[i_stave][i_kSens] = nModulesAdded;
       nSensorStackTotal[i_kSens] += nModulesAdded;
     }
-    std::string moduleDebugStr = "Module size counts for layer " + std::to_string(layerNumber)
-                             + " in direction " + std::to_string(direction) + ":\n";
+    std::string moduleDebugStr = "Module size counts for layer " + std::to_string(layerNumber) + " in direction " + std::to_string(direction) + ":\n";
     for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
-      moduleDebugStr += "\t" + std::to_string(nSensorStackCountPerStave[i_stave][i_kSens])
-                     + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens])
-                     + " sensors stacked\n";
+      moduleDebugStr += "\t" + std::to_string(nSensorStackCountPerStave[i_stave][i_kSens]) + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens]) + " sensors stacked\n";
     }
     LOG(debug) << moduleDebugStr;
   }
@@ -701,9 +684,7 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     "Total module size counts for layer " + std::to_string(layerNumber) +
     " in direction " + std::to_string(direction) + ":\n";
   for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
-    totalModuleInfoStr += "\t" + std::to_string(nSensorStackTotal[i_kSens])
-                        + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens])
-                        + " sensors stacked\n";
+    totalModuleInfoStr += "\t" + std::to_string(nSensorStackTotal[i_kSens]) + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens]) + " sensors stacked\n";
   }
   LOG(info) << totalModuleInfoStr;
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
@@ -368,7 +368,7 @@ void FT3Module::addStaveVolume(
 
 void FT3Module::addDetectorVolume(
   TGeoVolume* motherVolume, std::string volumeName, int color,
-  unsigned* volume_count, double x_mid, double y_mid, double z_mid,
+  unsigned volume_count, double x_mid, double y_mid, double z_mid,
   double x_half_length, double y_half_length, double z_half_length)
 {
   TGeoManager* geoManager = gGeoManager;
@@ -378,13 +378,12 @@ void FT3Module::addDetectorVolume(
   volume->SetFillColorAlpha(color, 0.4);
   motherVolume->AddNode(
     volume,
-    *volume_count,
+    volume_count,
     new TGeoTranslation( // midpoint of box to add
       x_mid,
       y_mid,
       z_mid) // TGeoTranslation
   );         // addNode
-  (*volume_count)++;
 }
 
 /*
@@ -393,10 +392,12 @@ void FT3Module::addDetectorVolume(
  */
 void FT3Module::add2x1GlueVolume(
   TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-  unsigned* volume_count, double x_mid, double y_mid, double z_mid,
+  unsigned volume_count, double x_mid, double y_mid, double z_mid,
   std::string element_glued_to)
 {
-  std::string glue_name = "FT3glue_" + element_glued_to + "_" + std::to_string(layerNumber) + "_" + std::to_string(direction) + "_" + std::to_string(stave_idx) + "_" + std::to_string(*volume_count);
+  std::string glue_name = "FT3glue_" + element_glued_to + "_"
+                        + std::to_string(direction) + "_" + std::to_string(layerNumber) + "_"
+                        + std::to_string(stave_idx) + "_" + std::to_string(volume_count);
   addDetectorVolume(
     motherVolume, glue_name, Constants::glueColor, volume_count,
     x_mid, y_mid, z_mid,
@@ -409,9 +410,11 @@ void FT3Module::add2x1GlueVolume(
  */
 void FT3Module::add2x1CopperVolume(
   TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-  unsigned* volume_count, double x_mid, double y_mid, double z_mid)
+  unsigned volume_count, double x_mid, double y_mid, double z_mid)
 {
-  std::string copper_name = "FT3Copper_" + std::to_string(layerNumber) + "_" + std::to_string(direction) + "_" + std::to_string(stave_idx) + "_" + std::to_string(*volume_count);
+  std::string copper_name = "FT3Copper_" + std::to_string(direction) + "_"
+                          + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
+                          + "_" + std::to_string(volume_count);
   addDetectorVolume(
     motherVolume, copper_name, Constants::CuColor, volume_count,
     x_mid, y_mid, z_mid,
@@ -424,9 +427,11 @@ void FT3Module::add2x1CopperVolume(
  */
 void FT3Module::add2x1KaptonVolume(
   TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-  unsigned* volume_count, double x_mid, double y_mid, double z_mid)
+  unsigned volume_count, double x_mid, double y_mid, double z_mid)
 {
-  std::string kapton_name = "FT3Kapton_" + std::to_string(layerNumber) + "_" + std::to_string(direction) + "_" + std::to_string(stave_idx) + "_" + std::to_string(*volume_count);
+  std::string kapton_name = "FT3Kapton_" + std::to_string(direction) + "_"
+                          + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
+                          + "_" + std::to_string(volume_count);
   addDetectorVolume(
     motherVolume, kapton_name, Constants::kaptonColor, volume_count,
     x_mid, y_mid, z_mid,
@@ -453,44 +458,47 @@ void FT3Module::add2x1KaptonVolume(
  */
 void FT3Module::addSingleSensorVolume(
   TGeoVolume* motherVolume, int layerNumber, int direction, unsigned stave_idx,
-  unsigned* volume_count, double active_x_mid, double y_mid, double z_mid,
+  unsigned volume_count, double active_x_mid, double y_mid, double z_mid,
   bool isLeft)
 {
   TGeoVolume* sensor;
   TGeoManager* geoManager = gGeoManager;
   // ACTIVE AREA
-  std::string sensor_name = "FT3Sensor_" + std::to_string(layerNumber) + "_" + std::to_string(direction) + "_" + std::to_string(stave_idx) + "_" + std::to_string(*volume_count);
+  std::string sensor_name = "FT3Sensor_" + std::to_string(direction) + "_"
+                          + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
+                          + "_" + std::to_string(volume_count);
   sensor = geoManager->MakeBox(sensor_name.c_str(), siliconMed, Constants::active_width / 2,
                                Constants::single_sensor_height / 2, Constants::siliconThickness / 2);
   sensor->SetLineColor(Constants::SiColor);
   sensor->SetFillColorAlpha(Constants::SiColor, 0.4);
   motherVolume->AddNode(
     sensor,
-    *volume_count,
+    volume_count,
     new TGeoTranslation( // midpoint of box to add
       active_x_mid,
       y_mid,
       z_mid) // TGeoTranslation
   );         // addNode
-  (*volume_count)++;
+  (volume_count)++;
   // INACTIVE STRIP ON LEFT OR RIGHT
   double inactive_x_mid = isLeft ? (active_x_mid - Constants::active_width / 2 - Constants::inactive_width / 2)
                                  : (active_x_mid + Constants::active_width / 2 + Constants::inactive_width / 2);
-  std::string sensor_inactive_name =
-    "FT3Sensor_Inactive_" + std::to_string(layerNumber) + "_" + std::to_string(direction) + "_" + std::to_string(stave_idx) + "_" + std::to_string(*volume_count);
+  std::string sensor_inactive_name = "FT3Sensor_Inactive_" + std::to_string(direction) + "_"
+                                   + std::to_string(layerNumber) + "_" + std::to_string(stave_idx)
+                                   + "_" + std::to_string(volume_count);
   sensor = geoManager->MakeBox(sensor_inactive_name.c_str(), siliconMed, Constants::inactive_width / 2,
                                Constants::single_sensor_height / 2, Constants::siliconThickness / 2);
   sensor->SetLineColor(Constants::SiInactiveColor);
   sensor->SetFillColorAlpha(Constants::SiInactiveColor, 0.4);
   motherVolume->AddNode(
     sensor,
-    *volume_count,
+    volume_count,
     new TGeoTranslation( // midpoint of box to add
       inactive_x_mid,
       y_mid,
       z_mid) // TGeoTranslation
   );         // addNode
-  (*volume_count)++;
+  (volume_count)++;
 }
 
 void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction,
@@ -498,8 +506,8 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
                                        const Constants::StaveConfig& staveConfig,
                                        TGeoVolume* motherVolume)
 {
-  LOG(debug) << "FT3Module: create_layout_staveGeo - Layer "
-             << layerNumber << ", Direction " << direction;
+  LOG(debug) << "FT3Module: create_layout_staveGeo - Direction "
+             << direction << ", Layer " << layerNumber;
 
   FT3Module::initialize_materials();
   auto& ft3Params = o2::ft3::FT3BaseParam::Instance();
@@ -546,7 +554,6 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
 
   // initialise all y_positions, vector over all staves/columns
   std::vector<PosNegPositionTypes> y_positionsPosNeg;
-  unsigned volume_count = 0; // give each subvolume a unique ID
   // stave triangle cross sections are the same for every stave (direction based)
   std::array<std::array<double, 3>, 4> staveTriangles = buildStaveTriangle(direction);
   // declare vector with number of 2xn sensor stacks (modules) -- only used for logging
@@ -556,6 +563,7 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     std::vector<unsigned>(Constants::kSensorsPerStack.size(), 0)
   );
   std::vector<unsigned> nSensorStackTotal(Constants::kSensorsPerStack.size(), 0);
+  unsigned staveVolumeCount = 0;
   for (unsigned i_stave = 0; i_stave < staveConfig.x_midpoints.size(); i_stave++) {
     y_positionsPosNeg.emplace_back(PosNegPositionTypes{PositionTypes{}, PositionTypes{}});
     const int staveID = Constants::staveIdxToID(i_stave, staveConfig.x_midpoints.size());
@@ -651,18 +659,18 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     double z_stave_shift_forward = // move staves more inward to fit in layer volume
       -z_offset_to_carbon_face + z_stave_shift_abs;
     std::string stave_volume_name =
-      "Stave_" + std::to_string(i_stave) + "_" + std::to_string(layerNumber) +
-      "_" + std::to_string(direction);
+      "FT3_Stave_" + std::to_string(direction) + "_" + std::to_string(layerNumber) +
+      "_" + std::to_string(i_stave);
 
     // Create the stave volumes and fill the y positions where to put sensors on the stave
     addStaveVolume(
-      motherVolume, stave_volume_name, direction, &volume_count,
+      motherVolume, stave_volume_name, direction, &staveVolumeCount,
       staveConfig.y_lengths[i_stave], staveTriangles, absAllowedYRange,
       staveConfig.x_midpoints[i_stave], y_midpoint, z_stave_shift_forward);
     // Now create the mirrored stave
     if (mirrorStaveAroundX) {
       addStaveVolume(
-        motherVolume, stave_volume_name + "_mirrored", direction, &volume_count,
+        motherVolume, stave_volume_name + "_mirrored", direction, &staveVolumeCount,
         staveConfig.y_lengths[i_stave], staveTriangles, absAllowedYRange,
         staveConfig.x_midpoints[i_stave], -y_midpoint, z_stave_shift_forward);
     }
@@ -728,6 +736,7 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
                                        : -Constants::z_offsetStave(staveConfig.x_midpoint_spacing);
     }
 
+    unsigned sensor_count = 0; // reset for each stave
     for (int y_sign = -1; y_sign < 2; y_sign += 2) {
       // place sensors at positive and negative y
       const auto& positions = (y_sign == 1) ? y_positionsPosNeg[i_stave].first
@@ -741,34 +750,35 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
           // left single sensor of the 2x1
           double z_mid = z_offset_to_silicon * z_offset_multiplier + z_stave_shift;
           addSingleSensorVolume(
-            motherVolume, layerNumber, direction, i_stave, &volume_count,
+            motherVolume, layerNumber, direction, i_stave, sensor_count,
             x_mid - Constants::active_width / 2, y_mid, z_mid, true);
           // right single sensor of the 2x1
           addSingleSensorVolume(
-            motherVolume, layerNumber, direction, i_stave, &volume_count,
+            motherVolume, layerNumber, direction, i_stave, sensor_count,
             x_mid + Constants::active_width / 2, y_mid, z_mid, false);
           // ------------ (2) Epoxy glue layer between silicon and copper (FPC) ------------
           z_mid = z_offset_to_glue_Si * z_offset_multiplier + z_stave_shift;
           add2x1GlueVolume(
-            motherVolume, layerNumber, direction, i_stave, &volume_count,
+            motherVolume, layerNumber, direction, i_stave, sensor_count,
             x_mid, y_mid, z_mid, "SiCu");
           // ------------ (3) Copper layer (FPC) ------------
           z_mid = z_offset_to_copper * z_offset_multiplier + z_stave_shift;
           add2x1CopperVolume(
-            motherVolume, layerNumber, direction, i_stave, &volume_count,
+            motherVolume, layerNumber, direction, i_stave, sensor_count,
             x_mid, y_mid, z_mid);
           // ------------ (4) Kapton layer (FPC) ------------
           z_mid = z_offset_to_kapton * z_offset_multiplier + z_stave_shift;
           add2x1KaptonVolume(
-            motherVolume, layerNumber, direction, i_stave, &volume_count,
+            motherVolume, layerNumber, direction, i_stave, sensor_count,
             x_mid, y_mid, z_mid);
           // ------------ (5) Epoxy glue layer between stave and Kapton ------------
           z_mid = z_offset_to_glue_Ka * z_offset_multiplier + z_stave_shift;
           add2x1GlueVolume(
-            motherVolume, layerNumber, direction, i_stave, &volume_count,
+            motherVolume, layerNumber, direction, i_stave, sensor_count,
             x_mid, y_mid, z_mid, "CarbonKapton");
           // increment to next sensor: (height + gap of one sensor)
           y_mid += y_sign * (Constants::sensor2x1_height + Constants::sensor2x1_gap);
+          sensor_count++; // same count for each material in the glued stack of materials
         } // sensors in stack
       } // for y_sign (writing of positive or negative y positions)
     } // i_y_pos

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Module.cxx
@@ -553,8 +553,7 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
   // each entry is a vector, where each entry is the number of modules of that stack height
   std::vector<std::vector<unsigned>> nSensorStackCountPerStave(
     staveConfig.x_midpoints.size(),
-    std::vector<unsigned>(Constants::kSensorsPerStack.size(), 0)
-  );
+    std::vector<unsigned>(Constants::kSensorsPerStack.size(), 0));
   std::vector<unsigned> nSensorStackTotal(Constants::kSensorsPerStack.size(), 0);
   for (unsigned i_stave = 0; i_stave < staveConfig.x_midpoints.size(); i_stave++) {
     y_positionsPosNeg.emplace_back(PosNegPositionTypes{PositionTypes{}, PositionTypes{}});
@@ -669,23 +668,17 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
 
     // now add the sensor positions on the stave
     for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
-      unsigned nModulesCurr = y_positionsPosNeg.back().first.size()
-                            + y_positionsPosNeg.back().second.size();
+      unsigned nModulesCurr = y_positionsPosNeg.back().first.size() + y_positionsPosNeg.back().second.size();
       fill_stave(y_positionsPosNeg.back(), Rin, Rout, x_left,
                  Constants::kSensorsPerStack[i_kSens], y_ranges,
                  absAllowedYRange);
-      unsigned nModulesAdded = y_positionsPosNeg.back().first.size()
-                             + y_positionsPosNeg.back().second.size()
-                             - nModulesCurr;
+      unsigned nModulesAdded = y_positionsPosNeg.back().first.size() + y_positionsPosNeg.back().second.size() - nModulesCurr;
       nSensorStackCountPerStave[i_stave][i_kSens] = nModulesAdded;
       nSensorStackTotal[i_kSens] += nModulesAdded;
     }
-    std::string moduleDebugStr = "Module size counts for layer " + std::to_string(layerNumber)
-                             + " in direction " + std::to_string(direction) + ":\n";
+    std::string moduleDebugStr = "Module size counts for layer " + std::to_string(layerNumber) + " in direction " + std::to_string(direction) + ":\n";
     for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
-      moduleDebugStr += "\t" + std::to_string(nSensorStackCountPerStave[i_stave][i_kSens])
-                     + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens])
-                     + " sensors stacked\n";
+      moduleDebugStr += "\t" + std::to_string(nSensorStackCountPerStave[i_stave][i_kSens]) + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens]) + " sensors stacked\n";
     }
     LOG(debug) << moduleDebugStr;
   }
@@ -693,9 +686,7 @@ void FT3Module::create_layout_staveGeo(double mZ, int layerNumber, int direction
     "Total module size counts for layer " + std::to_string(layerNumber) +
     " in direction " + std::to_string(direction) + ":\n";
   for (unsigned i_kSens = 0; i_kSens < Constants::kSensorsPerStack.size(); i_kSens++) {
-    totalModuleInfoStr += "\t" + std::to_string(nSensorStackTotal[i_kSens])
-                        + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens])
-                        + " sensors stacked\n";
+    totalModuleInfoStr += "\t" + std::to_string(nSensorStackTotal[i_kSens]) + " modules with " + std::to_string(Constants::kSensorsPerStack[i_kSens]) + " sensors stacked\n";
   }
   LOG(info) << totalModuleInfoStr;
 

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKServices.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKServices.cxx
@@ -625,7 +625,7 @@ void TRKServices::createMLServicesPeacock(TGeoVolume* motherVolume)
   motherVolume->AddNode(middleBarrelCarbonSupportVolume, 1, nullptr);
 
   // Get geometry information from TRK which is already present
-  float rMinMiddleServices = 38.0f;                       // cm, start radius of the ML services = maximum radius allowed for sensors (35 cm), plus some margin for disk paving with modules
+  float rMinMiddleServices = 38.5f;                       // cm, start radius of the ML services = maximum radius allowed for sensors (35 cm), plus some margin for disk paving with modules
   const float zMiddleServicesBarrel = 64.5f;              // cm, z position of the first barrel ML service disk
   const float zMiddleServicesBarrelFwdConnection = 143.f; // cm, z position of barrel to forward connection services
   const float zLengthCylinderMiddleServicesBarrel = zMiddleServicesBarrelFwdConnection - zMiddleServicesBarrel;


### PR DESCRIPTION
There are three changes in this PR.

1. **Main change: Tolerance on tiling to avoid overlaps.** Instead of having a simple flag regarding cutting on nominal radii, instead there are now four doubles to set -- the tolerance on the inner and outer radius for ML and OT layers respectively.
   - Change TRK ML Services inner radius from 38.0cm -> 38.5cm
   - Add maximum tolerances in stave config structs - pick smallest of that and user chosen value for running. Currently those values are 3.49cm and 0cm for outer and inner radii (same for ML and OT). This is to leave 0.1mm buffer to avoid overlaps with TRK services.
   - Invert the way tolerances were previously treated: Positive tolerance means ALLOWING placements beyond the nominal radius, and negative tolerance means introducing a padding from the nominal radius to the beginning of stave & tiling.
2. Add piping output for printing the number of various module sensor stacks were used, on a stave basis (DEBUG) and layer basis (INFO). For example, a stave might contain four 4x2 modules, as well as one 2x2 and one 1x2 module.
3. Change naming convention of staves and sensors in staves to. Numbers are now in the following order: `<direction>_<layer>_<stave_index>_<sensor_index>`.