### PR TITLE
fix warning final-dtor-non-final-class

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/IntegratedClusterCalibrator.h
@@ -759,7 +759,7 @@ class IntegratedClusters
 };
 
 template <typename DataT>
-class IntegratedClusterCalibrator : public o2::calibration::TimeSlotCalibration<IntegratedClusters<DataT>>
+class IntegratedClusterCalibrator final : public o2::calibration::TimeSlotCalibration<IntegratedClusters<DataT>>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<IntegratedClusters<DataT>>;

--- a/Detectors/EMCAL/base/include/EMCALBase/NonlinearityHandler.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/NonlinearityHandler.h
@@ -44,7 +44,7 @@ class NonlinearityHandler
  public:
   /// \class UninitException
   /// \brief Handling missing initialisation of the NonlinearityHanlder
-  class UninitException : public std::exception
+  class UninitException final : public std::exception
   {
    public:
     /// \brief Constructor
@@ -188,7 +188,7 @@ class NonlinearityFactory
  public:
   /// \class FunctionNotFoundExcpetion
   /// \brief Handling request of non-exisiting nonlinearity functions
-  class FunctionNotFoundExcpetion : public std::exception
+  class FunctionNotFoundExcpetion final : public std::exception
   {
    public:
     /// \brief Constructor
@@ -219,7 +219,7 @@ class NonlinearityFactory
 
   /// \class NonlinInitError
   /// \brief Handling errors of initialisation of a certain nonlinearity function
-  class NonlinInitError : public std::exception
+  class NonlinInitError final : public std::exception
   {
    public:
     /// \brief Constructor

--- a/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingErrors.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingErrors.h
@@ -24,7 +24,7 @@ namespace emcal
 /// \class TRUIndexException
 /// \brief Error handling of faulty TRU indices
 /// \ingroup EMCALbase
-class TRUIndexException : public std::exception
+class TRUIndexException final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -56,7 +56,7 @@ class TRUIndexException : public std::exception
 /// \class FastORIndexException
 /// \brief Error handling of faulty FastOR indices
 /// \ingroup EMCALbase
-class FastORIndexException : public std::exception
+class FastORIndexException final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -88,7 +88,7 @@ class FastORIndexException : public std::exception
 /// \class FastORPositionExceptionTRU
 /// \brief Handling of invalid positions of a FastOR within a TRU
 /// \ingroup EMCALbase
-class FastORPositionExceptionTRU : public std::exception
+class FastORPositionExceptionTRU final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -136,7 +136,7 @@ class FastORPositionExceptionTRU : public std::exception
 /// \class FastORPositionExceptionSupermodule
 /// \brief Handling of invalid positions of a FastOR within a supermodule
 /// \ingroup EMCALbase
-class FastORPositionExceptionSupermodule : public std::exception
+class FastORPositionExceptionSupermodule final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -184,7 +184,7 @@ class FastORPositionExceptionSupermodule : public std::exception
 /// \class FastORPositionExceptionEMCAL
 /// \brief Handling of invalid positions of a FastOR in the detector
 /// \ingroup EMCALbase
-class FastORPositionExceptionEMCAL : public std::exception
+class FastORPositionExceptionEMCAL final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -222,7 +222,7 @@ class FastORPositionExceptionEMCAL : public std::exception
 /// \class PHOSRegionException
 /// \brief Handling of invalid PHOS regions
 /// \ingroup EMCALbase
-class PHOSRegionException : public std::exception
+class PHOSRegionException final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -254,7 +254,7 @@ class PHOSRegionException : public std::exception
 /// \class GeometryNotSetException
 /// \brief Handling cases where the geometry is required but not defined
 /// \ingroup EMCALbase
-class GeometryNotSetException : public std::exception
+class GeometryNotSetException final : public std::exception
 {
  public:
   /// \brief Constructor
@@ -274,7 +274,7 @@ class GeometryNotSetException : public std::exception
 /// \class L0sizeInvalidException
 /// \brief Handlig access of L0 index mapping with invalid patch size
 /// \ingroup EMCALbase
-class L0sizeInvalidException : public std::exception
+class L0sizeInvalidException final : public std::exception
 {
  public:
   /// \brief Constructor

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -50,7 +50,7 @@ namespace emcal
 /// \brief class used for managment of bad channel and time calibration
 /// template DataInput can be ChannelData or TimeData   // o2::emcal::EMCALChannelData, o2::emcal::EMCALTimeCalibData
 template <typename DataInput, typename DataOutput>
-class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<DataInput>
+class EMCALChannelCalibrator final : public o2::calibration::TimeSlotCalibration<DataInput>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<DataInput>;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/PedestalCalibDevice.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/PedestalCalibDevice.h
@@ -26,7 +26,7 @@
 namespace o2::emcal
 {
 
-class PedestalCalibDevice : o2::framework::Task
+class PedestalCalibDevice final : o2::framework::Task
 {
  public:
   PedestalCalibDevice(bool dumpToFile, bool addRunNum) : mDumpToFile(dumpToFile), mAddRunNumber(addRunNum){};

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/PedestalProcessorData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/PedestalProcessorData.h
@@ -39,7 +39,7 @@ class PedestalProcessorData
  public:
   /// \class ChannelIndexException
   /// \brief Handling access to invalid channel index (out-of-bounds)
-  class ChannelIndexException : public std::exception
+  class ChannelIndexException final : public std::exception
   {
    private:
     unsigned short mChannelIndex; ///< Index of the channel raising the exception

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/PedestalProcessorDevice.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/PedestalProcessorDevice.h
@@ -30,12 +30,12 @@ class Geometry;
 /// \author Markus Fasel <markus.fasel@cern.ch.>, Oak Ridge National Laboratory
 /// \ingroup EMCALCalib
 /// \since March 21, 2024
-class PedestalProcessorDevice : o2::framework::Task
+class PedestalProcessorDevice final : o2::framework::Task
 {
  private:
   /// \class ModuleIndexException
   /// \brief Exception handling errors in calculation of the absolute module ID
-  class ModuleIndexException : public std::exception
+  class ModuleIndexException final : public std::exception
   {
    public:
     /// \enum ModuleType_t

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoContainer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoContainer.h
@@ -333,7 +333,7 @@ class RecoContainerReader
  public:
   /// \class InvalidAccessException
   /// \brief Handling of access to objects beyond container boundary
-  class InvalidAccessException : public std::exception
+  class InvalidAccessException final : public std::exception
   {
    public:
     /// \brief Constructor

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/TRUDecodingErrors.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/TRUDecodingErrors.h
@@ -24,7 +24,7 @@ namespace emcal
 /// \class FastOrStartTimeInvalidException
 /// \brief Handling of error if starttime is to large (>=14). This is most likely caused by a corrupted channel header where a FEC channel is identified as a TRU channel
 /// \ingroup EMCALbase
-class FastOrStartTimeInvalidException : public std::exception
+class FastOrStartTimeInvalidException final : public std::exception
 {
  public:
   /// \brief Constructor

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
@@ -53,7 +53,7 @@ class TriggerRecord;
 /// calibration decides whether a cell is accepted. Therefore the amount of cells can change
 /// for the given trigger. New trigger record objects are created and published to the same
 /// subspec as what is used for the output cell vector.
-class CellRecalibratorSpec : public framework::Task
+class CellRecalibratorSpec final : public framework::Task
 {
  public:
   /// \enum LEDEventSettings

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -182,7 +182,7 @@ class RawToCellConverterSpec : public framework::Task
  private:
   /// \class ModuleIndexException
   /// \brief Exception handling errors in calculation of the absolute module ID
-  class ModuleIndexException : public std::exception
+  class ModuleIndexException final : public std::exception
   {
    public:
     /// \enum ModuleType_t

--- a/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadData.h
+++ b/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadData.h
@@ -27,7 +27,7 @@ namespace o2::focal
 class ASICData
 {
  public:
-  class IndexException : public std::exception
+  class IndexException final : public std::exception
   {
    public:
     IndexException() = default;
@@ -125,7 +125,7 @@ class ASICContainer
 class PadData
 {
  public:
-  class IndexException : public std::exception
+  class IndexException final : public std::exception
   {
    public:
     IndexException() = default;

--- a/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadMapper.h
+++ b/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadMapper.h
@@ -27,7 +27,7 @@ class PadMapper
   static constexpr std::size_t NROW = 9;
   static constexpr std::size_t NCHANNELS = NCOLUMN * NROW;
 
-  class PositionException : public std::exception
+  class PositionException final : public std::exception
   {
    public:
     PositionException(unsigned int column, unsigned int row) : mColumn(column), mRow(row), mMessage()
@@ -51,7 +51,7 @@ class PadMapper
     std::string mMessage;
   };
 
-  class ChannelIDException : public std::exception
+  class ChannelIDException final : public std::exception
   {
    public:
     ChannelIDException(unsigned int channelID) : mChannelID(channelID), mMessage()

--- a/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PixelLaneData.h
+++ b/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PixelLaneData.h
@@ -46,7 +46,7 @@ class PixelLaneHandler
  public:
   static constexpr std::size_t NLANES = 28;
 
-  class LaneIndexException : public std::exception
+  class LaneIndexException final : public std::exception
   {
    public:
     LaneIndexException(int index) : std::exception(), mIndex(index), mMessage()

--- a/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PixelMapper.h
+++ b/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PixelMapper.h
@@ -64,7 +64,7 @@ class PixelMapper
     }
   };
 
-  class InvalidChipException : public std::exception
+  class InvalidChipException final : public std::exception
   {
    public:
     InvalidChipException(PixelMapper::ChipIdentifier& identifier) : mIdentifier(identifier), mMessage()
@@ -85,7 +85,7 @@ class PixelMapper
     std::string mMessage;
   };
 
-  class UninitException : public std::exception
+  class UninitException final : public std::exception
   {
    public:
     UninitException() = default;
@@ -95,7 +95,7 @@ class PixelMapper
     void print(std::ostream& stream) const;
   };
 
-  class MappingNotSetException : public std::exception
+  class MappingNotSetException final : public std::exception
   {
    public:
     MappingNotSetException() = default;

--- a/Detectors/GRP/workflows/src/rct-updater-workflow.cxx
+++ b/Detectors/GRP/workflows/src/rct-updater-workflow.cxx
@@ -31,7 +31,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 namespace o2::rct
 {
-class RCTUpdaterSpec : public o2::framework::Task
+class RCTUpdaterSpec final : public o2::framework::Task
 {
  public:
   RCTUpdaterSpec(std::shared_ptr<o2::base::GRPGeomRequest> gr) : mGGCCDBRequest(gr) {}

--- a/Detectors/GlobalTrackingWorkflow/study/src/CheckResidSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/CheckResidSpec.cxx
@@ -72,7 +72,7 @@ using VTIndex = o2::dataformats::VtxTrackIndex;
 using GTrackID = o2::dataformats::GlobalTrackID;
 using timeEst = o2::dataformats::TimeStampWithError<float, float>;
 
-class CheckResidSpec : public Task
+class CheckResidSpec final : public Task
 {
  public:
   CheckResidSpec(std::shared_ptr<DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, GTrackID::mask_t src, bool drawOnly, bool postProcOnly)

--- a/Detectors/GlobalTrackingWorkflow/study/src/ITSOffsStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/ITSOffsStudy.cxx
@@ -40,7 +40,7 @@ using GTrackID = o2::dataformats::GlobalTrackID;
 
 using timeEst = o2::dataformats::TimeStampWithError<float, float>;
 
-class ITSOffsStudy : public Task
+class ITSOffsStudy final : public Task
 {
  public:
   ITSOffsStudy(std::shared_ptr<DataRequest> dr, GTrackID::mask_t src) : mDataRequest(dr), mTracksSrc(src) {}

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCDataFilter.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCDataFilter.cxx
@@ -45,7 +45,7 @@ using TBracket = o2::math_utils::Bracketf_t;
 
 using timeEst = o2::dataformats::TimeStampWithError<float, float>;
 
-class TPCDataFilter : public Task
+class TPCDataFilter final : public Task
 {
  public:
   enum TrackDecision : char { NA,

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
@@ -35,7 +35,7 @@ class ROFRecord;
 namespace its
 {
 
-class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>
+class NoiseSlotCalibrator final : public o2::calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>
 {
   using Slot = calibration::TimeSlot<o2::itsmft::NoiseMap>;
 

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/AvgClusSize.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/AvgClusSize.cxx
@@ -64,7 +64,7 @@ using TrackITS = o2::its::TrackITS;
 using DCA = o2::dataformats::DCA;
 using PID = o2::track::PID;
 
-class AvgClusSizeStudy : public Task
+class AvgClusSizeStudy final : public Task
 {
  public:
   AvgClusSizeStudy(std::shared_ptr<DataRequest> dr,

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/Efficiency.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/Efficiency.cxx
@@ -56,7 +56,7 @@ using namespace o2::globaltracking;
 
 using GTrackID = o2::dataformats::GlobalTrackID;
 
-class EfficiencyStudy : public Task
+class EfficiencyStudy final : public Task
 {
  public:
   EfficiencyStudy(std::shared_ptr<DataRequest> dr,

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
@@ -60,7 +60,7 @@ using DetID = o2::detectors::DetID;
 using PVertex = o2::dataformats::PrimaryVertex;
 using GTrackID = o2::dataformats::GlobalTrackID;
 
-class ImpactParameterStudy : public Task
+class ImpactParameterStudy final : public Task
 {
  public:
   ImpactParameterStudy(std::shared_ptr<DataRequest> dr,

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackCheck.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackCheck.cxx
@@ -44,7 +44,7 @@ using namespace o2::globaltracking;
 
 using GTrackID = o2::dataformats::GlobalTrackID;
 using o2::steer::MCKinematicsReader;
-class TrackCheckStudy : public Task
+class TrackCheckStudy final : public Task
 {
   struct ParticleInfo {
     int event;

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackExtension.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/TrackExtension.cxx
@@ -40,7 +40,7 @@ using namespace o2::globaltracking;
 
 using GTrackID = o2::dataformats::GlobalTrackID;
 using o2::steer::MCKinematicsReader;
-class TrackExtensionStudy : public Task
+class TrackExtensionStudy final : public Task
 {
   struct ParticleInfo {
     float eventX;

--- a/Detectors/MUON/MCH/Geometry/MisAligner/include/MCHGeometryMisAligner/MisAligner.h
+++ b/Detectors/MUON/MCH/Geometry/MisAligner/include/MCHGeometryMisAligner/MisAligner.h
@@ -31,7 +31,7 @@ namespace mch
 namespace geo
 {
 
-class MisAligner : public TObject
+class MisAligner final : public TObject
 {
  public:
   MisAligner(double cartXMisAligM, double cartXMisAligW, double cartYMisAligM, double cartYMisAligW, double angMisAligM, double angMisAligW);

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CaloRawFitterGS.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CaloRawFitterGS.h
@@ -30,7 +30,7 @@ namespace o2
 namespace phos
 {
 
-class CaloRawFitterGS : public CaloRawFitter
+class CaloRawFitterGS final : public CaloRawFitter
 {
 
  public:

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratorPadGainTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratorPadGainTracks.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 /// \brief calibrator class for the residual gain map extraction used on an aggregator node
-class CalibratorPadGainTracks : public o2::calibration::TimeSlotCalibration<CalibPadGainTracksBase>
+class CalibratorPadGainTracks final : public o2::calibration::TimeSlotCalibration<CalibPadGainTracksBase>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibPadGainTracksBase>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 
-class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<CalibLaserTracks>
+class LaserTracksCalibrator final : public o2::calibration::TimeSlotCalibration<CalibLaserTracks>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tpc::CalibLaserTracks>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
@@ -96,7 +96,7 @@ struct TPCVDTglContainer {
   ClassDefNV(TPCVDTglContainer, 2);
 };
 
-class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<TPCVDTglContainer>
+class TPCVDriftTglCalibration final : public o2::calibration::TimeSlotCalibration<TPCVDTglContainer>
 {
   using Slot = o2::calibration::TimeSlot<TPCVDTglContainer>;
 

--- a/Detectors/Upgrades/ITS3/study/src/TrackingStudy.cxx
+++ b/Detectors/Upgrades/ITS3/study/src/TrackingStudy.cxx
@@ -59,7 +59,7 @@ using GTrackID = o2::dataformats::GlobalTrackID;
 using VtxTrackID = o2::dataformats::VtxTrackIndex;
 using T2VMap = std::unordered_map<GTrackID, size_t>;
 
-class TrackingStudySpec : public Task
+class TrackingStudySpec final : public Task
 {
  public:
   TrackingStudySpec(const TrackingStudySpec&) = delete;


### PR DESCRIPTION
Fixes these compilation warnings that started showing up after updating:
```
2026-06-04@21:16:17:DEBUG:O2:O2:0: /Users/f3sch/git/alice/sw/SOURCES/O2/dev_head/0/Detectors/EMCAL/base/include/EMCALBase/NonlinearityHandler.h:202:43: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
2026-06-04@21:16:17:DEBUG:O2:O2:0:   191 |   class FunctionNotFoundExcpetion : public std::exception
2026-06-04@21:16:17:DEBUG:O2:O2:0:       |                                   final
2026-06-04@21:16:17:DEBUG:O2:O2:0:   192 |   {
2026-06-04@21:16:17:DEBUG:O2:O2:0:   193 |    public:
2026-06-04@21:16:17:DEBUG:O2:O2:0:   194 |     /// \brief Constructor
2026-06-04@21:16:17:DEBUG:O2:O2:0:   195 |     /// \param Name of the nonlinearity function raising the exception
2026-06-04@21:16:17:DEBUG:O2:O2:0:   196 |     FunctionNotFoundExcpetion(const std::string_view name) : mName(name), mMessage()
2026-06-04@21:16:17:DEBUG:O2:O2:0:   197 |     {
2026-06-04@21:16:17:DEBUG:O2:O2:0:   198 |       mMessage = "Nonlinearity funciton " + mName + " not found";
2026-06-04@21:16:17:DEBUG:O2:O2:0:   199 |     }
2026-06-04@21:16:17:DEBUG:O2:O2:0:   200 |
2026-06-04@21:16:17:DEBUG:O2:O2:0:   201 |     /// \brief Destructor
2026-06-04@21:16:17:DEBUG:O2:O2:0:   202 |     ~FunctionNotFoundExcpetion() noexcept final = default;
2026-06-04@21:16:17:DEBUG:O2:O2:0:       |                                           ^

```