### PR TITLE
ALICE3: prepare IOTOF geometry for including TOF in tracking

### DIFF
--- a/Detectors/Upgrades/ALICE3/IOTOF/base/CMakeLists.txt
+++ b/Detectors/Upgrades/ALICE3/IOTOF/base/CMakeLists.txt
@@ -12,7 +12,8 @@
 o2_add_library(IOTOFBase
                SOURCES src/GeometryTGeo.cxx
                        src/IOTOFBaseParam.cxx
-               PUBLIC_LINK_LIBRARIES O2::DetectorsBase)
+               PUBLIC_LINK_LIBRARIES O2::DetectorsBase
+                                     O2::MathUtils)
 
 o2_target_root_dictionary(IOTOFBase
                HEADERS include/IOTOFBase/GeometryTGeo.h

--- a/Detectors/Upgrades/ALICE3/IOTOF/base/include/IOTOFBase/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/base/include/IOTOFBase/GeometryTGeo.h
@@ -13,7 +13,11 @@
 #define ALICEO2_IOTOF_GEOMETRYTGEO_H
 
 #include <memory>
+#include <string>
+#include <vector>
 #include <DetectorsCommonDataFormats/DetMatrixCache.h>
+#include <IOTOFBase/IOTOFBaseParam.h>
+#include <MathUtils/Cartesian.h>
 
 namespace o2
 {
@@ -88,8 +92,11 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
 
   int getIOTOFFirstChipIndex(int lay) const;
   int getIOTOFLayer(int index) const;
+  bool isValidIOTOFChipIndex(int index) const { return index >= 0 && index <= mLastChipIndex[1]; }
   int getIOTOFChipIndex(int lay, int sta, int mod, int chip) const;
   bool getIOTOFChipId(int index, int& lay, int& sta, int& mod, int& chip) const;
+  o2::math_utils::Point3D<float> detectorToLocal(int row, int col, int chipId) const;
+  static const ChipSpecifics& getChipSpecifics(int iotofLayer);
 
   /// Get the transformation matrix of the SENSOR (not necessary the same as the chip)
   /// for a given chip 'index' by querying the TGeoManager
@@ -156,18 +163,18 @@ class GeometryTGeo : public o2::detectors::DetMatrixCache
   static std::string sBTOFSensorName;
 
   // Inner/outer TOF
-  int mNumberOfStavesIOTOF[2];
-  int mNumberOfModulesIOTOF[2];
-  int mNumberOfChipsPerModuleIOTOF[2];
-  int mNumberOfChipsPerStaveIOTOF[2];
-  int mNumberOfChipsIOTOF[2];
-  int mLastChipIndex[2];
+  int mNumberOfStavesIOTOF[2]{};
+  int mNumberOfModulesIOTOF[2]{};
+  int mNumberOfChipsPerModuleIOTOF[2]{};
+  int mNumberOfChipsPerStaveIOTOF[2]{};
+  int mNumberOfChipsIOTOF[2]{};
+  int mLastChipIndex[2]{-1, -1};
 
   // Forward TOF
-  int mNumberOfChipsFTOF;
+  int mNumberOfChipsFTOF = 0;
 
   // Backward TOF
-  int mNumberOfChipsBTOF;
+  int mNumberOfChipsBTOF = 0;
 
   std::vector<int> sensors;
   std::vector<float> mCacheRefX;     /// cache for X of IOTOF

--- a/Detectors/Upgrades/ALICE3/IOTOF/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/base/src/GeometryTGeo.cxx
@@ -11,6 +11,7 @@
 
 #include <IOTOFBase/GeometryTGeo.h>
 #include <IOTOFBase/IOTOFBaseParam.h>
+#include <MathUtils/Utils.h>
 #include <TGeoManager.h>
 #include <TMath.h>
 
@@ -166,6 +167,24 @@ bool GeometryTGeo::getIOTOFChipId(int index, int& lay, int& sta, int& mod, int& 
   return true;
 }
 
+const ChipSpecifics& GeometryTGeo::getChipSpecifics(int iotofLayer)
+{
+  if (iotofLayer == 0) {
+    return ITOFChipSpecificParam::Instance();
+  }
+  return OTOFChipSpecificParam::Instance();
+}
+
+o2::math_utils::Point3D<float> GeometryTGeo::detectorToLocal(int row, int col, int chipId) const
+{
+  const auto& specs = getChipSpecifics(getIOTOFLayer(chipId));
+  o2::math_utils::Point3D<float> loc;
+  loc.SetCoordinates(0.5f * ((specs.ActiveMatrixSizeRows() - specs.PassiveEdgeTop + specs.PassiveEdgeReadOut) - specs.PitchRow) - row * specs.PitchRow,
+                     0.f,
+                     col * specs.PitchCol + 0.5f * (specs.PitchCol - specs.ActiveMatrixSizeCols()));
+  return loc;
+}
+
 TString GeometryTGeo::getMatrixPath(int index) const
 {
   int lay, sta, mod, chip;
@@ -276,6 +295,8 @@ void GeometryTGeo::Build(int loadTrans)
 
 void GeometryTGeo::defineSensors()
 {
+  sensors.clear();
+  sensors.reserve(mSize);
   for (int i = 0; i < mSize; i++) {
     sensors.push_back(i);
   }


### PR DESCRIPTION
Initialise GeometryTGeo members, add isValidIOTOFChipIndex helper, guard against repeated sensor definition, and link MathUtils.