### PR TITLE
GPU/TPC: Fix error that drops last digit in a TF

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChargeMapFiller.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChargeMapFiller.cxx
@@ -92,21 +92,17 @@ GPUdii() void GPUTPCCFChargeMapFiller::Thread<GPUTPCCFChargeMapFiller::findFragm
 
 GPUd() size_t GPUTPCCFChargeMapFiller::findTransition(int32_t time, const tpc::Digit* digits, size_t nDigits, size_t lower)
 {
-  if (!nDigits) {
-    return 0;
-  }
-  size_t upper = nDigits - 1;
+  size_t upper = nDigits;
 
   while (lower < upper) {
-    size_t middle = (lower + upper) / 2;
+    const size_t middle = (lower + upper) / 2;
 
     if (digits[middle].getTimeStamp() < time) {
       lower = middle + 1;
-    } else if (middle == lower || digits[middle - 1].getTimeStamp() < time) {
-      return middle;
     } else {
-      upper = middle - 1;
+      upper = middle;
     }
   }
+
   return lower;
 }


### PR DESCRIPTION
Fixes an off-by-one error in Digit and MC label handling that would silently drop the last digit in a TF. 

Fixes an issue made visible by #15528 where some clusters would not have any MC labels.