### PR TITLE
ITS: Remove redundant 'const' from getter methods

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -192,12 +192,11 @@ class TrackITSExt : public TrackITS
     getClusterRefs().setEntries(ncl);
   }
 
-  GPUhdi() const int getClusterIndex(int lr) const { return mIndex[lr]; }
+  GPUhdi() int getClusterIndex(int lr) const { return mIndex[lr]; }
 
-  GPUh() const int getFirstLayerClusterIndex() const
+  GPUh() int getFirstLayerClusterIndex() const
   {
-    int firstLayer = getFirstClusterLayer();
-    return getClusterIndex(firstLayer);
+    return getClusterIndex(getFirstClusterLayer());
   }
 
   GPUhdi() void setExternalClusterIndex(int layer, int idx, bool newCluster = false)


### PR DESCRIPTION
the redunant const from #15406 qualifiers lead to warnings:
```
O2/GPU/GPUTracking/Standalone/../../../DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h:195:12: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
  195 |   GPUhdi() const int getClusterIndex(int lr) const { return mIndex[lr]; }
      |            ^~~~~
/O2/GPU/GPUTracking/Standalone/../../../DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h:197:10: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
  197 |   GPUh() const int getFirstLayerClusterIndex() const
      |          ^~~~~
```