### PR TITLE
ITS: Modify computePhi to constexpr and clean includes

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
@@ -16,8 +16,6 @@
 #ifndef O2_ITS_TRACKING_MATHUTILS_H_
 #define O2_ITS_TRACKING_MATHUTILS_H_
 
-#include <cstdint>
-
 #include "CommonConstants/MathConstants.h"
 #include "ITStracking/Constants.h"
 #include "MathUtils/Utils.h"
@@ -27,7 +25,7 @@
 namespace o2::its::math_utils
 {
 
-GPUhdi() float computePhi(float x, float y)
+GPUhdi() constexpr float computePhi(float x, float y)
 {
   return o2::math_utils::fastATan2(-y, -x) + o2::constants::math::PI;
 }


### PR DESCRIPTION
Updated computePhi function to be constexpr and removed unnecessary include.