### PR TITLE
DPL Analysis: prevent HistogramRegistry from including ASoA.h

### DIFF
--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -13,15 +13,11 @@
 #define FRAMEWORK_HISTOGRAMREGISTRY_H_
 
 #include "Framework/HistogramSpec.h"
-#include "Framework/ASoA.h"
-#include "Framework/FunctionalHelpers.h"
-#include "Framework/Logger.h"
 #include "Framework/OutputRef.h"
 #include "Framework/OutputObjHeader.h"
 #include "Framework/OutputSpec.h"
-#include "Framework/SerializationMethods.h"
-#include "Framework/TableBuilder.h"
 #include "Framework/RuntimeError.h"
+#include "Framework/Expressions.h"
 #include "StepTHn.h"
 
 #include <TDataMember.h>
@@ -293,23 +289,6 @@ void HistFiller::fillHistAny(std::shared_ptr<T> hist, Ts... positionAndWeight)
   HistFiller::badHistogramFill(hist->GetName());
 }
 
-template <typename... Cs, typename R, typename T>
-void HistFiller::fillHistAny(std::shared_ptr<R> hist, const T& table, const o2::framework::expressions::Filter& filter)
-  requires(!ValidComplexFillStep<R, sizeof...(Cs)>) && requires(T t) { t.asArrowTable(); }
-{
-  auto s = o2::framework::expressions::createSelection(table.asArrowTable(), filter);
-  auto filtered = o2::soa::Filtered<T>{{table.asArrowTable()}, s};
-  for (auto& t : filtered) {
-    fillHistAny(hist, (*(static_cast<Cs>(t).getIterator()))...);
-  }
-}
-
-template <typename... Cs, typename R, typename T>
-void HistFiller::fillHistAny(std::shared_ptr<R> hist, const T& table, const o2::framework::expressions::Filter& filter)
-{
-  HistFiller::badHistogramFill(hist->GetName());
-}
-
 template <typename T>
 double HistFiller::getSize(std::shared_ptr<T> hist, double fillFraction)
 {
@@ -479,12 +458,5 @@ extern template std::shared_ptr<THnSparse> HistogramRegistry::add<THnSparse>(cha
 extern template std::shared_ptr<THnSparse> HistogramRegistry::add<THnSparse>(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2);
 extern template std::shared_ptr<StepTHn> HistogramRegistry::add<StepTHn>(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2);
 extern template std::shared_ptr<StepTHn> HistogramRegistry::add<StepTHn>(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2);
-
-template <typename... Cs, typename T>
-void HistogramRegistry::fill(const HistName& histName, const T& table, const o2::framework::expressions::Filter& filter)
-{
-  std::visit([&table, &filter](auto&& hist) { HistFiller::fillHistAny<Cs...>(hist, table, filter); }, mRegistryValue[getHistIndex(histName)]);
-}
-
 } // namespace o2::framework
 #endif // FRAMEWORK_HISTOGRAMREGISTRY_H_

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -289,6 +289,17 @@ void HistFiller::fillHistAny(std::shared_ptr<T> hist, Ts... positionAndWeight)
   HistFiller::badHistogramFill(hist->GetName());
 }
 
+template <typename... Cs, typename R, typename T>
+void HistFiller::fillHistAny(std::shared_ptr<R>, const T&, const o2::framework::expressions::Filter&)
+  requires(!ValidComplexFillStep<R, sizeof...(Cs)>) && requires(T t) { t.asArrowTable(); }
+{
+}
+
+template <typename... Cs, typename R, typename T>
+void HistFiller::fillHistAny(std::shared_ptr<R>, const T&, const o2::framework::expressions::Filter&)
+{
+}
+
 template <typename T>
 double HistFiller::getSize(std::shared_ptr<T> hist, double fillFraction)
 {
@@ -458,5 +469,11 @@ extern template std::shared_ptr<THnSparse> HistogramRegistry::add<THnSparse>(cha
 extern template std::shared_ptr<THnSparse> HistogramRegistry::add<THnSparse>(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2);
 extern template std::shared_ptr<StepTHn> HistogramRegistry::add<StepTHn>(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2);
 extern template std::shared_ptr<StepTHn> HistogramRegistry::add<StepTHn>(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2);
+
+template <typename... Cs, typename T>
+void HistogramRegistry::fill(const HistName& histName, const T& table, const o2::framework::expressions::Filter& filter)
+{
+  std::visit([&table, &filter](auto&& hist) { HistFiller::fillHistAny<Cs...>(hist, table, filter); }, mRegistryValue[getHistIndex(histName)]);
+}
 } // namespace o2::framework
 #endif // FRAMEWORK_HISTOGRAMREGISTRY_H_

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/HistogramRegistry.h"
+#include "Framework/ASoA.h"
 #include <regex>
 #include <TList.h>
 #include <TClass.h>

--- a/Framework/Core/test/benchmark_HistogramRegistry.cxx
+++ b/Framework/Core/test/benchmark_HistogramRegistry.cxx
@@ -10,7 +10,6 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/HistogramRegistry.h"
-#include "Framework/Logger.h"
 
 #include "TList.h"
 
@@ -19,7 +18,6 @@
 
 using namespace o2::framework;
 using namespace arrow;
-using namespace o2::soa;
 
 /// Number of lookups to perform
 const int nLookups = 100000;

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -10,6 +10,8 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/HistogramRegistry.h"
+#include "Framework/ASoA.h"
+#include "Framework/TableBuilder.h"
 #include <catch_amalgamated.hpp>
 
 using namespace o2;
@@ -70,40 +72,41 @@ TEST_CASE("HistogramRegistryLookup")
   */
 }
 
