### PR TITLE
ITSMFT: ITS3: fix asserts in TopoDict

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -92,67 +92,67 @@ class TopologyDictionary
   /// Returns the x position of the COG for the n_th element
   inline float getXCOG(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mXCOG;
   }
   /// Returns the error on the x position of the COG for the n_th element
   inline float getErrX(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mErrX;
   }
   /// Returns the z position of the COG for the n_th element
   inline float getZCOG(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mZCOG;
   }
   /// Returns the error on the z position of the COG for the n_th element
   inline float getErrZ(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mErrZ;
   }
   /// Returns the error^2 on the x position of the COG for the n_th element
   inline float getErr2X(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mErr2X;
   }
   /// Returns the error^2 on the z position of the COG for the n_th element
   inline float getErr2Z(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mErr2Z;
   }
   /// Returns the hash of the n_th element
   inline unsigned long getHash(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mHash;
   }
   /// Returns the number of fired pixels of the n_th element
   inline int getNpixels(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mNpixels;
   }
   /// Returns the frequency of the n_th element;
   inline double getFrequency(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mFrequency;
   }
   /// Returns true if the element corresponds to a group of rare topologies
   inline bool isGroup(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mIsGroup;
   }
   /// Returns the pattern of the topology
   inline const ClusterPattern& getPattern(int n) const
   {
-    assert(n >= 0 || n < (int)mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)mVectorOfIDs.size());
     return mVectorOfIDs[n].mPattern;
   }
 

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
@@ -65,77 +65,77 @@ class TopologyDictionary
   [[nodiscard]] float getXCOG(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mXCOG;
   }
   /// Returns the error on the x position of the COG for the n_th element
   [[nodiscard]] float getErrX(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mErrX;
   }
   /// Returns the z position of the COG for the n_th element
   [[nodiscard]] float getZCOG(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mZCOG;
   }
   /// Returns the error on the z position of the COG for the n_th element
   [[nodiscard]] float getErrZ(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mErrZ;
   }
   /// Returns the error^2 on the x position of the COG for the n_th element
   [[nodiscard]] float getErr2X(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mErr2X;
   }
   /// Returns the error^2 on the z position of the COG for the n_th element
   [[nodiscard]] float getErr2Z(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mErr2Z;
   }
   /// Returns the hash of the n_th element
   [[nodiscard]] unsigned long getHash(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mHash;
   }
   /// Returns the number of fired pixels of the n_th element
   [[nodiscard]] int getNpixels(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mNpixels;
   }
   /// Returns the frequency of the n_th element;
   [[nodiscard]] double getFrequency(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mFrequency;
   }
   /// Returns true if the element corresponds to a group of rare topologies
   [[nodiscard]] bool isGroup(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mIsGroup;
   }
   /// Returns the pattern of the topology
   [[nodiscard]] const itsmft::ClusterPattern& getPattern(int n, bool IB = true) const
   {
     const auto& data = (IB) ? mDataIB : mDataOB;
-    assert(n >= 0 || n < (int)data.mVectorOfIDs.size());
+    assert(n >= 0 && n < (int)data.mVectorOfIDs.size());
     return data.mVectorOfIDs[n].mPattern;
   }
 


### PR DESCRIPTION
Alex noticed that is should be `&&` instead of `||` since both should be true, should be trivial.