### PR TITLE
[EMCAL-1156] Modernize EMCal code and fix Digitizer

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/AnalysisCluster.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/AnalysisCluster.h
@@ -12,17 +12,17 @@
 #ifndef ALICEO2_EMCAL_ANALYSISCLUSTER_H_
 #define ALICEO2_EMCAL_ANALYSISCLUSTER_H_
 
+#include "MathUtils/Cartesian.h" // IWYU pragma: keep
+
+#include <Rtypes.h>
+#include <TLorentzVector.h>
+
 #include <fairlogger/Logger.h>
 #include <gsl/span>
+
 #include <array>
-#include "Rtypes.h"
-#include "MathUtils/Cartesian.h"
-#include "TLorentzVector.h"
 
-namespace o2
-{
-
-namespace emcal
+namespace o2::emcal
 {
 
 /// \class AnalysisCluster
@@ -45,8 +45,7 @@ class AnalysisCluster
    public:
     /// \brief Constructor, setting cell wrong cell index raising the exception
     /// \param cellIndex Cell index raising the exception
-    CellOutOfRangeException(Int_t cellIndex) : std::exception(),
-                                               mCellIndex(cellIndex),
+    CellOutOfRangeException(Int_t cellIndex) : mCellIndex(cellIndex),
                                                mMessage("Cell index " + std::to_string(mCellIndex) + " out of range.")
     {
     }
@@ -56,11 +55,11 @@ class AnalysisCluster
 
     /// \brief Access to cell ID raising the exception
     /// \return Cell ID
-    Int_t getCellIndex() const noexcept { return mCellIndex; }
+    [[nodiscard]] Int_t getCellIndex() const noexcept { return mCellIndex; }
 
     /// \brief Access to error message of the exception
     /// \return Error message
-    const char* what() const noexcept final { return mMessage.data(); }
+    [[nodiscard]] const char* what() const noexcept final { return mMessage.data(); }
 
    private:
     Int_t mCellIndex;     ///< Cell index raising the exception
@@ -76,55 +75,55 @@ class AnalysisCluster
   // Common EMCAL/PHOS/FMD/PMD
 
   void setID(int id) { mID = id; }
-  int getID() const { return mID; }
+  [[nodiscard]] int getID() const { return mID; }
 
   void setE(float ene) { mEnergy = ene; }
-  float E() const { return mEnergy; }
+  [[nodiscard]] float E() const { return mEnergy; }
 
   void setChi2(float chi2) { mChi2 = chi2; }
-  float Chi2() const { return mChi2; }
+  [[nodiscard]] float Chi2() const { return mChi2; }
 
   ///
   /// Set the cluster global position.
-  void setGlobalPosition(math_utils::Point3D<float> x);
-  math_utils::Point3D<float> getGlobalPosition() const
+  void setGlobalPosition(const math_utils::Point3D<float>& x);
+  [[nodiscard]] math_utils::Point3D<float> getGlobalPosition() const
   {
     return mGlobalPos;
   }
 
-  void setLocalPosition(math_utils::Point3D<float> x);
-  math_utils::Point3D<float> getLocalPosition() const
+  void setLocalPosition(const math_utils::Point3D<float>& x);
+  [[nodiscard]] math_utils::Point3D<float> getLocalPosition() const
   {
     return mLocalPos;
   }
 
   void setDispersion(float disp) { mDispersion = disp; }
-  float getDispersion() const { return mDispersion; }
+  [[nodiscard]] float getDispersion() const { return mDispersion; }
 
   void setM20(float m20) { mM20 = m20; }
-  float getM20() const { return mM20; }
+  [[nodiscard]] float getM20() const { return mM20; }
 
   void setM02(float m02) { mM02 = m02; }
-  float getM02() const { return mM02; }
+  [[nodiscard]] float getM02() const { return mM02; }
 
   void setNExMax(unsigned char nExMax) { mNExMax = nExMax; }
-  unsigned char getNExMax() const { return mNExMax; }
+  [[nodiscard]] unsigned char getNExMax() const { return mNExMax; }
 
   void setEmcCpvDistance(float dEmcCpv) { mEmcCpvDistance = dEmcCpv; }
-  float getEmcCpvDistance() const { return mEmcCpvDistance; }
+  [[nodiscard]] float getEmcCpvDistance() const { return mEmcCpvDistance; }
   void setTrackDistance(float dx, float dz)
   {
     mTrackDx = dx;
     mTrackDz = dz;
   }
-  float getTrackDx() const { return mTrackDx; }
-  float getTrackDz() const { return mTrackDz; }
+  [[nodiscard]] float getTrackDx() const { return mTrackDx; }
+  [[nodiscard]] float getTrackDz() const { return mTrackDz; }
 
   void setDistanceToBadChannel(float dist) { mDistToBadChannel = dist; }
-  float getDistanceToBadChannel() const { return mDistToBadChannel; }
+  [[nodiscard]] float getDistanceToBadChannel() const { return mDistToBadChannel; }
 
   void setNCells(int n) { mNCells = n; }
-  int getNCells() const { return mNCells; }
+  [[nodiscard]] int getNCells() const { return mNCells; }
 
   ///
   ///  Set the array of cell indices.
@@ -133,7 +132,7 @@ class AnalysisCluster
     mCellsIndices = array;
   }
 
-  const std::vector<unsigned short>& getCellsIndices() const { return mCellsIndices; }
+  [[nodiscard]] const std::vector<unsigned short>& getCellsIndices() const { return mCellsIndices; }
 
   ///
   ///  Set the array of cell amplitude fractions.
@@ -143,27 +142,25 @@ class AnalysisCluster
   {
     mCellsAmpFraction = array;
   }
-  const std::vector<float>& getCellsAmplitudeFraction() const { return mCellsAmpFraction; }
+  [[nodiscard]] const std::vector<float>& getCellsAmplitudeFraction() const { return mCellsAmpFraction; }
 
-  int getCellIndex(int i) const
+  [[nodiscard]] int getCellIndex(int i) const
   {
     if (i >= 0 && i < mNCells) {
       return mCellsIndices[i];
-    } else {
-      throw CellOutOfRangeException(i);
     }
+    throw CellOutOfRangeException(i);
   }
 
-  float getCellAmplitudeFraction(int i) const
+  [[nodiscard]] float getCellAmplitudeFraction(int i) const
   {
     if (i >= 0 && i < mNCells) {
       return mCellsAmpFraction[i];
-    } else {
-      throw CellOutOfRangeException(i);
     }
+    throw CellOutOfRangeException(i);
   }
 
-  bool getIsExotic() const { return mIsExotic; }
+  [[nodiscard]] bool getIsExotic() const { return mIsExotic; }
   void setIsExotic(bool b) { mIsExotic = b; }
 
   void setClusterTime(float time)
@@ -171,25 +168,25 @@ class AnalysisCluster
     mTime = time;
   }
 
-  float getClusterTime() const
+  [[nodiscard]] float getClusterTime() const
   {
     return mTime;
   }
 
-  int getIndMaxInput() const { return mInputIndMax; }
+  [[nodiscard]] int getIndMaxInput() const { return mInputIndMax; }
   void setIndMaxInput(const int ind) { mInputIndMax = ind; }
 
-  float getCoreEnergy() const { return mCoreEnergy; }
+  [[nodiscard]] float getCoreEnergy() const { return mCoreEnergy; }
   void setCoreEnergy(float energy) { mCoreEnergy = energy; }
 
-  float getFCross() const { return mFCross; }
+  [[nodiscard]] float getFCross() const { return mFCross; }
   void setFCross(float fCross) { mFCross = fCross; }
 
   ///
   /// Returns TLorentzVector with momentum of the cluster. Only valid for clusters
   /// identified as photons or pi0 (overlapped gamma) produced on the vertex
   /// Vertex can be recovered with esd pointer doing:
-  TLorentzVector getMomentum(std::array<const float, 3> vertexPosition) const;
+  [[nodiscard]] TLorentzVector getMomentum(std::array<const float, 3> vertexPosition) const;
 
  protected:
   /// TODO to replace later by o2::MCLabel when implementing the MC handling
@@ -230,9 +227,8 @@ class AnalysisCluster
 
   int mInputIndMax = -1; ///<  index of digit/cell with max energy
 
-  ClassDefNV(AnalysisCluster, 2);
+  ClassDefNV(AnalysisCluster, 3);
 };
 
-} // namespace emcal
-} // namespace o2
+} // namespace o2::emcal
 #endif // ANALYSISCLUSTER_H

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -12,14 +12,12 @@
 #ifndef ALICEO2_EMCAL_CELL_H_
 #define ALICEO2_EMCAL_CELL_H_
 
-#include <bitset>
-#include <cfloat>
-#include <climits>
 #include "DataFormatsEMCAL/Constants.h"
 
-namespace o2
-{
-namespace emcal
+#include <cfloat>
+#include <climits>
+
+namespace o2::emcal
 {
 
 /// \class Cell
@@ -90,7 +88,7 @@ class Cell
 
   /// \brief Get the tower ID
   /// \return Tower ID
-  short getTower() const { return mTowerID; }
+  [[nodiscard]] short getTower() const { return mTowerID; }
 
   /// \brief Set the time stamp
   /// \param timestamp Time in ns
@@ -98,7 +96,7 @@ class Cell
 
   /// \brief Get the time stamp
   /// \return Time in ns
-  float getTimeStamp() const { return mTimestamp; }
+  [[nodiscard]] float getTimeStamp() const { return mTimestamp; }
 
   /// \brief Set the energy of the cell
   /// \brief Energy of the cell in GeV
@@ -106,7 +104,7 @@ class Cell
 
   /// \brief Get the energy of the cell
   /// \return Energy of the cell
-  float getEnergy() const { return mEnergy; }
+  [[nodiscard]] float getEnergy() const { return mEnergy; }
 
   /// \brief Set the amplitude of the cell
   /// \param amplitude Cell amplitude
@@ -114,7 +112,7 @@ class Cell
 
   /// \brief Get cell amplitude
   /// \return Cell amplitude in GeV
-  float getAmplitude() const { return getEnergy(); }
+  [[nodiscard]] float getAmplitude() const { return getEnergy(); }
 
   /// \brief Set the type of the cell
   /// \param ctype Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
@@ -122,40 +120,40 @@ class Cell
 
   /// \brief Get the type of the cell
   /// \return Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
-  ChannelType_t getType() const { return mChannelType; }
+  [[nodiscard]] ChannelType_t getType() const { return mChannelType; }
 
   /// \brief Check whether the cell is of a given type
   /// \param ctype Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
   /// \return True if the type of the cell matches the requested type, false otherwise
-  bool isChannelType(ChannelType_t ctype) const { return mChannelType == ctype; }
+  [[nodiscard]] bool isChannelType(ChannelType_t ctype) const { return mChannelType == ctype; }
 
   /// \brief Mark cell as low gain cell
   void setLowGain() { setType(ChannelType_t::LOW_GAIN); }
 
   /// \brief Check whether the cell is a low gain cell
   /// \return True if the cell type is low gain, false otherwise
-  Bool_t getLowGain() const { return isChannelType(ChannelType_t::LOW_GAIN); }
+  [[nodiscard]] Bool_t getLowGain() const { return isChannelType(ChannelType_t::LOW_GAIN); }
 
   /// \brief Mark cell as high gain cell
   void setHighGain() { setType(ChannelType_t::HIGH_GAIN); }
 
   /// \brief Check whether the cell is a high gain cell
   /// \return True if the cell type is high gain, false otherwise
-  Bool_t getHighGain() const { return isChannelType(ChannelType_t::HIGH_GAIN); };
+  [[nodiscard]] Bool_t getHighGain() const { return isChannelType(ChannelType_t::HIGH_GAIN); };
 
   /// \brief Mark cell as LED monitor cell
   void setLEDMon() { setType(ChannelType_t::LEDMON); }
 
   /// \brief Check whether the cell is a LED monitor cell
   /// \return True if the cell type is LED monitor, false otherwise
-  Bool_t getLEDMon() const { return isChannelType(ChannelType_t::LEDMON); }
+  [[nodiscard]] Bool_t getLEDMon() const { return isChannelType(ChannelType_t::LEDMON); }
 
   /// \brief Mark cell as TRU cell
   void setTRU() { setType(ChannelType_t::TRU); }
 
   /// \brief Check whether the cell is a TRU cell
   /// \return True if the cell type is TRU, false otherwise
-  Bool_t getTRU() const { return isChannelType(ChannelType_t::TRU); }
+  [[nodiscard]] Bool_t getTRU() const { return isChannelType(ChannelType_t::TRU); }
 
   /// \brief Apply compression as done during writing to / reading from CTF
   /// \param version Encoder version
@@ -181,7 +179,7 @@ class Cell
   /// \return Encoded bit representation
   ///
   /// Same as getTower - no compression applied for tower ID
-  uint16_t getTowerIDEncoded() const;
+  [[nodiscard]] uint16_t getTowerIDEncoded() const;
 
   /// \brief Get encoded bit representation of timestamp (for CTF)
   /// \return Encoded bit representation
@@ -191,7 +189,7 @@ class Cell
   /// be stored is from -1023 to 1023 ns. In case the
   /// range is exceeded the time is set to the limit
   /// of the range.
-  uint16_t getTimeStampEncoded() const;
+  [[nodiscard]] uint16_t getTimeStampEncoded() const;
 
   /// \brief Get encoded bit representation of energy (for CTF)
   /// \param version Encoding verions
@@ -203,11 +201,11 @@ class Cell
   /// the limits is provided the energy is
   /// set to the limits (0 in case of negative
   /// energy, 250. in case of energies > 250 GeV)
-  uint16_t getEnergyEncoded(EncoderVersion version = EncoderVersion::EncodingV2) const;
+  [[nodiscard]] uint16_t getEnergyEncoded(EncoderVersion version = EncoderVersion::EncodingV2) const;
 
   /// \brief Get encoded bit representation of cell type (for CTF)
   /// \return Encoded bit representation
-  uint16_t getCellTypeEncoded() const;
+  [[nodiscard]] uint16_t getCellTypeEncoded() const;
 
   void initializeFromPackedBitfieldV0(const char* bitfield);
 
@@ -231,8 +229,8 @@ class Cell
  private:
   /// \brief Set cell energy from encoded bit representation (from CTF)
   /// \param energyBits Bit representation of energy
-  /// \param cellTypeBits Bit representation of cell type
-  void setEnergyEncoded(uint16_t energyBits, uint16_t cellTypeBits, EncoderVersion version = EncoderVersion::EncodingV1);
+  /// \param channelTypeBits Bit representation of cell type
+  void setEnergyEncoded(uint16_t energyBits, uint16_t channelTypeBits, EncoderVersion version = EncoderVersion::EncodingV1);
 
   /// \brief Set cell time from encoded bit representation (from CTF)
   /// \param timestampBits Bit representation of timestamp
@@ -259,7 +257,6 @@ class Cell
 /// \param cell Cell to be printed
 /// \return Stream after printing
 std::ostream& operator<<(std::ostream& stream, const Cell& cell);
-} // namespace emcal
-} // namespace o2
+} // namespace o2::emcal
 
 #endif

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
@@ -12,15 +12,13 @@
 #ifndef ALICEO2_EMCAL_CELLLABEL_H_
 #define ALICEO2_EMCAL_CELLLABEL_H_
 
+
 #include <cstddef>
 #include <cstdint>
-#include <gsl/span>
+#include <span>
 #include <vector>
 
