### PR TITLE
TPC: add ITS-TPC combined-momentum sampling trigger

### DIFF
--- a/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCTimeSeriesSpec.cxx
@@ -1335,12 +1335,17 @@ class TPCTimeSeries : public Task
     if (mUnbinnedWriter && mStreamer[iThread]) {
       const float factorPt = mSamplingFactor;
       bool writeData = true;
+      bool writeDataITSTPC = false;
       float weight = 0;
+      float weightITSTPC = 0;
       if (mSampleTsallis) {
         std::uniform_real_distribution<> distr(0., 1.);
         writeData = o2::math_utils::Tsallis::downsampleTsallisCharged(tracksTPC[iTrk].getPt(), factorPt, mSqrt, weight, distr(mGenerator[iThread]));
+        if (hasITSTPC) {
+          writeDataITSTPC = o2::math_utils::Tsallis::downsampleTsallisCharged(tracksITSTPC[idxITSTPC.front()].getPt(), factorPt, mSqrt, weightITSTPC, distr(mGenerator[iThread]));
+        }
       }
-      if (writeData || minBiasOk) {
+      if (writeData || writeDataITSTPC || minBiasOk) {
         auto clusterMask = makeClusterBitMask(trackFull);
         const auto& trkOrig = tracksTPC[iTrk];
         const bool isNearestVtx = (idxITSTPC.back() == -1); // is nearest vertex in case no vertex was found
@@ -1395,7 +1400,11 @@ class TPCTimeSeries : public Task
             }
           }
         }
-        const int triggerMask = 0x1 * minBiasOk + 0x2 * writeData;
+        // triggerMask bits:
+        // 0x1: flat minimum-bias stream
+        // 0x2: Tsallis stream sampled with TPC-only pT
+        // 0x4: Tsallis stream sampled with ITS-TPC combined pT
+        const int triggerMask = 0x1 * minBiasOk + 0x2 * writeData + 0x4 * writeDataITSTPC;
 
         float deltaP2ConstrVtx = -999;
         float deltaP3ConstrVtx = -999;
@@ -1446,6 +1455,7 @@ class TPCTimeSeries : public Task
                             << "factorMinBias=" << factorMinBias
                             << "factorPt=" << factorPt
                             << "weight=" << weight
+                            << "weight_ITSTPC=" << weightITSTPC
                             << "dcar_tpc_vertex=" << dcaTPCAtVertex
                             << "dcar_tpc=" << dca[0]
                             << "dcaz_tpc=" << dca[1]


### PR DESCRIPTION
Hello @matthias-kleiner and @shahor02,

Here is a pull request I discussed last week in the TPC distortion meeting. @matthias-kleiner, are you on holidays now, or could you run one small test at GSI?

===
Add a third sampling trigger bit for tracks with matched ITS–TPC combined momentum. The new trigger applies the Tsallis sampling function to the combined-track pT instead of the TPC-only pT and stores the corresponding weight as weight_ITSTPC.

This extends the existing trigger mask scheme:
  0x1: minimum-bias sampling
  0x2: Tsallis sampling using TPC-only track pT
  0x4: Tsallis sampling using ITS–TPC combined-track pT

The output condition is updated so that tracks selected by the new ITS–TPC sampling path are written even when they are not selected by the existing TPC-only or minimum-bias triggers.

Motivation:
Sampling only on TPC-only momentum can bias correlated observables such as qpt_TPC - qpt_Comb. The new trigger provides a dedicated sampled stream for combined-track performance studies while preserving the existing TPC-only and minimum-bias sampling streams.