### PR TITLE
DPL: adapt to FairMQ new API

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -167,7 +167,7 @@ void retryMetricCallback(uv_async_t* async)
     return;
   }
   fair::mq::MessagePtr payload(device->NewMessage());
-  payload->Rebuild(&oldestPossingTimeslice, sizeof(int64_t), nullptr, nullptr);
+  payload->Rebuild(&oldestPossingTimeslice, sizeof(int64_t), [](void*, void*) -> void {}, nullptr);
   auto consumed = oldestPossingTimeslice;
 
   size_t start = uv_hrtime();


### PR DESCRIPTION
Rebuild() of a message will call free() on the supplied buffer after copying it, if a custom free function was not given as an argument. Since `oldestPossingTimeslice` is not a heap object, calling free() on it is not allowed, which seems to be enforced by some compilers. 

@ktf 