### PR TITLE
Store TPC cluster flag in UnbinnedResid::channel

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -66,7 +66,8 @@ struct TPCClusterResiduals {
   float snp{};          ///< sin of the phi angle between padrow and track
   unsigned char sec{};  ///< sector number 0..35
   unsigned char dRow{}; ///< distance to previous row in units of pad rows
-  ClassDefNV(TPCClusterResiduals, 5);
+  unsigned char flags{}; ///< cluster flags
+  ClassDefNV(TPCClusterResiduals, 6);
 };
 
 /// This struct is used to store the unbinned TPC cluster residuals in a compact way
@@ -275,6 +276,7 @@ class TrackInterpolation
     float clAngle{0.f};
     unsigned short clAvailable{0};
     unsigned char clSec{0};
+    unsigned char clFlags{0};
   };
 
   /// Structure for on-the-fly re-calculated track parameters at the validation stage
@@ -460,8 +462,10 @@ class TrackInterpolation
   std::vector<int> mParentID{};                                             ///< entry of more global parent track for skimmed seeds (-1: no parent)
   std::map<int, int> mTrackTypes;                                           ///< mapping of track source to array index in mTrackIndices
   std::array<std::vector<uint32_t>, 4> mTrackIndices;                       ///< keep GIDs of input tracks separately for each track type
-  gsl::span<const TPCClRefElem> mTPCTracksClusIdx;                          ///< input TPC cluster indices from span
+  gsl::span<const TPCClRefElem> mTPCTrackClusIdx;                           ///< input TPC cluster indices from span
+  gsl::span<const unsigned char> mTPCShClassMap;                            ///< TPC cluster sharing map
   const ClusterNativeAccess* mTPCClusterIdxStruct = nullptr;                ///< struct holding the TPC cluster indices
+
   // ITS specific input only needed for debugging
   gsl::span<const int> mITSTrackClusIdx;                    ///< input ITS track cluster indices span
   std::vector<o2::BaseCluster<float>> mITSClustersArray;    ///< ITS clusters created in run() method from compact clusters

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -338,7 +338,8 @@ void TrackInterpolation::process()
     return;
   }
   // set the input containers
-  mTPCTracksClusIdx = mRecoCont->getTPCTracksClusterRefs();
+  mTPCTrackClusIdx = mRecoCont->getTPCTracksClusterRefs();
+  mTPCShClassMap = mRecoCont->clusterShMapTPC;
   mTPCClusterIdxStruct = &mRecoCont->getTPCClusters();
   int nbOccTOT = o2::gpu::GPUO2InterfaceRefit::fillOccupancyMapGetSize(mNHBPerTF, mTPCParam.get());
   o2::gpu::GPUO2InterfaceUtils::paramUseExternalOccupancyMap(mTPCParam.get(), mNHBPerTF, mRecoCont->occupancyMapTPC.data(), nbOccTOT);
@@ -511,7 +512,9 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   for (int iCl = trkTPC.getNClusterReferences(); iCl--;) {
     uint8_t sector, row;
     uint32_t clusterIndexInRow;
-    const auto& clTPC = trkTPC.getCluster(mTPCTracksClusIdx, iCl, *mTPCClusterIdxStruct, sector, row);
+    trkTPC.getClusterReference(mTPCTrackClusIdx, iCl, sector, row, clusterIndexInRow);
+    unsigned int absoluteIndex = mTPCClusterIdxStruct->clusterOffset[sector][row] + clusterIndexInRow;
+    const auto& clTPC = mTPCClusterIdxStruct->clustersLinear[absoluteIndex];
     float clTPCX;
     std::array<float, 2> clTPCYZ;
     mFastTransform->TransformIdeal(sector, row, clTPC.getPad(), clTPC.getTime(), clTPCX, clTPCYZ[0], clTPCYZ[1], clusterTimeBinOffset);
@@ -520,6 +523,10 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     mCache[row].clY = clTPCYZ[0];
     mCache[row].clZ = clTPCYZ[1];
     mCache[row].clAngle = o2::math_utils::sector2Angle(sector);
+    mCache[row].clFlags = clTPC.getFlags();
+    if (mTPCShClassMap[absoluteIndex] & o2::gpu::GPUTPCGMMergedTrackHit::flagShared) {
+      mCache[row].clFlags |= o2::gpu::GPUTPCGMMergedTrackHit::flagShared;
+    }
     mCacheDEDX[row].first = std::min<uint16_t>(clTPC.getQtot(), UINT16_MAX);
     mCacheDEDX[row].second = clTPC.getQmax();
     int imb = int(clTPC.getTime() * mNTPCOccBinLengthInv);
@@ -670,7 +677,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     const auto z = mCache[iRow].z[Int];
     const auto snp = mCache[iRow].snp[Int];
     const auto sec = mCache[iRow].clSec;
-    clusterResiduals.emplace_back(dY, dZ, y, z, snp, sec, deltaRow);
+    clusterResiduals.emplace_back(dY, dZ, y, z, snp, sec, deltaRow, mCache[iRow].clFlags);
 
     deltaRow = 1;
   }
