### PR TITLE
DPL Analysis: reserve binary views to avoid arrow preallocating extra buffers

### DIFF
--- a/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
@@ -148,6 +148,12 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
           builders.emplace_back(std::make_shared<arrow::BinaryViewBuilder>());
         }
 
+        auto reserveSize = timestampColumn->length();
+        arrow::Status status;
+        for (auto i = 0U; i < builders.size(); ++i) {
+          status &= builders[i]->Reserve(reserveSize);
+        }
+
         for (auto ci = 0; ci < timestampColumn->num_chunks(); ++ci) {
           std::shared_ptr<arrow::Array> chunk = timestampColumn->chunk(ci);
           auto const* timestamps = chunk->data()->GetValuesSafe<size_t>(1);


### PR DESCRIPTION
By default, Arrow preallocates about 2Gb for a non-specific binary view, wasting memory. Reserving the builder capacity to the table size avoids this behavior.