-namespace o2
-{
-
-namespace emcal
+namespace o2::emcal
 {
 
 /// \class CellLabel
@@ -40,10 +38,10 @@ class CellLabel
   /// \param amplitudeFractions list of amplitude fractions
   CellLabel(std::vector<int> labels, std::vector<float> amplitudeFractions);
 
-  /// \brief Constructor using gsl::span
+  /// \brief Constructor using std::span
   /// \param labels list of mc labels
   /// \param amplitudeFractions list of amplitude fractions
-  CellLabel(gsl::span<const int> labels, gsl::span<const float> amplitudeFractions);
+  CellLabel(std::span<const int> labels, std::span<const float> amplitudeFractions);
 
   // ~CellLabel() = default;
   // CellLabel(const CellLabel& clus) = default;
@@ -51,30 +49,29 @@ class CellLabel
 
   /// \brief Getter of label size
   /// \param index index which label to get
-  size_t GetLabelSize(void) const { return mLabels.size(); }
+  [[nodiscard]] size_t GetLabelSize() const { return mLabels.size(); }
 
   /// \brief Getter for label
   /// \param index index which label to get
-  int32_t GetLabel(size_t index) const { return mLabels[index]; }
+  [[nodiscard]] int32_t GetLabel(size_t index) const { return mLabels[index]; }
 
   /// \brief Getter for labels
-  std::vector<int32_t> GetLabels() const { return mLabels; }
+  [[nodiscard]] std::vector<int32_t> GetLabels() const { return mLabels; }
 
   /// \brief Getter for amplitude fraction
   /// \param index index which amplitude fraction to get
-  float GetAmplitudeFraction(size_t index) const { return mAmplitudeFraction[index]; }
+  [[nodiscard]] float GetAmplitudeFraction(size_t index) const { return mAmplitudeFraction[index]; }
 
   /// \brief Getter for amplitude fractions
-  std::vector<float> GetAmplitudeFractions() const { return mAmplitudeFraction; }
+  [[nodiscard]] std::vector<float> GetAmplitudeFractions() const { return mAmplitudeFraction; }
 
   /// \brief Getter for label with leading amplitude fraction
-  int32_t GetLeadingMCLabel() const;
+  [[nodiscard]] int32_t GetLeadingMCLabel() const;
 
  protected:
   std::vector<int32_t> mLabels;          ///< List of MC particles that generated the cluster, ordered in deposited energy.
   std::vector<float> mAmplitudeFraction; ///< List of the fraction of the cell energy coming from a MC particle. Index aligns with mLabels!
 };
 
-} // namespace emcal
-} // namespace o2
+} // namespace o2::emcal
 #endif // ALICEO2_EMCAL_CELLLABEL_H_

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellLabel.h
@@ -12,7 +12,6 @@
 #ifndef ALICEO2_EMCAL_CELLLABEL_H_
 #define ALICEO2_EMCAL_CELLLABEL_H_
 
-
 #include <cstddef>
 #include <cstdint>
 #include <span>

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cluster.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cluster.h
@@ -11,17 +11,12 @@
 #ifndef ALICEO2_EMCAL_CLUSTER_H_
 #define ALICEO2_EMCAL_CLUSTER_H_
 
-#include <array>
-#include <iosfwd>
-#include <string>
-#include <vector>
 #include "CommonDataFormat/TimeStamp.h"
 #include "CommonDataFormat/RangeReference.h"
 
-namespace o2
-{
+#include <iosfwd>
 
-namespace emcal
+namespace o2::emcal
 {
 
 /// \class Cluster
@@ -37,9 +32,9 @@ class Cluster : public o2::dataformats::TimeStamp<Float16_t>
   Cluster(Float_t time, int firstcell, int ncells);
   ~Cluster() noexcept = default;
 
-  Int_t getNCells() const { return mCellIndices.getEntries(); }
-  Int_t getCellIndexFirst() const { return mCellIndices.getFirstEntry(); }
-  CellIndexRange getCellIndexRange() const { return mCellIndices; }
+  [[nodiscard]] Int_t getNCells() const { return mCellIndices.getEntries(); }
+  [[nodiscard]] Int_t getCellIndexFirst() const { return mCellIndices.getFirstEntry(); }
+  [[nodiscard]] CellIndexRange getCellIndexRange() const { return mCellIndices; }
 
   void setCellIndices(int firstcell, int ncells)
   {
@@ -58,8 +53,6 @@ class Cluster : public o2::dataformats::TimeStamp<Float16_t>
 
 std::ostream& operator<<(std::ostream& stream, const o2::emcal::Cluster& cluster);
 
-} // namespace emcal
-
-} // namespace o2
+} // namespace o2::emcal
 
 #endif

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ClusterLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ClusterLabel.h
@@ -14,13 +14,10 @@
 
 #include <fairlogger/Logger.h>
 #include <gsl/span>
+
 #include <vector>
-#include "Rtypes.h"
 
-namespace o2
-{
-
-namespace emcal
+namespace o2::emcal
 {
 
 /// \class ClusterLabel
@@ -90,6 +87,5 @@ class ClusterLabel
   std::vector<labelWithE> mClusterLabels; ///< List of MC particles that generated the cluster, paired with energy fraction
 };
 
-} // namespace emcal
-} // namespace o2
+} // namespace o2::emcal
 #endif // ALICEO2_EMCAL_CLUSTERLABEL_H_

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
@@ -36,6 +36,6 @@ class MCLabel : public o2::MCCompLabel
 
   ClassDefNV(MCLabel, 2);
 };
-} //namespace o2::emcal
+} // namespace o2::emcal
 
 #endif

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
@@ -16,9 +16,7 @@
 
 #include "SimulationDataFormat/MCCompLabel.h"
 
-namespace o2
-{
-namespace emcal
+namespace o2::emcal
 {
 
 /// \class MCLabel
@@ -27,18 +25,17 @@ namespace emcal
 class MCLabel : public o2::MCCompLabel
 {
  private:
-  Double_t mAmplitudeFraction;
+  Double_t mAmplitudeFraction{0};
 
  public:
   MCLabel() = default;
   MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Bool_t fake, Double_t afraction) : o2::MCCompLabel(trackID, eventID, srcID, fake), mAmplitudeFraction(afraction) {}
   MCLabel(Bool_t noise, Double_t afraction) : o2::MCCompLabel(noise), mAmplitudeFraction(afraction) {}
   void setAmplitudeFraction(Double_t afraction) { mAmplitudeFraction = afraction; }
-  Double_t getAmplitudeFraction() const { return mAmplitudeFraction; }
+  [[nodiscard]] Double_t getAmplitudeFraction() const { return mAmplitudeFraction; }
 
-  ClassDefNV(MCLabel, 1);
+  ClassDefNV(MCLabel, 2);
 };
-} // namespace emcal
-} //namespace o2
+} //namespace o2::emcal
 
 #endif

--- a/DataFormats/Detectors/EMCAL/src/AnalysisCluster.cxx
+++ b/DataFormats/Detectors/EMCAL/src/AnalysisCluster.cxx
@@ -11,11 +11,13 @@
 
 /// \file AnalysisCluster.cxx
 
+#include "DataFormatsEMCAL/AnalysisCluster.h"
+#include <TLorentzVector.h>
+
 #include <fairlogger/Logger.h>
 #include <gsl/span>
+
 #include <array>
-#include <TLorentzVector.h>
-#include "DataFormatsEMCAL/AnalysisCluster.h"
 
 using namespace o2::emcal;
 
@@ -34,7 +36,7 @@ TLorentzVector AnalysisCluster::getMomentum(std::array<const float, 3> vertex) c
 
   TLorentzVector p;
 
-  float pos[3] = {mGlobalPos.X(), mGlobalPos.Y(), mGlobalPos.Z()};
+  std::array<float, 3> pos = {mGlobalPos.X(), mGlobalPos.Y(), mGlobalPos.Z()};
   pos[0] -= vertex[0];
   pos[1] -= vertex[1];
   pos[2] -= vertex[2];
@@ -51,7 +53,7 @@ TLorentzVector AnalysisCluster::getMomentum(std::array<const float, 3> vertex) c
 }
 
 //______________________________________________________________________________
-void AnalysisCluster::setGlobalPosition(math_utils::Point3D<float> x)
+void AnalysisCluster::setGlobalPosition(const math_utils::Point3D<float>& x)
 {
   mGlobalPos.SetX(x.X());
   mGlobalPos.SetY(x.Y());
@@ -59,7 +61,7 @@ void AnalysisCluster::setGlobalPosition(math_utils::Point3D<float> x)
 }
 
 //______________________________________________________________________________
-void AnalysisCluster::setLocalPosition(math_utils::Point3D<float> x)
+void AnalysisCluster::setLocalPosition(const math_utils::Point3D<float>& x)
 {
   mLocalPos.SetX(x.X());
   mLocalPos.SetY(x.Y());

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -62,7 +62,6 @@ const float
 }
 } // namespace EnergyEncoding
 
-
 namespace DecodingV0
 {
 struct __attribute__((packed)) CellDataPacked {

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -11,9 +11,10 @@
 
 #include "DataFormatsEMCAL/Constants.h"
 #include "DataFormatsEMCAL/Cell.h"
-#include <iostream>
-#include <bitset>
+
 #include <cmath>
+#include <cstring>
+#include <iostream>
 
 using namespace o2::emcal;
 
@@ -61,6 +62,7 @@ const float
 }
 } // namespace EnergyEncoding
 
