### PR TITLE
Add token for the test CCDB instance

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -213,8 +213,7 @@ void CcdbApi::init(std::string const& host)
     snapshotReport += ')';
   }
 
-  mNeedAlienToken = (host.find("https://") != std::string::npos) || (host.find("alice-ccdb.cern.ch") != std::string::npos);
-
+  mNeedAlienToken = (host.find("https://") != std::string::npos) || (host.find("alice-ccdb.cern.ch") != std::string::npos) || (host.find("ccdb-test.cern.ch") != std::string::npos);
   // Set the curl timeout. It can be forced with an env var or it has different defaults based on the deployment mode.
   if (getenv("ALICEO2_CCDB_CURL_TIMEOUT_DOWNLOAD")) {
     auto timeout = atoi(getenv("ALICEO2_CCDB_CURL_TIMEOUT_DOWNLOAD"));


### PR DESCRIPTION
Before the test instance did not need a token. This has changed, which broke tests that relied on hardcoded HTTP/. Now the test instance redirects to HTTPS and we need a token.

I ran the CCDB test again after this change and with also changing the redirect to from 302 to 307 on the server side,  it passes the tests again. 