### PR TITLE
Fix memleaks due to unmanaged ExpandPathName

### DIFF
--- a/Common/Field/src/MagFieldFast.cxx
+++ b/Common/Field/src/MagFieldFast.cxx
@@ -61,8 +61,11 @@ MagFieldFast::MagFieldFast(float factor, int nomField, const string inpFmt) : mF
 bool MagFieldFast::LoadData(const string inpFName)
 {
   // load field from text file
-
-  std::ifstream in(gSystem->ExpandPathName(inpFName.data()), std::ifstream::in);
+  TString sName(inpFName);
+  if (gSystem->ExpandPathName(sName)) {
+    LOG(fatal) << "Failed to expand file name " << inpFName;
+  }
+  std::ifstream in(sName.Data(), std::ifstream::in);
   if (in.fail()) {
     LOG(fatal) << "Failed to open file " << inpFName;
     return false;

--- a/Common/Field/src/MagneticField.cxx
+++ b/Common/Field/src/MagneticField.cxx
@@ -14,9 +14,10 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "Field/MagneticField.h"
-#include <TFile.h>      // for TFile
-#include <TPRegexp.h>   // for TPRegexp
-#include <TSystem.h>    // for TSystem, gSystem
+#include <TFile.h>             // for TFile
+#include <TPRegexp.h>          // for TPRegexp
+#include <TString.h>           // for TString
+#include <TSystem.h>           // for TSystem, gSystem
 #include <fairlogger/Logger.h> // for FairLogger
 #include "FairParamList.h"
 #include "FairRun.h"
@@ -242,7 +243,8 @@ Bool_t MagneticField::loadParameterization()
     LOG(fatal) << "MagneticField::loadParameterization: Field data " << getParameterName()
                << " are already loaded from " << getDataFileName() << "\n";
   }
-  const char* fname = gSystem->ExpandPathName(getDataFileName());
+  TString fname = getDataFileName();
+  gSystem->ExpandPathName(fname);
   TFile* file = TFile::Open(fname);
   if (!file) {
     LOG(fatal) << "MagneticField::loadParameterization: Failed to open magnetic field data file " << fname << "\n";

--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/LookUpTable.h
@@ -24,6 +24,7 @@
 #include <Rtypes.h>
 #include <iostream>
 #include <tuple>
+#include <TString.h>
 #include <TSystem.h>
 #include <map>
 #include <string>
@@ -236,7 +237,9 @@ class LookupTableBase
       }
       inputDir += "/share/Detectors/FT0/files/";
       filepath = inputDir + "LookupTable_FT0.json";
-      filepath = gSystem->ExpandPathName(filepath.data()); // Expand $(ALICE_ROOT) into real system path
+      TString expandedFilepath = filepath;
+      gSystem->ExpandPathName(expandedFilepath); // Expand $(ALICE_ROOT) into real system path
+      filepath = expandedFilepath.Data();
     } else {
       filepath = pathToFile;
     }

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -1268,7 +1268,7 @@ void Detector::DefineOpticalProperties()
   inputDir += "/share/Detectors/FT0/files/";
 
   TString optPropPath = inputDir + "quartzOptProperties.txt";
-  optPropPath = gSystem->ExpandPathName(optPropPath.Data()); // Expand $(ALICE_ROOT) into real system path
+  gSystem->ExpandPathName(optPropPath); // Expand $(ALICE_ROOT) into real system path
 
   Int_t result = ReadOptProperties(optPropPath.Data());
   if (result < 0) {
@@ -1426,15 +1426,15 @@ void Detector::DefineSim2LUTindex()
   }
   inputDir += "/share/Detectors/FT0/files/";
 
-  std::string indPath = inputDir + "Sim2DataChannels.txt";
-  indPath = gSystem->ExpandPathName(indPath.data()); // Expand $(ALICE_ROOT) into real system path
+  TString indPath = inputDir + "Sim2DataChannels.txt";
+  gSystem->ExpandPathName(indPath); // Expand $(ALICE_ROOT) into real system path
 
   std::ifstream infile;
