### PR TITLE
Use field-free media for the L3 magnet and the compensator

### DIFF
--- a/Detectors/Passive/data/simcuts_COMP.dat
+++ b/Detectors/Passive/data/simcuts_COMP.dat
@@ -27,6 +27,8 @@ COMP 50 1.e-3 1.e-2 1.e-3 1.e-3
 *       GAM   ELEC  NHAD  CHAD  MUON  EBREM MUHAB  EDEL  MUDEL MUPA ANNI BREM COMP DCAY DRAY HADR LOSS MULS PAIR PHOT RAYL STRA
 *COMP 17 1.e-3 1.e-3 1.e-3 1.e-3 1.e-3 1.e-3 1.e-3 -1.    -1.   -1.  -1    -1    -1   -1   -1   -1   -1   -1   -1   -1   -1   -1
 COMP 17 1.e-1 1.e-1 1.e0 1.e0 1.e-2 1.e-1 1.e-1 -1.    -1.   -1.  -1    -1    -1   -1   -1   -1   -1   -1   -1   -1   -1   -1
+* field-free twin of the above, same cuts
+COMP 18 1.e-1 1.e-1 1.e0 1.e0 1.e-2 1.e-1 1.e-1 -1.    -1.   -1.  -1    -1    -1   -1   -1   -1   -1   -1   -1   -1   -1   -1
 * shielded
 COMP 37 1.e-3 1.e-2 1.e-3 1.e-3
 * very shielded

--- a/Detectors/Passive/src/Compensator.cxx
+++ b/Detectors/Passive/src/Compensator.cxx
@@ -75,8 +75,10 @@ void Compensator::createMaterials()
 
   // --- Define the various materials + tracking media for GEANT ---
   //     Aluminum
+  //     ALU_C0 builds the coil supports only, and every one of them is placed
+  //     clear of the field, so they are tracked without one.
   matmgr.Material("COMP", 9, "ALUMINIUM0", 26.98, 13., 2.7, 8.9, 37.2);
