### PR TITLE
DPL Analysis: Fix DECLARE_SOA_CCDB_COLUMN_FULL's default construcor w…

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2384,7 +2384,7 @@ consteval static std::string_view namespace_prefix()
     {                                                                                                             \
     }                                                                                                             \
                                                                                                                   \
-    _Name_() = default;                                                                                           \
+    _Name_() : o2::soa::Column<int64_t[3], _Name_>() {}                                                           \
     _Name_(_Name_ const& other) = default;                                                                        \
     _Name_& operator=(_Name_ const& other) = default;                                                             \
                                                                                                                   \


### PR DESCRIPTION
…hich was firing `cppcoreguidelines-pro-type-member-init` in O2Physics code when used.
The concrete error was: `Constructor does not initialize these bases: Column`