### PR TITLE
TPC: add option for disabling corrections

### DIFF
--- a/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsLoader.cxx
@@ -28,8 +28,13 @@ using namespace o2::framework;
 void CorrectionMapsLoader::extractCCDBInputs(ProcessingContext& pc, float tpcScaler)
 {
   pc.inputs().get<o2::tpc::CorrMapParam*>("tpcCorrPar");
-  pc.inputs().get<o2::gpu::TPCFastTransform*>("tpcCorrMap");
-  pc.inputs().get<o2::gpu::TPCFastTransform*>("tpcCorrMapRef");
+  const auto lumiMode = getLumiScaleMode();
+  if (lumiMode != LumiScaleMode::NoCorrection && lumiMode != LumiScaleMode::StaticMapOnly) {
+    pc.inputs().get<o2::gpu::TPCFastTransform*>("tpcCorrMap");
+  }
+  if (lumiMode != LumiScaleMode::NoCorrection) {
+    pc.inputs().get<o2::gpu::TPCFastTransform*>("tpcCorrMapRef");
+  }
   const int maxDumRep = 5;
   int dumRep = 0;
   o2::ctp::LumiInfo lumiObj;
@@ -97,6 +102,10 @@ void CorrectionMapsLoader::requestCCDBInputs(std::vector<InputSpec>& inputs, con
     // for MC corrections
     addInput(inputs, {"tpcCorrMap", "TPC", "CorrMap", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalCorrMapMC), {}, 1)});            // time-dependent
     addInput(inputs, {"tpcCorrMapRef", "TPC", "CorrMapRef", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalCorrDerivMapMC), {}, 1)}); // time-dependent
+  } else if (gloOpts.lumiMode == LumiScaleMode::NoCorrection) {
+    // no correction maps needed — a dummy map is created at runtime
+  } else if (gloOpts.lumiMode == LumiScaleMode::StaticMapOnly) {
+    addInput(inputs, {"tpcCorrMapRef", "TPC", "CorrMapRef", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalCorrMapRef), {}, 0)}); // load once
   } else {
     LOG(fatal) << "Correction mode unknown! Choose either 0 (default) or 1 (derivative map) for flag corrmap-lumi-mode.";
   }

