### PR TITLE
Fix update of the magnetic field

### DIFF
--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -102,6 +102,7 @@ int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPObject* g
     } else {
       LOG(info) << "Destroying existing B field instance";
       delete TGeoGlobalMagField::Instance();
+      Instance()->mField = nullptr;
     }
   }
   auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());
@@ -112,6 +113,7 @@ int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPObject* g
     LOG(info) << "Access field via TGeoGlobalMagField::Instance()->Field(xyz,bxyz) or via";
     LOG(info) << "auto o2field = static_cast<o2::field::MagneticField*>( TGeoGlobalMagField::Instance()->GetField() )";
   }
+  Instance()->updateField();
   return 0;
 }
 
@@ -129,6 +131,7 @@ int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPMagField*
     } else {
       LOG(info) << "Destroying existing B field instance";
       delete TGeoGlobalMagField::Instance();
+      Instance()->mField = nullptr;
     }
   }
   auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());
@@ -139,6 +142,7 @@ int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPMagField*
     LOG(info) << "Access field via TGeoGlobalMagField::Instance()->Field(xyz,bxyz) or via";
     LOG(info) << "auto o2field = static_cast<o2::field::MagneticField*>( TGeoGlobalMagField::Instance()->GetField() )";
   }
+  Instance()->updateField();
   return 0;
 }
 

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -103,6 +103,7 @@ int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPObject* g
       LOG(info) << "Destroying existing B field instance";
       delete TGeoGlobalMagField::Instance();
       Instance()->mField = nullptr;
+      Instance()->mFieldFast = nullptr;
     }
   }
   auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());
@@ -132,6 +133,7 @@ int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPMagField*
       LOG(info) << "Destroying existing B field instance";
       delete TGeoGlobalMagField::Instance();
       Instance()->mField = nullptr;
+      Instance()->mFieldFast = nullptr;
     }
   }
   auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());


### PR DESCRIPTION
When using the standard CCDB loader, the magnetic field is initialised correctly.

However, when processing a second file from a different run, the `TGeoGlobalMagField` instance is deleted (https://github.com/AliceO2Group/AliceO2/blob/10eb61ecb63e4a906bd3ed57f9ec609dd21a856a/Detectors/Base/src/Propagator.cxx#L131), while the corresponding pointer `mField` is not reset (https://github.com/AliceO2Group/AliceO2/blob/10eb61ecb63e4a906bd3ed57f9ec609dd21a856a/Detectors/Base/src/Propagator.cxx#L51).

As a result, it becomes a dangling pointer and can return completely nonsensical magnetic field values (e.g. around 2e+22). The pointer therefore needs to be refreshed by calling `updateField`. Furthermore, `updateField` only updates the magnetic field if the pointer `mField` is a nullptr. If `mField` exists but points to invalid memory, `updateField` does not update the magnetic field, so this logic also had to be fixed.

Thank you @fchinu for reporting this bug!

@ddobrigk @dsekihat for your information!