### PR TITLE
GeometryManager::getSensID supports up to 2^17 sensors for DetID>FOCAL

### DIFF
--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -70,7 +70,7 @@ class GeometryManager : public TObject
   static int getSensID(o2::detectors::DetID detid, int sensid)
   {
     /// compose combined detector+sensor ID for sensitive volumes
-    return (detid << sDetOffset) | (sensid & sSensorMask);
+    return detid <= o2::detectors::DetID::FOC ? ((detid << sDetOffset) | (sensid & sSensorMask)) : ((detid << sDetOffsetLarge) | (sensid & sSensorMaskLarge));
   }
 
   /// Default destructor
@@ -140,8 +140,9 @@ class GeometryManager : public TObject
  private:
   /// sensitive volume identifier composed from (det_ID<<sDetOffset)|(sensid&sSensorMask)
   static constexpr UInt_t sDetOffset = 15; /// detector identifier will start from this bit
-  static constexpr UInt_t sSensorMask =
-    (0x1 << sDetOffset) - 1; /// mask=max sensitive volumes allowed per detector (0xffff)
+  static constexpr UInt_t sSensorMask = (0x1 << sDetOffset) - 1;           /// mask=max sensitive volumes allowed per detector (32767)
+  static constexpr UInt_t sDetOffsetLarge = 17;                            /// detector identifier will start from this bit for detectors after the FOC
+  static constexpr UInt_t sSensorMaskLarge = (0x1 << sDetOffsetLarge) - 1; /// mask=max sensitive volumes allowed per detector (131071)
   static std::mutex sTGMutex;
 
   ClassDefOverride(GeometryManager, 0); // Manager of geometry information for alignment


### PR DESCRIPTION
For detectors up to Focal inclusively only 1^15 chips per detector can be referred by this method (for the backward compatibility with existing geometry files).