### PR TITLE
Extend configurable params for std-container types

### DIFF
--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -9,15 +9,24 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//first version 8/2018, Sandro Wenzel
+// first version 8/2018, Sandro Wenzel
 
 #ifndef COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAM_H_
 #define COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAM_H_
 
-#include <vector>
+#include <algorithm>
 #include <cassert>
+#include <cctype>
+#include <concepts>
+#include <cstdint>
+#include <limits>
 #include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
 #include <unordered_map>
+#include <vector>
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <typeinfo>
 #include <iostream>
@@ -136,6 +145,233 @@ class EnumRegistry
   std::unordered_map<std::string, EnumLegalValues> entries;
 };
 
+template <typename T>
+concept Container = !std::is_same_v<std::remove_cvref_t<T>, std::string> && requires(T t) {
+  typename T::value_type;
+  typename T::iterator;
+  { t.begin() } -> std::same_as<typename T::iterator>;
+  { t.end() } -> std::same_as<typename T::iterator>;
+};
+
+template <typename T>
+concept MapLike = Container<T> && requires {
+  typename T::key_type;
+  typename T::mapped_type;
+};
+
+template <typename T>
+concept SequenceContainer = Container<T> && !MapLike<T>;
+
+template <typename T>
+concept HasPushBack = requires(T a, typename T::value_type v) {
+  { a.push_back(v) } -> std::same_as<void>;
+};
+
+template <typename>
+inline constexpr bool AlwaysFalse = false;
+
+class ContainerParser
+{
+ public:
+  template <typename T>
+  static T parse(const std::string& str)
+  {
+    if constexpr (MapLike<T>) {
+      return parseMap<T>(str);
+    } else if constexpr (SequenceContainer<T>) {
+      return parseSet<T>(str);
+    } else if constexpr (Container<T>) {
+      return parseSequence<T>(str);
+    } else {
+      return parseScalar<T>(str);
+    }
+  }
+
+  static std::string trim(const std::string& str)
+  {
+    auto start = str.find_first_not_of(" \t\n\r\f\v");
+    if (start == std::string::npos) {
+      return "";
+    }
+    auto end = str.find_last_not_of(" \t\n\r\f\v");
+    return str.substr(start, end - start + 1);
+  }
+
+ private:
+  // Parse vector, list, deque, array
+  template <SequenceContainer SequenceT>
+  static SequenceT parseSequence(const std::string& str)
+  {
+    SequenceT result;
+    using ValueType = typename SequenceT::value_type;
+    std::string cleaned = str;
+    if (!cleaned.empty() && cleaned.front() == '[' && cleaned.back() == ']') { // removed brackets [1,2,3] -> 1,2,3
+      cleaned = cleaned.substr(1, cleaned.length() - 2);
+    }
+    if (cleaned.empty() || cleaned == "{}") { // nothing to do
+      return result;
+    }
+    if constexpr (Container<ValueType>) {
+      static_assert(AlwaysFalse<ValueType>, "Nested containers are not supported as configurable parameters");
+    }
+    auto tokens = split(cleaned, ',');
+    for (const auto& token : tokens) {
+      std::string trimmed = trim(token);
+      result.insert(result.end(), parseScalar<ValueType>(trimmed));
+    }
+    return result;
+  }
+
+  // Parse map, unordered_map, multimap
+  template <MapLike MapT>
+  static MapT parseMap(const std::string& str)
+  {
+    MapT result;
+    using KeyType = typename MapT::key_type;
+    using ValueType = typename MapT::mapped_type;
+    std::string cleaned = str;
+    if (!cleaned.empty() && cleaned.front() == '{' && cleaned.back() == '}') { // stip braces {a:1,b:2} -> a:1,b:2
+      cleaned = cleaned.substr(1, cleaned.length() - 2);
+    }
+    if (cleaned.empty()) { // nothing to do
+      return result;
+    }
+    if constexpr (Container<KeyType> || Container<ValueType>) {
+      static_assert(AlwaysFalse<MapT>, "Nested containers are not supported as configurable parameters");
+    }
+    auto pairs = split(cleaned, ',');
+    for (const auto& pair_str : pairs) {
+      auto kv = split(pair_str, ':');
+      if (kv.size() != 2) {
+        throw std::runtime_error("Invalid map syntax: " + pair_str + ". Expected 'key:value' format, got ");
+      }
+      KeyType key = parseScalar<KeyType>(trim(kv[0]));
+      result[key] = parseScalar<ValueType>(trim(kv[1]));
+    }
+    return result;
+  }
+
+  // Parse set containers
+  template <SequenceContainer SetT>
+  static SetT parseSet(const std::string& str)
+  {
+    SetT result;
+    using ValueType = typename SetT::value_type;
+    auto vec = parseSequence<std::vector<ValueType>>(str);
+    for (const auto& val : vec) {
+      if constexpr (HasPushBack<SetT>) {
+        result.push_back(val);
+      } else {
+        result.insert(val);
+      }
+    }
+    return result;
+  }
+
+  // Parse scalar types
+  template <typename T>
+  static T parseScalar(const std::string& str)
+  {
+    if constexpr (std::is_same_v<T, std::string>) {
+      return str;
+    } else if constexpr (std::is_same_v<T, bool>) {
+      std::string lower = str;
+      std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+      if (lower == "true" || lower == "1") {
+        return true;
+      }
+      if (lower == "false" || lower == "0") {
+        return false;
+      }
+      throw std::runtime_error("Invalid boolean value: " + str);
+    } else if constexpr (std::is_same_v<T, char> || std::is_same_v<T, signed char>) {
+      size_t pos = 0;
+      long long value = std::stoll(str, &pos);
+      if (pos != str.size()) {
+        throw std::runtime_error("Failed to parse '" + str + "' as char type");
+      }
+      if (value < std::numeric_limits<T>::min() || value > std::numeric_limits<T>::max()) {
+        throw std::runtime_error("Value out of range for char type: " + str);
+      }
+      return static_cast<T>(value);
+    } else if constexpr (std::is_same_v<T, unsigned char>) {
+      size_t pos = 0;
+      unsigned long long value = std::stoull(str, &pos);
+      if (pos != str.size()) {
+        throw std::runtime_error("Failed to parse '" + str + "' as unsigned char type");
+      }
+      if (value > std::numeric_limits<T>::max()) {
+        throw std::runtime_error("Value out of range for unsigned char type: " + str);
+      }
+      return static_cast<T>(value);
+    } else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+      if (!str.empty() && str.front() == '-') {
+        throw std::runtime_error("Value out of range for unsigned integer type: " + str);
+      }
+      size_t pos = 0;
+      unsigned long long value = std::stoull(str, &pos);
+      if (pos != str.size() || value > std::numeric_limits<T>::max()) {
+        throw std::runtime_error("Failed to parse '" + str + "' as unsigned integer type");
+      }
+      return static_cast<T>(value);
+    } else if constexpr (std::is_integral_v<T>) {
+      size_t pos = 0;
+      long long value = std::stoll(str, &pos);
+      if (pos != str.size() || value < std::numeric_limits<T>::min() || value > std::numeric_limits<T>::max()) {
+        throw std::runtime_error("Failed to parse '" + str + "' as signed integer type");
+      }
+      return static_cast<T>(value);
+    } else if constexpr (std::is_floating_point_v<T>) {
+      size_t pos = 0;
+      long double value = std::stold(str, &pos);
+      if (pos != str.size()) {
+        throw std::runtime_error("Failed to parse '" + str + "' as floating point type");
+      }
+      return static_cast<T>(value);
+    } else {
+      std::istringstream iss(str);
+      T value;
+      iss >> value;
+      iss >> std::ws;
+      if (iss.fail() || !iss.eof()) {
+        throw std::runtime_error("Failed to parse '" + str + "' as " + typeid(T).name());
+      }
+      return value;
+    }
+  }
+
+  // Split respecting nested brackets and braces
+  static std::vector<std::string> split(const std::string& str, char delimiter)
+  {
+    std::vector<std::string> tokens;
+    std::string current;
+    int bracket_depth = 0;
+    int brace_depth = 0;
+    for (char c : str) {
+      if (c == '[') {
+        bracket_depth++;
+      } else if (c == ']') {
+        bracket_depth--;
+      } else if (c == '{') {
+        brace_depth++;
+      } else if (c == '}') {
+        brace_depth--;
+      } else if (c == delimiter && bracket_depth == 0 && brace_depth == 0) {
+        if (!current.empty()) {
+          tokens.push_back(current);
+          current.clear();
+        }
+        continue;
+      }
+      current += c;
+    }
+    if (!current.empty()) {
+      tokens.push_back(current);
+    }
+    return tokens;
+  }
+};
+
 class ConfigurableParam
 {
  public:
@@ -247,6 +483,13 @@ class ConfigurableParam
   static void setValue(std::string const& key, std::string const& valuestring);
   static void setEnumValue(const std::string&, const std::string&);
   static void setArrayValue(const std::string&, const std::string&);
+  static void setContainerValue(const std::string&, const std::string&);
+  static bool isRegisteredContainerType(const std::string& typeName);
+  static void registerContainerType(const std::string& key, const std::string& typeName);
+  static std::string getRegisteredContainerType(const std::string& key);
+  static bool assignRegisteredContainer(const std::string& typeName, void* target, const void* source);
+  static bool areRegisteredContainersEqual(const std::string& typeName, const void* lhs, const void* rhs);
+  static std::string registeredContainerAsString(const std::string& typeName, const void* source);
 
   // update the storagemap from a vector of key/value pairs, calling setValue for each pair
   static void setValues(std::vector<std::pair<std::string, std::string>> const& keyValues);
@@ -254,7 +497,7 @@ class ConfigurableParam
   // initializes the parameter database
   static void initialize();
 
-  // create CCDB snapsnot
+  // create CCDB snapshot
   static void toCCDB(std::string filename);
   // load from (CCDB) snapshot
   static void fromCCDB(std::string filename);

--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -162,11 +162,6 @@ concept MapLike = Container<T> && requires {
 template <typename T>
 concept SequenceContainer = Container<T> && !MapLike<T>;
 
-template <typename T>
-concept HasPushBack = requires(T a, typename T::value_type v) {
-  { a.push_back(v) } -> std::same_as<void>;
-};
-
 template <typename>
 inline constexpr bool AlwaysFalse = false;
 
@@ -178,9 +173,12 @@ class ContainerParser
   {
     if constexpr (MapLike<T>) {
       return parseMap<T>(str);
-    } else if constexpr (SequenceContainer<T>) {
-      return parseSet<T>(str);
     } else if constexpr (Container<T>) {
+      // Covers vector/list/deque as well as set/unordered_set: parseSequence
+      // inserts at end(), which both sequence and associative-set containers
+      // accept. (Any non-map Container is a SequenceContainer, so the previous
+      // separate parseSet branch was unreachable and re-parsed into a temporary
+      // vector first.)
       return parseSequence<T>(str);
     } else {
       return parseScalar<T>(str);
@@ -198,7 +196,7 @@ class ContainerParser
   }
 
  private:
-  // Parse vector, list, deque, array
+  // Parse sequence and set containers (vector, list, deque, set, unordered_set)
   template <SequenceContainer SequenceT>
   static SequenceT parseSequence(const std::string& str)
   {
@@ -247,23 +245,6 @@ class ContainerParser
       }
       KeyType key = parseScalar<KeyType>(trim(kv[0]));
       result[key] = parseScalar<ValueType>(trim(kv[1]));
-    }
-    return result;
-  }
-
-  // Parse set containers
-  template <SequenceContainer SetT>
-  static SetT parseSet(const std::string& str)
-  {
-    SetT result;
-    using ValueType = typename SetT::value_type;
-    auto vec = parseSequence<std::vector<ValueType>>(str);
-    for (const auto& val : vec) {
-      if constexpr (HasPushBack<SetT>) {
-        result.push_back(val);
-      } else {
-        result.insert(val);
-      }
     }
     return result;
   }
@@ -357,17 +338,17 @@ class ContainerParser
       } else if (c == '}') {
         brace_depth--;
       } else if (c == delimiter && bracket_depth == 0 && brace_depth == 0) {
-        if (!current.empty()) {
-          tokens.push_back(current);
-          current.clear();
-        }
+        // Keep empty fields: a stray delimiter (e.g. "[1,,3]" or "key:") must
+        // surface as a parse error downstream rather than silently dropping an
+        // element. The empty-container case ("[]"/"{}") is handled by the
+        // callers before split() is ever reached.
+        tokens.push_back(current);
+        current.clear();
         continue;
       }
       current += c;
     }
