### PR TITLE
tpc-time-series equiped with internal readers and HBFUtilsInitializer

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -231,7 +231,9 @@ o2_add_executable(merge-integrate-cluster-workflow
 o2_add_executable(time-series-workflow
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-time-series.cxx
-                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow
+                                        O2::GlobalTrackingWorkflowReaders
+                                        O2::GlobalTrackingWorkflowHelpers)
 
 o2_add_executable(scaler-workflow
                   COMPONENT_NAME tpc

--- a/Detectors/TPC/workflow/src/tpc-time-series.cxx
+++ b/Detectors/TPC/workflow/src/tpc-time-series.cxx
@@ -14,12 +14,25 @@
 
 #include "TPCWorkflow/TPCTimeSeriesSpec.h"
 #include "TPCWorkflow/TPCTimeSeriesWriterSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DataFormatsITSMFT/DPLAlpideParamInitializer.h"
 #include "Framework/ConfigParamSpec.h"
 #include "GPUDebugStreamer.h"
 
 using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
@@ -27,10 +40,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"disable-root-output", VariantType::Bool, false, {"disable root-files output writers"}},
+    {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
     {"enable-unbinned-root-output", VariantType::Bool, false, {"writing out unbinned track data"}},
-    {"track-sources", VariantType::String, std::string{o2::dataformats::GlobalTrackID::ALL}, {"comma-separated list of sources to use"}},
+    {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
     {"material-type", VariantType::Int, 2, {"Type for the material budget during track propagation: 0=None, 1=Geo, 2=LUT"}}};
-
+  o2::itsmft::DPLAlpideParamInitializer::addITSConfigOption(options);
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
 
@@ -42,11 +57,28 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   const bool disableWriter = config.options().get<bool>("disable-root-output");
   const bool enableUnbinnedWriter = config.options().get<bool>("enable-unbinned-root-output");
-  auto src = o2::dataformats::GlobalTrackID::getSourcesMask(config.options().get<std::string>("track-sources"));
+  GID::mask_t allowedSources = GID::getSourcesMask("ITS,TPC,ITS-TPC,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF,FT0");
+  auto srcTrc = allowedSources & GID::getSourcesMask(config.options().get<std::string>("track-sources"));
+  o2::dataformats::GlobalTrackID::mask_t srcCls = GID::getSourcesMask("TPC");
+  if (GID::includesDet(DetID::ITS, srcTrc)) {
+    srcCls |= GID::getSourcesMask("ITS");
+  }
+  if (GID::includesDet(DetID::TRD, srcTrc)) {
+    srcCls |= GID::getSourcesMask("TRD");
+  }
+  if (GID::includesDet(DetID::TOF, srcTrc)) {
+    srcCls |= GID::getSourcesMask("TOF");
+  }
+
   auto materialType = static_cast<o2::base::Propagator::MatCorrType>(config.options().get<int>("material-type"));
-  workflow.emplace_back(o2::tpc::getTPCTimeSeriesSpec(disableWriter, materialType, enableUnbinnedWriter, src));
+
+  o2::globaltracking::InputHelper::addInputSpecs(config, workflow, srcCls, srcTrc, srcTrc, false);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(config, workflow, false); // P-vertex is always needed
+
+  workflow.emplace_back(o2::tpc::getTPCTimeSeriesSpec(disableWriter, materialType, enableUnbinnedWriter, srcTrc));
   if (!disableWriter) {
     workflow.emplace_back(o2::tpc::getTPCTimeSeriesWriterSpec());
   }
+  o2::raw::HBFUtilsInitializer hbfIni(config, workflow);
   return workflow;
 }

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -23,7 +23,7 @@ fi
 if [[ "${CALIB_TPC_SCDCALIB_SENDTRKDATA:-}" == "1" ]]; then ENABLE_TRKDATA_OUTPUT="--send-track-data"; else ENABLE_TRKDATA_OUTPUT=""; fi
 
 # specific calibration workflows
-if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_W o2-tpc-scdcalib-interpolation-workflow "--vtx-sources $VERTEX_TRACK_MATCHING_SOURCES --tracking-sources $TRACK_SOURCES ${CALIB_TPC_SCDCALIB_SLOTLENGTH:+"--sec-per-slot $CALIB_TPC_SCDCALIB_SLOTLENGTH"} $ENABLE_TRKDATA_OUTPUT $DISABLE_ROOT_OUTPUT --disable-root-input --pipeline $(get_N tpc-track-interpolation TPC REST)"; fi
+if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_W o2-tpc-scdcalib-interpolation-workflow "--vtx-sources $VERTEX_TRACK_MATCHING_SOURCES --tracking-sources $TRACK_SOURCES ${CALIB_TPC_SCDCALIB_SLOTLENGTH:+"--sec-per-slot $CALIB_TPC_SCDCALIB_SLOTLENGTH"} $ENABLE_TRKDATA_OUTPUT $DISABLE_ROOT_OUTPUT $DISABLE_ROOT_INPUT --pipeline $(get_N tpc-track-interpolation TPC REST)"; fi
 if [[ $CALIB_TPC_TIMEGAIN == 1 ]]; then
   : ${SCALEEVENTS_TPC_TIMEGAIN:=40}
   : ${SCALETRACKS_TPC_TIMEGAIN:=1000}
@@ -77,7 +77,7 @@ if [[ $CALIB_ASYNC_EXTRACTTIMESERIES == 1 ]] ; then
   CONFIG_TPCTIMESERIES+=" --min-cluster ${TPCTIMESERIES_MIN_CLUSTER}"
   CONFIG_TPCTIMESERIES+=" --max-tgl ${TPCTIMESERIES_MAX_TGL}"
   CONFIG_TPCTIMESERIES+=" --mult-max ${TPCTIMESERIES_MULT_MAX}"
-  add_W o2-tpc-time-series-workflow "${CONFIG_TPCTIMESERIES}"
+  add_W o2-tpc-time-series-workflow "$DISABLE_ROOT_INPUT ${CONFIG_TPCTIMESERIES}"
 fi
 
 # output-proxy for aggregator


### PR DESCRIPTION
@miranov25 @matthias-kleiner 

The input cluster sources will be deduced from the track source. The InputHelper will be invoked if --disable-root-inputs option is absent. Possibility to prepend the workflow with the rate/maxTF limiter in standalone mode (i.e. w/o --disable-root-inputs). E.g

GLOSET="--shm-segment-size 10000000000  --timeframes-rate-limit 2 --timeframes-rate-limit-ipcid 1234 --hbfutils-config o2_tfidinfo.root,upstream" o2-reader-driver-workflow --max-tf ${MAXTF:--1}  $GLOSET | \
o2-tpc-time-series-workflow $GLOSET --enable-unbinned-root-output   -b --run

