### PR TITLE
Initial setup for G4 FastSim hooks

### DIFF
--- a/Common/SimConfig/include/SimConfig/G4Params.h
+++ b/Common/SimConfig/include/SimConfig/G4Params.h
@@ -54,6 +54,12 @@ struct G4Params : public o2::conf::ConfigurableParamHelper<G4Params> {
 
   bool g4scoring = false;
   bool g4fluenceweight = false;
+
+  // Fast simulation. Empty fastSimModels (the default) disables the feature
+  // entirely; see Detectors/gconfig/include/SimSetup/G4FastSimulation.h.
+  std::string fastSimModels = "";   // comma-separated model names to activate
+  std::string fastSimRegions = "";  // tracking media the models apply to (wildcards allowed)
+  float fastSimMinEnergy = 1.f;     // GeV; below this the detailed transport runs
   O2ParamDef(G4Params, "G4");
 };
 

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -53,6 +53,7 @@ add_subdirectory(ForwardAlign)
 
 
 if(BUILD_SIMULATION)
+  add_subdirectory(FastSim)
   add_subdirectory(gconfig)
   o2_data_file(COPY gconfig DESTINATION Detectors)
 endif()

--- a/Detectors/FastSim/CMakeLists.txt
+++ b/Detectors/FastSim/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_library(FastSim
+               SOURCES src/FastSimModel.cxx
+                       src/ToyAbsorberFastSim.cxx
+                       src/G4FastSimulation.cxx
+               PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 O2::SimConfig
+)

--- a/Detectors/FastSim/include/FastSim/FastSimModel.h
+++ b/Detectors/FastSim/include/FastSim/FastSimModel.h
@@ -1,0 +1,82 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FASTSIM_MODEL_H_
+#define O2_FASTSIM_MODEL_H_
+
+/// Base class for fast simulation models.
+///
+/// A fast simulation model replaces the detailed transport through a region of
+/// the geometry by a function from the particle that enters it to the particles
+/// that leave it. `DoIt()` below is the plumbing and is the same for every
+/// model; a model implements `sample()` and nothing else.
+
+#include "G4VFastSimulationModel.hh"
+
+#include <vector>
+
+class G4FastStep;
+class G4FastTrack;
+class G4ParticleDefinition;
+
+namespace o2::fastsim
+{
+
+/// The particle entering the envelope, plus the geometric context a model needs.
+/// Units are the O2/VMC ones: cm, GeV, ns.
+struct FastSimInput {
+  int pdg = 0;
+  double position[3] = {};   ///< global, on the envelope surface
+  double direction[3] = {};  ///< unit vector
+  double kineticEnergy = 0.; ///< GeV
+  double mass = 0.;          ///< GeV
+  double time = 0.;          ///< ns
+  double exitDistance = 0.;  ///< cm from `position` to the envelope surface along `direction`
+};
+
+/// One particle leaving the envelope.
+struct FastSimOutput {
+  int pdg = 0;
+  double position[3] = {}; ///< global; put it outside the envelope surface
+  double momentum[3] = {}; ///< GeV/c
+  double time = 0.;        ///< ns
+};
+
+/// A secondary created exactly on the envelope surface is located by the
+/// navigator in whichever daughter owns that point, which costs two extra
+/// zero-length steps before it gets out. Models should emit just beyond it.
+constexpr double kSurfaceEpsilonCm = 1e-5;
+
+class FastSimModel : public G4VFastSimulationModel
+{
+ public:
+  FastSimModel(const G4String& name, double minEnergyGeV);
+
+  G4bool IsApplicable(const G4ParticleDefinition& particle) override;
+  G4bool ModelTrigger(const G4FastTrack& fastTrack) override;
+
+  /// Measures the distance to the envelope surface, asks `sample()` what comes
+  /// out, kills the incident particle, stacks the result and books the energy
+  /// difference as a deposit.
+  void DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) final;
+
+ protected:
+  /// Given the particle that entered, return everything that leaves. This is
+  /// the function a trained model implements.
+  virtual std::vector<FastSimOutput> sample(const FastSimInput& input) const = 0;
+
+ private:
+  double mMinEnergy = 0.; ///< internal Geant4 units; below this the detailed transport runs
+};
+
+} // namespace o2::fastsim
+
+#endif // O2_FASTSIM_MODEL_H_

