### PR TITLE
Reduce Pythia8 verbosity on Hyperloop

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -263,8 +263,12 @@ class GeneratorPythia8 : public Generator
   /// performs seeding of the random state of Pythia (called from Init)
   void seedGenerator();
 
+  // Hyperloop flag
+  const bool mIsHyperloop = std::getenv("IS_HYPERLOOP") && std::atoi(std::getenv("IS_HYPERLOOP"));
+
   /** Pythia8 **/
-  Pythia8::Pythia mPythia; //!
+  // Show banner only when not running in Hyperloop
+  Pythia8::Pythia mPythia{/*Default*/ "../share/Pythia8/xmldoc", /*banner*/ !mIsHyperloop}; //!
 
   /** @{
    * @name Configurations */

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -66,6 +66,12 @@ GeneratorPythia8::GeneratorPythia8(Pythia8GenConfig const& config) : Generator("
   mInterface = reinterpret_cast<void*>(&mPythia);
   mInterfaceName = "pythia8";
 
+  // Decrease Pythia8 verbosity when running in Hyperloop
+  if (mIsHyperloop) {
+    LOG(info) << "Simulation running in Hyperloop => reducing Pythia8 logs";
+    mPythia.readString("Print:quiet on");
+  }
+
   LOG(info) << "Instance \'Pythia8\' generator with following parameters";
   LOG(info) << "config: " << config.config;
   LOG(info) << "hooksFileName: " << config.hooksFileName;


### PR DESCRIPTION
This development reduced the sgngen_serverlog output by a factor 16 (more if running parallel hybrid with 8 workers).