### PR TITLE
Data model fix: avoid classifying TPC loopers as physical primary

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1990,16 +1990,20 @@ namespace mcparticle_v2
 // note: this has to be declared in a separate namespace so it does not conflict with existing
 // derived data table declarations in O2Physics
 DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
-                           [](uint8_t flags, float vx, float vy) -> bool {
-                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent;
-                            return (flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
+                           [](uint8_t input_flags, float vx, float vy) -> bool {
+                            if((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)){
+                              return o2::aod::mcparticle::enums::FromBackgroundEvent;
+                            }
+                            return (input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
 
 // avoid that the stored flags are provided unprotected via
 // the getter '.flags': analysers will get the correct bit map transparently
 DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);   //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
 DECLARE_SOA_DYNAMIC_COLUMN(McParticleFlags, flags, //! protected against
                            [](uint8_t input_flags, float vx, float vy) -> uint8_t {
-                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent;
+                            if((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)){
+                              return o2::aod::mcparticle::enums::FromBackgroundEvent;
+                            }
                             return input_flags; });
 
 } // namespace mcparticle_v2

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1990,16 +1990,16 @@ namespace mcparticle_v2
 // note: this has to be declared in a separate namespace so it does not conflict with existing
 // derived data table declarations in O2Physics
 DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
-                           [](uint8_t flags, float vx, float vy) -> bool { 
-                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent; 
+                           [](uint8_t flags, float vx, float vy) -> bool {
+                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent;
                             return (flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
 
 // avoid that the stored flags are provided unprotected via
 // the getter '.flags': analysers will get the correct bit map transparently
 DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);   //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
 DECLARE_SOA_DYNAMIC_COLUMN(McParticleFlags, flags, //! protected against
-                           [](uint8_t input_flags, float vx, float vy) -> uint8_t { 
-                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent; 
+                           [](uint8_t input_flags, float vx, float vy) -> uint8_t {
+                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent;
                             return input_flags; });
 
 } // namespace mcparticle_v2

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1918,6 +1918,8 @@ DECLARE_SOA_TABLE_VERSIONED(McCollisions_001, "AOD", "MCCOLLISION", 1, //! MC co
 using McCollisions = McCollisions_001;
 using McCollision = McCollisions::iterator;
 
+
+
 namespace mcparticle
 {
 DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);                                     //! MC collision of this particle
@@ -1984,34 +1986,56 @@ DECLARE_SOA_EXPRESSION_COLUMN(Y, y, float, //! Particle rapidity, conditionally 
                                                  (aod::mcparticle::e - aod::mcparticle::pz))));
 } // namespace mcparticle
 
+namespace mcparticle_v2
+{ 
+// for improved getters with protection against incorrect physical primary tagging
+// note: this has to be declared in a separate namespace so it does not conflict with existing 
+// derived data table declarations in O2Physics 
+DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
+                          [](uint8_t flags, float vx, float vy) -> bool { 
+                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent; 
+                            return (flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
+
+// avoid that the stored flags are provided unprotected via 
+// the getter '.flags': analysers will get the correct bit map transparently
+DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t); //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
+DECLARE_SOA_DYNAMIC_COLUMN(McParticleFlags, flags, //! protected against
+                           [](uint8_t input_flags, float vx, float vy) -> uint8_t { 
+                            if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent; 
+                            return input_flags; });
+
+}
+
 DECLARE_SOA_TABLE_FULL(StoredMcParticles_000, "McParticles", "AOD", "MCPARTICLE", //! MC particle table, version 000
                        o2::soa::Index<>, mcparticle::McCollisionId,
-                       mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
+                       mcparticle::PdgCode, mcparticle::StatusCode, mcparticle_v2::Flags,
                        mcparticle::Mother0Id, mcparticle::Mother1Id,
                        mcparticle::Daughter0Id, mcparticle::Daughter1Id, mcparticle::Weight,
                        mcparticle::Px, mcparticle::Py, mcparticle::Pz, mcparticle::E,
                        mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
                        mcparticle::PVector<mcparticle::Px, mcparticle::Py, mcparticle::Pz>,
-                       mcparticle::ProducedByGenerator<mcparticle::Flags>,
-                       mcparticle::FromBackgroundEvent<mcparticle::Flags>,
-                       mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
-                       mcparticle::GetHepMCStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
-                       mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
-                       mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
+                       mcparticle::ProducedByGenerator<mcparticle_v2::Flags>,
+                       mcparticle::FromBackgroundEvent<mcparticle_v2::Flags>,
+                       mcparticle::GetGenStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
+                       mcparticle::GetHepMCStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
+                       mcparticle::GetProcess<mcparticle_v2::Flags, mcparticle::StatusCode>,
+                       mcparticle_v2::McParticleFlags<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>,
+                       mcparticle_v2::IsPhysicalPrimary<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>);
 
 DECLARE_SOA_TABLE_FULL_VERSIONED(StoredMcParticles_001, "McParticles", "AOD", "MCPARTICLE", 1, //! MC particle table, version 001
                                  o2::soa::Index<>, mcparticle::McCollisionId,
-                                 mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
+                                 mcparticle::PdgCode, mcparticle::StatusCode, mcparticle_v2::Flags,
                                  mcparticle::MothersIds, mcparticle::DaughtersIdSlice, mcparticle::Weight,
                                  mcparticle::Px, mcparticle::Py, mcparticle::Pz, mcparticle::E,
                                  mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
                                  mcparticle::PVector<mcparticle::Px, mcparticle::Py, mcparticle::Pz>,
-                                 mcparticle::ProducedByGenerator<mcparticle::Flags>,
-                                 mcparticle::FromBackgroundEvent<mcparticle::Flags>,
-                                 mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
-                                 mcparticle::GetHepMCStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
-                                 mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
-                                 mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
+                                 mcparticle::ProducedByGenerator<mcparticle_v2::Flags>,
+                                 mcparticle::FromBackgroundEvent<mcparticle_v2::Flags>,
+                                 mcparticle::GetGenStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
+                                 mcparticle::GetHepMCStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
+                                 mcparticle::GetProcess<mcparticle_v2::Flags, mcparticle::StatusCode>,
+                                 mcparticle_v2::McParticleFlags<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>,
+                                 mcparticle_v2::IsPhysicalPrimary<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>);
 
 DECLARE_SOA_EXTENDED_TABLE(McParticles_000, StoredMcParticles_000, "EXMCPARTICLE", 0, //! Basic MC particle properties
                            mcparticle::Phi,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1996,7 +1996,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if par
 // avoid that the stored flags are provided unprotected via
 // the getter '.flags': analysers will get the correct bit map transparently
 DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);   //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
-DECLARE_SOA_DYNAMIC_COLUMN(McParticleFlags, flags, //! protected against
+DECLARE_SOA_DYNAMIC_COLUMN(ProtectedFlags, flags, //! protected against
                            [](uint8_t input_flags, float vx, float vy) -> uint8_t {
                             return o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy); });
 
@@ -2015,7 +2015,7 @@ DECLARE_SOA_TABLE_FULL(StoredMcParticles_000, "McParticles", "AOD", "MCPARTICLE"
                        mcparticle::GetGenStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
                        mcparticle::GetHepMCStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
                        mcparticle::GetProcess<mcparticle_v2::Flags, mcparticle::StatusCode>,
-                       mcparticle_v2::McParticleFlags<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>,
+                       mcparticle_v2::ProtectedFlags<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>,
                        mcparticle_v2::IsPhysicalPrimary<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>);
 
 DECLARE_SOA_TABLE_FULL_VERSIONED(StoredMcParticles_001, "McParticles", "AOD", "MCPARTICLE", 1, //! MC particle table, version 001
@@ -2030,7 +2030,7 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredMcParticles_001, "McParticles", "AOD", "M
                                  mcparticle::GetGenStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
                                  mcparticle::GetHepMCStatusCode<mcparticle_v2::Flags, mcparticle::StatusCode>,
                                  mcparticle::GetProcess<mcparticle_v2::Flags, mcparticle::StatusCode>,
-                                 mcparticle_v2::McParticleFlags<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>,
+                                 mcparticle_v2::ProtectedFlags<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>,
                                  mcparticle_v2::IsPhysicalPrimary<mcparticle_v2::Flags, mcparticle::Vx, mcparticle::Vy>);
 
 DECLARE_SOA_EXTENDED_TABLE(McParticles_000, StoredMcParticles_000, "EXMCPARTICLE", 0, //! Basic MC particle properties

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1918,8 +1918,6 @@ DECLARE_SOA_TABLE_VERSIONED(McCollisions_001, "AOD", "MCCOLLISION", 1, //! MC co
 using McCollisions = McCollisions_001;
 using McCollision = McCollisions::iterator;
 
-
-
 namespace mcparticle
 {
 DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);                                     //! MC collision of this particle
@@ -1987,24 +1985,24 @@ DECLARE_SOA_EXPRESSION_COLUMN(Y, y, float, //! Particle rapidity, conditionally 
 } // namespace mcparticle
 
 namespace mcparticle_v2
-{ 
+{
 // for improved getters with protection against incorrect physical primary tagging
-// note: this has to be declared in a separate namespace so it does not conflict with existing 
-// derived data table declarations in O2Physics 
+// note: this has to be declared in a separate namespace so it does not conflict with existing
+// derived data table declarations in O2Physics
 DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
-                          [](uint8_t flags, float vx, float vy) -> bool { 
+                           [](uint8_t flags, float vx, float vy) -> bool { 
                             if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent; 
                             return (flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
 
-// avoid that the stored flags are provided unprotected via 
+// avoid that the stored flags are provided unprotected via
 // the getter '.flags': analysers will get the correct bit map transparently
-DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t); //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
+DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);   //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
 DECLARE_SOA_DYNAMIC_COLUMN(McParticleFlags, flags, //! protected against
                            [](uint8_t input_flags, float vx, float vy) -> uint8_t { 
                             if(std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) return o2::aod::mcparticle::enums::FromBackgroundEvent; 
                             return input_flags; });
 
-}
+} // namespace mcparticle_v2
 
 DECLARE_SOA_TABLE_FULL(StoredMcParticles_000, "McParticles", "AOD", "MCPARTICLE", //! MC particle table, version 000
                        o2::soa::Index<>, mcparticle::McCollisionId,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1991,20 +1991,14 @@ namespace mcparticle_v2
 // derived data table declarations in O2Physics
 DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
                            [](uint8_t input_flags, float vx, float vy) -> bool {
-                            if((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)){
-                              return o2::aod::mcparticle::enums::FromBackgroundEvent;
-                            }
-                            return (input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
+                            return (o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy) & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
 
 // avoid that the stored flags are provided unprotected via
 // the getter '.flags': analysers will get the correct bit map transparently
 DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);   //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
 DECLARE_SOA_DYNAMIC_COLUMN(McParticleFlags, flags, //! protected against
                            [](uint8_t input_flags, float vx, float vy) -> uint8_t {
-                            if((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)){
-                              return o2::aod::mcparticle::enums::FromBackgroundEvent;
-                            }
-                            return input_flags; });
+                            return o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy); });
 
 } // namespace mcparticle_v2
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1990,15 +1990,13 @@ namespace mcparticle_v2
 // note: this has to be declared in a separate namespace so it does not conflict with existing
 // derived data table declarations in O2Physics
 DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
-                           [](uint8_t input_flags, float vx, float vy) -> bool {
-                            return (o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy) & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
+                           [](uint8_t input_flags, float vx, float vy) -> bool { return (o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy) & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
 
 // avoid that the stored flags are provided unprotected via
 // the getter '.flags': analysers will get the correct bit map transparently
-DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);   //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
+DECLARE_SOA_COLUMN(Flags, storedFlags, uint8_t);  //! ALICE specific flags, see MCParticleFlags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
 DECLARE_SOA_DYNAMIC_COLUMN(ProtectedFlags, flags, //! protected against
-                           [](uint8_t input_flags, float vx, float vy) -> uint8_t {
-                            return o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy); });
+                           [](uint8_t input_flags, float vx, float vy) -> uint8_t { return o2::aod::mcparticle::Tools::removeIsPhysicalPrimaryBit(input_flags, vx, vy); });
 
 } // namespace mcparticle_v2
 

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -164,15 +164,16 @@ namespace o2::aod::mcparticle
 constexpr float maxRadiusForPhysicalPrimary{5.f};
 
 struct Tools {
-// trivial helper to remove Physical Primary bit
-  static uint8_t removeIsPhysicalPrimaryBit(uint8_t input_flags, float vx, float vy){ 
-    if((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)){
+  // trivial helper to remove Physical Primary bit
+  static uint8_t removeIsPhysicalPrimaryBit(uint8_t input_flags, float vx, float vy)
+  {
+    if ((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)) {
       input_flags = input_flags & ~enums::PhysicalPrimary; // remove physical primary bit, keep others
     }
-    return input_flags; 
+    return input_flags;
   }
 };
-}
+} // namespace o2::aod::mcparticle
 
 namespace o2::aod::run2
 {

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -148,7 +148,8 @@ enum ForwardTrackTypeEnum : uint8_t {
 };
 } // namespace o2::aod::fwdtrack
 
-namespace o2::aod::mcparticle{
+namespace o2::aod::mcparticle
+{
 constexpr float maxRadiusForPhysicalPrimary{5.f};
 }
 

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -148,6 +148,10 @@ enum ForwardTrackTypeEnum : uint8_t {
 };
 } // namespace o2::aod::fwdtrack
 
+namespace o2::aod::mcparticle{
+constexpr float maxRadiusForPhysicalPrimary{5.f};
+}
+
 namespace o2::aod::mcparticle::enums
 {
 enum MCParticleFlags : uint8_t {

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -13,6 +13,7 @@
 
 #include "CommonConstants/LHCConstants.h"
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <array>
@@ -148,11 +149,6 @@ enum ForwardTrackTypeEnum : uint8_t {
 };
 } // namespace o2::aod::fwdtrack
 
-namespace o2::aod::mcparticle
-{
-constexpr float maxRadiusForPhysicalPrimary{5.f};
-}
-
 namespace o2::aod::mcparticle::enums
 {
 enum MCParticleFlags : uint8_t {
@@ -162,6 +158,21 @@ enum MCParticleFlags : uint8_t {
   FromOutOfBunchPileUpCollision = 0x8 // Particle from out-of-bunch pile up collision (currently Run 2 only)
 };
 } // namespace o2::aod::mcparticle::enums
+
+namespace o2::aod::mcparticle
+{
+constexpr float maxRadiusForPhysicalPrimary{5.f};
+
+struct Tools {
+// trivial helper to remove Physical Primary bit
+  static uint8_t removeIsPhysicalPrimaryBit(uint8_t input_flags, float vx, float vy){ 
+    if((std::hypot(vx, vy) > o2::aod::mcparticle::maxRadiusForPhysicalPrimary) && ((input_flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary)){
+      input_flags = input_flags & ~enums::PhysicalPrimary; // remove physical primary bit, keep others
+    }
+    return input_flags; 
+  }
+};
+}
 
 namespace o2::aod::run2
 {


### PR DESCRIPTION
This PR re-defines `mcparticle::IsPhysicalPrimary` to embed a safety feature in which particles that are (a) created beyond 5 cm from the beam axis and (b) marked as physical primary will be forcibly re-classified as non-primary. The new definition is provided in a separate namespace called `mcparticle_v2`, given that `mcparticle::IsPhysicalPrimary` is used multiple times in derived data. 

Further, this PR adds a layer of abstraction to `mcparticle::Flags` by declaring two new columns: one standard `mcparticle_v2::Flags` (getter: `storedFlags()`) and a dynamic `mcparticle_v2::McParticleFlags` (getter: `flags()`), with the idea being that `Flags` are the ones read in, but the use of the `flags` getter is captured by the dynamic column, which explicitly includes a protection against the physical primary misclassification. This will mean any derived data creation task that directly asks for `flags()` will get a preprocessed `uint8_t` that embeds the correction, meaning a simple re-creation of derived data without any further derived data model change - i.e. even retaining the old `mcparticle::IsPhysicalPrimary` in the derived tables - should be enough to embed the fix. 

Note that this PR is only a draft for now: I'll still test it thoroughly, but wanted to share it here already for discussion. Tagging @jackal1-66, but also @aalkin (with whom I discussed this briefly today, thanks again!) as well as @alcaliva @catalinristea @dsekihat: please also let me know if you have any comments or suggestions. Thank you! 