### PR TITLE
DPL: take ownership of a string to prevent a crash on exit

### DIFF
--- a/Framework/Core/src/ResourcePolicyHelpers.cxx
+++ b/Framework/Core/src/ResourcePolicyHelpers.cxx
@@ -44,7 +44,7 @@ ResourcePolicy ResourcePolicyHelpers::rateLimitedSharedMemoryBoundTask(char cons
 {
   return ResourcePolicy{
     "ratelimited-shm-bound",
-    [matcher = std::regex(s)](DeviceSpec const& spec) -> bool {
+    [matcher = std::regex(std::string{s})](DeviceSpec const& spec) -> bool {
       return std::regex_match(spec.name, matcher);
     },
     [requestedSharedMemory, requestedTimeslices](ComputingQuotaOffer const& offer, ComputingQuotaOffer const& accumulated) -> OfferScore {


### PR DESCRIPTION
`std::regex` does not copy the provided null-terminated string, resulting in an occasional crash on workflow exit like this:
```
[83736:eventselection-run3]:     10  libO2Framework.dylib                0x0000000108ec9c84: std::__1::shared_ptr<std::__1::__empty_state<char>>::~shared_ptr[abi:nqe210106]()
[83736:eventselection-run3]:     11  libO2Framework.dylib                0x0000000108ec9c10: std::__1::shared_ptr<std::__1::__empty_state<char>>::~shared_ptr[abi:nqe210106]()
[83736:eventselection-run3]:     12  libO2Framework.dylib                0x0000000108ec9bdc: std::__1::basic_regex<char, std::__1::regex_traits<char>>::~basic_regex()
[83736:eventselection-run3]:     13  libO2Framework.dylib                0x0000000108ebf3fc: std::__1::basic_regex<char, std::__1::regex_traits<char>>::~basic_regex()
[83736:eventselection-run3]:     14  libO2Framework.dylib                0x000000010932ff6c: o2::framework::ResourcePolicyHelpers::rateLimitedSharedMemoryBoundTask(char const*, int, int)::$_0::~$_0()
[83736:eventselection-run3]:     15  libO2Framework.dylib                0x000000010932fd00: o2::framework::ResourcePolicyHelpers::rateLimitedSharedMemoryBoundTask(char const*, int, int)::$_0::~$_0()
```
Temporary `std::string` does the copy and prevents the crash.