--- a/Detectors/FastSim/include/FastSim/G4FastSimulation.h
+++ b/Detectors/FastSim/include/FastSim/G4FastSimulation.h
@@ -1,0 +1,63 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FASTSIM_G4_FAST_SIMULATION_H_
+#define O2_FASTSIM_G4_FAST_SIMULATION_H_
+
+/// Wiring of the fast simulation models into the Geant4 engine.
+///
+/// The feature is OFF unless `G4.fastSimModels` names a model.
+///
+///   o2-sim -n 10 -g pythia8pp -e TGeant4 -m PIPE ABSO
+///          --configKeyValues "G4.fastSimModels=toyAbsorber;
+///                             G4.fastSimRegions=ABSO_AIR_ENVELOPE"
+///
+/// Regions are selected by TRACKING MEDIUM name (wildcards allowed), which
+/// Geant4-VMC maps to the medium's MATERIAL; every volume of that material joins
+/// the region. That is why the absorber mother volume AFaM carries a material of
+/// its own (see Detectors/Passive/src/Absorber.cxx). Selection by volume is not
+/// available: the VMC special cuts already root every logical volume in a
+/// per-material region, and Geant4 allows a volume in only one region.
+
+#include "TG4RunConfiguration.h"
+#include "TG4VUserFastSimulation.h"
+
+#include <string>
+#include <vector>
+
+namespace o2::fastsim
+{
+
+/// Creates and registers the models named in `G4.fastSimModels`.
+class G4FastSimulation : public TG4VUserFastSimulation
+{
+ public:
+  G4FastSimulation(std::vector<std::string> models, const std::string& regions,
+                   double minEnergyGeV);
+  void Construct() override;
+
+ private:
+  std::vector<std::string> mModels;
+  double mMinEnergy = 1.;
+};
+
+/// The one hook O2 was missing. Returns nullptr when no model is configured,
+/// which is exactly the behaviour before this file existed.
+class G4RunConfiguration : public TG4RunConfiguration
+{
+ public:
+  using TG4RunConfiguration::TG4RunConfiguration;
+  TG4VUserFastSimulation* CreateUserFastSimulation() override;
+};
+
+} // namespace o2::fastsim
+
+#endif // O2_FASTSIM_G4_FAST_SIMULATION_H_

--- a/Detectors/FastSim/include/FastSim/ToyAbsorberFastSim.h
+++ b/Detectors/FastSim/include/FastSim/ToyAbsorberFastSim.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FASTSIM_TOY_ABSORBER_H_
+#define O2_FASTSIM_TOY_ABSORBER_H_
+
+#include "FastSim/FastSimModel.h"
+
+namespace o2::fastsim
+{
+
+/// A toy model: one particle out, continuing along the incident direction with
+/// the energy exponentially attenuated over the path through the envelope.
+/// It exists to exercise the machinery, not to describe an absorber.
+class ToyAbsorberFastSim : public FastSimModel
+{
+ public:
+  using FastSimModel::FastSimModel;
+
+ protected:
+  std::vector<FastSimOutput> sample(const FastSimInput& input) const override;
+};
+
+} // namespace o2::fastsim
+
+#endif // O2_FASTSIM_TOY_ABSORBER_H_

