### PR TITLE
TPC timeseries: make data requests conditional on input sources

### DIFF
--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1825,15 +1825,16 @@ o2::framework::DataProcessorSpec getTPCTimeSeriesSpec(const bool disableWriter, 
   auto dataRequest = std::make_shared<DataRequest>();
   bool useMC = false;
   GTrackID::mask_t srcTracks = GTrackID::getSourcesMask("TPC,ITS,ITS-TPC,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF") & src;
-  srcTracks.set(GTrackID::TPC); // TPC must be always there
   dataRequest->requestTracks(srcTracks, useMC);
-  dataRequest->requestClusters(GTrackID::getSourcesMask("TPC"), useMC);
+  if (src[GTrackID::TPC]) {
+    dataRequest->requestClusters(GTrackID::getSourcesMask("TPC"), useMC);
+  }
 
   bool tpcOnly = srcTracks == GTrackID::getSourcesMask("TPC");
-  if (!tpcOnly) {
+  if (srcTracks.any() && !tpcOnly) {
     dataRequest->requestFT0RecPoints(useMC);
+    dataRequest->requestPrimaryVertices(useMC);
   }
-  dataRequest->requestPrimaryVertices(useMC);
 
   const bool enableAskMatLUT = matType == o2::base::Propagator::MatCorrType::USEMatCorrLUT;
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(!disableWriter,                 // orbitResetTime


### PR DESCRIPTION
- do not request PV and FT0 in TPC-only mode
- do not request TPC clusters if TPC is not in input sources
- make time series work without any track input