-    if (!current.empty()) {
-      tokens.push_back(current);
-    }
+    tokens.push_back(current);
     return tokens;
   }
 };

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -9,21 +9,21 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//first version 8/2018, Sandro Wenzel
+// first version 8/2018, Sandro Wenzel
 
 #ifndef COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAMHELPER_H_
 #define COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAMHELPER_H_
 
 #include "CommonUtils/ConfigurableParam.h"
-#include "TClass.h"
+
 #include <memory>
+#include <TClass.h>
+#include <TFile.h>
+#include <TDataMember.h>
 #include <type_traits>
 #include <typeinfo>
-#include "TFile.h"
 
-namespace o2
-{
-namespace conf
+namespace o2::conf
 {
 
 // ----------------------------------------------------------------
@@ -342,7 +342,19 @@ class ConfigurableParamPromoter : public Base, virtual public ConfigurableParam
   }
 };
 
-} // namespace conf
-} // namespace o2
+inline bool isContainer(const std::string& typeName)
+{
+  return ConfigurableParam::isRegisteredContainerType(typeName);
+}
+
+inline bool isContainer(TDataMember const& dm)
+{
+  if (auto* cl = dm.GetClass(); cl && isContainer(cl->GetName())) {
+    return true;
+  }
+  return isContainer(dm.GetTrueTypeName()) || isContainer(dm.GetFullTypeName());
+}
+
+} // namespace o2::conf
 
 #endif /* COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAMHELPER_H_ */

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -48,10 +48,9 @@ inline std::size_t damerauLevenshteinDistance(std::string_view a, std::string_vi
     curr[0] = i;
     for (std::size_t j = 1; j <= m; ++j) {
       std::size_t cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
-      curr[j] = std::min({
-        prev[j] + 1,
-        curr[j - 1] + 1,
-        prev[j - 1] + cost});
+      curr[j] = std::min({prev[j] + 1,
+                          curr[j - 1] + 1,
+                          prev[j - 1] + cost});
       if (i > 1 && j > 1 && a[i - 1] == b[j - 2] &&
           a[i - 2] == b[j - 1]) {
         curr[j] = std::min(curr[j], prev2[j - 2] + 1);

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -16,15 +16,53 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 
+#include <algorithm>
 #include <memory>
+#include <numeric>
+#include <string_view>
 #include <TClass.h>
 #include <TFile.h>
 #include <TDataMember.h>
 #include <type_traits>
 #include <typeinfo>
+#include <utility>
 
 namespace o2::conf
 {
+
+// ----------------------------------------------------------------
+
+inline std::size_t damerauLevenshteinDistance(std::string_view a, std::string_view b)
+{
+  const std::size_t n = a.size();
+  const std::size_t m = b.size();
+  if (n == 0) {
+    return m;
+  }
+  if (m == 0) {
+    return n;
+  }
+  std::vector<std::size_t> prev(m + 1), curr(m + 1), prev2(m + 1);
+  std::iota(prev.begin(), prev.end(), 0);
+  for (std::size_t i = 1; i <= n; ++i) {
+    curr[0] = i;
+    for (std::size_t j = 1; j <= m; ++j) {
+      std::size_t cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
+      curr[j] = std::min({
+        prev[j] + 1,
+        curr[j - 1] + 1,
+        prev[j - 1] + cost});
+      if (i > 1 && j > 1 && a[i - 1] == b[j - 2] &&
+          a[i - 2] == b[j - 1]) {
+        curr[j] = std::min(curr[j], prev2[j - 2] + 1);
+      }
+    }
+    prev2 = std::move(prev);
+    prev = std::move(curr);
+    curr.assign(m + 1, 0);
+  }
+  return prev[m];
+}
 
 // ----------------------------------------------------------------
 

--- a/Common/Utils/include/CommonUtils/ConfigurableParamTest.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamTest.h
@@ -15,6 +15,12 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
 
+#include <array>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <vector>
+
 namespace o2::conf::test
 {
 struct TestParam : public o2::conf::ConfigurableParamHelper<TestParam> {
@@ -37,6 +43,11 @@ struct TestParam : public o2::conf::ConfigurableParamHelper<TestParam> {
   int iValueProvenanceTest{0};
   TestEnum eValue = TestEnum::C;
   int caValue[3] = {0, 1, 2};
+  std::vector<int> vec;
+  std::vector<uint8_t> u8vec;
+  std::map<int, uint32_t> map;
+  std::map<std::string, uint32_t> smap;
+  std::set<uint16_t> set;
 
   O2ParamDef(TestParam, "TestParam");
 };

--- a/Common/Utils/src/ConfigurableParam.cxx
+++ b/Common/Utils/src/ConfigurableParam.cxx
@@ -13,6 +13,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include <cstddef>
+#include "CommonUtils/ConfigurableParamHelper.h"
 #include "CommonUtils/StringUtils.h"
 #include "CommonUtils/KeyValParam.h"
 #include "CommonUtils/ConfigurableParamReaders.h"
@@ -431,6 +432,60 @@ const ContainerHandler* getContainerHandler(const std::type_info& type)
   const auto& handlers = containerHandlers().byType;
   auto iter = handlers.find(std::type_index(type));
   return iter == handlers.end() ? nullptr : &iter->second;
+}
+
+std::pair<std::string_view, std::string_view> splitConfigurableParamKey(std::string_view key)
+{
+  const auto separator = key.find('.');
+  if (separator == std::string_view::npos) {
+    return {key, {}};
+  }
+  return {key.substr(0, separator), key.substr(separator + 1)};
+}
+
+std::string findClosestConfigurableParamKey(const std::string& requestedKey,
+                                            const std::map<std::string, std::pair<std::type_info const&, void*>>& storageMap)
+{
+  if (storageMap.empty()) {
+    return {};
+  }
+
+  const auto [requestedMainKey, requestedSubKey] = splitConfigurableParamKey(requestedKey);
+  bool mainKeyExists = false;
+  for (const auto& entry : storageMap) {
+    const auto mainKey = splitConfigurableParamKey(entry.first).first;
+    if (mainKey == requestedMainKey) {
+      mainKeyExists = true;
+      break;
+    }
+  }
+
+  std::string closest;
+  std::size_t closestDistance = std::numeric_limits<std::size_t>::max();
+  for (const auto& entry : storageMap) {
+    const auto& key = entry.first;
+    const auto [mainKey, subKey] = splitConfigurableParamKey(key);
+    if (mainKeyExists && mainKey != requestedMainKey) {
+      continue;
+    }
+    const auto distance = mainKeyExists ? damerauLevenshteinDistance(requestedSubKey, subKey) : damerauLevenshteinDistance(requestedKey, key);
+    if (distance < closestDistance || (distance == closestDistance && (closest.empty() || key < closest))) {
+      closest = key;
+      closestDistance = distance;
+    }
+  }
+  return closest;
+}
+
+std::string formatUnknownConfigurableParamKeyMessage(const std::string& prefix, const std::string& key,
+                                                     const std::map<std::string, std::pair<std::type_info const&, void*>>& storageMap)
+{
+  std::string message = prefix + key;
+  auto closest = findClosestConfigurableParamKey(key, storageMap);
+  if (!closest.empty()) {
+    message += ". Did you mean '" + closest + "'?";
+  }
+  return message;
 }
 
 } // namespace
@@ -978,10 +1033,10 @@ void ConfigurableParam::setValues(std::vector<std::pair<std::string, std::string
 
     if (!keyInTree(sPtree, key)) {
       if (nonFatal) {
-        LOG(warn) << "Ignoring non-existent ConfigurableParam key: " << key;
+        LOG(warn) << formatUnknownConfigurableParamKeyMessage("Ignoring non-existent ConfigurableParam key: ", key, *sKeyToStorageMap);
         continue;
       }
-      LOG(fatal) << "Inexistent ConfigurableParam key: " << key;
+      LOG(fatal) << formatUnknownConfigurableParamKeyMessage("Inexistent ConfigurableParam key: ", key, *sKeyToStorageMap);
     }
 
     auto iter = sKeyToStorageMap->find(key);

--- a/Common/Utils/src/ConfigurableParam.cxx
+++ b/Common/Utils/src/ConfigurableParam.cxx
@@ -12,6 +12,7 @@
 // first version 8/2018, Sandro Wenzel
 
 #include "CommonUtils/ConfigurableParam.h"
+#include <cstddef>
 #include "CommonUtils/StringUtils.h"
 #include "CommonUtils/KeyValParam.h"
 #include "CommonUtils/ConfigurableParamReaders.h"
@@ -24,7 +25,12 @@
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <array>
+#include <cctype>
+#include <cstdlib>
+#include <functional>
+#include <iomanip>
 #include <limits>
+#include <utility>
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
@@ -32,6 +38,7 @@
 #include <iostream>
 #include <string>
 #include <fairlogger/Logger.h>
+#include <typeindex>
 #include <typeinfo>
 #include "TDataMember.h"
 #include "TDataType.h"
@@ -39,6 +46,13 @@
 #include "TEnum.h"
 #include "TEnumConstant.h"
 #include <filesystem>
+#include <map>
+#include <unordered_map>
+#include <set>
+#include <unordered_set>
+#include <deque>
+#include <vector>
+#include <list>
 
 namespace o2
 {
@@ -53,6 +67,11 @@ EnumRegistry* ConfigurableParam::sEnumRegistry = nullptr;
 
 bool ConfigurableParam::sIsFullyInitialized = false;
 bool ConfigurableParam::sRegisterMode = true;
+
+namespace
+{
+std::map<std::string, std::string> sKeyToContainerTypeMap;
+} // namespace
 
 // ------------------------------------------------------------------
 
@@ -77,7 +96,7 @@ bool keyInTree(boost::property_tree::ptree* pt, const std::string& key)
   return reply;
 }
 
-// Convert a type info to the appropiate literal suffix
+// Convert a type info to the appropriate literal suffix
 std::string getLiteralSuffixFromType(const std::type_info& type)
 {
   if (type == typeid(float)) {
@@ -100,6 +119,321 @@ std::string getLiteralSuffixFromType(const std::type_info& type)
   }
   return "";
 }
+
+namespace
+{
+
+struct ContainerHandler {
+  std::function<void(void*, const std::string&)> parseAssign;
+  std::function<std::string(const void*)> serialize;
+  std::function<void(void*, const void*)> assign;
+  std::function<bool(const void*, const void*)> equal;
+};
+
+struct ContainerHandlerRegistry {
+  std::map<std::string, ContainerHandler> byName;
+  std::map<std::type_index, ContainerHandler> byType;
+};
+
+template <typename>
+struct IsUnorderedSet : std::false_type {
+};
+
+template <typename T, typename Hash, typename KeyEqual, typename Allocator>
+struct IsUnorderedSet<std::unordered_set<T, Hash, KeyEqual, Allocator>> : std::true_type {
+};
+
+template <typename>
+struct IsUnorderedMap : std::false_type {
+};
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+struct IsUnorderedMap<std::unordered_map<Key, T, Hash, KeyEqual, Allocator>> : std::true_type {
+};
+
+std::string normalizeContainerTypeName(std::string typeName)
+{
+  typeName = ContainerParser::trim(typeName);
+  for (size_t pos = typeName.find("std::"); pos != std::string::npos; pos = typeName.find("std::", pos)) {
+    typeName.erase(pos, 5);
+  }
+
+  std::string out;
+  bool pendingSpace = false;
+  for (char c : typeName) {
+    if (std::isspace(static_cast<unsigned char>(c))) {
+      if (!out.empty() && out.back() != '<' && out.back() != ',') {
+        pendingSpace = true;
+      }
+      continue;
+    }
+    if ((c == ',' || c == '>') && !out.empty() && out.back() == ' ') {
+      out.pop_back();
+    }
+    if (pendingSpace && c != ',' && c != '>' && !out.empty() && out.back() != '<' && out.back() != ',') {
+      out += ' ';
+    }
+    out += c;
+    pendingSpace = false;
+  }
+  return out;
+}
+
+template <typename T>
+struct TypeName;
+
+#define REGISTER_SCALAR_NAME(TYPE, NAME)       \
+  template <>                                  \
+  struct TypeName<TYPE> {                      \
+    static constexpr const char* value = NAME; \
+  }
+
+REGISTER_SCALAR_NAME(bool, "bool");
+REGISTER_SCALAR_NAME(char, "char");
+REGISTER_SCALAR_NAME(signed char, "signed char");
+REGISTER_SCALAR_NAME(unsigned char, "unsigned char");
+REGISTER_SCALAR_NAME(short, "short");
+REGISTER_SCALAR_NAME(unsigned short, "unsigned short");
+REGISTER_SCALAR_NAME(int, "int");
+REGISTER_SCALAR_NAME(unsigned int, "unsigned int");
+REGISTER_SCALAR_NAME(long, "long");
+REGISTER_SCALAR_NAME(unsigned long, "unsigned long");
+REGISTER_SCALAR_NAME(long long, "long long");
+REGISTER_SCALAR_NAME(unsigned long long, "unsigned long long");
+REGISTER_SCALAR_NAME(float, "float");
+REGISTER_SCALAR_NAME(double, "double");
+REGISTER_SCALAR_NAME(std::string, "string");
+
+#undef REGISTER_SCALAR_NAME
+
+template <typename T>
+std::string scalarAsString(const T& value)
+{
+  if constexpr (std::is_same_v<T, bool>) {
+    return value ? "1" : "0";
+  } else if constexpr (std::is_same_v<T, char> || std::is_same_v<T, signed char>) {
+    return std::to_string(static_cast<int>(value));
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    return std::to_string(static_cast<unsigned int>(value));
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    return value;
+  } else if constexpr (std::is_floating_point_v<T>) {
+    std::ostringstream out;
+    out << std::setprecision(std::numeric_limits<T>::max_digits10) << value;
+    return out.str();
+  } else {
+    return std::to_string(value);
+  }
+}
+
+template <typename ContainerT>
+std::string sequenceAsString(const ContainerT& container)
+{
+  using ValueType = typename ContainerT::value_type;
+  std::ostringstream out;
+  out << '[';
+  bool first = true;
+  std::vector<std::string> unorderedValues;
+  if constexpr (IsUnorderedSet<ContainerT>::value) {
+    for (const auto& value : container) {
+      unorderedValues.push_back(scalarAsString(static_cast<ValueType>(value)));
+    }
+    std::sort(unorderedValues.begin(), unorderedValues.end());
+  }
+  const auto emitValue = [&out, &first](const std::string& value) {
+    if (!first) {
+      out << ',';
+    }
+    out << value;
+    first = false;
+  };
+  if constexpr (IsUnorderedSet<ContainerT>::value) {
+    for (const auto& value : unorderedValues) {
+      emitValue(value);
+    }
+  } else {
+    for (const auto& value : container) {
+      emitValue(scalarAsString(static_cast<ValueType>(value)));
+    }
+  }
+  out << ']';
+  return out.str();
+}
+
+template <typename MapT>
+std::string mapAsString(const MapT& container)
+{
+  std::ostringstream out;
+  out << '{';
+  bool first = true;
+  std::vector<std::pair<std::string, std::string>> unorderedValues;
+  if constexpr (IsUnorderedMap<MapT>::value) {
+    for (const auto& [key, value] : container) {
+      unorderedValues.emplace_back(scalarAsString(key), scalarAsString(value));
+    }
+    std::sort(unorderedValues.begin(), unorderedValues.end());
+  }
+  const auto emitValue = [&out, &first](const std::string& key, const std::string& value) {
+    if (!first) {
+      out << ',';
+    }
+    out << key << ':' << value;
+    first = false;
+  };
+  if constexpr (IsUnorderedMap<MapT>::value) {
+    for (const auto& [key, value] : unorderedValues) {
+      emitValue(key, value);
+    }
+  } else {
+    for (const auto& [key, value] : container) {
+      emitValue(scalarAsString(key), scalarAsString(value));
+    }
+  }
+  out << '}';
+  return out.str();
+}
+
+template <typename ContainerT>
+ContainerHandler makeSequenceHandler()
+{
+  return {
+    [](void* target, const std::string& value) {
+      *static_cast<ContainerT*>(target) = ContainerParser::parse<ContainerT>(value);
+    },
+    [](const void* source) {
+      return sequenceAsString(*static_cast<const ContainerT*>(source));
+    },
+    [](void* target, const void* source) {
+      *static_cast<ContainerT*>(target) = *static_cast<const ContainerT*>(source);
+    },
+    [](const void* lhs, const void* rhs) {
+      return *static_cast<const ContainerT*>(lhs) == *static_cast<const ContainerT*>(rhs);
+    }};
+}
+
+template <typename MapT>
+ContainerHandler makeMapHandler()
+{
+  return {
+    [](void* target, const std::string& value) {
+      *static_cast<MapT*>(target) = ContainerParser::parse<MapT>(value);
+    },
+    [](const void* source) {
+      return mapAsString(*static_cast<const MapT*>(source));
+    },
+    [](void* target, const void* source) {
+      *static_cast<MapT*>(target) = *static_cast<const MapT*>(source);
+    },
+    [](const void* lhs, const void* rhs) {
+      return *static_cast<const MapT*>(lhs) == *static_cast<const MapT*>(rhs);
+    }};
+}
+
+template <typename ContainerT>
+void addHandler(ContainerHandlerRegistry& registry, const std::string& name, ContainerHandler handler)
+{
+  registry.byName.emplace(normalizeContainerTypeName(name), handler);
+  registry.byType.emplace(std::type_index(typeid(ContainerT)), std::move(handler));
+}
+
+template <typename T>
+void addSequenceHandlers(ContainerHandlerRegistry& registry)
+{
+  const std::string tname = TypeName<T>::value;
+  addHandler<std::vector<T>>(registry, "vector<" + tname + ">", makeSequenceHandler<std::vector<T>>());
+  addHandler<std::list<T>>(registry, "list<" + tname + ">", makeSequenceHandler<std::list<T>>());
+  addHandler<std::deque<T>>(registry, "deque<" + tname + ">", makeSequenceHandler<std::deque<T>>());
+  addHandler<std::set<T>>(registry, "set<" + tname + ">", makeSequenceHandler<std::set<T>>());
+  addHandler<std::unordered_set<T>>(registry, "unordered_set<" + tname + ">", makeSequenceHandler<std::unordered_set<T>>());
+}
+
+template <typename K, typename V>
+void addMapHandlers(ContainerHandlerRegistry& registry)
+{
+  const std::string kname = TypeName<K>::value;
+  const std::string vname = TypeName<V>::value;
+  addHandler<std::map<K, V>>(registry, "map<" + kname + "," + vname + ">", makeMapHandler<std::map<K, V>>());
+  addHandler<std::unordered_map<K, V>>(registry, "unordered_map<" + kname + "," + vname + ">", makeMapHandler<std::unordered_map<K, V>>());
+}
+
+template <typename K>
+void addMapHandlersForKey(ContainerHandlerRegistry& registry)
+{
+  addMapHandlers<K, bool>(registry);
+  addMapHandlers<K, char>(registry);
+  addMapHandlers<K, signed char>(registry);
+  addMapHandlers<K, unsigned char>(registry);
+  addMapHandlers<K, short>(registry);
+  addMapHandlers<K, unsigned short>(registry);
+  addMapHandlers<K, int>(registry);
+  addMapHandlers<K, unsigned int>(registry);
+  addMapHandlers<K, long>(registry);
+  addMapHandlers<K, unsigned long>(registry);
+  addMapHandlers<K, long long>(registry);
+  addMapHandlers<K, unsigned long long>(registry);
+  addMapHandlers<K, float>(registry);
+  addMapHandlers<K, double>(registry);
+  addMapHandlers<K, std::string>(registry);
+}
+
+const ContainerHandlerRegistry& containerHandlers()
+{
+  static const ContainerHandlerRegistry handlers = [] {
+    ContainerHandlerRegistry result;
+
+    addSequenceHandlers<bool>(result);
+    addSequenceHandlers<char>(result);
+    addSequenceHandlers<signed char>(result);
+    addSequenceHandlers<unsigned char>(result);
+    addSequenceHandlers<short>(result);
+    addSequenceHandlers<unsigned short>(result);
+    addSequenceHandlers<int>(result);
+    addSequenceHandlers<unsigned int>(result);
+    addSequenceHandlers<long>(result);
+    addSequenceHandlers<unsigned long>(result);
+    addSequenceHandlers<long long>(result);
+    addSequenceHandlers<unsigned long long>(result);
+    addSequenceHandlers<float>(result);
+    addSequenceHandlers<double>(result);
+    addSequenceHandlers<std::string>(result);
+
+    addMapHandlersForKey<bool>(result);
+    addMapHandlersForKey<char>(result);
+    addMapHandlersForKey<signed char>(result);
+    addMapHandlersForKey<unsigned char>(result);
+    addMapHandlersForKey<short>(result);
+    addMapHandlersForKey<unsigned short>(result);
+    addMapHandlersForKey<int>(result);
+    addMapHandlersForKey<unsigned int>(result);
+    addMapHandlersForKey<long>(result);
+    addMapHandlersForKey<unsigned long>(result);
+    addMapHandlersForKey<long long>(result);
+    addMapHandlersForKey<unsigned long long>(result);
+    addMapHandlersForKey<float>(result);
+    addMapHandlersForKey<double>(result);
+    addMapHandlersForKey<std::string>(result);
+
+    return result;
+  }();
+  return handlers;
+}
+
+const ContainerHandler* getContainerHandler(const std::string& typeName)
+{
+  const auto normalized = normalizeContainerTypeName(typeName);
+  const auto& handlers = containerHandlers().byName;
+  auto iter = handlers.find(normalized);
+  return iter == handlers.end() ? nullptr : &iter->second;
+}
+
+const ContainerHandler* getContainerHandler(const std::type_info& type)
+{
+  const auto& handlers = containerHandlers().byType;
+  auto iter = handlers.find(std::type_index(type));
+  return iter == handlers.end() ? nullptr : &iter->second;
+}
+
+} // namespace
 
 // ------------------------------------------------------------------
 
@@ -192,6 +526,49 @@ int EnumLegalValues::getIntValue(const std::string& value) const
 
 // -----------------------------------------------------------------
 
+bool ConfigurableParam::isRegisteredContainerType(const std::string& typeName)
+{
+  return getContainerHandler(typeName) != nullptr;
+}
+
+void ConfigurableParam::registerContainerType(const std::string& key, const std::string& typeName)
+{
+  sKeyToContainerTypeMap[key] = typeName;
+}
+
+std::string ConfigurableParam::getRegisteredContainerType(const std::string& key)
+{
+  auto iter = sKeyToContainerTypeMap.find(key);
+  return iter == sKeyToContainerTypeMap.end() ? std::string{} : iter->second;
+}
+
+bool ConfigurableParam::assignRegisteredContainer(const std::string& typeName, void* target, const void* source)
+{
+  if (const auto* handler = getContainerHandler(typeName)) {
+    handler->assign(target, source);
+    return true;
+  }
+  return false;
+}
+
+bool ConfigurableParam::areRegisteredContainersEqual(const std::string& typeName, const void* lhs, const void* rhs)
+{
+  if (const auto* handler = getContainerHandler(typeName)) {
+    return handler->equal(lhs, rhs);
+  }
+  return false;
+}
+
+std::string ConfigurableParam::registeredContainerAsString(const std::string& typeName, const void* source)
+{
+  if (const auto* handler = getContainerHandler(typeName)) {
+    return handler->serialize(source);
+  }
+  return {};
+}
+
+// -----------------------------------------------------------------
+
 void ConfigurableParam::write(std::string const& filename, std::string const& keyOnly)
 {
   if (o2::utils::Str::endsWith(filename, ".ini")) {
@@ -253,6 +630,13 @@ void ConfigurableParam::setValue(std::string const& key, std::string const& valu
   };
   try {
     if (sPtree->get_optional<std::string>(key).is_initialized()) {
+      auto iter = sKeyToStorageMap->find(key);
+      if (iter != sKeyToStorageMap->end()) {
+        if (!getRegisteredContainerType(key).empty() || getContainerHandler(iter->second.first)) {
+          setContainerValue(key, valuestring);
+          return;
+        }
+      }
       try {
         // try first setting value without stripping a literal suffix
         setValueImpl(valuestring);
@@ -266,7 +650,7 @@ void ConfigurableParam::setValue(std::string const& key, std::string const& valu
         const auto expectedSuffix = getLiteralSuffixFromType(iter->second.first);
         if (!expectedSuffix.empty()) {
           auto valuestringLower = valuestring;
-          std::transform(valuestring.cbegin(), valuestring.cend(), valuestringLower.begin(), tolower);
+          std::transform(valuestring.cbegin(), valuestring.cend(), valuestringLower.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
           if (valuestringLower.ends_with(expectedSuffix)) {
             std::string strippedValue = valuestringLower.substr(0, valuestringLower.length() - expectedSuffix.length());
             setValueImpl(strippedValue);
@@ -436,7 +820,7 @@ void ConfigurableParam::printAllRegisteredParamNames()
 // If nonempty comma-separated paramsList is provided, only those params will
 // be updated, absence of data for any of requested params will lead to fatal
 // If unchangedOnly is true, then only those parameters whose provenance is kCODE will be updated
-// (to allow prefernce of run-time settings)
+// (to allow preference of run-time settings)
 void ConfigurableParam::updateFromFile(std::string const& configFile, std::string const& paramsList, bool unchangedOnly)
 {
   if (!sIsFullyInitialized) {
@@ -597,7 +981,15 @@ void ConfigurableParam::setValues(std::vector<std::pair<std::string, std::string
         LOG(warn) << "Ignoring non-existent ConfigurableParam key: " << key;
         continue;
       }
-      LOG(fatal) << "Inexistant ConfigurableParam key: " << key;
+      LOG(fatal) << "Inexistent ConfigurableParam key: " << key;
+    }
+
+    auto iter = sKeyToStorageMap->find(key);
+    if (iter != sKeyToStorageMap->end()) {
+      if (!getRegisteredContainerType(key).empty() || getContainerHandler(iter->second.first)) {
+        setContainerValue(key, value);
+        continue;
+      }
     }
 
     if (sEnumRegistry->contains(key)) {
@@ -614,9 +1006,7 @@ void ConfigurableParam::setValues(std::vector<std::pair<std::string, std::string
         value = "0";
       }
 
-      // TODO: this will trap complex types like maps and structs.
-      // These need to be broken into their own cases, so that we only
-      // get strings and scalars here.
+      // Non-registered complex types still fall through to scalar conversion and fail there.
       setValue(key, value);
     }
   }
@@ -635,6 +1025,31 @@ void ConfigurableParam::setArrayValue(const std::string& key, const std::string&
   for (int i = 0; i < elems.size(); ++i) {
     std::string indexKey = key + "[" + std::to_string(i) + "]";
     setValue(indexKey, elems[i]);
+  }
+}
+
+void ConfigurableParam::setContainerValue(const std::string& key, const std::string& value)
+{
+  auto iter = sKeyToStorageMap->find(key);
+  if (iter == sKeyToStorageMap->end()) {
+    LOG(error) << "Container parameter " << key << " not found";
+    return;
+  }
+  void* targetAddress = iter->second.second;
+  const auto typeName = getRegisteredContainerType(key);
+  const auto* handler = typeName.empty() ? getContainerHandler(iter->second.first) : getContainerHandler(typeName);
+  if (!handler) {
+    LOG(error) << "Unsupported container configuration: " << (typeName.empty() ? iter->second.first.name() : typeName);
+    return;
+  }
+  try {
+    handler->parseAssign(targetAddress, value);
+    sPtree->put(key, handler->serialize(targetAddress));
+    if (auto prov = sValueProvenanceMap->find(key); prov != sValueProvenanceMap->end()) {
+      prov->second = kRT;
+    }
+  } catch (const std::exception& e) {
+    LOG(error) << "Failed to parse container " << key << ": " << e.what();
   }
 }
 

--- a/Common/Utils/src/ConfigurableParamHelper.cxx
+++ b/Common/Utils/src/ConfigurableParamHelper.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//first version 8/2018, Sandro Wenzel
+// first version 8/2018, Sandro Wenzel
 
 #include "CommonUtils/ConfigurableParamHelper.h"
 #include "CommonUtils/ConfigurableParam.h"
@@ -27,6 +27,7 @@
 #include <boost/functional/hash.hpp>
 #include <functional>
 #include <format>
+#include <typeinfo>
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
@@ -72,6 +73,17 @@ bool isString(TDataMember const& dm)
   return strcmp(dm.GetTrueTypeName(), "string") == 0;
 }
 
+std::string getContainerTypeName(TDataMember const& dm)
+{
+  if (auto* cl = dm.GetClass(); cl && ConfigurableParam::isRegisteredContainerType(cl->GetName())) {
+    return cl->GetName();
+  }
+  if (ConfigurableParam::isRegisteredContainerType(dm.GetTrueTypeName())) {
+    return dm.GetTrueTypeName();
+  }
+  return dm.GetFullTypeName();
+}
+
 // ----------------------------------------------------------------------
 
 // a generic looper of data members of a TClass; calling a callback
@@ -94,6 +106,15 @@ void loopOverMembers(TClass* cl, void* obj,
 
     if (dm->IsaPointer()) {
       LOG(warning) << "Pointer types not supported in ConfigurableParams: " << dm->GetFullTypeName() << " " << dm->GetName();
+      continue;
+    }
+    if (isContainer(*dm)) {
+      TClass* c = dm->GetClass();
+      if (!c || !c->HasDictionary()) {
+        LOG(warning) << "Skipping container parameter '" << dm->GetName() << "' of type " << dm->GetTrueTypeName() << " - ROOT dictionary not found.";
+        continue;
+      }
+      callback(dm, 0, 1);
       continue;
     }
     if (!dm->IsBasic() && !isValidComplex()) {
@@ -138,7 +159,7 @@ size_t getSizeOfUnderlyingType(const TDataMember& dm)
   } else {
     // for now only catch std::string as other supported type
     auto tname = dm.GetFullTypeName();
-    if (strcmp(tname, "string") == 0 || strcmp(tname, "std::string")) {
+    if (strcmp(tname, "string") == 0 || strcmp(tname, "std::string") == 0) {
       return sizeof(std::string);
     }
     LOG(error) << "ENCOUNTERED AN UNSUPPORTED TYPE " << tname << "IN A CONFIGURABLE PARAMETER";
@@ -189,9 +210,12 @@ std::string asString(TDataMember const& dm, char* pointer)
   else if (isString(dm)) {
     return ((std::string*)pointer)->c_str();
   }
+  if (isContainer(dm)) {
+    return ConfigurableParam::registeredContainerAsString(getContainerTypeName(dm), pointer);
+  }
   // potentially other cases to be added here
 
-  LOG(error) << "COULD NOT REPRESENT AS STRING";
+  LOG(error) << "COULD NOT REPRESENT AS STRING: " << dm.GetFullTypeName();
   return std::string();
 }
 
@@ -203,7 +227,7 @@ std::vector<ParamDataMember>* _ParamHelper::getDataMembersImpl(std::string const
   std::vector<ParamDataMember>* members = new std::vector<ParamDataMember>;
 
   auto toDataMember = [&members, obj, mainkey, provmap, globaloffset](const TDataMember* dm, int index, int size) {
-    auto TS = getSizeOfUnderlyingType(*dm);
+    auto TS = isContainer(*dm) ? 0 : getSizeOfUnderlyingType(*dm);
     char* pointer = ((char*)obj) + dm->GetOffset() + index * TS + globaloffset;
     const std::string name = getName(dm, index, size);
     auto value = asString(*dm, pointer);
@@ -279,7 +303,7 @@ std::type_info const& nameToTypeInfo(const char* tname, TDataType const* dt)
     }
   }
   // if we get here none of the above worked
-  if (strcmp(tname, "string") == 0 || strcmp(tname, "std::string")) {
+  if (strcmp(tname, "string") == 0 || strcmp(tname, "std::string") == 0) {
     return typeid(std::string);
   }
   LOG(error) << "ENCOUNTERED AN UNSUPPORTED TYPE " << tname << "IN A CONFIGURABLE PARAMETER";
@@ -293,14 +317,37 @@ void _ParamHelper::fillKeyValuesImpl(std::string const& mainkey, TClass* cl, voi
                                      EnumRegistry* enumRegistry, size_t globaloffset)
 {
   boost::property_tree::ptree localtree;
+  using mapped_t = std::pair<std::type_info const&, void*>;
   auto fillMap = [obj, &mainkey, &localtree, &keytostoragemap, &enumRegistry, globaloffset](const TDataMember* dm, int index, int size) {
     const auto name = getName(dm, index, size);
     auto dt = dm->GetDataType();
-    auto TS = getSizeOfUnderlyingType(*dm);
-    char* pointer = ((char*)obj) + dm->GetOffset() + index * TS + globaloffset;
-    localtree.put(name, asString(*dm, pointer));
+    auto TS = isContainer(*dm) ? 0 : getSizeOfUnderlyingType(*dm);
+    char* pointer = ((char*)obj) + dm->GetOffset() + (index * TS) + globaloffset;
+    const auto key = mainkey + "." + name;
 
-    auto key = mainkey + "." + name;
+    if (isContainer(*dm)) {
+      const auto typeName = getContainerTypeName(*dm);
+      pointer = ((char*)obj) + dm->GetOffset() + globaloffset;
+      localtree.put(name, ConfigurableParam::registeredContainerAsString(typeName, pointer));
+      TClass* containerClass = dm->GetClass();
+      if (!containerClass) {
+        containerClass = TClass::GetClass(dm->GetFullTypeName());
+      }
+      if (!containerClass) {
+        LOG(error) << "Cannot get TClass for container " << typeName;
+        return;
+      }
+      const std::type_info* tinfo = containerClass->GetTypeInfo();
+      ConfigurableParam::registerContainerType(key, typeName);
+      keytostoragemap->insert(std::pair<std::string, mapped_t>(
+        key, mapped_t(tinfo ? *tinfo : typeid(std::string), pointer)));
+      if (!tinfo) {
+        LOG(error) << "Cannot get type_info for container " << typeName;
+      }
+      return;
+    }
+
+    localtree.put(name, asString(*dm, pointer));
 
     // If it's an enum, we need to store separately all the legal
     // values so that we can map to them from the command line
@@ -308,7 +355,6 @@ void _ParamHelper::fillKeyValuesImpl(std::string const& mainkey, TClass* cl, voi
       enumRegistry->add(key, dm);
     }
 
-    using mapped_t = std::pair<std::type_info const&, void*>;
     auto& ti = nameToTypeInfo(dm->GetTrueTypeName(), dt);
     keytostoragemap->insert(std::pair<std::string, mapped_t>(key, mapped_t(ti, pointer)));
   };
@@ -386,8 +432,7 @@ void _ParamHelper::assignmentImpl(std::string const& mainkey, TClass* cl, void* 
 {
   auto assignifchanged = [to, from, &mainkey, provmap, globaloffset](const TDataMember* dm, int index, int size) {
     const auto name = getName(dm, index, size);
-    auto dt = dm->GetDataType();
-    auto TS = getSizeOfUnderlyingType(*dm);
+    auto TS = isContainer(*dm) ? 0 : getSizeOfUnderlyingType(*dm);
     char* pointerto = ((char*)to) + dm->GetOffset() + index * TS + globaloffset;
     char* pointerfrom = ((char*)from) + dm->GetOffset() + index * TS + globaloffset;
 
@@ -404,6 +449,15 @@ void _ParamHelper::assignmentImpl(std::string const& mainkey, TClass* cl, void* 
 
     // TODO: this could dispatch to the same method used in ConfigurableParam::setValue
     // but will be slower
+
+    if (isContainer(*dm)) {
+      const auto typeName = getContainerTypeName(*dm);
+      if (!ConfigurableParam::areRegisteredContainersEqual(typeName, pointerto, pointerfrom)) {
+        updateProv();
+        ConfigurableParam::assignRegisteredContainer(typeName, pointerto, pointerfrom);
+      }
+      return;
+    }
 
     // test if a complicated case
     if (isString(*dm)) {
@@ -433,8 +487,7 @@ void _ParamHelper::syncCCDBandRegistry(const std::string& mainkey, TClass* cl, v
 {
   auto sync = [to, from, &mainkey, provmap, globaloffset](const TDataMember* dm, int index, int size) {
     const auto name = getName(dm, index, size);
-    auto dt = dm->GetDataType();
-    auto TS = getSizeOfUnderlyingType(*dm);
+    auto TS = isContainer(*dm) ? 0 : getSizeOfUnderlyingType(*dm);
     char* pointerto = ((char*)to) + dm->GetOffset() + index * TS + globaloffset;
     char* pointerfrom = ((char*)from) + dm->GetOffset() + index * TS + globaloffset;
 
@@ -449,6 +502,12 @@ void _ParamHelper::syncCCDBandRegistry(const std::string& mainkey, TClass* cl, v
     auto updateProv = [&proviter]() {
       proviter->second = ConfigurableParam::EParamProvenance::kCCDB;
     };
+
+    if (isContainer(*dm)) {
+      updateProv();
+      ConfigurableParam::assignRegisteredContainer(getContainerTypeName(*dm), pointerto, pointerfrom);
+      return;
+    }
 
     // test if a complicated case
     if (isString(*dm)) {

--- a/Common/Utils/test/testConfigurableParam.cxx
+++ b/Common/Utils/test/testConfigurableParam.cxx
@@ -9,6 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <boost/test/tools/old/interface.hpp>
+#include <stdexcept>
 #define BOOST_TEST_MODULE Test ConfigurableParams
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
@@ -48,7 +50,6 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_SG_Fundamental)
   ConfigurableParam::setValue("TestParam.eValue", "0");
 
   auto& param = TestParam::Instance();
-  param.printKeyValues();
   BOOST_CHECK_EQUAL(param.iValue, 100);
   BOOST_CHECK_EQUAL(param.dValue, 2.718);
   BOOST_CHECK_EQUAL(param.bValue, false);
@@ -68,6 +69,34 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_SG_CArray)
   BOOST_CHECK_EQUAL(ConfigurableParam::getValueAs<int>("TestParam.caValue[1]"), 99);
 }
 
+BOOST_AUTO_TEST_CASE(ConfigurableParam_SG_STD)
+{
+  // tests setting and getting for a std type
+  ConfigurableParam::setValue("TestParam.vec", "[10,20,30,40]");
+  auto& param = TestParam::Instance();
+  BOOST_CHECK_EQUAL(param.vec.size(), 4);
+  BOOST_CHECK_EQUAL(param.vec[0], 10);
+  BOOST_CHECK_EQUAL(param.vec[1], 20);
+  BOOST_CHECK_EQUAL(param.vec[2], 30);
+  BOOST_CHECK_EQUAL(param.vec[3], 40);
+  BOOST_CHECK_EQUAL(ConfigurableParam::getValueAs<std::string>("TestParam.vec"), "[10,20,30,40]");
+
+  ConfigurableParam::setValue("TestParam.u8vec", "[1,2,255]");
+  BOOST_CHECK_EQUAL(param.u8vec.size(), 3);
+  BOOST_CHECK_EQUAL(static_cast<unsigned int>(param.u8vec[0]), 1);
+  BOOST_CHECK_EQUAL(static_cast<unsigned int>(param.u8vec[1]), 2);
+  BOOST_CHECK_EQUAL(static_cast<unsigned int>(param.u8vec[2]), 255);
+  BOOST_CHECK_EQUAL(ConfigurableParam::getValueAs<std::string>("TestParam.u8vec"), "[1,2,255]");
+
+  ConfigurableParam::setValues({{"TestParam.map", "{0:1,10:42}"}});
+  BOOST_CHECK_EQUAL(param.map.size(), 2);
+  BOOST_CHECK(param.map.contains(0));
+  BOOST_CHECK_EQUAL(param.map.at(0), 1);
+  BOOST_CHECK(param.map.contains(10));
+  BOOST_CHECK_EQUAL(param.map.at(10), 42);
+  BOOST_CHECK_THROW(param.map.at(33), std::out_of_range);
+}
+
 BOOST_AUTO_TEST_CASE(ConfigurableParam_Provenance)
 {
   // tests correct setting of provenance
@@ -82,12 +111,16 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_FileIO_Ini)
   const std::string testFileName = "test_config.ini";
   auto iValueBefore = TestParam::Instance().iValue;
   auto sValueBefore = TestParam::Instance().sValue;
+  ConfigurableParam::setValue("TestParam.vec", "[7,8]");
+  const std::vector<int> vecBefore = TestParam::Instance().vec;
   ConfigurableParam::writeINI(testFileName);
   ConfigurableParam::setValue("TestParam.iValue", "999");
   ConfigurableParam::setValue("TestParam.sValue", testFileName);
+  ConfigurableParam::setValue("TestParam.vec", "[1]");
   ConfigurableParam::updateFromFile(testFileName);
   BOOST_CHECK_EQUAL(TestParam::Instance().iValue, iValueBefore);
   BOOST_CHECK_EQUAL(TestParam::Instance().sValue, sValueBefore);
+  BOOST_CHECK_EQUAL_COLLECTIONS(TestParam::Instance().vec.begin(), TestParam::Instance().vec.end(), vecBefore.begin(), vecBefore.end());
   std::remove(testFileName.c_str());
 }
 
@@ -97,12 +130,18 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_FileIO_Json)
   const std::string testFileName = "test_config.json";
   auto iValueBefore = TestParam::Instance().iValue;
   auto sValueBefore = TestParam::Instance().sValue;
+  ConfigurableParam::setValues({{"TestParam.map", "{3:4,5:6}"}});
+  const std::map<int, unsigned int> mapBefore = TestParam::Instance().map;
   ConfigurableParam::writeJSON(testFileName);
   ConfigurableParam::setValue("TestParam.iValue", "999");
   ConfigurableParam::setValue("TestParam.sValue", testFileName);
+  ConfigurableParam::setValues({{"TestParam.map", "{1:2}"}});
   ConfigurableParam::updateFromFile(testFileName);
   BOOST_CHECK_EQUAL(TestParam::Instance().iValue, iValueBefore);
   BOOST_CHECK_EQUAL(TestParam::Instance().sValue, sValueBefore);
+  BOOST_CHECK_EQUAL(TestParam::Instance().map.size(), mapBefore.size());
+  BOOST_CHECK_EQUAL(TestParam::Instance().map.at(3), mapBefore.at(3));
+  BOOST_CHECK_EQUAL(TestParam::Instance().map.at(5), mapBefore.at(5));
   std::remove(testFileName.c_str());
 }
 
@@ -142,4 +181,57 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_LiteralSuffix)
   // check using wrong literal suffix fails, prints error to std
   ConfigurableParam::setValue("TestParam.ullValue", "888u");
   BOOST_CHECK_NE(TestParam::Instance().ullValue, 888);
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserVector)
+{
+  auto v = ContainerParser::parse<std::vector<int>>("[1,2,3,4,5]");
+  BOOST_CHECK_EQUAL(v.size(), 5);
+  BOOST_CHECK_EQUAL(v[0], 1);
+  BOOST_CHECK_EQUAL(v[4], 5);
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserMap)
+{
+  auto m = ContainerParser::parse<std::map<std::string, double>>("{alpha:0.5,beta:0.3,gamma:0.2}");
+  BOOST_CHECK_EQUAL(m.size(), 3);
+  BOOST_CHECK_EQUAL(m["alpha"], 0.5);
+  BOOST_CHECK_EQUAL(m["beta"], 0.3);
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_Container_FileIO_ROOT)
+{
+  // test for root file serialization
+  const std::string testFileName = "test_config.root";
+  TFile* testFile = TFile::Open(testFileName.c_str(), "RECREATE");
+  ConfigurableParam::setValue("TestParam.vec", "[1,2,3]");
+  ConfigurableParam::setValue("TestParam.u8vec", "[4,5,6]");
+  ConfigurableParam::setValue("TestParam.map", "{1:16,2:9,3:23456}");
+  ConfigurableParam::setValue("TestParam.smap", "{a:16,b:9,c:23456}");
+  ConfigurableParam::setValue("TestParam.set", "[2,3,2,3,2,5]");
+  TestParam::Instance().serializeTo(testFile);
+  testFile->Close();
+  ConfigurableParam::setValue("TestParam.vec", "[9]");
+  ConfigurableParam::fromCCDB(testFileName);
+  const auto& tp = TestParam::Instance();
+  const std::vector<int> v = {1, 2, 3};
+  BOOST_CHECK_EQUAL_COLLECTIONS(tp.vec.begin(), tp.vec.end(), v.begin(), v.end());
+  const std::vector<uint8_t> v8 = {4, 5, 6};
+  BOOST_CHECK_EQUAL_COLLECTIONS(tp.u8vec.begin(), tp.u8vec.end(), v8.begin(), v8.end());
+  std::map<int, uint32_t> map{{1, 16}, {2, 9}, {3, 23456}};
+  auto testMapEqual = [](const auto& m1, const auto& m2) {
+    for (const auto& [k, v] : m1) {
+      BOOST_CHECK(m2.find(k) != m2.end());
+      BOOST_CHECK_EQUAL(v, m2.at(k));
+    }
+  };
+  testMapEqual(map, tp.map);
+  std::map<std::string, uint32_t> smap{{"a", 16}, {"b", 9}, {"c", 23456}};
+  testMapEqual(smap, tp.smap);
+  std::set<uint16_t> set{2, 3, 5};
+  BOOST_CHECK_EQUAL(set.size(), tp.set.size());
+  for (const auto& s : set) {
+    BOOST_CHECK(tp.set.contains(s));
+  }
+  // std::remove(testFileName.c_str());
 }

--- a/Common/Utils/test/testConfigurableParam.cxx
+++ b/Common/Utils/test/testConfigurableParam.cxx
@@ -18,7 +18,12 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cstdlib>
+#include <deque>
 #include <filesystem>
+#include <list>
+#include <set>
+#include <unordered_set>
+#include <vector>
 
 #include "CommonUtils/ConfigurableParamTest.h"
 
@@ -200,6 +205,40 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserMap)
   BOOST_CHECK_EQUAL(m["beta"], 0.3);
 }
 
+BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserSetAndSequenceTypes)
+{
+  // All non-map containers go through the single parseSequence path. Verify the
+  // set containers (which previously took a separate, doubly-parsing parseSet
+  // branch) still parse and de-duplicate correctly.
+  auto se = ContainerParser::parse<std::set<int>>("[2,3,2,3,2,5]");
+  BOOST_CHECK_EQUAL(se.size(), 3);
+  BOOST_CHECK(se == (std::set<int>{2, 3, 5}));
+
+  auto us = ContainerParser::parse<std::unordered_set<int>>("[1,2,3,3]");
+  BOOST_CHECK_EQUAL(us.size(), 3);
+  BOOST_CHECK(us.count(1) && us.count(2) && us.count(3));
+
+  auto li = ContainerParser::parse<std::list<int>>("[7,8]");
+  BOOST_CHECK(li == (std::list<int>{7, 8}));
+
+  auto dq = ContainerParser::parse<std::deque<int>>("[9,10]");
+  BOOST_CHECK(dq == (std::deque<int>{9, 10}));
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserRejectsEmptyToken)
+{
+  // A stray delimiter must be reported, not silently swallowed: "[1,,3]" used to
+  // parse to a 2-element vector with no error, masking malformed configuration.
+  BOOST_CHECK_THROW(ContainerParser::parse<std::vector<int>>("[1,,3]"), std::exception);
+  BOOST_CHECK_THROW(ContainerParser::parse<std::vector<int>>("[1,2,]"), std::exception);
+  // ... and on the map side, an empty value/entry is rejected too.
+  BOOST_CHECK_THROW((ContainerParser::parse<std::map<int, int>>("{1:2,,3:4}")), std::exception);
+  BOOST_CHECK_THROW((ContainerParser::parse<std::map<int, int>>("{1:}")), std::exception);
+  // Well-formed input is unaffected.
+  auto v = ContainerParser::parse<std::vector<int>>("[1,2,3]");
+  BOOST_CHECK_EQUAL(v.size(), 3);
+}
+
 BOOST_AUTO_TEST_CASE(ConfigurableParam_DamerauLevenshteinDistance)
 {
   BOOST_CHECK_EQUAL(damerauLevenshteinDistance("TestParam.iValue", "TestParam.iValue"), 0);
@@ -255,5 +294,5 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_Container_FileIO_ROOT)
   for (const auto& s : set) {
     BOOST_CHECK(tp.set.contains(s));
   }
-  // std::remove(testFileName.c_str());
+  std::remove(testFileName.c_str());
 }

--- a/Common/Utils/test/testConfigurableParam.cxx
+++ b/Common/Utils/test/testConfigurableParam.cxx
@@ -17,6 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <cstdlib>
 #include <filesystem>
 
 #include "CommonUtils/ConfigurableParamTest.h"
@@ -197,6 +198,27 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserMap)
   BOOST_CHECK_EQUAL(m.size(), 3);
   BOOST_CHECK_EQUAL(m["alpha"], 0.5);
   BOOST_CHECK_EQUAL(m["beta"], 0.3);
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_DamerauLevenshteinDistance)
+{
+  BOOST_CHECK_EQUAL(damerauLevenshteinDistance("TestParam.iValue", "TestParam.iValue"), 0);
+  BOOST_CHECK_EQUAL(damerauLevenshteinDistance("TestParam.iValu", "TestParam.iValue"), 1);
+  BOOST_CHECK_EQUAL(damerauLevenshteinDistance("TestParam.jValue", "TestParam.iValue"), 1);
+  BOOST_CHECK_EQUAL(damerauLevenshteinDistance("TestParam.iVaule", "TestParam.iValue"), 1);
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_UnknownKeySuggestionsNonFatal)
+{
+  setenv("ALICEO2_CONFIGURABLEPARAM_WRONGKEYISNONFATAL", "1", 1);
+  ConfigurableParam::setValue("TestParam.iValue", "222");
+  ConfigurableParam::setValue("TestParam.caValue[1]", "33");
+  ConfigurableParam::setValues({{"TestParam.iValu", "777"},
+                                {"TstParam.iValue", "888"},
+                                {"TestParam.caValue[", "999"}});
+  BOOST_CHECK_EQUAL(TestParam::Instance().iValue, 222);
+  BOOST_CHECK_EQUAL(TestParam::Instance().caValue[1], 33);
+  unsetenv("ALICEO2_CONFIGURABLEPARAM_WRONGKEYISNONFATAL");
 }
 
 BOOST_AUTO_TEST_CASE(ConfigurableParam_Container_FileIO_ROOT)


### PR DESCRIPTION
Add support for std container types (not nested, see ConfigurableParamTest.h) and on failure to parse offers suggestions for closest matching setting via Damerau-Levenshtein metric:
```
[FATAL] Inexistent ConfigurableParam key: ITSCATrackerParam.addTimeEror[1]. Did you mean 'ITSCATrackerParam.addTimeError[1]'?
```