--- a/Detectors/FastSim/src/FastSimModel.cxx
+++ b/Detectors/FastSim/src/FastSimModel.cxx
@@ -1,0 +1,115 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FastSim/FastSimModel.h"
+
+#include <fairlogger/Logger.h>
+
+#include <G4DynamicParticle.hh>
+#include <G4FastStep.hh>
+#include <G4FastTrack.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4ParticleTable.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4ThreeVector.hh>
+#include <G4Track.hh>
+#include <G4VSolid.hh>
+
+#include <algorithm>
+
+namespace o2::fastsim
+{
+
+//_____________________________________________________________________________
+FastSimModel::FastSimModel(const G4String& name, double minEnergyGeV)
+  : G4VFastSimulationModel(name), mMinEnergy(minEnergyGeV * CLHEP::GeV)
+{
+}
+
+//_____________________________________________________________________________
+G4bool FastSimModel::IsApplicable(const G4ParticleDefinition&)
+{
+  // Which particles a model sees is decided by the `setParticles` selection,
+  // not here.
+  return true;
+}
+
+//_____________________________________________________________________________
+G4bool FastSimModel::ModelTrigger(const G4FastTrack& fastTrack)
+{
+  // Below the threshold the detailed transport is cheap and a surrogate would
+  // be extrapolating.
+  return fastTrack.GetPrimaryTrack()->GetKineticEnergy() > mMinEnergy;
+}
+
+//_____________________________________________________________________________
+void FastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep)
+{
+  const G4Track* track = fastTrack.GetPrimaryTrack();
+  const G4ThreeVector& position = track->GetPosition();
+  const G4ThreeVector& direction = track->GetMomentumDirection();
+
+  FastSimInput input;
+  input.pdg = track->GetDefinition()->GetPDGEncoding();
+  input.position[0] = position.x() / CLHEP::cm;
+  input.position[1] = position.y() / CLHEP::cm;
+  input.position[2] = position.z() / CLHEP::cm;
+  input.direction[0] = direction.x();
+  input.direction[1] = direction.y();
+  input.direction[2] = direction.z();
+  input.kineticEnergy = track->GetKineticEnergy() / CLHEP::GeV;
+  input.mass = track->GetDefinition()->GetPDGMass() / CLHEP::GeV;
+  input.time = track->GetGlobalTime() / CLHEP::ns;
+  input.exitDistance = fastTrack.GetEnvelopeSolid()->DistanceToOut(
+                         fastTrack.GetPrimaryTrackLocalPosition(),
+                         fastTrack.GetPrimaryTrackLocalDirection()) /
+                       CLHEP::cm;
+
+  const std::vector<FastSimOutput> outgoing = sample(input);
+
+  fastStep.KillPrimaryTrack();
+  fastStep.ProposePrimaryTrackPathLength(input.exitDistance * CLHEP::cm);
+
+  // NOTE: a fast step defaults to AvoidHitInvocation, so Geant4 does not call
+  // the sensitive detector and TVirtualMCApplication::Stepping() is not invoked
+  // for it. For a passive envelope that is what we want -- there are no hits to
+  // lose, and the steps disappearing from the step log is the saving. A model
+  // covering a region that scores would add
+  //   fastStep.ProposeSteppingControl(NormalCondition);
+  // here.
+
+  double outgoingKineticEnergy = 0.;
+  fastStep.SetNumberOfSecondaryTracks(outgoing.size());
+  for (const auto& out : outgoing) {
+    const G4ParticleDefinition* definition =
+      G4ParticleTable::GetParticleTable()->FindParticle(out.pdg);
+    if (definition == nullptr) {
+      LOG(error) << "fast simulation: model " << GetName() << " returned unknown pdg " << out.pdg
+                 << "; particle dropped";
+      continue;
+    }
+    const G4ThreeVector momentum(out.momentum[0] * CLHEP::GeV, out.momentum[1] * CLHEP::GeV,
+                                 out.momentum[2] * CLHEP::GeV);
+    G4DynamicParticle particle(definition, momentum);
+    outgoingKineticEnergy += particle.GetKineticEnergy();
+    fastStep.CreateSecondaryTrack(particle,
+                                  G4ThreeVector(out.position[0] * CLHEP::cm,
+                                                out.position[1] * CLHEP::cm,
+                                                out.position[2] * CLHEP::cm),
+                                  out.time * CLHEP::ns, /*localCoordinates=*/false);
+  }
+
+  // Whatever did not come out stayed in.
+  fastStep.ProposeTotalEnergyDeposited(
+    std::max(0., track->GetKineticEnergy() - outgoingKineticEnergy));
+}
+
+} // namespace o2::fastsim

