### PR TITLE
TPC addHits: remove short type limitation

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/Point.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Point.h
@@ -117,7 +117,7 @@ class HitGroup : public o2::BaseHit
 
   ~HitGroup() = default;
 
-  void addHit(float x, float y, float z, float time, short e)
+  void addHit(float x, float y, float z, float time, float e)
   {
 #ifdef HIT_AOS
     mHits.emplace_back(x, y, z, time, e);


### PR DESCRIPTION
Change type from short to float to remove possible overflow errors

There is no deep reason for this to be short in any case. The underlaying storage was already of type float.

Fixes a problem observed in monopole simulations inside TPC