@@ -717,8 +724,9 @@ void TrackInterpolation::interpolateTrack(int iSeed)
       const auto y = clusterResiduals[iCl].y;
       const auto z = clusterResiduals[iCl].z;
       const auto sec = clusterResiduals[iCl].sec;
+      const short flags = clusterResiduals[iCl].flags;
       if ((std::abs(dy) < param::MaxResid) && (std::abs(dz) < param::MaxResid) && (std::abs(y) < param::MaxY) && (std::abs(z) < param::MaxZ) && (std::abs(tgPhi) < param::MaxTgSlp)) {
-        mClRes.emplace_back(dy, dz, tgPhi, y, z, iRow, sec, -1, rej);
+        mClRes.emplace_back(dy, dz, tgPhi, y, z, iRow, sec, flags, rej);
         mDetInfoRes.emplace_back().setTPC(mCacheDEDX[iRow].first, mCacheDEDX[iRow].second); // qtot, qmax
         ++nClValidated;
       } else {
@@ -983,7 +991,9 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
   for (int iCl = trkTPC.getNClusterReferences(); iCl--;) {
     uint8_t sector, row;
     uint32_t clusterIndexInRow;
-    const auto& cl = trkTPC.getCluster(mTPCTracksClusIdx, iCl, *mTPCClusterIdxStruct, sector, row);
+    trkTPC.getClusterReference(mTPCTrackClusIdx, iCl, sector, row, clusterIndexInRow);
+    unsigned int absoluteIndex = mTPCClusterIdxStruct->clusterOffset[sector][row] + clusterIndexInRow;
+    const auto& cl = mTPCClusterIdxStruct->clustersLinear[absoluteIndex];
     if (clRowPrev == row) {
       // if there are split clusters we only take the first one on the pad row
       continue;
@@ -1014,7 +1024,11 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
     const auto tz = trkWork.getZ();
     const auto snp = trkWork.getSnp();
     const auto sec = sector;
-    clusterResiduals.emplace_back(dY, dZ, ty, tz, snp, sec, row - rowPrev);
+    unsigned char flags = cl.getFlags();
+    if (mTPCShClassMap[absoluteIndex] & o2::gpu::GPUTPCGMMergedTrackHit::flagShared) {
+      flags |= o2::gpu::GPUTPCGMMergedTrackHit::flagShared;
+    }
+    clusterResiduals.emplace_back(dY, dZ, ty, tz, snp, sec, row - rowPrev, flags);
     mCacheDEDX[row].first = cl.getQtot();
     mCacheDEDX[row].second = cl.getQmax();
     rowPrev = row;
@@ -1061,8 +1075,9 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
       const auto dz = clusterResiduals[iCl].dz;
       const auto y = clusterResiduals[iCl].y;
       const auto z = clusterResiduals[iCl].z;
+      const short flags = clusterResiduals[iCl].flags;
       if ((std::abs(dy) < param::MaxResid) && (std::abs(dz) < param::MaxResid) && (std::abs(y) < param::MaxY) && (std::abs(z) < param::MaxZ) && (std::abs(tgPhi) < param::MaxTgSlp)) {
-        mClRes.emplace_back(dy, dz, tgPhi, y, z, iRow, clusterResiduals[iCl].sec, -1, rej);
+        mClRes.emplace_back(dy, dz, tgPhi, y, z, iRow, clusterResiduals[iCl].sec, flags, rej);
         mDetInfoRes.emplace_back().setTPC(mCacheDEDX[iRow].first, mCacheDEDX[iRow].second); // qtot, qmax
         ++nClValidated;
       } else {


### PR DESCRIPTION
The TPC cluster flags are now stored in the residulas `channel` word. Before it was set to -1 for TPC residuals and provided the detector channel info for ITS, TRD, TOF residuals (row>=160).
Now it is assigned for TPC residuals as:
```
short channel = cluster.getFlags();
if (TPCCusterSharingMap[clusterIndex] & o2::gpu::GPUTPCGMMergedTrackHit::flagShared) {
  channel |= o2::gpu::GPUTPCGMMergedTrackHit::flagShared;
}
```
Tested on OO data:
<img width="838" height="688" alt="image" src="https://github.com/user-attachments/assets/3f1c6729-4362-4687-b3f7-337930ce4a2b" />
