### PR TITLE
DPL Analysis: fail with an error if ASoA.h is being included in a ROOT dictionary

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -12,6 +12,10 @@
 #ifndef O2_FRAMEWORK_ASOA_H_
 #define O2_FRAMEWORK_ASOA_H_
 
+#if defined(__CLING__)
+#error "Please do no include this file in ROOT dictionary generation"
+#endif
+
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/Pack.h"                   // IWYU pragma: export
 #include "Framework/FunctionalHelpers.h"      // IWYU pragma: export

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -13,7 +13,7 @@
 #define O2_FRAMEWORK_ASOA_H_
 
 #if defined(__CLING__)
-#error "Please do no include this file in ROOT dictionary generation"
+#error "Please do not include this file in ROOT dictionary generation"
 #endif
 
 #include "Framework/ConcreteDataMatcher.h"


### PR DESCRIPTION
Occasionally, ASoA.h will silently get included in ROOT dictionaries in O2Physics, which explodes compilation time and memory usage, and will often mean that we will need to fix this on the side of O2Physics before integrating some changes in Analysis Framework. With this change, the compilation will explicitly fail with an error if ASoA.h is seen by cling. 