### PR TITLE
Change return type to value_T in getCurvature

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -548,7 +548,7 @@ GPUdi() void TrackParametrization<value_T>::getLineParams(o2::math_utils::Interv
 template <typename value_T>
 GPUdi() auto TrackParametrization<value_T>::getCurvature(value_t b) const -> value_t
 {
-  return mAbsCharge ? mP[kQ2Pt] * b * o2::constants::math::B2C : 0.;
+  return mAbsCharge ? mP[kQ2Pt] * b * o2::constants::math::B2C : value_T(0);
 }
 
 //____________________________________________________________


### PR DESCRIPTION
This causes all calls where getCurvature is called in an expression to be promoted to double even if TrackParam is float