### PR TITLE
ITS: adjust printing and use mask

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
@@ -309,8 +309,7 @@ void TrackerTraitsGPU<NLayers>::findRoads(const int iteration)
     bounded_vector<TrackSeed<NLayers>> trackSeeds(this->getMemoryPool().get());
     for (int startCellTopologyId{0}; startCellTopologyId < hostTopology.nCells; ++startCellTopologyId) {
       const int startLayer = hostTopology.getCell(startCellTopologyId).hitLayerMask.last();
-      if ((this->mTrkParams[iteration].StartLayerMask & (1 << startLayer)) == 0 ||
-          mTimeFrameGPU->getNCells()[startCellTopologyId] == 0) {
+      if (!(this->mTrkParams[iteration].StartLayerMask.has(startLayer)) || mTimeFrameGPU->getNCells()[startCellTopologyId] == 0) {
         continue;
       }
       processNeighboursHandler<NLayers>(startLevel,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -26,6 +26,7 @@
 #include "CommonUtils/EnumFlags.h"
 #include "DetectorsBase/Propagator.h"
 #include "ITStracking/Constants.h"
+#include "ITStracking/LayerMask.h"
 
 namespace o2::its
 {
@@ -70,10 +71,9 @@ struct TrackingParameters {
   float DiamondCov[6] = {25.e-6f, 0.f, 0.f, 25.e-6f, 0.f, 36.f};
 
   /// General parameters
-  int ClusterSharing = 0;
   int MinTrackLength = 7;
   int MaxHoles = 0;
-  uint16_t HoleLayerMask = 0;
+  LayerMask HoleLayerMask = 0;
   float NSigmaCut = 5;
   float PVres = 1.e-2f;
   /// Trackleting cuts
@@ -86,7 +86,7 @@ struct TrackingParameters {
   float MaxChi2NDF = 30.f;
   int ReseedIfShorter = 6; // reseed for the final fit track with the length shorter than this
   std::vector<float> MinPt = {0.f, 0.f, 0.f, 0.f};
-  uint16_t StartLayerMask = 0x7F;
+  LayerMask StartLayerMask = 0x7F;
   bool RepeatRefitOut = false;   // repeat outward refit using inward refit as a seed
   bool ShiftRefToCluster = true; // TrackFit: after update shift the linearization reference to cluster
   bool PerPrimaryVertexProcessing = false;
@@ -103,6 +103,7 @@ struct TrackingParameters {
   float SharedClusterMaxDeltaPhi = 0.05f; // For tracks sharing clusters, maximum allowed delta phi at the cluster position
   float SharedClusterMaxDeltaEta = 0.03f; // For tracks sharing clusters, maximum allowed delta eta at the cluster position
   bool SharedClusterOppositeSign = false; // For tracks sharing clusters, require opposite sign of the tracklets
+  int SharedMaxClusters = 0;              // Maximal allowed shared clusters (excluding first cluster)
 };
 
 struct VertexingParameters {

--- a/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
@@ -24,8 +24,9 @@ using namespace o2::its;
 
 std::string TrackingParameters::asString() const
 {
-  std::string str = std::format("NZb:{} NPhB:{} PerVtx:{} DropFail:{} ClSh:{} TtklMinPt:{:.2f} MinCl:{} MaxHoles:{} HoleMask:{:#x}",
-                                ZBins, PhiBins, PerPrimaryVertexProcessing, DropTFUponFailure, ClusterSharing, TrackletMinPt, MinTrackLength, MaxHoles, HoleLayerMask);
+  std::string str = std::format("NZb:{} NPhB:{} PerVtx:{} DropFail:{} TtklMinPt:{:.2f} MinCl:{}", ZBins, PhiBins, PerPrimaryVertexProcessing, DropTFUponFailure, TrackletMinPt, MinTrackLength);
+  auto isSet = [](auto e) { return e >= 0; };
+  auto isAnySet = [&isSet](auto v) { return !v.empty() && std::any_of(v.begin(), v.end(), isSet); };
   bool first = true;
   for (int il = NLayers; il >= MinTrackLength; il--) {
     int slot = NLayers - il;
@@ -37,17 +38,26 @@ std::string TrackingParameters::asString() const
       str += std::format("L{}:{:.2f} ", il, MinPt[slot]);
     }
   }
-  if (!SystErrorY2.empty() || !SystErrorZ2.empty()) {
+  if (isAnySet(SystErrorY2) || isAnySet(SystErrorZ2)) {
     str += " SystErrY/Z:";
     for (size_t i = 0; i < SystErrorY2.size(); i++) {
       str += std::format("{:.2e}/{:.2e} ", SystErrorY2[i], SystErrorZ2[i]);
     }
   }
-  if (!AddTimeError.empty()) {
+  if (isAnySet(AddTimeError)) {
     str += " AddTimeError:";
     for (unsigned int i : AddTimeError) {
       str += std::format("{} ", i);
     }
+  }
+  if (SharedMaxClusters) {
+    str += std::format(" ShaMaxCls:{} ", SharedMaxClusters);
+  }
+  if (AllowSharingFirstCluster) {
+    str += std::format(" ShaClsDPhi:{} ShaClsDEta:{} ShaClsSign:{}", SharedClusterMaxDeltaPhi, SharedClusterMaxDeltaEta, SharedClusterOppositeSign);
+  }
+  if (MaxHoles) {
+    str += std::format(" MaxHoles:{} HoleMask:{}", MaxHoles, HoleLayerMask.asString());
   }
   if (std::numeric_limits<size_t>::max() != MaxMemory) {
     str += std::format(" MemLimit {:.2f} GB", double(MaxMemory) / constants::GB);

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -681,8 +681,7 @@ void TrackerTraits<NLayers>::findRoads(const int iteration)
     bounded_vector<TrackSeedN> trackSeeds(mMemoryPool.get());
     for (int startCellTopologyId{0}; startCellTopologyId < topology.nCells; ++startCellTopologyId) {
       const int startLayer = topology.getCell(startCellTopologyId).hitLayerMask.last();
-      if ((mTrkParams[iteration].StartLayerMask & (1 << startLayer)) == 0 ||
-          mTimeFrame->getCells()[startCellTopologyId].empty()) {
+      if (!(mTrkParams[iteration].StartLayerMask.has(startLayer)) || mTimeFrame->getCells()[startCellTopologyId].empty()) {
         continue;
       }
 
@@ -814,7 +813,7 @@ void TrackerTraits<NLayers>::acceptTracks(int iteration, bounded_vector<TrackITS
     }
 
     /// do not account for the first cluster in the shared clusters number if it is allowed
-    if (nShared - int(isFirstShared && mTrkParams[iteration].AllowSharingFirstCluster) > mTrkParams[iteration].ClusterSharing) {
+    if (nShared - int(isFirstShared && mTrkParams[iteration].AllowSharingFirstCluster) > mTrkParams[iteration].SharedMaxClusters) {
       continue;
     }
 

--- a/Detectors/Upgrades/ALICE3/GlobalReconstruction/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ALICE3/GlobalReconstruction/workflow/src/TrackerSpec.cxx
@@ -113,8 +113,8 @@ std::vector<o2::its::TrackingParameters> TrackerDPL::createTrackingParamsFromCon
       if (paramConfig.contains("PhiBins")) {
         params.PhiBins = paramConfig["PhiBins"].get<int>();
       }
-      if (paramConfig.contains("ClusterSharing")) {
-        params.ClusterSharing = paramConfig["ClusterSharing"].get<int>();
+      if (paramConfig.contains("SharedMaxClusters")) {
+        params.SharedMaxClusters = paramConfig["SharedMaxClusters"].get<int>();
       }
       if (paramConfig.contains("MinTrackLength")) {
         params.MinTrackLength = paramConfig["MinTrackLength"].get<int>();


### PR DESCRIPTION
This changes the type of previous integers used as masks to LayerMask, renames an unused parameter `ClusterSharing` to something more meaningful and changes the printing of the config to only actually extra set values.