### PR TITLE
Properly discard Alice3 TRK hits preceding RO start

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Digitizer.h
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/include/TRKSimulation/Digitizer.h
@@ -65,7 +65,7 @@ class Digitizer
     mROFrameMin = 0;
     mROFrameMax = 0;
     mNewROFrame = 0;
-    mIsBeforeFirstRO = false;
+    mROFsWrtFirstRO = 0;
     mExtraBuff.clear();
   }
 
@@ -139,7 +139,7 @@ class Digitizer
   uint32_t mROFrameMax = 0; ///< highest RO frame of current digits
   uint32_t mNewROFrame = 0; ///< ROFrame corresponding to provided time
 
-  bool mIsBeforeFirstRO = false;
+  int mROFsWrtFirstRO = 0;
 
   uint32_t mEventROFrameMin = 0xffffffff; ///< lowest RO frame for processed events (w/o automatic noise ROFs)
   uint32_t mEventROFrameMax = 0;          ///< highest RO frame forfor processed events (w/o automatic noise ROFs)

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Digitizer.cxx
@@ -164,15 +164,14 @@ void Digitizer::setEventTime(const o2::InteractionTimeRecord& irt, int layer)
     nbc--;
   }
 
+  mROFsWrtFirstRO = std::floor(float(nbc) / mParams.getROFrameLengthInBC(layer));
   if (nbc < 0) {
     mNewROFrame = 0;
-    mIsBeforeFirstRO = true;
   } else {
     mNewROFrame = nbc / mParams.getROFrameLengthInBC(layer);
-    mIsBeforeFirstRO = false;
   }
 
-  LOG(debug) << " NewROFrame " << mNewROFrame << " = " << nbc << "/" << mParams.getROFrameLengthInBC(layer) << " (nbc/mParams.getROFrameLengthInBC()";
+  LOG(debug) << " NewROFrame " << mNewROFrame << " nbc " << nbc << " ROFsWrtFirstRO " << mROFsWrtFirstRO;
 
   // in continuous mode depends on starts of periodic readout frame
   mCollisionTimeWrtROF += (nbc % mParams.getROFrameLengthInBC(layer)) * o2::constants::lhc::LHCBunchSpacingNS;
@@ -283,7 +282,7 @@ void Digitizer::processHit(const o2::trk::Hit& hit, uint32_t& maxFr, int evID, i
     return;
   }
   timeInROF += mCollisionTimeWrtROF;
-  if (mIsBeforeFirstRO && timeInROF < 0) {
+  if (mROFsWrtFirstRO < -1 || (mROFsWrtFirstRO == -1 && timeInROF < 0)) {
     // disregard this hit because it comes from an event byefore readout starts and it does not effect this RO
     LOG(debug) << "Ignoring hit with timeInROF = " << timeInROF;
     return;


### PR DESCRIPTION
Copied from https://github.com/AliceO2Group/AliceO2/pull/15601, the hits with any time distance before the readout start could be digitized if they were on the right side of the boundary of the ROF start.