### PR TITLE
Create the inputs filter on the fly if it was not set externally

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -40,8 +40,7 @@ RawPixelDecoder<Mapping>::RawPixelDecoder()
   mTimerDecode.Stop();
   mTimerFetchData.Stop();
   mSelfName = o2::utils::Str::concat_string(Mapping::getName(), "Decoder");
-  DPLRawParser<>::setCheckIncompleteHBF(false);                                                                             // Disable incomplete HBF checking, see ErrPacketCounterJump check in GBTLink.cxx
-  mInputFilter = {InputSpec{"filter", ConcreteDataTypeMatcher{Mapping::getOrigin(), o2::header::gDataDescriptionRawData}}}; // by default take all raw data
+  DPLRawParser<>::setCheckIncompleteHBF(false); // Disable incomplete HBF checking, see ErrPacketCounterJump check in GBTLink.cxx
 }
 
 ///______________________________________________________________
@@ -235,6 +234,11 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
   auto nLinks = mGBTLinks.size();
   auto origin = (mUserDataOrigin == o2::header::gDataOriginInvalid) ? mMAP.getOrigin() : mUserDataOrigin;
   auto datadesc = (mUserDataDescription == o2::header::gDataDescriptionInvalid) ? o2::header::gDataDescriptionRawData : mUserDataDescription;
+
+  if (mInputFilter.empty()) { // if no filter set externally, create a global one from imposed or default origin / description
+    mInputFilter.emplace_back("filter", ConcreteDataTypeMatcher{origin, datadesc});
+  }
+
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
   {


### PR DESCRIPTION
In this way the user (e.g. QC) set DataOrigin and DataDescription or default ITS(MFT)/RAWDATA will propagate to the input selection filter, unless it was set explicitly