### PR TITLE
DPL Analysis: remove std::set from analysis task

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1762,6 +1762,12 @@ class Table
 
   using columns_t = decltype(getColumns<ref, Ts...>());
 
+  static constexpr auto column_hashes = []<typename... C>(framework::pack<C...>) consteval {
+    auto hashes = []<typename... CC>() consteval { return std::array{CC::hash...}; }.template operator()<C...>();
+    std::ranges::sort(hashes);
+    return hashes;
+  }(columns_t{});
+
   using persistent_columns_t = decltype([]<typename... C>(framework::pack<C...>&&) -> framework::selected_pack<soa::is_persistent_column_t, C...> {}(columns_t{}));
   using column_types = decltype([]<typename... C>(framework::pack<C...>) -> framework::pack<typename C::type...> {}(persistent_columns_t{}));
 
@@ -1944,11 +1950,6 @@ class Table
   using unfiltered_iterator = iterator;
   using const_iterator = iterator;
   using unfiltered_const_iterator = unfiltered_iterator;
-
-  static constexpr auto hashes()
-  {
-    return []<typename... C>(framework::pack<C...>) { return std::set{{C::hash...}}; }(columns_t{});
-  }
 
   Table(o2::soa::ArrowTableRef tableRef)
     : mArrowTableRef(tableRef),

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1763,7 +1763,7 @@ class Table
   using columns_t = decltype(getColumns<ref, Ts...>());
 
   static constexpr auto column_hashes = []<typename... C>(framework::pack<C...>) consteval {
-    auto hashes = []<typename... CC>() consteval { return std::array{CC::hash...}; }.template operator()<C...>();
+    auto hashes = std::array{C::hash...};
     std::ranges::sort(hashes);
     return hashes;
   }(columns_t{});

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -953,7 +953,7 @@ auto getTableFromFilter(soa::is_not_filtered_table auto const& table, soa::Selec
   return std::make_unique<o2::soa::Filtered<std::decay_t<decltype(table)>>>(std::vector{table.asArrowTableRef()}, std::forward<soa::SelectionVector>(selection));
 }
 
-void initializePartitionCaches(const std::span<const uint32_t>& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter);
+void initializePartitionCaches(std::span<const uint32_t> hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter);
 
 /// Partition ties directly to the argument type
 /// in a case with several origins in subscriptions it will get the correct input, as the type contains the origin
@@ -975,7 +975,7 @@ struct Partition {
     setTable(table);
   }
 
-  void intializeCaches(std::span<const uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema)
+  void intializeCaches(std::span<const uint32_t> hashes, std::shared_ptr<arrow::Schema> const& schema)
   {
     initializePartitionCaches(hashes, schema, filter, tree, gfilter);
   }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -953,7 +953,7 @@ auto getTableFromFilter(soa::is_not_filtered_table auto const& table, soa::Selec
   return std::make_unique<o2::soa::Filtered<std::decay_t<decltype(table)>>>(std::vector{table.asArrowTableRef()}, std::forward<soa::SelectionVector>(selection));
 }
 
-void initializePartitionCaches(std::set<uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter);
+void initializePartitionCaches(const std::span<const uint32_t>& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter);
 
 /// Partition ties directly to the argument type
 /// in a case with several origins in subscriptions it will get the correct input, as the type contains the origin
@@ -975,14 +975,14 @@ struct Partition {
     setTable(table);
   }
 