-TEST_CASE("HistogramRegistryExpressionFill")
-{
-  TableBuilder builderA;
-  auto rowWriterA = builderA.persist<float, float>({"x", "y"});
-  rowWriterA(0, 0.0f, -2.0f);
-  rowWriterA(0, 1.0f, -4.0f);
-  rowWriterA(0, 2.0f, -1.0f);
-  rowWriterA(0, 3.0f, -5.0f);
-  rowWriterA(0, 4.0f, 0.0f);
-  rowWriterA(0, 5.0f, -9.0f);
-  rowWriterA(0, 6.0f, -7.0f);
-  rowWriterA(0, 7.0f, -4.0f);
-  auto tableA = builderA.finalize();
-  REQUIRE(tableA->num_rows() == 8);
-  using TestA = o2::soa::InPlaceTable<"A/1"_h, o2::soa::Index<>, test::X, test::Y>;
-  TestA tests{tableA};
-  REQUIRE(8 == tests.size());
+// FIXME: feature not used in its current state, requires rework
+// TEST_CASE("HistogramRegistryExpressionFill")
+// {
+//   TableBuilder builderA;
+//   auto rowWriterA = builderA.persist<float, float>({"x", "y"});
+//   rowWriterA(0, 0.0f, -2.0f);
+//   rowWriterA(0, 1.0f, -4.0f);
+//   rowWriterA(0, 2.0f, -1.0f);
+//   rowWriterA(0, 3.0f, -5.0f);
+//   rowWriterA(0, 4.0f, 0.0f);
+//   rowWriterA(0, 5.0f, -9.0f);
+//   rowWriterA(0, 6.0f, -7.0f);
+//   rowWriterA(0, 7.0f, -4.0f);
+//   auto tableA = builderA.finalize();
+//   REQUIRE(tableA->num_rows() == 8);
+//   using TestA = o2::soa::InPlaceTable<"A/1"_h, o2::soa::Index<>, test::X, test::Y>;
+//   TestA tests{tableA};
+//   REQUIRE(8 == tests.size());
 
-  /// Construct a registry object with direct declaration
-  HistogramRegistry registry{
-    "registry", {
-                  {"x", "test x", {HistType::kTH1F, {{100, 0.0f, 10.0f}}}},                            //
-                  {"xy", "test xy", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}} //
-                }                                                                                      //
-  };
+//   /// Construct a registry object with direct declaration
+//   HistogramRegistry registry{
+//     "registry", {
+//                   {"x", "test x", {HistType::kTH1F, {{100, 0.0f, 10.0f}}}},                            //
+//                   {"xy", "test xy", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}} //
+//                 }                                                                                      //
+//   };
 
-  /// Fill histogram with expression and table
-  registry.fill<test::X>(HIST("x"), tests, test::x > 3.0f);
-  REQUIRE(registry.get<TH1>(HIST("x"))->GetEntries() == 4);
+//   /// Fill histogram with expression and table
+//   registry.fill<test::X>(HIST("x"), tests, test::x > 3.0f);
+//   REQUIRE(registry.get<TH1>(HIST("x"))->GetEntries() == 4);
 
-  /// Fill histogram with expression and table
-  registry.fill<test::X, test::Y>(HIST("xy"), tests, test::x > 3.0f && test::y > -5.0f);
-  REQUIRE(registry.get<TH2>(HIST("xy"))->GetEntries() == 2);
-}
+//   /// Fill histogram with expression and table
+//   registry.fill<test::X, test::Y>(HIST("xy"), tests, test::x > 3.0f && test::y > -5.0f);
+//   REQUIRE(registry.get<TH2>(HIST("xy"))->GetEntries() == 2);
+// }
 
 TEST_CASE("HistogramRegistryStepTHn")
 {


### PR DESCRIPTION
* Remove ASoA.h and TableBuilder.h includes from HistogramRegistry.h as it is used in various inclusion chains in PWG code
* Temporarily deprecate "fill with filter" feature, as it not used in O2Physics and requires rework to be efficient