### PR TITLE
DPL Analysis: cddb tables using FairMQ side channel metadata

### DIFF
--- a/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
@@ -175,6 +175,8 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         }
         int outputRouteIndex = bindings.at(outRouteDesc);
         auto& spec = helper->routes[outputRouteIndex].matcher;
+        auto concrete = DataSpecUtils::asConcreteDataMatcher(spec);
+        Output output{concrete.origin, concrete.description, concrete.subSpec};
         auto builders = allbuilders | std::views::filter([&i](auto const& builder) { return builder.first == i; });
         unsigned int numBuilders = std::ranges::count_if(allbuilders, [&i](auto const& builder) { return builder.first == i; });
         arrow::Status status;
@@ -186,6 +188,8 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         if (!status.ok()) {
           throw framework::runtime_error_f("Failed to reserve arrays: ", status.ToString().c_str());
         }
+
+        std::vector<DataAllocator::CacheId> lastIds(numBuilders, DataAllocator::CacheId{.value = -1, .handle = -1, .segment = -1});
 
         for (auto ci = 0; ci < timestampColumn->num_chunks(); ++ci) {
           std::shared_ptr<arrow::Array> chunk = timestampColumn->chunk(ci);
@@ -218,6 +222,11 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
             int bi = 0;
             for (auto& builder : builders) {
               auto& response = responses[bi];
+              auto& lastId = lastIds[bi];
+              if (response.id.value != lastId.value) {
+                lastId.value = response.id.value;
+                allocator.adoptFromCache(output, response.id, header::gSerializationMethodCCDB);
+              }
 #if (FAIRMQ_VERSION_DEC >= 111000)
               result &= builder.second->Append();
               auto* value_builder = dynamic_cast<arrow::Int64Builder*>(builder.second->value_builder());
@@ -239,8 +248,7 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         arrow::ArrayVector arrays;
         std::ranges::for_each(builders, [&arrays](auto& builder) { arrays.push_back(*builder.second->Finish()); });
         auto outTable = arrow::Table::Make(schema, arrays);
-        auto concrete = DataSpecUtils::asConcreteDataMatcher(spec);
-        allocator.adopt(Output{concrete.origin, concrete.description, concrete.subSpec}, outTable);
+        allocator.adopt(output, outTable);
       }
 
       stats.updateStats({(int)ProcessingStatsId::CCDB_CACHE_FETCHED_BYTES, DataProcessingStats::Op::Set, (int64_t)helper->totalFetchedBytes});

--- a/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
@@ -168,7 +168,7 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         auto reserveSize = timestampColumn->length();
         O2_SIGNPOST_EVENT_EMIT_INFO(ccdb, sid, "fetchFromAnalysisCCDB",
                                     "There are %zu bindings available", bindings.size());
-        for (auto& binding : bindings) {
+        for (auto const& binding : bindings) {
           O2_SIGNPOST_EVENT_EMIT_INFO(ccdb, sid, "fetchFromAnalysisCCDB",
                                       "* %{public}s: %d",
                                       binding.first.c_str(), binding.second);

--- a/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
+++ b/Framework/CCDBSupport/src/AnalysisCCDBHelpers.cxx
@@ -11,6 +11,7 @@
 
 #include "AnalysisCCDBHelpers.h"
 #include "CCDBFetcherHelper.h"
+#include "Framework/ArrowTypes.h"
 #include "Framework/DataProcessingStats.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/TimingInfo.h"
@@ -22,6 +23,7 @@
 #include "Framework/DanglingEdgesContext.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/ConfigParamsHelper.h"
+#include <fairmq/Version.h>
 #include <arrow/array/builder_binary.h>
 #include <arrow/type.h>
 #include <arrow/type_fwd.h>
@@ -109,9 +111,36 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         auto it = ccdbUrls.find(m.name);
         fieldMetadata->Append("url", it != ccdbUrls.end() ? it->second : m.defaultValue.asString());
         auto columnName = m.name.substr(strlen("ccdb:"));
+#if (FAIRMQ_VERSION_DEC >= 111000)
+        fields.emplace_back(std::make_shared<arrow::Field>(columnName, soa::asArrowDataType<int64_t[3]>(), false, fieldMetadata));
+#else
         fields.emplace_back(std::make_shared<arrow::Field>(columnName, arrow::binary_view(), false, fieldMetadata));
+#endif
       }
       schemas.emplace_back(std::make_shared<arrow::Schema>(fields, schemaMetadata));
+    }
+
+#if (FAIRMQ_VERSION_DEC >= 111000)
+    std::vector<std::pair<uint32_t, std::shared_ptr<arrow::FixedSizeListBuilder>>> allbuilders;
+#else
+    std::vector<std::pair<uint32_t, std::shared_ptr<arrow::BinaryViewBuilder>>> allbuilders;
+#endif
+    allbuilders.resize([&schemas]() { size_t size = 0; for (auto& schema : schemas) { size += schema->num_fields(); }; return size; }());
+    auto* pool = arrow::default_memory_pool();
+
+    int idx = 0;
+    int sidx = 0;
+    for (auto const& schema : schemas) {
+      for (auto const& _ : schema->fields()) {
+#if (FAIRMQ_VERSION_DEC >= 111000)
+        auto value_builder = std::make_shared<arrow::Int64Builder>();
+        allbuilders[idx] = std::make_pair(sidx, std::make_shared<arrow::FixedSizeListBuilder>(pool, std::move(value_builder), 3));
+#else
+        allbuilders[idx] = std::make_pair(sidx, std::make_shared<arrow::BinaryViewBuilder>());
+#endif
+        ++idx;
+      }
+      ++sidx;
     }
 
     std::shared_ptr<CCDBFetcherHelper> helper = std::make_shared<CCDBFetcherHelper>();
@@ -119,10 +148,12 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
     std::unordered_map<std::string, int> bindings;
     fillValidRoutes(*helper, spec.outputs, bindings);
 
-    return adaptStateless([schemas, bindings, helper](InputRecord& inputs, DataTakingContext& dtc, DataAllocator& allocator, TimingInfo& timingInfo, DataProcessingStats& stats) {
+    return adaptStateless([schemas, bindings, helper, allbuilders](InputRecord& inputs, DataTakingContext& dtc, DataAllocator& allocator, TimingInfo& timingInfo, DataProcessingStats& stats) {
       O2_SIGNPOST_ID_GENERATE(sid, ccdb);
       O2_SIGNPOST_START(ccdb, sid, "fetchFromAnalysisCCDB", "Fetching CCDB objects for analysis%" PRIu64, (uint64_t)timingInfo.timeslice);
-      for (auto& schema : schemas) {
+      std::ranges::for_each(allbuilders, [](auto& builder) { builder.second->Reset(); });
+      for (auto i = 0U; i < schemas.size(); ++i) {
+        auto& schema = schemas[i];
         std::vector<CCDBFetcherHelper::FetchOp> ops;
         auto inputBinding = *schema->metadata()->Get("sourceTable");
         auto inputMatcher = DataSpecUtils::fromString(*schema->metadata()->Get("sourceMatcher"));
@@ -134,6 +165,7 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         auto table = inputs.get<TableConsumer>(inputMatcher)->asArrowTable();
         // FIXME: make the fTimestamp column configurable.
         auto timestampColumn = table->GetColumnByName("fTimestamp");
+        auto reserveSize = timestampColumn->length();
         O2_SIGNPOST_EVENT_EMIT_INFO(ccdb, sid, "fetchFromAnalysisCCDB",
                                     "There are %zu bindings available", bindings.size());
         for (auto& binding : bindings) {
@@ -143,9 +175,16 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
         }
         int outputRouteIndex = bindings.at(outRouteDesc);
         auto& spec = helper->routes[outputRouteIndex].matcher;
-        std::vector<std::shared_ptr<arrow::BinaryViewBuilder>> builders;
-        for (auto const& _ : schema->fields()) {
-          builders.emplace_back(std::make_shared<arrow::BinaryViewBuilder>());
+        auto builders = allbuilders | std::views::filter([&i](auto const& builder) { return builder.first == i; });
+        unsigned int numBuilders = std::ranges::count_if(allbuilders, [&i](auto const& builder) { return builder.first == i; });
+        arrow::Status status;
+        std::ranges::for_each(builders, [&status, &reserveSize](auto& builder) {
+          if (reserveSize > builder.second->capacity()) {
+            status &= builder.second->Reserve(reserveSize - builder.second->capacity());
+          }
+        });
+        if (!status.ok()) {
+          throw framework::runtime_error_f("Failed to reserve arrays: ", status.ToString().c_str());
         }
 
         for (auto ci = 0; ci < timestampColumn->num_chunks(); ++ci) {
@@ -171,15 +210,25 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
             O2_SIGNPOST_START(ccdb, sid, "handlingResponses",
                               "Got %zu responses from server.",
                               responses.size());
-            if (builders.size() != responses.size()) {
-              LOGP(fatal, "Not enough responses (expected {}, found {})", builders.size(), responses.size());
+            if (numBuilders != responses.size()) {
+              LOGP(fatal, "Not enough responses (expected {}, found {})", numBuilders, responses.size());
             }
             arrow::Status result;
-            for (size_t bi = 0; bi < responses.size(); bi++) {
-              auto& builder = builders[bi];
+
+            int bi = 0;
+            for (auto& builder : builders) {
               auto& response = responses[bi];
+#if (FAIRMQ_VERSION_DEC >= 111000)
+              result &= builder.second->Append();
+              auto* value_builder = dynamic_cast<arrow::Int64Builder*>(builder.second->value_builder());
+              result &= value_builder->Append(response.id.handle);
+              result &= value_builder->Append(response.id.segment);
+              result &= value_builder->Append(response.size);
+#else
               char const* address = reinterpret_cast<char const*>(response.id.value);
-              result &= builder->Append(std::string_view(address, response.size));
+              result &= builder.second->Append(std::string_view(address, response.size));
+#endif
+              ++bi;
             }
             if (!result.ok()) {
               LOGP(fatal, "Error adding results from CCDB");
@@ -188,9 +237,7 @@ AlgorithmSpec AnalysisCCDBHelpers::fetchFromCCDB(ConfigContext const& /*ctx*/)
           }
         }
         arrow::ArrayVector arrays;
-        for (auto& builder : builders) {
-          arrays.push_back(*builder->Finish());
-        }
+        std::ranges::for_each(builders, [&arrays](auto& builder) { arrays.push_back(*builder.second->Finish()); });
         auto outTable = arrow::Table::Make(schema, arrays);
         auto concrete = DataSpecUtils::asConcreteDataMatcher(spec);
         allocator.adopt(Output{concrete.origin, concrete.description, concrete.subSpec}, outTable);

--- a/Framework/CCDBSupport/src/CCDBFetcherHelper.cxx
+++ b/Framework/CCDBSupport/src/CCDBFetcherHelper.cxx
@@ -289,7 +289,7 @@ auto CCDBFetcherHelper::populateCacheWith(std::shared_ptr<CCDBFetcherHelper> con
     O2_SIGNPOST_EVENT_EMIT(ccdb, sid, "populateCacheWith", "Reusing %{public}s for %{public}s (DPL id %" PRIu64 ")", path.data(), headers["ETag"].data(), cacheId.value);
     helper->mapURL2UUID[path].cacheHit++;
     responses.emplace_back(Response{.id = cacheId, .size = helper->mapURL2UUID[path].size, .request = nullptr});
-    allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
+    // allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
     // the outputBuffer was not used, can we destroy it?
   }
   O2_SIGNPOST_END(ccdb, sid, "populateCacheWith", "Finished populating cache with CCDB objects");

--- a/Framework/CCDBSupport/src/CCDBFetcherHelper.cxx
+++ b/Framework/CCDBSupport/src/CCDBFetcherHelper.cxx
@@ -167,7 +167,6 @@ auto CCDBFetcherHelper::populateCacheWith(std::shared_ptr<CCDBFetcherHelper> con
                                           DataTakingContext& dtc,
                                           DataAllocator& allocator) -> std::vector<CCDBFetcherHelper::Response>
 {
-  int objCnt = -1;
   // We use the timeslice, so that we hook into the same interval as the rest of the
   // callback.
   static bool isOnline = isOnlineRun(dtc);
@@ -175,10 +174,9 @@ auto CCDBFetcherHelper::populateCacheWith(std::shared_ptr<CCDBFetcherHelper> con
   auto sid = _o2_signpost_id_t{(int64_t)timingInfo.timeslice};
   O2_SIGNPOST_START(ccdb, sid, "populateCacheWith", "Starting to populate cache with CCDB objects");
   std::vector<Response> responses;
-  for (auto& op : ops) {
+  for (auto const& op : ops) {
     int64_t timestampToUse = op.timestamp;
     O2_SIGNPOST_EVENT_EMIT(ccdb, sid, "populateCacheWith", "Fetching object for route %{public}s", DataSpecUtils::describe(op.spec).data());
-    objCnt++;
     auto concrete = DataSpecUtils::asConcreteDataMatcher(op.spec);
     Output output{concrete.origin, concrete.description, concrete.subSpec};
     auto&& v = allocator.makeVector<char>(output);
@@ -198,7 +196,7 @@ auto CCDBFetcherHelper::populateCacheWith(std::shared_ptr<CCDBFetcherHelper> con
              concrete.origin.as<std::string>(), concrete.description.as<std::string>(), int(concrete.subSpec));
       }
     }
-    for (auto m : op.metadata) {
+    for (auto const& m : op.metadata) {
       O2_SIGNPOST_EVENT_EMIT(ccdb, sid, "populateCacheWith", "Adding metadata %{public}s: %{public}s to the request", m.key.data(), m.value.data());
       metadata[m.key] = m.value;
     }
@@ -215,7 +213,7 @@ auto CCDBFetcherHelper::populateCacheWith(std::shared_ptr<CCDBFetcherHelper> con
       uint64_t cachePopulatedAt = url2uuid->second.cachePopulatedAt;
       // If timestamp is before the time the element was cached or after the claimed validity, we need to check validity, again
       // when online.
-      bool cacheExpired = (validUntil <= timestampToUse) || (op.timestamp < cachePopulatedAt);
+      bool cacheExpired = (validUntil <= (uint64_t)timestampToUse) || ((uint64_t)op.timestamp < cachePopulatedAt);
       if (isOnline || cacheExpired) {
         if (!helper->useTFSlice) {
           checkValidity = chRate > 0 ? (std::abs(int(timingInfo.tfCounter - url2uuid->second.lastCheckedTF)) >= chRate) : (timingInfo.tfCounter % -chRate) == 0;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -28,6 +28,7 @@
 #include "Framework/ArrowTableSlicingCache.h" // IWYU pragma: export
 #include "Framework/SliceCache.h"             // IWYU pragma: export
 #include "Framework/VariantHelpers.h"         // IWYU pragma: export
+#include <fairmq/Version.h>
 #include <arrow/array/array_binary.h>
 #include <arrow/table.h>              // IWYU pragma: export
 #include <arrow/array.h>              // IWYU pragma: export
@@ -40,9 +41,17 @@
 #include <cstring>
 #include <gsl/span> // IWYU pragma: export
 
+namespace fair::mq::shmem
+{
+struct MetaHeader;
+}
+
 namespace o2::framework
 {
 using ListVector = std::vector<std::vector<int64_t>>;
+#if (FAIRMQ_VERSION_DEC >= 111000)
+using PointerReconstructor = std::function<std::byte*(fair::mq::shmem::MetaHeader&&)>;
+#endif
 
 std::string cutString(std::string&& str);
 std::string strToUpper(std::string&& str);
@@ -1014,6 +1023,9 @@ struct ColumnDataHolder {
   arrow::ChunkedArray* second;
 };
 
+template <typename C>
+concept needs_ptr_rec = C::needs_ptr_rec;
+
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
  public:
@@ -1182,6 +1194,21 @@ struct TableIterator : IP, C... {
   {
     doSetCurrentInternal(internal_index_columns_t{}, table);
   }
+#if (FAIRMQ_VERSION_DEC >= 111000)
+  void setPointerReconstructor(framework::PointerReconstructor const& pointerReconstructor)
+  {
+    [&pointerReconstructor, this]<typename... Cs>(framework::pack<Cs...>) {
+      ([&pointerReconstructor, this]<typename CC>() {
+        if constexpr (needs_ptr_rec<CC>) {
+          if (pointerReconstructor) {
+            CC::ptrRec = &pointerReconstructor;
+          }
+        }
+      }.template operator()<Cs>(),
+       ...);
+    }(all_columns{});
+  }
+#endif
 
  private:
   /// Helper to move at the end of columns which actually have an iterator.
@@ -2146,7 +2173,12 @@ class Table
   {
     return self_t{mTable->Slice(0, 0), 0};
   }
-
+#if (FAIRMQ_VERSION_DEC >= 111000)
+  void setPointerReconstructor(framework::PointerReconstructor const& pointerReconstructor)
+  {
+    mBegin.setPointerReconstructor(pointerReconstructor);
+  }
+#endif
  private:
   template <typename T>
   arrow::ChunkedArray* lookupColumn()
@@ -2325,6 +2357,57 @@ consteval static std::string_view namespace_prefix()
   };                                                                                                                                                                              \
   [[maybe_unused]] static constexpr o2::framework::expressions::BindingNode _Getter_ { _Label_, _Name_::hash, o2::framework::expressions::selectArrowType<_Type_>() }
 
+#if (FAIRMQ_VERSION_DEC >= 111000)
+#define DECLARE_SOA_CCDB_COLUMN_FULL(_Name_, _Label_, _Getter_, _ConcreteType_, _CCDBQuery_)                      \
+  struct _Name_ : o2::soa::Column<int64_t[3], _Name_> {                                                           \
+    static constexpr const char* mLabel = _Label_;                                                                \
+    static constexpr const char* query = _CCDBQuery_;                                                             \
+    static constexpr const uint32_t hash = crc32(namespace_prefix<_Name_>(), std::string_view{#_Getter_});        \
+    static constexpr bool needs_ptr_rec = true;                                                                   \
+    std::function<std::byte*(fair::mq::shmem::MetaHeader&&)> const* ptrRec = nullptr;                             \
+    using base = o2::soa::Column<int64_t[3], _Name_>;                                                             \
+    using type = int64_t[3];                                                                                      \
+    using column_t = _Name_;                                                                                      \
+    _Name_(arrow::ChunkedArray const* column)                                                                     \
+      : o2::soa::Column<int64_t[3], _Name_>(o2::soa::ColumnIterator<int64_t[3]>(column))                          \
+    {                                                                                                             \
+    }                                                                                                             \
+                                                                                                                  \
+    _Name_() = default;                                                                                           \
+    _Name_(_Name_ const& other) = default;                                                                        \
+    _Name_& operator=(_Name_ const& other) = default;                                                             \
+                                                                                                                  \
+    decltype(auto) _Getter_() const                                                                               \
+    {                                                                                                             \
+      auto& [handle, segment, size] = *mColumnIterator;                                                           \
+      auto span = std::span<std::byte>{(*ptrRec)(fair::mq::shmem::MetaHeader{                                     \
+                                         static_cast<size_t>(size),                                               \
+                                         0, handle, 0, 0,                                                         \
+                                         static_cast<uint16_t>(segment), true}),                                  \
+                                       static_cast<size_t>(size)};                                                \
+      if constexpr (std::same_as<_ConcreteType_, std::span<std::byte>>) {                                         \
+        return span;                                                                                              \
+      } else {                                                                                                    \
+        static std::byte* payload = nullptr;                                                                      \
+        static _ConcreteType_* deserialised = nullptr;                                                            \
+        static TClass* c = TClass::GetClass(#_ConcreteType_);                                                     \
+        if (payload != (std::byte*)span.data()) {                                                                 \
+          payload = (std::byte*)span.data();                                                                      \
+          delete deserialised;                                                                                    \
+          TBufferFile f(TBufferFile::EMode::kRead, span.size(), (char*)span.data(), kFALSE);                      \
+          deserialised = (_ConcreteType_*)soa::extractCCDBPayload((char*)payload, span.size(), c, "ccdb_object"); \
+        }                                                                                                         \
+        return *deserialised;                                                                                     \
+      }                                                                                                           \
+    }                                                                                                             \
+                                                                                                                  \
+    decltype(auto)                                                                                                \
+      get() const                                                                                                 \
+    {                                                                                                             \
+      return _Getter_();                                                                                          \
+    }                                                                                                             \
+  };
+#else
 #define DECLARE_SOA_CCDB_COLUMN_FULL(_Name_, _Label_, _Getter_, _ConcreteType_, _CCDBQuery_)                      \
   struct _Name_ : o2::soa::Column<std::span<std::byte>, _Name_> {                                                 \
     static constexpr const char* mLabel = _Label_;                                                                \
@@ -2367,6 +2450,7 @@ consteval static std::string_view namespace_prefix()
       return _Getter_();                                                                                          \
     }                                                                                                             \
   };
+#endif
 
 #define DECLARE_SOA_CCDB_COLUMN(_Name_, _Getter_, _ConcreteType_, _CCDBQuery_) \
   DECLARE_SOA_CCDB_COLUMN_FULL(_Name_, "f" #_Name_, _Getter_, _ConcreteType_, _CCDBQuery_)
@@ -3715,7 +3799,12 @@ class FilteredBase : public T
   {
     return mCached;
   }
-
+#if (FAIRMQ_VERSION_DEC >= 111000)
+  void setPointerReconstructor(framework::PointerReconstructor const& pointerReconstructor)
+  {
+    mFilteredBegin.setPointerReconstructor(pointerReconstructor);
+  }
+#endif
  private:
   void resetRanges()
   {

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -26,6 +26,11 @@
 #include "SimulationDataFormat/MCGenProperties.h"
 #include "Framework/PID.h"
 
+#include <fairmq/Version.h>
+#if (FAIRMQ_VERSION_DEC >= 111000)
+#include <fairmq/shmem/Common.h>
+#endif
+
 namespace o2
 {
 namespace aod

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -26,6 +26,8 @@
 #include "Framework/TypeIdHelpers.h"
 #include "Framework/ArrowTableSlicingCache.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/DanglingEdgesContext.h"
+#include <fairmq/Version.h>
 
 #include <arrow/compute/kernel.h>
 #include <arrow/table.h>
@@ -302,11 +304,19 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename Task, is_table_iterator_or_enumeration Grouping, std::ranges::input_range R, soa::is_table... Associated>
+#if (FAIRMQ_VERSION_DEC >= 111000)
+  static void invokeProcess(Task& task, InputRecord& inputs, R matchers, PointerReconstructor const& pointerReconstructor, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+#else
   static void invokeProcess(Task& task, InputRecord& inputs, R matchers, void (Task::*processingFunction)(Grouping, Associated...), std::vector<ExpressionInfo>& infos, ArrowTableSlicingCache& slices, header::DataOrigin newOrigin = header::DataOrigin{"AOD"})
+#endif
   {
     using G = std::decay_t<Grouping>;
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, matchers, processingFunction, infos);
-
+#if (FAIRMQ_VERSION_DEC >= 111000)
+    if constexpr (!is_enumeration<G>) {
+      groupingTable.setPointerReconstructor(pointerReconstructor);
+    }
+#endif
     constexpr const int numElements = nested_brace_constructible_size<false, std::decay_t<Task>>() / 10;
 
     // set filtered tables for partitions with grouping
@@ -347,6 +357,12 @@ struct AnalysisDataProcessorBuilder {
            ...);
         },
         associatedTables);
+#if (FAIRMQ_VERSION_DEC >= 111000)
+      std::apply([&pointerReconstructor](auto&... table) {
+        (table.setPointerReconstructor(pointerReconstructor), ...);
+      },
+                 associatedTables);
+#endif
 
       auto binder = [&task, &groupingTable, &associatedTables](auto& x) mutable {
         x.bindExternalIndices(&groupingTable, &std::get<std::decay_t<Associated>>(associatedTables)...);
@@ -377,6 +393,12 @@ struct AnalysisDataProcessorBuilder {
         auto slicer = GroupSlicer(groupingTable, associatedTables, slices, newOrigin);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
+#if (FAIRMQ_VERSION_DEC >= 111000)
+          std::apply([&pointerReconstructor](auto&... table) {
+            (table.setPointerReconstructor(pointerReconstructor), ...);
+          },
+                     associatedSlices);
+#endif
           overwriteInternalIndices(associatedSlices, associatedTables);
           std::apply(
             [&binder](auto&... x) mutable {
@@ -580,118 +602,144 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   // replace origins in Preslice declarations
   homogeneous_apply_refs_sized<numElements>([&newOrigin](auto& element) { return analysis_task_parsers::replaceOrigin(element, newOrigin); }, *task.get());
 
-  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, inputInfos, newOrigin, newOriginStr](InitContext& ic) mutable {
-    Cache bindingsKeys;
-    Cache bindingsKeysUnsorted;
-    // add preslice declarations to slicing cache definition
-    homogeneous_apply_refs_sized<numElements>([&bindingsKeys, &bindingsKeysUnsorted](auto& element) { return analysis_task_parsers::registerCache(element, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
+  auto algo = AlgorithmSpec::InitCallback
+  {
+    [task = task, expressionInfos, inputInfos, newOrigin, newOriginStr](InitContext& ic) mutable {
+      Cache bindingsKeys;
+      Cache bindingsKeysUnsorted;
+      // add preslice declarations to slicing cache definition
+      homogeneous_apply_refs_sized<numElements>([&bindingsKeys, &bindingsKeysUnsorted](auto& element) { return analysis_task_parsers::registerCache(element, bindingsKeys, bindingsKeysUnsorted); }, *task.get());
 
-    homogeneous_apply_refs_sized<numElements>([&ic](auto&& element) { return analysis_task_parsers::prepareOption(ic, element); }, *task.get());
-    homogeneous_apply_refs_sized<numElements>([&ic](auto&& element) { return analysis_task_parsers::prepareService(ic, element); }, *task.get());
+      homogeneous_apply_refs_sized<numElements>([&ic](auto&& element) { return analysis_task_parsers::prepareOption(ic, element); }, *task.get());
+      homogeneous_apply_refs_sized<numElements>([&ic](auto&& element) { return analysis_task_parsers::prepareService(ic, element); }, *task.get());
 
-    auto& callbacks = ic.services().get<CallbackService>();
-    auto eoscb = [task](EndOfStreamContext& eosContext) {
-      homogeneous_apply_refs_sized<numElements>([&eosContext](auto& element) {
+      auto& callbacks = ic.services().get<CallbackService>();
+      auto eoscb = [task](EndOfStreamContext& eosContext) {
+        homogeneous_apply_refs_sized<numElements>([&eosContext](auto& element) {
           analysis_task_parsers::postRunService(eosContext, element);
           analysis_task_parsers::postRunOutput(eosContext, element);
           return true; },
-                                                *task.get());
-      eosContext.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-    };
+                                                  *task.get());
+        eosContext.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+      };
 
-    callbacks.set<CallbackService::Id::EndOfStream>(eoscb);
+      callbacks.set<CallbackService::Id::EndOfStream>(eoscb);
 
-    /// call the task's init() function first as it may manipulate the task's elements
-    if constexpr (requires { task->init(ic); }) {
-      task->init(ic);
-    }
-
-    /// update configurables in filters and partitions
-    homogeneous_apply_refs_sized<numElements>(
-      [&ic](auto& element) -> bool { return analysis_task_parsers::updatePlaceholders(ic, element); },
-      *task.get());
-    /// create expression trees for filters gandiva trees matched to schemas and store the pointers into expressionInfos
-    homogeneous_apply_refs_sized<numElements>([&expressionInfos](auto& element) {
-      return analysis_task_parsers::createExpressionTrees(expressionInfos, element);
-    },
-                                              *task.get());
-
-    /// parse process functions to enable requested grouping caches - note that at this state process configurables have their final values
-    if constexpr (requires { &T::process; }) {
-      AnalysisDataProcessorBuilder::cacheFromArgs(&T::process, true, bindingsKeys, bindingsKeysUnsorted);
-    }
-    homogeneous_apply_refs_sized<numElements>(
-      [&bindingsKeys, &bindingsKeysUnsorted](auto& x) {
-        return AnalysisDataProcessorBuilder::requestCacheFromArgs(x, bindingsKeys, bindingsKeysUnsorted);
-      },
-      *task.get());
-
-    /// replace origin in slicing caches
-    std::ranges::transform(bindingsKeys, bindingsKeys.begin(), [&newOrigin](Entry& entry) {
-      if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
-        entry.matcher = replaceOrigin(entry.matcher, newOrigin);
+      /// call the task's init() function first as it may manipulate the task's elements
+      if constexpr (requires { task->init(ic); }) {
+        task->init(ic);
       }
-      return entry;
-    });
-    std::ranges::transform(bindingsKeysUnsorted, bindingsKeysUnsorted.begin(), [&newOrigin](Entry& entry) {
-      if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
-        entry.matcher = replaceOrigin(entry.matcher, newOrigin);
-      }
-      return entry;
-    });
 
-    ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
-    ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));
-    ic.services().get<ArrowTableSlicingCacheDef>().setOrigin(newOrigin);
-
-    return [task, expressionInfos, inputInfos, newOrigin](ProcessingContext& pc) mutable {
-      // load the ccdb object from their cache
-      homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::newDataframeCondition(pc.inputs(), element); }, *task.get());
-      // reset partitions once per dataframe
-      homogeneous_apply_refs_sized<numElements>([](auto& element) { return analysis_task_parsers::newDataframePartition(element); }, *task.get());
-      // reset selections for the next dataframe
-      std::ranges::for_each(expressionInfos, [](auto& info) { info.resetSelection = true; });
-      // reset pre-slice for the next dataframe
-      auto& slices = pc.services().get<ArrowTableSlicingCache>();
-      homogeneous_apply_refs_sized<numElements>([&slices](auto& element) {
-        return analysis_task_parsers::updateSliceInfo(element, slices);
-      },
-                                                *(task.get()));
-      // initialize local caches
-      homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::initializeCache(pc, element); }, *(task.get()));
-      // prepare outputs
-      homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::prepareOutput(pc, element); }, *task.get());
-      // execute run()
-      if constexpr (requires { task->run(pc); }) {
-        task->run(pc);
-      }
-      // execute process()
-      if constexpr (requires { &T::process; }) {
-        auto loc = std::ranges::find_if(inputInfos, [](auto const& info) { return info.hash == o2::framework::TypeIdHelpers::uniqueId<decltype(&T::process)>(); });
-        auto matchers = loc == inputInfos.end() ? std::vector<std::pair<int, ConcreteDataMatcher>>{} : loc->matchers;
-        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), matchers, &T::process, expressionInfos, slices, newOrigin);
-      }
-      // execute optional process()
+      /// update configurables in filters and partitions
       homogeneous_apply_refs_sized<numElements>(
-        [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOrigin](auto& x) {
-          if constexpr (is_process_configurable<decltype(x)>) {
-            if (x.value == true) {
-              auto loc = std::ranges::find_if(inputInfos, [](auto const& info) { return info.hash == o2::framework::TypeIdHelpers::uniqueId<decltype(x.process)>(); });
-              auto matchers = loc == inputInfos.end() ? std::vector<std::pair<int, ConcreteDataMatcher>>{} : loc->matchers;
-              AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), matchers, x.process, expressionInfos, slices, newOrigin);
-              return true;
-            }
-            return false;
-          }
-          return false;
+        [&ic](auto& element) -> bool { return analysis_task_parsers::updatePlaceholders(ic, element); },
+        *task.get());
+      /// create expression trees for filters gandiva trees matched to schemas and store the pointers into expressionInfos
+      homogeneous_apply_refs_sized<numElements>([&expressionInfos](auto& element) {
+        return analysis_task_parsers::createExpressionTrees(expressionInfos, element);
+      },
+                                                *task.get());
+
+      /// parse process functions to enable requested grouping caches - note that at this state process configurables have their final values
+      if constexpr (requires { &T::process; }) {
+        AnalysisDataProcessorBuilder::cacheFromArgs(&T::process, true, bindingsKeys, bindingsKeysUnsorted);
+      }
+      homogeneous_apply_refs_sized<numElements>(
+        [&bindingsKeys, &bindingsKeysUnsorted](auto& x) {
+          return AnalysisDataProcessorBuilder::requestCacheFromArgs(x, bindingsKeys, bindingsKeysUnsorted);
         },
         *task.get());
-      // prepare delayed outputs
-      homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::prepareDelayedOutput(pc, element); }, *task.get());
-      // finalize outputs
-      homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::finalizeOutput(pc, element); }, *task.get());
-    };
-  }};
+
+      /// replace origin in slicing caches
+      std::ranges::transform(bindingsKeys, bindingsKeys.begin(), [&newOrigin](Entry& entry) {
+        if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
+          entry.matcher = replaceOrigin(entry.matcher, newOrigin);
+        }
+        return entry;
+      });
+      std::ranges::transform(bindingsKeysUnsorted, bindingsKeysUnsorted.begin(), [&newOrigin](Entry& entry) {
+        if ((entry.matcher.origin == header::DataOrigin{"AOD"}) && (newOrigin != header::DataOrigin{"AOD"})) {
+          entry.matcher = replaceOrigin(entry.matcher, newOrigin);
+        }
+        return entry;
+      });
+
+      ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
+      ic.services().get<ArrowTableSlicingCacheDef>().setCachesUnsorted(std::move(bindingsKeysUnsorted));
+      ic.services().get<ArrowTableSlicingCacheDef>().setOrigin(newOrigin);
+#if (FAIRMQ_VERSION_DEC >= 111000)
+      PointerReconstructor pointerReconstructor(nullptr);
+      bool hasCCDBTables = !ic.services().get<DanglingEdgesContext>().requestedTIMs.empty();
+
+      return [task, expressionInfos, inputInfos, newOrigin, hasCCDBTables, pointerReconstructor](ProcessingContext& pc) mutable {
+        if (hasCCDBTables && (!pointerReconstructor)) {
+          auto& proxy = pc.services().get<FairMQDeviceProxy>();
+          auto& spec = pc.services().get<DanglingEdgesContext>().requestedTIMs.front();
+          pointerReconstructor = proxy.getShmPointerReconstructor(spec, 0);
+        }
+#else
+      return [task, expressionInfos, inputInfos, newOrigin](ProcessingContext& pc) mutable {
+#endif
+        // load the ccdb object from their cache
+        homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::newDataframeCondition(pc.inputs(), element); }, *task.get());
+        // reset partitions once per dataframe
+        homogeneous_apply_refs_sized<numElements>([](auto& element) { return analysis_task_parsers::newDataframePartition(element); }, *task.get());
+        // reset selections for the next dataframe
+        std::ranges::for_each(expressionInfos, [](auto& info) { info.resetSelection = true; });
+        // reset pre-slice for the next dataframe
+        auto& slices = pc.services().get<ArrowTableSlicingCache>();
+        homogeneous_apply_refs_sized<numElements>([&slices](auto& element) {
+          return analysis_task_parsers::updateSliceInfo(element, slices);
+        },
+                                                  *(task.get()));
+        // initialize local caches
+        homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::initializeCache(pc, element); }, *(task.get()));
+        // prepare outputs
+        homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::prepareOutput(pc, element); }, *task.get());
+        // execute run()
+        if constexpr (requires { task->run(pc); }) {
+          task->run(pc);
+        }
+        // execute process()
+        if constexpr (requires { &T::process; }) {
+          auto loc = std::ranges::find_if(inputInfos, [](auto const& info) { return info.hash == o2::framework::TypeIdHelpers::uniqueId<decltype(&T::process)>(); });
+          auto matchers = loc == inputInfos.end() ? std::vector<std::pair<int, ConcreteDataMatcher>>{} : loc->matchers;
+#if (FAIRMQ_VERSION_DEC >= 111000)
+          AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), matchers, pointerReconstructor, &T::process, expressionInfos, slices, newOrigin);
+#else
+          AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), matchers, &T::process, expressionInfos, slices, newOrigin);
+#endif
+        }
+        // execute optional process()
+        homogeneous_apply_refs_sized<numElements>(
+#if (FAIRMQ_VERSION_DEC >= 111000)
+          [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOrigin, &pointerReconstructor](auto& x) {
+#else
+          [&pc, &expressionInfos, &task, &slices, &inputInfos, &newOrigin](auto& x) {
+#endif
+            if constexpr (is_process_configurable<decltype(x)>) {
+              if (x.value == true) {
+                auto loc = std::ranges::find_if(inputInfos, [](auto const& info) { return info.hash == o2::framework::TypeIdHelpers::uniqueId<decltype(x.process)>(); });
+                auto matchers = loc == inputInfos.end() ? std::vector<std::pair<int, ConcreteDataMatcher>>{} : loc->matchers;
+#if (FAIRMQ_VERSION_DEC >= 111000)
+                AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), matchers, pointerReconstructor, x.process, expressionInfos, slices, newOrigin);
+#else
+                AnalysisDataProcessorBuilder::invokeProcess(*task.get(), pc.inputs(), matchers, x.process, expressionInfos, slices, newOrigin);
+#endif
+                return true;
+              }
+              return false;
+            }
+            return false;
+          },
+          *task.get());
+        // prepare delayed outputs
+        homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::prepareDelayedOutput(pc, element); }, *task.get());
+        // finalize outputs
+        homogeneous_apply_refs_sized<numElements>([&pc](auto& element) { return analysis_task_parsers::finalizeOutput(pc, element); }, *task.get());
+      };
+    }
+  };
 
   return {
     name,

--- a/Framework/Core/include/Framework/ArrowTypes.h
+++ b/Framework/Core/include/Framework/ArrowTypes.h
@@ -93,6 +93,11 @@ struct arrow_array_for<int8_t[N]> {
   using type = arrow::FixedSizeListArray;
   using value_type = int8_t;
 };
+template <int N>
+struct arrow_array_for<int64_t[N]> {
+  using type = arrow::FixedSizeListArray;
+  using value_type = int64_t;
+};
 
 #define ARROW_VECTOR_FOR(_type_)                \
   template <>                                   \

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -42,6 +42,10 @@
 
 // Do not change this for a full inclusion of fair::mq::Device.
 #include <fairmq/FwdDecls.h>
+#include <fairmq/Version.h>
+#if (FAIRMQ_VERSION_DEC >= 111000)
+#include <fairmq/shmem/Message.h>
+#endif
 
 namespace arrow
 {
@@ -496,6 +500,8 @@ class DataAllocator
 
   struct CacheId {
     int64_t value;
+    int64_t handle;
+    int64_t segment;
   };
 
   enum struct CacheStrategy : int {
@@ -507,7 +513,7 @@ class DataAllocator
   CacheId adoptContainer(const Output& /*spec*/, ContainerT& /*container*/, CacheStrategy /* cache  = false */, o2::header::SerializationMethod /* method = header::gSerializationMethodNone*/)
   {
     static_assert(always_static_assert_v<ContainerT>, "Container cannot be moved. Please make sure it is backed by a o2::pmr::FairMQMemoryResource");
-    return {0};
+    return {0, 0, 0};
   }
 
   /// Adopt a PMR container. Notice that the container must be moveable and
@@ -599,12 +605,17 @@ DataAllocator::CacheId DataAllocator::adoptContainer(const Output& spec, Contain
                                                                payloadMessage->GetSize() //
   );
 
-  CacheId cacheId{0}; //
+  CacheId cacheId{0, 0, 0}; //
   if (cache == CacheStrategy::Always) {
     // The message will be shallow cloned in the cache. Since the
     // clone is indistinguishable from the original, we can keep sending
     // the original.
     cacheId.value = context.addToCache(payloadMessage);
+#if (FAIRMQ_VERSION_DEC >= 111000)
+    auto meta = dynamic_cast<fair::mq::shmem::Message*>(payloadMessage.get())->GetMeta();
+    cacheId.handle = meta.fHandle;
+    cacheId.segment = meta.fSegmentId;
+#endif
   }
 
   context.add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), routeIndex);

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -20,6 +20,10 @@
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
 #include <fairmq/FwdDecls.h>
+#include <fairmq/Version.h>
+#if (FAIRMQ_VERSION_DEC >= 111000)
+#include <fairmq/shmem/Common.h>
+#endif
 #include <vector>
 
 namespace o2::header
@@ -29,6 +33,9 @@ struct DataHeader;
 
 namespace o2::framework
 {
+#if (FAIRMQ_VERSION_DEC >= 111000)
+using PointerReconstructor = std::function<std::byte*(fair::mq::shmem::MetaHeader&&)>;
+#endif
 /// Helper class to hide fair::mq::Device headers in the DataAllocator header.
 /// This is done because fair::mq::Device brings in a bunch of boost.mpl /
 /// boost.fusion stuff, slowing down compilation times enourmously.
@@ -58,6 +65,10 @@ class FairMQDeviceProxy
   [[nodiscard]] ChannelIndex getForwardChannelIndexByName(std::string const& channelName) const;
   /// Retrieve the channel index from a given OutputSpec and the associated timeslice
   [[nodiscard]] ChannelIndex getOutputChannelIndex(OutputSpec const& spec, size_t timeslice) const;
+#if (FAIRMQ_VERSION_DEC >= 111000)
+  /// Retrieve the pointer-reconstruction function for the shm manager for a given input spec
+  [[nodiscard]] PointerReconstructor getShmPointerReconstructor(InputSpec const& spec, size_t timeslice);
+#endif
   /// Retrieve the channel index from a given OutputSpec and the associated timeslice
   void getMatchingForwardChannelIndexes(std::vector<ChannelIndex>& result, header::DataHeader const& header, size_t timeslice) const;
   /// ChannelIndex from a RouteIndex

--- a/Framework/Core/src/FairMQDeviceProxy.cxx
+++ b/Framework/Core/src/FairMQDeviceProxy.cxx
@@ -364,4 +364,25 @@ void FairMQDeviceProxy::bind(std::vector<OutputRoute> const& outputs, std::vecto
   }
   mStateChangeCallback = newStatePending;
 }
+
+#if (FAIRMQ_VERSION_DEC >= 111000)
+PointerReconstructor FairMQDeviceProxy::getShmPointerReconstructor(InputSpec const& spec, size_t timeslice)
+{
+  assert(mInputRoutes.size() == mInputs.size());
+  ChannelIndex c{-1};
+  for (size_t ri = 0; ri < mInputs.size(); ++ri) {
+    auto& route = mInputs[ri];
+
+    LOG(debug) << "matching: " << DataSpecUtils::describe(spec) << " to route " << DataSpecUtils::describe(route.matcher);
+    if ((spec == route.matcher) && (timeslice == route.timeslice)) {
+      c = mInputRoutes[ri].channel;
+      break;
+    }
+  }
+  if (c.value != ChannelIndex::INVALID) {
+    return {[transport = getInputChannel(c)->Transport()](fair::mq::shmem::MetaHeader&& meta) { return reinterpret_cast<std::byte*>(fair::mq::shmem::GetDataAddressFromHandle(*transport, meta)); }};
+  }
+  return {};
+}
+#endif
 } // namespace o2::framework


### PR DESCRIPTION
Based on a new FairMQ feature (https://github.com/alisw/alidist/pull/6239) it is now possible to resolve the shared memory location of an unsent message from its metadata transferred through a side channel. The API is available through shared memory message header, and return a payload pointer, using transport and message metadata as input. This allows us to provide true zero-copy CCDB tables, that contain the shared memory metadata instead of the objects themselves. FairMQDeviceProxy is used to provide a pointer reconstructor function to the table objects. Compatibility with older FairMQ is preserved. 