-  void intializeCaches(std::set<uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema)
+  void intializeCaches(std::span<const uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema)
   {
     initializePartitionCaches(hashes, schema, filter, tree, gfilter);
   }
 
   void bindTable(T const& table)
   {
-    intializeCaches(T::table_t::hashes(), table.asArrowTableRef()->schema());
+    intializeCaches(T::table_t::column_hashes, table.asArrowTableRef()->schema());
     if (dataframeChanged) {
       mFiltered = getTableFromFilter(table, soa::selectionToVector(framework::expressions::createSelection(table.asArrowTable(), gfilter)));
       dataframeChanged = false;

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -126,7 +126,7 @@ struct AnalysisDataProcessorBuilder {
   static void addExpression(int ai, uint32_t hash, std::vector<ExpressionInfo>& eInfos)
   {
     auto fields = soa::createFieldsFromColumns(typename std::decay_t<A>::persistent_columns_t{});
-    eInfos.emplace_back(ai, hash, std::decay_t<A>::hashes(), std::make_shared<arrow::Schema>(fields));
+    eInfos.emplace_back(ai, hash, std::span{std::decay_t<A>::column_hashes}, std::make_shared<arrow::Schema>(fields));
   }
 
   template <soa::is_iterator A>

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -681,7 +681,7 @@ using Operations = std::vector<ColumnOperationSpec>;
 Operations createOperations(Filter const& expression);
 
 /// Function to check compatibility of a given arrow schema with operation sequence
-bool isTableCompatible(const std::span<const uint32_t>& hashes, Operations const& specs);
+bool isTableCompatible(std::span<const uint32_t> hashes, Operations const& specs);
 /// Function to create gandiva expression tree from operation sequence
 gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
                                       gandiva::SchemaPtr const& Schema);

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -39,7 +39,6 @@ class Projector;
 #include <variant>
 #include <string>
 #include <memory>
-#include <set>
 #include <stack>
 namespace gandiva
 {
@@ -49,7 +48,8 @@ using FilterPtr = std::shared_ptr<gandiva::Filter>;
 
 using atype = arrow::Type;
 struct ExpressionInfo {
-  ExpressionInfo(int ai, size_t hash, std::set<uint32_t>&& hs, gandiva::SchemaPtr sc)
+  template <typename T>
+  ExpressionInfo(int ai, size_t hash, T hs, gandiva::SchemaPtr sc)
     : argumentIndex(ai),
       processHash(hash),
       hashes(hs),
@@ -58,7 +58,7 @@ struct ExpressionInfo {
   }
   int argumentIndex;
   size_t processHash;
-  std::set<uint32_t> hashes;
+  std::span<const uint32_t> hashes;
   gandiva::SchemaPtr schema;
   gandiva::NodePtr tree = nullptr;
   gandiva::FilterPtr filter = nullptr;
@@ -681,7 +681,7 @@ using Operations = std::vector<ColumnOperationSpec>;
 Operations createOperations(Filter const& expression);
 
 /// Function to check compatibility of a given arrow schema with operation sequence
-bool isTableCompatible(std::set<uint32_t> const& hashes, Operations const& specs);
+bool isTableCompatible(const std::span<const uint32_t>& hashes, Operations const& specs);
 /// Function to create gandiva expression tree from operation sequence
 gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
                                       gandiva::SchemaPtr const& Schema);

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -155,7 +155,7 @@ std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const&
   return arrow::Table::Make(newSchema, arrays);
 }
 
-void initializePartitionCaches(std::span<const uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter)
+void initializePartitionCaches(std::span<const uint32_t> hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter)
 {
   if (tree == nullptr) {
     expressions::Operations ops = createOperations(filter);

--- a/Framework/Core/src/AnalysisHelpers.cxx
+++ b/Framework/Core/src/AnalysisHelpers.cxx
@@ -155,7 +155,7 @@ std::shared_ptr<arrow::Table> spawnerHelper(std::shared_ptr<arrow::Table> const&
   return arrow::Table::Make(newSchema, arrays);
 }
 
-void initializePartitionCaches(std::set<uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter)
+void initializePartitionCaches(std::span<const uint32_t> const& hashes, std::shared_ptr<arrow::Schema> const& schema, expressions::Filter const& filter, gandiva::NodePtr& tree, gandiva::FilterPtr& gfilter)
 {
   if (tree == nullptr) {
     expressions::Operations ops = createOperations(filter);

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -783,11 +783,11 @@ bool isTableCompatible(std::span<const uint32_t> hashes, Operations const& specs
   auto [ret, last] = std::ranges::unique(opHashes);
   opHashes.erase(ret, last);
   bool contains = true;
-  std::ranges::for_each(opHashes, [hashes, &contains](auto const& hash){
-    contains = contains && std::ranges::any_of(hashes, [hash](auto const& h){
-        return h == hash;
-      });
-    });
+  std::ranges::for_each(opHashes, [hashes, &contains](auto const& hash) {
+    contains = contains && std::ranges::any_of(hashes, [hash](auto const& h) {
+                 return h == hash;
+               });
+  });
   return contains;
 }
 

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -768,7 +768,7 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
   return tree;
 }
 
-bool isTableCompatible(std::span<const uint32_t> const& hashes, Operations const& specs)
+bool isTableCompatible(std::span<const uint32_t> hashes, Operations const& specs)
 {
   std::vector<uint32_t> opHashes;
   for (auto const& spec : specs) {
@@ -779,8 +779,16 @@ bool isTableCompatible(std::span<const uint32_t> const& hashes, Operations const
       opHashes.emplace_back(spec.right.hash);
     }
   }
-
-  return std::ranges::includes(hashes, opHashes);
+  std::ranges::sort(opHashes);
+  auto [ret, last] = std::ranges::unique(opHashes);
+  opHashes.erase(ret, last);
+  bool contains = true;
+  std::ranges::for_each(opHashes, [hashes, &contains](auto const& hash){
+    contains = contains && std::ranges::any_of(hashes, [hash](auto const& h){
+        return h == hash;
+      });
+    });
+  return contains;
 }
 
 void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos)

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -768,20 +768,19 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
   return tree;
 }
 
-bool isTableCompatible(std::set<uint32_t> const& hashes, Operations const& specs)
+bool isTableCompatible(std::span<const uint32_t> const& hashes, Operations const& specs)
 {
-  std::set<uint32_t> opHashes;
+  std::vector<uint32_t> opHashes;
   for (auto const& spec : specs) {
     if (spec.left.datum.index() == 3) {
-      opHashes.insert(spec.left.hash);
+      opHashes.emplace_back(spec.left.hash);
     }
     if (spec.right.datum.index() == 3) {
-      opHashes.insert(spec.right.hash);
+      opHashes.emplace_back(spec.right.hash);
     }
   }
 
-  return std::includes(hashes.begin(), hashes.end(),
-                       opHashes.begin(), opHashes.end());
+  return std::ranges::includes(hashes, opHashes);
 }
 
 void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos)


### PR DESCRIPTION
Matching filters to process function and Partition arguments is done through matching hashes that identify individual columns. This change removes runtime std::set creation in favor of a static array of hashes that is viewed as a span by the the compatibility check function.