-  infile.open(indPath.data());
-  LOG(info) << " file  open " << indPath.data();
+  infile.open(indPath.Data());
+  LOG(info) << " file  open " << indPath.Data();
   // Check if file is opened correctly
   if (infile.fail() == true) {
-    LOG(error) << "Error opening ascii file (it is probably a folder!): " << indPath.c_str();
+    LOG(error) << "Error opening ascii file (it is probably a folder!): " << indPath;
   }
   int fromfile;
   for (int iind = 0; iind < Geometry::Nchannels; iind++) {

--- a/Detectors/GlobalTrackingWorkflow/study/src/HistoManager.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/HistoManager.cxx
@@ -22,6 +22,7 @@
 #include <TPaveStats.h>
 #include <TROOT.h>
 #include <TSystem.h>
+#include <TString.h>
 #include "Framework/Logger.h"
 #include "GlobalTrackingStudy/HistoManager.h"
 
@@ -384,7 +385,9 @@ void HistoManager::purify(bool emptyToo)
 
 void HistoManager::setFileName(const std::string& name)
 {
-  mDefName = gSystem->ExpandPathName(name.c_str());
+  TString sName = name;
+  gSystem->ExpandPathName(sName);
+  mDefName = sName.Data();
 }
 
 void HistoManager::reset()
@@ -401,7 +404,12 @@ void HistoManager::reset()
 
 int HistoManager::load(const std::string& fname, const std::string& dirname)
 {
-  TFile* file = TFile::Open(gSystem->ExpandPathName(fname.c_str()));
+  TString sName = fname;
+  if (gSystem->ExpandPathName(sName)) {
+    LOGP(error, "Cannot expand file name {}", fname);
+    return 0;
+  }
+  TFile* file = TFile::Open(sName);
   if (!file) {
     LOGP(error, "No file {}", fname);
     return 0;

--- a/Detectors/ITSMFT/MFT/base/src/Geometry.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Geometry.cxx
@@ -13,7 +13,8 @@
 /// \brief Implementation of the Geometry class
 /// \author Raphael Tieulent <raphael.tieulent@cern.ch>
 
-#include "TSystem.h"
+#include <TString.h>
+#include <TSystem.h>
 
 #include <fairlogger/Logger.h>
 
@@ -128,7 +129,9 @@ void Geometry::build()
 
   // load the detector segmentation
   if (!mSegmentation) {
-    mSegmentation = new Segmentation(gSystem->ExpandPathName("$(VMCWORKDIR)/Detectors/Geometry/MFT/data/Geometry.xml"));
+    TString sName = "$(VMCWORKDIR)/Detectors/Geometry/MFT/data/Geometry.xml";
+    gSystem->ExpandPathName(sName);
+    mSegmentation = new Segmentation(sName);
   }
 
   // build the geometry

--- a/Detectors/ITSMFT/common/simulation/src/AlpideSimResponse.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/AlpideSimResponse.cxx
@@ -14,6 +14,7 @@
 
 #include "ITSMFTSimulation/AlpideSimResponse.h"
 #include "ITSMFTSimulation/DPLDigitizerParam.h"
+#include <TString.h>
 #include <TSystem.h>
 #include <cstdio>
 #include <cstddef>
@@ -57,7 +58,9 @@ void AlpideSimResponse::initData(int tableNumber, std::string dataPath, const bo
   if (mDataPath.length() && mDataPath.back() != '/') {
     mDataPath.push_back('/');
   }
-  mDataPath = gSystem->ExpandPathName(mDataPath.data());
+  TString expandedDataPath = mDataPath;
+  gSystem->ExpandPathName(expandedDataPath);
+  mDataPath = expandedDataPath.Data();
   string inpfname = mDataPath + mGridColName;
   std::ifstream inpGrid;
 

--- a/Detectors/TOF/calibration/src/TOFFEElightReader.cxx
+++ b/Detectors/TOF/calibration/src/TOFFEElightReader.cxx
@@ -11,7 +11,8 @@
 
 #include <TOFCalibration/TOFFEElightReader.h>
 #include "Framework/Logger.h"
-#include "TSystem.h"
+#include <TString.h>
+#include <TSystem.h>
 #include <fstream>
 
 using namespace o2::tof;
@@ -20,9 +21,10 @@ void TOFFEElightReader::loadFEElightConfig(const char* fileName)
 {
   // load FEElight config
 
-  char* expandedFileName = gSystem->ExpandPathName(fileName);
+  TString expandedFileName = fileName;
+  gSystem->ExpandPathName(expandedFileName);
   std::ifstream is;
-  is.open(expandedFileName, std::ios::binary);
+  is.open(expandedFileName.Data(), std::ios::binary);
   mFileLoadBuff.reset(new char[sizeof(o2::tof::TOFFEElightConfig)]);
   is.read(mFileLoadBuff.get(), sizeof(o2::tof::TOFFEElightConfig));
   is.close();

--- a/Generators/src/DecayerPythia8.cxx
+++ b/Generators/src/DecayerPythia8.cxx
@@ -17,6 +17,7 @@
 #include "TLorentzVector.h"
 #include "TClonesArray.h"
 #include "TParticle.h"
+#include "TString.h"
 #include "TSystem.h"
 
 #include <iostream>
@@ -43,9 +44,10 @@ void DecayerPythia8::Init()
     if (param.config[i].empty()) {
       continue;
     }
-    std::string config = gSystem->ExpandPathName(param.config[i].c_str());
+    TString config = param.config[i];
+    gSystem->ExpandPathName(config);
     LOG(info) << "Reading configuration from file: " << config;
-    if (!mPythia.readFile(config, true)) {
+    if (!mPythia.readFile(config.Data(), true)) {
       LOG(fatal) << "Failed to init \'DecayerPythia8\': problems with configuration file "
                  << config;
       return;

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -23,6 +23,7 @@
 #include <cmath>
 #include "TClonesArray.h"
 #include "TParticle.h"
+#include "TString.h"
 #include "TSystem.h"
 #include "TGrid.h"
 #include "CCDB/BasicCCDBManager.h"
@@ -117,13 +118,18 @@ bool Generator::initTPCLoopersGen()
 {
   // Expand all environment paths
   const auto& loopersParam = o2::eventgen::GenTPCLoopersParam::Instance();
-  std::string model_pairs = gSystem->ExpandPathName(loopersParam.model_pairs.c_str());
-  std::string model_compton = gSystem->ExpandPathName(loopersParam.model_compton.c_str());
-  std::string nclxrate = gSystem->ExpandPathName(loopersParam.nclxrate.c_str());
-  const auto& scaler_pair = gSystem->ExpandPathName(loopersParam.scaler_pair.c_str());
-  const auto& scaler_compton = gSystem->ExpandPathName(loopersParam.scaler_compton.c_str());
-  const auto& poisson = gSystem->ExpandPathName(loopersParam.poisson.c_str());
-  const auto& gauss = gSystem->ExpandPathName(loopersParam.gauss.c_str());
+  auto expandPathName = [](const std::string& path) {
+    TString expandedPath = path;
+    gSystem->ExpandPathName(expandedPath);
+    return std::string(expandedPath.Data());
+  };
+  std::string model_pairs = expandPathName(loopersParam.model_pairs);
+  std::string model_compton = expandPathName(loopersParam.model_compton);
+  std::string nclxrate = expandPathName(loopersParam.nclxrate);
+  const std::string scaler_pair = expandPathName(loopersParam.scaler_pair);
+  const std::string scaler_compton = expandPathName(loopersParam.scaler_compton);
+  const std::string poisson = expandPathName(loopersParam.poisson);
+  const std::string gauss = expandPathName(loopersParam.gauss);
   const auto& flat_gas = loopersParam.flat_gas;
   const auto& colsys = loopersParam.colsys;
   if (flat_gas) {

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -27,6 +27,7 @@
 #include "Pythia8/HIUserHooks.h"
 #endif
 #include "Pythia8Plugins/PowhegHooks.h"
+#include "TString.h"
 #include "TSystem.h"
 #include "ZDCBase/FragmentParam.h"
 #include <CommonUtils/ConfigurationMacroHelper.h>
@@ -155,7 +156,9 @@ Bool_t GeneratorPythia8::Init()
     std::stringstream ss(mConfig);
     std::string config;
     while (getline(ss, config, ' ')) {
-      config = gSystem->ExpandPathName(config.c_str());
+      TString expandedConfig = config;
+      gSystem->ExpandPathName(expandedConfig);
+      config = expandedConfig.Data();
       LOG(info) << "Reading configuration from file: " << config;
       if (!mPythia.readFile(config, true)) {
         LOG(fatal) << "Failed to init \'Pythia8\': problems with configuration file "

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -10,9 +10,9 @@
 // or submit itself to any jurisdiction.
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include "TGeoManager.h"
-#include "TString.h"
-#include "TSystem.h"
+#include <TGeoManager.h>
+#include <TString.h>
+#include <TSystem.h>
 
 #include "DetectorsPassive/Cave.h"
 #include "DetectorsPassive/Magnet.h"
@@ -353,7 +353,9 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (isActivated("FOC")) {
     // FOCAL
-    addReadoutDetector(new o2::focal::Detector(isReadout("FOC"), gSystem->ExpandPathName("$O2_ROOT/share/Detectors/Geometry/FOC/geometryFiles/geometry_Sheets.txt")));
+    TString sName = "$O2_ROOT/share/Detectors/Geometry/FOC/geometryFiles/geometry_Sheets.txt";
+    gSystem->ExpandPathName(sName);
+    addReadoutDetector(new o2::focal::Detector(isReadout("FOC"), sName.Data()));
   }
 
   if (geomonly) {

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -26,10 +26,12 @@
 #include <DetectorsCommonDataFormats/DetID.h>
 #include <DetectorsCommonDataFormats/DetectorNameConf.h>
 #include <gsl/gsl>
-#include "TFile.h"
-#include "TMemFile.h"
-#include "TTree.h"
-#include "TROOT.h"
+#include <TFile.h>
+#include <TMemFile.h>
+#include <TTree.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <TROOT.h>
 #include <memory>
 #include <TMessage.h>
 #include <fairmq/Parts.h>
@@ -1003,7 +1005,9 @@ void O2HitMerger::initDetInstances()
       counter++;
     }
     if (i == DetID::FOC) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::focal::Detector>(true, gSystem->ExpandPathName("$O2_ROOT/share/Detectors/Geometry/FOC/geometryFiles/geometry_Sheets.txt")));
+      TString sName = "$O2_ROOT/share/Detectors/Geometry/FOC/geometryFiles/geometry_Sheets.txt";
+      gSystem->ExpandPathName(sName);
+      mDetectorInstances[i] = std::move(std::make_unique<o2::focal::Detector>(true, sName.Data()));
       counter++;
     }
 #ifdef ENABLE_UPGRADES


### PR DESCRIPTION
ExpandPathName returns a ptr to const char* to be managed by the user. This shows up in tracing memory leaks.