--- a/Detectors/FastSim/src/G4FastSimulation.cxx
+++ b/Detectors/FastSim/src/G4FastSimulation.cxx
@@ -1,0 +1,82 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FastSim/G4FastSimulation.h"
+#include "FastSim/ToyAbsorberFastSim.h"
+#include "SimConfig/G4Params.h"
+
+#include <fairlogger/Logger.h>
+
+#include <sstream>
+
+namespace o2::fastsim
+{
+
+namespace
+{
+std::vector<std::string> split(const std::string& value, char sep)
+{
+  std::vector<std::string> out;
+  std::stringstream stream(value);
+  std::string token;
+  while (std::getline(stream, token, sep)) {
+    if (!token.empty()) {
+      out.push_back(token);
+    }
+  }
+  return out;
+}
+} // namespace
+
+//_____________________________________________________________________________
+G4FastSimulation::G4FastSimulation(std::vector<std::string> models, const std::string& regions,
+                                   double minEnergyGeV)
+  : TG4VUserFastSimulation(), mModels(std::move(models)), mMinEnergy(minEnergyGeV)
+{
+  for (const auto& model : mModels) {
+    SetModel(model);
+    SetModelParticles(model, "all");
+    if (!regions.empty()) {
+      SetModelRegions(model, regions);
+    } else {
+      LOG(warn) << "fast simulation: model " << model
+                << " has no G4.fastSimRegions; it will not be applied anywhere";
+    }
+  }
+}
+
+//_____________________________________________________________________________
+void G4FastSimulation::Construct()
+{
+  for (const auto& model : mModels) {
+    if (model == "toyAbsorber") {
+      LOG(info) << "fast simulation: registering model " << model << " above " << mMinEnergy
+                << " GeV";
+      Register(new ToyAbsorberFastSim(model, mMinEnergy));
+    } else {
+      LOG(error) << "fast simulation: unknown model " << model << "; ignored";
+    }
+  }
+}
+
+//_____________________________________________________________________________
+TG4VUserFastSimulation* G4RunConfiguration::CreateUserFastSimulation()
+{
+  const auto& params = o2::conf::G4Params::Instance();
+  auto models = split(params.fastSimModels, ',');
+  if (models.empty()) {
+    return nullptr; // the default: no fast simulation, unchanged behaviour
+  }
+  LOG(info) << "fast simulation is ENABLED for regions '" << params.fastSimRegions << "'";
+  return new G4FastSimulation(std::move(models), params.fastSimRegions, params.fastSimMinEnergy);
+}
+
+} // namespace o2::fastsim

--- a/Detectors/FastSim/src/ToyAbsorberFastSim.cxx
+++ b/Detectors/FastSim/src/ToyAbsorberFastSim.cxx
@@ -1,0 +1,48 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FastSim/ToyAbsorberFastSim.h"
+
+#include <cmath>
+
+namespace o2::fastsim
+{
+
+namespace
+{
+/// Attenuation length of the toy transformation.
+constexpr double kAbsorptionLengthCm = 60.;
+} // namespace
+
+//_____________________________________________________________________________
+std::vector<FastSimOutput> ToyAbsorberFastSim::sample(const FastSimInput& input) const
+{
+  // A toy transformation, not a physics model: the incident particle carries on
+  // in its direction with the energy attenuated over the path through the
+  // envelope. A trained model returns a shower here instead.
+  const double kinetic = input.kineticEnergy * std::exp(-input.exitDistance / kAbsorptionLengthCm);
+  if (kinetic <= 0.) {
+    return {};
+  }
+  const double momentum = std::sqrt(kinetic * (kinetic + 2. * input.mass));
+
+  FastSimOutput out;
+  out.pdg = input.pdg;
+  out.time = input.time;
+  for (int i = 0; i < 3; ++i) {
+    out.position[i] =
+      input.position[i] + (input.exitDistance + kSurfaceEpsilonCm) * input.direction[i];
+    out.momentum[i] = momentum * input.direction[i];
+  }
+  return {out};
+}
+
+} // namespace o2::fastsim

