### PR TITLE
GPU/TPC: Increase assumed cacheline size to 128 byte in cluster finder

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/CfArray2D.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfArray2D.h
@@ -86,10 +86,13 @@ class LinearLayout
 template <tpccf::SizeT S>
 struct GridSize;
 
+// GridSize for 1 byte and 2 byte elements are adjusted for 128 byte cachelines,
+// as these are prevelant on modern GPUs.
+
 template <>
 struct GridSize<1> {
   enum {
-    Width = 8,
+    Width = 16,
     Height = 8,
   };
 };
@@ -98,9 +101,12 @@ template <>
 struct GridSize<2> {
   enum {
     Width = 8,
-    Height = 4,
+    Height = 8,
   };
 };
+
+// GridSize for 4 bytes is only used for MC indexing on CPU.
+// So assume 64 byte cachelines here instead.
 
 template <>
 struct GridSize<4> {

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFCheckPadBaseline.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFCheckPadBaseline.h
@@ -53,7 +53,6 @@ class GPUTPCCFCheckPadBaseline : public GPUKernelTemplate
     TimebinsPerCacheline = TPCMapMemoryLayout<uint16_t>::Height,
     EntriesPerCacheline = PadsPerCacheline * TimebinsPerCacheline,
     NumOfCachedPads = GPUCA_WARP_SIZE / TimebinsPerCacheline,
-    NumCLsPerWarp = GPUCA_WARP_SIZE / EntriesPerCacheline,
     NumOfCachedTBs = TimebinsPerCacheline * 8,
     // Threads index shared memory as [iThread / MaxNPadsPerRow][iThread % MaxNPadsPerRow].
     // Rounding up to a multiple of PadsPerCacheline ensures iThread / MaxNPadsPerRow < NumOfCachedTBs


### PR DESCRIPTION
Adjust memory layout in TPC cluster finder for 128 byte cachelines found in modern GPU architectures.

On RTX 5080 this increases the throughput of the noisy pad filter from 221 GB/s to 379 GB/s.

On Radeon VII throughput increases from 58 GB/s to 81 GB/s.

Other kernels of the cluster finder either slightly increase in performance or stay the same.

In my test this makes the full cluster finder slightly slower on CPU (869ms -> 891ms), but I don't think this is large enough to justify adding a separate path for 64 byte cachelines.