--- a/Detectors/TPC/calibration/src/CorrectionMapsOptions.cxx
+++ b/Detectors/TPC/calibration/src/CorrectionMapsOptions.cxx
@@ -21,13 +21,13 @@ CorrectionMapsGloOpts CorrectionMapsOptions::parseGlobalOptions(const o2::framew
 {
   CorrectionMapsGloOpts tpcopt;
   auto lumiTypeVal = opts.get<int>("lumi-type");
-  if (lumiTypeVal < -1 || lumiTypeVal > 2) {
+  if (lumiTypeVal < static_cast<int>(LumiScaleType::Unset) || lumiTypeVal >= static_cast<int>(LumiScaleType::Count)) {
     LOGP(fatal, "Invalid lumi-type value: {}", lumiTypeVal);
   }
   tpcopt.lumiType = static_cast<LumiScaleType>(lumiTypeVal);
 
   auto lumiModeVal = opts.get<int>("corrmap-lumi-mode");
-  if (lumiModeVal < -1 || lumiModeVal > 2) {
+  if (lumiModeVal < static_cast<int>(LumiScaleMode::Unset) || lumiModeVal >= static_cast<int>(LumiScaleMode::Count)) {
     LOGP(fatal, "Invalid corrmap-lumi-mode value: {}", lumiModeVal);
   }
   tpcopt.lumiMode = static_cast<LumiScaleMode>(lumiModeVal);

--- a/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCScalerSpec.cxx
@@ -183,40 +183,45 @@ class TPCScalerSpec : public Task
 
   void buildMap(ProcessingContext& pc)
   {
-    // reference map
-    auto* corrMap = mTPCCorrMapsLoader.getCorrMap();
-
-    // // new correction map
+    const auto lumiMode = mTPCCorrMapsLoader.getLumiScaleMode();
     o2::gpu::TPCFastTransform finalMap;
-    finalMap.cloneFromObject(*corrMap, nullptr);
-    finalMap.setApplyCorrectionOn();
-
-    const auto* corrMapRef = mTPCCorrMapsLoader.getCorrMapRef();
-    const float lumiScale = mTPCCorrMapsLoader.getLumiScale();
     std::vector<std::pair<const o2::gpu::TPCFastSpaceChargeCorrection*, float>> additionalCorrections;
 
-    // if standard scaling is used: map(lumi) = (mean_map - ref_map) * lumiScale + ref_map
-    if (mTPCCorrMapsLoader.getLumiScaleMode() == LumiScaleMode::Linear) {
-      const std::vector<std::pair<const o2::gpu::TPCFastSpaceChargeCorrection*, float>> step0{{&(corrMapRef->getCorrection()), -1.f}};
-      // finalMap = (mean_map - finalMap)
-      TPCFastSpaceChargeCorrectionHelper::instance()->mergeCorrections(finalMap.getCorrection(), 1, step0, true);
+    if (lumiMode == LumiScaleMode::NoCorrection) {
+      std::unique_ptr<o2::gpu::TPCFastTransform> dummy(TPCFastTransformHelperO2::instance()->create(0));
+      finalMap.cloneFromObject(*dummy, nullptr);
+      finalMap.setApplyCorrectionOff();
+    } else {
+      auto* corrMap = mTPCCorrMapsLoader.getCorrMap();
+      const auto* corrMapRef = mTPCCorrMapsLoader.getCorrMapRef();
+      finalMap.cloneFromObject(lumiMode == LumiScaleMode::StaticMapOnly && corrMapRef ? *corrMapRef : *corrMap, nullptr);
+      finalMap.setApplyCorrectionOn();
 
-      // finalMap = finalMap * lumiScale + ref_map
-      const std::vector<std::pair<const o2::gpu::TPCFastSpaceChargeCorrection*, float>> step1{{&(corrMapRef->getCorrection()), 1.f}};
-      TPCFastSpaceChargeCorrectionHelper::instance()->mergeCorrections(finalMap.getCorrection(), lumiScale, step1, true);
+      const float lumiScale = mTPCCorrMapsLoader.getLumiScale();
 
-    } else if (mTPCCorrMapsLoader.getLumiScaleMode() == LumiScaleMode::DerivativeMap || mTPCCorrMapsLoader.getLumiScaleMode() == LumiScaleMode::DerivativeMapMC) {
-      additionalCorrections.emplace_back(&(corrMapRef->getCorrection()), lumiScale);
-    }
+      // if standard scaling is used: map(lumi) = (mean_map - ref_map) * lumiScale + ref_map
+      if (lumiMode == LumiScaleMode::Linear) {
+        const std::vector<std::pair<const o2::gpu::TPCFastSpaceChargeCorrection*, float>> step0{{&(corrMapRef->getCorrection()), -1.f}};
+        // finalMap = (mean_map - finalMap)
+        TPCFastSpaceChargeCorrectionHelper::instance()->mergeCorrections(finalMap.getCorrection(), 1, step0, true);
 
-    // if mshape map valid
-    if (!mTPCCorrMapsLoader.isCorrMapMShapeDummy()) {
-      LOGP(info, "Adding M-shape correction to the final map with scaling factor {}", mMShapeScalingFac);
-      additionalCorrections.emplace_back(&(mTPCCorrMapsLoader.getCorrMapMShape()->getCorrection()), 1.f);
-    }
+        // finalMap = finalMap * lumiScale + ref_map
+        const std::vector<std::pair<const o2::gpu::TPCFastSpaceChargeCorrection*, float>> step1{{&(corrMapRef->getCorrection()), 1.f}};
+        TPCFastSpaceChargeCorrectionHelper::instance()->mergeCorrections(finalMap.getCorrection(), lumiScale, step1, true);
 
-    if (!additionalCorrections.empty()) {
-      TPCFastSpaceChargeCorrectionHelper::instance()->mergeCorrections(finalMap.getCorrection(), 1, additionalCorrections, true);
+      } else if (lumiMode == LumiScaleMode::DerivativeMap || lumiMode == LumiScaleMode::DerivativeMapMC) {
+        additionalCorrections.emplace_back(&(corrMapRef->getCorrection()), lumiScale);
+      }
+
+      // if mshape map valid
+      if (!mTPCCorrMapsLoader.isCorrMapMShapeDummy()) {
+        LOGP(info, "Adding M-shape correction to the final map with scaling factor {}", mMShapeScalingFac);
+        additionalCorrections.emplace_back(&(mTPCCorrMapsLoader.getCorrMapMShape()->getCorrection()), 1.f);
+      }
+
+      if (!additionalCorrections.empty()) {
+        TPCFastSpaceChargeCorrectionHelper::instance()->mergeCorrections(finalMap.getCorrection(), 1, additionalCorrections, true);
+      }
     }
 
     Output corrMapOutput{header::gDataOriginTPC, "TPCCORRMAP", 0};

--- a/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
+++ b/GPU/TPCFastTransformation/CorrectionMapsHelper.cxx
@@ -38,6 +38,10 @@ void CorrectionMapsHelper::setCorrMapMShape(std::unique_ptr<TPCFastTransform>&& 
 void CorrectionMapsHelper::updateLumiScale(bool report)
 {
   if (!canUseCorrections()) {
+    if (mLumiScaleMode != LumiScaleMode::NoCorrection) {
+      LOGP(warning, "Negative meanLumi={} detected, switching to NoCorrection mode for backward compatibility", mMeanLumi);
+      mLumiScaleMode = LumiScaleMode::NoCorrection;
+    }
     mLumiScale = -1.f;
   } else if ((mLumiScaleMode == LumiScaleMode::DerivativeMap) || (mLumiScaleMode == LumiScaleMode::DerivativeMapMC)) {
     mLumiScale = mMeanLumiRef ? (mInstLumi - mMeanLumi) / mMeanLumiRef : 0.f;
@@ -54,7 +58,40 @@ void CorrectionMapsHelper::updateLumiScale(bool report)
 //________________________________________________________
 void CorrectionMapsHelper::reportScaling()
 {
-  LOGP(info, "Map scaling update: LumiScaleType={} instLumi(CTP)={} instLumi(scaling)={} meanLumiRef={}, meanLumi={} -> LumiScale={} lumiScaleMode={}, M-Shape map valid: {}, M-Shape default: {}",
-       mLumiScaleType == LumiScaleType::NoScaling ? "NoScaling" : (mLumiScaleType == LumiScaleType::CTPLumi ? "LumiCTP" : "TPCScaler"), getInstLumiCTP(), getInstLumi(), getMeanLumiRef(), getMeanLumi(), getLumiScale(),
-       mLumiScaleMode == LumiScaleMode::Linear ? "Linear" : "Derivative", (mCorrMapMShape != nullptr), isCorrMapMShapeDummy());
+  auto lumiTypeName = [](LumiScaleType t) {
+    switch (t) {
+      case LumiScaleType::NoScaling:
+        return "NoScaling";
+      case LumiScaleType::CTPLumi:
+        return "CTPLumi";
+      case LumiScaleType::TPCScaler:
+        return "TPCScaler";
+      default:
+        return "Unknown";
+    }
+  };
+
+  const bool mshapeValid = (mCorrMapMShape != nullptr) && !isCorrMapMShapeDummy();
+
+  if (mLumiScaleMode == LumiScaleMode::NoCorrection) {
+    LOGP(info, "Map scaling update: mode=NoCorrection (corrections disabled, dummy map in use)");
+  } else if (mLumiScaleMode == LumiScaleMode::StaticMapOnly) {
+    LOGP(info, "Map scaling update: mode=StaticMapOnly (static reference map, no lumi scaling), M-Shape correction: {}", mshapeValid ? "applied" : "not applied");
+  } else {
+    auto lumiModeName = [](LumiScaleMode m) {
+      switch (m) {
+        case LumiScaleMode::Linear:
+          return "Linear";
+        case LumiScaleMode::DerivativeMap:
+          return "DerivativeMap";
+        case LumiScaleMode::DerivativeMapMC:
+          return "DerivativeMapMC";
+        default:
+          return "Unknown";
+      }
+    };
+    LOGP(info, "Map scaling update: LumiScaleType={} instLumi(CTP)={} instLumi(scaling)={} meanLumiRef={} meanLumi={} -> LumiScale={} lumiScaleMode={}, M-Shape correction: {}",
+         lumiTypeName(mLumiScaleType), getInstLumiCTP(), getInstLumi(), getMeanLumiRef(), getMeanLumi(), getLumiScale(),
+         lumiModeName(mLumiScaleMode), mshapeValid ? "applied" : "not applied");
+  }
 }

--- a/GPU/TPCFastTransformation/CorrectionMapsTypes.h
+++ b/GPU/TPCFastTransformation/CorrectionMapsTypes.h
@@ -22,14 +22,18 @@ enum class LumiScaleType : int {
   Unset = -1,    ///< init value
   NoScaling = 0, ///< no scaling, use map as is
   CTPLumi = 1,   ///< use CTP luminosity for scaling
-  TPCScaler = 2  ///< use TPC scaler for scaling
+  TPCScaler = 2, ///< use TPC scaler for scaling
+  Count          ///< sentinel - keep last
 };
 
 enum class LumiScaleMode : int {
-  Unset = -1,         ///< init value
-  Linear = 0,         ///< map(lumi) = (mean_map - referenceMap) * lumiScale + referenceMap
-  DerivativeMap = 1,  ///< map(lumi) = mean_map + lumiScale * (derivativeMap) where derivativeMap = (mean_map_A - mean_map_B)
-  DerivativeMapMC = 2 ///< same DerivativeMap, but for MC
+  Unset = -1,          ///< init value
+  Linear = 0,          ///< map(lumi) = (mean_map - referenceMap) * lumiScale + referenceMap
+  DerivativeMap = 1,   ///< map(lumi) = mean_map + lumiScale * (derivativeMap) where derivativeMap = (mean_map_A - mean_map_B)
+  DerivativeMapMC = 2, ///< same DerivativeMap, but for MC
+  NoCorrection = 3,    ///< no corrections at all
+  StaticMapOnly = 4,   ///< use only static map instead of main map
+  Count                ///< sentinel - keep last
 };
 
 struct CorrectionMapsGloOpts {


### PR DESCRIPTION
- add option for using static corrections instead of main corrections

`o2-tpc-scaler-workflow --corrmap-lumi-mode 3` disables all corrections
`o2-tpc-scaler-workflow --corrmap-lumi-mode 4` uses only the static correction map
`o2-tpc-scaler-workflow --configKeyValues "TPCCorrMap.lumiMean=-1"` disables all corrections for backward compatibility