### PR TITLE
Mergers: actually collect only mergeable objects belonging to TCanvas

### DIFF
--- a/Utilities/Mergers/src/MergerAlgorithm.cxx
+++ b/Utilities/Mergers/src/MergerAlgorithm.cxx
@@ -18,6 +18,7 @@
 
 #include "Mergers/MergeInterface.h"
 #include "Mergers/ObjectStore.h"
+#include "Mergers/Mergeable.h"
 #include "Framework/Logger.h"
 
 #include <TEfficiency.h>
@@ -63,7 +64,7 @@ auto collectUnderlyingObjects(TCanvas* canvas) -> std::vector<TObject*>
       auto* primitive = primitives->At(i);
       if (auto* primitivePad = dynamic_cast<TPad*>(primitive)) {
         collectFromTPad(primitivePad, objects, collectFromTPad);
-      } else {
+      } else if (isMergeable(primitive)) {
         objects.push_back(primitive);
       }
     }

--- a/Utilities/Mergers/test/test_Algorithm.cxx
+++ b/Utilities/Mergers/test/test_Algorithm.cxx
@@ -26,6 +26,7 @@
 #include "Mergers/MergerAlgorithm.h"
 #include "Mergers/CustomMergeableTObject.h"
 #include "Mergers/CustomMergeableObject.h"
+#include "Mergers/Mergeable.h"
 #include "Mergers/ObjectStore.h"
 
 #include <TObjArray.h>
@@ -40,6 +41,7 @@
 #include <TGraph.h>
 #include <TProfile.h>
 #include <TCanvas.h>
+#include <TPaveText.h>
 
 // using namespace o2::framework;
 using namespace o2::mergers;
@@ -329,6 +331,12 @@ TCanvas* createCanvas(std::string name, std::string title, std::vector<std::shar
   for (size_t i = 1; const auto& hist : histograms) {
     canvas->cd(i);
     hist->Draw();
+
+    // non-mergeable TPaveText
+    TPaveText* pt = new TPaveText(.05, .1, .95, .8);
+    pt->AddText("test");
+    pt->Draw();
+
     ++i;
   }
   return canvas;
@@ -345,7 +353,7 @@ auto collectUnderlyingObjects(TCanvas* canvas) -> std::vector<TObject*>
       auto* primitive = primitives->At(i);
       if (auto* primitivePad = dynamic_cast<TPad*>(primitive)) {
         collectFromTPad(primitivePad, objects, collectFromTPad);
-      } else {
+      } else if (isMergeable(primitive)) {
         objects.push_back(primitive);
       }
     }


### PR DESCRIPTION
We were seeing warnings like below when merging certain TCanvases:
```
W	11	Object 'title' with type 'TPaveText' is not one of the mergeable types, skipping
W	11	Object 'TPave' with type 'TLegend' is not one of the mergeable types, skipping
W	11	Object 'TFrame' with type 'TFrame' is not one of the mergeable types, skipping
```
It is perfectly OK to have some TPaveText in a canvas and expect to have just the histogram merged, but the text should remain as it was, so there is no reason to produce warnings.

The change ensures that collectUnderlyingObject actually collects just the mergeable objects from TCanvas, as promised in the documentation.

Fixes QC-1344.