### PR TITLE
Ctpdev: cinsistency checker fix

### DIFF
--- a/Detectors/CTP/macro/PlotPbLumi.C
+++ b/Detectors/CTP/macro/PlotPbLumi.C
@@ -173,7 +173,7 @@ void PlotPbLumi(int runNumber = 572073, bool sum = 1, double cut = 0, bool qc = 
   Double_t* tcetoznc = tcetozncvec.data();
   Double_t* vchtoznc = vchtozncvec.data();
   for (int i = i0; i < ilast; i++) {
-  //for (int i = 30; i < 40; i++) {
+    // for (int i = 30; i < 40; i++) {
 
     int iv = i - i0;
     x[iv] = (double_t)(recs[i + 1].intRecord.orbit + recs[i].intRecord.orbit) / 2. - orbit0;
@@ -181,9 +181,9 @@ void PlotPbLumi(int runNumber = 572073, bool sum = 1, double cut = 0, bool qc = 
     // x[i] = (double_t)(recs[i+1].epochTime + recs[i].epochTime)/2.;
     double_t tt = (double_t)(recs[i + 1].intRecord.orbit - recs[i].intRecord.orbit);
     tt = tt * 88e-6;
-    //std::cout << i << " " << iv << " " << tt << std::endl;
+    // std::cout << i << " " << iv << " " << tt << std::endl;
     //
-    // std::cout << recs[i+1].scalersInps[25] << std::endl;
+    //  std::cout << recs[i+1].scalersInps[25] << std::endl;
     double_t znci = (double_t)(recs[i + 1].scalersInps[25] - recs[i].scalersInps[25]);
     double_t mu = -TMath::Log(1. - znci / tt / nbc / frev);
     double_t zncipp = mu * nbc * frev;
@@ -202,14 +202,14 @@ void PlotPbLumi(int runNumber = 572073, bool sum = 1, double cut = 0, bool qc = 
     // std::cout << recs[i+1].scalers[tce].lmBefore << std::endl;
     had += recs[i + 1].scalers[tsc].lmBefore - recs[i].scalers[tsc].lmBefore;
     // rat = (double_t)(had)/double_t(recs[i+1].scalersInps[25] - recs[i].scalersInps[25])*28;
-    if(zncpp[iv] > cut) {
+    if (zncpp[iv] > cut) {
       tcetsctoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
     } else {
       tcetsctoznc[iv] = 0.;
     }
     had = recs[i + 1].scalers[tce].lmBefore - recs[i].scalers[tce].lmBefore;
     // rat = (double_t)(had)/double_t(recs[i+1].scalersInps[25] - recs[i].scalersInps[25])*28;
-    if(zncpp[iv] > cut) {
+    if (zncpp[iv] > cut) {
       tcetoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
     } else {
       tcetoznc[iv] = 0.;
@@ -218,7 +218,7 @@ void PlotPbLumi(int runNumber = 572073, bool sum = 1, double cut = 0, bool qc = 
     double_t muvch = -TMath::Log(1. - had / tt / nbc / frev);
 
     // rat = (double_t)(had)/double_t(recs[i+1].scalersInps[25] - recs[i].scalersInps[25])*28;
-    if(zncpp[iv] > cut) {
+    if (zncpp[iv] > cut) {
       vchtoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
     } else {
       vchtoznc[iv] = 0.;

--- a/Detectors/CTP/macro/PlotPbLumi.C
+++ b/Detectors/CTP/macro/PlotPbLumi.C
@@ -35,7 +35,7 @@ using namespace o2::ctp;
 // qc = 0: takes scalers from CCDB (available only for finished runs) otherwise from QCCDB (available for active runs)
 // t0-tlast: window in seconds counted from beginning of run
 //
-void PlotPbLumi(int runNumber = 567905, bool sum = 0, bool qc = 0, Double_t t0 = 0., Double_t tlast = 0.)
+void PlotPbLumi(int runNumber = 572073, bool sum = 1, double cut = 0, bool qc = 0, Double_t t0 = 0., Double_t tlast = 0.)
 { //
   // PLots in one canvas
   // znc rate/28
@@ -173,12 +173,15 @@ void PlotPbLumi(int runNumber = 567905, bool sum = 0, bool qc = 0, Double_t t0 =
   Double_t* tcetoznc = tcetozncvec.data();
   Double_t* vchtoznc = vchtozncvec.data();
   for (int i = i0; i < ilast; i++) {
+  //for (int i = 30; i < 40; i++) {
+
     int iv = i - i0;
     x[iv] = (double_t)(recs[i + 1].intRecord.orbit + recs[i].intRecord.orbit) / 2. - orbit0;
     x[iv] *= 88e-6;
     // x[i] = (double_t)(recs[i+1].epochTime + recs[i].epochTime)/2.;
     double_t tt = (double_t)(recs[i + 1].intRecord.orbit - recs[i].intRecord.orbit);
     tt = tt * 88e-6;
+    //std::cout << i << " " << iv << " " << tt << std::endl;
     //
     // std::cout << recs[i+1].scalersInps[25] << std::endl;
     double_t znci = (double_t)(recs[i + 1].scalersInps[25] - recs[i].scalersInps[25]);
@@ -199,15 +202,27 @@ void PlotPbLumi(int runNumber = 567905, bool sum = 0, bool qc = 0, Double_t t0 =
     // std::cout << recs[i+1].scalers[tce].lmBefore << std::endl;
     had += recs[i + 1].scalers[tsc].lmBefore - recs[i].scalers[tsc].lmBefore;
     // rat = (double_t)(had)/double_t(recs[i+1].scalersInps[25] - recs[i].scalersInps[25])*28;
-    tcetsctoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
+    if(zncpp[iv] > cut) {
+      tcetsctoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
+    } else {
+      tcetsctoznc[iv] = 0.;
+    }
     had = recs[i + 1].scalers[tce].lmBefore - recs[i].scalers[tce].lmBefore;
     // rat = (double_t)(had)/double_t(recs[i+1].scalersInps[25] - recs[i].scalersInps[25])*28;
-    tcetoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
+    if(zncpp[iv] > cut) {
+      tcetoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
+    } else {
+      tcetoznc[iv] = 0.;
+    }
     had = recs[i + 1].scalers[vch].lmBefore - recs[i].scalers[vch].lmBefore;
     double_t muvch = -TMath::Log(1. - had / tt / nbc / frev);
 
     // rat = (double_t)(had)/double_t(recs[i+1].scalersInps[25] - recs[i].scalersInps[25])*28;
-    vchtoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
+    if(zncpp[iv] > cut) {
+      vchtoznc[iv] = (double_t)(had) / zncpp[iv] / tt;
+    } else {
+      vchtoznc[iv] = 0.;
+    }
     // std::cout << "muzdc:" << mu << " mu tce:" << mutce << " muvch:" << muvch << std::endl;
   }
   //

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -603,6 +603,7 @@ int RawDataDecoder::checkReadoutConsistentncy(o2::pmr::vector<CTPDigit>& digits,
   LOG(debug) << "Checking readout";
   int ret = 0;
   static int nerror = 0;
+  int32_t magicBC =  o2::constants::lhc::LHCMaxBunches - o2::ctp::TriggerOffsetsParam::Instance().LM_L0 - o2::ctp::TriggerOffsetsParam::Instance().L0_L1_classes - 1;
   for (auto const& digit : digits) {
     // if class mask => inps
     for (int i = 0; i < digit.CTPClassMask.size(); i++) {
@@ -624,12 +625,15 @@ int RawDataDecoder::checkReadoutConsistentncy(o2::pmr::vector<CTPDigit>& digits,
         uint64_t clsinpmask = cls->descriptor->getInputsMask();
         uint64_t diginpmask = digit.CTPInputMask.to_ullong();
         if (!((clsinpmask & diginpmask) == clsinpmask)) {
-          if (nerror < mErrorMax) {
-            LOG(error) << "Cls=>Inps: CTP class:" << cls->name << " inpmask:" << clsinpmask << " not compatible with inputs mask:" << diginpmask;
-            nerror++;
+          if(!((digit.intRecord.bc == magicBC) && (clsinpmask & L1MASKInputs.to_ullong())))
+          {
+            if (nerror < mErrorMax) {
+              LOG(error) << "Cls=>Inps: CTP class:" << cls->name << " inpmask:" << clsinpmask << " not compatible with inputs mask:" << diginpmask << " " << digit.intRecord ;
+              nerror++;
+            }
+            mClassErrorsA[i]++;
+            ret = 128;
           }
-          mClassErrorsA[i]++;
-          ret = 128;
         }
       }
     }

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -625,7 +625,8 @@ int RawDataDecoder::checkReadoutConsistentncy(o2::pmr::vector<CTPDigit>& digits,
         uint64_t clsinpmask = cls->descriptor->getInputsMask();
         uint64_t diginpmask = digit.CTPInputMask.to_ullong();
         if (!((clsinpmask & diginpmask) == clsinpmask)) {
-          if (!((digit.intRecord.bc == magicBC) && (clsinpmask & L1MASKInputs.to_ullong()))) {
+          bool e = !(((digit.intRecord.bc == magicBC) || (digit.intRecord.bc == (magicBC + 1))) && (clsinpmask & L1MASKInputs.to_ullong()));
+          if (e) {
             if (nerror < mErrorMax) {
               LOG(error) << "Cls=>Inps: CTP class:" << cls->name << " inpmask:" << clsinpmask << " not compatible with inputs mask:" << diginpmask << " " << digit.intRecord;
               nerror++;

--- a/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
+++ b/Detectors/CTP/reconstruction/src/RawDataDecoder.cxx
@@ -603,7 +603,7 @@ int RawDataDecoder::checkReadoutConsistentncy(o2::pmr::vector<CTPDigit>& digits,
   LOG(debug) << "Checking readout";
   int ret = 0;
   static int nerror = 0;
-  int32_t magicBC =  o2::constants::lhc::LHCMaxBunches - o2::ctp::TriggerOffsetsParam::Instance().LM_L0 - o2::ctp::TriggerOffsetsParam::Instance().L0_L1_classes - 1;
+  int32_t magicBC = o2::constants::lhc::LHCMaxBunches - o2::ctp::TriggerOffsetsParam::Instance().LM_L0 - o2::ctp::TriggerOffsetsParam::Instance().L0_L1_classes - 1;
   for (auto const& digit : digits) {
     // if class mask => inps
     for (int i = 0; i < digit.CTPClassMask.size(); i++) {
@@ -625,10 +625,9 @@ int RawDataDecoder::checkReadoutConsistentncy(o2::pmr::vector<CTPDigit>& digits,
         uint64_t clsinpmask = cls->descriptor->getInputsMask();
         uint64_t diginpmask = digit.CTPInputMask.to_ullong();
         if (!((clsinpmask & diginpmask) == clsinpmask)) {
-          if(!((digit.intRecord.bc == magicBC) && (clsinpmask & L1MASKInputs.to_ullong())))
-          {
+          if (!((digit.intRecord.bc == magicBC) && (clsinpmask & L1MASKInputs.to_ullong()))) {
             if (nerror < mErrorMax) {
-              LOG(error) << "Cls=>Inps: CTP class:" << cls->name << " inpmask:" << clsinpmask << " not compatible with inputs mask:" << diginpmask << " " << digit.intRecord ;
+              LOG(error) << "Cls=>Inps: CTP class:" << cls->name << " inpmask:" << clsinpmask << " not compatible with inputs mask:" << diginpmask << " " << digit.intRecord;
               nerror++;
             }
             mClassErrorsA[i]++;

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -50,6 +50,18 @@ void RawDecoderSpec::init(framework::InitContext& ctx)
 }
 void RawDecoderSpec::endOfStream(framework::EndOfStreamContext& ec)
 {
+  auto clsEA = mDecoder.getClassErrorsA();
+  auto clsEB = mDecoder.getClassErrorsB();
+  auto cntCA = mDecoder.getClassCountersA();
+  auto cntCB = mDecoder.getClassCountersB();
+  int totClasses = 0;
+  for (int i = 0; i < o2::ctp::CTP_NCLASSES; i++) {
+    mClsEA[i] += clsEA[i];
+    mClsEB[i] += clsEB[i];
+    mClsA[i] += cntCA[i];
+    mClsB[i] += cntCB[i];
+    totClasses += cntCA[i];
+  }
   auto& TFOrbits = mDecoder.getTFOrbits();
   std::sort(TFOrbits.begin(), TFOrbits.end());
   size_t l = TFOrbits.size();
@@ -79,6 +91,7 @@ void RawDecoderSpec::endOfStream(framework::EndOfStreamContext& ec)
   }
   if (mCheckConsistency) {
     LOG(info) << "Lost due to the shift Consistency Checker:" << mDecoder.getLostDueToShiftCls();
+    LOG(info) << "Toatl classes:" << totClasses;
     auto ctpcfg = mDecoder.getCTPConfig();
     for (int i = 0; i < o2::ctp::CTP_NCLASSES; i++) {
       std::string name = ctpcfg.getClassNameFromIndex(i);
@@ -168,16 +181,6 @@ void RawDecoderSpec::run(framework::ProcessingContext& ctx)
     mErrorTCR += mDecoder.getErrorTCR();
     mIRRejected += mDecoder.getIRRejected();
     mTCRRejected += mDecoder.getTCRRejected();
-    auto clsEA = mDecoder.getClassErrorsA();
-    auto clsEB = mDecoder.getClassErrorsB();
-    auto cntCA = mDecoder.getClassCountersA();
-    auto cntCB = mDecoder.getClassCountersB();
-    for (int i = 0; i < o2::ctp::CTP_NCLASSES; i++) {
-      mClsEA[i] += clsEA[i];
-      mClsEB[i] += clsEB[i];
-      mClsA[i] += cntCA[i];
-      mClsB[i] += cntCB[i];
-    }
   }
   if (mDoLumi) {
     uint32_t tfCountsT = 0;

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -91,7 +91,7 @@ void RawDecoderSpec::endOfStream(framework::EndOfStreamContext& ec)
   }
   if (mCheckConsistency) {
     LOG(info) << "Lost due to the shift Consistency Checker:" << mDecoder.getLostDueToShiftCls();
-    LOG(info) << "Toatl classes:" << totClasses;
+    LOG(info) << "Total classes:" << totClasses;
     auto ctpcfg = mDecoder.getCTPConfig();
     for (int i = 0; i < o2::ctp::CTP_NCLASSES; i++) {
       std::string name = ctpcfg.getClassNameFromIndex(i);


### PR DESCRIPTION
fix for consistency checker for border case of class with l1 inputs versus inputs (in practice C1ZNC is affected)
Then it seems minor previous PR was not merged so it is in this one.