### PR TITLE
Apply the ZNC cross-section ratio after the pile-up correction

### DIFF
--- a/DataFormats/Detectors/CTP/src/CTPRateFetcher.cxx
+++ b/DataFormats/Detectors/CTP/src/CTPRateFetcher.cxx
@@ -17,13 +17,32 @@
 #include "CommonConstants/LHCConstants.h"
 
 using namespace o2::ctp;
+
+namespace
+{
+// The ZDC counts hadronic collisions together with electromagnetic dissociation, whose cross
+// section is much the larger of the two: sigma_ZNC / sigma_hadronic is about 28. Being a ratio of
+// cross sections it relates mean numbers of interactions per crossing, so it has to be applied to
+// mu and not to a counting rate that has already saturated. getLumi() below applies it in that
+// order; fetch() has to do the same.
+double zncHadronicRatio(const std::string& sourceName)
+{
+  const bool isZNChadronic = sourceName.find("ZNC") != std::string::npos &&
+                             sourceName.find("hadronic") != std::string::npos;
+  return isZNChadronic ? 28. : 1.;
+}
+} // namespace
+
 double CTPRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName)
 {
   auto triggerRate = fetchNoPuCorr(ccdb, timeStamp, runNumber, sourceName);
-  if (triggerRate >= 0) {
-    return pileUpCorrection(triggerRate);
+  if (triggerRate < 0) {
+    return -1;
   }
-  return -1;
+  // fetchNoPuCorr has already divided by the cross-section ratio, so put it back before inverting
+  // the Poisson and divide again afterwards
+  const double ratio = zncHadronicRatio(sourceName);
+  return pileUpCorrection(triggerRate * ratio) / ratio;
 }
 double CTPRateFetcher::fetchNoPuCorr(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName)
 {


### PR DESCRIPTION
This fixes the order of the division by 28 and the Poisson inversion in `CTPRateFetcher::fetch`,
because the 28 is a ratio of cross sections and belongs on mu, not on a counting rate that has
already saturated, and it harmonizes `fetch` with `getLumi`, which already divides after the
correction.

The PbPb hadronic rate returned by `fetch(..., "ZNC hadronic")` is 2.7 % low at `mu_ZNC = 0.055`
and 5.4 % low at `mu_ZNC = 0.116`, so anything reading it as the PbPb interaction rate rises by
that much. Every other source is unchanged. Derivation and numbers are in the added
`DataFormats/Detectors/CTP/CTPRateFetcher.md`.