### PR TITLE
[ALICE3] TF3: switch substaves according to close gaps between staves

### DIFF
--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Layer.cxx
@@ -420,7 +420,7 @@ void OTOFLayer::createLayer(TGeoVolume* motherVolume)
       for (int i = 0; i < 2; ++i) {
         LOGP(info, "oTOF: Creating substave {}/{} for stave {}/{}", i + 1, 2, 1, 1);
         int sign = i > 0 ? 1 : -1;
-        auto* translation2 = new TGeoTranslation(sign * 0.5 * (subStaveSizeX) - sign * 0.5 * subStavesOverlapX, -sign * 0.5 * subStavesDistanceY, 0);
+        auto* translation2 = new TGeoTranslation(sign * 0.5 * (subStaveSizeX)-sign * 0.5 * subStavesOverlapX, -sign * 0.5 * subStavesDistanceY, 0);
         staveVol->AddNode(subStaveVol, i + 1, translation2);
       }
 

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Layer.cxx
@@ -420,7 +420,7 @@ void OTOFLayer::createLayer(TGeoVolume* motherVolume)
       for (int i = 0; i < 2; ++i) {
         LOGP(info, "oTOF: Creating substave {}/{} for stave {}/{}", i + 1, 2, 1, 1);
         int sign = i > 0 ? 1 : -1;
-        auto* translation2 = new TGeoTranslation(sign * 0.5 * (subStaveSizeX)-sign * 0.5 * subStavesOverlapX, sign * 0.5 * subStavesDistanceY, 0);
+        auto* translation2 = new TGeoTranslation(sign * 0.5 * (subStaveSizeX) - sign * 0.5 * subStavesOverlapX, -sign * 0.5 * subStavesDistanceY, 0);
         staveVol->AddNode(subStaveVol, i + 1, translation2);
       }
 


### PR DESCRIPTION
This makes OTOF staves overlaps as in the CAD. (Might change in future if swapped along z)

<img width="1944" height="1910" alt="Screenshot from 2026-08-26 14-43-14" src="https://github.com/user-attachments/assets/82ae0d33-2f23-4b58-8f5c-d7b6901efb22" />