--- a/Detectors/Passive/src/Absorber.cxx
+++ b/Detectors/Passive/src/Absorber.cxx
@@ -172,6 +172,21 @@ void Absorber::createMaterials()
   matmgr.Medium("ABSO", 55, "AIR_C2", 55, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   //
+  //    Air of the absorber envelope
+  //
+  //    Chemically identical to AIR0$ above. It exists so that the absorber
+  //    mother volume AFaM has a material no other volume shares: Geant4-VMC
+  //    selects fast-simulation regions by MATERIAL name and adds every volume of
+  //    that material to the region, so a volume can only be addressed as a
+  //    region of its own if its material is its own. Naming ABSO_AIR_ENVELOPE
+  //    therefore means exactly "the front absorber", with all of its daughters
+  //    inside it. Cuts and processes are the global defaults, the same ones
+  //    ABSO_AIR_C0 gets, so the physics is unchanged.
+  matmgr.Mixture("ABSO", 20, "AIR_ENVELOPE0$", aAir, zAir, dAir, 4, wAir);
+  matmgr.Medium("ABSO", 20, "AIR_ENVELOPE", 20, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil,
+                stmin);
+
+  //
   //    Vacuum
   matmgr.Mixture("ABSO", 16, "VACUUM0$", aAir, zAir, dAir1, 4, wAir);
   matmgr.Mixture("ABSO", 36, "VACUUM1$", aAir, zAir, dAir1, 4, wAir);
@@ -249,6 +264,8 @@ void Absorber::ConstructGeometry()
   auto kMedSteelSh = matmgr.getTGeoMedium("ABSO_ST_C3");
   //
   auto kMedAir = matmgr.getTGeoMedium("ABSO_AIR_C0");
+  // Air again, under a name only AFaM uses -- see the comment at its definition.
+  auto kMedAirEnvelope = matmgr.getTGeoMedium("ABSO_AIR_ENVELOPE");
   //
   auto kMedPb = matmgr.getTGeoMedium("ABSO_PB_C0");
   auto kMedPbSh = matmgr.getTGeoMedium("ABSO_PB_C2");
@@ -867,7 +884,9 @@ void Absorber::ConstructGeometry()
   shFaM->DefineSection(14, z, rInFaCH2Cone2 - dz * angle10, rOuSteelEnvelopeR2);
   z += dzSteelEnvelopeR / 2.;
   shFaM->DefineSection(15, z, rInFaCH2Cone2, rOuSteelEnvelopeR2);
-  TGeoVolume* voFaM = new TGeoVolume("AFaM", shFaM, kMedAir);
+  // AFaM is the mother of the whole absorber, and its dedicated medium is what
+  // makes "the absorber" addressable as one fast-simulation region.
+  TGeoVolume* voFaM = new TGeoVolume("AFaM", shFaM, kMedAirEnvelope);
   voFaM->SetVisibility(0);
 
   //

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -16,7 +16,7 @@ o2_add_library(G3Setup
 
 o2_add_library(G4Setup
                SOURCES src/G4Config.cxx
-               PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup
+               PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup O2::FastSim
 )
 
 o2_add_library(FLUKASetup

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -61,6 +61,7 @@ R__LOAD_LIBRARY(libgeant4vmc)
 #include "TG4RunConfiguration.h"
 #include "SimConfig/G4Params.h"
 #include "SimConfig/FluenceWeightCalculator.h"
+#include "FastSim/G4FastSimulation.h"
 #endif
 #include "commonConfig.C"
 
@@ -114,8 +115,12 @@ void Config()
     LOG(fatal) << "Unsupported geometry navigation mode";
   }
 
-  auto runConfiguration = new TG4RunConfiguration(geomNavStr, physicsSetup, "stepLimiter+specialCuts",
-                                                  specialStacking, mtMode);
+  // o2::fastsim::G4RunConfiguration differs from TG4RunConfiguration only in
+  // providing the fast-simulation hook; with G4.fastSimModels empty it behaves
+  // identically.
+  auto runConfiguration = new o2::fastsim::G4RunConfiguration(geomNavStr, physicsSetup,
+                                                              "stepLimiter+specialCuts",
+                                                              specialStacking, mtMode);
   if (g4Params.g4scoring) {
     runConfiguration->SetUseOfG4Scoring();
     if (g4Params.g4fluenceweight) {

--- a/run/SimExamples/FastSim_Absorber/README.md
+++ b/run/SimExamples/FastSim_Absorber/README.md
@@ -51,7 +51,31 @@ Selection by volume is not available: the VMC special cuts already root every
 logical volume in a per-material region, and Geant4 allows a logical volume in
 exactly one region.
 
-## What is not measured here
+## Measured
 
-CPU. The step and track counts show that the transport is being replaced; a
-timing number needs a realistic workload rather than five events of PIPE+ABSO.
+Five pp minimum-bias events, Pythia8 and Geant4, `-m PIPE ABSO`, on one EPN node
+against `O2PDPSuite/daily-20260819-0000-1`:
+
+| | full | fast |
+|---|---|---|
+| tracks per event | 3544 | 3160 |
+| transport real time | 29.8 s | 28.0 s |
+
+The model is demonstrably applied — geant4_vmc reports
+
+```
+fast simulation is ENABLED for regions 'ABSO_AIR_ENVELOPE'
+fast simulation: registering model toyAbsorber above 1 GeV
+Adding fast simulation model toyAbsorber to regions ABSO_AIR_ENVELOPE0$
+```
+
+where the last line is the tracking medium having resolved to its material, which
+is the step that silently does nothing if the medium name is wrong.
+
+**But the saving here is small, and the example should not be read as a
+performance claim.** The absorber sits at z = −90 to −501 cm and only the forward
+cone of a minimum-bias pp event ever enters it, so most of the transport this
+setup does is not in the region at all; and `fastSimMinEnergy=1` leaves
+everything below 1 GeV to the detailed transport. An honest CPU number needs a
+workload where the absorber is on the critical path — a forward-biased generator,
+or the full detector where the muon arm is what the absorber exists to protect.

--- a/run/SimExamples/FastSim_Absorber/README.md
+++ b/run/SimExamples/FastSim_Absorber/README.md
@@ -51,6 +51,45 @@ Selection by volume is not available: the VMC special cuts already root every
 logical volume in a per-material region, and Geant4 allows a logical volume in
 exactly one region.
 
+## Status: the model does not fire on the muon-arm path
+
+Measured on a real run, and it is a limitation of the region mechanism rather
+than of the model.
+
+`ABSO_AIR_ENVELOPE` selects a region containing `AFaM` **and nothing else**. The
+VMC special cuts create one `G4Region` per material and make every logical volume
+a root of its own, and Geant4 stops propagating a region down the tree at any
+daughter that is itself a region root — so `AFaMgRing` is in `ABSO_MAGNESIUM$`,
+`AFaGraphiteConeO` in `ABSO_CARBON0$`, and the absorber's mother region covers
+none of them. On top of that, `AFaM`'s daughters touch its surface, so a track
+entering the absorber lands straight in a daughter and never has `AFaM` as its
+volume at all.
+
+A 20 GeV muon fired into the muon-arm acceptance with `/tracking/verbose 1`
+therefore steps through the absorber identically with and without the fast
+simulation enabled:
+
+```
+   13     54.2   -0.238     -900  1.99e+04   0.0405      287       902   AFaMgRing Transportation
+   14     55.5   -0.244     -920  1.99e+04     5.33       20       922 AFaGraphiteConeO Transportation
+   15     56.7   -0.254     -940  1.99e+04     5.33     20.2       942 AFaGraphiteConeO muIoni
+```
+
+Only `muIoni`, `eIoni`, `Transportation` and `specialCutForElectron` appear; no
+fast-simulation process does.
+
+So a region in O2 can be "every volume of a given material" but not "this volume
+and its daughters", and a surrogate for a whole module is not expressible through
+this interface as it stands. The two ways forward are to name the absorber's
+constituent materials and accept a per-piece envelope, or to change
+`TG4RegionsManager` upstream so that the cuts regions do not claim every volume
+as a root.
+
+**Do not read the track counts below as a measurement of the model.** They come
+from two runs whose random sequences diverge before the absorber is even reached
+— visible in the beam pipe — so the difference is not attributable to the fast
+simulation.
+
 ## Measured
 
 Five pp minimum-bias events, Pythia8 and Geant4, `-m PIPE ABSO`, on one EPN node
@@ -61,7 +100,8 @@ against `O2PDPSuite/daily-20260819-0000-1`:
 | tracks per event | 3544 | 3160 |
 | transport real time | 29.8 s | 28.0 s |
 
-The model is demonstrably applied — geant4_vmc reports
+geant4_vmc does report that the region resolved, which is necessary but, as
+above, not sufficient:
 
 ```
 fast simulation is ENABLED for regions 'ABSO_AIR_ENVELOPE'
@@ -72,10 +112,6 @@ Adding fast simulation model toyAbsorber to regions ABSO_AIR_ENVELOPE0$
 where the last line is the tracking medium having resolved to its material, which
 is the step that silently does nothing if the medium name is wrong.
 
-**But the saving here is small, and the example should not be read as a
-performance claim.** The absorber sits at z = −90 to −501 cm and only the forward
-cone of a minimum-bias pp event ever enters it, so most of the transport this
-setup does is not in the region at all; and `fastSimMinEnergy=1` leaves
-everything below 1 GeV to the detailed transport. An honest CPU number needs a
-workload where the absorber is on the critical path — a forward-biased generator,
-or the full detector where the muon arm is what the absorber exists to protect.
+**These numbers are not a performance result and not a measurement of the
+model** — see the section above. They are recorded only to show what the example
+currently produces.

--- a/run/SimExamples/FastSim_Absorber/README.md
+++ b/run/SimExamples/FastSim_Absorber/README.md
@@ -1,0 +1,57 @@
+# Fast simulation of the front absorber
+
+Replaces the detailed transport through the ALICE front absorber by a model, and
+compares the result against a full simulation of the same events.
+
+`run.sh` runs both: a reference `o2-sim` with PIPE and ABSO only, and the same
+setup with the fast simulation switched on.
+
+| file | |
+|---|---|
+| `run.sh` | the two simulations and the comparison |
+| `countTracks.macro` | tracks per event of an `o2-sim` output |
+
+## Switching it on
+
+The feature does nothing unless a model is named:
+
+```
+--configKeyValues "G4.fastSimModels=toyAbsorber;G4.fastSimRegions=ABSO_AIR_ENVELOPE"
+```
+
+`G4.fastSimMinEnergy` (GeV, default 1) is the threshold below which the detailed
+transport still runs, because a surrogate below it would be extrapolating and
+the transport there is cheap anyway.
+
+## What the model does
+
+`toyAbsorber` is a placeholder. It returns the incident particle continuing in
+its direction with the energy attenuated exponentially over the path through the
+envelope — a real absorber turns one incident hadron into a shower, so the
+numbers this produces are not physics. It is here so that the machinery can be
+exercised end to end before a trained model exists.
+
+A model implements one function, `sample()`, which maps the particle that
+entered the region to the particles that leave it
+(`Detectors/FastSim/include/FastSim/FastSimModel.h`). Everything around it —
+measuring the distance to the envelope surface, killing the incident particle,
+stacking what comes back, booking the energy difference as a deposit — is shared
+and does not have to be reimplemented.
+
+## Why the region is named `ABSO_AIR_ENVELOPE`
+
+Regions are selected by tracking medium, which Geant4-VMC maps to that medium's
+material, adding every volume of that material to the region. A volume can
+therefore only be addressed on its own if its material is its own, which is why
+`AFaM` — the mother volume of the whole absorber — carries a dedicated air
+material (`Detectors/Passive/src/Absorber.cxx`). Selecting it means "the
+absorber", with all of its daughters inside.
+
+Selection by volume is not available: the VMC special cuts already root every
+logical volume in a per-material region, and Geant4 allows a logical volume in
+exactly one region.
+
+## What is not measured here
+
+CPU. The step and track counts show that the transport is being replaced; a
+timing number needs a realistic workload rather than five events of PIPE+ABSO.

--- a/run/SimExamples/FastSim_Absorber/countTracks.macro
+++ b/run/SimExamples/FastSim_Absorber/countTracks.macro
@@ -1,0 +1,20 @@
+// Tracks per event of an o2-sim output, as a cheap proxy for how much transport
+// happened. Usage: root -l -b -q 'countTracks.macro("o2sim")'
+void countTracks(const char* prefix = "o2sim")
+{
+  TFile file(Form("%s_Kine.root", prefix));
+  auto* tree = (TTree*)file.Get("o2sim");
+  if (!tree) {
+    printf("no o2sim tree in %s_Kine.root\n", prefix);
+    return;
+  }
+  std::vector<o2::MCTrack>* tracks = nullptr;
+  tree->SetBranchAddress("MCTrack", &tracks);
+  Long64_t total = 0;
+  for (Long64_t entry = 0; entry < tree->GetEntries(); ++entry) {
+    tree->GetEntry(entry);
+    total += tracks->size();
+  }
+  printf("%s: %lld events, %lld tracks, %.1f per event\n", prefix, tree->GetEntries(), total,
+         tree->GetEntries() ? double(total) / tree->GetEntries() : 0.);
+}

--- a/run/SimExamples/FastSim_Absorber/run.sh
+++ b/run/SimExamples/FastSim_Absorber/run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# This example exercises the Geant4 fast simulation route on the front absorber.
+#
+# A fast simulation model replaces the detailed transport through a region of
+# the geometry by a function from the particle that enters it to the particles
+# that leave it. The model shipped here, `toyAbsorber`, is a placeholder: it
+# returns the incident particle carrying on in its direction with an
+# exponentially attenuated energy. What the example demonstrates is the
+# machinery, not the physics.
+#
+# The region is named by TRACKING MEDIUM. `ABSO_AIR_ENVELOPE` is the medium of
+# AFaM, the mother volume of the whole absorber, and it exists for exactly this
+# purpose: Geant4-VMC builds a region per MATERIAL and adds every volume of that
+# material to it, so a volume can only be addressed on its own if its material
+# is its own.
+#
+# The setup is PIPE and ABSO only, which keeps the run short and puts the
+# absorber in the path of everything.
+
+set -x
+
+EVENTS=5
+MODULES="-m PIPE ABSO"
+GEN="-g pythia8pp"
+# Alignment is irrelevant here and switching it off keeps the example from
+# needing a CCDB connection and an alien token.
+COMMON="align-geom.mDetectors=none"
+
+# --------------------------------------------------------------- 1. reference
+# Detailed transport, for comparison.
+mkdir -p full && cd full
+o2-sim-serial -n ${EVENTS} ${GEN} -e TGeant4 ${MODULES} -o full \
+    --configKeyValues "${COMMON}" > logfull 2>&1
+cd ..
+
+# -------------------------------------------------------------------- 2. fast
+# G4.fastSimModels is what switches the feature on; with it empty (the default)
+# nothing about the simulation changes.
+mkdir -p fast && cd fast
+o2-sim-serial -n ${EVENTS} ${GEN} -e TGeant4 ${MODULES} -o fast \
+    --configKeyValues "${COMMON};\
+G4.fastSimModels=toyAbsorber;\
+G4.fastSimRegions=ABSO_AIR_ENVELOPE;\
+G4.fastSimMinEnergy=1.0" > logfast 2>&1
+cd ..
+
+# ----------------------------------------------------------------- 3. compare
+# The model prints once at setup; if this line is missing the region name did
+# not resolve to a medium and nothing was applied.
+grep -h "fast simulation" fast/logfast
+
+# Tracks written per event. The absorber normally turns one incident hadron into
+# a shower, and the toy model returns a single particle instead, so the fast run
+# has to produce far fewer.
+for d in full fast; do
+  echo "=== ${d}"
+  root -l -b -q "$(dirname "$0")/countTracks.macro(\"${d}/${d}\")"
+done


### PR DESCRIPTION
This development makes it possible to register and use per-region fast simulation hooks with the Geant4 engine.
A toy demonstrator is added, showing this for the ALICE Absorber. This provides the grounding to hook a ML-model for the Absorber at a later stage.

**WIP : Not to be merged yet **