### PR TITLE
Add riscv64 support 

### DIFF
--- a/Framework/Foundation/3rdparty/x9/x9.c
+++ b/Framework/Foundation/3rdparty/x9/x9.c
@@ -38,6 +38,7 @@
 #if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h> /* _mm_pause */
 #elif defined(__aarch64__)
+#elif defined(__riscv)
 #else
 #error Not supported architecture
 #endif
@@ -370,6 +371,8 @@ void x9_read_from_inbox_spin(x9_inbox* const inbox,
     _mm_pause();
 #elif defined(__aarch64__)
     __asm__ __volatile__ ("yield");
+#elif defined(__riscv)
+    __asm__ __volatile__ (".4byte 0x0100000F"); /* PAUSE hint (Zihintpause); NOP if unsupported */
 #else
 #error Not supported architecture
 #endif

--- a/Utilities/rANS/include/rANS/internal/common/defines.h
+++ b/Utilities/rANS/include/rANS/internal/common/defines.h
@@ -40,7 +40,7 @@
 #error RANS_FMA cannot be directly set
 #endif
 
-#if (defined(__x86_64__) || defined(__aarch64__))
+#if (defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64))
 #define RANS_COMPAT
 #if defined(__SIZEOF_INT128__)
 #define RANS_SINGLE_STREAM


### PR DESCRIPTION
x9.c had an arch guard that only knew x86 and aarch64. I added a riscv64 branch using the PAUSE hint (raw .4byte, works on any march, no-op if unsupported).

rANS defines.h had the same problem in its coder detection, hitting an #error on riscv64. Added it so the scalar Compat coder gets picked. No SIMD.

Both build and run fine on riscv64 (Ubuntu, GCC 15).

More infos in the issue: https://github.com/AliceO2Group/AliceO2/issues/15664