-  matmgr.Medium("COMP", 9, "ALU_C0", 9, 0, isxfld1, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("COMP", 9, "ALU_C0", 9, 0, isxfld2, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   matmgr.Material("COMP", 29, "ALUMINIUM1", 26.98, 13., 2.7, 8.9, 37.2);
   matmgr.Medium("COMP", 29, "ALU_C1", 29, 0, isxfld1, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   matmgr.Material("COMP", 49, "ALUMINIUM2", 26.98, 13., 2.7, 8.9, 37.2);
@@ -95,6 +97,12 @@ void Compensator::createMaterials()
   matmgr.Material("COMP", 37, "COPPER1", 63.55, 29., 8.96, 1.43, 15.1);
   matmgr.Material("COMP", 57, "COPPER2", 63.55, 29., 8.96, 1.43, 15.1);
   matmgr.Medium("COMP", 17, "Cu_C0", 17, 0, isxfld1, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  // The horizontal coils are the only copper that stays clear of the field. The
+  // vertical ones reach the beam axis, where the machine compensators are, so
+  // they keep Cu_C0. This medium needs its own line in simcuts_COMP.dat: cuts
+  // are assigned per material, so without one both media fall back to the
+  // default and the copper loses the cuts Cu_C0 relies on.
+  matmgr.Medium("COMP", 18, "Cu_C0_NF", 17, 0, isxfld2, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   matmgr.Medium("COMP", 37, "Cu_C1", 37, 0, isxfld1, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   matmgr.Medium("COMP", 57, "Cu_C2", 57, 0, isxfld1, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 }
@@ -121,6 +129,7 @@ TGeoVolume* Compensator::createMagnetYoke()
   auto& matmgr = o2::base::MaterialManager::Instance();
   auto kMedAlu = matmgr.getTGeoMedium("COMP_ALU_C0");
   auto kMedCooper = matmgr.getTGeoMedium("COMP_Cu_C0");
+  auto kMedCooperNF = matmgr.getTGeoMedium("COMP_Cu_C0_NF");
   auto kMedIron = matmgr.getTGeoMedium("COMP_FE_C0");
 
   // we use a special optimized tracking medium for the inner part
@@ -170,7 +179,7 @@ TGeoVolume* Compensator::createMagnetYoke()
   }
 
   // Make the coils:
-  TGeoVolume* voCoilH = gGeoManager->MakeBox("voCoilH", kMedCooper, 12.64 / 2.0, 21.46 / 2.0, 310.5 / 2.0);
+  TGeoVolume* voCoilH = gGeoManager->MakeBox("voCoilH", kMedCooperNF, 12.64 / 2.0, 21.46 / 2.0, 310.5 / 2.0);
   TGeoVolume* voCoilV = gGeoManager->MakeBox("voCoilV", kMedCooper, 12.64 / 2.0, 35.80 / 2.0, 26.9 / 2.0);
 
   // Make the top coil supports:

--- a/Detectors/Passive/src/Magnet.cxx
+++ b/Detectors/Passive/src/Magnet.cxx
@@ -66,6 +66,11 @@ void Magnet::createMaterials()
   Int_t isxfld = 2.;
   Float_t sxmgmx = 10.;
   o2::base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
+
+  // The coils, the yoke and the crown sit outside the region the field map
+  // covers, so they are tracked without a field. The doors and the plugs are
+  // the exception: they reach the beam axis inside the solenoid and keep it.
+  Int_t isxfldNoField = 0;
   Float_t epsil, stmin, deemax, tmaxfd, stemax;
 
   // --- Define the various materials for GEANT ---
@@ -117,19 +122,20 @@ void Magnet::createMaterials()
   matmgr.Medium("MAG", 30, "FE_C1", 30, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   //     ALUMINUM
-  matmgr.Medium("MAG", 9, "ALU_C0", 9, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
-  matmgr.Medium("MAG", 29, "ALU_C1", 29, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("MAG", 9, "ALU_C0", 9, 0, isxfldNoField, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("MAG", 29, "ALU_C1", 29, 0, isxfldNoField, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   //     AIR
   matmgr.Medium("MAG", 15, "AIR_C0", 15, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
-  matmgr.Medium("MAG", 35, "AIR_C1", 35, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("MAG", 35, "AIR_C1", 35, 0, isxfldNoField, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   //    Steel
   matmgr.Medium("MAG", 19, "ST_C0", 19, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   matmgr.Medium("MAG", 39, "ST_C1", 39, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("MAG", 49, "ST_C1_NF", 39, 0, isxfldNoField, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   matmgr.Medium("MAG", 59, "ST_C3", 59, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   //    WATER
-  matmgr.Medium("MAG", 16, "WATER", 16, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Medium("MAG", 16, "WATER", 16, 0, isxfldNoField, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 }
 
 void Magnet::ConstructGeometry()
@@ -183,6 +189,7 @@ void Magnet::ConstructGeometry()
   auto medAlu = matmgr.getTGeoMedium("MAG_ALU_C1");
   auto medAluI = matmgr.getTGeoMedium("MAG_ALU_C0");
   auto medSteel = matmgr.getTGeoMedium("MAG_ST_C1");
+  auto medSteelNF = matmgr.getTGeoMedium("MAG_ST_C1_NF");
   auto medWater = matmgr.getTGeoMedium("MAG_WATER");
   //
   // Offset between LHC and LEP axis
@@ -282,7 +289,7 @@ void Magnet::ConstructGeometry()
   shYoke->DefineSection(0, -kLYoke, kRYokeInner, kRYokeOuter);
   shYoke->DefineSection(1, +kLYoke, kRYokeInner, kRYokeOuter);
   //
-  TGeoVolume* voYoke = new TGeoVolume("L3YO", shYoke, medSteel);
+  TGeoVolume* voYoke = new TGeoVolume("L3YO", shYoke, medSteelNF);
   voBMother->AddNode(voYoke, 1, new TGeoTranslation(0., 0., 0.));
 
   //
@@ -294,7 +301,7 @@ void Magnet::ConstructGeometry()
   shCrown->DefineSection(2, kLCrown2, kRCrownInner, kRCrownOuter);
   shCrown->DefineSection(3, kLCrown3, kRCrownInner, kRCrownOuter);
   //
-  TGeoVolume* voCrown = new TGeoVolume("L3CR", shCrown, medSteel);
+  TGeoVolume* voCrown = new TGeoVolume("L3CR", shCrown, medSteelNF);
 
   //
   // Door including "Plug"


### PR DESCRIPTION
This changes the media of volumes that sit outside the field map, diagnosed with the geometry doctor. 17 volumes were built from media that declare a magnetic field, whereas the field there is always zero. This is now fixed by switching five media in place, and by giving a field-free variant to the three volumes whose medium is shared with volumes that do reach the field.

The new copper medium also needs its own line in simcuts_COMP.dat, because Geant4 assigns cuts per material and it would otherwise take the default ones.

https://github.com/AliceO2Group/AliceO2/pull/15683