### PR TITLE
move OT barrel service 'disk' z 132 to 142 cm (space for readout cards)

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKServices.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/TRKServices.cxx
@@ -922,7 +922,7 @@ void TRKServices::createOTServicesPeacock(TGeoVolume* motherVolume)
   // geometry of service "disk" for OT barrel
   double rMinOTbarrelServices = 45.0; // cm, radius of first OT barrel layer
   double rMaxOTbarrelServices = 78.0; // cm, radius of last OT barrel layer
-  double zOTbarrelServices = 132.0;   // cm, approximate position of OT services in z
+  double zOTbarrelServices = 142.0;   // cm, approximate position of OT services in z
 
   // geometry of service "tubes" for OT barrel
   float rMinOuterBarrelTubeServices = rMaxOTbarrelServices;       // cm, IA, May 11, 2026: temporary radius (?)


### PR DESCRIPTION
Readout cards will be plugged at the ends of OT staves, card `z` length is ~12 cm => need to move existing "averaged cable services" in z to allocate enough space.

<img width="2156" height="702" alt="image" src="https://github.com/user-attachments/assets/e723b281-0d16-4725-8e57-12b49dedfdb0" />
