### PR TITLE
RICH: make local Z the radial axis for radiator and photosensor tiles

### DIFF
--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
@@ -68,8 +68,9 @@ Ring::Ring(int rPosId,
   // Radiator tiles
   for (auto& radiatorTile : radiatorTiles) {
     // Local Z is the thin (radial) dimension, looking outward from the IP
-    // (previously this was local X). The placement rotation below is adjusted
-    // by +90 deg about Y to keep the tile in the same physical position.
+    // (previously this was local X, while for running with ACTS we need local Z).
+    // The placement rotation below is adjusted by +90 deg about Y
+    // to keep the tile in the same physical position.
     radiatorTile = new TGeoArb8(radThick / 2);
     radiatorTile->SetVertex(0, radZ / 2, -radYmin / 2);
     radiatorTile->SetVertex(1, -radZ / 2, -radYmax / 2);
@@ -100,8 +101,6 @@ Ring::Ring(int rPosId,
   // Photosensor tiles
   for (auto& photoTile : photoTiles) {
     // Local Z is the thin (radial) dimension, looking outward from the IP
-    // (previously this was local X, while for running with ACTS we need local Z).
-    // The placement rotation below is adjusted by +90 deg about Y
     // to keep the tile in the same physical position.
     photoTile = new TGeoArb8(photThick / 2);
     photoTile->SetVertex(0, photZ / 2, -photYmin / 2);

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
@@ -67,22 +67,25 @@ Ring::Ring(int rPosId,
   int radTileCount{0}, photTileCount{0}, argSectorsCount{0};
   // Radiator tiles
   for (auto& radiatorTile : radiatorTiles) {
-    radiatorTile = new TGeoArb8(radZ / 2);
-    radiatorTile->SetVertex(0, -radThick / 2, -radYmin / 2);
-    radiatorTile->SetVertex(1, -radThick / 2, radYmin / 2);
-    radiatorTile->SetVertex(2, radThick / 2, radYmin / 2);
-    radiatorTile->SetVertex(3, radThick / 2, -radYmin / 2);
-    radiatorTile->SetVertex(4, -radThick / 2, -radYmax / 2);
-    radiatorTile->SetVertex(5, -radThick / 2, radYmax / 2);
-    radiatorTile->SetVertex(6, radThick / 2, radYmax / 2);
-    radiatorTile->SetVertex(7, radThick / 2, -radYmax / 2);
+    // Local Z is the thin (radial) dimension, looking outward from the IP
+    // (previously this was local X). The placement rotation below is adjusted
+    // by +90 deg about Y to keep the tile in the same physical position.
+    radiatorTile = new TGeoArb8(radThick / 2);
+    radiatorTile->SetVertex(0, radZ / 2, -radYmin / 2);
+    radiatorTile->SetVertex(1, -radZ / 2, -radYmax / 2);
+    radiatorTile->SetVertex(2, -radZ / 2, radYmax / 2);
+    radiatorTile->SetVertex(3, radZ / 2, radYmin / 2);
+    radiatorTile->SetVertex(4, radZ / 2, -radYmin / 2);
+    radiatorTile->SetVertex(5, -radZ / 2, -radYmax / 2);
+    radiatorTile->SetVertex(6, -radZ / 2, radYmax / 2);
+    radiatorTile->SetVertex(7, radZ / 2, radYmin / 2);
 
     TGeoVolume* radiatorTileVol = new TGeoVolume(Form("radTile_%d_%d", rPosId, radTileCount), radiatorTile, medAerogel);
     radiatorTileVol->SetLineColor(kOrange - 8);
     radiatorTileVol->SetLineWidth(1);
 
     auto* rotRadiator = new TGeoRotation(Form("radTileRotation_%d_%d", radTileCount, rPosId));
-    rotRadiator->RotateY(-thetaBDeg);
+    rotRadiator->RotateY(90.0 - thetaBDeg); // +90 compensates the X->Z swap of the tile's local axes
     rotRadiator->RotateZ(radTileCount * deltaPhiDeg);
 
     auto* rotTransRadiator = new TGeoCombiTrans(radRad0 * TMath::Cos(radTileCount * TMath::Pi() / (nTilesPhi / 2)),
@@ -96,22 +99,26 @@ Ring::Ring(int rPosId,
 
   // Photosensor tiles
   for (auto& photoTile : photoTiles) {
-    photoTile = new TGeoArb8(photZ / 2);
-    photoTile->SetVertex(0, -photThick / 2, -photYmin / 2);
-    photoTile->SetVertex(1, -photThick / 2, photYmin / 2);
-    photoTile->SetVertex(2, photThick / 2, photYmin / 2);
-    photoTile->SetVertex(3, photThick / 2, -photYmin / 2);
-    photoTile->SetVertex(4, -photThick / 2, -photYmax / 2);
-    photoTile->SetVertex(5, -photThick / 2, photYmax / 2);
-    photoTile->SetVertex(6, photThick / 2, photYmax / 2);
-    photoTile->SetVertex(7, photThick / 2, -photYmax / 2);
+    // Local Z is the thin (radial) dimension, looking outward from the IP
+    // (previously this was local X, while for running with ACTS we need local Z).
+    // The placement rotation below is adjusted by +90 deg about Y
+    // to keep the tile in the same physical position.
+    photoTile = new TGeoArb8(photThick / 2);
+    photoTile->SetVertex(0, photZ / 2, -photYmin / 2);
+    photoTile->SetVertex(1, -photZ / 2, -photYmax / 2);
+    photoTile->SetVertex(2, -photZ / 2, photYmax / 2);
+    photoTile->SetVertex(3, photZ / 2, photYmin / 2);
+    photoTile->SetVertex(4, photZ / 2, -photYmin / 2);
+    photoTile->SetVertex(5, -photZ / 2, -photYmax / 2);
+    photoTile->SetVertex(6, -photZ / 2, photYmax / 2);
+    photoTile->SetVertex(7, photZ / 2, photYmin / 2);
 
     TGeoVolume* photoTileVol = new TGeoVolume(Form("%s_%d_%d", GeometryTGeo::getRICHSensorPattern(), rPosId, photTileCount), photoTile, medSi);
     photoTileVol->SetLineColor(kOrange - 8);
     photoTileVol->SetLineWidth(1);
 
     auto* rotPhoto = new TGeoRotation(Form("photoTileRotation_%d_%d", photTileCount, rPosId));
-    rotPhoto->RotateY(-thetaBDeg);
+    rotPhoto->RotateY(90.0 - thetaBDeg); // +90 compensates the X->Z swap of the tile's local axes
     rotPhoto->RotateZ(photTileCount * deltaPhiDeg);
     auto* rotTransPhoto = new TGeoCombiTrans(photR0 * TMath::Cos(photTileCount * TMath::Pi() / (nTilesPhi / 2)),
                                              photR0 * TMath::Sin(photTileCount * TMath::Pi() / (nTilesPhi / 2)),

--- a/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
+++ b/Detectors/Upgrades/ALICE3/RICH/simulation/src/RICHRing.cxx
@@ -101,7 +101,6 @@ Ring::Ring(int rPosId,
   // Photosensor tiles
   for (auto& photoTile : photoTiles) {
     // Local Z is the thin (radial) dimension, looking outward from the IP
-    // to keep the tile in the same physical position.
     photoTile = new TGeoArb8(photThick / 2);
     photoTile->SetVertex(0, photZ / 2, -photYmin / 2);
     photoTile->SetVertex(1, -photZ / 2, -photYmax / 2);


### PR DESCRIPTION
In `RICHRing.cxx` the `TGeoArb8` solids for the radiator tiles (`radTile_*`) and photosensor tiles (`RICHPhotoTile`) are redefined so their thin (radial) dimension is now the local Z axis, pointing radially outward from the IP, instead of local X. The placement rotation is changed from `RotateY(-thetaBDeg)` to `RotateY(90 - thetaBDeg)` to compensate the X→Z swap. The tiles therefore stay in exactly the same physical position — only the local frame is relabeled — which lets downstream tooling (e.g. ACTS) use the local Z = surface-normal convention directly.

`argonSector_*` is left unchanged, since its gap dimension is already on local Z.

Verified numerically that the 8 world-space corners of every tile are identical before and after (zero displacement). 
(Note that any code relying on the previous local-axis convention should be rechecked.)

@NNicassio99
