### PR TITLE
DPL Analysis: extract concepts definitions from headers

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -15,7 +15,7 @@
 #if defined(__CLING__)
 #error "Please do not include this file in ROOT dictionary generation"
 #endif
-
+#include "Framework/Concepts.h"
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/Pack.h"                   // IWYU pragma: export
 #include "Framework/FunctionalHelpers.h"      // IWYU pragma: export
@@ -189,29 +189,12 @@ consteval auto intersectOriginals()
 
 namespace o2::soa
 {
-struct Binding;
-
-template <typename T>
-concept not_void = requires { !std::same_as<T, void>; };
-
-/// column identification concepts
-template <typename C>
-concept is_persistent_column = requires(C c) { c.mColumnIterator; };
-
+/// column identification
 template <typename C>
 constexpr bool is_persistent_v = is_persistent_column<C>;
 
 template <typename C>
 using is_persistent_column_t = std::conditional_t<is_persistent_column<C>, std::true_type, std::false_type>;
-
-template <typename C>
-concept is_self_index_column = not_void<typename C::self_index_t> && std::same_as<typename C::self_index_t, std::true_type>;
-
-template <typename C>
-concept is_index_column = !is_self_index_column<C> && requires(C c, o2::soa::Binding b) {
-  { c.setCurrentRaw(b) } -> std::same_as<bool>;
-  requires std::same_as<decltype(c.mBinding), o2::soa::Binding>;
-};
 
 template <typename C>
 using is_external_index_t = typename std::conditional_t<is_index_column<C>, std::true_type, std::false_type>;
@@ -239,6 +222,8 @@ static consteval int getIndexPosToKey_impl()
 /// Base type for table metadata
 template <typename D, typename... Cs>
 struct TableMetadata {
+  static constexpr void isTableMetadata()
+  {};
   using columns = framework::pack<Cs...>;
   using persistent_columns_t = framework::selected_pack<soa::is_persistent_column_t, Cs...>;
   using external_index_columns_t = framework::selected_pack<soa::is_external_index_t, Cs...>;
@@ -270,6 +255,8 @@ struct TableMetadata {
 
 template <typename D>
 struct MetadataTrait {
+  static constexpr void isMetadataTrait()
+  {};
   using metadata = void;
 };
 
@@ -277,6 +264,8 @@ struct MetadataTrait {
 /// type signature
 template <uint32_t H>
 struct Hash {
+  static constexpr void isHash()
+  {};
   static constexpr uint32_t hash = H;
   static constexpr char const* const str{""};
 };
@@ -298,6 +287,8 @@ consteval auto filterForKey()
 #define O2HASH(_Str_)                              \
   template <>                                      \
   struct Hash<_Str_ ""_h> {                        \
+    static constexpr void isHash()                 \
+    {};                                            \
     static constexpr uint32_t hash = _Str_ ""_h;   \
     static constexpr char const* const str{_Str_}; \
   };
@@ -306,6 +297,10 @@ consteval auto filterForKey()
 #define O2ORIGIN(_Str_)                                \
   template <>                                          \
   struct Hash<_Str_ ""_h> {                            \
+    static constexpr void isHash()                     \
+    {};                                                \
+    static constexpr void isOriginHash()               \
+    {};                                                \
     static constexpr header::DataOrigin origin{_Str_}; \
     static constexpr uint32_t hash = _Str_ ""_h;       \
     static constexpr char const* const str{_Str_};     \
@@ -386,13 +381,6 @@ constexpr framework::ConcreteDataMatcher matcher()
   return {origin<R>(), description(signature<R>()), R.version};
 }
 
-/// hash identification concepts
-template <typename T>
-concept is_aod_hash = requires(T t) { t.hash; t.str; };
-
-template <typename T>
-concept is_origin_hash = is_aod_hash<T> && requires(T t) { t.origin; };
-
 /// convert TableRef to a DPL source specification
 template <soa::TableRef R>
 static constexpr auto sourceSpec()
@@ -445,27 +433,6 @@ struct Binding {
 };
 
 using SelectionVector = std::vector<int64_t>;
-
-template <typename T>
-concept has_parent_t = not_void<typename T::parent_t>;
-
-template <typename T>
-concept is_metadata = framework::base_of_template<aod::TableMetadata, T>;
-
-template <typename T>
-concept is_metadata_trait = framework::specialization_of_template<aod::MetadataTrait, T>;
-
-template <typename T>
-concept has_metadata = is_metadata_trait<T> && not_void<typename T::metadata>;
-
-template <typename T>
-concept has_extension = is_metadata<T> && not_void<typename T::extension_table_t>;
-
-template <typename T>
-concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; requires std::same_as<std::true_type, typename T::configurable_t>; };
-
-template <typename T>
-concept is_spawnable_column = std::same_as<typename T::spawnable_t, std::true_type>;
 
 template <typename B, typename E>
 struct EquivalentIndex {
@@ -696,6 +663,9 @@ class ColumnIterator : ChunkingPolicy
 
 template <typename T, typename INHERIT>
 struct Column {
+  static constexpr void isIteratableColumn()
+  {};
+
   using inherited_t = INHERIT;
   Column(ColumnIterator<T> const& it)
     : mColumnIterator{it}
@@ -730,6 +700,8 @@ struct Column {
 /// method call.
 template <typename F, typename INHERIT>
 struct DynamicColumn {
+  static constexpr void isDynamicColumn()
+  {};
   using inherited_t = INHERIT;
 
   static constexpr const char* const& columnLabel() { return INHERIT::mLabel; }
@@ -737,6 +709,8 @@ struct DynamicColumn {
 
 template <typename INHERIT>
 struct IndexColumn {
+  static constexpr void isEnumeratingColumn()
+  {};
   using inherited_t = INHERIT;
   static constexpr const uint32_t hash = 0;
 
@@ -745,6 +719,8 @@ struct IndexColumn {
 
 template <typename INHERIT>
 struct MarkerColumn {
+  static constexpr void isMarkingColumn()
+  {};
   using inherited_t = INHERIT;
   static constexpr const uint32_t hash = 0;
 
@@ -846,29 +822,6 @@ struct Index : o2::soa::IndexColumn<Index<START, END>> {
   std::tuple<uint64_t const*> rowOffsets;
 };
 
-template <typename C>
-concept is_indexing_column = requires(C& c) {
-  c.rowIndices;
-  c.rowOffsets;
-};
-
-template <typename C>
-concept is_dynamic_column = requires(C& c) {
-  c.boundIterators;
-};
-
-template <typename C>
-concept is_marker_column = requires { &C::mark; };
-
-template <typename T>
-using is_dynamic_t = std::conditional_t<is_dynamic_column<T>, std::true_type, std::false_type>;
-
-template <typename T>
-concept is_column = is_persistent_column<T> || is_dynamic_column<T> || is_indexing_column<T> || is_marker_column<T>;
-
-template <typename T>
-using is_indexing_t = std::conditional_t<is_indexing_column<T>, std::true_type, std::false_type>;
-
 struct IndexPolicyBase {
   /// Position inside the current table
   int64_t mRowIndex = 0;
@@ -877,10 +830,13 @@ struct IndexPolicyBase {
 };
 
 struct RowViewSentinel {
+  static constexpr void isRowViewSentinel()
+  {};
   int64_t const index;
 };
 
 struct FilteredIndexPolicy : IndexPolicyBase {
+  static constexpr void isFilteredIndexPolicy();
   // We use -1 in the IndexPolicyBase to indicate that the index is
   // invalid. What will validate the index is the this->setCursor()
   // which happens below which will properly setup the first index
@@ -986,6 +942,8 @@ struct FilteredIndexPolicy : IndexPolicyBase {
 };
 
 struct DefaultIndexPolicy : IndexPolicyBase {
+  static constexpr void isDefaultIndexPolicy()
+  {};
   /// Needed to be able to copy the policy
   DefaultIndexPolicy() = default;
   DefaultIndexPolicy(DefaultIndexPolicy&&) = default;
@@ -1088,6 +1046,8 @@ concept has_index = (is_indexing_column<C> || ...);
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
  public:
+  static constexpr void isTableIterator()
+  {};
   using self_t = TableIterator<D, O, IP, C...>;
   using policy_t = IP;
   using all_columns = framework::pack<C...>;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -3115,6 +3115,7 @@ consteval auto getIndexTargets()
 #define DECLARE_SOA_TABLE_METADATA_TRAIT(_Name_, _Desc_, _Version_) \
   template <>                                                       \
   struct MetadataTrait<Hash<_Desc_ "/" #_Version_ ""_h>> {          \
+    static constexpr void isMetadataTrait() {};                     \
     using metadata = _Name_##Metadata;                              \
   };
 
@@ -3125,6 +3126,7 @@ consteval auto getIndexTargets()
   using _Name_ = _Name_##From<Hash<_Origin_ ""_h>>;                                             \
   template <>                                                                                   \
   struct MetadataTrait<Hash<_Desc_ "/" #_Version_ ""_h>> {                                      \
+    static constexpr void isMetadataTrait() {};                                                 \
     using metadata = _Name_##Metadata;                                                          \
   };
 
@@ -3184,6 +3186,7 @@ consteval auto getIndexTargets()
   };                                                                                                                            \
   template <>                                                                                                                   \
   struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                             \
+    static constexpr void isMetadataTrait() {};                                                                                 \
     using metadata = _Name_##ExtensionMetadata;                                                                                 \
   };                                                                                                                            \
   template <typename O>                                                                                                         \
@@ -3218,6 +3221,7 @@ consteval auto getIndexTargets()
   };                                                                                                                                  \
   template <>                                                                                                                         \
   struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                   \
+    static constexpr void isMetadataTrait() {};                                                                                       \
     using metadata = _Name_##CfgExtensionMetadata;                                                                                    \
   };                                                                                                                                  \
   template <typename O>                                                                                                               \
@@ -3253,6 +3257,7 @@ consteval auto getIndexTargets()
   };                                                                                                                                                \
   template <>                                                                                                                                       \
   struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                                                 \
+    static constexpr void isMetadataTrait() {};                                                                                                     \
     using metadata = _Name_##Metadata;                                                                                                              \
   };                                                                                                                                                \
   template <o2::aod::is_origin_hash O>                                                                                                              \
@@ -3307,6 +3312,7 @@ consteval auto getIndexTargets()
   };                                                                                                                      \
   template <>                                                                                                             \
   struct MetadataTrait<o2::aod::Hash<_Desc_ "/" #_Version_ ""_h>> {                                                       \
+    static constexpr void isMetadataTrait() {};                                                                           \
     using metadata = _Name_##TimestampMetadata;                                                                           \
   };                                                                                                                      \
   template <typename O>                                                                                                   \

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -222,8 +222,7 @@ static consteval int getIndexPosToKey_impl()
 /// Base type for table metadata
 template <typename D, typename... Cs>
 struct TableMetadata {
-  static constexpr void isTableMetadata()
-  {};
+  static constexpr void isTableMetadata() {};
   using columns = framework::pack<Cs...>;
   using persistent_columns_t = framework::selected_pack<soa::is_persistent_column_t, Cs...>;
   using external_index_columns_t = framework::selected_pack<soa::is_external_index_t, Cs...>;
@@ -255,8 +254,7 @@ struct TableMetadata {
 
 template <typename D>
 struct MetadataTrait {
-  static constexpr void isMetadataTrait()
-  {};
+  static constexpr void isMetadataTrait() {};
   using metadata = void;
 };
 
@@ -264,8 +262,7 @@ struct MetadataTrait {
 /// type signature
 template <uint32_t H>
 struct Hash {
-  static constexpr void isHash()
-  {};
+  static constexpr void isHash() {};
   static constexpr uint32_t hash = H;
   static constexpr char const* const str{""};
 };
@@ -287,8 +284,7 @@ consteval auto filterForKey()
 #define O2HASH(_Str_)                              \
   template <>                                      \
   struct Hash<_Str_ ""_h> {                        \
-    static constexpr void isHash()                 \
-    {};                                            \
+    static constexpr void isHash() {};             \
     static constexpr uint32_t hash = _Str_ ""_h;   \
     static constexpr char const* const str{_Str_}; \
   };
@@ -297,10 +293,8 @@ consteval auto filterForKey()
 #define O2ORIGIN(_Str_)                                \
   template <>                                          \
   struct Hash<_Str_ ""_h> {                            \
-    static constexpr void isHash()                     \
-    {};                                                \
-    static constexpr void isOriginHash()               \
-    {};                                                \
+    static constexpr void isHash() {};                 \
+    static constexpr void isOriginHash() {};           \
     static constexpr header::DataOrigin origin{_Str_}; \
     static constexpr uint32_t hash = _Str_ ""_h;       \
     static constexpr char const* const str{_Str_};     \
@@ -663,8 +657,7 @@ class ColumnIterator : ChunkingPolicy
 
 template <typename T, typename INHERIT>
 struct Column {
-  static constexpr void isIteratableColumn()
-  {};
+  static constexpr void isIteratableColumn() {};
 
   using inherited_t = INHERIT;
   Column(ColumnIterator<T> const& it)
@@ -700,8 +693,7 @@ struct Column {
 /// method call.
 template <typename F, typename INHERIT>
 struct DynamicColumn {
-  static constexpr void isDynamicColumn()
-  {};
+  static constexpr void isDynamicColumn() {};
   using inherited_t = INHERIT;
 
   static constexpr const char* const& columnLabel() { return INHERIT::mLabel; }
@@ -709,8 +701,7 @@ struct DynamicColumn {
 
 template <typename INHERIT>
 struct IndexColumn {
-  static constexpr void isEnumeratingColumn()
-  {};
+  static constexpr void isEnumeratingColumn() {};
   using inherited_t = INHERIT;
   static constexpr const uint32_t hash = 0;
 
@@ -719,8 +710,7 @@ struct IndexColumn {
 
 template <typename INHERIT>
 struct MarkerColumn {
-  static constexpr void isMarkingColumn()
-  {};
+  static constexpr void isMarkingColumn() {};
   using inherited_t = INHERIT;
   static constexpr const uint32_t hash = 0;
 
@@ -830,8 +820,7 @@ struct IndexPolicyBase {
 };
 
 struct RowViewSentinel {
-  static constexpr void isRowViewSentinel()
-  {};
+  static constexpr void isRowViewSentinel() {};
   int64_t const index;
 };
 
@@ -942,8 +931,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
 };
 
 struct DefaultIndexPolicy : IndexPolicyBase {
-  static constexpr void isDefaultIndexPolicy()
-  {};
+  static constexpr void isDefaultIndexPolicy() {};
   /// Needed to be able to copy the policy
   DefaultIndexPolicy() = default;
   DefaultIndexPolicy(DefaultIndexPolicy&&) = default;
@@ -1029,8 +1017,7 @@ struct ColumnDataHolder {
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
  public:
-  static constexpr void isTableIterator()
-  {};
+  static constexpr void isTableIterator() {};
   using self_t = TableIterator<D, O, IP, C...>;
   using policy_t = IP;
   using all_columns = framework::pack<C...>;
@@ -1404,8 +1391,7 @@ namespace o2::framework
 {
 /// tracks origin in bindingKey matcher to handle the correct arguments
 struct PreslicePolicyBase {
-  static constexpr void isPreslicePolicy()
-  {};
+  static constexpr void isPreslicePolicy() {};
   const std::string binding;
   Entry bindingKey;
 
@@ -1434,8 +1420,7 @@ struct PreslicePolicyGeneral : public PreslicePolicyBase {
 
 template <soa::is_table T, is_preslice_policy Policy, bool OPT = false>
 struct PresliceBase : public Policy {
-  static constexpr void isPresliceContainer()
-  {};
+  static constexpr void isPresliceContainer() {};
   constexpr static bool optional = OPT;
   using target_t = T;
   using policy_t = Policy;
@@ -1489,8 +1474,7 @@ using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 ///
 /// preslices.perCol;
 struct PresliceGroup {
-  static constexpr void isPresliceGroup()
-  {};
+  static constexpr void isPresliceGroup() {};
 };
 } // namespace o2::framework
 
@@ -1716,8 +1700,7 @@ template <aod::is_aod_hash L, aod::is_aod_hash D, aod::is_origin_hash O, typenam
 class Table
 {
  public:
-  static constexpr void isSOATable()
-  {};
+  static constexpr void isSOATable() {};
   static constexpr const auto ref = TableRef{L::hash, D::hash, O::hash, o2::aod::version(D::str)};
   using self_t = Table<L, D, O, Ts...>;
   using table_t = self_t;
@@ -3329,8 +3312,7 @@ namespace o2::soa
 {
 template <typename... Ts>
 struct Join : Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Ts...> {
-  static constexpr void isJoin()
-  {};
+  static constexpr void isJoin() {};
   using base = Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Ts...>;
 
   Join(std::shared_ptr<arrow::Table>&& table, uint64_t offset = 0)
@@ -3484,8 +3466,7 @@ template <soa::is_table T>
 class FilteredBase : public T
 {
  public:
-  static constexpr void isFilteredBase()
-  {};
+  static constexpr void isFilteredBase() {};
   using self_t = FilteredBase<T>;
   using table_t = typename T::table_t;
   using T::originals;
@@ -4097,8 +4078,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
 /// First index will be used by process() as the grouping
 template <typename L, typename D, typename O, typename Key, typename H, typename... Ts>
 struct IndexTable : Table<L, D, O> {
-  static constexpr void isIndexTable()
-  {};
+  static constexpr void isIndexTable() {};
   using self_t = IndexTable<L, D, O, Key, H, Ts...>;
   using base_t = Table<L, D, O>;
   using table_t = base_t;
@@ -4144,8 +4124,7 @@ struct IndexTable : Table<L, D, O> {
 
 template <typename T, bool APPLY>
 struct SmallGroupsBase : public Filtered<T> {
-  static constexpr void isSmallGroups()
-  {};
+  static constexpr void isSmallGroups() {};
   static constexpr bool applyFilters = APPLY;
   SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), selection, offset) {}

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -4097,6 +4097,8 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
 /// First index will be used by process() as the grouping
 template <typename L, typename D, typename O, typename Key, typename H, typename... Ts>
 struct IndexTable : Table<L, D, O> {
+  static constexpr void isIndexTable()
+  {};
   using self_t = IndexTable<L, D, O, Key, H, Ts...>;
   using base_t = Table<L, D, O>;
   using table_t = base_t;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1018,15 +1018,6 @@ struct DefaultIndexPolicy : IndexPolicyBase {
   int64_t mMaxRow = 0;
 };
 
-// template <OriginEnc ORIGIN, typename... C>
-// class Table;
-
-template <aod::is_aod_hash L, aod::is_aod_hash D, aod::is_origin_hash O, typename... T>
-class Table;
-
-template <typename T>
-concept is_table = framework::specialization_of_template<soa::Table, T> || framework::base_of_template<soa::Table, T>;
-
 /// Similar to a pair but not a pair, to avoid
 /// exposing the second type everywhere.
 template <typename C>
@@ -1034,14 +1025,6 @@ struct ColumnDataHolder {
   C* first;
   arrow::ChunkedArray* second;
 };
-
-template <typename T, typename B>
-concept can_bind = requires(T&& t) {
-  { t.B::mColumnIterator };
-};
-
-template <typename... C>
-concept has_index = (is_indexing_column<C> || ...);
 
 template <typename D, typename O, typename IP, typename... C>
 struct TableIterator : IP, C... {
@@ -1272,48 +1255,6 @@ struct ArrowHelpers {
   static std::shared_ptr<arrow::Table> concatTables(std::vector<std::shared_ptr<arrow::Table>>&& tables);
 };
 
-//! Helper to check if a type T is an iterator
-template <typename T>
-concept is_iterator = framework::base_of_template<TableIterator, T> || framework::specialization_of_template<TableIterator, T>;
-
-template <typename T>
-concept is_table_or_iterator = is_table<T> || is_iterator<T>;
-
-template <typename T>
-concept with_originals = requires {
-  T::originals.size();
-};
-
-template <typename T>
-concept with_sources = requires {
-  T::sources.size();
-};
-
-template <typename T>
-concept with_sources_generator = requires(T t) {
-  t.template generateSources<o2::aod::Hash<"AOD"_h>>();
-};
-
-template <typename T>
-concept with_ccdb_urls = requires {
-  T::ccdb_urls.size();
-};
-
-template <typename T>
-concept with_base_table = requires {
-  typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata::base_table_t;
-};
-
-template <typename T>
-concept with_expression_pack = requires {
-  typename T::expression_pack_t{};
-};
-
-template <typename T>
-concept with_index_pack = requires {
-  typename T::index_pack_t{};
-};
-
 template <size_t N1, std::array<TableRef, N1> os1, size_t N2, std::array<TableRef, N2> os2>
 consteval bool is_compatible()
 {
@@ -1335,12 +1276,6 @@ consteval bool is_binding_compatible_v()
 
 template <typename T, typename B>
 using is_binding_compatible = std::conditional_t<is_binding_compatible_v<T, typename B::binding_t>(), std::true_type, std::false_type>;
-
-template <typename L, typename D, typename O, typename Key, typename H, typename... Ts>
-struct IndexTable;
-
-template <typename T>
-concept is_index_table = framework::specialization_of_template<o2::soa::IndexTable, T>;
 
 template <soa::is_table T>
 static constexpr std::string getLabelForTable()
@@ -1469,6 +1404,8 @@ namespace o2::framework
 {
 /// tracks origin in bindingKey matcher to handle the correct arguments
 struct PreslicePolicyBase {
+  static constexpr void isPreslicePolicy()
+  {};
   const std::string binding;
   Entry bindingKey;
 
@@ -1495,11 +1432,10 @@ struct PreslicePolicyGeneral : public PreslicePolicyBase {
   std::span<const int64_t> getSliceFor(int value) const;
 };
 
-template <typename T>
-concept is_preslice_policy = std::derived_from<T, PreslicePolicyBase>;
-
 template <soa::is_table T, is_preslice_policy Policy, bool OPT = false>
 struct PresliceBase : public Policy {
+  static constexpr void isPresliceContainer()
+  {};
   constexpr static bool optional = OPT;
   using target_t = T;
   using policy_t = Policy;
@@ -1540,13 +1476,6 @@ using Preslice = PresliceBase<T, PreslicePolicySorted, false>;
 template <soa::is_table T>
 using PresliceOptional = PresliceBase<T, PreslicePolicySorted, true>;
 
-template <typename T>
-concept is_preslice = std::derived_from<T, PreslicePolicyBase>&&
-  requires(T)
-{
-  T::optional;
-};
-
 /// Can be user to group together a number of Preslice declaration
 /// to avoid the limit of 100 data members per task
 ///
@@ -1560,11 +1489,9 @@ concept is_preslice = std::derived_from<T, PreslicePolicyBase>&&
 ///
 /// preslices.perCol;
 struct PresliceGroup {
+  static constexpr void isPresliceGroup()
+  {};
 };
-
-template <typename T>
-concept is_preslice_group = std::derived_from<T, PresliceGroup>;
-
 } // namespace o2::framework
 
 namespace o2::soa
@@ -1574,24 +1501,9 @@ class FilteredBase;
 template <typename T>
 class Filtered;
 
-template <typename T>
-concept has_filtered_policy = not_void<typename T::policy_t> && std::same_as<typename T::policy_t, soa::FilteredIndexPolicy>;
-
-template <typename T>
-concept is_filtered_iterator = is_iterator<T> && has_filtered_policy<T>;
-
-template <typename T>
-concept is_filtered_table = framework::base_of_template<soa::FilteredBase, T>;
-
 // FIXME: compatbility declaration to be removed
 template <typename T>
 constexpr bool is_soa_filtered_v = is_filtered_table<T>;
-
-template <typename T>
-concept is_filtered = is_filtered_table<T> || is_filtered_iterator<T>;
-
-template <typename T>
-concept is_not_filtered_table = is_table<T> && !is_filtered_table<T>;
 
 /// Helper function to extract bound indices
 template <typename... Is>
@@ -1804,6 +1716,8 @@ template <aod::is_aod_hash L, aod::is_aod_hash D, aod::is_origin_hash O, typenam
 class Table
 {
  public:
+  static constexpr void isSOATable()
+  {};
   static constexpr const auto ref = TableRef{L::hash, D::hash, O::hash, o2::aod::version(D::str)};
   using self_t = Table<L, D, O, Ts...>;
   using table_t = self_t;
@@ -2297,7 +2211,7 @@ concept dynamic_with_common_getter = is_dynamic_column<T> &&
                                      };
 
 template <typename T, typename R>
-concept persistent_with_common_getter = is_persistent_v<T> && requires(T t) {
+concept persistent_with_common_getter = is_persistent_column<T> && requires(T t) {
   { t.get() } -> std::convertible_to<R>;
 };
 
@@ -3409,6 +3323,8 @@ namespace o2::soa
 {
 template <typename... Ts>
 struct Join : Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Ts...> {
+  static constexpr void isJoin()
+  {};
   using base = Table<o2::aod::Hash<"JOIN"_h>, o2::aod::Hash<"JOIN/0"_h>, o2::aod::Hash<"JOIN"_h>, Ts...>;
 
   Join(std::shared_ptr<arrow::Table>&& table, uint64_t offset = 0)
@@ -3518,9 +3434,6 @@ constexpr auto join(Ts const&... t)
 }
 
 template <typename T>
-concept is_join = framework::specialization_of_template<Join, T>;
-
-template <typename T>
 constexpr bool is_soa_join_v = is_join<T>;
 
 template <typename... Ts>
@@ -3565,6 +3478,8 @@ template <soa::is_table T>
 class FilteredBase : public T
 {
  public:
+  static constexpr void isFilteredBase()
+  {};
   using self_t = FilteredBase<T>;
   using table_t = typename T::table_t;
   using T::originals;
@@ -4221,6 +4136,8 @@ struct IndexTable : Table<L, D, O> {
 
 template <typename T, bool APPLY>
 struct SmallGroupsBase : public Filtered<T> {
+  static constexpr void isSmallGroups()
+  {};
   static constexpr bool applyFilters = APPLY;
   SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), selection, offset) {}
@@ -4237,11 +4154,6 @@ using SmallGroups = SmallGroupsBase<T, true>;
 
 template <typename T>
 using SmallGroupsUnfiltered = SmallGroupsBase<T, false>;
-
-template <typename T>
-concept is_smallgroups = requires {
-  []<typename B, bool A>(SmallGroupsBase<B, A>*) {}(std::declval<std::decay_t<T>*>());
-};
 } // namespace o2::soa
 
 #endif // O2_FRAMEWORK_ASOA_H_

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -493,7 +493,7 @@ class TableConsumer;
 /// a table. The provided template arguments are if type Column and
 /// therefore refer only to the persisted columns.
 template <typename T>
-concept is_producable = soa::has_metadata<aod::MetadataTrait<T>> || soa::has_metadata<aod::MetadataTrait<typename T::parent_t>>;
+concept is_producable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> || soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::parent_t::ref.desc_hash>>>;
 
 template <typename T>
 concept is_enumerated_iterator = requires(T t) { t.globalIndex(); };

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -838,7 +838,7 @@ struct Builds : decltype(transformBase<T>()) {
 /// to determine the target file, e.g. analysis result, QA or control histogram,
 /// etc.
 template <typename T>
-  requires(std::derived_from<T, TNamed>)
+  requires(std::derived_from<T, TObject>)
 struct OutputObj {
   using obj_t = T;
 

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -492,12 +492,6 @@ class TableConsumer;
 /// Helper class actually implementing the cursor which can write to
 /// a table. The provided template arguments are if type Column and
 /// therefore refer only to the persisted columns.
-template <typename T>
-concept is_producable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> || soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::parent_t::ref.desc_hash>>>;
-
-template <typename T>
-concept is_enumerated_iterator = requires(T t) { t.globalIndex(); };
-
 template <is_producable T>
 struct WritingCursor {
  public:
@@ -579,13 +573,13 @@ struct WritingCursor {
   decltype(FFL(std::declval<cursor_t>())) cursor;
 
  private:
-  static decltype(auto) extract(is_enumerated_iterator auto const& arg)
+  static decltype(auto) extract(soa::is_enumerated_iterator auto const& arg)
   {
     return arg.globalIndex();
   }
 
   template <typename A>
-    requires(!is_enumerated_iterator<A>)
+    requires(!soa::is_enumerated_iterator<A>)
   static decltype(auto) extract(A&& arg)
   {
     return arg;
@@ -642,9 +636,6 @@ template <is_producable T>
 struct Produces : WritingCursor<T> {
 };
 
-template <typename T>
-concept is_produces = requires(T t) { typename T::cursor_t; typename T::persistent_table_t; &T::cursor; };
-
 /// Use this to group together produces. Useful to separate them logically
 /// or simply to stay within the 100 elements per Task limit.
 /// Use as:
@@ -654,10 +645,9 @@ concept is_produces = requires(T t) { typename T::cursor_t; typename T::persiste
 ///
 /// Notice the label MySetOfProduces is just a mnemonic and can be omitted.
 struct ProducesGroup {
+  static constexpr void isProducesGroup()
+  {};
 };
-
-template <typename T>
-concept is_produces_group = std::derived_from<T, ProducesGroup>;
 
 /// Helper template for table transformations
 template <soa::is_metadata M, soa::TableRef Ref>
@@ -682,12 +672,6 @@ struct TableTransform {
 
 /// This helper struct allows you to declare extended tables which should be
 /// created by the task (as opposed to those pre-defined by data model)
-template <typename T>
-concept is_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
-
-template <typename T>
-concept is_dynamically_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_configurable_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
-
 template <is_spawnable T>
 consteval auto transformBase()
 {
@@ -734,13 +718,6 @@ struct Spawns : decltype(transformBase<T>()) {
     s->WithMetadata(std::make_shared<arrow::KeyValueMetadata>(std::vector{std::string{"label"}}, std::vector{std::string{o2::aod::label<T::ref>()}}));
     return s;
   }();
-};
-
-template <typename T>
-concept is_spawns = requires(T t) {
-  typename T::metadata;
-  typename T::expression_pack_t;
-  requires std::same_as<decltype(t.projector), std::shared_ptr<gandiva::Projector>>;
 };
 
 /// This helper struct allows you to declare extended tables with dynamically-supplied
@@ -791,15 +768,6 @@ struct Defines : decltype(transformBase<T>()) {
 
 template <is_dynamically_spawnable T>
 using DefinesDelayed = Defines<T, true>;
-
-template <typename T>
-concept is_defines = requires(T t) {
-  typename T::metadata;
-  typename T::placeholders_pack_t;
-  requires std::same_as<decltype(t.projector), std::shared_ptr<gandiva::Projector>>;
-  requires std::same_as<decltype(t.needRecompilation), bool>;
-  &T::recompile;
-};
 
 /// Policy to control index building
 /// Exclusive index: each entry in a row has a valid index
@@ -859,13 +827,6 @@ struct Builds : decltype(transformBase<T>()) {
   }
 };
 
-template <typename T>
-concept is_builds = requires(T t) {
-  typename T::metadata;
-  typename T::Key;
-  requires std::same_as<decltype(t.map), std::vector<soa::IndexRecord>>;
-};
-
 /// a task with rewritten origin, if running together with a task with the default, will
 /// have a different name and thus its output would be routed separately
 
@@ -877,6 +838,7 @@ concept is_builds = requires(T t) {
 /// to determine the target file, e.g. analysis result, QA or control histogram,
 /// etc.
 template <typename T>
+  requires(std::derived_from<T, TNamed>)
 struct OutputObj {
   using obj_t = T;
 
@@ -964,15 +926,6 @@ struct OutputObj {
   uint32_t mTaskHash;
 };
 
-template <typename T>
-concept is_outputobj = requires(T t) {
-  &T::setHash;
-  &T::spec;
-  &T::ref;
-  requires std::same_as<decltype(t.operator->()), typename T::obj_t*>;
-  requires std::same_as<decltype(t.object), std::shared_ptr<typename T::obj_t>>;
-};
-
 /// This helper allows you to fetch a Sevice from the context or
 /// by using some singleton. This hopefully will hide the Singleton and
 /// We will be able to retrieve it in a more thread safe manner later on.
@@ -989,12 +942,6 @@ struct Service {
       return service;
     }
   }
-};
-
-template <typename T>
-concept is_service = requires(T t) {
-  requires std::same_as<decltype(t.service), typename T::service_t*>;
-  &T::operator->;
 };
 
 auto getTableFromFilter(soa::is_filtered_table auto const& table, soa::SelectionVector&& selection)
@@ -1016,7 +963,7 @@ void initializePartitionCaches(std::set<uint32_t> const& hashes, std::shared_ptr
 ///        the real reason is to provide grouped parts for the process functions that request it
 ///        better solution would be to "slice" the selection, as is already done in GroupSlicer
 ///        for the same purpose, instead of reapplying the filtering
-template <typename T>
+template <soa::is_table T>
 struct Partition {
   using content_t = T;
   Partition(expressions::Node&& filter_) : filter{std::forward<expressions::Node>(filter_)}
@@ -1127,13 +1074,6 @@ struct Partition {
   {
     return mFiltered->size();
   }
-};
-
-template <typename T>
-concept is_partition = requires(T t) {
-  &T::updatePlaceholders;
-  requires std::same_as<decltype(t.filter), expressions::Filter>;
-  requires std::same_as<decltype(t.mFiltered), std::unique_ptr<o2::soa::Filtered<typename T::content_t>>>;
 };
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -645,8 +645,7 @@ struct Produces : WritingCursor<T> {
 ///
 /// Notice the label MySetOfProduces is just a mnemonic and can be omitted.
 struct ProducesGroup {
-  static constexpr void isProducesGroup()
-  {};
+  static constexpr void isProducesGroup() {};
 };
 
 /// Helper template for table transformations

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -1,0 +1,98 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_CONCEPTS_H
+#define O2_FRAMEWORK_CONCEPTS_H
+
+#include <concepts>
+
+namespace o2::aod
+{
+/// hash
+template <typename T>
+concept is_aod_hash = requires(T t) { &T::isHash; };
+
+template <typename T>
+concept is_origin_hash = requires(T t) { &T::isOriginHash; };
+} // namespace o2::aod
+
+namespace o2::soa
+{
+/// general
+template <typename T>
+concept not_void = requires { requires !std::same_as<T, void>; };
+
+/// columns
+template <typename C>
+concept is_persistent_column = requires(C c) { &C::isIteratableColumn; };
+
+template <typename C>
+concept is_self_index_column = not_void<typename C::self_index_t> && std::same_as<typename C::self_index_t, std::true_type>;
+
+/// FIXME: this should really rely on the struct's content instead
+struct Binding;
+template <typename C>
+concept is_index_column = !is_self_index_column<C> && requires(C c, o2::soa::Binding b) {
+  { c.setCurrentRaw(b) } -> std::same_as<bool>;
+  requires std::same_as<decltype(c.mBinding), o2::soa::Binding>;
+};
+
+template <typename T>
+concept is_spawnable_column = std::same_as<typename T::spawnable_t, std::true_type>;
+
+template <typename C>
+concept is_indexing_column = requires(C c) { &C::isEnumeratingColumn; };
+
+template <typename C>
+concept is_dynamic_column = requires(C c) { &C::isDynamicColumn; };
+
+template <typename C>
+concept is_marker_column = requires { &C::isMarkingColumn; };
+
+template <typename T>
+concept is_column = is_persistent_column<T> || is_dynamic_column<T> || is_indexing_column<T> || is_marker_column<T>;
+
+/// pack filtering helpers
+template <typename T>
+using is_dynamic_t = std::conditional_t<is_dynamic_column<T>, std::true_type, std::false_type>;
+
+template <typename T>
+using is_indexing_t = std::conditional_t<is_indexing_column<T>, std::true_type, std::false_type>;
+
+/// tables, iterators and metadata
+template <typename T>
+concept has_parent_t = not_void<typename T::parent_t>;
+
+/// FIXME: this should really rely on the struct's content instead
+template <typename T>
+concept is_metadata_trait = requires(T t) { &T::isMetadataTrait; };
+
+/// FIXME: this should really rely on the struct's content instead
+template <typename T>
+concept is_metadata = requires(T t) { &T::isTableMetadata; };
+
+template <typename T>
+concept has_metadata = is_metadata_trait<T> && not_void<typename T::metadata>;
+
+template <typename T>
+concept has_extension = is_metadata<T> && not_void<typename T::extension_table_t>;
+
+template <typename T>
+concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; requires std::same_as<std::true_type, typename T::configurable_t>; };
+
+} // namespace o2::soa
+
+namespace o2::framework
+{
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_CONCEPTS_H

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -46,18 +46,16 @@ concept is_persistent_column = requires(C c) { c.isIteratableColumn(); };
 
 /// 2. require self-index column
 template <typename C>
-concept is_self_index_column = requires(C c)
-{
+concept is_self_index_column = requires(C c) {
   typename C::compatible_signature;
-  //requires aod::is_aod_hash<typename C::compatible_signature>;
+  // requires aod::is_aod_hash<typename C::compatible_signature>;
   typename C::self_index_t;
   requires std::same_as<typename C::self_index_t, std::true_type>;
 };
 
 /// 3. require bindable index column
 template <typename C>
-concept is_index_column = requires(C c)
-{
+concept is_index_column = requires(C c) {
   typename C::binding_t;
   requires not_void<typename C::binding_t>;
 };
@@ -138,8 +136,7 @@ concept is_table_or_iterator = is_table<T> || is_iterator<T>;
 
 /// 10. require soa::IndexTable
 template <typename T>
-concept is_index_table = requires(T t)
-{
+concept is_index_table = requires(T t) {
   t.isIndexTable();
 };
 

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -22,12 +22,12 @@ struct Hash;
 /// hash
 /// 1. require aod::Hash
 template <typename T>
-concept is_aod_hash = requires(T t) { &T::isHash; };
+concept is_aod_hash = requires(T t) { t.isHash(); };
 /// 2. requires aod::Hash with header::DataOrigin
 template <typename T>
-concept is_origin_hash = requires(T t) { &T::isOriginHash; };
+concept is_origin_hash = requires(T t) { t.isOriginHash(); };
 
-template <is_aod_hash H>
+template <typename H>
 struct MetadataTrait;
 } // namespace o2::aod
 
@@ -41,11 +41,11 @@ concept not_void = requires { requires !std::same_as<T, void>; };
 /// columns
 /// 1. require a storage-backed column
 template <typename C>
-concept is_persistent_column = requires(C c) { &C::isIteratableColumn; };
+concept is_persistent_column = requires(C c) { c.isIteratableColumn(); };
 
 /// 2. require self-index column
 template <typename C>
-concept is_self_index_column = not_void<typename C::self_index_t> && std::same_as<typename C::self_index_t, std::true_type>;
+concept is_self_index_column = not_void<typename std::decay_t<C>::self_index_t> && std::same_as<typename std::decay_t<C>::self_index_t, std::true_type>;
 
 /// 3. require bidable index column
 /// FIXME: this should really rely on the struct's content instead
@@ -58,19 +58,19 @@ concept is_index_column = !is_self_index_column<C> && requires(C c, o2::soa::Bin
 
 /// 4. require a column that can be created from an expression
 template <typename T>
-concept is_spawnable_column = std::same_as<typename T::spawnable_t, std::true_type>;
+concept is_spawnable_column = std::same_as<typename std::decay_t<T>::spawnable_t, std::true_type>;
 
 /// 5. require an enumerating column, like soa::Index
 template <typename C>
-concept is_indexing_column = requires(C c) { &C::isEnumeratingColumn; };
+concept is_indexing_column = requires(C c) { c.isEnumeratingColumn(); };
 
 /// 6. require a dynamic column
 template <typename C>
-concept is_dynamic_column = requires(C c) { &C::isDynamicColumn; };
+concept is_dynamic_column = requires(C c) { c.isDynamicColumn(); };
 
 /// 7. require a marking column
 template <typename C>
-concept is_marker_column = requires { &C::isMarkingColumn; };
+concept is_marker_column = requires(C c) { c.isMarkingColumn(); };
 
 /// 8. require any supported column
 template <typename T>
@@ -101,38 +101,39 @@ concept has_parent_t = not_void<typename T::parent_t>;
 /// 2. require a MetadataTrait specialization/descendant
 /// FIXME: this should really rely on the struct's content instead
 template <typename T>
-concept is_metadata_trait = requires(T t) { &T::isMetadataTrait; };
+concept is_metadata_trait = requires(T t) { t.isMetadataTrait(); };
 
 /// 3. require a TableMetadata depcialization/descendant
 /// FIXME: this should really rely on the struct's content instead
 template <typename T>
-concept is_metadata = requires(T t) { &T::isTableMetadata; };
+concept is_metadata = requires(T t) { t.isTableMetadata(); };
 
 /// 4. require a type with non-void metadata dependent type
 template <typename T>
-concept has_metadata = is_metadata_trait<T> && not_void<typename T::metadata>;
+concept has_metadata = is_metadata<typename std::decay_t<T>::metadata>;
 
 /// 5. require a type with non-void extension_table_t dependent type
 template <typename T>
-concept has_extension = is_metadata<T> && not_void<typename T::extension_table_t>;
+concept has_extension = is_metadata<T> && not_void<typename std::decay_t<T>::extension_table_t>;
 
 /// 6. require a type with non-void configurable_t dependent type, that is same as true_type
 template <typename T>
-concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; requires std::same_as<std::true_type, typename T::configurable_t>; };
+concept has_configurable_extension = has_extension<T> && requires(T t) { typename std::decay_t<T>::configurable_t; requires std::same_as<std::true_type, typename std::decay_t<T>::configurable_t>; };
 
 /// 7. require an soa::Table
 template <typename T>
-concept is_table = requires(T t) { &T::isSOATable(); };
+concept is_table = requires(T t) { t.isSOATable(); };
 
 /// 8. require a specialization/descendant of a TableIterator
 template <typename T>
-concept is_iterator = requires (T t) { &T::isTableIterator(); };
+concept is_iterator = requires(T t) { t.isTableIterator(); };
 
 /// 9. require a table or iterator
 template <typename T>
 concept is_table_or_iterator = is_table<T> || is_iterator<T>;
 
 /// 10. require soa::IndexTable
+/// FIXME: this should really rely on the struct's content instead
 template <typename L, typename D, typename O, typename Key, typename H, typename... Ts>
 struct IndexTable;
 
@@ -141,7 +142,7 @@ concept is_index_table = framework::specialization_of_template<o2::soa::IndexTab
 
 /// 11. require a type with a filtered policy
 template <typename T>
-concept has_filtered_policy = not_void<typename T::policy_t> && requires{T::policy_t::isFilteredIndexPolicy();};
+concept has_filtered_policy = not_void<typename std::decay_t<T>::policy_t> && requires { std::decay_t<T>::policy_t::isFilteredIndexPolicy(); };
 
 /// 12. require a filtered table iterator
 template <typename T>
@@ -149,7 +150,7 @@ concept is_filtered_iterator = is_iterator<T> && has_filtered_policy<T>;
 
 /// 13. require a filtered table
 template <typename T>
-concept is_filtered_table = requires(T t) { &T::isFilteredBase; };
+concept is_filtered_table = requires(T t) { t.isFilteredBase(); };
 
 /// 14. require a filtered table or iterator
 template <typename T>
@@ -161,7 +162,7 @@ concept is_not_filtered_table = is_table<T> && !is_filtered_table<T>;
 
 /// 16. require a join
 template <typename T>
-concept is_join = requires(T t) { &T::isJoin; };
+concept is_join = requires(T t) { t.isJoin(); };
 
 /// misc
 /// 1. require a type with originals container
@@ -177,16 +178,15 @@ concept with_sources = requires {
 };
 
 /// 3. require a type with sources generator method
-/// FIXME: this should really rely on the struct's content instead
 template <typename T>
 concept with_sources_generator = requires(T t) {
-  t.template generateSources<o2::aod::Hash<0>>();
+  t.generateSources();
 };
 
 /// 4. require a type with ccd_urls container
 template <typename T>
-concept with_ccdb_urls = requires {
-  T::ccdb_urls.size();
+concept with_ccdb_urls = requires(T t) {
+  t.ccdb_urls.size();
 };
 
 /// 5. require a type, whos metadata has base_table_t dependant type
@@ -213,7 +213,7 @@ concept with_index_pack = requires {
 
 /// 8. require SmallGroups
 template <typename T>
-concept is_smallgroups = requires(T t) { &T::isSmallGroups; };
+concept is_smallgroups = requires(T t) { t.isSmallGroups(); };
 } // namespace o2::soa
 
 namespace o2::framework
@@ -221,15 +221,15 @@ namespace o2::framework
 /// preslice
 /// 1. require a preslice policy
 template <typename T>
-concept is_preslice_policy = requires(T t) { &T::isPreslicePolicy; };
+concept is_preslice_policy = requires(T t) { t.isPreslicePolicy(); };
 
 /// 2. require a preslice container
 template <typename T>
-concept is_preslice = requires(T t) { &T::isPresliceContainer; };
+concept is_preslice = requires(T t) { t.isPresliceContainer(); };
 
 /// 3. reqiures a preslice group
 template <typename T>
-concept is_preslice_group = requires(T t) { &T::isPresliceGroup; };
+concept is_preslice_group = requires(T t) { t.isPresliceGroup(); };
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_CONCEPTS_H

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -12,31 +12,42 @@
 #ifndef O2_FRAMEWORK_CONCEPTS_H
 #define O2_FRAMEWORK_CONCEPTS_H
 
+#include <Framework/Traits.h>
 #include <concepts>
 
 namespace o2::aod
 {
+template <uint32_t>
+struct Hash;
 /// hash
+/// 1. require aod::Hash
 template <typename T>
 concept is_aod_hash = requires(T t) { &T::isHash; };
-
+/// 2. requires aod::Hash with header::DataOrigin
 template <typename T>
 concept is_origin_hash = requires(T t) { &T::isOriginHash; };
+
+template <is_aod_hash H>
+struct MetadataTrait;
 } // namespace o2::aod
 
 namespace o2::soa
 {
 /// general
+/// require a type to be not void
 template <typename T>
 concept not_void = requires { requires !std::same_as<T, void>; };
 
 /// columns
+/// 1. require a storage-backed column
 template <typename C>
 concept is_persistent_column = requires(C c) { &C::isIteratableColumn; };
 
+/// 2. require self-index column
 template <typename C>
 concept is_self_index_column = not_void<typename C::self_index_t> && std::same_as<typename C::self_index_t, std::true_type>;
 
+/// 3. require bidable index column
 /// FIXME: this should really rely on the struct's content instead
 struct Binding;
 template <typename C>
@@ -45,20 +56,35 @@ concept is_index_column = !is_self_index_column<C> && requires(C c, o2::soa::Bin
   requires std::same_as<decltype(c.mBinding), o2::soa::Binding>;
 };
 
+/// 4. require a column that can be created from an expression
 template <typename T>
 concept is_spawnable_column = std::same_as<typename T::spawnable_t, std::true_type>;
 
+/// 5. require an enumerating column, like soa::Index
 template <typename C>
 concept is_indexing_column = requires(C c) { &C::isEnumeratingColumn; };
 
+/// 6. require a dynamic column
 template <typename C>
 concept is_dynamic_column = requires(C c) { &C::isDynamicColumn; };
 
+/// 7. require a marking column
 template <typename C>
 concept is_marker_column = requires { &C::isMarkingColumn; };
 
+/// 8. require any supported column
 template <typename T>
 concept is_column = is_persistent_column<T> || is_dynamic_column<T> || is_indexing_column<T> || is_marker_column<T>;
+
+/// 9. require a type that can be bound as a column of type B
+template <typename T, typename B>
+concept can_bind = requires(T&& t) {
+  { t.B::mColumnIterator };
+};
+
+/// 10. require at least one column in an exploded pack to be an indexing column
+template <typename... C>
+concept has_index = (is_indexing_column<C> || ...);
 
 /// pack filtering helpers
 template <typename T>
@@ -68,31 +94,142 @@ template <typename T>
 using is_indexing_t = std::conditional_t<is_indexing_column<T>, std::true_type, std::false_type>;
 
 /// tables, iterators and metadata
+/// 1. require a type with parent_t dependent type
 template <typename T>
 concept has_parent_t = not_void<typename T::parent_t>;
 
+/// 2. require a MetadataTrait specialization/descendant
 /// FIXME: this should really rely on the struct's content instead
 template <typename T>
 concept is_metadata_trait = requires(T t) { &T::isMetadataTrait; };
 
+/// 3. require a TableMetadata depcialization/descendant
 /// FIXME: this should really rely on the struct's content instead
 template <typename T>
 concept is_metadata = requires(T t) { &T::isTableMetadata; };
 
+/// 4. require a type with non-void metadata dependent type
 template <typename T>
 concept has_metadata = is_metadata_trait<T> && not_void<typename T::metadata>;
 
+/// 5. require a type with non-void extension_table_t dependent type
 template <typename T>
 concept has_extension = is_metadata<T> && not_void<typename T::extension_table_t>;
 
+/// 6. require a type with non-void configurable_t dependent type, that is same as true_type
 template <typename T>
 concept has_configurable_extension = has_extension<T> && requires(T t) { typename T::configurable_t; requires std::same_as<std::true_type, typename T::configurable_t>; };
 
+/// 7. require an soa::Table
+template <typename T>
+concept is_table = requires(T t) { &T::isSOATable(); };
+
+/// 8. require a specialization/descendant of a TableIterator
+template <typename T>
+concept is_iterator = requires (T t) { &T::isTableIterator(); };
+
+/// 9. require a table or iterator
+template <typename T>
+concept is_table_or_iterator = is_table<T> || is_iterator<T>;
+
+/// 10. require soa::IndexTable
+template <typename L, typename D, typename O, typename Key, typename H, typename... Ts>
+struct IndexTable;
+
+template <typename T>
+concept is_index_table = framework::specialization_of_template<o2::soa::IndexTable, T>;
+
+/// 11. require a type with a filtered policy
+template <typename T>
+concept has_filtered_policy = not_void<typename T::policy_t> && requires{T::policy_t::isFilteredIndexPolicy();};
+
+/// 12. require a filtered table iterator
+template <typename T>
+concept is_filtered_iterator = is_iterator<T> && has_filtered_policy<T>;
+
+/// 13. require a filtered table
+template <typename T>
+concept is_filtered_table = requires(T t) { &T::isFilteredBase; };
+
+/// 14. require a filtered table or iterator
+template <typename T>
+concept is_filtered = is_filtered_table<T> || is_filtered_iterator<T>;
+
+/// 15. require not filtered table
+template <typename T>
+concept is_not_filtered_table = is_table<T> && !is_filtered_table<T>;
+
+/// 16. require a join
+template <typename T>
+concept is_join = requires(T t) { &T::isJoin; };
+
+/// misc
+/// 1. require a type with originals container
+template <typename T>
+concept with_originals = requires {
+  T::originals.size();
+};
+
+/// 2. require a type with sources container
+template <typename T>
+concept with_sources = requires {
+  T::sources.size();
+};
+
+/// 3. require a type with sources generator method
+/// FIXME: this should really rely on the struct's content instead
+template <typename T>
+concept with_sources_generator = requires(T t) {
+  t.template generateSources<o2::aod::Hash<0>>();
+};
+
+/// 4. require a type with ccd_urls container
+template <typename T>
+concept with_ccdb_urls = requires {
+  T::ccdb_urls.size();
+};
+
+/// 5. require a type, whos metadata has base_table_t dependant type
+/// FIXME: this should really rely on the struct's content instead
+template <typename T>
+concept with_base_table = with_originals<T> && has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && requires {
+  typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata::base_table_t;
+};
+
+template <typename T>
+concept with_base_table_ng = not_void<typename T::base_table_t>; // redicrection should be done at the check site
+
+/// 6. require a type with expression_pack_t dependant type
+template <typename T>
+concept with_expression_pack = requires {
+  typename T::expression_pack_t{};
+};
+
+/// 7. require a type with index_pack_t dependant type
+template <typename T>
+concept with_index_pack = requires {
+  typename T::index_pack_t{};
+};
+
+/// 8. require SmallGroups
+template <typename T>
+concept is_smallgroups = requires(T t) { &T::isSmallGroups; };
 } // namespace o2::soa
 
 namespace o2::framework
 {
+/// preslice
+/// 1. require a preslice policy
+template <typename T>
+concept is_preslice_policy = requires(T t) { &T::isPreslicePolicy; };
 
+/// 2. require a preslice container
+template <typename T>
+concept is_preslice = requires(T t) { &T::isPresliceContainer; };
+
+/// 3. reqiures a preslice group
+template <typename T>
+concept is_preslice_group = requires(T t) { &T::isPresliceGroup; };
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_CONCEPTS_H

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -164,6 +164,10 @@ concept is_not_filtered_table = is_table<T> && !is_filtered_table<T>;
 template <typename T>
 concept is_join = requires(T t) { t.isJoin(); };
 
+/// 17. require an enumerated iterator
+template <typename T>
+concept is_enumerated_iterator = requires(T t) { t.globalIndex(); };
+
 /// misc
 /// 1. require a type with originals container
 template <typename T>
@@ -227,9 +231,84 @@ concept is_preslice_policy = requires(T t) { t.isPreslicePolicy(); };
 template <typename T>
 concept is_preslice = requires(T t) { t.isPresliceContainer(); };
 
-/// 3. reqiures a preslice group
+/// 3. reqiure a preslice group
 template <typename T>
 concept is_preslice_group = requires(T t) { t.isPresliceGroup(); };
+
+/// 4. require a producable entity
+template <typename T>
+concept is_producable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::ref.desc_hash>>> || soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::parent_t::ref.desc_hash>>>;
+
+/// 5. require produces declaration
+template <typename T>
+concept is_produces = requires(T t) { typename T::cursor_t; typename T::persistent_table_t; &T::cursor; };
+
+/// 6. require produces group
+template <typename T>
+concept is_produces_group = requires(T t) { t.isProducesGroup(); };
+
+/// 7. require spawnable entity
+template <typename T>
+concept is_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
+
+/// 8. require dynamically spawnable entity
+template <typename T>
+concept is_dynamically_spawnable = soa::has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && soa::has_configurable_extension<typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata>;
+
+/// 9. require spawns declaration
+template <typename T>
+concept is_spawns = requires(T t) {
+  typename T::metadata;
+  typename T::expression_pack_t;
+  t.projector.get();
+};
+
+/// 10. require defines declaration
+template <typename T>
+concept is_defines = requires(T t) {
+  typename T::metadata;
+  typename T::placeholders_pack_t;
+  t.projector.get();
+  requires std::same_as<decltype(t.needRecompilation), bool>;
+  t.recompile();
+};
+
+/// 11. require builds declaration
+template <typename T>
+concept is_builds = requires(T t) {
+  typename T::metadata;
+  typename T::Key;
+  t.map.size();
+};
+
+/// 12. require outputobj declaration
+template <typename T>
+concept is_outputobj = requires(T t) {
+  &T::setHash;
+  &T::spec;
+  &T::ref;
+  requires std::same_as<decltype(t.operator->()), typename T::obj_t*>;
+  requires std::same_as<decltype(t.object.get()), typename T::obj_t*>;
+};
+
+/// 13. require service declaration
+template <typename T>
+concept is_service = requires(T t) {
+  requires std::same_as<decltype(t.service), typename T::service_t*>;
+  &T::operator->;
+};
+
+/// 14. require partition declaration
+template <typename T>
+concept is_partition = requires(T t) {
+  &T::updatePlaceholders;
+  t.mFiltered.get();
+  &T::operator->;
+  requires std::same_as<decltype(t.dataframeChanged), bool>;
+  t.begin();
+  t.end();
+  t.size();
+};
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_CONCEPTS_H

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -45,15 +45,20 @@ concept is_persistent_column = requires(C c) { c.isIteratableColumn(); };
 
 /// 2. require self-index column
 template <typename C>
-concept is_self_index_column = not_void<typename std::decay_t<C>::self_index_t> && std::same_as<typename std::decay_t<C>::self_index_t, std::true_type>;
+concept is_self_index_column = requires(C c)
+{
+  typename C::compatible_signature;
+  //requires aod::is_aod_hash<typename C::compatible_signature>;
+  typename C::self_index_t;
+  requires std::same_as<typename C::self_index_t, std::true_type>;
+};
 
-/// 3. require bidable index column
-/// FIXME: this should really rely on the struct's content instead
-struct Binding;
+/// 3. require bindable index column
 template <typename C>
-concept is_index_column = !is_self_index_column<C> && requires(C c, o2::soa::Binding b) {
-  { c.setCurrentRaw(b) } -> std::same_as<bool>;
-  requires std::same_as<decltype(c.mBinding), o2::soa::Binding>;
+concept is_index_column = requires(C c)
+{
+  typename C::binding_t;
+  requires not_void<typename C::binding_t>;
 };
 
 /// 4. require a column that can be created from an expression
@@ -99,12 +104,10 @@ template <typename T>
 concept has_parent_t = not_void<typename T::parent_t>;
 
 /// 2. require a MetadataTrait specialization/descendant
-/// FIXME: this should really rely on the struct's content instead
 template <typename T>
 concept is_metadata_trait = requires(T t) { t.isMetadataTrait(); };
 
 /// 3. require a TableMetadata depcialization/descendant
-/// FIXME: this should really rely on the struct's content instead
 template <typename T>
 concept is_metadata = requires(T t) { t.isTableMetadata(); };
 
@@ -133,12 +136,11 @@ template <typename T>
 concept is_table_or_iterator = is_table<T> || is_iterator<T>;
 
 /// 10. require soa::IndexTable
-/// FIXME: this should really rely on the struct's content instead
-template <typename L, typename D, typename O, typename Key, typename H, typename... Ts>
-struct IndexTable;
-
 template <typename T>
-concept is_index_table = framework::specialization_of_template<o2::soa::IndexTable, T>;
+concept is_index_table = requires(T t)
+{
+  t.isIndexTable();
+};
 
 /// 11. require a type with a filtered policy
 template <typename T>
@@ -194,7 +196,6 @@ concept with_ccdb_urls = requires(T t) {
 };
 
 /// 5. require a type, whos metadata has base_table_t dependant type
-/// FIXME: this should really rely on the struct's content instead
 template <typename T>
 concept with_base_table = with_originals<T> && has_metadata<aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>> && requires {
   typename aod::MetadataTrait<o2::aod::Hash<T::originals[T::originals.size() - 1].desc_hash>>::metadata::base_table_t;

--- a/Framework/Core/include/Framework/Concepts.h
+++ b/Framework/Core/include/Framework/Concepts.h
@@ -13,6 +13,7 @@
 #define O2_FRAMEWORK_CONCEPTS_H
 
 #include <Framework/Traits.h>
+#include <cstdint>
 #include <concepts>
 
 namespace o2::aod

--- a/Framework/Core/test/test_Concepts.cxx
+++ b/Framework/Core/test/test_Concepts.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "Framework/Concepts.h"
 #include <TH1.h>
 #include "Framework/ASoA.h"
 #include "Framework/AnalysisDataModel.h"
@@ -87,6 +88,9 @@ TEST_CASE("IdentificationConcepts")
 
   REQUIRE(with_originals<o2::aod::Collisions>);
 
+  REQUIRE(o2::soa::is_metadata_trait<o2::aod::MetadataTrait<o2::aod::Hash<"MA_RN3_SP/0"_h>>>);
+  REQUIRE(o2::soa::has_metadata<o2::aod::MetadataTrait<o2::aod::Hash<"MA_RN3_SP/0"_h>>>);
+  REQUIRE(o2::soa::is_metadata<o2::aod::MetadataTrait<o2::aod::Hash<"MA_RN3_SP/0"_h>>::metadata>);
   REQUIRE(with_sources_generator<o2::aod::MetadataTrait<o2::aod::Hash<"MA_RN3_SP/0"_h>>::metadata>);
 
   REQUIRE(with_base_table<o2::aod::Tracks>);


### PR DESCRIPTION
Many of framework-defined concepts can be employed in user code to restrict various templates. Having the concepts defined in a separate header allows users to avoid including heavy headers like ASoA.h in many contexts.