### PR TITLE
DPL: speedup startup

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -35,7 +35,7 @@ struct ConfigParamsHelper {
   /// all options which are found in the vetos are skipped
   static bool dpl2BoostOptions(const std::vector<ConfigParamSpec>& spec,
                                options_description& options,
-                               boost::program_options::options_description vetos = options_description());
+                               boost::program_options::options_description const& vetos = options_description());
 
   /// Check if option is defined
   static bool hasOption(const std::vector<ConfigParamSpec>& specs, const std::string& optName);

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -136,7 +136,7 @@ void ConfigParamsHelper::addOptionIfMissing(std::vector<ConfigParamSpec>& specs,
 /// this is used for filtering the command line argument
 bool ConfigParamsHelper::dpl2BoostOptions(const std::vector<ConfigParamSpec>& spec,
                                           boost::program_options::options_description& options,
-                                          boost::program_options::options_description vetos)
+                                          boost::program_options::options_description const& vetos)
 {
   bool haveOption = false;
   for (const auto& configSpec : spec) {


### PR DESCRIPTION

Avoid copying vetos by value, over and over again.
