### PR TITLE
TPC: clamp zOut to TPC length

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -133,10 +133,12 @@ void TrackResiduals::setZ2XBinning(const std::vector<float>& binning)
   mZ2XBinsDH.clear();
   mZ2XBinsDI.clear();
   mZ2XBinsCenter.clear();
+  const float maxZ2X = SpacePointsCalibConfParam::Instance().maxZ2X;
+  LOGP(info, "Using maxZ2X {} for setZ2XBinning", maxZ2X);
   for (int iBin = 0; iBin < nBins; ++iBin) {
-    mZ2XBinsDH.push_back(.5f * (binning[iBin + 1] - binning[iBin]) * mMaxZ2X);
+    mZ2XBinsDH.push_back(.5f * (binning[iBin + 1] - binning[iBin]) * maxZ2X);
     mZ2XBinsDI.push_back(.5f / mZ2XBinsDH[iBin]);
-    mZ2XBinsCenter.push_back(binning[iBin] * mMaxZ2X + mZ2XBinsDH[iBin]);
+    mZ2XBinsCenter.push_back(binning[iBin] * maxZ2X + mZ2XBinsDH[iBin]);
     LOGF(info, "Bin %i: center (%.3f), half bin width (%.3f)", iBin, mZ2XBinsCenter.back(), mZ2XBinsDH.back());
   }
 }

--- a/Detectors/TPC/calibration/src/TPCFastSpaceChargeCorrectionHelper.cxx
+++ b/Detectors/TPC/calibration/src/TPCFastSpaceChargeCorrectionHelper.cxx
@@ -497,7 +497,7 @@ std::unique_ptr<o2::gpu::TPCFastSpaceChargeCorrection> TPCFastSpaceChargeCorrect
     double yMax = rowX * trackResiduals.getY2X(iRow, trackResiduals.getNY2XBins() - 1);
     double zMin = rowX * trackResiduals.getZ2X(0);
     double zMax = rowX * trackResiduals.getZ2X(trackResiduals.getNZ2XBins() - 1);
-    double zOut = std::min(zMax, (double)geo.getTPCzLength()); // clamp to physical TPC extent to avoid negative spline scale
+    double zOut = std::min(zMax, (double)geo.getTPCzLength());                // clamp to physical TPC extent to avoid negative spline scale
     info.gridMeasured.set(yMin, spline.getGridX1().getUmax() / (yMax - yMin), // y
                           zMin, spline.getGridX2().getUmax() / (zMax - zMin), // z
                           zOut, geo.getTPCzLength());                         // correction scaling region

--- a/Detectors/TPC/calibration/src/TPCFastSpaceChargeCorrectionHelper.cxx
+++ b/Detectors/TPC/calibration/src/TPCFastSpaceChargeCorrectionHelper.cxx
@@ -497,7 +497,7 @@ std::unique_ptr<o2::gpu::TPCFastSpaceChargeCorrection> TPCFastSpaceChargeCorrect
     double yMax = rowX * trackResiduals.getY2X(iRow, trackResiduals.getNY2XBins() - 1);
     double zMin = rowX * trackResiduals.getZ2X(0);
     double zMax = rowX * trackResiduals.getZ2X(trackResiduals.getNZ2XBins() - 1);
-    double zOut = zMax;
+    double zOut = std::min(zMax, (double)geo.getTPCzLength()); // clamp to physical TPC extent to avoid negative spline scale
     info.gridMeasured.set(yMin, spline.getGridX1().getUmax() / (yMax - yMin), // y
                           zMin, spline.getGridX2().getUmax() / (zMax - zMin), // z
                           zOut, geo.getTPCzLength());                         // correction scaling region


### PR DESCRIPTION
Fix zero corrections for outer pad rows when maxZ2X * rowX > TPC z length, which caused a negative spline scaling factor.

- use maxZ2X from SpacePointsCalibConfParam