+
 namespace DecodingV0
 {
 struct __attribute__((packed)) CellDataPacked {
@@ -71,6 +73,16 @@ struct __attribute__((packed)) CellDataPacked {
   uint16_t mZerod : 6;      ///< bits 42-47: Zerod
 };
 } // namespace DecodingV0
+
+namespace
+{
+inline DecodingV0::CellDataPacked unpackV0(const char* bitfield)
+{
+  DecodingV0::CellDataPacked out{};
+  std::memcpy(&out, bitfield, sizeof(out));
+  return out;
+}
+} // namespace
 
 Cell::Cell(short tower, float energy, float timestamp, ChannelType_t ctype) : mTowerID(tower), mEnergy(energy), mTimestamp(timestamp), mChannelType(ctype)
 {
@@ -147,31 +159,31 @@ void Cell::setChannelTypeEncoded(uint16_t channelTypeBits)
 
 void Cell::initializeFromPackedBitfieldV0(const char* bitfield)
 {
-  auto bitrepresentation = reinterpret_cast<const DecodingV0::CellDataPacked*>(bitfield);
-  mEnergy = decodeEnergyV0(bitrepresentation->mEnergy);
-  mTimestamp = decodeTime(bitrepresentation->mTime);
-  mTowerID = bitrepresentation->mTowerID;
-  mChannelType = static_cast<ChannelType_t>(bitrepresentation->mCellStatus);
+  auto bitrepresentation = unpackV0(bitfield);
+  mEnergy = decodeEnergyV0(bitrepresentation.mEnergy);
+  mTimestamp = decodeTime(bitrepresentation.mTime);
+  mTowerID = bitrepresentation.mTowerID;
+  mChannelType = static_cast<ChannelType_t>(bitrepresentation.mCellStatus);
 }
 
 float Cell::getEnergyFromPackedBitfieldV0(const char* bitfield)
 {
-  return decodeEnergyV0(reinterpret_cast<const DecodingV0::CellDataPacked*>(bitfield)->mEnergy);
+  return decodeEnergyV0(unpackV0(bitfield).mEnergy);
 }
 
 float Cell::getTimeFromPackedBitfieldV0(const char* bitfield)
 {
-  return decodeTime(reinterpret_cast<const DecodingV0::CellDataPacked*>(bitfield)->mTime);
+  return decodeTime(unpackV0(bitfield).mTime);
 }
 
 ChannelType_t Cell::getCellTypeFromPackedBitfieldV0(const char* bitfield)
 {
-  return static_cast<ChannelType_t>(reinterpret_cast<const DecodingV0::CellDataPacked*>(bitfield)->mCellStatus);
+  return static_cast<ChannelType_t>(unpackV0(bitfield).mCellStatus);
 }
 
 short Cell::getTowerFromPackedBitfieldV0(const char* bitfield)
 {
-  return reinterpret_cast<const DecodingV0::CellDataPacked*>(bitfield)->mTowerID;
+  return unpackV0(bitfield).mTowerID;
 }
 
 void Cell::truncate(EncoderVersion version)

--- a/DataFormats/Detectors/EMCAL/src/CellLabel.cxx
+++ b/DataFormats/Detectors/EMCAL/src/CellLabel.cxx
@@ -12,12 +12,14 @@
 /// \file CellLabel.cxx
 
 #include "DataFormatsEMCAL/CellLabel.h"
-#include "fairlogger/Logger.h"
+
+#include <fairlogger/Logger.h>
+
 #include <cstddef>
 #include <cstdint>
-#include <gsl/span>
-#include <vector>
+#include <span>
 #include <utility>
+#include <vector>
 
 using namespace o2::emcal;
 
@@ -28,7 +30,7 @@ CellLabel::CellLabel(std::vector<int> labels, std::vector<float> amplitudeFracti
   }
 }
 
-CellLabel::CellLabel(gsl::span<const int> labels, gsl::span<const float> amplitudeFractions) : mLabels(labels.begin(), labels.end()), mAmplitudeFraction(amplitudeFractions.begin(), amplitudeFractions.end())
+CellLabel::CellLabel(std::span<const int> labels, std::span<const float> amplitudeFractions) : mLabels(labels.begin(), labels.end()), mAmplitudeFraction(amplitudeFractions.begin(), amplitudeFractions.end())
 {
   if (labels.size() != amplitudeFractions.size()) {
     LOG(error) << "Size of labels " << labels.size() << " does not match size of amplitude fraction " << amplitudeFractions.size() << " !";

--- a/DataFormats/Detectors/EMCAL/src/Cluster.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cluster.cxx
@@ -8,10 +8,11 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#include "DataFormatsEMCAL/Cluster.h"
+
 #include <cfloat>
 #include <cmath>
 #include <iostream>
-#include "DataFormatsEMCAL/Cluster.h"
 
 using namespace o2::emcal;
 

--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -10,25 +10,26 @@
 // or submit itself to any jurisdiction.
 #ifndef ALICEO2_EMCAL_CLUSTERFACTORY_H_
 #define ALICEO2_EMCAL_CLUSTERFACTORY_H_
-#include <array>
-#include <vector>
-#include <utility>
-#include <gsl/span>
-#include "Rtypes.h"
-#include "fmt/format.h"
-#include "DataFormatsEMCAL/Cluster.h"
-#include "DataFormatsEMCAL/Digit.h"
-#include "DataFormatsEMCAL/Cell.h"
-#include "DataFormatsEMCAL/AnalysisCluster.h"
-#include "DataFormatsEMCAL/CellLabel.h"
-#include "DataFormatsEMCAL/ClusterLabel.h"
+
 #include "EMCALBase/Geometry.h"
-#include "MathUtils/Cartesian.h"
+#include "DataFormatsEMCAL/AnalysisCluster.h"
+#include "DataFormatsEMCAL/Cell.h" // IWYU pragma: keep
+#include "DataFormatsEMCAL/CellLabel.h"
+#include "DataFormatsEMCAL/Cluster.h"
+#include "DataFormatsEMCAL/ClusterLabel.h"
+#include "DataFormatsEMCAL/Digit.h" // IWYU pragma: keep
+// #include "MathUtils/Cartesian.h"
 
-namespace o2
-{
+#include <Rtypes.h>
 
-namespace emcal
+#include <fmt/format.h>
+
+#include <array>
+#include <span>
+// #include <vector>
+// #include <utility>
+
+namespace o2::emcal
 {
 
 /// \class ClusterFactory
@@ -52,9 +53,8 @@ class ClusterFactory
     ClusterRangeException(int clusterIndex, int maxClusters) : std::exception(),
                                                                mClusterID(clusterIndex),
                                                                mMaxClusters(maxClusters),
-                                                               mErrorMessage()
+                                                               mErrorMessage(fmt::format("Cluster out of range: %d, max %d", mClusterID, mMaxClusters))
     {
-      mErrorMessage = fmt::format("Cluster out of range: %d, max %d", mClusterID, mMaxClusters);
     }
 
     /// \brief Destructor
@@ -62,15 +62,15 @@ class ClusterFactory
 
     /// \brief Provide error message
     /// \return Error message connected to this exception
-    const char* what() const noexcept final { return mErrorMessage.data(); }
+    [[nodiscard]] const char* what() const noexcept final { return mErrorMessage.data(); }
 
     /// \brief Get the ID of the event raising the exception
     /// \return Event ID
-    int getClusterID() const { return mClusterID; }
+    [[nodiscard]] int getClusterID() const { return mClusterID; }
 
     /// \brief Get the maximum number of events handled by the event handler
     /// \return Max. number of event
-    int getMaxNumberOfClusters() const { return mMaxClusters; }
+    [[nodiscard]] int getMaxNumberOfClusters() const { return mMaxClusters; }
 
    private:
     int mClusterID = 0;        ///< Cluster ID raising the exception
@@ -87,9 +87,8 @@ class ClusterFactory
     CellIndexRangeException(int cellIndex, int maxCellIndex) : std::exception(),
                                                                mCellIndex(cellIndex),
                                                                mMaxCellIndex(maxCellIndex),
-                                                               mErrorMessage()
+                                                               mErrorMessage(fmt::format("Cell Index out of range: %d, max %d", mCellIndex, mMaxCellIndex))
     {
-      mErrorMessage = Form("Cell Index out of range: %d, max %d", mCellIndex, mMaxCellIndex);
     }
 
     /// \brief Destructor
@@ -97,15 +96,15 @@ class ClusterFactory
 
     /// \brief Provide error message
     /// \return Error message connected to this exception
-    const char* what() const noexcept final { return mErrorMessage.data(); }
+    [[nodiscard]] const char* what() const noexcept final { return mErrorMessage.data(); }
 
     /// \brief Get the index of the cell raising the exception
     /// \return Cell index
-    int getCellIndex() const { return mCellIndex; }
+    [[nodiscard]] int getCellIndex() const { return mCellIndex; }
 
     /// \brief Get the maximum number of cell indices handled by the cluster factory
     /// \return Max. number of cell indices
-    int getMaxNumberOfCellIndexs() const { return mMaxCellIndex; }
+    [[nodiscard]] int getMaxNumberOfCellIndexs() const { return mMaxCellIndex; }
 
    private:
     int mCellIndex = 0;        ///< CellIndex ID raising the exception
@@ -125,7 +124,7 @@ class ClusterFactory
 
     /// \brief Provide error message
     /// \return Error message connected to this exception
-    const char* what() const noexcept final { return "Geometry not set"; }
+    [[nodiscard]] const char* what() const noexcept final { return "Geometry not set"; }
   };
 
   class ClusterIterator
@@ -180,10 +179,10 @@ class ClusterFactory
 
     /// \brief Get the index of the current event
     /// \return Index of the current event
-    int current_index() const { return mClusterID; }
+    [[nodiscard]] int current_index() const { return mClusterID; }
 
    private:
-    const ClusterFactory& mClusterFactory; ///< Event factory connected to the iterator
+    const ClusterFactory* mClusterFactory; ///< Event factory connected to the iterator
     AnalysisCluster mCurrentCluster;       ///< Cache for current cluster
     int mClusterID = 0;                    ///< Current cluster ID within the cluster factory
     bool mForward = true;                  ///< Iterator direction (forward or backward)
@@ -198,7 +197,7 @@ class ClusterFactory
   /// \param clustersContainer cluster container
   /// \param inputsContainer cells/digits container
   /// \param cellsIndices for cells/digits indices
-  ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<const int> cellsIndices);
+  ClusterFactory(std::span<const o2::emcal::Cluster> clustersContainer, std::span<const InputType> inputsContainer, std::span<const int> cellsIndices);
 
   ///
   /// Copy constructor
@@ -245,17 +244,17 @@ class ClusterFactory
 
   ///
   /// Calculates the center of gravity in the local EMCAL-module coordinates
-  void evalLocalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& cluster) const;
+  void evalLocalPosition(std::span<const int> inputsIndices, AnalysisCluster& cluster) const;
 
   ///
   /// Calculates the center of gravity in the global ALICE coordinates
-  void evalGlobalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& cluster) const;
+  void evalGlobalPosition(std::span<const int> inputsIndices, AnalysisCluster& cluster) const;
 
   void evalLocal2TrackingCSTransform() const;
 
   ///
   /// evaluates local position of clusters in SM
-  void evalLocalPositionFit(Double_t deff, Double_t w0, Double_t phiSlope, gsl::span<const int> inputsIndices, AnalysisCluster& cluster) const;
+  void evalLocalPositionFit(double deff, double mLogWeight, double phiSlope, std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Applied for simulation data with threshold 3 adc
@@ -271,7 +270,7 @@ class ClusterFactory
   /// \return the maximum energy
   /// \return the total energy of the cluster
   /// \return if cluster is shared between super models
-  std::tuple<int, float, float, bool> getMaximalEnergyIndex(gsl::span<const int> inputsIndices) const;
+  std::tuple<int, float, float, bool> getMaximalEnergyIndex(std::span<const int> inputsIndices) const;
 
   /// \brief Look to cell neighbourhood and reject if it seems exotic
   /// \param towerId: tower ID of cell with largest energy fraction in cluster
@@ -295,17 +294,17 @@ class ClusterFactory
 
   ///
   /// Calculates the multiplicity of digits/cells with energy larger than level*energy
-  int getMultiplicityAtLevel(float level, gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  int getMultiplicityAtLevel(float level, std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   int getSuperModuleNumber() const { return mSuperModuleNumber; }
 
   // searches for the local maxima
   // energy above relative level
   // int getNumberOfLocalMax(int nInputMult,
-  //                        float locMaxCut, gsl::span<InputType> inputs) const;
+  //                        float locMaxCut, std::span<InputType> inputs) const;
 
   // int getNumberOfLocalMax(std::vector<InputType>& maxAt, std::vector<float>& maxAtEnergy,
-  //                         float locMaxCut, gsl::span<InputType> inputs) const;
+  //                         float locMaxCut, std::span<InputType> inputs) const;
 
   bool sharedCluster() const { return mSharedCluster; }
   void setSharedCluster(bool s) { mSharedCluster = s; }
@@ -317,7 +316,7 @@ class ClusterFactory
 
   bool getLookUpInit() const { return mLookUpInit; }
 
-  bool getCoreRadius() const { return mCoreRadius; }
+  float getCoreRadius() const { return mCoreRadius; }
   void setCoreRadius(float radius) { mCoreRadius = radius; }
 
   float getExoticCellFraction() const { return mExoticCellFraction; }
@@ -333,9 +332,9 @@ class ClusterFactory
   void setExoticCellInCrossMinAmplitude(float exoticCellInCrossMinAmplitude) { mExoticCellInCrossMinAmplitude = exoticCellInCrossMinAmplitude; }
 
   bool getUseWeightExotic() const { return mUseWeightExotic; }
-  void setUseWeightExotic(float useWeightExotic) { mUseWeightExotic = useWeightExotic; }
+  void setUseWeightExotic(bool useWeightExotic) { mUseWeightExotic = useWeightExotic; }
 
-  void setContainer(gsl::span<const o2::emcal::Cluster> clusterContainer, gsl::span<const InputType> cellContainer, gsl::span<const int> indicesContainer, gsl::span<const o2::emcal::CellLabel> cellLabelContainer = {})
+  void setContainer(std::span<const o2::emcal::Cluster> clusterContainer, std::span<const InputType> cellContainer, std::span<const int> indicesContainer, std::span<const o2::emcal::CellLabel> cellLabelContainer = {})
   {
     mClustersContainer = clusterContainer;
     mInputsContainer = cellContainer;
@@ -348,7 +347,7 @@ class ClusterFactory
     }
   }
 
-  void setLookUpTable(void)
+  void setLookUpTable()
   {
     mLoolUpTowerToIndex.fill(-1);
     for (auto iCellIndex : mCellsIndices) {
@@ -378,7 +377,7 @@ class ClusterFactory
     ~UninitLookUpTableException() noexcept final = default;
 
     /// \brief Access to error message of the exception
-    const char* what() const noexcept final { return "Lookup table not initialized, exotics evaluation not possible!"; }
+    [[nodiscard]] const char* what() const noexcept final { return "Lookup table not initialized, exotics evaluation not possible!"; }
   };
 
  protected:
@@ -389,25 +388,25 @@ class ClusterFactory
   /// should be less than 2%
   /// Unfinished - Nov 15,2006
   /// Distance is calculate in (phi,eta) units
-  void evalCoreEnergy(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalCoreEnergy(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Calculates the dispersion of the shower at the origin of the cluster
   /// in cell units
-  void evalDispersion(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalDispersion(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Calculates the axis of the shower ellipsoid in eta and phi
   /// in cell units
-  void evalElipsAxis(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalElipsAxis(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Calculate the number of local maxima in the cluster
-  void evalNExMax(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalNExMax(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Time is set to the time of the digit with the maximum energy
-  void evalTime(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalTime(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Converts Theta (Radians) to Eta (Radians)
@@ -436,15 +435,14 @@ class ClusterFactory
   float mExoticCellInCrossMinAmplitude = 0.1; ///<  Minimum energy of cells in cross, if lower not considered in cross
   bool mUseWeightExotic = false;              ///<  States if weights should be used for exotic cell cut
 
-  gsl::span<const o2::emcal::Cluster> mClustersContainer;    ///< Container for all the clusters in the event
-  gsl::span<const InputType> mInputsContainer;               ///< Container for all the cells/digits in the event
-  gsl::span<const int> mCellsIndices;                        ///< Container for cells indices in the event
-  std::array<short, 17664> mLoolUpTowerToIndex;              ///< Lookup table to match tower id with cell index, needed for exotic check
-  gsl::span<const o2::emcal::CellLabel> mCellLabelContainer; ///< Container for all the cell labels in the event
+  std::span<const o2::emcal::Cluster> mClustersContainer;    ///<! Container for all the clusters in the event
+  std::span<const InputType> mInputsContainer;               ///<! Container for all the cells/digits in the event
+  std::span<const int> mCellsIndices;                        ///<! Container for cells indices in the event
+  std::array<short, 17664> mLoolUpTowerToIndex{};            ///< Lookup table to match tower id with cell index, needed for exotic check
+  std::span<const o2::emcal::CellLabel> mCellLabelContainer; ///<! Container for all the cell labels in the event
 
   ClassDefNV(ClusterFactory, 2);
 };
 
-} // namespace emcal
-} // namespace o2
+} // namespace o2::emcal
 #endif // ALICEO2_EMCAL_CLUSTERFACTORY_H_

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -473,7 +473,7 @@ class Geometry
   {
     if (GetSMType(nSupMod) == EMCAL_HALF) {
       return mNPhi / 2;
-    } 
+    }
     if (GetSMType(nSupMod) == EMCAL_THIRD || GetSMType(nSupMod) == DCAL_EXT) {
       return mNPhi / 3;
     }
@@ -633,12 +633,12 @@ class Geometry
   std::tuple<int, int, int, int> CalculateCellIndex(Int_t absId) const;
 
   std::string mGeoName;                     ///< Geometry name string
-  Int_t mKey110DEG = 0;                         ///< For calculation abs cell id; 19-oct-05
-  Int_t mnSupModInDCAL = 0;                     ///< For calculation abs cell id; 06-nov-12
-  Int_t mNCellsInSupMod = 0;                    ///< Number cell in super module
-  Int_t mNETAdiv = 0;                           ///< Number eta division of module
-  Int_t mNPHIdiv = 0;                           ///< Number phi division of module
-  Int_t mNCellsInModule = 0;                    ///< Number cell in module
+  Int_t mKey110DEG = 0;                     ///< For calculation abs cell id; 19-oct-05
+  Int_t mnSupModInDCAL = 0;                 ///< For calculation abs cell id; 06-nov-12
+  Int_t mNCellsInSupMod = 0;                ///< Number cell in super module
+  Int_t mNETAdiv = 0;                       ///< Number eta division of module
+  Int_t mNPHIdiv = 0;                       ///< Number phi division of module
+  Int_t mNCellsInModule = 0;                ///< Number cell in module
   std::vector<Double_t> mPhiBoundariesOfSM; ///< Phi boundaries of SM in rad; size is fNumberOfSuperModules;
   std::vector<Double_t> mPhiCentersOfSM;    ///< Phi of centers of SM; size is fNumberOfSuperModules/2
   std::vector<Double_t> mPhiCentersOfSMSec; ///< Phi of centers of section where SM lies; size is fNumberOfSuperModules/2
@@ -649,30 +649,30 @@ class Geometry
   std::vector<Double_t> mCentersOfCellsPhiDir; ///< Size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
   std::vector<Double_t>
     mEtaCentersOfCells;                                     ///< [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
-  Int_t mNCells = 0;                                            ///< Number of cells in calo
-  Int_t mNPhi = 0;                                              ///< Number of Towers in the PHI direction
+  Int_t mNCells = 0;                                        ///< Number of cells in calo
+  Int_t mNPhi = 0;                                          ///< Number of Towers in the PHI direction
   std::vector<Double_t> mCentersOfCellsXDir;                ///< Size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
   std::array<float, 3> mEnvelop{};                          ///< The GEANT TUB for the detector
-  Float_t mArm1EtaMin = 0;                                      ///< Minimum pseudorapidity position of EMCAL in Eta
-  Float_t mArm1EtaMax = 0;                                      ///< Maximum pseudorapidity position of EMCAL in Eta
-  Float_t mArm1PhiMin = 0;                                      ///< Minimum angular position of EMCAL in Phi (degrees)
-  Float_t mArm1PhiMax = 0;                                      ///< Maximum angular position of EMCAL in Phi (degrees)
-  Float_t mEtaMaxOfTRD1 = 0;                                    ///< Max eta in case of TRD1 geometry (see AliEMCALShishKebabTrd1Module)
-  Float_t mDCALPhiMin = 0;                                      ///< Minimum angular position of DCAL in Phi (degrees)
-  Float_t mDCALPhiMax = 0;                                      ///< Maximum angular position of DCAL in Phi (degrees)
-  Float_t mEMCALPhiMax = 0;                                     ///< Maximum angular position of EMCAL in Phi (degrees)
-  Float_t mDCALStandardPhiMax = 0;                              ///< Special edge for the case that DCAL contian extension
-  Float_t mDCALInnerExtandedEta = 0;                            ///< DCAL inner edge in Eta (with some extension)
-  Float_t mDCALInnerEdge = 0;                                   ///< Inner edge for DCAL
+  Float_t mArm1EtaMin = 0;                                  ///< Minimum pseudorapidity position of EMCAL in Eta
+  Float_t mArm1EtaMax = 0;                                  ///< Maximum pseudorapidity position of EMCAL in Eta
+  Float_t mArm1PhiMin = 0;                                  ///< Minimum angular position of EMCAL in Phi (degrees)
+  Float_t mArm1PhiMax = 0;                                  ///< Maximum angular position of EMCAL in Phi (degrees)
+  Float_t mEtaMaxOfTRD1 = 0;                                ///< Max eta in case of TRD1 geometry (see AliEMCALShishKebabTrd1Module)
+  Float_t mDCALPhiMin = 0;                                  ///< Minimum angular position of DCAL in Phi (degrees)
+  Float_t mDCALPhiMax = 0;                                  ///< Maximum angular position of DCAL in Phi (degrees)
+  Float_t mEMCALPhiMax = 0;                                 ///< Maximum angular position of EMCAL in Phi (degrees)
+  Float_t mDCALStandardPhiMax = 0;                          ///< Special edge for the case that DCAL contian extension
+  Float_t mDCALInnerExtandedEta = 0;                        ///< DCAL inner edge in Eta (with some extension)
+  Float_t mDCALInnerEdge = 0;                               ///< Inner edge for DCAL
   std::vector<ShishKebabTrd1Module> mShishKebabTrd1Modules; ///< List of modules
   std::array<float, 3> mParSM{};                            ///< SM sizes as in GEANT (TRD1)
-  Float_t mPhiModuleSize = 0;                                   ///< Phi -> X
-  Float_t mEtaModuleSize = 0;                                   ///< Eta -> Y
-  Float_t mPhiTileSize = 0;                                     ///< Size of phi tile
-  Float_t mEtaTileSize = 0;                                     ///< Size of eta tile
-  Int_t mNZ = 0;                                                ///< Number of Towers in the Z direction
-  Float_t mIPDistance = 0;                                      ///< Radial Distance of the inner surface of the EMCAL
-  Float_t mLongModuleSize = 0;                                  ///< Size of long module
+  Float_t mPhiModuleSize = 0;                               ///< Phi -> X
+  Float_t mEtaModuleSize = 0;                               ///< Eta -> Y
+  Float_t mPhiTileSize = 0;                                 ///< Size of phi tile
+  Float_t mEtaTileSize = 0;                                 ///< Size of eta tile
+  Int_t mNZ = 0;                                            ///< Number of Towers in the Z direction
+  Float_t mIPDistance = 0;                                  ///< Radial Distance of the inner surface of the EMCAL
+  Float_t mLongModuleSize = 0;                              ///< Size of long module
 
   // Geometry Parameters
   Float_t mShellThickness = 0; ///< Total thickness in (x,y) direction

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -12,11 +12,9 @@
 #ifndef ALICEO2_EMCAL_GEOMETRY_H_
 #define ALICEO2_EMCAL_GEOMETRY_H_
 
-#include <array>
-#include <string>
-#include <string_view>
-#include <tuple>
-#include <vector>
+#include "DataFormatsEMCAL/Constants.h"
+#include "EMCALBase/GeometryBase.h"
+#include "GPUROOTCartesianFwd.h"
 
 #include <RStringView.h>
 #include <RtypesCore.h>
@@ -25,14 +23,16 @@
 #include <TParticle.h>
 #include <TVector3.h>
 
-#include "DataFormatsEMCAL/Constants.h"
-#include "EMCALBase/GeometryBase.h"
-#include "MathUtils/Cartesian.h"
+#include <array>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+#include <span>
 
-namespace o2
+namespace o2::emcal
 {
-namespace emcal
-{
+
 class ShishKebabTrd1Module;
 
 /// \class Geometry
@@ -285,15 +285,15 @@ class Geometry
   /// \param[in] ind super module number
   ///
   /// Use the supermodule alignment.
-  void GetGlobal(const Double_t* loc, Double_t* glob, int ind) const;
+  void GetGlobal(std::span<const double, 3> loc, std::span<double, 3> glob, int iSM) const;
 
   /// \brief Figure out the global coordinates from local coordinates on a supermodule.
   /// \param[in] vloc local coordinates
   /// \param[out] vglob global coordinates
-  /// \param[in] ind super module number
+  /// \param[in] iSM super module number
   ///
   /// Use the supermodule alignment.
-  void GetGlobal(const TVector3& vloc, TVector3& vglob, int ind) const;
+  void GetGlobal(const TVector3& vloc, TVector3& vglob, int iSM) const;
 
   /// \brief Figure out the global coordinates of a cell.
   /// Use the supermodule alignment. Use double[3].
@@ -301,14 +301,14 @@ class Geometry
   /// \param absId cell absolute id. number.
   /// \param glob 3-double coordinates, output
   ///
-  void GetGlobal(Int_t absId, Double_t glob[3]) const;
+  void GetGlobal(int absId, std::span<double, 3> glob) const;
 
   /// \brief Figure out the global coordinates of a cell.
   /// \param absId cell absolute id. number.
   /// \param vglob TVector3 coordinates, output
   ///
   /// Use the supermodule alignment. Use TVector3.
-  void GetGlobal(Int_t absId, TVector3& vglob) const;
+  void GetGlobal(int absId, TVector3& vglob) const;
 
   ////////////////////////////////////////
   // May 31, 2006; ALICE numbering scheme:
@@ -473,13 +473,11 @@ class Geometry
   {
     if (GetSMType(nSupMod) == EMCAL_HALF) {
       return mNPhi / 2;
-    } else if (GetSMType(nSupMod) == EMCAL_THIRD) {
+    } 
+    if (GetSMType(nSupMod) == EMCAL_THIRD || GetSMType(nSupMod) == DCAL_EXT) {
       return mNPhi / 3;
-    } else if (GetSMType(nSupMod) == DCAL_EXT) {
-      return mNPhi / 3;
-    } else {
-      return mNPhi;
     }
+    return mNPhi;
   }
 
   /// \brief Transition from cell indexes (iphi, ieta) to module indexes (iphim, ietam, nModule)
@@ -597,8 +595,8 @@ class Geometry
   ///
   ///  Federico.Ronchetti@cern.ch
   void RecalculateTowerPosition(Float_t drow, Float_t dcol, const Int_t sm, const Float_t depth,
-                                const Float_t misaligTransShifts[15], const Float_t misaligRotShifts[15],
-                                Float_t global[3]) const;
+                                std::span<const float, 15> misaligTransShifts, std::span<const float, 15> misaligRotShifts,
+                                std::span<float, 3> global) const;
 
   /// \brief Provides shift-rotation matrix for EMCAL from externally set matrix or
   /// from TGeoManager
@@ -635,12 +633,12 @@ class Geometry
   std::tuple<int, int, int, int> CalculateCellIndex(Int_t absId) const;
 
   std::string mGeoName;                     ///< Geometry name string
-  Int_t mKey110DEG;                         ///< For calculation abs cell id; 19-oct-05
-  Int_t mnSupModInDCAL;                     ///< For calculation abs cell id; 06-nov-12
-  Int_t mNCellsInSupMod;                    ///< Number cell in super module
-  Int_t mNETAdiv;                           ///< Number eta division of module
-  Int_t mNPHIdiv;                           ///< Number phi division of module
-  Int_t mNCellsInModule;                    ///< Number cell in module
+  Int_t mKey110DEG = 0;                         ///< For calculation abs cell id; 19-oct-05
+  Int_t mnSupModInDCAL = 0;                     ///< For calculation abs cell id; 06-nov-12
+  Int_t mNCellsInSupMod = 0;                    ///< Number cell in super module
+  Int_t mNETAdiv = 0;                           ///< Number eta division of module
+  Int_t mNPHIdiv = 0;                           ///< Number phi division of module
+  Int_t mNCellsInModule = 0;                    ///< Number cell in module
   std::vector<Double_t> mPhiBoundariesOfSM; ///< Phi boundaries of SM in rad; size is fNumberOfSuperModules;
   std::vector<Double_t> mPhiCentersOfSM;    ///< Phi of centers of SM; size is fNumberOfSuperModules/2
   std::vector<Double_t> mPhiCentersOfSMSec; ///< Phi of centers of section where SM lies; size is fNumberOfSuperModules/2
@@ -651,72 +649,72 @@ class Geometry
   std::vector<Double_t> mCentersOfCellsPhiDir; ///< Size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
   std::vector<Double_t>
     mEtaCentersOfCells;                                     ///< [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
-  Int_t mNCells;                                            ///< Number of cells in calo
-  Int_t mNPhi;                                              ///< Number of Towers in the PHI direction
+  Int_t mNCells = 0;                                            ///< Number of cells in calo
+  Int_t mNPhi = 0;                                              ///< Number of Towers in the PHI direction
   std::vector<Double_t> mCentersOfCellsXDir;                ///< Size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
-  Float_t mEnvelop[3];                                      ///< The GEANT TUB for the detector
-  Float_t mArm1EtaMin;                                      ///< Minimum pseudorapidity position of EMCAL in Eta
-  Float_t mArm1EtaMax;                                      ///< Maximum pseudorapidity position of EMCAL in Eta
-  Float_t mArm1PhiMin;                                      ///< Minimum angular position of EMCAL in Phi (degrees)
-  Float_t mArm1PhiMax;                                      ///< Maximum angular position of EMCAL in Phi (degrees)
-  Float_t mEtaMaxOfTRD1;                                    ///< Max eta in case of TRD1 geometry (see AliEMCALShishKebabTrd1Module)
-  Float_t mDCALPhiMin;                                      ///< Minimum angular position of DCAL in Phi (degrees)
-  Float_t mDCALPhiMax;                                      ///< Maximum angular position of DCAL in Phi (degrees)
-  Float_t mEMCALPhiMax;                                     ///< Maximum angular position of EMCAL in Phi (degrees)
-  Float_t mDCALStandardPhiMax;                              ///< Special edge for the case that DCAL contian extension
-  Float_t mDCALInnerExtandedEta;                            ///< DCAL inner edge in Eta (with some extension)
-  Float_t mDCALInnerEdge;                                   ///< Inner edge for DCAL
+  std::array<float, 3> mEnvelop{};                          ///< The GEANT TUB for the detector
+  Float_t mArm1EtaMin = 0;                                      ///< Minimum pseudorapidity position of EMCAL in Eta
+  Float_t mArm1EtaMax = 0;                                      ///< Maximum pseudorapidity position of EMCAL in Eta
+  Float_t mArm1PhiMin = 0;                                      ///< Minimum angular position of EMCAL in Phi (degrees)
+  Float_t mArm1PhiMax = 0;                                      ///< Maximum angular position of EMCAL in Phi (degrees)
+  Float_t mEtaMaxOfTRD1 = 0;                                    ///< Max eta in case of TRD1 geometry (see AliEMCALShishKebabTrd1Module)
+  Float_t mDCALPhiMin = 0;                                      ///< Minimum angular position of DCAL in Phi (degrees)
+  Float_t mDCALPhiMax = 0;                                      ///< Maximum angular position of DCAL in Phi (degrees)
+  Float_t mEMCALPhiMax = 0;                                     ///< Maximum angular position of EMCAL in Phi (degrees)
+  Float_t mDCALStandardPhiMax = 0;                              ///< Special edge for the case that DCAL contian extension
+  Float_t mDCALInnerExtandedEta = 0;                            ///< DCAL inner edge in Eta (with some extension)
+  Float_t mDCALInnerEdge = 0;                                   ///< Inner edge for DCAL
   std::vector<ShishKebabTrd1Module> mShishKebabTrd1Modules; ///< List of modules
-  Float_t mParSM[3];                                        ///< SM sizes as in GEANT (TRD1)
-  Float_t mPhiModuleSize;                                   ///< Phi -> X
-  Float_t mEtaModuleSize;                                   ///< Eta -> Y
-  Float_t mPhiTileSize;                                     ///< Size of phi tile
-  Float_t mEtaTileSize;                                     ///< Size of eta tile
-  Int_t mNZ;                                                ///< Number of Towers in the Z direction
-  Float_t mIPDistance;                                      ///< Radial Distance of the inner surface of the EMCAL
-  Float_t mLongModuleSize;                                  ///< Size of long module
+  std::array<float, 3> mParSM{};                            ///< SM sizes as in GEANT (TRD1)
+  Float_t mPhiModuleSize = 0;                                   ///< Phi -> X
+  Float_t mEtaModuleSize = 0;                                   ///< Eta -> Y
+  Float_t mPhiTileSize = 0;                                     ///< Size of phi tile
+  Float_t mEtaTileSize = 0;                                     ///< Size of eta tile
+  Int_t mNZ = 0;                                                ///< Number of Towers in the Z direction
+  Float_t mIPDistance = 0;                                      ///< Radial Distance of the inner surface of the EMCAL
+  Float_t mLongModuleSize = 0;                                  ///< Size of long module
 
   // Geometry Parameters
-  Float_t mShellThickness; ///< Total thickness in (x,y) direction
-  Float_t mZLength;        ///< Total length in z direction
-  Float_t mSampling;       ///< Sampling factor
+  Float_t mShellThickness = 0; ///< Total thickness in (x,y) direction
+  Float_t mZLength = 0;        ///< Total length in z direction
+  Float_t mSampling = 0;       ///< Sampling factor
 
   // Members from the EMCGeometry class
-  Float_t mECPbRadThickness; ///< cm, Thickness of the Pb radiators
-  Float_t mECScintThick;     ///< cm, Thickness of the scintillators
-  Int_t mNECLayers;          ///< number of scintillator layers
+  Float_t mECPbRadThickness = 0; ///< cm, Thickness of the Pb radiators
+  Float_t mECScintThick = 0;     ///< cm, Thickness of the scintillators
+  Int_t mNECLayers = 0;          ///< number of scintillator layers
 
   // Shish-kebab option - 23-aug-04 by PAI; COMPACT, TWIST, TRD1 and TRD2
-  Int_t mNumberOfSuperModules; ///< default is 12 = 6 * 2
+  Int_t mNumberOfSuperModules = 0; ///< default is 12 = 6 * 2
 
   /// geometry structure
   std::vector<EMCALSMType> mEMCSMSystem; ///< Type of the supermodule (size number of supermodules
 
-  Float_t mFrontSteelStrip;   ///< 13-may-05
-  Float_t mLateralSteelStrip; ///< 13-may-05
-  Float_t mPassiveScintThick; ///< 13-may-05
+  Float_t mFrontSteelStrip = 0;   ///< 13-may-05
+  Float_t mLateralSteelStrip = 0; ///< 13-may-05
+  Float_t mPassiveScintThick = 0; ///< 13-may-05
 
-  Float_t mPhiSuperModule; ///< Phi of normal supermodule (20, in degree)
-  Int_t mNPhiSuperModule;  ///< 9 - number supermodule in phi direction
+  Float_t mPhiSuperModule = 0; ///< Phi of normal supermodule (20, in degree)
+  Int_t mNPhiSuperModule = 0;  ///< 9 - number supermodule in phi direction
 
   // TRD1 options - 30-sep-04
-  Float_t mTrd1Angle;   ///< angle in x-z plane (in degree)
-  Float_t m2Trd1Dx2;    ///< 2*dx2 for TRD1
-  Float_t mPhiGapForSM; ///< Gap betweeen supermodules in phi direction
+  Float_t mTrd1Angle = 0;   ///< angle in x-z plane (in degree)
+  Float_t m2Trd1Dx2 = 0;    ///< 2*dx2 for TRD1
+  Float_t mPhiGapForSM = 0; ///< Gap betweeen supermodules in phi direction
 
   // Oct 26,2010
-  Float_t mTrd1AlFrontThick;   ///< Thickness of the Al front plate
-  Float_t mTrd1BondPaperThick; ///< Thickness of the Bond Paper sheet
+  Float_t mTrd1AlFrontThick = 0;   ///< Thickness of the Al front plate
+  Float_t mTrd1BondPaperThick = 0; ///< Thickness of the Bond Paper sheet
 
-  Int_t mILOSS; ///< Options for Geant (MIP business) - will call in AliEMCAL
-  Int_t mIHADR; ///< Options for Geant (MIP business) - will call in AliEMCAL
+  Int_t mILOSS = -1; ///< Options for Geant (MIP business) - will call in AliEMCAL
+  Int_t mIHADR = -1; ///< Options for Geant (MIP business) - will call in AliEMCAL
 
-  Float_t mSteelFrontThick; ///< Thickness of the front stell face of the support box - 9-sep-04; obsolete?
+  Float_t mSteelFrontThick = 0; ///< Thickness of the front stell face of the support box - 9-sep-04; obsolete?
 
   std::array<int, 46> mCRORCID = {110, 110, 112, 112, 110, 110, 112, 112, 110, 110, 112, 112, 111, 111, 113, 113, 111, 111, 113, 113, 111, 111, 113, 113, 114, 114, 116, 116, 114, 114, 116, 116, 115, 115, 117, 117, 115, 115, 117, 117, -1, -1, -1, -1, 111, 117}; // CRORC ID w.r.t SM
   std::array<int, 46> mCRORCLink = {0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 0, 1, 0, 1, 2, 3, 2, 3, 4, -1, 4, 5, 0, 1, 0, 1, 2, 3, 2, 3, 0, 1, 0, 1, 2, 3, 2, -1, -1, -1, -1, -1, 5, 3};                                                                                 // CRORC limk w.r.t FEE ID
 
-  mutable const TGeoHMatrix* SMODULEMATRIX[EMCAL_MODULES];      ///< Orientations of EMCAL super modules
+  mutable std::array<const TGeoHMatrix*, EMCAL_MODULES> SMODULEMATRIX{}; ///< Orientations of EMCAL super modules
   std::vector<std::tuple<int, int, int, int>> mCellIndexLookup; ///< Lookup table for cell indices
 
  private:
@@ -727,10 +725,9 @@ inline Bool_t Geometry::CheckAbsCellId(Int_t absId) const
 {
   if (absId < 0 || absId >= mNCells) {
     return kFALSE;
-  } else {
-    return kTRUE;
   }
+  return kTRUE;
 }
-} // namespace emcal
-} // namespace o2
+
+} // namespace o2::emcal
 #endif

--- a/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
@@ -14,9 +14,7 @@
 
 #include <string>
 
-namespace o2
-{
-namespace emcal
+namespace o2::emcal
 {
 enum EMCALSMType {
   NOT_EXISTENT = -1,
@@ -47,7 +45,7 @@ class GeometryNotInitializedException final : public std::exception
 
   /// \brief Access to error message
   /// \return Error message
-  const char* what() const noexcept { return "Geometry not initialized"; }
+  [[nodiscard]] const char* what() const noexcept override { return "Geometry not initialized"; }
 };
 
 /// \class InvalidModuleException
@@ -59,8 +57,7 @@ class InvalidModuleException final : public std::exception
   /// \brief Constructor
   /// \param nModule Module number raising the exception
   /// \param nMax Maximum amount of modules in setup
-  InvalidModuleException(int nModule, int nMax) : std::exception(),
-                                                  mModule(nModule),
+  InvalidModuleException(int nModule, int nMax) : mModule(nModule),
                                                   mMax(nMax),
                                                   mMessage("Invalid Module [ " + std::to_string(mModule) + "|" + std::to_string(mMax) + "]")
   {
@@ -71,15 +68,15 @@ class InvalidModuleException final : public std::exception
 
   /// \brief Get ID of the module raising the exception
   /// \return ID of the module
-  int GetModuleID() const noexcept { return mModule; }
+  [[nodiscard]] int GetModuleID() const noexcept { return mModule; }
 
   /// \brief Get number of modules
   /// \return Number of modules
-  int GetMaxNumberOfModules() const noexcept { return mMax; }
+  [[nodiscard]] int GetMaxNumberOfModules() const noexcept { return mMax; }
 
   /// \brief Access to error message
   /// \return Error message for given exception
-  const char* what() const noexcept final { return mMessage.c_str(); }
+  [[nodiscard]] const char* what() const noexcept final { return mMessage.c_str(); }
 
  private:
   int mModule;          ///< Module ID raising the exception
@@ -96,8 +93,7 @@ class InvalidPositionException final : public std::exception
   /// \brief Constructor, setting the position raising the exception
   /// \param eta Eta coordinate of the position
   /// \param phi Phi coordinate of the position
-  InvalidPositionException(double eta, double phi) : std::exception(),
-                                                     mEta(eta),
+  InvalidPositionException(double eta, double phi) : mEta(eta),
                                                      mPhi(phi),
                                                      mMessage("Position phi (" + std::to_string(mPhi) + "), eta(" + std::to_string(mEta) + ") not im EMCAL")
   {
@@ -108,15 +104,15 @@ class InvalidPositionException final : public std::exception
 
   /// \brief Access to eta coordinate raising the exception
   /// \return Eta coordinate of the position
-  double getEta() const noexcept { return mEta; }
+  [[nodiscard]] double getEta() const noexcept { return mEta; }
 
   /// \brief Access to phi corrdinate raising the exception
   /// \return Phi coordinate of the position
-  double getPhi() const noexcept { return mPhi; }
+  [[nodiscard]] double getPhi() const noexcept { return mPhi; }
 
   /// \brief Access to error message of the exception
   /// \return Error message
-  const char* what() const noexcept final { return mMessage.data(); }
+  [[nodiscard]] const char* what() const noexcept final { return mMessage.data(); }
 
  private:
   double mEta = 0.;     ///< Position in eta raising the exception
@@ -132,8 +128,7 @@ class InvalidCellIDException final : public std::exception
  public:
   /// \brief Constructor, setting cell ID raising the exception
   /// \param cellID Cell ID raising the exception
-  InvalidCellIDException(int cellID) : std::exception(),
-                                       mCellID(cellID),
+  InvalidCellIDException(int cellID) : mCellID(cellID),
                                        mMessage("Cell ID " + std::to_string(mCellID) + " outside limits.")
   {
   }
@@ -143,11 +138,11 @@ class InvalidCellIDException final : public std::exception
 
   /// \brief Access to cell ID raising the exception
   /// \return Cell ID
-  int getCellID() const noexcept { return mCellID; }
+  [[nodiscard]] int getCellID() const noexcept { return mCellID; }
 
   /// \brief Access to error message of the exception
   /// \return Error message
-  const char* what() const noexcept final { return mMessage.data(); }
+  [[nodiscard]] const char* what() const noexcept final { return mMessage.data(); }
 
  private:
   int mCellID;          ///< Cell ID raising the exception
@@ -167,7 +162,7 @@ class InvalidSupermoduleTypeException final : public std::exception
   ~InvalidSupermoduleTypeException() noexcept final = default;
 
   /// \brief Access to error message of the exception
-  const char* what() const noexcept final { return "Uknown SuperModule Type !!"; }
+  [[nodiscard]] const char* what() const noexcept final { return "Uknown SuperModule Type !!"; }
 };
 
 /// \class SupermoduleIndexException
@@ -179,8 +174,7 @@ class SupermoduleIndexException final : public std::exception
   /// \brief Constructor, initializing the exception
   /// \param supermodule Supermodule ID raising the exception
   /// \param maxSupermodules Max. number of supermodules in the geometry setup
-  SupermoduleIndexException(int supermodule, int maxSupermodules) : std::exception(),
-                                                                    mSupermoduleIndex(supermodule),
+  SupermoduleIndexException(int supermodule, int maxSupermodules) : mSupermoduleIndex(supermodule),
                                                                     mMaxSupermodules(maxSupermodules)
   {
     mMessage = "Invalid supermodule ID " + std::to_string(mSupermoduleIndex) + ", max " + std::to_string(mMaxSupermodules);
@@ -191,15 +185,15 @@ class SupermoduleIndexException final : public std::exception
 
   /// \brief Access to supermodule index raising the exception
   /// \return Supermodule index
-  int getSupermodule() const noexcept { return mSupermoduleIndex; }
+  [[nodiscard]] int getSupermodule() const noexcept { return mSupermoduleIndex; }
 
   /// \brief Access to maximum number of supermodules
   /// \return Max. number of supermodules
-  int getMaxSupermodule() const noexcept { return mMaxSupermodules; }
+  [[nodiscard]] int getMaxSupermodule() const noexcept { return mMaxSupermodules; }
 
   /// \brief Access to error message of the exception
   /// \return Error message
-  const char* what() const noexcept final { return mMessage.data(); }
+  [[nodiscard]] const char* what() const noexcept final { return mMessage.data(); }
 
  private:
   int mSupermoduleIndex; ///< Supermodule index raising the exception
@@ -216,7 +210,7 @@ class RowColException final : public std::exception
   /// \brief Constructor, initializing the exception with invalid row-column position
   /// \param row Row ID of the position
   /// \param col Column ID of the position
-  RowColException(int row, int col) : mRow(row), mCol(col), mMessage("")
+  RowColException(int row, int col) : mRow(row), mCol(col)
   {
     mMessage = "Invalid position: row " + std::to_string(mRow) + ", col " + std::to_string(mCol);
   }
@@ -226,22 +220,21 @@ class RowColException final : public std::exception
 
   /// \brief Get row of the position raising the exception
   /// \return Row ID
-  int getRow() const noexcept { return mRow; }
+  [[nodiscard]] int getRow() const noexcept { return mRow; }
 
   /// \brief Get column of the position raising the exception
   /// \brief Column ID
-  int getCol() const noexcept { return mCol; }
+  [[nodiscard]] int getCol() const noexcept { return mCol; }
 
   /// \brief Access tp error message of the exception
   /// \return Error message
-  const char* what() const noexcept final { return mMessage.data(); }
+  [[nodiscard]] const char* what() const noexcept final { return mMessage.data(); }
 
  private:
   int mRow, mCol;
   std::string mMessage;
 };
 
-} // namespace emcal
 } // namespace o2
 
 #endif

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -817,7 +817,7 @@ float ClusterFactory<InputType>::GetCellWeight(float eCell, float eCluster) cons
       return std::max(0.f, mLogWeight + std::log(eCell / eCluster));
     }
     return std::log(eCluster / eCell);
-  } 
+  }
   return 0.;
 }
 

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -10,9 +10,7 @@
 // or submit itself to any jurisdiction.
 
 /// \file ClusterFactory.cxx
-#include <array>
-#include <gsl/span>
-#include "Rtypes.h"
+#include "EMCALBase/ClusterFactory.h"
 #include "DataFormatsEMCAL/Cluster.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/Cell.h"
@@ -21,14 +19,17 @@
 #include "DataFormatsEMCAL/CellLabel.h"
 #include "DataFormatsEMCAL/ClusterLabel.h"
 #include "EMCALBase/Geometry.h"
-#include "MathUtils/Cartesian.h"
+// #include "MathUtils/Cartesian.h"
 
-#include "EMCALBase/ClusterFactory.h"
+#include <Rtypes.h>
+
+#include <array>
+#include <span>
 
 using namespace o2::emcal;
 
 template <class InputType>
-ClusterFactory<InputType>::ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<const int> cellsIndices)
+ClusterFactory<InputType>::ClusterFactory(std::span<const o2::emcal::Cluster> clustersContainer, std::span<const InputType> inputsContainer, std::span<const int> cellsIndices)
 {
   setContainer(clustersContainer, inputsContainer, cellsIndices);
 }
@@ -36,11 +37,11 @@ ClusterFactory<InputType>::ClusterFactory(gsl::span<const o2::emcal::Cluster> cl
 template <class InputType>
 void ClusterFactory<InputType>::reset()
 {
-  mClustersContainer = gsl::span<const o2::emcal::Cluster>();
-  mInputsContainer = gsl::span<const InputType>();
-  mCellsIndices = gsl::span<int>();
+  mClustersContainer = std::span<const o2::emcal::Cluster>();
+  mInputsContainer = std::span<const InputType>();
+  mCellsIndices = std::span<int>();
   mLookUpInit = false;
-  mCellLabelContainer = gsl::span<const o2::emcal::CellLabel>();
+  mCellLabelContainer = std::span<const o2::emcal::CellLabel>();
 }
 
 ///
@@ -62,7 +63,7 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
   int firstCellIndex = mClustersContainer[clusterIndex].getCellIndexFirst();
   int nCells = mClustersContainer[clusterIndex].getNCells();
 
-  gsl::span<const int> inputsIndices = gsl::span<const int>(&mCellsIndices[firstCellIndex], nCells);
+  std::span<const int> inputsIndices = std::span<const int>(&mCellsIndices[firstCellIndex], nCells);
 
   // First calculate the index of input with maximum amplitude and get
   // the supermodule number where it sits.
@@ -144,7 +145,7 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
 /// in cell units
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalDispersion(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalDispersion(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   double d = 0., wtot = 0.;
   int nstat = 0;
@@ -165,8 +166,8 @@ void ClusterFactory<InputType>::evalDispersion(gsl::span<const int> inputsIndice
         ieta += EMCAL_COLS;
       }
 
-      double etai = (double)ieta;
-      double phii = (double)iphi;
+      auto etai = static_cast<double>(ieta);
+      auto phii = static_cast<double>(iphi);
       double w = TMath::Max(0., mLogWeight + TMath::Log(mInputsContainer[iInput].getEnergy() / clusterAnalysis.E()));
 
       if (w > 0.0) {
@@ -197,8 +198,8 @@ void ClusterFactory<InputType>::evalDispersion(gsl::span<const int> inputsIndice
         ieta += EMCAL_COLS;
       }
 
-      double etai = (double)ieta;
-      double phii = (double)iphi;
+      auto etai = static_cast<double>(ieta);
+      auto phii = static_cast<double>(iphi);
       double w = TMath::Max(0., mLogWeight + TMath::Log(mInputsContainer[iInput].getEnergy() / clusterAnalysis.E()));
 
       if (w > 0.0) {
@@ -221,14 +222,15 @@ void ClusterFactory<InputType>::evalDispersion(gsl::span<const int> inputsIndice
 /// Calculates the center of gravity in the local EMCAL-module coordinates
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalLocalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalLocalPosition(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
 
   int nstat = 0;
 
   double dist = tMaxInCm(double(clusterAnalysis.E()));
 
-  double clXYZ[3] = {0., 0., 0.}, clRmsXYZ[3] = {0., 0., 0.}, xyzi[3], wtot = 0., w = 0.;
+  std::array<double, 3> clXYZ = {0., 0., 0.}, clRmsXYZ = {0., 0., 0.}, xyzi{};
+  double wtot = 0., w = 0.;
 
   for (auto iInput : inputsIndices) {
 
@@ -294,14 +296,15 @@ void ClusterFactory<InputType>::evalLocalPosition(gsl::span<const int> inputsInd
 /// Calculates the center of gravity in the global ALICE coordinates
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalGlobalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalGlobalPosition(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
 
   int i = 0, nstat = 0;
 
   double dist = tMaxInCm(double(clusterAnalysis.E()));
 
-  double clXYZ[3] = {0., 0., 0.}, clRmsXYZ[3] = {0., 0., 0.}, lxyzi[3], xyzi[3], wtot = 0., w = 0.;
+  std::array<double, 3> clXYZ = {0., 0., 0.}, clRmsXYZ = {0., 0., 0.}, lxyzi{}, xyzi{};
+  double wtot = 0., w = 0.;
 
   for (auto iInput : inputsIndices) {
 
@@ -367,10 +370,11 @@ void ClusterFactory<InputType>::evalGlobalPosition(gsl::span<const int> inputsIn
 //____________________________________________________________________________
 template <class InputType>
 void ClusterFactory<InputType>::evalLocalPositionFit(double deff, double mLogWeight,
-                                                     double phiSlope, gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+                                                     double phiSlope, std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   int i = 0, nstat = 0;
-  double clXYZ[3] = {0., 0., 0.}, clRmsXYZ[3] = {0., 0., 0.}, xyzi[3], wtot = 0., w = 0.;
+  std::array<double, 3> clXYZ = {0., 0., 0.}, clRmsXYZ = {0., 0., 0.}, xyzi{};
+  double wtot = 0., w = 0.;
 
   for (auto iInput : inputsIndices) {
 
@@ -426,7 +430,7 @@ void ClusterFactory<InputType>::evalLocalPositionFit(double deff, double mLogWei
 
   // clRmsXYZ[i] ??
 
-  if (phiSlope != 0.0 && mLogWeight > 0.0 && wtot) {
+  if (phiSlope != 0.0 && mLogWeight > 0.0 && wtot != 0.0) {
     // Correction in phi direction (y - coords here); Aug 16;
     // May be put to global level or seperate method
     double ycorr = clXYZ[1] * (1. + phiSlope);
@@ -467,12 +471,12 @@ void ClusterFactory<InputType>::getDeffW0(const double esum, double& deff, doubl
 /// Distance is calculate in (phi,eta) units
 //______________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalCoreEnergy(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalCoreEnergy(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
 
   float coreEnergy = 0.;
 
-  if (!clusterAnalysis.getLocalPosition().Mag2()) {
+  if (clusterAnalysis.getLocalPosition().Mag2() > 0.) {
     evalLocalPosition(inputsIndices, clusterAnalysis);
   }
 
@@ -496,7 +500,7 @@ void ClusterFactory<InputType>::evalCoreEnergy(gsl::span<const int> inputsIndice
 /// Calculate the number of local maxima in the cluster
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalNExMax(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalNExMax(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   // Pre-compute cell indices and energies for all cells in cluster to avoid multiple expensive geometry lookups
   const size_t n = inputsIndices.size();
@@ -555,7 +559,7 @@ void ClusterFactory<InputType>::evalNExMax(gsl::span<const int> inputsIndices, A
 /// in cell units
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalElipsAxis(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalElipsAxis(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   double wtot = 0.;
   double x = 0.;
@@ -564,7 +568,7 @@ void ClusterFactory<InputType>::evalElipsAxis(gsl::span<const int> inputsIndices
   double dzz = 0.;
   double dxz = 0.;
 
-  std::array<float, 2> lambda;
+  std::array<float, 2> lambda{};
 
   for (auto iInput : inputsIndices) {
 
@@ -577,8 +581,8 @@ void ClusterFactory<InputType>::evalElipsAxis(gsl::span<const int> inputsIndices
       ieta += EMCAL_COLS;
     }
 
-    double etai = (double)ieta;
-    double phii = (double)iphi;
+    auto etai = static_cast<double>(ieta);
+    auto phii = static_cast<double>(iphi);
 
     double w = TMath::Max(0., mLogWeight + TMath::Log(mInputsContainer[iInput].getEnergy() / clusterAnalysis.E()));
     // clusterAnalysis.E() summed amplitude of inputs, i.e. energy of cluster
@@ -633,7 +637,7 @@ void ClusterFactory<InputType>::evalElipsAxis(gsl::span<const int> inputsIndices
 /// Finds the maximum energy in the cluster and computes the Summed amplitude of digits/cells
 //____________________________________________________________________________
 template <class InputType>
-std::tuple<int, float, float, bool> ClusterFactory<InputType>::getMaximalEnergyIndex(gsl::span<const int> inputsIndices) const
+std::tuple<int, float, float, bool> ClusterFactory<InputType>::getMaximalEnergyIndex(std::span<const int> inputsIndices) const
 {
 
   float energy = 0.;
@@ -690,9 +694,9 @@ bool ClusterFactory<InputType>::isExoticCell(short towerId, float ecell, float c
 ///  Calculate the energy in the cross around the energy of a given cell.
 //____________________________________________________________________________
 template <class InputType>
-float ClusterFactory<InputType>::getECross(short towerId, float energy, float const exoticTime) const
+float ClusterFactory<InputType>::getECross(short absID, float energy, float const exoticTime) const
 {
-  auto [iSM, iMod, iIphi, iIeta] = mGeomPtr->GetCellIndex(towerId);
+  auto [iSM, iMod, iIphi, iIeta] = mGeomPtr->GetCellIndex(absID);
   auto [iphi, ieta] = mGeomPtr->GetCellPhiEtaIndexInSModule(iSM, iMod, iIphi, iIeta);
 
   // Get close cells index, energy and time, not in corners
@@ -720,7 +724,7 @@ float ClusterFactory<InputType>::getECross(short towerId, float energy, float co
   short towerId3 = -1;
   short towerId4 = -1;
 
-  if (ieta == o2::emcal::EMCAL_COLS - 1 && !(iSM % 2)) {
+  if (ieta == o2::emcal::EMCAL_COLS - 1 && (iSM % 2) == 0) {
     try {
       towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM + 1, iphi, 0);
     } catch (InvalidCellIDException& e) {
@@ -731,7 +735,7 @@ float ClusterFactory<InputType>::getECross(short towerId, float energy, float co
     } catch (InvalidCellIDException& e) {
       towerId4 = -1 * e.getCellID();
     }
-  } else if (ieta == 0 && iSM % 2) {
+  } else if (ieta == 0 && (iSM % 2) != 0) {
     try {
       towerId3 = mGeomPtr->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta + 1);
     } catch (InvalidCellIDException& e) {
@@ -759,7 +763,7 @@ float ClusterFactory<InputType>::getECross(short towerId, float energy, float co
     }
   }
 
-  LOG(debug) << "iSM " << iSM << ", towerId " << towerId << ", a " << towerId1 << ", b " << towerId2 << ", c " << towerId3 << ", e " << towerId3;
+  LOG(debug) << "iSM " << iSM << ", absID " << absID << ", a " << towerId1 << ", b " << towerId2 << ", c " << towerId3 << ", e " << towerId3;
 
   short index1 = (towerId1 > -1) ? mLoolUpTowerToIndex.at(towerId1) : -1;
   short index2 = (towerId2 > -1) ? mLoolUpTowerToIndex.at(towerId2) : -1;
@@ -811,23 +815,21 @@ float ClusterFactory<InputType>::GetCellWeight(float eCell, float eCluster) cons
   if (eCell > 0 && eCluster > 0) {
     if (mLogWeight > 0) {
       return std::max(0.f, mLogWeight + std::log(eCell / eCluster));
-    } else {
-      return std::log(eCluster / eCell);
     }
-  } else {
-    return 0.;
-  }
+    return std::log(eCluster / eCell);
+  } 
+  return 0.;
 }
 
 ///
 /// Calculates the multiplicity of inputs with energy larger than H*energy
 //____________________________________________________________________________
 template <class InputType>
-int ClusterFactory<InputType>::getMultiplicityAtLevel(float H, gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+int ClusterFactory<InputType>::getMultiplicityAtLevel(float level, std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   int multipl = 0;
   for (auto iInput : inputsIndices) {
-    if (mInputsContainer[iInput].getEnergy() > H * clusterAnalysis.E()) {
+    if (mInputsContainer[iInput].getEnergy() > level * clusterAnalysis.E()) {
       multipl++;
     }
   }
@@ -839,7 +841,7 @@ int ClusterFactory<InputType>::getMultiplicityAtLevel(float H, gsl::span<const i
 /// Time is set to the time of the input with the maximum energy
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalTime(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalTime(std::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   float maxE = 0;
   unsigned short maxAt = 0;
@@ -897,18 +899,17 @@ float ClusterFactory<InputType>::thetaToEta(float arg) const
 }
 
 template <class InputType>
-ClusterFactory<InputType>::ClusterIterator::ClusterIterator(const ClusterFactory& factory, int clusterIndex, bool forward) : mClusterFactory(factory),
-                                                                                                                             mCurrentCluster(),
+ClusterFactory<InputType>::ClusterIterator::ClusterIterator(const ClusterFactory& factory, int clusterIndex, bool forward) : mClusterFactory(&factory),
+                                                                                                                             mCurrentCluster(mClusterFactory->buildCluster(clusterIndex)),
                                                                                                                              mClusterID(clusterIndex),
                                                                                                                              mForward(forward)
 {
-  mCurrentCluster = mClusterFactory.buildCluster(mClusterID);
 }
 
 template <class InputType>
 bool ClusterFactory<InputType>::ClusterIterator::operator==(const ClusterFactory<InputType>::ClusterIterator& rhs) const
 {
-  return &mClusterFactory == &rhs.mClusterFactory && mClusterID == rhs.mClusterID && mForward == rhs.mForward;
+  return mClusterFactory == rhs.mClusterFactory && mClusterID == rhs.mClusterID && mForward == rhs.mForward;
 }
 
 template <class InputType>
@@ -919,7 +920,7 @@ typename ClusterFactory<InputType>::ClusterIterator& ClusterFactory<InputType>::
   } else {
     mClusterID--;
   }
-  mCurrentCluster = mClusterFactory.buildCluster(mClusterID);
+  mCurrentCluster = mClusterFactory->buildCluster(mClusterID);
   return *this;
 }
 
@@ -939,7 +940,7 @@ typename ClusterFactory<InputType>::ClusterIterator& ClusterFactory<InputType>::
   } else {
     mClusterID++;
   }
-  mCurrentCluster = mClusterFactory.buildCluster(mClusterID);
+  mCurrentCluster = mClusterFactory->buildCluster(mClusterID);
   return *this;
 }
 

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -9,6 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "EMCALBase/Geometry.h"
+#include "EMCALBase/GeometryBase.h"
+
+#include "DataFormatsEMCAL/Constants.h"
+#include "CCDB/CcdbApi.h"
+#include "EMCALBase/ShishKebabTrd1Module.h"
+#include "GPUROOTCartesianFwd.h"
+#include "MathUtils/Cartesian.h" // IWYU pragma: keep
 
 #include <RtypesCore.h>
 #include <TMath.h>
@@ -22,26 +29,21 @@
 #include <TObjArray.h>
 #include <fairlogger/Logger.h>
 
-#include <cstring>
+#include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <iomanip>
 #include <ostream>
 #include <string>
-#include <algorithm>
-#include <cstdio>
+#include <span>
 #include <string_view>
 #include <tuple>
 
 #include <TGeoBBox.h>
 #include <TGeoManager.h>
 #include <TGeoMatrix.h>
-
-#include "DataFormatsEMCAL/Constants.h"
-#include "EMCALBase/GeometryBase.h"
-#include "CCDB/CcdbApi.h"
-#include "EMCALBase/ShishKebabTrd1Module.h"
-#include "GPUROOTCartesianFwd.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -68,6 +70,7 @@ Geometry::Geometry(const Geometry& geo)
     mNCells(geo.mNCells),
     mNPhi(geo.mNPhi),
     mCentersOfCellsXDir(geo.mCentersOfCellsXDir),
+    mEnvelop(geo.mEnvelop),
     mArm1EtaMin(geo.mArm1EtaMin),
     mArm1EtaMax(geo.mArm1EtaMax),
     mArm1PhiMin(geo.mArm1PhiMin),
@@ -80,6 +83,7 @@ Geometry::Geometry(const Geometry& geo)
     mDCALInnerExtandedEta(geo.mDCALInnerExtandedEta),
     mDCALInnerEdge(geo.mDCALInnerEdge),
     mShishKebabTrd1Modules(geo.mShishKebabTrd1Modules),
+    mParSM(geo.mParSM),
     mPhiModuleSize(geo.mPhiModuleSize),
     mEtaModuleSize(geo.mEtaModuleSize),
     mPhiTileSize(geo.mPhiTileSize),
@@ -110,73 +114,12 @@ Geometry::Geometry(const Geometry& geo)
     mSteelFrontThick(geo.mSteelFrontThick), // obsolete data member?
     mCellIndexLookup(geo.mCellIndexLookup)
 {
-  memcpy(mEnvelop, geo.mEnvelop, sizeof(Float_t) * 3);
-  memcpy(mParSM, geo.mParSM, sizeof(Float_t) * 3);
-
-  memset(SMODULEMATRIX, 0, sizeof(TGeoHMatrix*) * EMCAL_MODULES);
 }
 
 Geometry::Geometry(const std::string_view name, const std::string_view mcname, const std::string_view mctitle)
-  : mGeoName(name),
-    mKey110DEG(0),
-    mnSupModInDCAL(0),
-    mNCellsInSupMod(0),
-    mNETAdiv(0),
-    mNPHIdiv(0),
-    mNCellsInModule(0),
-    mPhiBoundariesOfSM(),
-    mPhiCentersOfSM(),
-    mPhiCentersOfSMSec(),
-    mPhiCentersOfCells(),
-    mCentersOfCellsEtaDir(),
-    mCentersOfCellsPhiDir(),
-    mEtaCentersOfCells(),
-    mNCells(0),
-    mNPhi(0),
-    mCentersOfCellsXDir(),
-    mArm1EtaMin(0),
-    mArm1EtaMax(0),
-    mArm1PhiMin(0),
-    mArm1PhiMax(0),
-    mEtaMaxOfTRD1(0),
-    mDCALPhiMin(0),
-    mDCALPhiMax(0),
-    mEMCALPhiMax(0),
-    mDCALStandardPhiMax(0),
-    mDCALInnerExtandedEta(0),
-    mDCALInnerEdge(0.),
-    mShishKebabTrd1Modules(),
-    mPhiModuleSize(0.),
-    mEtaModuleSize(0.),
-    mPhiTileSize(0.),
-    mEtaTileSize(0.),
-    mNZ(0),
-    mIPDistance(0.),
-    mLongModuleSize(0.),
-    mShellThickness(0.),
-    mZLength(0.),
-    mSampling(0.),
-    mECPbRadThickness(0.),
-    mECScintThick(0.),
-    mNECLayers(0),
-    mNumberOfSuperModules(0),
-    mEMCSMSystem(),
-    mFrontSteelStrip(0.),
-    mLateralSteelStrip(0.),
-    mPassiveScintThick(0.),
-    mPhiSuperModule(0),
-    mNPhiSuperModule(0),
-    mTrd1Angle(0.),
-    m2Trd1Dx2(0.),
-    mPhiGapForSM(0.),
-    mTrd1AlFrontThick(0.0),
-    mTrd1BondPaperThick(0.),
-    mILOSS(-1),
-    mIHADR(-1),
-    mSteelFrontThick(0.) // obsolete data member?
+  : mGeoName(name)
 {
   DefineEMC(mcname, mctitle);
-  mNCellsInModule = mNPHIdiv * mNETAdiv;
 
   CreateListOfTrd1Modules();
 
@@ -184,8 +127,6 @@ Geometry::Geometry(const std::string_view name, const std::string_view mcname, c
   for (auto icell = 0; icell < mNCells; icell++) {
     mCellIndexLookup[icell] = CalculateCellIndex(icell);
   }
-
-  memset(SMODULEMATRIX, 0, sizeof(TGeoHMatrix*) * EMCAL_MODULES);
 
   LOG(debug) << "Name <<" << name << ">>";
 }
@@ -212,7 +153,7 @@ Geometry::~Geometry()
 
 Geometry* Geometry::GetInstance()
 {
-  Geometry* rv = static_cast<Geometry*>(sGeom);
+  Geometry* rv = sGeom;
   if (!rv) {
     throw GeometryNotInitializedException();
   }
@@ -223,18 +164,17 @@ Geometry* Geometry::GetInstance(const std::string_view name, const std::string_v
                                 const std::string_view mctitle)
 {
   if (!sGeom) {
-    if (!name.length()) { // get default geometry
+    if (name.length() == 0) { // get default geometry
       sGeom = new Geometry(DEFAULT_GEOMETRY, mcname, mctitle);
     } else {
       sGeom = new Geometry(name, mcname, mctitle);
     } // end if strcmp(name,"")
     return sGeom;
-  } else {
-    if (sGeom->GetName() != name) {
-      LOG(info) << "\n current geometry is " << sGeom->GetName() << " : you should not call " << name;
-    } // end
-    return sGeom;
   } // end if sGeom
+  if (sGeom->GetName() != name) {
+    LOG(info) << "\n current geometry is " << sGeom->GetName() << " : you should not call " << name;
+  } // end
+  return sGeom;
 
   return nullptr;
 }
@@ -261,7 +201,8 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
     }
 
     return Geometry::GetInstance("EMCAL_FIRSTYEARV1", mcname, mctitle);
-  } else if (runNumber >= 140000 && runNumber <= 170593) {
+  }
+  if (runNumber >= 140000 && runNumber <= 170593) {
     // Almost complete EMCAL geometry, 10 SM. Year 2011 configuration
 
     if (contains(geoName, "COMPLETEV1") && geoName != std::string("")) {
@@ -274,7 +215,8 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
         << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_COMPLETEV1>>";
     }
     return Geometry::GetInstance("EMCAL_COMPLETEV1", mcname, mctitle);
-  } else if (runNumber > 176000 && runNumber <= 197692) {
+  }
+  if (runNumber > 176000 && runNumber <= 197692) {
     // Complete EMCAL geometry, 12 SM. Year 2012 and on
     // The last 2 SM were not active, anyway they were there.
 
@@ -288,21 +230,20 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
                    "<<EMCAL_COMPLETE12SMV1>>";
     }
     return Geometry::GetInstance("EMCAL_COMPLETE12SMV1", mcname, mctitle);
-  } else // Run 2
-  {
-    // EMCAL + DCAL geometry, 20 SM. Year 2015 and on
+  } 
+  // Run 2
+  // EMCAL + DCAL geometry, 20 SM. Year 2015 and on
 
-    if (contains(geoName, "DCAL_8SM") && geoName != std::string("")) {
-      LOG(info) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
-                << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
-                << " is not considered! \n"
-                << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year";
-    } else {
-      LOG(info) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
-                   "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
-    }
-    return Geometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM", mcname, mctitle);
+  if (contains(geoName, "DCAL_8SM") && geoName != std::string("")) {
+    LOG(info) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
+              << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
+              << " is not considered! \n"
+              << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year";
+  } else {
+    LOG(info) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
+                  "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
   }
+  return Geometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM", mcname, mctitle);
 }
 
 void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::string_view mctitle)
@@ -335,10 +276,8 @@ void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::
   // Note: The sampling factors are chosen so that results from the simulation
   // engines correspond well with testbeam data
 
-  if (contains(mcname, "Geant3")) {
+  if (contains(mcname, "Geant3") || contains(mcname, "Fluka")) {
     samplingFactorTranportModel = 1.; // 0.988 // Do nothing
-  } else if (contains(mcname, "Fluka")) {
-    samplingFactorTranportModel = 1.; // To be set
   } else if (contains(mcname, "Geant4")) {
     std::string physicslist = mctitle.substr(mctitle.find(":") + 2).data();
     LOG(info) << "Selected physics list: " << physicslist;
@@ -349,9 +288,7 @@ void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::
     samplingFactorTranportModel = 0.81;
     if (physicslist == "FTFP_BERT_EMV+optical") {
       samplingFactorTranportModel = 0.821;
-    } else if (physicslist == "FTFP_BERT_EMV+optical+biasing") {
-      samplingFactorTranportModel = 0.81;
-    } else if (physicslist == "FTFP_INCLXX_EMV+optical") {
+    } else if (physicslist == "FTFP_BERT_EMV+optical+biasing" || physicslist == "FTFP_INCLXX_EMV+optical") {
       samplingFactorTranportModel = 0.81;
     }
   }
@@ -363,7 +300,7 @@ void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::
   mSampling *= samplingFactorTranportModel;
 }
 
-void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
+void Geometry::DefineEMC(std::string_view /*mcname*/, std::string_view /*mctitle*/)
 {
   using boost::algorithm::contains;
 
@@ -530,7 +467,7 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
 
   //
   // EMCAL 110SM
-  if (mKey110DEG && contains(mGeoName, "12SM")) {
+  if (mKey110DEG > 0 && contains(mGeoName, "12SM")) {
     for (int i = 0; i < 2; i++) {
       mEMCSMSystem[iSM] = EMCAL_HALF;
       if (contains(mGeoName, "12SMV1")) {
@@ -542,7 +479,7 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
 
   //
   // DCAL SM
-  if (mnSupModInDCAL && contains(mGeoName, "DCAL")) {
+  if (mnSupModInDCAL > 0 && contains(mGeoName, "DCAL")) {
     if (contains(mGeoName, "8SM")) {
       for (int i = 0; i < mnSupModInDCAL - 2; i++) {
         mEMCSMSystem[iSM] = DCAL_STANDARD;
@@ -569,12 +506,10 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
       mNCells += mNCellsInSupMod;
     } else if (GetSMType(i) == EMCAL_HALF) {
       mNCells += mNCellsInSupMod / 2;
-    } else if (GetSMType(i) == EMCAL_THIRD) {
+    } else if (GetSMType(i) == EMCAL_THIRD || GetSMType(i) == DCAL_EXT) {
       mNCells += mNCellsInSupMod / 3;
     } else if (GetSMType(i) == DCAL_STANDARD) {
       mNCells += 2 * mNCellsInSupMod / 3;
-    } else if (GetSMType(i) == DCAL_EXT) {
-      mNCells += mNCellsInSupMod / 3;
     } else {
       LOG(error) << "Uknown SuperModule Type !!\n";
     }
@@ -701,11 +636,11 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
   // DefineSamplingFraction(mcname,mctitle);
 }
 
-void Geometry::GetGlobal(const Double_t* loc, Double_t* glob, int iSM) const
+void Geometry::GetGlobal(std::span<const double, 3> loc, std::span<double, 3> glob, int iSM) const
 {
   const TGeoHMatrix* m = GetMatrixForSuperModule(iSM);
   if (m) {
-    m->LocalToMaster(loc, glob);
+    m->LocalToMaster(loc.data(), glob.data());
   } else {
     LOG(fatal) << "Geo matrixes are not loaded \n";
   }
@@ -713,17 +648,16 @@ void Geometry::GetGlobal(const Double_t* loc, Double_t* glob, int iSM) const
 
 void Geometry::GetGlobal(const TVector3& vloc, TVector3& vglob, int iSM) const
 {
-  Double_t tglob[3], tloc[3];
-  vloc.GetXYZ(tloc);
+  std::array<double, 3> tglob{}, tloc{};
+  vloc.GetXYZ(tloc.data());
   GetGlobal(tloc, tglob, iSM);
   vglob.SetXYZ(tglob[0], tglob[1], tglob[2]);
 }
 
-void Geometry::GetGlobal(Int_t absId, Double_t glob[3]) const
+void Geometry::GetGlobal(int absId, std::span<double, 3> glob) const
 {
-  double loc[3];
-
-  memset(glob, 0, sizeof(Double_t) * 3);
+  std::array<double, 3> loc{};
+  std::ranges::fill(glob, 0.0);
   try {
     auto cellpos = RelPosCellInSModule(absId);
     loc[0] = cellpos.X();
@@ -737,15 +671,15 @@ void Geometry::GetGlobal(Int_t absId, Double_t glob[3]) const
   Int_t nSupMod = std::get<0>(GetCellIndex(absId));
   const TGeoHMatrix* m = GetMatrixForSuperModule(nSupMod);
   if (m) {
-    m->LocalToMaster(loc, glob);
+    m->LocalToMaster(loc.data(), glob.data());
   } else {
     LOG(fatal) << "Geo matrixes are not loaded \n";
   }
 }
 
-void Geometry::GetGlobal(Int_t absId, TVector3& vglob) const
+void Geometry::GetGlobal(int absId, TVector3& vglob) const
 {
-  Double_t glob[3];
+  std::array<double, 3> glob{};
 
   GetGlobal(absId, glob);
   vglob.SetXYZ(glob[0], glob[1], glob[2]);
@@ -840,7 +774,7 @@ std::tuple<int, int> Geometry::GlobalRowColFromIndex(int cellID) const
     // DCal odd SMs need shift of the col. index in oder to get the global col. index
     col += 16;
   }
-  if (supermodule % 2) {
+  if (supermodule % 2 != 0) {
     col += mNZ * 2;
   }
   int sector = supermodule / 2;
@@ -939,7 +873,8 @@ Int_t Geometry::SuperModuleNumberFromEtaPhi(Double_t eta, Double_t phi) const
       }
 
       if (GetSMType(nSupMod) == DCAL_STANDARD) { // Gap between DCAL
-        if (TMath::Abs(eta) < GetNEta() / 3 * mTrd1Angle * TMath::DegToRad()) {
+        const Int_t nEtaThird = GetNEta() / 3; // integer division intended: truncate to whole eta-bin count
+        if (TMath::Abs(eta) < nEtaThird * mTrd1Angle * TMath::DegToRad()) {
           throw InvalidPositionException(eta, phi);
         }
       }
@@ -1030,7 +965,7 @@ std::tuple<int, int, int, int> Geometry::CalculateCellIndex(Int_t absId) const
   Int_t tmp = absId;
   Int_t test = absId;
 
-  Int_t nSupMod;
+  Int_t nSupMod = -1;
   for (nSupMod = -1; test >= 0;) {
     nSupMod++;
     tmp = test;
@@ -1084,7 +1019,7 @@ std::tuple<int, int> Geometry::GetModulePhiEtaIndexInSModule(int supermoduleID, 
       nModulesInPhi = mNPhi; // full SM
       break;
   };
-  return std::make_tuple(int(moduleID % nModulesInPhi), int(moduleID / nModulesInPhi));
+  return std::make_tuple(moduleID % nModulesInPhi, moduleID / nModulesInPhi);
 }
 
 std::tuple<int, int> Geometry::GetCellPhiEtaIndexInSModule(int supermoduleID, int moduleID, int phiInModule,
@@ -1136,7 +1071,7 @@ std::tuple<int, int> Geometry::ShiftOnlineToOfflineCellIndexes(Int_t supermodule
     // DCal 1/3 SMs
     iphi -= 16; // Needed due to cabling mistake.
   }
-  return std::tuple<int, int>(iphi, ieta);
+  return {iphi, ieta};
 }
 
 std::tuple<int, int> Geometry::ShiftOfflineToOnlineCellIndexes(Int_t supermoduleID, Int_t iphi, Int_t ieta) const
@@ -1148,7 +1083,7 @@ std::tuple<int, int> Geometry::ShiftOfflineToOnlineCellIndexes(Int_t supermodule
     // DCal 1/3 SMs
     iphi += 16; // Needed due to cabling mistake.
   }
-  return std::tuple<int, int>(iphi, ieta);
+  return {iphi, ieta};
 }
 
 o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId) const
@@ -1158,16 +1093,15 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId) const
 
   Int_t phiindex = mCentersOfCellsPhiDir.size();
   Double_t zshift = 0.5 * GetDCALInnerEdge();
-  Double_t xr, yr, zr;
+  Double_t xr = 0, yr = 0, zr = 0;
 
   if (!CheckAbsCellId(absId)) {
     throw InvalidCellIDException(absId);
   }
 
   auto cellindex = GetCellIndex(absId);
-  Int_t nSupMod = std::get<0>(cellindex), nModule = std::get<1>(cellindex), nIphi = std::get<2>(cellindex),
-        nIeta = std::get<3>(cellindex);
-  auto indexinsm = GetCellPhiEtaIndexInSModule(nSupMod, nModule, nIphi, nIeta);
+  Int_t nSupMod = std::get<0>(cellindex), nModule = std::get<1>(cellindex), phiInModule = std::get<2>(cellindex), etaInModule = std::get<3>(cellindex);
+  auto indexinsm = GetCellPhiEtaIndexInSModule(nSupMod, nModule, phiInModule, etaInModule);
   Int_t iphi = std::get<0>(indexinsm), ieta = std::get<1>(indexinsm);
 
   // Get eta position. Careful with ALICE conventions (increase index decrease eta)
@@ -1177,7 +1111,7 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId) const
             ieta; // 47-ieta, revert the ordering on A side in order to keep convention.
   }
 
-  if (GetSMType(nSupMod) == DCAL_STANDARD && nSupMod % 2) {
+  if (GetSMType(nSupMod) == DCAL_STANDARD && nSupMod % 2 != 0) {
     ieta2 += 16; // DCAL revert the ordering on C side ...
   }
   zr = mCentersOfCellsEtaDir[ieta2];
@@ -1188,7 +1122,7 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId) const
 
   // Get phi position. Careful with ALICE conventions (increase index increase phi)
   Int_t iphi2 = iphi;
-  if (GetSMType(nSupMod) == DCAL_EXT) {
+  if (GetSMType(nSupMod) == DCAL_EXT || GetSMType(nSupMod) == EMCAL_THIRD) {
     if (nSupMod % 2 != 0) {
       iphi2 = (phiindex / 3 - 1) - iphi; // 7-iphi [1/3SM], revert the ordering on C side in order to keep convention.
     }
@@ -1199,11 +1133,6 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId) const
     }
     // convention.
     yr = mCentersOfCellsPhiDir[iphi2 + phiindex / 4];
-  } else if (GetSMType(nSupMod) == EMCAL_THIRD) {
-    if (nSupMod % 2 != 0) {
-      iphi2 = (phiindex / 3 - 1) - iphi; // 7-iphi [1/3SM], revert the ordering on C side in order to keep convention.
-    }
-    yr = mCentersOfCellsPhiDir[iphi2 + phiindex / 3];
   } else {
     if (nSupMod % 2 != 0) {
       iphi2 = (phiindex - 1) - iphi; // 23-iphi, revert the ordering on C side in order to keep conventi
@@ -1213,14 +1142,14 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId) const
 
   LOG(debug) << "absId " << absId << " nSupMod " << nSupMod << " iphi " << iphi << " ieta " << ieta << " xr " << xr
              << " yr " << yr << " zr " << zr;
-  return o2::math_utils::Point3D<double>(xr, yr, zr);
+  return {xr, yr, zr};
 }
 
 o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId, Double_t distEff) const
 {
   // Shift index taking into account the difference between standard SM
   // and SM of half (or one third) size in phi direction
-  Double_t xr, yr, zr;
+  Double_t xr = 0, yr = 0, zr = 0;
   Int_t nphiIndex = mCentersOfCellsPhiDir.size();
   Double_t zshift = 0.5 * GetDCALInnerEdge();
   Int_t kDCalshift = 8; // wangml DCal cut first 8 modules(16 cells)
@@ -1232,30 +1161,29 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId, Doubl
   }
 
   auto cellindex = GetCellIndex(absId);
-  Int_t nSupMod = std::get<0>(cellindex), nModule = std::get<1>(cellindex), nIphi = std::get<2>(cellindex),
-        nIeta = std::get<3>(cellindex);
+  Int_t nSupMod = std::get<0>(cellindex), nModule = std::get<1>(cellindex), phiInModule = std::get<2>(cellindex), etaInModule = std::get<3>(cellindex);
   auto indmodep = GetModulePhiEtaIndexInSModule(nSupMod, nModule);
   iphim = std::get<0>(indmodep);
   ietam = std::get<1>(indmodep);
-  auto indexinsm = GetCellPhiEtaIndexInSModule(nSupMod, nModule, nIphi, nIeta);
+  auto indexinsm = GetCellPhiEtaIndexInSModule(nSupMod, nModule, phiInModule, etaInModule);
   Int_t iphi = std::get<0>(indexinsm), ieta = std::get<1>(indexinsm);
 
   // Get eta position. Careful with ALICE conventions (increase index decrease eta)
   if (nSupMod % 2 == 0) {
     ietam = (mCentersOfCellsEtaDir.size() / 2 - 1) -
             ietam; // 24-ietam, revert the ordering on A side in order to keep convention.
-    if (nIeta == 0) {
-      nIeta = 1;
+    if (etaInModule == 0) {
+      etaInModule = 1;
     } else {
-      nIeta = 0;
+      etaInModule = 0;
     }
   }
 
-  if (GetSMType(nSupMod) == DCAL_STANDARD && nSupMod % 2) {
+  if (GetSMType(nSupMod) == DCAL_STANDARD && (nSupMod % 2) != 0) {
     ietam += kDCalshift; // DCAL revert the ordering on C side ....
   }
   const ShishKebabTrd1Module& mod = GetShishKebabModule(ietam);
-  mod.GetPositionAtCenterCellLine(nIeta, distEff, v);
+  mod.GetPositionAtCenterCellLine(etaInModule, distEff, v);
   xr = v.Y() - mParSM[0];
   zr = v.X() - mParSM[2];
   if (GetSMType(nSupMod) == DCAL_STANDARD) {
@@ -1264,7 +1192,7 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId, Doubl
 
   // Get phi position. Careful with ALICE conventions (increase index increase phi)
   Int_t iphi2 = iphi;
-  if (GetSMType(nSupMod) == DCAL_EXT) {
+  if (GetSMType(nSupMod) == DCAL_EXT || GetSMType(nSupMod) == EMCAL_THIRD) {
     if (nSupMod % 2 != 0) {
       iphi2 = (nphiIndex / 3 - 1) - iphi; // 7-iphi [1/3SM], revert the ordering on C side in order to keep convention.
     }
@@ -1275,11 +1203,6 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId, Doubl
     }
     // convention.
     yr = mCentersOfCellsPhiDir[iphi2 + nphiIndex / 2];
-  } else if (GetSMType(nSupMod) == EMCAL_THIRD) {
-    if (nSupMod % 2 != 0) {
-      iphi2 = (nphiIndex / 3 - 1) - iphi; // 7-iphi [1/3SM], revert the ordering on C side in order to keep convention.
-    }
-    yr = mCentersOfCellsPhiDir[iphi2 + nphiIndex / 3];
   } else {
     if (nSupMod % 2 != 0) {
       iphi2 = (nphiIndex - 1) - iphi; // 23-iphi, revert the ordering on C side in order to keep convention.
@@ -1289,14 +1212,14 @@ o2::math_utils::Point3D<double> Geometry::RelPosCellInSModule(Int_t absId, Doubl
 
   LOG(debug) << "absId " << absId << " nSupMod " << nSupMod << " iphi " << iphi << " ieta " << ieta << " xr " << xr
              << " yr " << yr << " zr " << zr;
-  return math_utils::Point3D<double>(xr, yr, zr);
+  return {xr, yr, zr};
 }
 
 void Geometry::CreateListOfTrd1Modules()
 {
   LOG(debug2) << " o2::emcal::Geometry::CreateListOfTrd1Modules() started\n";
 
-  if (!mShishKebabTrd1Modules.size()) {
+  if (mShishKebabTrd1Modules.empty()) {
     for (int iz = 0; iz < mNZ; iz++) {
       if (iz == 0) {
         //        mod  = new AliEMCALShishKebabTrd1Module(TMath::Pi()/2.,this);
@@ -1407,7 +1330,7 @@ void Geometry::CreateListOfTrd1Modules()
 
 const ShishKebabTrd1Module& Geometry::GetShishKebabModule(Int_t neta) const
 {
-  if (mShishKebabTrd1Modules.size() && neta >= 0 && neta < mShishKebabTrd1Modules.size()) {
+  if (mShishKebabTrd1Modules.size() > 0 && neta >= 0 && neta < mShishKebabTrd1Modules.size()) {
     return mShishKebabTrd1Modules.at(neta);
   }
   throw InvalidModuleException(neta, mShishKebabTrd1Modules.size());
@@ -1447,8 +1370,8 @@ void Geometry::ImpactOnEmcal(const math_utils::Point3D<double>& vtx, Double_t th
 
   // tower absID hitted -> tower/module plane (evaluated at the center of the tower)
 
-  Double_t loc[3], loc2[3], loc3[3];
-  Double_t glob[3] = {}, glob2[3] = {}, glob3[3] = {};
+  std::array<double, 3> loc{}, loc2{}, loc3{};
+  std::array<double, 3> glob{}, glob2{}, glob3{};
 
   try {
     RelPosCellInSModule(absId).GetCoordinates(loc[0], loc[1], loc[2]);
@@ -1459,22 +1382,22 @@ void Geometry::ImpactOnEmcal(const math_utils::Point3D<double>& vtx, Double_t th
 
   // loc is cell center of tower
   auto cellindex = GetCellIndex(absId);
-  Int_t nSupMod = std::get<0>(cellindex), nModule = std::get<1>(cellindex), nIphi = std::get<2>(cellindex),
-        nIeta = std::get<3>(cellindex);
-  // look at 2 neighbours-s cell using nIphi={0,1} and nIeta={0,1}
-  Int_t nIphi2 = -1, nIeta2 = -1, absId2 = -1, absId3 = -1;
-  if (nIeta == 0) {
-    nIeta2 = 1;
+  Int_t nSupMod = std::get<0>(cellindex), nModule = std::get<1>(cellindex), phiInModule = std::get<2>(cellindex),
+        etaInModule = std::get<3>(cellindex);
+  // look at 2 neighbours-s cell using phiInModule={0,1} and etaInModule={0,1}
+  Int_t phiInModule2 = -1, etaInModule2 = -1, absId2 = -1, absId3 = -1;
+  if (etaInModule == 0) {
+    etaInModule2 = 1;
   } else {
-    nIeta2 = 0;
+    etaInModule2 = 0;
   }
-  absId2 = GetAbsCellId(nSupMod, nModule, nIphi, nIeta2);
-  if (nIphi == 0) {
-    nIphi2 = 1;
+  absId2 = GetAbsCellId(nSupMod, nModule, phiInModule, etaInModule2); // NOLINT(readability-suspicious-call-argument)
+  if (phiInModule == 0) {
+    phiInModule2 = 1;
   } else {
-    nIphi2 = 0;
+    phiInModule2 = 0;
   }
-  absId3 = GetAbsCellId(nSupMod, nModule, nIphi2, nIeta);
+  absId3 = GetAbsCellId(nSupMod, nModule, phiInModule2, etaInModule); // NOLINT(readability-suspicious-call-argument)
 
   // 2nd point on emcal cell plane
   try {
@@ -1495,9 +1418,9 @@ void Geometry::ImpactOnEmcal(const math_utils::Point3D<double>& vtx, Double_t th
   // Get Matrix
   const TGeoHMatrix* m = GetMatrixForSuperModule(nSupMod);
   if (m) {
-    m->LocalToMaster(loc, glob);
-    m->LocalToMaster(loc2, glob2);
-    m->LocalToMaster(loc3, glob3);
+    m->LocalToMaster(loc.data(), glob.data());
+    m->LocalToMaster(loc2.data(), glob2.data());
+    m->LocalToMaster(loc3.data(), glob3.data());
   } else {
     LOG(fatal) << "Geo matrixes are not loaded \n";
   }
@@ -1514,7 +1437,7 @@ void Geometry::ImpactOnEmcal(const math_utils::Point3D<double>& vtx, Double_t th
   // shift equation of plane from tower/module center to surface along vector (A,B,C) normal to tower/module plane
   Double_t dist = mLongModuleSize / 2.;
   Double_t norm = TMath::Sqrt(a * a + b * b + c * c);
-  Double_t glob4[3] = {};
+  std::array<double, 3> glob4{};
   math_utils::Vector3D<double> dir = {a, b, c};
   math_utils::Point3D<double> point = {glob[0], glob[1], glob[2]};
   if (point.Dot(dir) < 0) {
@@ -1548,18 +1471,16 @@ Bool_t Geometry::IsInEMCAL(const math_utils::Point3D<double>& pnt) const
 {
   if (IsInEMCALOrDCAL(pnt) == EMCAL_ACCEPTANCE) {
     return kTRUE;
-  } else {
-    return kFALSE;
   }
+  return kFALSE;
 }
 
 Bool_t Geometry::IsInDCAL(const math_utils::Point3D<double>& pnt) const
 {
   if (IsInEMCALOrDCAL(pnt) == DCAL_ACCEPTANCE) {
     return kTRUE;
-  } else {
-    return kFALSE;
   }
+  return kFALSE;
 }
 
 o2::emcal::AcceptanceType_t Geometry::IsInEMCALOrDCAL(const math_utils::Point3D<double>& pnt) const
@@ -1568,32 +1489,34 @@ o2::emcal::AcceptanceType_t Geometry::IsInEMCALOrDCAL(const math_utils::Point3D<
 
   if (r <= mEnvelop[0]) {
     return NON_ACCEPTANCE;
+  }
+  Double_t theta = TMath::ATan2(r, pnt.Z());
+  Double_t eta = 0;
+  if (theta == 0) {
+    eta = 9999;
   } else {
-    Double_t theta = TMath::ATan2(r, pnt.Z());
-    Double_t eta;
-    if (theta == 0) {
-      eta = 9999;
-    } else {
-      eta = -TMath::Log(TMath::Tan(theta / 2.));
-    }
-    if (eta < mArm1EtaMin || eta > mArm1EtaMax) {
-      return NON_ACCEPTANCE;
-    }
-
-    Double_t phi = TMath::ATan2(pnt.Y(), pnt.X()) * 180. / TMath::Pi();
-    if (phi < 0) {
-      phi += 360; // phi should go from 0 to 360 in this case
-    }
-
-    if (phi >= mArm1PhiMin && phi <= mEMCALPhiMax) {
-      return EMCAL_ACCEPTANCE;
-    } else if (phi >= mDCALPhiMin && phi <= mDCALStandardPhiMax && TMath::Abs(eta) > mDCALInnerExtandedEta) {
-      return DCAL_ACCEPTANCE;
-    } else if (phi > mDCALStandardPhiMax && phi <= mDCALPhiMax) {
-      return DCAL_ACCEPTANCE;
-    }
+    eta = -TMath::Log(TMath::Tan(theta / 2.));
+  }
+  if (eta < mArm1EtaMin || eta > mArm1EtaMax) {
     return NON_ACCEPTANCE;
   }
+
+  Double_t phi = TMath::ATan2(pnt.Y(), pnt.X()) * 180. / TMath::Pi();
+  if (phi < 0) {
+    phi += 360; // phi should go from 0 to 360 in this case
+  }
+
+  if (phi >= mArm1PhiMin && phi <= mEMCALPhiMax) {
+    return EMCAL_ACCEPTANCE;
+  } 
+  if (phi >= mDCALPhiMin && phi <= mDCALStandardPhiMax && TMath::Abs(eta) > mDCALInnerExtandedEta) {
+    return DCAL_ACCEPTANCE;
+  } 
+  if (phi > mDCALStandardPhiMax && phi <= mDCALPhiMax) {
+    return DCAL_ACCEPTANCE;
+  }
+  return NON_ACCEPTANCE;
+
 }
 
 const TGeoHMatrix* Geometry::GetMatrixForSuperModule(Int_t smod) const
@@ -1630,8 +1553,6 @@ const TGeoHMatrix* Geometry::GetMatrixForSuperModuleFromArray(Int_t smod) const
 
 const TGeoHMatrix* Geometry::GetMatrixForSuperModuleFromGeoManager(Int_t smod) const
 {
-  const Int_t buffersize = 255;
-  char path[buffersize];
   Int_t tmpType = -1;
   Int_t smOrder = 0;
 
@@ -1662,9 +1583,9 @@ const TGeoHMatrix* Geometry::GetMatrixForSuperModuleFromGeoManager(Int_t smod) c
     LOG(error) << "Unkown SM Type!!\n";
   }
 
-  snprintf(path, buffersize, "/cave/barrel_1/%s_%d", smName.Data(), smOrder);
+  std::string path = fmt::format("/cave/barrel_1/{}_{}", smName.Data(), smOrder);
 
-  if (!gGeoManager->cd(path)) {
+  if (!gGeoManager->cd(path.c_str())) {
     LOG(fatal) << "Geo manager can not find path " << path << "!\n";
   }
 
@@ -1672,8 +1593,8 @@ const TGeoHMatrix* Geometry::GetMatrixForSuperModuleFromGeoManager(Int_t smod) c
 }
 
 void Geometry::RecalculateTowerPosition(Float_t drow, Float_t dcol, const Int_t sm, const Float_t depth,
-                                        const Float_t misaligTransShifts[15], const Float_t misaligRotShifts[15],
-                                        Float_t global[3]) const
+                                        std::span<const float, 15> misaligTransShifts, std::span<const float, 15> misaligRotShifts,
+                                        std::span<float, 3> global) const
 {
   // To use in a print later
   Float_t droworg = drow;
@@ -1686,11 +1607,11 @@ void Geometry::RecalculateTowerPosition(Float_t drow, Float_t dcol, const Int_t 
 
     gGeoManager->cd("/cave/barrel_1/");
     TGeoNode* geoXEn1 = gGeoManager->GetCurrentNode();
-    TGeoNodeMatrix* geoSM[nSMod];
-    TGeoVolume* geoSMVol[nSMod];
-    TGeoShape* geoSMShape[nSMod];
-    TGeoBBox* geoBox[nSMod];
-    TGeoMatrix* geoSMMatrix[nSMod];
+    std::vector<TGeoNodeMatrix*> geoSM(nSMod);
+    std::vector<TGeoVolume*> geoSMVol(nSMod);
+    std::vector<TGeoShape*> geoSMShape(nSMod);
+    std::vector<TGeoBBox*> geoBox(nSMod);
+    std::vector<TGeoMatrix*> geoSMMatrix(nSMod);
 
     for (int iSM = 0; iSM < nSMod; iSM++) {
       geoSM[iSM] = dynamic_cast<TGeoNodeMatrix*>(geoXEn1->GetDaughter(iSM));
@@ -1710,7 +1631,7 @@ void Geometry::RecalculateTowerPosition(Float_t drow, Float_t dcol, const Int_t 
     Float_t zb = 0;
     Float_t zIs = 0;
 
-    Float_t x, y, z; // return variables in terry's RF
+    Float_t x = 0, y = 0, z = 0; // return variables in terry's RF
 
     //***********************************************************
     // Do not like this: too many hardcoded values, is it not already stored somewhere else?
@@ -1770,12 +1691,12 @@ void Geometry::RecalculateTowerPosition(Float_t drow, Float_t dcol, const Int_t 
     double xx = y - geoBox[sm]->GetDX();
     double yy = -x + geoBox[sm]->GetDY();
     double zz = z - geoBox[sm]->GetDZ();
-    const double localIn[3] = {xx, yy, zz};
-    double dglobal[3];
+    const std::array<double, 3> localIn = {xx, yy, zz};
+    std::array<double, 3> dglobal{};
     // geoSMMatrix[sm]->Print();
     // printf("TFF Local    (row = %d, col = %d, x = %3.2f,  y = %3.2f, z = %3.2f)\n", iroworg, icolorg, localIn[0],
     // localIn[1], localIn[2]);
-    geoSMMatrix[sm]->LocalToMaster(localIn, dglobal);
+    geoSMMatrix[sm]->LocalToMaster(localIn.data(), dglobal.data());
     // printf("TFF Global   (row = %2.0f, col = %2.0f, x = %3.2f,  y = %3.2f, z = %3.2f)\n", drow, dcol, dglobal[0],
     // dglobal[1], dglobal[2]);
 
@@ -1819,7 +1740,7 @@ void Geometry::SetMisalMatrixFromCcdb(const char* path, int timestamp) const
   TObjArray* matrices = api.retrieveFromTFileAny<TObjArray>(path, metadata, timestamp);
 
   for (int iSM = 0; iSM < mNumberOfSuperModules; ++iSM) {
-    TGeoHMatrix* mat = reinterpret_cast<TGeoHMatrix*>(matrices->At(iSM));
+    auto* mat = dynamic_cast<TGeoHMatrix*>(matrices->At(iSM));
     if (mat) {
 
       SetMisalMatrix(mat, iSM);
@@ -1829,18 +1750,18 @@ void Geometry::SetMisalMatrixFromCcdb(const char* path, int timestamp) const
   }
 }
 
-Bool_t Geometry::IsDCALSM(Int_t iSupMod) const
+Bool_t Geometry::IsDCALSM(Int_t nSupMod) const
 {
-  if (mEMCSMSystem[iSupMod] == DCAL_STANDARD || mEMCSMSystem[iSupMod] == DCAL_EXT) {
+  if (mEMCSMSystem[nSupMod] == DCAL_STANDARD || mEMCSMSystem[nSupMod] == DCAL_EXT) {
     return kTRUE;
   }
 
   return kFALSE;
 }
 
-Bool_t Geometry::IsDCALExtSM(Int_t iSupMod) const
+Bool_t Geometry::IsDCALExtSM(Int_t nSupMod) const
 {
-  if (mEMCSMSystem[iSupMod] == DCAL_EXT) {
+  if (mEMCSMSystem[nSupMod] == DCAL_EXT) {
     return kTRUE;
   }
 
@@ -1861,7 +1782,7 @@ Double_t Geometry::GetPhiCenterOfSM(Int_t nsupmod) const
 
 std::tuple<double, double> Geometry::GetPhiBoundariesOfSM(Int_t nSupMod) const
 {
-  int i;
+  int i = 0;
   if (nSupMod < 0 || nSupMod > 12 + mnSupModInDCAL - 1) {
     throw InvalidModuleException(nSupMod, 12 + mnSupModInDCAL);
   }
@@ -1886,14 +1807,10 @@ std::tuple<int, int, int> Geometry::getOnlineID(int towerID)
   int row = std::get<0>(etaphishift), col = std::get<1>(etaphishift);
 
   int ddlInSupermoudel = -1;
-  if (0 <= row && row < 8) {
-    ddlInSupermoudel = 0; // first cable row
-  } else if (8 <= row && row < 16 && 0 <= col && col < 24) {
-    ddlInSupermoudel = 0; // first half;
-  } else if (8 <= row && row < 16 && 24 <= col && col < 48) {
-    ddlInSupermoudel = 1; // second half;
-  } else if (16 <= row && row < 24) {
-    ddlInSupermoudel = 1; // third cable row
+  if ((0 <= row && row < 8) || (8 <= row && row < 16 && 0 <= col && col < 24)) {
+    ddlInSupermoudel = 0; // first cable row or first half
+  } else if ((8 <= row && row < 16 && 24 <= col && col < 48) || (16 <= row && row < 24)) {
+    ddlInSupermoudel = 1; // second half or third cable row;
   }
   if (supermoduleID % 2 == 1) {
     ddlInSupermoudel = 1 - ddlInSupermoudel; // swap for odd=C side, to allow us to cable both sides the same
@@ -1920,10 +1837,10 @@ std::tuple<bool, int, int> Geometry::areAbsIDsFromSameTCard(int absId1, int absI
   }
 
   // Get the column and row of each absId
-  const auto [_, iTower1, iIphi1, iIeta1] = GetCellIndex(absId1);
+  const auto [smUnused1, iTower1, iIphi1, iIeta1] = GetCellIndex(absId1);
   const auto [row1, col1] = GetCellPhiEtaIndexInSModule(sm1, iTower1, iIphi1, iIeta1);
 
-  const auto [__, iTower2, iIphi2, iIeta2] = GetCellIndex(absId2);
+  const auto [smUnused2, iTower2, iIphi2, iIeta2] = GetCellIndex(absId2);
   const auto [row2, col2] = GetCellPhiEtaIndexInSModule(sm2, iTower2, iIphi2, iIeta2);
 
   // Define corner of TCard for absId1

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -230,7 +230,7 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
                    "<<EMCAL_COMPLETE12SMV1>>";
     }
     return Geometry::GetInstance("EMCAL_COMPLETE12SMV1", mcname, mctitle);
-  } 
+  }
   // Run 2
   // EMCAL + DCAL geometry, 20 SM. Year 2015 and on
 
@@ -241,7 +241,7 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
               << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year";
   } else {
     LOG(info) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
-                  "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
+                 "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
   }
   return Geometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM", mcname, mctitle);
 }
@@ -873,7 +873,7 @@ Int_t Geometry::SuperModuleNumberFromEtaPhi(Double_t eta, Double_t phi) const
       }
 
       if (GetSMType(nSupMod) == DCAL_STANDARD) { // Gap between DCAL
-        const Int_t nEtaThird = GetNEta() / 3; // integer division intended: truncate to whole eta-bin count
+        const Int_t nEtaThird = GetNEta() / 3;   // integer division intended: truncate to whole eta-bin count
         if (TMath::Abs(eta) < nEtaThird * mTrd1Angle * TMath::DegToRad()) {
           throw InvalidPositionException(eta, phi);
         }
@@ -1508,15 +1508,14 @@ o2::emcal::AcceptanceType_t Geometry::IsInEMCALOrDCAL(const math_utils::Point3D<
 
   if (phi >= mArm1PhiMin && phi <= mEMCALPhiMax) {
     return EMCAL_ACCEPTANCE;
-  } 
+  }
   if (phi >= mDCALPhiMin && phi <= mDCALStandardPhiMax && TMath::Abs(eta) > mDCALInnerExtandedEta) {
     return DCAL_ACCEPTANCE;
-  } 
+  }
   if (phi > mDCALStandardPhiMax && phi <= mDCALPhiMax) {
     return DCAL_ACCEPTANCE;
   }
   return NON_ACCEPTANCE;
-
 }
 
 const TGeoHMatrix* Geometry::GetMatrixForSuperModule(Int_t smod) const

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -142,10 +142,11 @@ void Digitizer::process(const std::vector<LabeledDigit>& labeledSDigits)
           label.setAmplitudeFraction(0);
         }
         if (iLabel == 0) {
+          ++iLabel;
           continue;
         }
         d.addLabel(label);
-        iLabel++;
+        ++iLabel;
       }
       listofLabeledDigit.push_back(d);
     }


### PR DESCRIPTION
Fix a bug in the Digitizer where `iLabel` was initialized at 0 and the incrementation in the loop was skipped due to always continue if the value is 0 without incrementing the value. Local testing showed that while it is clearly a logic bug, it did not effect MC production.

Modernize EMCal code: EMCALBase/Geometry and ClusterFactory Classes and DataFormatsEMCAL classes:

- Marking functions as no discard when the return type is not void
- Switching from gsl::span to std::span to use official stl container
- Removal of unused includes
- Ensuring initialization of all members
- Switching from C-style arrays to either std::array or std::span
- Removing else after return statements
- Merging of switch and if statements that had the same body
- In Cell.cxx add new function unpackV0 to unpack/decode the bitfields. Previously we just reinterpret_cast<const DecodingV0::CellDataPacked*> some const char* variable which violate type safety. Now it uses memcpy to safely copy the data from the buffer into the new DecodingV0::CellDataPacked  object.

Fix return type for getCoreRadius (was bool should be float) and argument type for setUseWeightExotic(float useWeightExotic which should be setUseWeightExotic(bool useWeightExotic).

Removes streaming of spans from ROOT IO in ClusterFactory, since they are non owing spans.

Fixed some argument name differences between the definition and implementation of some functions.