### PR TITLE
DPL: avoid one allocation per match

### DIFF
--- a/Framework/Core/src/DataDescriptorMatcher.cxx
+++ b/Framework/Core/src/DataDescriptorMatcher.cxx
@@ -17,7 +17,9 @@
 #include "Framework/RuntimeError.h"
 #include "Headers/DataHeader.h"
 #include "Headers/Stack.h"
+#include <array>
 #include <iostream>
+#include <memory_resource>
 
 namespace o2::framework::data_matcher
 {
@@ -202,9 +204,10 @@ bool DataDescriptorMatcher::match(ConcreteDataMatcher const& matcher, VariableCo
   dh.dataOrigin = matcher.origin;
   dh.dataDescription = matcher.description;
   dh.subSpecification = matcher.subSpec;
-  DataProcessingHeader dph;
-  dph.startTime = 0;
-  header::Stack s{dh, dph};
+  DataProcessingHeader dph{0, 0, 0};
+  alignas(std::max_align_t) std::array<std::byte, sizeof(header::DataHeader) + sizeof(DataProcessingHeader) + alignof(std::max_align_t)> buffer;
+  std::pmr::monotonic_buffer_resource resource{buffer.data(), buffer.size(), std::pmr::null_memory_resource()};
+  header::Stack s{header::Stack::allocator_type{&resource}, dh, dph};
 
   return this->match(reinterpret_cast<char const*>(s.data()), context);
 }
@@ -217,9 +220,10 @@ bool DataDescriptorMatcher::match(ConcreteDataTypeMatcher const& matcher, Variab
   dh.dataOrigin = matcher.origin;
   dh.dataDescription = matcher.description;
   dh.subSpecification = 0;
-  DataProcessingHeader dph;
-  dph.startTime = 0;
-  header::Stack s{dh, dph};
+  DataProcessingHeader dph{0, 0, 0};
+  alignas(std::max_align_t) std::array<std::byte, sizeof(header::DataHeader) + sizeof(DataProcessingHeader) + alignof(std::max_align_t)> buffer;
+  std::pmr::monotonic_buffer_resource resource{buffer.data(), buffer.size(), std::pmr::null_memory_resource()};
+  header::Stack s{header::Stack::allocator_type{&resource}, dh, dph};
 
   return this->match(reinterpret_cast<char const*>(s.data()), context);
 }


### PR DESCRIPTION

The constructed Stack object is thrown away immediately after
the matching, introducing unneeded memory churn.
