### PR TITLE
ITS: new CPU + GPU seeding vertexer

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/Vertex.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/Vertex.h
@@ -15,6 +15,8 @@
 #include "GPUCommonDef.h"
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
 #endif
 #include "ReconstructionDataFormats/Vertex.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -25,6 +27,36 @@ namespace o2::its
 // NOTE: this uses the internal asymmetrical time reprenstation!
 using Vertex = o2::dataformats::Vertex<o2::its::TimeEstBC>;
 using VertexLabel = std::pair<o2::MCCompLabel, float>;
+
+#ifndef GPUCA_GPUCODE_DEVICE
+/// Majority-vote MC label of a vertex: the most frequent (source, event) among its
+/// contributors, flagged fake when no label reaches more than half of them. Templated
+/// on the container so both bounded_vector and std::vector callers share one copy
+template <typename Container>
+VertexLabel computeMainVertexLabel(const Container& elements)
+{
+  // we only care about the source&event of the tracks, not the trackId
+  auto composeVtxLabel = [](const o2::MCCompLabel& lbl) -> o2::MCCompLabel {
+    return {o2::MCCompLabel::maxTrackID(), lbl.getEventID(), lbl.getSourceID(), lbl.isFake()};
+  };
+  std::unordered_map<o2::MCCompLabel, size_t> frequency;
+  for (const auto& element : elements) {
+    ++frequency[composeVtxLabel(element)];
+  }
+  o2::MCCompLabel elem{};
+  size_t maxCount = 0;
+  for (const auto& [key, count] : frequency) {
+    if (count > maxCount) {
+      maxCount = count;
+      elem = key;
+    }
+  }
+  if (maxCount <= 1) { // need >50%
+    elem.setFakeFlag();
+  }
+  return std::make_pair(elem, static_cast<float>(maxCount) / static_cast<float>(elements.size()));
+}
+#endif
 } // namespace o2::its
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -21,6 +21,8 @@
 #include "ITStracking/Configuration.h"
 #include "ITStracking/TrackExtensionHypothesis.h"
 #include "ITStrackingGPU/Utils.h"
+#include "ITStracking/ClusterLines.h"
+#include "ITStracking/LineProjection.h"
 
 namespace o2::its::gpu
 {
@@ -54,10 +56,14 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   void createTrackingFrameInfoDeviceArray(const int = NLayers);
   void loadUnsortedClustersDevice(const int);
   void createUnsortedClustersDeviceArray(const int = NLayers);
-  void loadClustersDevice(const int);
   void createClustersDeviceArray(const int = NLayers);
   void loadClustersIndexTables(const int);
   void createClustersIndexTablesArray(const int = NLayers);
+  void createClustersDevice(const int);
+  void createClustersIndexTables(const int);
+  void createClusterRadiiDevice();
+  void uploadClusterRadii();
+  void sortClustersDevice(const int layer, const TrackingParameters& trkParam);
   void createUsedClustersDevice(const int);
   void createUsedClustersDeviceArray(const int = NLayers);
   void loadUsedClustersDevice();
@@ -87,6 +93,20 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   void createTrackExtensionScratchDevice(const int nThreads, const int maxHypotheses);
   void downloadTrackITSExtDevice();
 
+  // Seeding-vertexer
+  void createClusterOwnersDeviceArray();
+  void createClusterOwnersDevice();
+  void resetClusterOwnersDevice();
+  void createClusterSortScratchDevice(const int layer);
+
+  void createLinesDevice(const int nCells);
+  void createDiamondDevice(const Vertex& diamond);
+  unsigned int downloadLinesDevice();
+  unsigned int getNLines();
+  const auto& getHostLines() const { return mLinesHost; }
+  const auto& getHostLineRof() const { return mLineRofHost; }
+  const auto& getHostLineClusters() const { return mLineClustersHost; }
+
   /// synchronization
   auto& getStream(const size_t stream) { return mGpuStreams[stream]; }
   auto& getStreams() { return mGpuStreams; }
@@ -111,6 +131,17 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   auto& getTrackITSExt() { return mTrackITSExt; }
   auto& getTrackIndices() { return mTrackIndices; }
   Vertex* getDeviceVertices() { return mPrimaryVerticesDevice; }
+  int* getDeviceROFramesClusters(const int layer) { return mROFramesClustersDevice[layer]; }
+  int* getDeviceClusterSortKeys(const int layer) { return mClusterSortKeysDevice[layer]; }
+  int* getDeviceClusterSortPerm(const int layer) { return mClusterSortPermDevice[layer]; }
+  Cluster* getDeviceUnsortedClusters(const int layer) { return mUnsortedClustersDevice[layer]; }
+  Cluster* getDeviceClusters(const int layer) { return mClustersDevice[layer]; }
+  int* getDeviceClustersIndexTable(const int layer) { return mClustersIndexTablesDevice[layer]; }
+  const float* getDeviceMinRs() const { return mClusterMinRDevice; }
+  const float* getDeviceMaxRs() const { return mClusterMaxRDevice; }
+  int* getDeviceROFramesPV() { return mROFramesPVDevice; }
+  unsigned char* getDeviceUsedClusters(const int);
+  const o2::base::Propagator* getChainPropagator();
 
   // Hybrid
   TrackITSExt* getDeviceTrackITSExt() { return mTrackITSExtDevice; }
@@ -119,6 +150,39 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   TrackExtensionHypothesis<NLayers>* getDeviceNextTrackExtensionHypotheses() { return mNextTrackExtensionHypothesesDevice; }
   int* getDeviceNeighboursLUT(const int layer) { return mNeighboursLUTDevice[layer]; }
   CellNeighbour** getDeviceArrayNeighbours() { return mNeighboursDeviceArray; }
+  unsigned long long** getDeviceArrayClusterOwners() { return mClusterOwnersDeviceArray; }
+  o2::its::Line* getDeviceLines() { return mLinesDevice; }
+  int* getDeviceLineSlots() { return mLineSlotsDevice; }
+  int* getDeviceLineRof() { return mLineRofDevice; }
+  int* getDeviceLineClusters() { return mLineClustersDevice; }
+  float* getDeviceLineChi2() { return mLineChi2Device; }
+  float* getDeviceLinePt() { return mLinePtDevice; }
+  float* getDeviceLineZs() { return mLineZsDevice; }
+  o2::its::TimeEstBC* getDeviceLineTimes() { return mLineTimesDevice; }
+  int* getDeviceLineSortedIdx() { return mLinesSortedIdx; }
+  LineProjSoA getLineProjSoA() { return {mLineZsDevice, mLineTimesDevice, mLinesSortedIdx, mLineRofDevice}; }
+  LineProjSoA getLineProjSortedSoA() { return {mLineZsSortedDevice, mLineTimesSortedDevice, mLinesSortedIdx, mLineRofSortedDevice}; }
+  int* getDeviceRofLineOffsets() { return mRofLineOffsetsDevice; }
+  int* getDeviceLineDensity() { return mLineDensityDevice; }
+  gpu::LineWindow* getDeviceLineWin() { return mLineWinDevice; }
+  uint8_t* getDeviceLineIsPeak() { return mLineIsPeakDevice; }
+  int* getDeviceLineDensityFine() { return mLineDensityFineDevice; }
+  gpu::LineWindow* getDeviceLineWinFine() { return mLineWinFineDevice; }
+  uint8_t* getDeviceLineIsPeakFine() { return mLineIsPeakFineDevice; }
+  int* getDevicePeakScan() { return mPeakScanDevice; }
+  int* getDevicePeakLineIdx() { return mPeakLineIdxDevice; }
+  int* getDevicePeakOffsets() { return mPeakOffsetsDevice; }
+  const int* getDeviceNPeaks() { return mPeakOffsetsDevice + this->getNrof(1); }
+  VertexCand* getDeviceVertexCands() { return mVertexCandsDevice; }
+  int downloadVertexCandsDevice();
+  void downloadPeakMembershipInputs(); // MC-only: peak indices, z-windows and the sorted time/idx columns
+  const auto& getHostVertexCands() const { return mVertexCandsHost; }
+  const auto& getHostPeakOffsets() const { return mPeakOffsetsHost; }
+  const auto& getHostPeakMembership() const { return mPeakMembershipHost; }
+  std::vector<o2::MCCompLabel>& getLineLabelFlat() { return mLineLabelFlatHost; }
+  const std::vector<o2::MCCompLabel>& getLineLabelFlat() const { return mLineLabelFlatHost; }
+  Vertex* getDeviceDiamond() { return mDiamondDevice; }
+  std::array<CellNeighbour*, MaxCells>& getDeviceNeighboursAll() { return mNeighboursDevice; }
   CellNeighbour* getDeviceNeighbours(const int layer) { return mNeighboursDevice[layer]; }
   const TrackingFrameInfo** getDeviceArrayTrackingFrameInfo() const { return mTrackingFrameInfoDeviceArray; }
   const Cluster** getDeviceArrayClusters() const { return mClustersDeviceArray; }
@@ -155,6 +219,10 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   size_t getNumberOfTracklets() const final;
   size_t getNumberOfCells() const final;
   size_t getNumberOfNeighbours() const final;
+
+ protected:
+  void prepareClusters(const TrackingParameters& trkParam, const int maxLayers) override;
+  void allocateClusterSortStorage(const TrackingParameters& trkParam, const int maxLayers) override;
 
  private:
   enum class SlotInit {
@@ -215,6 +283,11 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   const int** mClustersIndexTablesDeviceArray{nullptr};
   uint8_t** mUsedClustersDeviceArray{nullptr};
   const int** mROFramesClustersDeviceArray{nullptr};
+  int* mROFramesPVDevice;
+  std::array<int*, NLayers> mClusterSortKeysDevice{};
+  std::array<int*, NLayers> mClusterSortPermDevice{};
+  float* mClusterMinRDevice{nullptr};
+  float* mClusterMaxRDevice{nullptr};
   std::array<Tracklet*, MaxLinks> mTrackletsDevice{};
   std::array<int*, MaxLinks> mTrackletsLUTDevice{};
   std::array<int*, MaxCells> mCellsLUTDevice{};
@@ -239,6 +312,40 @@ class TimeFrameGPU : public TimeFrame<NLayers>
   CellNeighbour** mNeighboursDeviceArray{nullptr};
   std::array<TrackingFrameInfo*, NLayers> mTrackingFrameInfoDevice{};
   const TrackingFrameInfo** mTrackingFrameInfoDeviceArray{nullptr};
+  std::array<unsigned long long*, 3> mClusterOwnersDevice{};
+  unsigned long long** mClusterOwnersDeviceArray{nullptr};
+  int* mLineSlotsDevice{nullptr};
+  o2::its::Line* mLinesDevice{nullptr};
+  int* mLineRofDevice{nullptr};
+  int* mLineClustersDevice{nullptr};
+  float* mLineChi2Device{nullptr};
+  float* mLinePtDevice{nullptr};
+  float* mLineZsDevice{nullptr};
+  o2::its::TimeEstBC* mLineTimesDevice{nullptr};
+  float* mLineZsSortedDevice{nullptr};
+  o2::its::TimeEstBC* mLineTimesSortedDevice{nullptr};
+  int* mLinesSortedIdx{nullptr};
+  int* mLineRofSortedDevice{nullptr};       // per (sorted) line's ROF
+  int* mRofLineOffsetsDevice{nullptr};      // CSR offsets into the (rof,z)-sorted lines, size nRofs+1
+  int* mLineDensityDevice{nullptr};         // per (sorted) line: count of time-compatible neighbours in its z-window
+  gpu::LineWindow* mLineWinDevice{nullptr}; // per (sorted) line: [lo,hi) bounds of its z-window (sorted coords)
+  uint8_t* mLineIsPeakDevice{nullptr};      // per (sorted) line: 1 if it is a local density peak (vertex candidate)
+  int* mLineDensityFineDevice{nullptr};
+  gpu::LineWindow* mLineWinFineDevice{nullptr};
+  uint8_t* mLineIsPeakFineDevice{nullptr};
+  int* mPeakScanDevice{nullptr};    // per (sorted) line: number of peaks strictly before it
+  int* mPeakLineIdxDevice{nullptr}; // per peak slot: the sorted line index it came from
+  int* mPeakOffsetsDevice{nullptr}; // CSR offsets into the compacted peaks
+  VertexCand* mVertexCandsDevice{nullptr};
+  int mNLinesCapacity{0}; // = nCells the line buffers were sized for
+  std::vector<o2::its::Line> mLinesHost;
+  std::vector<int> mLineRofHost;
+  std::vector<int> mLineClustersHost;
+  std::vector<VertexCand> mVertexCandsHost;
+  std::vector<int> mPeakOffsetsHost;
+  PeakMembershipHost mPeakMembershipHost;
+  std::vector<o2::MCCompLabel> mLineLabelFlatHost;
+  Vertex* mDiamondDevice{nullptr};
 
   // State
   Streams mGpuStreams;

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TrackerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TrackerTraitsGPU.h
@@ -29,6 +29,9 @@ class TrackerTraitsGPU final : public TrackerTraits<NLayers>
   void adoptTimeFrame(TimeFrame<NLayers>* tf) final;
   void initialiseTimeFrame(const int iteration) final;
 
+  void computeVertexCandidates(const int iteration) final;
+  void computeVertices(const int iteration) final;
+
   void computeLayerTracklets(const int iteration, int) final;
   void computeLayerCells(const int iteration) final;
   void findCellsNeighbours(const int iteration) final;

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TrackingKernels.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TrackingKernels.h
@@ -22,6 +22,8 @@
 #include "ITStracking/TrackingTopology.h"
 #include "ITStracking/TrackExtensionHypothesis.h"
 #include "ITStrackingGPU/Utils.h"
+#include "ITStracking/ClusterLines.h"
+#include "ITStracking/LineProjection.h"
 #include "DetectorsBase/Propagator.h"
 
 namespace o2::its
@@ -52,6 +54,7 @@ struct TrackingKernels {
                                            const typename ROFVertexLookupTable<NLayers>::View& vertexLUT,
                                            const int vertexId,
                                            const Vertex* vertices,
+                                           const bool vtxMode,
                                            const Cluster** clusters,
                                            const std::vector<unsigned int>& nClusters,
                                            const int** ROFClusters,
@@ -67,8 +70,8 @@ struct TrackingKernels {
                                            const typename TrackingTopology<NLayers>::View topology,
                                            bounded_vector<float>& linkPhiCuts,
                                            const float resolutionPV,
-                                           std::array<float, NLayers>& minR,
-                                           std::array<float, NLayers>& maxR,
+                                           const float* minRs,
+                                           const float* maxRs,
                                            bounded_vector<float>& resolutions,
                                            std::vector<float>& radii,
                                            bounded_vector<float>& linkMSAngles,
@@ -89,6 +92,7 @@ struct TrackingKernels {
                                  const float bz,
                                  const float maxChi2ClusterAttachment,
                                  const float cellDeltaTanLambdaSigma,
+                                 const float cellDeltaPhiCut,
                                  const float nSigmaCut,
                                  const float* layerxX0,
                                  o2::its::ExternalAllocator* alloc,
@@ -172,6 +176,108 @@ struct TrackingKernels {
                                      const o2::base::Propagator* propagator,
                                      const o2::base::PropagatorF::MatCorrType matCorrType,
                                      o2::its::ExternalAllocator* alloc);
+
+  static void sortClustersHandler(const Cluster* unsorted,
+                                  Cluster* sorted,
+                                  const int* clusterOffsets,
+                                  int* indexTable,
+                                  const IndexTableUtils<NLayers>* utils,
+                                  const typename ROFMaskTable<NLayers>::View& rofMask,
+                                  float beamX, float beamY,
+                                  int zBins, int phiBins, int nRofs, int nClustersLayer, int iLayer,
+                                  float* minRadiusLayer, float* maxRadiusLayer,
+                                  int* keys,
+                                  int* perm,
+                                  o2::its::ExternalAllocator* alloc,
+                                  gpu::Stream& stream);
+
+  static void registerClusterOwnershipHandler(const CellSeed* cellsLayersDevice,
+                                              const int nCells,
+                                              unsigned long long** clusterOwnersDeviceArray,
+                                              gpu::Stream& stream);
+
+  static void linearizeCellsToLinesHandler(const int nCells,
+                                           const CellSeed* cells,
+                                           const unsigned long long* const* clusterOwners,
+                                           const int* rofFramesClustersL1,
+                                           const int nRofsL1,
+                                           const int ownedClustersCut,
+                                           o2::its::Line* lines,
+                                           int* lineRof,
+                                           int* lineClusters,
+                                           int* lineSlots,
+                                           const float beamX,
+                                           const float beamY,
+                                           const float maxZ,
+                                           const float minPt,
+                                           float* linesZs,
+                                           o2::its::TimeEstBC* lineTimes,
+                                           float* lineChi2,
+                                           float* linePt,
+                                           o2::its::ExternalAllocator* alloc,
+                                           gpu::Stream& stream);
+
+  static void sortLinesHandler(const int nLines,
+                               const int nRofs,
+                               const gpu::LineProjSoA soa,
+                               const gpu::LineProjSoA sortedSoa,
+                               const int* lineRof,
+                               int* rofOffsets,
+                               o2::its::ExternalAllocator* alloc,
+                               gpu::Stream& stream);
+
+  static void scanDensityHandler(const int nLines,
+                                 const gpu::LineProjSoA sortedSoa,
+                                 const int* rofOffsets,
+                                 int* density,
+                                 gpu::LineWindow* win,
+                                 const float zWindow,
+                                 gpu::Stream& stream);
+
+  static void findPeaksHandler(const int nLines,
+                               const int nRofs,
+                               const gpu::LineProjSoA sortedSoa,
+                               const int* rofOffsets,
+                               const int* density,
+                               const gpu::LineWindow* win,
+                               uint8_t* isPeak,
+                               const int* densityFine,
+                               const gpu::LineWindow* winFine,
+                               const int fineMinDensity,
+                               uint8_t* isPeakFine,
+                               int* peakScan,
+                               int* peakLineIdx,
+                               int* peakOffsets,
+                               o2::its::ExternalAllocator* alloc,
+                               gpu::Stream& stream);
+
+  static void fitPeaksHandler(const int* nPeaksDevice,
+                              const int* peakLineIdx,
+                              const gpu::LineWindow* win,
+                              const gpu::LineProjSoA sortedSoa,
+                              const o2::its::Line* lines,
+                              const float* lineChi2,
+                              const float* linePt,
+                              const float goodLineChi2Cut,
+                              const float goodLinePtCut,
+                              const float pairCut2,
+                              const float nSigmaCut,
+                              const int minContributors,
+                              const float beamX,
+                              const float beamY,
+                              const uint8_t* isPeakFine,
+                              const float fineMaxDrift,
+                              gpu::VertexCand* cands,
+                              gpu::Stream& stream);
+
+  static void dedupVertexCandidatesHandler(const int* nPeaksDevice,
+                                           const int* peakLineIdx,
+                                           const int* peakOffsets,
+                                           const gpu::LineProjSoA sortedSoa,
+                                           const float duplicateZCut,
+                                           const float duplicateZScale,
+                                           gpu::VertexCand* cands,
+                                           gpu::Stream& stream);
 };
 
 void resetOutputCounterHandler(int* outputCounter, gpu::Stream& stream);

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Utils.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Utils.h
@@ -38,10 +38,17 @@
 #endif
 
 #ifdef ITS_GPU_LOG
-#define GPULog(...)                      \
-  do {                                   \
-    LOGP(info, __VA_ARGS__);             \
-    GPUChkErrS(cudaDeviceSynchronize()); \
+#if defined(__HIPCC__)
+#define GPULogSync() GPUChkErrS(hipDeviceSynchronize())
+#elif defined(__CUDACC__)
+#define GPULogSync() GPUChkErrS(cudaDeviceSynchronize())
+#else
+#define GPULogSync()
+#endif
+#define GPULog(...)          \
+  do {                       \
+    LOGP(info, __VA_ARGS__); \
+    GPULogSync();            \
   } while (0)
 #else
 #define GPULog(...)
@@ -342,6 +349,36 @@ struct TypedAllocator {
  private:
   ExternalAllocator* mInternalAllocator;
 };
+
+// first i in [beg,end) with a[i] >= key
+template <typename T>
+GPUdii() int deviceLowerBound(const T* a, int beg, int end, const T key)
+{
+  while (beg < end) {
+    const int mid = beg + (end - beg) / 2;
+    if (a[mid] < key) {
+      beg = mid + 1;
+    } else {
+      end = mid;
+    }
+  }
+  return beg;
+}
+
+// first i in [beg,end) with a[i] > key
+template <typename T>
+GPUdii() int deviceUpperBound(const T* a, int beg, int end, const T key)
+{
+  while (beg < end) {
+    const int mid = beg + (end - beg) / 2;
+    if (a[mid] <= key) {
+      beg = mid + 1;
+    } else {
+      end = mid;
+    }
+  }
+  return beg;
+}
 
 GPUdii() gpuSpan<const Cluster> getClustersOnLayer(const int rof,
                                                    const int totROFs,

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -16,6 +16,7 @@
 #include <numeric>
 #include <array>
 #include <type_traits>
+#include <cmath>
 #include <unistd.h>
 #include <vector>
 
@@ -23,6 +24,9 @@
 #include "ITSMFTTracking/Constants.h"
 #include "ITSMFTTracking/BoundedAllocator.h"
 #include "ITStrackingGPU/Utils.h"
+#include "ITStracking/ClusterLines.h"
+#include "ITStracking/LineProjection.h"
+#include "ITStrackingGPU/TrackingKernels.h"
 
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
@@ -171,6 +175,22 @@ typename Table::View TimeFrameGPU<NLayers>::uploadNavigationTable(const Table& t
 }
 
 template <int NLayers>
+void TimeFrameGPU<NLayers>::prepareClusters(const TrackingParameters& trkParam, const int maxLayers)
+{
+  if (maxLayers < NLayers) { // only if former seeding vertexer is run
+    TimeFrame<NLayers>::prepareClusters(trkParam, maxLayers);
+  }
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::allocateClusterSortStorage(const TrackingParameters& trkParam, const int maxLayers)
+{
+  if (maxLayers < NLayers) { // only if former seeding vertexer is run
+    TimeFrame<NLayers>::allocateClusterSortStorage(trkParam, maxLayers);
+  }
+}
+
+template <int NLayers>
 void TimeFrameGPU<NLayers>::loadIndexTableUtils()
 {
   GPUTimer timer("loading indextable utils");
@@ -224,13 +244,6 @@ void TimeFrameGPU<NLayers>::createClustersDeviceArray(const int maxLayers)
 }
 
 template <int NLayers>
-void TimeFrameGPU<NLayers>::loadClustersDevice(const int layer)
-{
-  GPUTimer timer(mGpuStreams[layer], "loading sorted clusters", layer);
-  uploadSlot(mClustersDevice, mClustersDeviceArray, layer, this->mClusters[layer], "sorted clusters");
-}
-
-template <int NLayers>
 void TimeFrameGPU<NLayers>::createClustersIndexTablesArray(const int maxLayers)
 {
   GPUTimer timer("creating clustersindextable array");
@@ -239,10 +252,66 @@ void TimeFrameGPU<NLayers>::createClustersIndexTablesArray(const int maxLayers)
 }
 
 template <int NLayers>
+void TimeFrameGPU<NLayers>::createClustersDevice(const int layer)
+{
+  GPUTimer timer(mGpuStreams[layer], "creating sorted clusters", layer);
+  createSlot(mClustersDevice, mClustersDeviceArray, layer, this->mUnsortedClusters[layer].size(), "sorted clusters");
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createClustersIndexTables(const int layer)
+{
+  GPUTimer timer(mGpuStreams[layer], "creating clusters index table", layer);
+  const int nBins = this->mIndexTableUtils.getNphiBins() * this->mIndexTableUtils.getNzBins();
+  const size_t nEntries = static_cast<size_t>(this->getNrof(layer)) * (nBins + 1);
+  createSlot(mClustersIndexTablesDevice, mClustersIndexTablesDeviceArray, layer, nEntries, "clusters index table entries");
+}
+
+template <int NLayers>
 void TimeFrameGPU<NLayers>::loadClustersIndexTables(const int layer)
 {
   GPUTimer timer(mGpuStreams[layer], "loading clusters indextables", layer);
   uploadSlot(mClustersIndexTablesDevice, mClustersIndexTablesDeviceArray, layer, this->mIndexTables[layer], "clusters indextable entries");
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createClusterRadiiDevice()
+{
+  GPUTimer timer("creating cluster radii bounds");
+  mClusterMinRDevice = allocDevice<float>(NLayers);
+  mClusterMaxRDevice = allocDevice<float>(NLayers);
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::uploadClusterRadii()
+{
+  GPUTimer timer("loading cluster radii bounds");
+  GPUChkErrS(cudaMemcpy(mClusterMinRDevice, this->getMinRs().data(), NLayers * sizeof(float), cudaMemcpyHostToDevice));
+  GPUChkErrS(cudaMemcpy(mClusterMaxRDevice, this->getMaxRs().data(), NLayers * sizeof(float), cudaMemcpyHostToDevice));
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::sortClustersDevice(const int layer, const TrackingParameters& trkParam)
+{
+  GPUTimer timer(mGpuStreams[layer], "sorting clusters on device", layer);
+  const int nClusters = static_cast<int>(this->mUnsortedClusters[layer].size());
+  const int nRofs = this->getNrof(layer);
+  const size_t nEntries = static_cast<size_t>(nRofs) * (trkParam.ZBins * trkParam.PhiBins + 1);
+  createClustersDevice(layer);
+  createClustersIndexTables(layer);
+  if (!nClusters) {
+    GPUChkErrS(cudaMemsetAsync(mClustersIndexTablesDevice[layer], 0, nEntries * sizeof(int), mGpuStreams[layer].get()));
+    return;
+  }
+  createClusterSortScratchDevice(layer);
+  TrackingKernels<NLayers>::sortClustersHandler(mUnsortedClustersDevice[layer], mClustersDevice[layer],
+                                                mROFramesClustersDevice[layer], mClustersIndexTablesDevice[layer],
+                                                mIndexTableUtilsDevice, mDeviceROFMaskTableView,
+                                                this->mBeamPos[0], this->mBeamPos[1],
+                                                trkParam.ZBins, trkParam.PhiBins, nRofs, nClusters, layer,
+                                                mClusterMinRDevice, mClusterMaxRDevice,
+                                                mClusterSortKeysDevice[layer], mClusterSortPermDevice[layer],
+                                                this->getFrameworkAllocator(), mGpuStreams[layer]);
 }
 
 template <int NLayers>
@@ -375,6 +444,7 @@ template <int NLayers>
 void TimeFrameGPU<NLayers>::uploadROFVertexLookupTable()
 {
   GPUTimer timer("updating device view of ROFVertexLookupTable");
+  TimeFrame<NLayers>::updateROFVertexLookupTable();
   const auto& hostTable = this->getROFVertexLookupTable();
   const auto& hostView = this->getROFVertexLookupTableView();
   using TableEntry = ROFVertexLookupTable<NLayers>::TableEntry;
@@ -394,7 +464,7 @@ void TimeFrameGPU<NLayers>::createTrackletsLUTDevice(bool allocate, const int la
 {
   GPUTimer timer(mGpuStreams[layer], "creating tracklets LUTs", layer);
   const int fromLayer = this->mTrackingTopologyView.getLink(layer).fromLayer;
-  const size_t ncls = this->mClusters[fromLayer].size() + 1;
+  const size_t ncls = this->mUnsortedClusters[fromLayer].size() + 1; // host mClusters is empty: the sort runs on device
   if (allocate || mTrackletsLUTDevice[layer] == nullptr) {
     createSlot(mTrackletsLUTDevice, mTrackletsLUTDeviceArray, layer, ncls, "tracklets LUT");
   }
@@ -445,6 +515,160 @@ void TimeFrameGPU<NLayers>::createCellsBuffersArray()
   GPUTimer timer("creating cells buffers array");
   mCellsDeviceArray = allocSlotArray<CellSeed*>(MaxCells);
   mNeighboursDeviceArray = allocSlotArray<CellNeighbour*>(MaxCells);
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createClusterOwnersDeviceArray()
+{
+  GPUTimer timer("creating cluster owners array");
+  mClusterOwnersDeviceArray = allocDevice<unsigned long long*>(3);
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createClusterOwnersDevice()
+{
+  const auto sizes = getClusterSizes();
+  for (int l = 0; l < 3; ++l) {
+    mClusterOwnersDevice[l] = allocDeviceAsync<unsigned long long>(sizes[l], mGpuStreams[l], (o2::gpu::GPUMemoryResource::MEMORY_GPU | o2::gpu::GPUMemoryResource::MEMORY_STACK));
+    GPUChkErrS(cudaMemcpyAsync(&mClusterOwnersDeviceArray[l], &mClusterOwnersDevice[l], sizeof(unsigned long long*), cudaMemcpyHostToDevice, mGpuStreams[l].get()));
+  }
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::resetClusterOwnersDevice()
+{
+  const auto sizes = getClusterSizes();
+  for (int l = 0; l < 3; ++l) {
+    GPUChkErrS(cudaMemsetAsync(mClusterOwnersDevice[l], 0xFF, sizes[l] * sizeof(unsigned long long), mGpuStreams[l].get()));
+  }
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createDiamondDevice(const Vertex& diamond)
+{
+  GPUTimer timer("Creating diamond device");
+  mDiamondDevice = allocDevice<Vertex>(1, (o2::gpu::GPUMemoryResource::MEMORY_GPU | o2::gpu::GPUMemoryResource::MEMORY_STACK));
+  GPUChkErrS(cudaMemcpyAsync(mDiamondDevice, &diamond, sizeof(Vertex), cudaMemcpyHostToDevice, mGpuStreams[0].get()));
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createClusterSortScratchDevice(const int layer)
+{
+  GPUTimer timer("creating cluster-sort scratch device");
+  const size_t nClusters = this->mUnsortedClusters[layer].size();
+  mClusterSortKeysDevice[layer] = allocDeviceAsync<int>(nClusters, mGpuStreams[layer]);
+  mClusterSortPermDevice[layer] = allocDeviceAsync<int>(nClusters, mGpuStreams[layer]);
+}
+
+template <int NLayers>
+void TimeFrameGPU<NLayers>::createLinesDevice(const int nCells)
+{
+  GPUTimer timer("creating lines device");
+  constexpr auto kStack = (o2::gpu::GPUMemoryResource::MEMORY_GPU | o2::gpu::GPUMemoryResource::MEMORY_STACK);
+  mLinesDevice = allocDeviceAsync<o2::its::Line>(nCells, mGpuStreams[0], kStack);
+  mLineRofDevice = allocDeviceAsync<int>(nCells, mGpuStreams[0], kStack);
+  mLineClustersDevice = allocDeviceAsync<int>(3 * nCells, mGpuStreams[0], kStack);
+  mLineChi2Device = allocDeviceAsync<float>(nCells, mGpuStreams[0], kStack);
+  mLinePtDevice = allocDeviceAsync<float>(nCells, mGpuStreams[0], kStack);
+  mLineSlotsDevice = allocDeviceAsync<int>((nCells + 1), mGpuStreams[0], kStack);
+  mLineZsDevice = allocDeviceAsync<float>(nCells, mGpuStreams[0], kStack);
+  mLineTimesDevice = allocDeviceAsync<o2::its::TimeEstBC>(nCells, mGpuStreams[0], kStack);
+  mLineZsSortedDevice = allocDeviceAsync<float>(nCells, mGpuStreams[0], kStack);
+  mLineTimesSortedDevice = allocDeviceAsync<o2::its::TimeEstBC>(nCells, mGpuStreams[0], kStack);
+  mLinesSortedIdx = allocDeviceAsync<int>(nCells, mGpuStreams[0], kStack);
+  mLineRofSortedDevice = allocDeviceAsync<int>(nCells, mGpuStreams[0], kStack);
+  mRofLineOffsetsDevice = allocDeviceAsync<int>((this->getNrof(1) + 1), mGpuStreams[0], kStack);
+  mLineDensityDevice = allocDeviceAsync<int>(nCells, mGpuStreams[0], kStack);
+  mLineWinDevice = allocDeviceAsync<gpu::LineWindow>(nCells, mGpuStreams[0], kStack);
+  mLineIsPeakDevice = allocDeviceAsync<uint8_t>(nCells, mGpuStreams[0], kStack);
+  mLineDensityFineDevice = allocDeviceAsync<int>(nCells, mGpuStreams[0], kStack);
+  mLineWinFineDevice = allocDeviceAsync<gpu::LineWindow>(nCells, mGpuStreams[0], kStack);
+  mLineIsPeakFineDevice = allocDeviceAsync<uint8_t>(nCells, mGpuStreams[0], kStack);
+  mPeakScanDevice = allocDeviceAsync<int>((nCells + 1), mGpuStreams[0], kStack);
+  mPeakLineIdxDevice = allocDeviceAsync<int>(nCells, mGpuStreams[0], kStack);
+  mPeakOffsetsDevice = allocDeviceAsync<int>((this->getNrof(1) + 1), mGpuStreams[0], kStack);
+  mVertexCandsDevice = allocDeviceAsync<VertexCand>(nCells, mGpuStreams[0], kStack);
+  mNLinesCapacity = nCells;
+}
+
+template <int NLayers>
+unsigned int TimeFrameGPU<NLayers>::getNLines()
+{
+  GPUTimer timer("getting number of lines");
+  int nLinesSigned{0};
+  GPUChkErrS(cudaMemcpyAsync(&nLinesSigned, mLineSlotsDevice + mNLinesCapacity, sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+  GPUChkErrS(cudaStreamSynchronize(mGpuStreams[0].get())); // need the count before sizing the staging buffers
+  if (nLinesSigned < 0 || nLinesSigned > mNLinesCapacity) {
+    LOGP(fatal, "ITS GPU linearizer produced {} lines for a capacity of {}: bad compaction scan total.", nLinesSigned, mNLinesCapacity);
+  }
+  return static_cast<unsigned int>(nLinesSigned);
+}
+
+template <int NLayers>
+int TimeFrameGPU<NLayers>::downloadVertexCandsDevice()
+{
+  GPUTimer timer("downloading vertex candidates");
+  mPeakOffsetsHost.resize(this->getNrof(1) + 1);
+  GPUChkErrS(cudaMemcpyAsync(mPeakOffsetsHost.data(), mPeakOffsetsDevice, mPeakOffsetsHost.size() * sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+  GPUChkErrS(cudaStreamSynchronize(mGpuStreams[0].get())); // need nPeaks before sizing the staging buffers
+  const int nPeaks = mPeakOffsetsHost.empty() ? 0 : mPeakOffsetsHost.back();
+  if (nPeaks < 0 || nPeaks > mNLinesCapacity) {
+    LOGP(fatal, "ITS GPU vertexer produced {} peaks for a capacity of {}: bad peak compaction total.", nPeaks, mNLinesCapacity);
+  }
+
+  mVertexCandsHost.resize(nPeaks);
+  if (nPeaks) {
+    GPUChkErrS(cudaMemcpyAsync(mVertexCandsHost.data(), mVertexCandsDevice, nPeaks * sizeof(VertexCand), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+    GPUChkErrS(cudaStreamSynchronize(mGpuStreams[0].get()));
+  }
+  return nPeaks;
+}
+
+// MC only
+template <int NLayers>
+void TimeFrameGPU<NLayers>::downloadPeakMembershipInputs()
+{
+  GPUTimer timer("downloading peak membership inputs");
+  const int nPeaks = mPeakOffsetsHost.empty() ? 0 : mPeakOffsetsHost.back();
+  const int nLines = mNLinesCapacity;
+  auto& mc = mPeakMembershipHost;
+  mc.peakLineIdx.resize(nPeaks);
+  mc.win.resize(nLines);
+  mc.times.resize(nLines);
+  mc.sortedToLine.resize(nLines);
+  if (nPeaks) {
+    GPUChkErrS(cudaMemcpyAsync(mc.peakLineIdx.data(), mPeakLineIdxDevice, nPeaks * sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+  }
+  if (nLines) {
+    GPUChkErrS(cudaMemcpyAsync(mc.win.data(), mLineWinDevice, nLines * sizeof(gpu::LineWindow), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+    GPUChkErrS(cudaMemcpyAsync(mc.times.data(), mLineTimesSortedDevice, nLines * sizeof(o2::its::TimeEstBC), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+    GPUChkErrS(cudaMemcpyAsync(mc.sortedToLine.data(), mLinesSortedIdx, nLines * sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+  }
+  GPUChkErrS(cudaStreamSynchronize(mGpuStreams[0].get()));
+}
+
+template <int NLayers>
+unsigned int TimeFrameGPU<NLayers>::downloadLinesDevice()
+{
+  GPUTimer timer("downloading lines");
+  int nLinesSigned{0};
+  GPUChkErrS(cudaMemcpyAsync(&nLinesSigned, mLineSlotsDevice + mNLinesCapacity, sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+  GPUChkErrS(cudaStreamSynchronize(mGpuStreams[0].get())); // need the count before sizing the staging buffers
+  if (nLinesSigned < 0 || nLinesSigned > mNLinesCapacity) {
+    LOGP(fatal, "ITS GPU linearizer produced {} lines for a capacity of {}: bad compaction scan total.", nLinesSigned, mNLinesCapacity);
+  }
+  const unsigned int nLines = static_cast<unsigned int>(nLinesSigned);
+  GPULog("gpu-transfer: downloading {} lines, for {:.2f} MB.", nLines, nLines * (sizeof(o2::its::Line) + sizeof(int)) / constants::MB);
+  mLinesHost.resize(nLines);
+  mLineRofHost.resize(nLines);
+  mLineClustersHost.resize(3 * nLines);
+  if (nLines) {
+    GPUChkErrS(cudaMemcpyAsync(mLinesHost.data(), mLinesDevice, nLines * sizeof(o2::its::Line), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+    GPUChkErrS(cudaMemcpyAsync(mLineRofHost.data(), mLineRofDevice, nLines * sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+    GPUChkErrS(cudaMemcpyAsync(mLineClustersHost.data(), mLineClustersDevice, 3 * nLines * sizeof(int), cudaMemcpyDeviceToHost, mGpuStreams[0].get()));
+    GPUChkErrS(cudaStreamSynchronize(mGpuStreams[0].get()));
+  }
+  return nLines;
 }
 
 template <int NLayers>
@@ -555,7 +779,7 @@ constexpr auto makeIterTags(std::index_sequence<I...>)
 {
   return std::array<uint64_t, sizeof...(I)>{makeIterTag<I>()...};
 }
-constexpr auto kIterTags = makeIterTags(std::make_index_sequence<constants::MaxIter>{});
+constexpr auto kIterTags = makeIterTags(std::make_index_sequence<constants::MaxIter + constants::MaxSeedingPasses>{});
 } // namespace detail
 
 template <int NLayers>

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cxx
@@ -12,14 +12,21 @@
 
 #include <unistd.h>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <numeric>
+#include <vector>
+
 #include "ITStrackingGPU/TrackerTraitsGPU.h"
 #include "ITStrackingGPU/TrackingKernels.h"
 #include "ITStrackingGPU/LaunchGeometry.h"
+#include "ITSMFTTracking/MathUtils.h"
 #include "ITStracking/Configuration.h"
 
 namespace o2::its
 {
-
 using o2::itsmft::tracking::runOnSlab;
 using o2::itsmft::tracking::SlabSite;
 
@@ -35,10 +42,11 @@ void TrackerTraitsGPU<NLayers>::initialiseTimeFrame(const int iteration)
   if (this->mTrkParams[iteration].PassFlags[IterationStep::FirstPass]) {
     // on default stream
     mTimeFrameGPU->loadVertices();
-    // TODO these tables can be put in persistent memory
-    mTimeFrameGPU->loadROFOverlapTable(); // this can be put in constant memory actually
+    if (this->mTrkParams[iteration].PassFlags[IterationStep::LoadPersistentTables]) {
+      mTimeFrameGPU->loadROFOverlapTable(); // this can be put in constant memory actually
+      mTimeFrameGPU->loadTrackingTopologies();
+    }
     mTimeFrameGPU->loadROFVertexLookupTable();
-    mTimeFrameGPU->loadTrackingTopologies();
     // once the tables are in persistent memory just re-upload the vertex one
     // mTimeFrameGPU->uploadROFVertexLookupTable();
     mTimeFrameGPU->loadIndexTableUtils();
@@ -50,10 +58,13 @@ void TrackerTraitsGPU<NLayers>::initialiseTimeFrame(const int iteration)
     mTimeFrameGPU->createTrackingFrameInfoDeviceArray();
     mTimeFrameGPU->createROFrameClustersDeviceArray();
     // device array
+    mTimeFrameGPU->createClusterRadiiDevice();
+    mTimeFrameGPU->uploadClusterRadii();
     mTimeFrameGPU->createTrackletsLUTDeviceArray();
     mTimeFrameGPU->createTrackletsBuffersArray();
     mTimeFrameGPU->createCellsBuffersArray();
     mTimeFrameGPU->createCellsLUTDeviceArray();
+    mTimeFrameGPU->createClusterOwnersDeviceArray();
   }
   if (this->mTrkParams[iteration].PassFlags[IterationStep::FirstPass] || this->mTrkParams[iteration].PassFlags[IterationStep::UseUPCMask]) {
     mTimeFrameGPU->loadROFCutMask(iteration);
@@ -76,9 +87,9 @@ void TrackerTraitsGPU<NLayers>::computeLayerTracklets(const int iteration, int i
   for (int iLayer{0}; iLayer < this->mTrkParams[iteration].NLayers; ++iLayer) {
     if (loadFirstPassData) {
       mTimeFrameGPU->createUsedClustersDevice(iLayer);
-      mTimeFrameGPU->loadClustersDevice(iLayer);
-      mTimeFrameGPU->loadClustersIndexTables(iLayer);
+      mTimeFrameGPU->loadUnsortedClustersDevice(iLayer);
       mTimeFrameGPU->loadROFrameClustersDevice(iLayer);
+      mTimeFrameGPU->sortClustersDevice(iLayer, this->mTrkParams[iteration]);
     }
     mTimeFrameGPU->recordEvent(iLayer);
   }
@@ -92,10 +103,26 @@ void TrackerTraitsGPU<NLayers>::computeLayerTracklets(const int iteration, int i
   mTimeFrameGPU->pushMemoryStack(iteration);
 
   const auto nClusters = mTimeFrameGPU->getClusterSizes();
+  const bool vtxMode = this->mTrkParams[iteration].PassFlags[IterationStep::SeedingVertexPass];
+  const bool useDiamond = this->mTrkParams[iteration].UseDiamond;
+  if (useDiamond) {
+    const Vertex diamondVert(this->mTrkParams[iteration].Diamond, this->mTrkParams[iteration].DiamondCov, 1, 1.f);
+    mTimeFrameGPU->createDiamondDevice(diamondVert);
+    mTimeFrameGPU->recordEvent(0);
+  }
+  const Vertex* deviceVertices = useDiamond ? mTimeFrameGPU->getDeviceDiamond() : mTimeFrameGPU->getDeviceVertices();
+  bounded_vector<float> vtxPhiCuts(vtxMode ? hostTopology.nLinks : 0,
+                                   this->mTrkParams[iteration].VtxPhiCut,
+                                   this->getMemoryPool().get());
+  auto& linkPhiCuts = vtxMode ? vtxPhiCuts : mTimeFrameGPU->getLinkPhiCuts();
+
   for (int linkId{0}; linkId < hostTopology.nLinks; ++linkId) {
     const auto link = hostTopology.getLink(linkId);
     mTimeFrameGPU->waitEvent(linkId, link.fromLayer);
     mTimeFrameGPU->waitEvent(linkId, link.toLayer);
+    if (useDiamond) {
+      mTimeFrameGPU->waitEvent(linkId, 0); // links not anchored on layer 0 must still wait for the diamond upload
+    }
     const auto key = CapacityEstimator::makeKey(SlabSite::Tracklets, iteration, iVertex + 1, linkId);
     const auto scale = static_cast<double>(nClusters[link.fromLayer]);
     runOnSlab(mTimeFrameGPU->getCapacityEstimator(), key, scale, [&](const int capacity) {
@@ -108,7 +135,8 @@ void TrackerTraitsGPU<NLayers>::computeLayerTracklets(const int iteration, int i
                                                                      mTimeFrameGPU->getDeviceROFOverlapTableView(),
                                                                      mTimeFrameGPU->getDeviceROFVertexLookupTableView(),
                                                                      iVertex,
-                                                                     mTimeFrameGPU->getDeviceVertices(),
+                                                                     deviceVertices,
+                                                                     vtxMode,
                                                                      mTimeFrameGPU->getDeviceArrayClusters(),
                                                                      nClusters,
                                                                      mTimeFrameGPU->getDeviceROFrameClusters(),
@@ -122,10 +150,10 @@ void TrackerTraitsGPU<NLayers>::computeLayerTracklets(const int iteration, int i
                                                                      this->mTrkParams[iteration].PassFlags[IterationStep::SelectUPCVertices],
                                                                      this->mTrkParams[iteration].NSigmaCut,
                                                                      topology,
-                                                                     mTimeFrameGPU->getLinkPhiCuts(),
+                                                                     linkPhiCuts,
                                                                      this->mTrkParams[iteration].PVres,
-                                                                     mTimeFrameGPU->getMinRs(),
-                                                                     mTimeFrameGPU->getMaxRs(),
+                                                                     mTimeFrameGPU->getDeviceMinRs(),
+                                                                     mTimeFrameGPU->getDeviceMaxRs(),
                                                                      mTimeFrameGPU->getPositionResolutions(),
                                                                      this->mTrkParams[iteration].LayerRadii,
                                                                      mTimeFrameGPU->getLinkMSAngles(),
@@ -143,7 +171,7 @@ void TrackerTraitsGPU<NLayers>::computeLayerCells(const int iteration)
   const auto hostTopology = mTimeFrameGPU->getTrackingTopologyView();
   for (int iLayer{0}; iLayer < this->mTrkParams[iteration].NLayers; ++iLayer) {
     if (this->mTrkParams[iteration].PassFlags[IterationStep::FirstPass]) {
-      mTimeFrameGPU->loadUnsortedClustersDevice(iLayer);
+      mTimeFrameGPU->loadUnsortedClustersDevice(iLayer); // latched: a no-op if trackleting already did it
       mTimeFrameGPU->loadTrackingFrameInfoDevice(iLayer);
     }
     mTimeFrameGPU->recordEvent(iLayer);
@@ -153,6 +181,15 @@ void TrackerTraitsGPU<NLayers>::computeLayerCells(const int iteration)
     const auto cellTopology = hostTopology.getCell(cellTopologyId);
     const auto first = hostTopology.getLink(cellTopology.firstLink);
     const auto second = hostTopology.getLink(cellTopology.secondLink);
+    const float cellDeltaPhiCut = this->mTrkParams[iteration].PassFlags[IterationStep::SeedingVertexPass] ? math_utils::cellDeltaPhiBound(this->mBz, this->mTrkParams[iteration].CellDeltaPhiMinPt,
+                                                                                                                                          this->mTrkParams[iteration].LayerRadii[first.fromLayer],
+                                                                                                                                          this->mTrkParams[iteration].LayerRadii[first.toLayer],
+                                                                                                                                          this->mTrkParams[iteration].LayerRadii[second.toLayer],
+                                                                                                                                          mTimeFrameGPU->getLinkMSAngle(cellTopology.firstLink))
+                                                                                                          : -1.f;
+    const float cellTanLNSigma = this->mTrkParams[iteration].CellDeltaTanLambdaNSigma > 0.f
+                                   ? this->mTrkParams[iteration].CellDeltaTanLambdaNSigma
+                                   : this->mTrkParams[iteration].NSigmaCut;
     const int currentLayerTrackletsNum{static_cast<int>(mTimeFrameGPU->getNTracklets()[cellTopology.firstLink])};
     if (!currentLayerTrackletsNum || !mTimeFrameGPU->getNTracklets()[cellTopology.secondLink]) {
       mTimeFrameGPU->getNCells()[cellTopologyId] = 0;
@@ -183,7 +220,8 @@ void TrackerTraitsGPU<NLayers>::computeLayerCells(const int iteration)
                                                            this->mBz,
                                                            this->mTrkParams[iteration].MaxChi2ClusterAttachment,
                                                            this->mTrkParams[iteration].CellDeltaTanLambdaSigma,
-                                                           this->mTrkParams[iteration].NSigmaCut,
+                                                           cellDeltaPhiCut,
+                                                           cellTanLNSigma,
                                                            mTimeFrameGPU->getDeviceLayerxX0(),
                                                            mTimeFrameGPU->getFrameworkAllocator(),
                                                            mTimeFrameGPU->getStreams());
@@ -192,6 +230,316 @@ void TrackerTraitsGPU<NLayers>::computeLayerCells(const int iteration)
     mTimeFrameGPU->recordEvent(cellTopologyId);
   }
   mTimeFrameGPU->syncStreams(false);
+}
+
+template <int NLayers>
+void TrackerTraitsGPU<NLayers>::computeVertexCandidates(const int iteration)
+{
+  const int nCells = mTimeFrameGPU->getNCells()[0];
+  if (!nCells) {
+    mTimeFrameGPU->setNLinesTotal(0);
+    return;
+  }
+  mTimeFrameGPU->createClusterOwnersDevice();
+  mTimeFrameGPU->createLinesDevice(nCells);
+  mTimeFrameGPU->resetClusterOwnersDevice();
+  mTimeFrameGPU->syncStreams(false);
+
+  TrackingKernels<NLayers>::registerClusterOwnershipHandler(mTimeFrameGPU->getDeviceCells()[0],
+                                                            nCells,
+                                                            mTimeFrameGPU->getDeviceArrayClusterOwners(),
+                                                            mTimeFrameGPU->getStream(0));
+
+  TrackingKernels<NLayers>::linearizeCellsToLinesHandler(nCells,
+                                                         mTimeFrameGPU->getDeviceCells()[0],
+                                                         mTimeFrameGPU->getDeviceArrayClusterOwners(),
+                                                         mTimeFrameGPU->getDeviceROFramesClusters(1),
+                                                         mTimeFrameGPU->getNrof(1),
+                                                         this->mTrkParams[iteration].CellLineSharedClusterCut,
+                                                         mTimeFrameGPU->getDeviceLines(),
+                                                         mTimeFrameGPU->getDeviceLineRof(),
+                                                         mTimeFrameGPU->getDeviceLineClusters(),
+                                                         mTimeFrameGPU->getDeviceLineSlots(),
+                                                         mTimeFrameGPU->getBeamX(),
+                                                         mTimeFrameGPU->getBeamY(),
+                                                         this->mTrkParams[iteration].VtxMaxZPositionAllowed,
+                                                         this->mTrkParams[iteration].VtxLineMinPt,
+                                                         mTimeFrameGPU->getDeviceLineZs(),
+                                                         mTimeFrameGPU->getDeviceLineTimes(),
+                                                         mTimeFrameGPU->getDeviceLineChi2(),
+                                                         mTimeFrameGPU->getDeviceLinePt(),
+                                                         mTimeFrameGPU->getFrameworkAllocator(),
+                                                         mTimeFrameGPU->getStream(0));
+  const unsigned int nLines = mTimeFrameGPU->downloadLinesDevice();
+
+  TrackingKernels<NLayers>::sortLinesHandler(nLines,
+                                             mTimeFrameGPU->getNrof(1),
+                                             mTimeFrameGPU->getLineProjSoA(),
+                                             mTimeFrameGPU->getLineProjSortedSoA(),
+                                             mTimeFrameGPU->getDeviceLineRof(),
+                                             mTimeFrameGPU->getDeviceRofLineOffsets(),
+                                             mTimeFrameGPU->getFrameworkAllocator(),
+                                             mTimeFrameGPU->getStream(0));
+
+  const auto& tp = this->mTrkParams[iteration];
+  const float zWindow = 0.5f * tp.VtxClusterCut;
+  TrackingKernels<NLayers>::scanDensityHandler(static_cast<int>(nLines),
+                                               mTimeFrameGPU->getLineProjSortedSoA(),
+                                               mTimeFrameGPU->getDeviceRofLineOffsets(),
+                                               mTimeFrameGPU->getDeviceLineDensity(),
+                                               mTimeFrameGPU->getDeviceLineWin(),
+                                               zWindow,
+                                               mTimeFrameGPU->getStream(0));
+
+  const float fineZWindow = tp.VtxFineZWindow;
+  const bool doFine = fineZWindow > 0.f && fineZWindow < zWindow;
+  if (doFine) {
+    TrackingKernels<NLayers>::scanDensityHandler(static_cast<int>(nLines),
+                                                 mTimeFrameGPU->getLineProjSortedSoA(),
+                                                 mTimeFrameGPU->getDeviceRofLineOffsets(),
+                                                 mTimeFrameGPU->getDeviceLineDensityFine(),
+                                                 mTimeFrameGPU->getDeviceLineWinFine(),
+                                                 fineZWindow,
+                                                 mTimeFrameGPU->getStream(0));
+  }
+
+  TrackingKernels<NLayers>::findPeaksHandler(nLines,
+                                             mTimeFrameGPU->getNrof(1),
+                                             mTimeFrameGPU->getLineProjSortedSoA(),
+                                             mTimeFrameGPU->getDeviceRofLineOffsets(),
+                                             mTimeFrameGPU->getDeviceLineDensity(),
+                                             mTimeFrameGPU->getDeviceLineWin(),
+                                             mTimeFrameGPU->getDeviceLineIsPeak(),
+                                             doFine ? mTimeFrameGPU->getDeviceLineDensityFine() : nullptr,
+                                             doFine ? mTimeFrameGPU->getDeviceLineWinFine() : nullptr,
+                                             tp.VtxFineMinDensity,
+                                             doFine ? mTimeFrameGPU->getDeviceLineIsPeakFine() : nullptr,
+                                             mTimeFrameGPU->getDevicePeakScan(),
+                                             mTimeFrameGPU->getDevicePeakLineIdx(),
+                                             mTimeFrameGPU->getDevicePeakOffsets(),
+                                             mTimeFrameGPU->getFrameworkAllocator(),
+                                             mTimeFrameGPU->getStream(0));
+
+  const float goodLinePtCut = std::abs(mTimeFrameGPU->getBz()) > 0.01f ? tp.VtxGoodLinePtCut : -1.f;
+  TrackingKernels<NLayers>::fitPeaksHandler(mTimeFrameGPU->getDeviceNPeaks(),
+                                            mTimeFrameGPU->getDevicePeakLineIdx(),
+                                            mTimeFrameGPU->getDeviceLineWin(),
+                                            mTimeFrameGPU->getLineProjSortedSoA(),
+                                            mTimeFrameGPU->getDeviceLines(),
+                                            mTimeFrameGPU->getDeviceLineChi2(),
+                                            mTimeFrameGPU->getDeviceLinePt(),
+                                            tp.VtxGoodLineChi2Cut,
+                                            goodLinePtCut,
+                                            tp.VtxPairCut * tp.VtxPairCut,
+                                            tp.VtxNSigmaCut,
+                                            tp.VtxClusterContributorsCut,
+                                            mTimeFrameGPU->getBeamX(),
+                                            mTimeFrameGPU->getBeamY(),
+                                            doFine ? mTimeFrameGPU->getDeviceLineIsPeakFine() : nullptr,
+                                            tp.VtxFineMaxDrift,
+                                            mTimeFrameGPU->getDeviceVertexCands(),
+                                            mTimeFrameGPU->getStream(0));
+
+  const float duplicateZCut = tp.VtxDuplicateZCut > 0.f
+                                ? tp.VtxDuplicateZCut
+                                : std::max(4.f * tp.VtxPairCut, 0.5f * tp.VtxClusterCut);
+  TrackingKernels<NLayers>::dedupVertexCandidatesHandler(mTimeFrameGPU->getDeviceNPeaks(),
+                                                         mTimeFrameGPU->getDevicePeakLineIdx(),
+                                                         mTimeFrameGPU->getDevicePeakOffsets(),
+                                                         mTimeFrameGPU->getLineProjSortedSoA(),
+                                                         duplicateZCut,
+                                                         tp.VtxDuplicateZScale,
+                                                         mTimeFrameGPU->getDeviceVertexCands(),
+                                                         mTimeFrameGPU->getStream(0));
+
+  const bool withMC = mTimeFrameGPU->hasMCinformation() && this->mTrkParams[iteration].CreateArtefactLabels;
+  mTimeFrameGPU->downloadVertexCandsDevice(); // sets nPeaks + host candidate/peak-offset mirrors
+  if (withMC) {
+    // pull back the peak windows and re-run the membership test here
+    mTimeFrameGPU->downloadPeakMembershipInputs();
+  }
+  const auto& lines = mTimeFrameGPU->getHostLines();
+  const auto& lineRof = mTimeFrameGPU->getHostLineRof();
+  const auto& lineClusters = mTimeFrameGPU->getHostLineClusters();
+  const int nRofs = mTimeFrameGPU->getNrof(1);
+  if (withMC) {
+    mTimeFrameGPU->getLineLabelFlat().assign(nLines, o2::MCCompLabel()); // global-indexed, for the vertex-label vote
+  }
+  auto lineLabel = [&](const int* cl) -> o2::MCCompLabel {
+    const auto l0 = mTimeFrameGPU->getClusterLabels(0, cl[0]);
+    const auto l1 = mTimeFrameGPU->getClusterLabels(1, cl[1]);
+    const auto l2 = mTimeFrameGPU->getClusterLabels(2, cl[2]);
+    for (const auto& a : l0) {
+      if (!a.isValid()) {
+        continue;
+      }
+      bool in1{false}, in2{false};
+      for (const auto& b : l1) {
+        if (b == a) {
+          in1 = true;
+          break;
+        }
+      }
+      for (const auto& c : l2) {
+        if (c == a) {
+          in2 = true;
+          break;
+        }
+      }
+      if (in1 && in2) {
+        return a;
+      }
+    }
+    return o2::MCCompLabel();
+  };
+  for (unsigned int i{0}; i < nLines; ++i) {
+    const int rof = lineRof[i];
+    if (rof < 0 || rof >= nRofs) {
+      LOGP(fatal, "ITS GPU linearizer: line {} carries out-of-range ROF {} (nRofs={}).", i, rof, nRofs);
+    }
+    const auto& l = lines[i];
+    mTimeFrameGPU->getLines(rof).emplace_back(std::array<float, 3>{l.originPoint[0], l.originPoint[1], l.originPoint[2]},
+                                              std::array<float, 3>{l.cosinesDirector[0], l.cosinesDirector[1], l.cosinesDirector[2]},
+                                              l.mTime);
+    if (withMC) {
+      const auto lbl = lineLabel(&lineClusters[3 * i]);
+      mTimeFrameGPU->getLinesLabel(rof).emplace_back(lbl);
+      mTimeFrameGPU->getLineLabelFlat()[i] = lbl; // same label, global-indexed for the vote
+    }
+  }
+  mTimeFrameGPU->setNLinesTotal(nLines);
+}
+
+template <int NLayers>
+void TrackerTraitsGPU<NLayers>::computeVertices(const int iteration)
+{
+  const int nRofs = mTimeFrameGPU->getNrof(1);
+  const bool withMC = mTimeFrameGPU->hasMCinformation() && this->mTrkParams[iteration].CreateArtefactLabels;
+  const int suppressLowMultDebris = this->mTrkParams[iteration].VtxSuppressLowMultDebris;
+  const bool skipHighMultRofs = this->mTrkParams[iteration].PassFlags[IterationStep::SkipROFsAboveThreshold];
+
+  const auto& cands = mTimeFrameGPU->getHostVertexCands();       // per compacted peak slot [0, nPeaks)
+  const auto& peakOffsets = mTimeFrameGPU->getHostPeakOffsets(); // nRofs+1; per-ROF peak slices
+
+  std::vector<std::vector<Vertex>> rofVertices(nRofs);
+  std::vector<std::vector<VertexLabel>> rofLabels(nRofs);
+  const float goodSig = this->mTrkParams[iteration].VtxGoodContributorsSignificance;
+
+  for (int rofId = 0; rofId < nRofs; ++rofId) {
+    if (skipHighMultRofs &&
+        static_cast<int>(mTimeFrameGPU->getROFVertexLookupTableView().getVertices(1, rofId).getEntries()) > this->mTrkParams[iteration].VertPerRofThreshold) {
+      continue;
+    }
+    // Survivors of this ROF, sorted by contributor count desc
+    std::vector<int> accepted;
+    for (int p = peakOffsets[rofId]; p < peakOffsets[rofId + 1]; ++p) {
+      if (cands[p].keep) {
+        accepted.push_back(p);
+      }
+    }
+    std::sort(accepted.begin(), accepted.end(), [&](const int a, const int b) { return cands[a].size > cands[b].size; });
+
+    double rofLoad = 0.;
+    if (goodSig > 0.f) { // compute the number of contributors in this ROF
+      for (int p = peakOffsets[rofId]; p < peakOffsets[rofId + 1]; ++p) {
+        if (cands[p].ok && !cands[p].fine) {
+          rofLoad += cands[p].size;
+        }
+      }
+    }
+    const float sigThreshold = goodSig > 0.f ? goodSig * std::sqrt(static_cast<float>(std::max(rofLoad, 1.))) : 0.f;
+
+    for (const int p : accepted) {
+      const auto& c = cands[p];
+      if (!rofVertices[rofId].empty()) {
+        if (goodSig > 0.f) {
+          if (c.nGood <= sigThreshold) {
+            continue;
+          }
+        } else if (c.size < suppressLowMultDebris) {
+          continue;
+        }
+      }
+      const float pos[3] = {c.x, c.y, c.z};
+      Vertex vertex(pos, c.rms2, static_cast<ushort>(c.size), c.avgDist2);
+      vertex.setTimeStamp(c.time);
+      if (this->mTrkParams[iteration].PassFlags[IterationStep::MarkVerticesAsUPC]) {
+        vertex.setFlags(Vertex::UPCMode);
+      }
+      rofVertices[rofId].push_back(vertex);
+      if (withMC) {
+        // Re-apply here the rule the fit used: a line contributes when it is
+        // time-compatible with the peak line and within pairCut of the candidate's seed
+        const auto& memb = mTimeFrameGPU->getHostPeakMembership();
+        const auto& lines = mTimeFrameGPU->getHostLines();
+        const auto& lineLabelFlat = mTimeFrameGPU->getLineLabelFlat(); // nLines, global-indexed
+        const int nLab = static_cast<int>(lineLabelFlat.size());
+        const float pairCut2 = this->mTrkParams[iteration].VtxPairCut * this->mTrkParams[iteration].VtxPairCut;
+        const int k = memb.peakLineIdx[p];
+        const auto tk = memb.times[k];
+        const auto wk = memb.win[k];
+        std::vector<o2::MCCompLabel> labels;
+        labels.reserve(wk.hi - wk.lo);
+        for (int j = wk.lo; j < wk.hi; ++j) {
+          const auto tj = memb.times[j];
+          if (!tk.isCompatible(tj)) {
+            continue;
+          }
+          const int gi = memb.sortedToLine[j];
+          if (gi < 0 || gi >= nLab) {
+            LOGP(error, "Seeding vertexer: member line {} out of range (nLines={}), skipping label", gi, nLab);
+            continue;
+          }
+          if (o2::its::Line::getDistance2FromPoint(lines[gi], c.seed) >= pairCut2) {
+            continue;
+          }
+          labels.push_back(lineLabelFlat[gi]);
+        }
+        rofLabels[rofId].push_back(computeMainVertexLabel(labels));
+      }
+    }
+  }
+
+  for (int rofId = 0; rofId < nRofs; ++rofId) {
+    for (auto& vertex : rofVertices[rofId]) {
+      mTimeFrameGPU->addPrimaryVertex(vertex);
+    }
+    if (withMC) {
+      for (auto& label : rofLabels[rofId]) {
+        mTimeFrameGPU->addPrimaryVertexLabel(label);
+      }
+    }
+  }
+
+  auto& pvs = mTimeFrameGPU->getPrimaryVertices();
+  std::vector<size_t> indices(pvs.size());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::sort(indices.begin(), indices.end(), [&pvs](const size_t i, const size_t j) {
+    const auto aLower = pvs[i].getTimeStamp().lower();
+    const auto bLower = pvs[j].getTimeStamp().lower();
+    if (aLower != bLower) {
+      return aLower < bLower;
+    }
+    return pvs[i].getNContributors() > pvs[j].getNContributors();
+  });
+  std::decay_t<decltype(pvs)> sortedVtx(pvs.get_allocator());
+  sortedVtx.reserve(pvs.size());
+  for (const size_t idx : indices) {
+    sortedVtx.push_back(pvs[idx]);
+  }
+  pvs.swap(sortedVtx);
+  if (withMC) {
+    auto& mc = mTimeFrameGPU->getPrimaryVerticesLabels();
+    std::decay_t<decltype(mc)> sortedMC(mc.get_allocator());
+    sortedMC.reserve(mc.size());
+    for (const size_t idx : indices) {
+      sortedMC.push_back(mc[idx]);
+    }
+    mc.swap(sortedMC);
+  }
+  mTimeFrameGPU->updateROFVertexLookupTable();
+
+  mTimeFrameGPU->popMemoryStack(iteration); // frees the whole seeding-pass stack frame
 }
 
 template <int NLayers>

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackingKernels.cu
@@ -14,6 +14,7 @@
 #include <array>
 #include <type_traits>
 #include <cmath>
+#include <limits>
 #include <unistd.h>
 
 #include <thrust/execution_policy.h>
@@ -22,11 +23,19 @@
 #include <thrust/gather.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/fill.h>
 #include <thrust/reduce.h>
 #include <thrust/functional.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 #include <thrust/unique.h>
+#include <thrust/remove.h>
+#include <thrust/binary_search.h>
+#include <thrust/scatter.h>
+#include <thrust/gather.h>
+#include <thrust/iterator/permutation_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 
 #include "DataFormatsITS/TrackITS.h"
 #include "ITSMFTTracking/Constants.h"
@@ -43,6 +52,8 @@
 #include "ITStrackingGPU/TrackingKernels.h"
 #include "ITStrackingGPU/Utils.h"
 #include "MathUtils/Utils.h"
+#include "ITStracking/ClusterLines.h"
+#include "ITStracking/LineProjection.h"
 #include "utils/strtag.h"
 
 // O2 track model
@@ -275,6 +286,7 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerCells) computeLa
   int* outputCounter,
   const int outputCapacity,
   const float cellDeltaTanLambdaSigma,
+  const float cellDeltaPhiCut,
   const float nSigmaCut)
 {
   const auto cellTopology = topology.getCell(cellTopologyId);
@@ -292,6 +304,10 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerCells) computeLa
       }
       const Tracklet& nextTracklet = tracklets[cellTopology.secondLink][iNextTrackletIndex];
       if (!currentTracklet.getTimeStamp().isCompatible(nextTracklet.getTimeStamp())) {
+        continue;
+      }
+      if (cellDeltaPhiCut > 0.f &&
+          !math_utils::isPhiDifferenceBelow(currentTracklet.phi, nextTracklet.phi, cellDeltaPhiCut)) {
         continue;
       }
       const float deltaTanLambda{o2::gpu::CAMath::Abs(currentTracklet.tanLambda - nextTracklet.tanLambda)};
@@ -400,6 +416,7 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerTracklets) compu
   const typename ROFOverlapTable<NLayers>::View rofOverlaps,
   const typename ROFVertexLookupTable<NLayers>::View vertexLUT,
   const Vertex* vertices,
+  const bool vtxMode,
   const int vertexId,
   const Cluster** clusters,
   const int** ROFClusters,
@@ -412,8 +429,8 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerTracklets) compu
   const float NSigmaCut,
   const float phiCut,
   const float resolutionPV,
-  const float minR,
-  const float maxR,
+  const float* minRs,
+  const float* maxRs,
   const float positionResolution,
   const float meanDeltaR,
   const float MSAngle)
@@ -421,6 +438,8 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerTracklets) compu
   const auto link = topology.getLink(linkId);
   const int fromLayer = link.fromLayer;
   const int toLayer = link.toLayer;
+  const float minR = minRs[toLayer];
+  const float maxR = maxRs[toLayer];
   const int phiBins{utils->getNphiBins()};
   const int zBins{utils->getNzBins()};
   const int tableSize{phiBins * zBins + 1};
@@ -450,8 +469,14 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerTracklets) compu
       continue;
     }
 
-    const auto& pvs = vertexLUT.getVertices(fromLayer, pivotROF);
-    auto primaryVertices = gpuSpan<const Vertex>(&vertices[pvs.getFirstEntry()], pvs.getEntries());
+    // The diamond is a single PV-independent vertex: the lookup table is not consulted at all, since during the seeding-vertex pass it holds no vertices yet
+    gpuSpan<const Vertex> primaryVertices;
+    if (vtxMode) {
+      primaryVertices = gpuSpan<const Vertex>(vertices, 1);
+    } else {
+      const auto& pvs = vertexLUT.getVertices(fromLayer, pivotROF);
+      primaryVertices = gpuSpan<const Vertex>(&vertices[pvs.getFirstEntry()], pvs.getEntries());
+    }
     if (primaryVertices.empty()) {
       continue;
     }
@@ -475,7 +500,7 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerTracklets) compu
       const float inverseR0{1.f / currentCluster.radius};
       for (int iV{startVtx}; iV < endVtx; ++iV) {
         auto& primaryVertex{primaryVertices[iV]};
-        if (!vertexLUT.isVertexCompatible(fromLayer, pivotROF, primaryVertex)) {
+        if (!vtxMode && !vertexLUT.isVertexCompatible(fromLayer, pivotROF, primaryVertex)) {
           continue;
         }
         if (primaryVertex.isFlagSet(Vertex::Flags::UPCMode) != selectUPCVertices) {
@@ -507,7 +532,7 @@ GPUg() void __launch_bounds__(GPUThreads, MinBlocks.computeLayerTracklets) compu
             continue;
           }
           const auto ts = rofOverlaps.getTimeStamp(fromLayer, pivotROF, toLayer, targetROF);
-          if (!ts.isCompatible(primaryVertex.getTimeStamp())) {
+          if (!vtxMode && !ts.isCompatible(primaryVertex.getTimeStamp())) {
             continue;
           }
           for (int iPhiCount{0}; iPhiCount < phiBinsNum; iPhiCount++) {
@@ -820,6 +845,405 @@ void sortNeighbourCandidates(const int defaultCellTopologyId,
   thrust::stable_sort_by_key(policy, keys, keys + nCandidates, thrust::device_ptr<NeighbourCandidate>(candidates));
 }
 
+GPUg() void vertexingRegisterCellClustersOwnership(
+  const CellSeed* cells,
+  const int nCells,
+  unsigned long long** clusterOwners)
+{
+  for (int k = blockIdx.x * blockDim.x + threadIdx.x; k < nCells; k += blockDim.x * gridDim.x) {
+    const CellSeed& cell = cells[k];
+    if (o2::gpu::CAMath::Abs(cell.getQ2Pt()) < o2::constants::math::Almost0 ||
+        o2::gpu::CAMath::Abs(cell.getSnp()) > o2::constants::math::Almost1) {
+      continue;
+    }
+    const float pt = cell.getPt();
+    const float rank = pt > 1.e-6f ? 1.f / pt : 1.e9f;
+    const unsigned long long key = (static_cast<unsigned long long>(__float_as_uint(rank)) << 32) | static_cast<unsigned long long>(k);
+    o2::gpu::GPUCommonMath::AtomicMin(&clusterOwners[0][cell.getFirstClusterIndex()], key);
+    o2::gpu::GPUCommonMath::AtomicMin(&clusterOwners[1][cell.getSecondClusterIndex()], key);
+    o2::gpu::GPUCommonMath::AtomicMin(&clusterOwners[2][cell.getThirdClusterIndex()], key);
+  }
+}
+
+GPUdi() int clusterROF(const int* rofArr, const int nRofs, const int clusterIdx)
+{
+  const int key = clusterIdx + 1;
+  int lo = 0, hi = nRofs + 1;
+  while (lo < hi) {
+    const int mid = (lo + hi) >> 1;
+    if (rofArr[mid] < key) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo - 1;
+}
+
+template <int NLayers>
+GPUg() void dedupCellsKernel(
+  const int nCells,
+  const CellSeed* cells,
+  const unsigned long long* const* clusterOwners,
+  const int ownedClustersCut,
+  const float beamX,
+  const float beamY,
+  const float maxZ,
+  const float minPt,
+  int* cellAccepted)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < nCells; i += blockDim.x * gridDim.x) {
+    const CellSeed& cell = cells[i];
+    std::array<float, 3> origin, direction;
+    if (!cell.getPxPyPzGlo(direction)) {
+      cellAccepted[i] = 0;
+      continue;
+    }
+    const bool owned0 = static_cast<uint32_t>(clusterOwners[0][cell.getFirstClusterIndex()]) == static_cast<uint32_t>(i);
+    const bool owned1 = static_cast<uint32_t>(clusterOwners[1][cell.getSecondClusterIndex()]) == static_cast<uint32_t>(i);
+    const bool owned2 = static_cast<uint32_t>(clusterOwners[2][cell.getThirdClusterIndex()]) == static_cast<uint32_t>(i);
+    const bool keepCell = (static_cast<int>(owned0) + static_cast<int>(owned1) + static_cast<int>(owned2)) >= 3 - ownedClustersCut;
+    cell.getXYZGlo(origin);
+    const float dx = origin[0] - beamX;
+    const float dy = origin[1] - beamY;
+    const float den = direction[0] * direction[0] + direction[1] * direction[1];
+    const bool projOk = den >= constants::Tolerance && o2::gpu::CAMath::Abs(origin[2] - (dx * direction[0] + dy * direction[1]) / den * direction[2]) < maxZ;
+    const bool ptOk = minPt <= 0.f || cell.getPt() >= minPt;
+    cellAccepted[i] = keepCell && projOk && ptOk ? 1 : 0;
+  }
+}
+
+template <int NLayers>
+GPUg() void linearizeCellsKernel(
+  const int nCells,
+  const CellSeed* cells,
+  const int* rofFramesClustersL1, // layer-1 ROF boundaries, size nRofsL1 + 1
+  const int nRofsL1,
+  const int* lineSlots, // exclusive-scanned accept flags, size nCells + 1
+  o2::its::Line* lines,
+  int* lineRof,
+  const float beamX,
+  const float beamY,
+  float* lineZs,
+  o2::its::TimeEstBC* lineTimes,
+  int* lineClusters, // 3 per line (L0,L1,L2 cluster ids), for the host-side MC label derivation
+  float* lineChi2,
+  float* linePt)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < nCells; i += blockDim.x * gridDim.x) {
+    const int slot = lineSlots[i];
+    if (slot == lineSlots[i + 1]) {
+      continue;
+    }
+    const CellSeed& cell = cells[i];
+    std::array<float, 3> origin, direction;
+    cell.getXYZGlo(origin);
+    cell.getPxPyPzGlo(direction);
+    lines[slot] = o2::its::Line{origin.data(), direction.data(), cell.getTimeStamp()};
+    lineRof[slot] = clusterROF(rofFramesClustersL1, nRofsL1, cell.getSecondClusterIndex());
+    const float dx = origin[0] - beamX;
+    const float dy = origin[1] - beamY;
+    const float den = direction[0] * direction[0] + direction[1] * direction[1];
+    const float s0 = -(dx * direction[0] + dy * direction[1]) / den;
+    lineZs[slot] = origin[2] + s0 * direction[2];
+    lineTimes[slot] = cell.getTimeStamp();
+    lineClusters[3 * slot + 0] = cell.getFirstClusterIndex();
+    lineClusters[3 * slot + 1] = cell.getSecondClusterIndex();
+    lineClusters[3 * slot + 2] = cell.getThirdClusterIndex();
+    lineChi2[slot] = cell.getChi2();
+    linePt[slot] = cell.getPt();
+  }
+}
+
+template <int NLayers>
+GPUg() void gatherSortedLinesKernel(const int nLines, LineProjSoA lineProj, LineProjSoA lineProjSorted)
+{
+  const int* sortedIdx = lineProj.idx;
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < nLines; i += blockDim.x * gridDim.x) {
+    lineProjSorted.z[i] = lineProj.z[sortedIdx[i]];
+    lineProjSorted.t[i] = lineProj.t[sortedIdx[i]];
+    lineProjSorted.rof[i] = lineProj.rof[sortedIdx[i]];
+  }
+}
+
+template <int NLayers>
+GPUg() void scanDensityKernel(int* zDensity, LineWindow* win, const int nLines, const int* offsets, const LineProjSoA lineProjSorted, const float zWindow)
+{
+  const float* z = lineProjSorted.z;
+  const o2::its::TimeEstBC* t = lineProjSorted.t;
+  const int* rof = lineProjSorted.rof;
+  for (int iLine = blockIdx.x * blockDim.x + threadIdx.x; iLine < nLines; iLine += blockDim.x * gridDim.x) {
+    const int rofId = rof[iLine];
+    const int rofOffset = offsets[rofId];
+    const int nextRofOffset = offsets[rofId + 1];
+    const float zk = z[iLine];
+    const int lo = deviceLowerBound(z, rofOffset, nextRofOffset, zk - zWindow); // first line with z >= zk - zWindow
+    const int hi = deviceUpperBound(z, rofOffset, nextRofOffset, zk + zWindow); // first line with z  > zk + zWindow
+    win[iLine] = LineWindow{lo, hi};
+    const auto ti = t[iLine];
+    int count = 0;
+    for (int j = lo; j < hi; ++j) {
+      const auto tj = t[j];
+      if (ti.isCompatible(tj)) { // count only if time compatible (includes self)
+        ++count;
+      }
+    }
+    zDensity[iLine] = count;
+  }
+}
+
+template <int NLayers>
+GPUg() void fitPeaksKernel(const int* nPeaksDevice,
+                           const int* peakLineIdx,
+                           const gpu::LineWindow* win,
+                           const LineProjSoA lineProjSorted,
+                           const o2::its::Line* lines,
+                           const float* lineChi2,       // global-indexed, same indexing as lines[]
+                           const float* linePt,         // idem
+                           const float goodLineChi2Cut, // a contributor counts towards nGood only if its own
+                           const float goodLinePtCut,   // cell passes both; <= 0 disables that half
+                           const float pairCut2,
+                           const float nSigmaCut,
+                           const int minContributors,
+                           const float beamX,
+                           const float beamY,
+                           const uint8_t* isZPeakFine, // null when the fine pass is off
+                           const float fineMaxDrift,   // <= 0 disables; see VertexerParamConfig::fineMaxDrift
+                           VertexCand* cands)
+{
+  const int nPeaks = *nPeaksDevice;
+  const o2::its::TimeEstBC* t = lineProjSorted.t;
+  const int* idx = lineProjSorted.idx;
+  for (int p = blockIdx.x * blockDim.x + threadIdx.x; p < nPeaks; p += blockDim.x * gridDim.x) {
+    cands[p].ok = 0;
+    cands[p].nGood = 0;
+    const int k = peakLineIdx[p];
+    cands[p].fine = isZPeakFine != nullptr ? isZPeakFine[k] : 0;
+    const auto tk = t[k];
+    const LineWindow wk = win[k];
+
+    o2::its::ClusterLines seed;
+    int nMembers = 0;
+    for (int j = wk.lo; j < wk.hi; ++j) {
+      const auto tj = t[j];
+      if (tk.isCompatible(tj)) {
+        seed.add(lines[idx[j]]);
+        ++nMembers;
+      }
+    }
+    float seedVertex[3];
+    if (nMembers < 2 || !seed.solve(seedVertex)) {
+      continue;
+    }
+
+    o2::its::ClusterLines fit;
+    int nKept = 0;
+    int nGood = 0;
+    for (int j = wk.lo; j < wk.hi; ++j) {
+      const auto tj = t[j];
+      if (tk.isCompatible(tj)) {
+        const o2::its::Line& line = lines[idx[j]];
+        if (o2::its::Line::getDistance2FromPoint(line, seedVertex) < pairCut2) {
+          fit.add(line);
+          const float c = lineChi2[idx[j]];
+          const float pt = linePt[idx[j]];
+          const bool okChi2 = (goodLineChi2Cut <= 0.f || c <= goodLineChi2Cut);
+          const bool okPt = (goodLinePtCut <= 0.f || pt >= goodLinePtCut);
+          nGood += okChi2 && okPt;
+          ++nKept;
+        }
+      }
+    }
+    float vertex[3];
+    if (nKept < 2 || !fit.solve(vertex)) {
+      continue;
+    }
+    cands[p].seed[0] = seedVertex[0];
+    cands[p].seed[1] = seedVertex[1];
+    cands[p].seed[2] = seedVertex[2];
+    const float bd2 = (beamX - vertex[0]) * (beamX - vertex[0]) + (beamY - vertex[1]) * (beamY - vertex[1]);
+    if (nKept < minContributors || !(bd2 < nSigmaCut)) {
+      continue;
+    }
+    if (fineMaxDrift > 0.f && cands[p].fine &&
+        o2::gpu::GPUCommonMath::Abs(vertex[2] - seedVertex[2]) > fineMaxDrift) {
+      continue;
+    }
+
+    for (int j = wk.lo; j < wk.hi; ++j) {
+      const auto tj = t[j];
+      if (tk.isCompatible(tj)) {
+        const o2::its::Line& line = lines[idx[j]];
+        if (o2::its::Line::getDistance2FromPoint(line, seedVertex) < pairCut2) {
+          fit.addResidual(line, vertex);
+        }
+      }
+    }
+
+    cands[p].x = vertex[0];
+    cands[p].y = vertex[1];
+    cands[p].z = vertex[2];
+    for (int i = 0; i < 6; ++i) {
+      cands[p].rms2[i] = fit.getRMS2()[i];
+    }
+    cands[p].avgDist2 = fit.getAvgDistance2();
+    cands[p].nGood = nGood;
+    cands[p].time = fit.getTimeStamp();
+    cands[p].size = nKept;
+    cands[p].ok = 1;
+  }
+}
+
+// Strict local maximum of the density over a line's own z-window, ties broken by smaller z
+GPUdi() bool isDensityPeak(const int* density, const float* z, const LineWindow w, const int iLine)
+{
+  const int di = density[iLine];
+  const float zi = z[iLine];
+  for (int j = w.lo; j < w.hi; ++j) {
+    const int dj = density[j];
+    if (dj > di || (dj == di && z[j] < zi)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <int NLayers>
+GPUg() void findPeaksKernel(const int* zDensity, const LineWindow* win, const int nLines, const LineProjSoA lineProjSorted, uint8_t* isZPeak,
+                            const int* zDensityFine, const LineWindow* winFine,
+                            const int fineMinDensity, uint8_t* isZPeakFine)
+{
+  const float* z = lineProjSorted.z;
+  for (int iLine = blockIdx.x * blockDim.x + threadIdx.x; iLine < nLines; iLine += blockDim.x * gridDim.x) {
+    uint8_t peak = zDensity[iLine] >= 2 && isDensityPeak(zDensity, z, win[iLine], iLine);
+
+    // fine pass: if the coarse pass did not find a peak, check if the fine density is above threshold and is a peak
+    uint8_t fine = 0;
+    if (!peak && zDensityFine != nullptr) {
+      fine = zDensityFine[iLine] >= fineMinDensity && isDensityPeak(zDensityFine, z, winFine[iLine], iLine);
+      peak = fine;
+    }
+    isZPeak[iLine] = peak;
+    if (isZPeakFine != nullptr) {
+      isZPeakFine[iLine] = fine;
+    }
+  }
+}
+
+template <int NLayers>
+GPUg() void dedupVertexCandidatesKernel(const int* nPeaksDevice,
+                                        const int* peakLineIdx,
+                                        const int* peakOffsets,
+                                        const LineProjSoA lineProjSorted,
+                                        const float duplicateZCut,
+                                        const float duplicateZScale,
+                                        VertexCand* cands)
+{
+  const int nPeaks = *nPeaksDevice;
+  for (int p = blockIdx.x * blockDim.x + threadIdx.x; p < nPeaks; p += blockDim.x * gridDim.x) {
+    cands[p].keep = 0; // every visited slot must be written: this array is never memset
+    if (!cands[p].ok) {
+      continue;
+    }
+    const int r = lineProjSorted.rof[peakLineIdx[p]];
+    const float zp = cands[p].z;
+    const int sp = cands[p].size;
+    float radius = duplicateZCut;
+    if (duplicateZScale > 0.f && sp > 0) {
+      radius = duplicateZScale / o2::gpu::GPUCommonMath::Sqrt((float)sp);
+    }
+    const auto tp = cands[p].time;
+    uint8_t survive = 1;
+    for (int q = peakOffsets[r]; q < peakOffsets[r + 1] && survive; ++q) {
+      if (q == p || !cands[q].ok) {
+        continue;
+      }
+      if (!tp.isCompatible(cands[q].time)) {
+        continue;
+      }
+      if (o2::gpu::GPUCommonMath::Abs(zp - cands[q].z) >= radius) {
+        continue;
+      }
+      const int sq = cands[q].size;
+      if (sq > sp || (sq == sp && q < p)) {
+        survive = 0;
+      }
+    }
+    cands[p].keep = survive;
+  }
+}
+
+template <int NLayers>
+GPUg() void emitKeysForClusterSortingKernel(const Cluster* unsorted,
+                                            const int* clusterOffsets, // this layer, size nRofs+1
+                                            const IndexTableUtils<NLayers>* utils,
+                                            const typename ROFMaskTable<NLayers>::View rofMask,
+                                            float beamX, float beamY,
+                                            int zBins, int phiBins, int nRofs, int iLayer,
+                                            float* minRadiusLayer, float* maxRadiusLayer,
+                                            int* keys)
+{
+  const int numBins = zBins * phiBins;
+  for (int iROF = blockIdx.x; iROF < nRofs; iROF += gridDim.x) {
+    const bool enabled = rofMask.isROFEnabled(iLayer, iROF);
+    const int start = clusterOffsets[iROF];
+    const int n = clusterOffsets[iROF + 1] - start;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) {
+      const Cluster& c = unsorted[start + i];
+      const float x = c.xCoordinate - beamX, y = c.yCoordinate - beamY;
+      const float phi = math_utils::computePhi(x, y);
+      int zBin = utils->getZBinIndex(iLayer, c.zCoordinate);
+      zBin = o2::gpu::GPUCommonMath::Max(0, o2::gpu::GPUCommonMath::Min(zBin, zBins - 1)); // TODO: count bogus (clamped) if hasBogusClusters() is ever needed
+      const int bin = utils->getBinIndex(zBin, utils->getPhiBinIndex(phi));
+      if (enabled) {
+        const float r = math_utils::hypot(x, y);
+        o2::gpu::GPUCommonMath::AtomicMin(&minRadiusLayer[iLayer], r);
+        o2::gpu::GPUCommonMath::AtomicMax(&maxRadiusLayer[iLayer], r);
+      }
+      keys[start + i] = iROF * numBins + bin;
+    }
+  }
+}
+
+template <int NLayers>
+GPUg() void gatherSortedClustersKernel(const Cluster* unsorted,
+                                       Cluster* sorted,
+                                       const int* perm,
+                                       const IndexTableUtils<NLayers>* utils,
+                                       float beamX, float beamY,
+                                       int zBins, int nClustersLayer, int iLayer)
+{
+  for (int j = blockIdx.x * blockDim.x + threadIdx.x; j < nClustersLayer; j += blockDim.x * gridDim.x) {
+    Cluster c = unsorted[perm[j]];
+    const float x = c.xCoordinate - beamX, y = c.yCoordinate - beamY;
+    const float phi = math_utils::computePhi(x, y);
+    int zBin = utils->getZBinIndex(iLayer, c.zCoordinate);
+    zBin = o2::gpu::GPUCommonMath::Max(0, o2::gpu::GPUCommonMath::Min(zBin, zBins - 1));
+    c.phi = phi;
+    c.radius = math_utils::hypot(x, y);
+    c.indexTableBinIndex = utils->getBinIndex(zBin, utils->getPhiBinIndex(phi));
+    sorted[j] = c;
+  }
+}
+
+template <int NLayers>
+GPUg() void buildClusterIndexTableKernel(const int* sortedKeys,
+                                         const int* clusterOffsets, // this layer, size nRofs+1
+                                         int* indexTable,           // output, size nRofs*(numBins+1)
+                                         int numBins, int nRofs)
+{
+  const int stride = numBins + 1;
+  for (int iROF = blockIdx.x; iROF < nRofs; iROF += gridDim.x) {
+    const int rofStart = clusterOffsets[iROF];
+    const int rofEnd = clusterOffsets[iROF + 1];
+    int* base = indexTable + iROF * stride;
+    for (int b = threadIdx.x; b <= numBins; b += blockDim.x) {
+      const int keyB = iROF * numBins + b;
+      base[b] = deviceLowerBound(sortedKeys, rofStart, rofEnd, keyB) - rofStart; // ROF-local
+    }
+  }
+}
+
 } // namespace gpu
 
 template <int NLayers>
@@ -832,6 +1256,7 @@ int TrackingKernels<NLayers>::computeTrackletsInROFsHandler(const IndexTableUtil
                                                             const typename ROFVertexLookupTable<NLayers>::View& vertexLUT,
                                                             const int vertexId,
                                                             const Vertex* vertices,
+                                                            const bool vtxMode,
                                                             const Cluster** clusters,
                                                             const std::vector<unsigned int>& nClusters,
                                                             const int** ROFClusters,
@@ -847,8 +1272,8 @@ int TrackingKernels<NLayers>::computeTrackletsInROFsHandler(const IndexTableUtil
                                                             const typename TrackingTopology<NLayers>::View topology,
                                                             bounded_vector<float>& linkPhiCuts,
                                                             const float resolutionPV,
-                                                            std::array<float, NLayers>& minRs,
-                                                            std::array<float, NLayers>& maxRs,
+                                                            const float* minRs,
+                                                            const float* maxRs,
                                                             bounded_vector<float>& resolutions,
                                                             std::vector<float>& radii,
                                                             bounded_vector<float>& linkMSAngles,
@@ -866,6 +1291,7 @@ int TrackingKernels<NLayers>::computeTrackletsInROFsHandler(const IndexTableUtil
     rofOverlaps,
     vertexLUT,
     vertices,
+    vtxMode,
     vertexId,
     clusters,
     ROFClusters,
@@ -878,8 +1304,8 @@ int TrackingKernels<NLayers>::computeTrackletsInROFsHandler(const IndexTableUtil
     NSigmaCut,
     linkPhiCuts[linkId],
     resolutionPV,
-    minRs[toLayer],
-    maxRs[toLayer],
+    minRs,
+    maxRs,
     resolutions[fromLayer],
     radii[toLayer] - radii[fromLayer],
     linkMSAngles[linkId]);
@@ -932,6 +1358,7 @@ int TrackingKernels<NLayers>::computeCellsHandler(
   const float bz,
   const float maxChi2ClusterAttachment,
   const float cellDeltaTanLambdaSigma,
+  const float cellDeltaPhiCut,
   const float nSigmaCut,
   const float* layerxX0,
   o2::its::ExternalAllocator* alloc,
@@ -950,7 +1377,7 @@ int TrackingKernels<NLayers>::computeCellsHandler(
   gpu::computeLayerCellCandidatesKernel<NLayers, false><<<candidateBlocks, gpu::GPUThreads, 0, stream.get()>>>(
     tracklets, trackletsLUT, nTracklets, cellTopologyId, topology,
     sortedClusters, unsortedClusters, tfInfo, layerxX0, bz,
-    nullptr, nullptr, outputCounter, 0, cellDeltaTanLambdaSigma, nSigmaCut);
+    nullptr, nullptr, outputCounter, 0, cellDeltaTanLambdaSigma, cellDeltaPhiCut, nSigmaCut);
   int nCandidates = 0;
   GPUChkErrS(cudaMemcpyAsync(&nCandidates, outputCounter, sizeof(int), cudaMemcpyDeviceToHost, stream.get()));
   stream.sync();
@@ -970,7 +1397,7 @@ int TrackingKernels<NLayers>::computeCellsHandler(
     tracklets, trackletsLUT, nTracklets, cellTopologyId, topology,
     sortedClusters, unsortedClusters, tfInfo, layerxX0, bz,
     thrust::raw_pointer_cast(candidates), thrust::raw_pointer_cast(candidateKeys),
-    outputCounter, nCandidates, cellDeltaTanLambdaSigma, nSigmaCut);
+    outputCounter, nCandidates, cellDeltaTanLambdaSigma, cellDeltaPhiCut, nSigmaCut);
 
   // order the candidates by momentum before fitting them, so that the ELoss iteration count inside is uniform
   {
@@ -1085,6 +1512,223 @@ void TrackingKernels<NLayers>::computeCellNeighboursHandler(CellSeed** cellsLaye
 
   stream.sync(); // the candidate slab must outlive the kernels reading it
   alloc->popTagOffStack(CandidateTag);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::sortClustersHandler(const Cluster* unsorted,   // this layer (resident unsorted)
+                                                   Cluster* sorted,           // this layer (output)
+                                                   const int* clusterOffsets, // this layer ROF boundaries, size nRofs+1
+                                                   int* indexTable,           // this layer (output), size nRofs*(zBins*phiBins+1)
+                                                   const IndexTableUtils<NLayers>* utils,
+                                                   const typename ROFMaskTable<NLayers>::View& rofMask,
+                                                   float beamX, float beamY,
+                                                   int zBins, int phiBins, int nRofs, int nClustersLayer, int iLayer,
+                                                   float* minRadiusLayer, float* maxRadiusLayer, // per-layer device arrays
+                                                   int* keys,                                    // scratch, size nClustersLayer
+                                                   int* perm,                                    // scratch, size nClustersLayer
+                                                   o2::its::ExternalAllocator* alloc,
+                                                   gpu::Stream& stream)
+{
+  if (nClustersLayer == 0) {
+    return;
+  }
+  const int numBins = zBins * phiBins;
+  auto policy = THRUST_NAMESPACE::par_nosync(gpu::TypedAllocator<char>(alloc)).on(stream.get());
+  thrust::fill_n(policy, minRadiusLayer + iLayer, 1, std::numeric_limits<float>::max());
+  thrust::fill_n(policy, maxRadiusLayer + iLayer, 1, std::numeric_limits<float>::min());
+
+  gpu::emitKeysForClusterSortingKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    unsorted, clusterOffsets, utils, rofMask, beamX, beamY, zBins, phiBins, nRofs, iLayer,
+    minRadiusLayer, maxRadiusLayer, keys);
+
+  thrust::sequence(policy, perm, perm + nClustersLayer);
+  thrust::stable_sort_by_key(policy, keys, keys + nClustersLayer, perm);
+
+  gpu::gatherSortedClustersKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    unsorted, sorted, perm, utils, beamX, beamY, zBins, nClustersLayer, iLayer);
+
+  gpu::buildClusterIndexTableKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    keys, clusterOffsets, indexTable, numBins, nRofs);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::registerClusterOwnershipHandler(const CellSeed* cells,
+                                                               const int nCells,
+                                                               unsigned long long** clusterOwnersDeviceArray,
+                                                               gpu::Stream& stream)
+{
+
+  gpu::vertexingRegisterCellClustersOwnership<<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    cells,
+    nCells,
+    clusterOwnersDeviceArray);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::linearizeCellsToLinesHandler(const int nCells,
+                                                            const CellSeed* cells,
+                                                            const unsigned long long* const* clusterOwners,
+                                                            const int* rofFramesClustersL1,
+                                                            const int nRofsL1,
+                                                            const int ownedClustersCut,
+                                                            o2::its::Line* lines,
+                                                            int* lineRof,
+                                                            int* lineClusters,
+                                                            int* lineSlots, // nCells + 1 scratch: accept flags, scanned in place into slots
+                                                            const float beamX,
+                                                            const float beamY,
+                                                            const float maxZ,
+                                                            const float minPt,
+                                                            float* linesZs,
+                                                            o2::its::TimeEstBC* lineTimes,
+                                                            float* lineChi2,
+                                                            float* linePt,
+                                                            o2::its::ExternalAllocator* alloc,
+                                                            gpu::Stream& stream)
+{
+  gpu::dedupCellsKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    nCells,
+    cells,
+    clusterOwners,
+    ownedClustersCut,
+    beamX,
+    beamY,
+    maxZ,
+    minPt,
+    lineSlots);
+  auto nosync_policy = THRUST_NAMESPACE::par_nosync(gpu::TypedAllocator<char>(alloc)).on(stream.get());
+  thrust::exclusive_scan(nosync_policy, lineSlots, lineSlots + nCells + 1, lineSlots);
+  gpu::linearizeCellsKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    nCells,
+    cells,
+    rofFramesClustersL1,
+    nRofsL1,
+    lineSlots,
+    lines,
+    lineRof,
+    beamX,
+    beamY,
+    linesZs,
+    lineTimes,
+    lineClusters,
+    lineChi2,
+    linePt);
+}
+
+// Orders lines by (ROF, z): primary key the ROF, secondary the projected z within the ROF.
+struct RofZLess {
+  const int* rof;
+  const float* z;
+  GPUhdi() bool operator()(const int a, const int b) const
+  {
+    return rof[a] != rof[b] ? rof[a] < rof[b] : z[a] < z[b];
+  }
+};
+
+template <int NLayers>
+void TrackingKernels<NLayers>::sortLinesHandler(const int nLines,
+                                                const int nRofs,
+                                                const gpu::LineProjSoA soa,
+                                                const gpu::LineProjSoA sortedSoa,
+                                                const int* lineRof,
+                                                int* rofOffsets,
+                                                o2::its::ExternalAllocator* alloc,
+                                                gpu::Stream& stream)
+{
+  if (nLines < 2) {
+    return;
+  }
+  auto policy = THRUST_NAMESPACE::par_nosync(gpu::TypedAllocator<char>(alloc)).on(stream.get());
+  thrust::sequence(policy, soa.idx, soa.idx + nLines);
+  thrust::sort(policy, soa.idx, soa.idx + nLines, RofZLess{lineRof, soa.z});
+  gpu::gatherSortedLinesKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(nLines, soa, sortedSoa);
+  auto rofSorted = thrust::make_permutation_iterator(lineRof, soa.idx);
+  thrust::lower_bound(policy, rofSorted, rofSorted + nLines,
+                      thrust::make_counting_iterator(0), thrust::make_counting_iterator(nRofs + 1),
+                      rofOffsets);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::scanDensityHandler(const int nLines,
+                                                  const gpu::LineProjSoA sortedSoa,
+                                                  const int* rofOffsets,
+                                                  int* density,
+                                                  gpu::LineWindow* win,
+                                                  const float zWindow,
+                                                  gpu::Stream& stream)
+{
+  if (nLines < 2) {
+    return;
+  }
+  gpu::scanDensityKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(density, win, nLines, rofOffsets, sortedSoa, zWindow);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::findPeaksHandler(const int nLines,
+                                                const int nRofs,
+                                                const gpu::LineProjSoA sortedSoa,
+                                                const int* rofOffsets,
+                                                const int* density,
+                                                const gpu::LineWindow* win,
+                                                uint8_t* isPeak,
+                                                const int* densityFine,
+                                                const gpu::LineWindow* winFine,
+                                                const int fineMinDensity,
+                                                uint8_t* isPeakFine,
+                                                int* peakScan,
+                                                int* peakLineIdx,
+                                                int* peakOffsets,
+                                                o2::its::ExternalAllocator* alloc,
+                                                gpu::Stream& stream)
+{
+  if (nLines < 2) {
+    return;
+  }
+  gpu::findPeaksKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(density, win, nLines, sortedSoa, isPeak,
+                                                                                                                         densityFine, winFine, fineMinDensity, isPeakFine);
+  auto nosync_policy = THRUST_NAMESPACE::par_nosync(gpu::TypedAllocator<char>(alloc)).on(stream.get());
+  thrust::exclusive_scan(nosync_policy, isPeak, isPeak + nLines + 1, peakScan, 0, thrust::plus<int>());
+  thrust::scatter_if(nosync_policy, thrust::make_counting_iterator(0), thrust::make_counting_iterator(nLines),
+                     peakScan, isPeak, peakLineIdx);
+  thrust::gather(nosync_policy, rofOffsets, rofOffsets + nRofs + 1, peakScan, peakOffsets);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::fitPeaksHandler(const int* nPeaksDevice,
+                                               const int* peakLineIdx,
+                                               const gpu::LineWindow* win,
+                                               const gpu::LineProjSoA sortedSoa,
+                                               const o2::its::Line* lines,
+                                               const float* lineChi2,
+                                               const float* linePt,
+                                               const float goodLineChi2Cut,
+                                               const float goodLinePtCut,
+                                               const float pairCut2,
+                                               const float nSigmaCut,
+                                               const int minContributors,
+                                               const float beamX,
+                                               const float beamY,
+                                               const uint8_t* isPeakFine,
+                                               const float fineMaxDrift,
+                                               gpu::VertexCand* cands,
+                                               gpu::Stream& stream)
+{
+  gpu::fitPeaksKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    nPeaksDevice, peakLineIdx, win, sortedSoa, lines, lineChi2, linePt, goodLineChi2Cut, goodLinePtCut, pairCut2, nSigmaCut, minContributors, beamX, beamY, isPeakFine, fineMaxDrift, cands);
+}
+
+template <int NLayers>
+void TrackingKernels<NLayers>::dedupVertexCandidatesHandler(const int* nPeaksDevice,
+                                                            const int* peakLineIdx,
+                                                            const int* peakOffsets,
+                                                            const gpu::LineProjSoA sortedSoa,
+                                                            const float duplicateZCut,
+                                                            const float duplicateZScale,
+                                                            gpu::VertexCand* cands,
+                                                            gpu::Stream& stream)
+{
+  gpu::dedupVertexCandidatesKernel<NLayers><<<gpu::gridBlocks(gpu::DefaultBlocksPerComputeUnit), gpu::GPUThreads, 0, stream.get()>>>(
+    nPeaksDevice, peakLineIdx, peakOffsets, sortedSoa, duplicateZCut, duplicateZScale, cands);
 }
 
 int finalizeCellNeighboursHandler(CellNeighbour* cellNeighbours,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -15,78 +15,188 @@
 #include <gsl/span>
 #include <vector>
 #include <array>
-#include <Math/SMatrix.h>
-#include <Math/SVector.h>
 #include "ITStracking/Cluster.h"
 #include "ITSMFTTracking/Constants.h"
 #include "ITStracking/Tracklet.h"
-#include "GPUCommonRtypes.h"
+#include "GPUCommonDef.h"
+#include "GPUCommonMath.h"
 
 namespace o2::its
 {
 
 struct Line final {
-#if !defined(__HIPCC__) && !defined(__CUDACC__) // hide the class completely for gpu-cc
-  using SVector3f = ROOT::Math::SVector<float, 3>;
-  using SMatrix3f = ROOT::Math::SMatrix<float, 3, 3, ROOT::Math::MatRepSym<float, 3>>;
-
-  Line() = default;
+  GPUhdDefault() Line() = default;
   Line(const Tracklet&, const Cluster*, const Cluster*);
+  GPUhdi() Line(const float origin[3], const float direction[3], const TimeEstBC& time) : mTime(time)
+  {
+    float norm2 = 0.f;
+    for (int i = 0; i < 3; ++i) {
+      norm2 += direction[i] * direction[i];
+    }
+    const float inv = norm2 > 0.f ? 1.f / o2::gpu::GPUCommonMath::Sqrt(norm2) : 0.f;
+    for (int i = 0; i < 3; ++i) {
+      originPoint[i] = origin[i];
+      cosinesDirector[i] = direction[i] * inv;
+    }
+  }
+  Line(const std::array<float, 3>& origin, const std::array<float, 3>& direction, const TimeEstBC& time)
+    : Line(origin.data(), direction.data(), time) {}
   bool operator==(const Line&) const = default;
 
-  static float getDistance2FromPoint(const Line& line, const std::array<float, 3>& point);
+  GPUhdi() static float getDistance2FromPoint(const Line& line, const float point[3])
+  {
+    float delta[3], proj = 0.f;
+    for (int i = 0; i < 3; ++i) {
+      delta[i] = point[i] - line.originPoint[i];
+      proj += delta[i] * line.cosinesDirector[i];
+    }
+    float d2 = 0.f;
+    for (int i = 0; i < 3; ++i) {
+      const float residual = delta[i] - proj * line.cosinesDirector[i];
+      d2 += residual * residual;
+    }
+    return d2;
+  }
+
+  /// Packed symmetric DCA components in {XX, XY, YY, XZ, YZ, ZZ} order
+  GPUhdi() static void getDCAComponents(const Line& line, const float point[3], float out[6])
+  {
+    float delta[3], proj = 0.f;
+    for (int i = 0; i < 3; ++i) {
+      delta[i] = line.originPoint[i] - point[i];
+      proj += delta[i] * line.cosinesDirector[i];
+    }
+    float r[3];
+    for (int i = 0; i < 3; ++i) {
+      r[i] = delta[i] - proj * line.cosinesDirector[i];
+    }
+    out[0] = r[0];
+    out[1] = o2::gpu::GPUCommonMath::Hypot(r[0], r[1]);
+    out[2] = r[1];
+    out[3] = o2::gpu::GPUCommonMath::Hypot(r[0], r[2]);
+    out[4] = o2::gpu::GPUCommonMath::Hypot(r[1], r[2]);
+    out[5] = r[2];
+  }
+
+  static float getDistance2FromPoint(const Line& line, const std::array<float, 3>& point)
+  {
+    return getDistance2FromPoint(line, point.data());
+  }
   static float getDistanceFromPoint(const Line& line, const std::array<float, 3>& point);
-  static SMatrix3f getDCAComponents(const Line& line, const std::array<float, 3>& point);
   static float getDCA2(const Line&, const Line&, const float precision = constants::Tolerance);
   static float getDCA(const Line&, const Line&, const float precision = constants::Tolerance);
-  bool isEmpty() const noexcept;
+  GPUhdi() bool isEmpty() const noexcept
+  {
+    return originPoint[0] == 0.f && originPoint[1] == 0.f && originPoint[2] == 0.f &&
+           cosinesDirector[0] == 0.f && cosinesDirector[1] == 0.f && cosinesDirector[2] == 0.f;
+  }
   void print() const;
 
-  SVector3f originPoint;
-  SVector3f cosinesDirector;
+  float originPoint[3] = {0.f, 0.f, 0.f};
+  float cosinesDirector[3] = {0.f, 0.f, 0.f};
   TimeEstBC mTime;
-
-  ClassDefNV(Line, 1);
-#endif
 };
 
+/// Least-squares vertex fit over a set of lines (the normal equations AX = -B).
 class ClusterLines final
 {
-#if !defined(__HIPCC__) && !defined(__CUDACC__) // hide the class completely for gpu-cc
-  using SMatrix3 = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>>;
-  using SMatrix3f = ROOT::Math::SMatrix<float, 3, 3, ROOT::Math::MatRepSym<float, 3>>;
-  using SVector3 = ROOT::Math::SVector<double, 3>;
-
  public:
-  ClusterLines() = default;
-  ClusterLines(const int firstLabel, const Line& firstLine, const int secondLabel, const Line& secondLine);
-  ClusterLines(gsl::span<const int> lineLabels, gsl::span<const Line> lines);
-  void add(const int lineLabel, const Line& line);
-  void computeClusterCentroid();
-  void accumulate(const Line& line);
-  bool isValid() const noexcept { return mIsValid; }
-  auto const& getVertex() const { return mVertex; }
-  const float* getRMS2() const { return mRMS2.Array(); }
-  float getAvgDistance2() const { return mAvgDistance2; }
-  auto getSize() const noexcept { return mLabels.size(); }
-  auto& getLabels() const noexcept { return mLabels; }
-  const auto& getTimeStamp() const noexcept { return mTime; }
+  GPUhdDefault() ClusterLines() = default;
+  /// Fit over lines[lineIndices[i]]; lineIndices must be sorted and unique.
+  ClusterLines(gsl::span<const int> lineIndices, gsl::span<const Line> lines);
+
+  /// Accumulate one line into the normal equations and the time estimate.
+  GPUhdi() void add(const Line& line)
+  {
+    const double d0 = line.cosinesDirector[0], d1 = line.cosinesDirector[1], d2 = line.cosinesDirector[2];
+    const double o0 = line.originPoint[0], o1 = line.originPoint[1], o2 = line.originPoint[2];
+    const double det = d0 * d0 + d1 * d1 + d2 * d2; // == 1 for a normalised director
+    if (det <= 0.) {
+      return;
+    }
+    if (mNContributors <= 0) {
+      mTime = line.mTime;
+    } else {
+      mTime += line.mTime;
+    }
+    mA[0] += (det - d0 * d0) / det;
+    mA[1] += (-d0 * d1) / det;
+    mA[2] += (-d0 * d2) / det;
+    mA[3] += (det - d1 * d1) / det;
+    mA[4] += (-d1 * d2) / det;
+    mA[5] += (det - d2 * d2) / det;
+    const double dDotO = d0 * o0 + d1 * o1 + d2 * o2;
+    mB[0] += (d0 * dDotO - det * o0) / det;
+    mB[1] += (d1 * dDotO - det * o1) / det;
+    mB[2] += (d2 * dDotO - det * o2) / det;
+    ++mNContributors;
+  }
+
+  /// Solve the symmetric 3x3 system into an external vertex (= -A^-1 B)
+  GPUhdi() bool solve(float vertex[3]) const
+  {
+    const double a = mA[0], b = mA[1], c = mA[2], d = mA[3], e = mA[4], f = mA[5];
+    const double c00 = d * f - e * e;
+    const double c01 = c * e - b * f;
+    const double c02 = b * e - c * d;
+    const double c11 = a * f - c * c;
+    const double c12 = b * c - a * e;
+    const double c22 = a * d - b * b;
+    const double det = a * c00 + b * c01 + c * c02;
+    if (o2::gpu::GPUCommonMath::Abs(det) < 1.e-12) {
+      return false;
+    }
+    const double invDet = 1. / det;
+    const double x0 = (c00 * mB[0] + c01 * mB[1] + c02 * mB[2]) * invDet;
+    const double x1 = (c01 * mB[0] + c11 * mB[1] + c12 * mB[2]) * invDet;
+    const double x2 = (c02 * mB[0] + c12 * mB[1] + c22 * mB[2]) * invDet;
+    vertex[0] = static_cast<float>(-x0);
+    vertex[1] = static_cast<float>(-x1);
+    vertex[2] = static_cast<float>(-x2);
+    return true;
+  }
+
+  /// Solve into the stored vertex, setting the validity flag
+  GPUhdi() void computeClusterCentroid() { mIsValid = solve(mVertex); }
+
+  /// Running-mean update of the RMS2 and average distance about the stored vertex
+  GPUhdi() void addResidual(const Line& line) { addResidual(line, mVertex); }
+
+  /// Running-mean update about an externally solved vertex
+  GPUhdi() void addResidual(const Line& line, const float vertex[3])
+  {
+    float dca[6];
+    Line::getDCAComponents(line, vertex, dca);
+    const float d2 = Line::getDistance2FromPoint(line, vertex);
+    ++mResidualCount;
+    const float inv = 1.f / static_cast<float>(mResidualCount);
+    for (int i = 0; i < 6; ++i) {
+      mRMS2[i] += (dca[i] - mRMS2[i]) * inv;
+    }
+    mAvgDistance2 += (d2 - mAvgDistance2) * inv;
+  }
+
+  GPUhdi() bool isValid() const noexcept { return mIsValid; }
+  GPUhdi() const float* getVertex() const noexcept { return mVertex; }
+  GPUhdi() const float* getRMS2() const noexcept { return mRMS2; } // {XX, XY, YY, XZ, YZ, ZZ}
+  GPUhdi() float getAvgDistance2() const noexcept { return mAvgDistance2; }
+  GPUhdi() int getSize() const noexcept { return mNContributors; }
+  GPUhdi() int getNContributors() const noexcept { return mNContributors; }
+  GPUhdi() const TimeEstBC& getTimeStamp() const noexcept { return mTime; }
+  GPUhdi() float getR2() const noexcept { return (mVertex[0] * mVertex[0]) + (mVertex[1] * mVertex[1]); }
+  GPUhdi() float getR() const noexcept { return o2::gpu::GPUCommonMath::Sqrt(getR2()); }
   bool operator==(const ClusterLines& rhs) const noexcept;
-  float getR2() const noexcept { return (mVertex[0] * mVertex[0]) + (mVertex[1] * mVertex[1]); }
-  float getR() const noexcept { return std::sqrt(getR2()); }
 
- protected:
-  SMatrix3 mAMatrix;                 // AX=B, symmetric normal matrix
-  SVector3 mBMatrix;                 // AX=B, right-hand side
-  std::array<float, 3> mVertex = {}; // cluster centroid position
-  SMatrix3f mRMS2;                   // symmetric matrix: diagonal is RMS2
-  float mAvgDistance2 = 0.f;         // substitute for chi2
-  bool mIsValid = false;             // true if linear system was solved successfully
-  TimeEstBC mTime;                   // time stamp
-  std::vector<int> mLabels;          // contributing labels
-
-  ClassDefNV(ClusterLines, 1);
-#endif
+ private:
+  double mA[6] = {0., 0., 0., 0., 0., 0.}; // AX=B, packed symmetric normal matrix
+  double mB[3] = {0., 0., 0.};             // AX=B, right-hand side
+  float mVertex[3] = {0.f, 0.f, 0.f};      // cluster centroid position
+  float mRMS2[6] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  float mAvgDistance2 = 0.f;
+  int mNContributors = 0;
+  int mResidualCount = 0;
+  bool mIsValid = false; // true if the linear system was solved successfully
+  TimeEstBC mTime;
 };
 
 } // namespace o2::its

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -16,6 +16,8 @@
 #ifndef TRACKINGITSU_INCLUDE_CONFIGURATION_H_
 #define TRACKINGITSU_INCLUDE_CONFIGURATION_H_
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <limits>
@@ -25,6 +27,7 @@
 
 #include "CommonUtils/EnumFlags.h"
 #include "DetectorsBase/Propagator.h"
+#include "CommonConstants/MathConstants.h"
 #include "ITSMFTTracking/Constants.h"
 #include "ITStracking/LayerMask.h"
 
@@ -42,6 +45,8 @@ enum class IterationStep : uint16_t {
   MarkVerticesAsUPC,
   TrackFollowerTop,
   TrackFollowerBot,
+  SeedingVertexPass,    // this iteration runs the seeding-vertex step instead of track finding
+  LoadPersistentTables, // this pass uploads the per-TF tables (ROF overlap, tracking topologies); set on whichever pass runs first
 };
 using IterationSteps = o2::utils::EnumFlags<IterationStep>;
 
@@ -111,6 +116,8 @@ struct TrackingParameters {
   float TrackletMinPt = 0.3f;
   /// Cell finding cuts
   float CellDeltaTanLambdaSigma = 0.007f;
+  float CellDeltaTanLambdaNSigma = -1.f;
+  float CellDeltaPhiMinPt = -1.f;
   /// Fitter parameters
   o2::base::PropagatorImpl<float>::MatCorrType CorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrNONE;
   float MaxChi2ClusterAttachment = 60.f;
@@ -138,6 +145,26 @@ struct TrackingParameters {
   float SharedClusterMaxDeltaEta = 0.03f; // For tracks sharing clusters, maximum allowed delta eta at the cluster position
   bool SharedClusterOppositeSign = false; // For tracks sharing clusters, require opposite sign of the tracklets
   int SharedMaxClusters = 0;              // Maximal allowed shared clusters (excluding first cluster)
+
+  int CellLineSharedClusterCut = 2; // Seeding-vertex pass: max clusters a cell->Line may share with already-accepted Lines before it is dropped
+
+  int VertPerRofThreshold = 0; // max vertices in a ROF for the UPC pass to still run on it
+  float VtxPhiCut = -1.f;
+  float VtxLineMinPt = -1.f;
+  float VtxMaxZPositionAllowed = -1.f;
+  float VtxClusterCut = -1.f;
+  float VtxPairCut = -1.f;
+  float VtxNSigmaCut = -1.f;
+  float VtxDuplicateZCut = -1.f;
+  float VtxDuplicateZScale = -1.f;
+  float VtxFineZWindow = -1.f;
+  int VtxFineMinDensity = -1;
+  float VtxFineMaxDrift = -1.f;
+  float VtxGoodLineChi2Cut = -1.f;
+  float VtxGoodLinePtCut = -1.f;
+  float VtxGoodContributorsSignificance = -1.f;
+  int VtxClusterContributorsCut = -1;
+  int VtxSuppressLowMultDebris = -1;
 };
 
 struct VertexingParameters {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/LineProjection.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/LineProjection.h
@@ -1,0 +1,89 @@
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file LineProjection.h
+/// \brief small types shared by the host and device seeding vertexers, describing lines
+///        projected onto the beam line: their time interval and their z-window bounds.
+
+#ifndef O2_ITS_TRACKING_LINE_PROJECTION_H_
+#define O2_ITS_TRACKING_LINE_PROJECTION_H_
+
+#include "GPUCommonDef.h"
+#include "DataFormatsITS/TimeEstBC.h"
+#include <cstdint>
+#include <vector>
+
+namespace o2::its
+{
+
+// Half-open [lo, hi) range of sorted-line slots falling inside one z-window.
+struct LineWindow {
+  int lo{0};
+  int hi{0};
+};
+
+// Per-line quality estimators carried alongside the projected line.
+struct LineQuality {
+  float chi2{-1.f};
+  float pt{-1.f};
+};
+
+// Host mirror of the per-peak inputs needed to recompute, off-device, which lines a vertex candidate accepted.
+// MC-only: filled just to feed the majority-vote labels.
+struct PeakMembershipHost {
+  std::vector<int> peakLineIdx;  // per compacted peak: the sorted line slot it came from
+  std::vector<LineWindow> win;   // per sorted line: [lo, hi) z-window bounds
+  std::vector<TimeEstBC> times;  // per sorted line: its time interval
+  std::vector<int> sortedToLine; // sorted slot -> global line index
+
+  void clear()
+  {
+    peakLineIdx.clear();
+    win.clear();
+    times.clear();
+    sortedToLine.clear();
+  }
+};
+
+namespace gpu
+{
+
+// Spelled gpu::LineWindow at the device call sites; qualified lookup does not reach the
+// enclosing namespace, so the alias has to be declared here.
+using LineWindow = o2::its::LineWindow;
+
+// Device SoA view of the lines projected onto the beam line.
+struct LineProjSoA {
+  float* z{nullptr};              // projected z at the beamline; sort key and binary-search key, kept dense
+  o2::its::TimeEstBC* t{nullptr}; // time interval of the line
+  int* idx{nullptr};              // sorted slot -> original line index
+  int* rof{nullptr};              // ROF of the line
+};
+
+// One vertex candidate produced by the device fit, before the host emit step
+struct VertexCand {
+  float x, y, z;
+  float rms2[6];
+  float avgDist2;
+  int nGood;
+  float seed[3];
+  o2::its::TimeEstBC time;
+  int size;
+  uint8_t ok;   // 1 if the candidate passed the fit cuts
+  uint8_t keep; // 1 if it survived duplicate suppression (subset of ok)
+  uint8_t fine;
+};
+
+} // namespace gpu
+
+} // namespace o2::its
+
+#endif

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/LineVertexerHelpers.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/LineVertexerHelpers.h
@@ -42,7 +42,20 @@ struct Settings {
   std::shared_ptr<BoundedMemoryResource> memoryPool;
 };
 
-bounded_vector<ClusterLines> buildClusters(std::span<const Line> lines, const Settings& settings);
+struct ClusterWithLines {
+  ClusterLines fit;
+  bounded_vector<int> lineIndices;
+
+  const float* getVertex() const noexcept { return fit.getVertex(); }
+  const float* getRMS2() const noexcept { return fit.getRMS2(); }
+  int getSize() const noexcept { return fit.getSize(); }
+  float getAvgDistance2() const noexcept { return fit.getAvgDistance2(); }
+  const auto& getTimeStamp() const noexcept { return fit.getTimeStamp(); }
+  bool isValid() const noexcept { return fit.isValid(); }
+  const auto& getLabels() const noexcept { return lineIndices; }
+};
+
+bounded_vector<ClusterWithLines> buildClusters(std::span<const Line> lines, const Settings& settings);
 
 } // namespace o2::its::line_vertexer
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -28,6 +28,7 @@
 #include "ITStracking/Cluster.h"
 #include "ITStracking/Configuration.h"
 #include "ITStracking/ClusterLines.h"
+#include "ITStracking/LineProjection.h"
 #include "ITStracking/Tracklet.h"
 #include "ITStracking/IndexTableUtils.h"
 #include "ITStracking/ExternalAllocator.h"
@@ -116,6 +117,7 @@ struct TimeFrame {
 
   float getBeamX() const { return mBeamPos[0]; }
   float getBeamY() const { return mBeamPos[1]; }
+  bool isBeamOverridden() const { return isBeamPositionOverridden; }
   std::array<float, 2>& getBeamXY() { return mBeamPos; }
 
   auto& getMinRs() { return mMinR; }
@@ -171,6 +173,12 @@ struct TimeFrame {
     mROFMaskView = mROFMask->getView();
   }
   void setUPCCutMask(ROFMaskTableN cutMask) { mUPCCutMask = std::move(cutMask); }
+  void setSeedingUPCMask(ROFMaskTableN cutMask) { mSeedingUPCMask = std::move(cutMask); }
+  void useSeedingUPCMask() noexcept
+  {
+    mROFMask = &mSeedingUPCMask;
+    mROFMaskView = mROFMask->getView();
+  }
   void useUPCMask() noexcept
   {
     mROFMask = &mUPCCutMask;
@@ -243,6 +251,8 @@ struct TimeFrame {
   void computeTracletsPerClusterScans();
   int& getNTrackletsROF(int rofId, int combId) { return mNTrackletsPerROF[combId][rofId]; }
   auto& getLines(int rofId) { return mLines[rofId]; }
+  auto& getLinesQuality(int rofId) { return mLinesQuality[rofId]; }
+  const auto& getLinesQuality(int rofId) const { return mLinesQuality[rofId]; }
   int getNLinesTotal() const noexcept { return mTotalLines; }
   void setNLinesTotal(uint32_t a) noexcept { mTotalLines = a; }
   auto& getTrackletClusters(int rofId) { return mTrackletClusters[rofId]; }
@@ -310,7 +320,8 @@ struct TimeFrame {
   virtual const char* getName() const noexcept { return "CPU"; }
 
  protected:
-  void prepareClusters(const TrackingParameters& trkParam, const int maxLayers = NLayers);
+  virtual void prepareClusters(const TrackingParameters& trkParam, const int maxLayers = NLayers);
+  virtual void allocateClusterSortStorage(const TrackingParameters& trkParam, const int maxLayers);
   float mBz = 5.;
   unsigned int mNTotalLowPtVertices = 0;
   int mBeamPosWeight = 0;
@@ -336,6 +347,7 @@ struct TimeFrame {
   bounded_vector<VertexLabel> mPrimaryVerticesLabels;
   std::vector<bounded_vector<int>> mNTrackletsPerROF;
   std::vector<bounded_vector<Line>> mLines;
+  std::vector<bounded_vector<LineQuality>> mLinesQuality; // lockstep with mLines, see getLinesQuality()
   std::vector<bounded_vector<ClusterLines>> mTrackletClusters;
   std::array<bounded_vector<int>, 2> mTrackletsIndexROF;
   std::vector<bounded_vector<MCCompLabel>> mLinesLabels;
@@ -355,6 +367,7 @@ struct TimeFrame {
   ROFVertexLookupTableN::View mROFVertexLookupTableView;
   ROFMaskTableN mMultiplicityCutMask;
   ROFMaskTableN mUPCCutMask;
+  ROFMaskTableN mSeedingUPCMask;
   ROFMaskTableN* mROFMask = &mMultiplicityCutMask;
   ROFMaskTableN::View mROFMaskView;
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -59,6 +59,10 @@ class Tracker
     const LogFunc& = [](const std::string& s) { std::cout << s << '\n'; },
     const LogFunc& = [](const std::string& s) { std::cerr << s << '\n'; });
 
+  // Self-contained seeding-vertex phase (own TimeFrame init + own timer), run before clustersToTracks.
+  float clustersToVertices(
+    const LogFunc& = [](const std::string& s) { std::cout << s << '\n'; });
+
   void setParameters(const std::vector<TrackingParameters>& p) { mTrkParams = p; }
   void setMemoryPool(std::shared_ptr<BoundedMemoryResource> pool) { mMemoryPool = pool; }
   std::vector<TrackingParameters>& getParameters() { return mTrkParams; }
@@ -72,6 +76,9 @@ class Tracker
   void initialiseTimeFrame(int iteration) { mTraits->initialiseTimeFrame(iteration); }
   void computeTracklets(int iteration, int iVertex) { mTraits->computeLayerTracklets(iteration, iVertex); }
   void computeCells(int iteration) { mTraits->computeLayerCells(iteration); }
+  void computeVertexCandidates(int iteration) { mTraits->computeVertexCandidates(iteration); }
+  void computeBeamFromVertices(int iteration) { mTraits->computeBeamFromVertices(iteration); }
+  void computeVertices(int iteration) { mTraits->computeVertices(iteration); }
   void findCellsNeighbours(int iteration) { mTraits->findCellsNeighbours(iteration); }
   void findRoads(int iteration) { mTraits->findRoads(iteration); }
 
@@ -100,10 +107,13 @@ class Tracker
     Neighbouring,
     Roading,
     Extending,
+    CellLinearising,
+    BeamPositioning,
+    SeedingVertices,
     NSteps,
   };
   Steps mCurStep{TFInit};
-  static constexpr std::array<const char*, NSteps> StateNames{"TimeFrame initialisation", "Tracklet finding", "Cell finding", "Neighbour finding", "Road finding", "Track extending"};
+  static constexpr std::array<const char*, NSteps> StateNames{"TimeFrame initialisation", "Tracklet finding", "Cell finding", "Neighbour finding", "Road finding", "Track extending", "Cell linearisation", "Beam positioning", "Seeding vertices"};
   std::vector<std::array<TimingStats, NSteps>> mTimingStats;
   void addTimingStatCurStep(int iteration, double timeMs);
 };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -71,6 +71,10 @@ class TrackerTraits
   virtual void findCellsNeighbours(const int iteration);
   virtual void findRoads(const int iteration);
 
+  virtual void computeVertexCandidates(const int iteration);
+  virtual void computeBeamFromVertices(const int iteration);
+  virtual void computeVertices(const int iteration);
+
   template <typename InputSeed>
   void processNeighbours(int iteration, int defaultCellTopologyId, int iLevel, uint64_t capacityKey, const bounded_vector<InputSeed>& currentSeeds, bounded_vector<RoadSeedN>& updatedSeeds);
 
@@ -99,6 +103,8 @@ class TrackerTraits
   virtual int getTFNumberOfCells() const { return mTimeFrame->getNumberOfCells(); }
 
  private:
+  bool skipROF(int iteration, int rof) const; // seeding-vertex pass: skip ROFs above the per-ROF vertex threshold
+
   std::shared_ptr<BoundedMemoryResource> mMemoryPool;
 
  protected:

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingInterface.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingInterface.h
@@ -29,6 +29,8 @@
 #include "GPUChainITS.h"
 
 #include <oneapi/tbb/task_arena.h>
+#include <utility>
+#include <vector>
 
 namespace o2::its
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -75,30 +75,6 @@ class VertexerTraits
   virtual bool usesMemoryPool() const noexcept { return true; }
   void setMemoryPool(std::shared_ptr<BoundedMemoryResource> pool) { mMemoryPool = pool; }
 
-  static VertexLabel computeMain(const bounded_vector<o2::MCCompLabel>& elements)
-  {
-    // we only care about the source&event of the tracks, not the trackId
-    auto composeVtxLabel = [](const o2::MCCompLabel& lbl) -> o2::MCCompLabel {
-      return {o2::MCCompLabel::maxTrackID(), lbl.getEventID(), lbl.getSourceID(), lbl.isFake()};
-    };
-    std::unordered_map<o2::MCCompLabel, size_t> frequency;
-    for (const auto& element : elements) {
-      ++frequency[composeVtxLabel(element)];
-    }
-    o2::MCCompLabel elem{};
-    size_t maxCount = 0;
-    for (const auto& [key, count] : frequency) {
-      if (count > maxCount) {
-        maxCount = count;
-        elem = key;
-      }
-    }
-    if (maxCount <= 1) { // need >50%
-      elem.setFakeFlag();
-    }
-    return std::make_pair(elem, static_cast<float>(maxCount) / static_cast<float>(elements.size()));
-  }
-
  protected:
   std::vector<VertexingParameters> mVrtParams;
   IndexTableUtilsN mIndexTableUtils;

--- a/Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
@@ -16,47 +16,52 @@
 namespace o2::its
 {
 
-Line::Line(const Tracklet& tracklet, const Cluster* innerClusters, const Cluster* outerClusters) : mTime(tracklet.mTime)
+Line::Line(const Tracklet& tracklet, const Cluster* innerClusters, const Cluster* outerClusters)
 {
   const auto& inner = innerClusters[tracklet.firstClusterIndex];
   const auto& outer = outerClusters[tracklet.secondClusterIndex];
 
-  originPoint = SVector3f(inner.xCoordinate, inner.yCoordinate, inner.zCoordinate);
-  cosinesDirector = SVector3f(outer.xCoordinate - inner.xCoordinate,
+  const float origin[3] = {inner.xCoordinate, inner.yCoordinate, inner.zCoordinate};
+  const float direction[3] = {outer.xCoordinate - inner.xCoordinate,
                               outer.yCoordinate - inner.yCoordinate,
-                              outer.zCoordinate - inner.zCoordinate);
-  cosinesDirector /= std::sqrt(ROOT::Math::Dot(cosinesDirector, cosinesDirector));
-}
-
-float Line::getDistance2FromPoint(const Line& line, const std::array<float, 3>& point)
-{
-  const SVector3f p(point.data(), 3);
-  const SVector3f delta = p - line.originPoint;
-  const float proj = ROOT::Math::Dot(delta, line.cosinesDirector);
-  const SVector3f residual = delta - proj * line.cosinesDirector;
-  return ROOT::Math::Dot(residual, residual);
+                              outer.zCoordinate - inner.zCoordinate};
+  *this = Line(origin, direction, tracklet.mTime);
 }
 
 float Line::getDistanceFromPoint(const Line& line, const std::array<float, 3>& point)
 {
-  return std::sqrt(getDistance2FromPoint(line, point));
+  return std::sqrt(getDistance2FromPoint(line, point.data()));
 }
 
 float Line::getDCA2(const Line& firstLine, const Line& secondLine, const float precision)
 {
-  const SVector3f n = ROOT::Math::Cross(firstLine.cosinesDirector, secondLine.cosinesDirector);
-  const float norm2 = ROOT::Math::Dot(n, n);
+  const auto& a = firstLine.cosinesDirector;
+  const auto& b = secondLine.cosinesDirector;
+  const float n[3] = {a[1] * b[2] - a[2] * b[1],
+                      a[2] * b[0] - a[0] * b[2],
+                      a[0] * b[1] - a[1] * b[0]};
+  const float norm2 = n[0] * n[0] + n[1] * n[1] + n[2] * n[2];
+
+  float d[3];
+  for (int i = 0; i < 3; ++i) {
+    d[i] = secondLine.originPoint[i] - firstLine.originPoint[i];
+  }
 
   if (norm2 <= precision * precision) {
     // lines are parallel, fall back to point-to-line distance
-    const SVector3f d = secondLine.originPoint - firstLine.originPoint;
-    const float proj = ROOT::Math::Dot(d, firstLine.cosinesDirector);
-    const SVector3f residual = d - proj * firstLine.cosinesDirector;
-    return ROOT::Math::Dot(residual, residual);
+    float proj = 0.f;
+    for (int i = 0; i < 3; ++i) {
+      proj += d[i] * a[i];
+    }
+    float res2 = 0.f;
+    for (int i = 0; i < 3; ++i) {
+      const float residual = d[i] - proj * a[i];
+      res2 += residual * residual;
+    }
+    return res2;
   }
 
-  const SVector3f delta = secondLine.originPoint - firstLine.originPoint;
-  const float numerator = ROOT::Math::Dot(delta, n);
+  const float numerator = d[0] * n[0] + d[1] * n[1] + d[2] * n[2];
   return (numerator * numerator) / norm2;
 }
 
@@ -65,153 +70,44 @@ float Line::getDCA(const Line& firstLine, const Line& secondLine, const float pr
   return std::sqrt(getDCA2(firstLine, secondLine, precision));
 }
 
-Line::SMatrix3f Line::getDCAComponents(const Line& line, const std::array<float, 3>& point)
-{
-  const SVector3f p(point.data(), 3);
-  const SVector3f delta = line.originPoint - p;
-  const float proj = ROOT::Math::Dot(line.cosinesDirector, delta);
-  const SVector3f residual = delta - proj * line.cosinesDirector;
-
-  // symmetric 3x3: diagonal = residual components, off-diagonal = 2D projected distances
-  SMatrix3f m;
-  m(0, 0) = residual(0);
-  m(1, 1) = residual(1);
-  m(2, 2) = residual(2);
-  m(0, 1) = std::hypot(m(0, 0), m(1, 1));
-  m(0, 2) = std::hypot(m(0, 0), m(2, 2));
-  m(1, 2) = std::hypot(m(1, 1), m(2, 2));
-  return m;
-}
-
-bool Line::isEmpty() const noexcept
-{
-  return ROOT::Math::Dot(originPoint, originPoint) == 0.f &&
-         ROOT::Math::Dot(cosinesDirector, cosinesDirector) == 0.f;
-}
-
 void Line::print() const
 {
   LOGP(info, "\tLine: originPoint = ({}, {}, {}), cosinesDirector = ({}, {}, {}) ts={}+-{}",
-       originPoint(0), originPoint(1), originPoint(2),
-       cosinesDirector(0), cosinesDirector(1), cosinesDirector(2),
+       originPoint[0], originPoint[1], originPoint[2],
+       cosinesDirector[0], cosinesDirector[1], cosinesDirector[2],
        mTime.getTimeStamp(), mTime.getTimeStampError());
 }
 
-// Accumulate the weighted normal equation contributions (A matrix and B vector)
-// from a single line into the running sums. The covariance is assumed to be
-// diagonal and uniform ({1,1,1}) so the weights simplify accordingly.
-// The A matrix entry (i,j) = (delta_ij - d_i*d_j) / det, and the B vector
-// entry b_i = sum_j d_j*(d_j*o_i - d_i*o_j) / det, where d = cosinesDirector
-// and o = originPoint.
-void ClusterLines::accumulate(const Line& line)
+ClusterLines::ClusterLines(gsl::span<const int> lineIndices, gsl::span<const Line> lines)
 {
-  const ROOT::Math::SVector<double, 3> d(line.cosinesDirector(0), line.cosinesDirector(1), line.cosinesDirector(2));
-  const ROOT::Math::SVector<double, 3> o(line.originPoint(0), line.originPoint(1), line.originPoint(2));
-
-  // == 1 for normalised directors, kept for generality
-  const double det = ROOT::Math::Dot(d, d);
-
-  // A matrix (symmetric): A_ij = (delta_ij * |d|^2 - d_i * d_j) / det
-  for (int i = 0; i < 3; ++i) {
-    for (int j = i; j < 3; ++j) {
-      mAMatrix(i, j) += ((i == j ? det : 0.) - d(i) * d(j)) / det;
-    }
-  }
-
-  // B vector: b_i = (d_i * dot(d,o) - |d|^2 * o_i) / det
-  const double dDotO = ROOT::Math::Dot(d, o);
-  for (int i = 0; i < 3; ++i) {
-    mBMatrix(i) += (d(i) * dDotO - det * o(i)) / det;
-  }
-}
-
-ClusterLines::ClusterLines(const int firstLabel, const Line& firstLine, const int secondLabel, const Line& secondLine) : mTime(firstLine.mTime)
-{
-  mTime += secondLine.mTime;
-
-  mLabels.push_back(firstLabel);
-  if (secondLabel > 0) {
-    mLabels.push_back(secondLabel); // don't add info in case of beamline used
-  }
-
-  accumulate(firstLine);
-  accumulate(secondLine);
-  computeClusterCentroid();
-
-  // RMS2: running mean update
-  mRMS2 = Line::getDCAComponents(firstLine, mVertex);
-  const auto tmpRMS2 = Line::getDCAComponents(secondLine, mVertex);
-  mRMS2 += (tmpRMS2 - mRMS2) * (1.f / static_cast<float>(getSize()));
-
-  // AvgDistance2
-  mAvgDistance2 = Line::getDistance2FromPoint(firstLine, mVertex);
-  mAvgDistance2 += (Line::getDistance2FromPoint(secondLine, mVertex) - mAvgDistance2) / (float)getSize();
-}
-
-ClusterLines::ClusterLines(gsl::span<const int> lineLabels, gsl::span<const Line> lines)
-{
-  if (lineLabels.size() < 2) {
+  if (lineIndices.size() < 2) {
     return;
   }
-
-  mLabels.reserve(lineLabels.size());
-  mTime = lines[lineLabels[0]].mTime;
-  for (size_t index = 0; index < lineLabels.size(); ++index) {
-    const auto lineLabel = lineLabels[index];
-    if (index > 0) {
-      mTime += lines[lineLabel].mTime;
-    }
-    mLabels.push_back(lineLabel);
-    accumulate(lines[lineLabel]);
+  for (const auto idx : lineIndices) {
+    add(lines[idx]);
   }
-
   computeClusterCentroid();
   if (!mIsValid) {
     return;
   }
-
-  mRMS2 = Line::getDCAComponents(lines[lineLabels[0]], mVertex);
-  mAvgDistance2 = Line::getDistance2FromPoint(lines[lineLabels[0]], mVertex);
-  for (size_t index = 1; index < lineLabels.size(); ++index) {
-    const auto lineLabel = lineLabels[index];
-    const auto tmpRMS2 = Line::getDCAComponents(lines[lineLabel], mVertex);
-    mRMS2 += (tmpRMS2 - mRMS2) * (1.f / static_cast<float>(index + 1));
-    mAvgDistance2 += (Line::getDistance2FromPoint(lines[lineLabel], mVertex) - mAvgDistance2) / static_cast<float>(index + 1);
+  for (const auto idx : lineIndices) {
+    addResidual(lines[idx]);
   }
-}
-
-void ClusterLines::add(const int lineLabel, const Line& line)
-{
-  mTime += line.mTime;
-  mLabels.push_back(lineLabel);
-
-  accumulate(line);
-  computeClusterCentroid();
-  mAvgDistance2 += (Line::getDistance2FromPoint(line, mVertex) - mAvgDistance2) / (float)getSize();
-}
-
-void ClusterLines::computeClusterCentroid()
-{
-  // Solve the 3x3 symmetric linear system AX = -B using SMatrix inversion.
-  // Invert() returns false if the matrix is singular or ill-conditioned.
-  SMatrix3 invA{mAMatrix};
-  mIsValid = invA.Invert();
-  if (!mIsValid) {
-    return;
-  }
-
-  SVector3 result = invA * mBMatrix;
-  mVertex[0] = static_cast<float>(-result(0));
-  mVertex[1] = static_cast<float>(-result(1));
-  mVertex[2] = static_cast<float>(-result(2));
 }
 
 bool ClusterLines::operator==(const ClusterLines& rhs) const noexcept
 {
-  return mRMS2 == rhs.mRMS2 &&
-         mVertex == rhs.mVertex &&
-         mLabels == rhs.mLabels &&
-         mAvgDistance2 == rhs.mAvgDistance2;
+  for (int i = 0; i < 6; ++i) {
+    if (mRMS2[i] != rhs.mRMS2[i]) {
+      return false;
+    }
+  }
+  for (int i = 0; i < 3; ++i) {
+    if (mVertex[i] != rhs.mVertex[i]) {
+      return false;
+    }
+  }
+  return mNContributors == rhs.mNContributors && mAvgDistance2 == rhs.mAvgDistance2;
 }
 
 } // namespace o2::its

--- a/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Configuration.cxx
@@ -284,6 +284,71 @@ std::vector<TrackingParameters> TrackingMode::getTrackingParameters(TrackingMode
     trackParams.resize(tc.nIterations);
   }
 
+  if (tc.seedingVertexIteration && !trackParams.empty()) {
+    const auto& vc = o2::its::VertexerParamConfig::Instance();
+    TrackingParameters seedingPass = trackParams.front();
+    seedingPass.PassFlags = IterationSteps{IterationStep::FirstPass, IterationStep::RebuildClusterLUT,
+                                           IterationStep::ResetVertices, IterationStep::SeedingVertexPass};
+    seedingPass.PerPrimaryVertexProcessing = false;
+    seedingPass.UseDiamond = true;  // PV-independent
+    seedingPass.NLayers = 3;        // 3-layer {0,1,2} vertexing topology
+    seedingPass.MinTrackLength = 3; // only trackleting+celling on the 3 inner layers
+    seedingPass.ZBins = vc.ZBins;
+    seedingPass.PhiBins = vc.PhiBins;
+    seedingPass.Diamond[0] = tc.diamondPos[0];
+    seedingPass.Diamond[1] = tc.diamondPos[1];
+    seedingPass.Diamond[2] = tc.diamondPos[2];
+    seedingPass.NSigmaCut = tc.diamondTrackletingNSigmaCut;
+    seedingPass.PVres = tc.diamondTrackletingPVres;
+    seedingPass.CellDeltaTanLambdaSigma = tc.diamondTrackletingCellDeltaTanLambdaSigma;
+    seedingPass.CellDeltaTanLambdaNSigma = tc.diamondCellTanLambdaNSigma;
+    seedingPass.CellDeltaPhiMinPt = tc.diamondTrackletingCellDeltaPhiMinPt;
+    seedingPass.CellLineSharedClusterCut = tc.cellLineSharedClusterCut;
+    seedingPass.VertPerRofThreshold = vc.vertPerRofThreshold;
+    seedingPass.VtxPhiCut = vc.phiCut;
+    seedingPass.VtxLineMinPt = vc.lineMinPt;
+    seedingPass.VtxMaxZPositionAllowed = vc.maxZPositionAllowed;
+    seedingPass.VtxClusterCut = vc.clusterCut;
+    seedingPass.VtxPairCut = vc.pairCut;
+    seedingPass.VtxNSigmaCut = vc.nSigmaCut;
+    seedingPass.VtxDuplicateZCut = vc.duplicateZCut;
+    seedingPass.VtxDuplicateZScale = vc.duplicateZScale;
+    seedingPass.VtxFineZWindow = vc.fineZWindow;
+    seedingPass.VtxFineMinDensity = vc.fineMinDensity;
+    seedingPass.VtxFineMaxDrift = vc.fineMaxDrift;
+    seedingPass.VtxGoodLineChi2Cut = vc.goodLineChi2Cut;
+    seedingPass.VtxGoodLinePtCut = vc.goodLinePtCut;
+    seedingPass.VtxGoodContributorsSignificance = vc.goodContributorsSignificance;
+    seedingPass.VtxClusterContributorsCut = vc.clusterContributorsCut;
+    seedingPass.VtxSuppressLowMultDebris = vc.suppressLowMultDebris;
+    std::vector<TrackingParameters> seedingPasses;
+    seedingPasses.push_back(seedingPass);
+
+    if (tc.doUPCIteration) {
+      TrackingParameters upcPass = seedingPass;
+      upcPass.PassFlags = IterationSteps{IterationStep::FirstPass,
+                                         IterationStep::RebuildClusterLUT,
+                                         IterationStep::SeedingVertexPass,
+                                         IterationStep::SkipROFsAboveThreshold,
+                                         IterationStep::MarkVerticesAsUPC};
+      upcPass.VtxClusterContributorsCut = 2;
+      upcPass.VtxSuppressLowMultDebris = 0;
+      seedingPasses.push_back(upcPass);
+    }
+
+    trackParams.insert(trackParams.begin(), seedingPasses.begin(), seedingPasses.end());
+  }
+
+  if (!trackParams.empty()) {
+    trackParams.front().PassFlags.set(IterationStep::LoadPersistentTables);
+  }
+
+  if (trackParams.size() > static_cast<size_t>(constants::MaxIter + constants::MaxSeedingPasses)) {
+    LOGP(fatal, "{} tracking passes configured, but at most {} are supported (MaxIter={} + MaxSeedingPasses={})",
+         trackParams.size(), constants::MaxIter + constants::MaxSeedingPasses,
+         constants::MaxIter, constants::MaxSeedingPasses);
+  }
+
   return trackParams;
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/LineVertexerHelpers.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/LineVertexerHelpers.cxx
@@ -53,11 +53,11 @@ struct LineRef {
     const auto symTime = line.mTime.makeSymmetrical();
     tCenter = symTime.getTimeStamp();
     tHalfWidth = symTime.getTimeStampError();
-    const auto dx = line.originPoint(0) - beamX;
-    const auto dy = line.originPoint(1) - beamY;
-    const auto ux = line.cosinesDirector(0);
-    const auto uy = line.cosinesDirector(1);
-    const auto uz = line.cosinesDirector(2);
+    const auto dx = line.originPoint[0] - beamX;
+    const auto dy = line.originPoint[1] - beamY;
+    const auto ux = line.cosinesDirector[0];
+    const auto uy = line.cosinesDirector[1];
+    const auto uz = line.cosinesDirector[2];
     const auto den = math_utils::SqSum(ux, uy);
     if (den <= constants::Tolerance) {
       lineIndex = constants::UnusedIndex;
@@ -66,7 +66,7 @@ struct LineRef {
     const auto s0 = -((dx * ux) + (dy * uy)) / den;
     const auto xb = dx + (s0 * ux);
     const auto yb = dy + (s0 * uy);
-    zBeam = line.originPoint(2) + s0 * uz;
+    zBeam = line.originPoint[2] + s0 * uz;
     if (!std::isfinite(zBeam) || o2::gpu::CAMath::Abs(zBeam) > maxZ) {
       lineIndex = constants::UnusedIndex;
     }
@@ -403,20 +403,20 @@ class VertexFit
   {
     const auto& direction = line.cosinesDirector;
     const auto& origin = line.originPoint;
-    const auto det = ROOT::Math::Dot(direction, direction);
+    const auto det = direction[0] * direction[0] + direction[1] * direction[1] + direction[2] * direction[2];
     if (det <= constants::Tolerance) {
       return;
     }
 
     for (int i = 0; i < 3; ++i) {
       for (int j = i; j < 3; ++j) {
-        mMatrix(i, j) += weight * (((i == j ? det : 0.f) - direction(i) * direction(j)) / det);
+        mMatrix(i, j) += weight * (((i == j ? det : 0.f) - direction[i] * direction[j]) / det);
       }
     }
 
-    const auto dDotO = ROOT::Math::Dot(direction, origin);
+    const auto dDotO = direction[0] * origin[0] + direction[1] * origin[1] + direction[2] * origin[2];
     for (int i = 0; i < 3; ++i) {
-      mRhs(i) += weight * ((direction(i) * dDotO - det * origin(i)) / det);
+      mRhs(i) += weight * ((direction[i] * dDotO - det * origin[i]) / det);
     }
   }
 
@@ -934,10 +934,10 @@ void assignLinesToSeeds(bounded_vector<VertexSeed>& seeds,
   }
 }
 
-ClusterLines materializeCluster(const VertexSeed& seed,
-                                std::span<const LineRef> lineRefs,
-                                std::span<const Line> lines,
-                                const std::shared_ptr<BoundedMemoryResource>& mr)
+ClusterWithLines materializeCluster(const VertexSeed& seed,
+                                    std::span<const LineRef> lineRefs,
+                                    std::span<const Line> lines,
+                                    const std::shared_ptr<BoundedMemoryResource>& mr)
 {
   bounded_vector<int> lineIndices{mr.get()};
   lineIndices.reserve(seed.contributors.size());
@@ -948,17 +948,18 @@ ClusterLines materializeCluster(const VertexSeed& seed,
   lineIndices.erase(std::unique(lineIndices.begin(), lineIndices.end()), lineIndices.end());
 
   if (lineIndices.size() < 2) {
-    return {};
+    return {ClusterLines{}, bounded_vector<int>{mr.get()}};
   }
 
-  return {std::span<const int>{lineIndices.data(), lineIndices.size()}, lines};
+  ClusterLines fit{std::span<const int>{lineIndices.data(), lineIndices.size()}, lines};
+  return {std::move(fit), std::move(lineIndices)};
 }
 
 } // namespace
 
-bounded_vector<ClusterLines> buildClusters(std::span<const Line> lines, const Settings& settings)
+bounded_vector<ClusterWithLines> buildClusters(std::span<const Line> lines, const Settings& settings)
 {
-  bounded_vector<ClusterLines> clusters(settings.memoryPool.get());
+  bounded_vector<ClusterWithLines> clusters(settings.memoryPool.get());
   if (lines.size() < 2) {
     return clusters;
   }
@@ -1020,10 +1021,10 @@ bounded_vector<ClusterLines> buildClusters(std::span<const Line> lines, const Se
     deduplicateRefittedSeeds(seeds, settings);
     for (auto& refit : seeds) {
       auto cluster = materializeCluster(refit, refs, lines, settings.memoryPool);
-      if (cluster.getSize() < 2) {
+      if (cluster.fit.getSize() < 2) {
         continue;
       }
-      if (!cluster.isValid()) {
+      if (!cluster.fit.isValid()) {
         continue;
       }
       clusters.push_back(std::move(cluster));

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -191,6 +191,17 @@ void TimeFrame<NLayers>::prepareROFrameData(gsl::span<const itsmft::CompClusterE
 }
 
 template <int NLayers>
+void TimeFrame<NLayers>::allocateClusterSortStorage(const TrackingParameters& trkParam, const int maxLayers)
+{
+  for (unsigned int iLayer{0}; iLayer < std::min((int)mClusters.size(), maxLayers); ++iLayer) {
+    clearResizeBoundedVector(mClusters[iLayer], mUnsortedClusters[iLayer].size(), getMaybeFrameworkHostResource(maxLayers != NLayers));
+  }
+  for (int iLayer{0}; iLayer < NLayers; ++iLayer) {
+    clearResizeBoundedVector(mIndexTables[iLayer], getNrof(iLayer) * ((trkParam.ZBins * trkParam.PhiBins) + 1), getMaybeFrameworkHostResource());
+  }
+}
+
+template <int NLayers>
 void TimeFrame<NLayers>::prepareClusters(const TrackingParameters& trkParam, const int maxLayers)
 {
   const int numBins{trkParam.PhiBins * trkParam.ZBins};
@@ -304,6 +315,7 @@ void TimeFrame<NLayers>::initialise(const TrackingParameters& trkParam, const in
     deepVectorClear(mTracks);
     deepVectorClear(mTracksLabel);
     deepVectorClear(mLines);
+    deepVectorClear(mLinesQuality);
     deepVectorClear(mLinesLabels);
     if (trkParam.PassFlags[IterationStep::ResetVertices]) {
       deepVectorClear(mPrimaryVertices);
@@ -311,26 +323,26 @@ void TimeFrame<NLayers>::initialise(const TrackingParameters& trkParam, const in
     }
     clearResizeBoundedVector(mLinesLabels, getNrof(1), mMemoryPool.get());
     mIndexTableUtils.setTrackingParameters(trkParam);
-    clearResizeBoundedVector(mPositionResolution, trkParam.NLayers, mMemoryPool.get());
-    clearResizeBoundedVector(mBogusClusters, trkParam.NLayers, mMemoryPool.get());
+    clearResizeBoundedVector(mPositionResolution, NLayers, mMemoryPool.get());
+    clearResizeBoundedVector(mBogusClusters, NLayers, mMemoryPool.get());
     deepVectorClear(mTrackletClusters);
     for (unsigned int iLayer{0}; iLayer < std::min((int)mClusters.size(), maxLayers); ++iLayer) {
-      clearResizeBoundedVector(mClusters[iLayer], mUnsortedClusters[iLayer].size(), getMaybeFrameworkHostResource(maxLayers != NLayers));
       clearResizeBoundedVector(mUsedClusters[iLayer], mUnsortedClusters[iLayer].size(), getMaybeFrameworkHostResource(maxLayers != NLayers));
       mPositionResolution[iLayer] = o2::gpu::CAMath::Sqrt((0.5f * (trkParam.SystErrorZ2[iLayer] + trkParam.SystErrorY2[iLayer])) + (trkParam.LayerResolution[iLayer] * trkParam.LayerResolution[iLayer]));
     }
     clearResizeBoundedVector(mLines, getNrof(1), mMemoryPool.get());
+    clearResizeBoundedVector(mLinesQuality, getNrof(1), mMemoryPool.get());
     clearResizeBoundedVector(mTrackletClusters, getNrof(1), mMemoryPool.get());
-
-    for (int iLayer{0}; iLayer < NLayers; ++iLayer) {
-      clearResizeBoundedVector(mIndexTables[iLayer], getNrof(iLayer) * ((trkParam.ZBins * trkParam.PhiBins) + 1), getMaybeFrameworkHostResource());
-    }
-    for (int iLayer{0}; iLayer < trkParam.NLayers; ++iLayer) {
-      if (trkParam.SystErrorY2[iLayer] > 0.f || trkParam.SystErrorZ2[iLayer] > 0.f) {
-        for (auto& tfInfo : mTrackingFrameInfo[iLayer]) {
-          /// Account for alignment systematics in the cluster covariance matrix
-          tfInfo.covarianceTrackingFrame[0] += trkParam.SystErrorY2[iLayer];
-          tfInfo.covarianceTrackingFrame[2] += trkParam.SystErrorZ2[iLayer];
+    allocateClusterSortStorage(trkParam, maxLayers);
+    // Applied by the only FirstPass pass that covers every layer (tracking iteration 0).
+    // The 3-layer seeding passes must be excluded: they run first and would otherwise apply this to layers 0..2 only
+    if (trkParam.NLayers == NLayers) {
+      for (int iLayer{0}; iLayer < trkParam.NLayers; ++iLayer) {
+        if (trkParam.SystErrorY2[iLayer] > 0.f || trkParam.SystErrorZ2[iLayer] > 0.f) {
+          for (auto& tfInfo : mTrackingFrameInfo[iLayer]) {
+            tfInfo.covarianceTrackingFrame[0] += trkParam.SystErrorY2[iLayer];
+            tfInfo.covarianceTrackingFrame[2] += trkParam.SystErrorZ2[iLayer];
+          }
         }
       }
     }
@@ -352,6 +364,10 @@ void TimeFrame<NLayers>::initialise(const TrackingParameters& trkParam, const in
   mNTrackletsPerROF.resize(2);
   for (auto& v : mNTrackletsPerROF) {
     v = bounded_vector<int>(getNrof(1) + 1, 0, mMemoryPool.get());
+  }
+  for (int i = 0; i < 2; ++i) {
+    mNTrackletsPerCluster[i].assign(mUnsortedClusters[1].size(), 0);
+    mNTrackletsPerClusterSum[i].assign(mUnsortedClusters[1].size() + 1, 0);
   }
   if (trkParam.PassFlags[IterationStep::RebuildClusterLUT]) {
     prepareClusters(trkParam, maxLayers);
@@ -529,6 +545,7 @@ void TimeFrame<NLayers>::wipe()
   deepVectorClear(mTrackletsIndexROF);
   deepVectorClear(mTrackletClusters);
   deepVectorClear(mLines);
+  deepVectorClear(mLinesQuality);
   // if we use the external host allocator then the assumption is that we
   // don't clear the memory ourself
   if (!hasFrameworkAllocator()) {

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -36,6 +36,77 @@ Tracker<NLayers>::Tracker(TrackerTraits<NLayers>* traits) : mTraits(traits)
 }
 
 template <int NLayers>
+float Tracker<NLayers>::clustersToVertices(const LogFunc& logger)
+{
+  mTraits->updateTrackingParameters(mTrkParams);
+  // The seeding-vertex passes are prepended to mTrkParams so they occupy [0, nSeedingPasses)
+  int nSeedingPasses{0};
+  while (nSeedingPasses < (int)mTrkParams.size() &&
+         mTrkParams[nSeedingPasses].PassFlags[IterationStep::SeedingVertexPass]) {
+    ++nSeedingPasses;
+  }
+  if (nSeedingPasses == 0) {
+    return 0.f;
+  }
+  logger(std::format("==== ITS {} Seeding-vertex pass ====", mTraits->getName()));
+  float total{0.f};
+  for (int it = 0; it < nSeedingPasses; ++it) {
+    mMemoryPool->setMaxMemory(mTrkParams[it].MaxMemory);
+    const bool bootstrapBeam = !mTimeFrame->isBeamOverridden();
+    const int maxBootstrap = (it == 0 && bootstrapBeam) ? constants::MaxBootstrapPasses : 1;
+    if (it > 0) {
+      ROFMaskTable<NLayers> upcMask{mTimeFrame->getROFOverlapTable()};
+      const auto& vtxLookup = mTimeFrame->getROFVertexLookupTableView();
+      const int threshold = mTrkParams[it].VertPerRofThreshold;
+      int nEnabled = 0, nTotal = 0;
+      for (int layer = 0; layer < NLayers; ++layer) {
+        const int nRofs = mTimeFrame->getROFOverlapTableView().getLayer(layer).mNROFsTF;
+        for (int rof = 0; rof < nRofs; ++rof) {
+          // Same predicate as skipROF(), applied earlier.
+          const bool empty = (int)vtxLookup.getVertices(layer, rof).getEntries() <= threshold;
+          upcMask.setROFEnabled(layer, rof, empty ? 1u : 0u);
+          if (layer == 1) {
+            nTotal++;
+            nEnabled += empty;
+          }
+        }
+      }
+      mTimeFrame->setSeedingUPCMask(std::move(upcMask));
+      mTimeFrame->useSeedingUPCMask();
+      logger(std::format(" - Seeding pass {}: UPC pass on {}/{} ROFs without vertices",
+                         it, nEnabled, nTotal));
+    }
+    for (int pass = 0; pass < maxBootstrap; ++pass) {
+      const float prevBeamX = mTimeFrame->getBeamX();
+      const float prevBeamY = mTimeFrame->getBeamY();
+      total += evaluateTask(&Tracker::initialiseTimeFrame, StateNames[mCurStep = TFInit], it, logger, it);
+      total += evaluateTask(&Tracker::computeTracklets, StateNames[mCurStep = Trackleting], it, logger, it, -1);
+      const int nTracklets = mTraits->getTFNumberOfTracklets();
+      total += evaluateTask(&Tracker::computeCells, StateNames[mCurStep = Celling], it, logger, it);
+      total += evaluateTask(&Tracker::computeVertexCandidates, StateNames[mCurStep = CellLinearising], it, logger, it);
+      logger(std::format(" - Seeding pass {}.{}: {} tracklets, {} cells, {} lines", it, pass,
+                         nTracklets, mTraits->getTFNumberOfCells(),
+                         mTimeFrame->getNLinesTotal()));
+      total += evaluateTask(&Tracker::computeVertices, StateNames[mCurStep = SeedingVertices], it, logger, it);
+      if (it > 0 || !bootstrapBeam) {
+        continue;
+      }
+      total += evaluateTask(&Tracker::computeBeamFromVertices, StateNames[mCurStep = BeamPositioning], it, logger, it);
+      const float dx = mTimeFrame->getBeamX() - prevBeamX;
+      const float dy = mTimeFrame->getBeamY() - prevBeamY;
+      if (dx * dx + dy * dy < constants::BeamConvergence2) {
+        logger(std::format(" - Beam bootstrap converged after pass {} (beam shift < 50 um)", pass));
+        break;
+      }
+    }
+  }
+  if (nSeedingPasses > 1) {
+    mTimeFrame->useMultiplictyMask();
+  }
+  return total;
+}
+
+template <int NLayers>
 float Tracker<NLayers>::clustersToTracks(const LogFunc& logger, const LogFunc& error)
 {
   LogFunc evalLog = [](const std::string&) {};
@@ -44,11 +115,16 @@ float Tracker<NLayers>::clustersToTracks(const LogFunc& logger, const LogFunc& e
   mTraits->updateTrackingParameters(mTrkParams);
 
   int maxNvertices{-1};
-  if (mTrkParams[0].PerPrimaryVertexProcessing) {
+  int firstTrackingIteration{0};
+  while (firstTrackingIteration < (int)mTrkParams.size() &&
+         mTrkParams[firstTrackingIteration].PassFlags[IterationStep::SeedingVertexPass]) {
+    ++firstTrackingIteration;
+  }
+  if (firstTrackingIteration < (int)mTrkParams.size() && mTrkParams[firstTrackingIteration].PerPrimaryVertexProcessing) {
     maxNvertices = mTimeFrame->getROFVertexLookupTableView().getMaxVerticesPerROF();
   }
 
-  int iteration{0}, iVertex{0};
+  int iteration{firstTrackingIteration}, iVertex{0};
   auto handleException = [&](const auto& err) {
     if (mTrkParams[iteration].MaxMemory == std::numeric_limits<size_t>::max()) {
       LOGP(error, "Allocation failed in {} in iteration {} iVtx={} ({:.2f} GB of host artefacts, no host limit set), check the detector status and/or the selections.",
@@ -75,7 +151,7 @@ float Tracker<NLayers>::clustersToTracks(const LogFunc& logger, const LogFunc& e
   };
 
   try {
-    for (iteration = 0; iteration < (int)mTrkParams.size(); ++iteration) {
+    for (iteration = firstTrackingIteration; iteration < (int)mTrkParams.size(); ++iteration) {
       mMemoryPool->setMaxMemory(mTrkParams[iteration].MaxMemory);
       if (mTrkParams[iteration].PassFlags[IterationStep::UseUPCMask]) {
         mTimeFrame->useUPCMask();

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -15,7 +15,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdlib>
+#include <bit>
 #include <iterator>
+#include <limits>
 #include <mutex>
 #include <ranges>
 #include <cmath>
@@ -31,16 +34,19 @@
 #include "DetectorsBase/Propagator.h"
 #include "GPUCommonMath.h"
 #include "ITSMFTTracking/BoundedAllocator.h"
+#include "ITSMFTTracking/MathUtils.h"
 #include "ITStracking/Cell.h"
 #include "ITSMFTTracking/Constants.h"
 #include "ITStracking/IndexTableUtils.h"
 #include "ITStracking/LayerMask.h"
+#include "ITStracking/LineProjection.h"
 #include "ITSMFTTracking/ROFLookupTables.h"
 #include "ITSMFTTracking/SlabBumpAllocator.h"
 #include "ITStracking/TrackerTraits.h"
 #include "ITStracking/TrackFollower.h"
 #include "ITStracking/TrackHelpers.h"
 #include "ITStracking/Tracklet.h"
+#include "ITSMFTTracking/ITSTrackingConfigParam.h"
 
 namespace o2::its
 {
@@ -62,6 +68,8 @@ template <int NLayers>
 void TrackerTraits<NLayers>::computeLayerTracklets(const int iteration, int iVertex)
 {
   const auto topology = mTimeFrame->getTrackingTopologyView();
+  const bool vtxMode = mTrkParams[iteration].PassFlags[IterationStep::SeedingVertexPass];
+
   const Vertex diamondVert(mTrkParams[iteration].Diamond, mTrkParams[iteration].DiamondCov, 1, 1.f);
   gsl::span<const Vertex> diamondSpan(&diamondVert, 1);
 
@@ -99,7 +107,7 @@ void TrackerTraits<NLayers>::computeLayerTracklets(const int iteration, int iVer
       }
 
       const float meanDeltaR = mTrkParams[iteration].LayerRadii[link.toLayer] - mTrkParams[iteration].LayerRadii[link.fromLayer];
-      const float phiCut = mTimeFrame->getLinkPhiCut(linkId);
+      const float phiCut = vtxMode ? mTrkParams[iteration].VtxPhiCut : mTimeFrame->getLinkPhiCut(linkId);
       const float msAngle = mTimeFrame->getLinkMSAngle(linkId);
 
       for (int iCluster = 0; iCluster < int(layer0.size()); ++iCluster) {
@@ -112,7 +120,7 @@ void TrackerTraits<NLayers>::computeLayerTracklets(const int iteration, int iVer
 
         for (int iV = startVtx; iV < endVtx; ++iV) {
           const auto& pv = primaryVertices[iV];
-          if (!mTimeFrame->getROFVertexLookupTableView().isVertexCompatible(link.fromLayer, pivotROF, pv)) {
+          if (!vtxMode && !mTimeFrame->getROFVertexLookupTableView().isVertexCompatible(link.fromLayer, pivotROF, pv)) {
             continue;
           }
           if (pv.isFlagSet(Vertex::Flags::UPCMode) != mTrkParams[iteration].PassFlags[IterationStep::SelectUPCVertices]) {
@@ -144,7 +152,7 @@ void TrackerTraits<NLayers>::computeLayerTracklets(const int iteration, int iVer
               continue;
             }
             const auto ts = mTimeFrame->getROFOverlapTableView().getTimeStamp(link.fromLayer, pivotROF, link.toLayer, targetROF);
-            if (!ts.isCompatible(pv.getTimeStamp())) {
+            if (!vtxMode && !ts.isCompatible(pv.getTimeStamp())) {
               continue;
             }
             const auto& targetIndexTable = mTimeFrame->getIndexTable(targetROF, link.toLayer);
@@ -282,6 +290,515 @@ void TrackerTraits<NLayers>::computeLayerTracklets(const int iteration, int iVer
 }
 
 template <int NLayers>
+void TrackerTraits<NLayers>::computeVertexCandidates(const int iteration)
+{
+  const auto& cells = mTimeFrame->getCells()[0];
+  const bool withMC = mTimeFrame->hasMCinformation() && mTrkParams[iteration].CreateArtefactLabels;
+  const auto& cellLabels = mTimeFrame->getCellsLabel(0);
+  const auto nClusterLayer0 = mTimeFrame->getUnsortedClusters()[0].size();
+  const auto nClusterLayer1 = mTimeFrame->getUnsortedClusters()[1].size();
+  const auto nClusterLayer2 = mTimeFrame->getUnsortedClusters()[2].size();
+  const int nCells = static_cast<int>(cells.size());
+  const int keepThreshold = 3 - mTrkParams[iteration].CellLineSharedClusterCut;
+  const float maxZ = mTrkParams[iteration].VtxMaxZPositionAllowed;
+  const float lineMinPt = mTrkParams[iteration].VtxLineMinPt;
+  const float beamX = mTimeFrame->getBeamX();
+  const float beamY = mTimeFrame->getBeamY();
+  auto makeKey = [](float attribute, int cellIdx) -> size_t {
+    const uint32_t attributeInt = std::bit_cast<uint32_t>(attribute);
+    return (static_cast<size_t>(attributeInt) << 32) | static_cast<uint32_t>(cellIdx);
+  };
+
+  // Per-cell precompute (geometry, line, pivot ROF, label), indexed directly by cell id k.
+  bounded_vector<int> kCl0(nCells, 0, mMemoryPool.get());
+  bounded_vector<int> kCl1(nCells, 0, mMemoryPool.get());
+  bounded_vector<int> kCl2(nCells, 0, mMemoryPool.get());
+  bounded_vector<int> kPivotRof(nCells, 0, mMemoryPool.get());
+  bounded_vector<uint8_t> kGeomOk(nCells, 0, mMemoryPool.get());
+  bounded_vector<uint8_t> kProjOk(nCells, 0, mMemoryPool.get());
+  bounded_vector<Line> kLine(nCells, mMemoryPool.get());
+  bounded_vector<o2::MCCompLabel> kLabel(withMC ? nCells : 0, o2::MCCompLabel{}, mMemoryPool.get());
+  mTaskArena->execute([&] {
+    tbb::parallel_for(0, nCells, [&](const int k) {
+      const auto& cell = cells[k];
+      const int c1 = cell.getSecondClusterIndex();
+      kCl0[k] = cell.getFirstClusterIndex();
+      kCl1[k] = c1;
+      kCl2[k] = cell.getThirdClusterIndex();
+      std::array<float, 3> origin, direction;
+      cell.getXYZGlo(origin);
+      if (!cell.getPxPyPzGlo(direction)) {
+        return;
+      }
+      kGeomOk[k] = 1;
+      kLine[k] = Line(origin, direction, cell.getTimeStamp());
+      kPivotRof[k] = mTimeFrame->getClusterROF(1, c1);
+      const float dx = origin[0] - beamX;
+      const float dy = origin[1] - beamY;
+      const float den = direction[0] * direction[0] + direction[1] * direction[1];
+      kProjOk[k] = den >= constants::Tolerance &&
+                   o2::gpu::CAMath::Abs(origin[2] - (dx * direction[0] + dy * direction[1]) / den * direction[2]) < maxZ;
+      if (withMC) {
+        kLabel[k] = cellLabels[k];
+      }
+    });
+  });
+
+  bounded_vector<size_t> clusterOwnershipLayer0(nClusterLayer0, std::numeric_limits<size_t>::max(), mMemoryPool.get());
+  bounded_vector<size_t> clusterOwnershipLayer1(nClusterLayer1, std::numeric_limits<size_t>::max(), mMemoryPool.get());
+  bounded_vector<size_t> clusterOwnershipLayer2(nClusterLayer2, std::numeric_limits<size_t>::max(), mMemoryPool.get());
+  mTaskArena->execute([&] {
+    tbb::parallel_for(0, nCells, [&](const int k) {
+      if (!kGeomOk[k]) {
+        return;
+      }
+      const float pt = cells[k].getPt();
+      const size_t key = makeKey(pt > 1.e-6f ? 1.f / pt : 1.e9f, k);
+      o2::gpu::GPUCommonMath::AtomicMin(&clusterOwnershipLayer0[kCl0[k]], key);
+      o2::gpu::GPUCommonMath::AtomicMin(&clusterOwnershipLayer1[kCl1[k]], key);
+      o2::gpu::GPUCommonMath::AtomicMin(&clusterOwnershipLayer2[kCl2[k]], key);
+    });
+  });
+
+  bounded_vector<uint8_t> cellAccepted(nCells, 0, mMemoryPool.get());
+  mTaskArena->execute([&] {
+    tbb::parallel_for(0, nCells, [&](const int k) {
+      if (!kGeomOk[k]) {
+        return;
+      }
+      int nOwned = 0;
+      nOwned += static_cast<uint32_t>(clusterOwnershipLayer0[kCl0[k]]) == static_cast<uint32_t>(k);
+      nOwned += static_cast<uint32_t>(clusterOwnershipLayer1[kCl1[k]]) == static_cast<uint32_t>(k);
+      nOwned += static_cast<uint32_t>(clusterOwnershipLayer2[kCl2[k]]) == static_cast<uint32_t>(k);
+      const bool ptOk = lineMinPt <= 0.f || cells[k].getPt() >= lineMinPt;
+      cellAccepted[k] = (nOwned >= keepThreshold) && kProjOk[k] && ptOk ? 1 : 0;
+    });
+  });
+
+  int total{0};
+  for (int k = 0; k < nCells; ++k) {
+    if (!cellAccepted[k]) {
+      continue;
+    }
+    const int pivotRof = kPivotRof[k];
+    mTimeFrame->getLines(pivotRof).emplace_back(kLine[k]);
+    mTimeFrame->getLinesQuality(pivotRof).emplace_back(
+      LineQuality{cells[k].getChi2(), cells[k].getPt()});
+    if (withMC) {
+      mTimeFrame->getLinesLabel(pivotRof).emplace_back(kLabel[k]);
+    }
+    ++total;
+  }
+  mTimeFrame->setNLinesTotal(total);
+}
+
+namespace
+{
+// Per-line density: for each line, how many time-compatible lines fall inside its z-window
+void computeDensities(const bounded_vector<float>& Z,
+                      const bounded_vector<TimeEstBC>& T,
+                      const float zWindow,
+                      bounded_vector<LineWindow>& win,
+                      bounded_vector<int>& density)
+{
+  const int m = static_cast<int>(Z.size());
+  // Z is sorted, so the window bounds advance monotonically with k
+  int lo{0}, hi{0};
+  for (int k = 0; k < m; ++k) {
+    const float zk = Z[k];
+    while (lo < m && Z[lo] < zk - zWindow) {
+      ++lo;
+    }
+    while (hi < m && Z[hi] <= zk + zWindow) {
+      ++hi;
+    }
+    win[k] = LineWindow{lo, hi};
+    int count = 0;
+    for (int j = lo; j < hi; ++j) {
+      count += T[k].isCompatible(T[j]);
+    }
+    density[k] = count;
+  }
+}
+
+void markLeftmostMaxima(const bounded_vector<int>& density,
+                        const bounded_vector<LineWindow>& win,
+                        std::pmr::memory_resource* pool,
+                        bounded_vector<uint8_t>& isMax)
+{
+  const int m = static_cast<int>(density.size());
+  // Monotonic deque over the (monotonically advancing) windowsDetectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+  bounded_vector<int> maxDeque(m, pool);
+  int front{0}, back{0}, next{0};
+  for (int k = 0; k < m; ++k) {
+    while (next < win[k].hi) {
+      while (back > front && density[maxDeque[back - 1]] < density[next]) {
+        --back;
+      }
+      maxDeque[back++] = next++;
+    }
+    while (front < back && maxDeque[front] < win[k].lo) {
+      ++front;
+    }
+    isMax[k] = maxDeque[front] == k; // the window always contains k itself, so the deque is non-empty
+  }
+}
+} // namespace
+
+template <int NLayers>
+bool TrackerTraits<NLayers>::skipROF(int iteration, int rof) const
+{
+  return mTrkParams[iteration].PassFlags[IterationStep::SkipROFsAboveThreshold] &&
+         (int)mTimeFrame->getROFVertexLookupTableView().getVertices(1, rof).getEntries() >
+           mTrkParams[iteration].VertPerRofThreshold;
+}
+
+template <int NLayers>
+void TrackerTraits<NLayers>::computeBeamFromVertices(const int)
+{
+  if (mTimeFrame->isBeamOverridden()) {
+    return; // beam pinned externally
+  }
+  const auto& vertices = mTimeFrame->getPrimaryVertices();
+  double sx{0.}, sy{0.}, sw{0.};
+  for (const auto& v : vertices) {
+    const double w = static_cast<double>(v.getNContributors());
+    sx += w * v.getX();
+    sy += w * v.getY();
+    sw += w;
+  }
+  if (sw <= 0.) {
+    return;
+  }
+  const float bx = static_cast<float>(sx / sw);
+  const float by = static_cast<float>(sy / sw);
+  mTimeFrame->resetBeamXY(bx, by, static_cast<float>(sw));
+}
+
+template <int NLayers>
+void TrackerTraits<NLayers>::computeVertices(const int iteration)
+{
+  const int nRofs = mTimeFrame->getNrof(1);
+  const bool withMC = mTimeFrame->hasMCinformation() && mTrkParams[iteration].CreateArtefactLabels;
+  std::vector<std::vector<Vertex>> rofVertices(nRofs);
+  std::vector<std::vector<VertexLabel>> rofLabels(nRofs);
+
+  const float beamX = mTimeFrame->getBeamX();
+  const float beamY = mTimeFrame->getBeamY();
+  const auto& tp = mTrkParams[iteration];
+  const float maxZ = tp.VtxMaxZPositionAllowed;
+  const float clusterCut = tp.VtxClusterCut;
+  const float pairCut2 = tp.VtxPairCut * tp.VtxPairCut;
+  const float zWindow = 0.5f * clusterCut;
+  const float nSigmaCut = tp.VtxNSigmaCut;
+  const float duplicateZCut = tp.VtxDuplicateZCut > 0.f
+                                ? tp.VtxDuplicateZCut
+                                : std::max(4.f * tp.VtxPairCut, 0.5f * clusterCut);
+  const int minContributors = tp.VtxClusterContributorsCut;
+  const int suppressLowMultDebris = tp.VtxSuppressLowMultDebris;
+  const float fineZWindow = tp.VtxFineZWindow;
+  const bool doFine = fineZWindow > 0.f && fineZWindow < zWindow;
+  const int fineMinDensity = tp.VtxFineMinDensity;
+  const float fineMaxDrift = tp.VtxFineMaxDrift;
+  const float goodSig = tp.VtxGoodContributorsSignificance;
+  const float duplicateZScale = tp.VtxDuplicateZScale;
+  const float goodLineChi2Cut = tp.VtxGoodLineChi2Cut;
+  const float goodLinePtCut = std::abs(mBz) > 0.01f ? tp.VtxGoodLinePtCut : -1.f;
+
+  const auto processROF = [&](const int rofId) {
+    if (skipROF(iteration, rofId)) {
+      return;
+    }
+    auto& lines = mTimeFrame->getLines(rofId);
+    const int n = static_cast<int>(lines.size());
+    if (n < 2) {
+      return;
+    }
+    const auto lineSpan = gsl::span<const Line>(lines.data(), lines.size());
+
+    // project every line onto the beam line
+    bounded_vector<float> zc(mMemoryPool.get());
+    bounded_vector<TimeEstBC> tc(mMemoryPool.get());
+    bounded_vector<int> lic(mMemoryPool.get());
+    zc.reserve(n);
+    tc.reserve(n);
+    lic.reserve(n);
+    for (int i = 0; i < n; ++i) {
+      const auto& line = lines[i];
+      const float dx = line.originPoint[0] - beamX;
+      const float dy = line.originPoint[1] - beamY;
+      const float ux = line.cosinesDirector[0];
+      const float uy = line.cosinesDirector[1];
+      const float uz = line.cosinesDirector[2];
+      const float den = ux * ux + uy * uy;
+      if (den < constants::Tolerance) {
+        continue;
+      }
+      const float s0 = -(dx * ux + dy * uy) / den;
+      const float z = line.originPoint[2] + s0 * uz;
+      if (!(o2::gpu::CAMath::Abs(z) < maxZ)) {
+        continue;
+      }
+      zc.push_back(z);
+      tc.push_back(line.mTime);
+      lic.push_back(i);
+    }
+    const int m = static_cast<int>(zc.size());
+    if (m < 2) {
+      return;
+    }
+
+    // sort by z
+    bounded_vector<int> order(m, mMemoryPool.get());
+    std::iota(order.begin(), order.end(), 0);
+    std::sort(order.begin(), order.end(), [&](const int a, const int b) { return zc[a] < zc[b]; });
+    bounded_vector<float> Z(m, mMemoryPool.get());
+    bounded_vector<TimeEstBC> T(m, mMemoryPool.get());
+    bounded_vector<int> LI(m, mMemoryPool.get());
+    for (int i = 0; i < m; ++i) {
+      Z[i] = zc[order[i]];
+      T[i] = tc[order[i]];
+      LI[i] = lic[order[i]];
+    }
+
+    // density of time-compatible neighbours in a z window
+    bounded_vector<int> density(m, mMemoryPool.get());
+    bounded_vector<LineWindow> win(m, mMemoryPool.get());
+    computeDensities(Z, T, zWindow, win, density);
+    bounded_vector<int> densityFine(doFine ? m : 0, mMemoryPool.get());
+    bounded_vector<LineWindow> winFine(doFine ? m : 0, mMemoryPool.get());
+    if (doFine) {
+      computeDensities(Z, T, fineZWindow, winFine, densityFine);
+    }
+
+    // peaks: leftmost density maxima
+    bounded_vector<uint8_t> isMax(m, mMemoryPool.get());
+    markLeftmostMaxima(density, win, mMemoryPool.get(), isMax);
+    bounded_vector<uint8_t> isMaxFine(doFine ? m : 0, mMemoryPool.get());
+    if (doFine) {
+      markLeftmostMaxima(densityFine, winFine, mMemoryPool.get(), isMaxFine);
+    }
+    bounded_vector<int> peaks(mMemoryPool.get());
+    bounded_vector<uint8_t> isPeakFine(m, 0, mMemoryPool.get());
+    for (int k = 0; k < m; ++k) {
+      bool peak = density[k] >= 2 && isMax[k];
+      if (!peak && doFine && densityFine[k] >= fineMinDensity && isMaxFine[k]) {
+        peak = true;
+        isPeakFine[k] = 1;
+      }
+      if (peak) {
+        peaks.push_back(k);
+      }
+    }
+    const int np = static_cast<int>(peaks.size());
+    if (np == 0) {
+      return;
+    }
+
+    // one candidate per peak: seed fit over the window, prune outliers, refit, apply the cuts
+    bounded_vector<ClusterLines> cand(np, mMemoryPool.get());
+    bounded_vector<uint8_t> ok(np, mMemoryPool.get());
+    bounded_vector<int> nGoodCand(np, 0, mMemoryPool.get());
+    bounded_vector<uint8_t> fineCand(np, 0, mMemoryPool.get());
+    bounded_vector<bounded_vector<int>> candMembers(withMC ? np : 0, bounded_vector<int>(mMemoryPool.get()), mMemoryPool.get());
+    const auto& linesQuality = mTimeFrame->getLinesQuality(rofId);
+    const int nQual = static_cast<int>(linesQuality.size());
+    for (int p = 0; p < np; p++) {
+      const int k = peaks[p];
+      fineCand[p] = isPeakFine[k];
+      bounded_vector<int> members(mMemoryPool.get());
+      members.reserve(density[k]);
+      for (int j = win[k].lo; j < win[k].hi; ++j) {
+        if (T[k].isCompatible(T[j])) {
+          members.push_back(LI[j]);
+        }
+      }
+      if (members.size() < 2) {
+        ok[p] = 0;
+        continue;
+      }
+      ClusterLines seed{gsl::span<const int>{members.data(), members.size()}, lineSpan};
+      if (!seed.isValid()) {
+        ok[p] = 0;
+        continue;
+      }
+      bounded_vector<int> kept(mMemoryPool.get());
+      kept.reserve(members.size());
+      for (const int idx : members) {
+        if (Line::getDistance2FromPoint(lines[idx], seed.getVertex()) < pairCut2) {
+          kept.push_back(idx);
+        }
+      }
+      if (kept.size() < 2) {
+        ok[p] = 0;
+        continue;
+      }
+      int nGood = 0;
+      if (nQual == 0) {
+        nGood = static_cast<int>(kept.size());
+      } else {
+        for (const int idx : kept) {
+          const float chi2 = idx < nQual ? linesQuality[idx].chi2 : -1.f;
+          const float pt = idx < nQual ? linesQuality[idx].pt : -1.f;
+          const bool okChi2 = goodLineChi2Cut <= 0.f || chi2 <= goodLineChi2Cut;
+          const bool okPt = goodLinePtCut <= 0.f || pt >= goodLinePtCut;
+          nGood += okChi2 && okPt;
+        }
+      }
+      nGoodCand[p] = nGood;
+      ClusterLines fit{gsl::span<const int>{kept.data(), kept.size()}, lineSpan};
+      const float bd2 = (beamX - fit.getVertex()[0]) * (beamX - fit.getVertex()[0]) +
+                        (beamY - fit.getVertex()[1]) * (beamY - fit.getVertex()[1]);
+      if (!fit.isValid() || static_cast<int>(fit.getSize()) < minContributors || !(bd2 < nSigmaCut)) {
+        ok[p] = 0;
+        continue;
+      }
+      if (fineMaxDrift > 0.f && fineCand[p] && std::abs(fit.getVertex()[2] - seed.getVertex()[2]) > fineMaxDrift) {
+        ok[p] = 0;
+        continue;
+      }
+      cand[p] = std::move(fit);
+      if (withMC) {
+        candMembers[p] = std::move(kept);
+      }
+      ok[p] = 1;
+    }
+
+    // duplicate suppression
+    bounded_vector<uint8_t> keep(np, mMemoryPool.get());
+    for (int p = 0; p < np; ++p) {
+      if (!ok[p]) {
+        keep[p] = 0;
+        continue;
+      }
+      uint8_t survive = 1;
+      const float zp = cand[p].getVertex()[2];
+      const auto sp = cand[p].getSize();
+      const float radius = (duplicateZScale > 0.f && sp > 0)
+                             ? duplicateZScale / std::sqrt(static_cast<float>(sp))
+                             : duplicateZCut;
+      for (int q = 0; q < np && survive; ++q) {
+        if (q == p || !ok[q]) {
+          continue;
+        }
+        if (!cand[p].getTimeStamp().isCompatible(cand[q].getTimeStamp())) {
+          continue;
+        }
+        if (o2::gpu::GPUCommonMath::Abs(zp - cand[q].getVertex()[2]) < radius) {
+          const auto sq = cand[q].getSize();
+          if (sq > sp || (sq == sp && q < p)) {
+            survive = 0;
+          }
+        }
+      }
+      keep[p] = survive;
+    }
+
+    // emit
+    bounded_vector<int> accepted(mMemoryPool.get());
+    for (int p = 0; p < np; ++p) {
+      if (keep[p]) {
+        accepted.push_back(p);
+      }
+    }
+    std::sort(accepted.begin(), accepted.end(),
+              [&](int a, int b) { return cand[a].getSize() > cand[b].getSize(); });
+    double rofLoad = 0.;
+    if (goodSig > 0.f) {
+      for (int p = 0; p < np; ++p) {
+        if (ok[p] && !fineCand[p]) {
+          rofLoad += cand[p].getSize();
+        }
+      }
+    }
+    const float sigThreshold = goodSig > 0.f ? goodSig * std::sqrt(static_cast<float>(std::max(rofLoad, 1.))) : 0.f;
+    for (const int p : accepted) {
+      if (!rofVertices[rofId].empty()) {
+        if (goodSig > 0.f) {
+          if (nGoodCand[p] <= sigThreshold) {
+            continue;
+          }
+        } else if (static_cast<int>(cand[p].getSize()) < suppressLowMultDebris) {
+          continue;
+        }
+      }
+      Vertex vertex{cand[p].getVertex(),
+                    cand[p].getRMS2(),
+                    (ushort)cand[p].getSize(),
+                    cand[p].getAvgDistance2()};
+      vertex.setTimeStamp(cand[p].getTimeStamp());
+      if (mTrkParams[iteration].PassFlags[IterationStep::MarkVerticesAsUPC]) {
+        vertex.setFlags(Vertex::UPCMode);
+      }
+      rofVertices[rofId].push_back(vertex);
+      if (withMC) {
+        auto& lineLabels = mTimeFrame->getLinesLabel(rofId);
+        const int nLab = static_cast<int>(lineLabels.size());
+        bounded_vector<o2::MCCompLabel> labels(mMemoryPool.get());
+        for (const auto idx : candMembers[p]) {
+          if (idx < 0 || idx >= nLab) {
+            LOGP(error, "Seeding vertexer: line label index {} out of range (nLab={}, rof={}), skipping label", idx, nLab, rofId);
+            continue;
+          }
+          labels.push_back(lineLabels[idx]);
+        }
+        rofLabels[rofId].push_back(computeMainVertexLabel(labels));
+      }
+    }
+  };
+
+  if (mTaskArena->max_concurrency() <= 1) {
+    for (int rofId{0}; rofId < nRofs; ++rofId) {
+      processROF(rofId);
+    }
+  } else {
+    mTaskArena->execute([&] {
+      tbb::parallel_for(0, nRofs, [&](const int rofId) {
+        processROF(rofId);
+      });
+    });
+  }
+  for (int rofId{0}; rofId < nRofs; ++rofId) {
+    for (auto& vertex : rofVertices[rofId]) {
+      mTimeFrame->addPrimaryVertex(vertex);
+    }
+    if (withMC) {
+      for (auto& label : rofLabels[rofId]) {
+        mTimeFrame->addPrimaryVertexLabel(label);
+      }
+    }
+  }
+
+  auto& pvs = mTimeFrame->getPrimaryVertices();
+  bounded_vector<size_t> indices(pvs.size(), mMemoryPool.get());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::sort(indices.begin(), indices.end(), [&pvs](const size_t i, const size_t j) {
+    const auto aLower = pvs[i].getTimeStamp().lower();
+    const auto bLower = pvs[j].getTimeStamp().lower();
+    if (aLower != bLower) {
+      return aLower < bLower;
+    }
+    return pvs[i].getNContributors() > pvs[j].getNContributors();
+  });
+  bounded_vector<Vertex> sortedVtx(pvs.get_allocator());
+  sortedVtx.reserve(pvs.size());
+  for (const size_t idx : indices) {
+    sortedVtx.push_back(pvs[idx]);
+  }
+  pvs.swap(sortedVtx);
+  if (withMC) {
+    auto& mc = mTimeFrame->getPrimaryVerticesLabels();
+    bounded_vector<VertexLabel> sortedMC(mc.get_allocator());
+    sortedMC.reserve(mc.size());
+    for (const size_t idx : indices) {
+      sortedMC.push_back(mc[idx]);
+    }
+    mc.swap(sortedMC);
+  }
+  mTimeFrame->updateROFVertexLookupTable();
+}
+
+template <int NLayers>
 void TrackerTraits<NLayers>::computeLayerCells(const int iteration)
 {
   const auto topology = mTimeFrame->getTrackingTopologyView();
@@ -308,6 +825,14 @@ void TrackerTraits<NLayers>::computeLayerCells(const int iteration)
       const auto& cellTopology = topology.getCell(cellTopologyId);
       const auto& firstLink = topology.getLink(cellTopology.firstLink);
       const auto& secondLink = topology.getLink(cellTopology.secondLink);
+      const float cellDeltaPhiCut =
+        mTrkParams[iteration].PassFlags[IterationStep::SeedingVertexPass]
+          ? math_utils::cellDeltaPhiBound(mBz, mTrkParams[iteration].CellDeltaPhiMinPt,
+                                          mTrkParams[iteration].LayerRadii[firstLink.fromLayer],
+                                          mTrkParams[iteration].LayerRadii[firstLink.toLayer],
+                                          mTrkParams[iteration].LayerRadii[secondLink.toLayer],
+                                          mTimeFrame->getLinkMSAngle(cellTopology.firstLink))
+          : -1.f;
       const Tracklet& currentTracklet{mTimeFrame->getTracklets()[cellTopology.firstLink][iTracklet]};
       const int nextLayerClusterIndex{currentTracklet.secondClusterIndex};
       const int nextLayerFirstTrackletIndex{mTimeFrame->getTrackletsLookupTable()[cellTopology.secondLink][nextLayerClusterIndex]};
@@ -320,9 +845,16 @@ void TrackerTraits<NLayers>::computeLayerCells(const int iteration)
         if (!currentTracklet.getTimeStamp().isCompatible(nextTracklet.getTimeStamp())) {
           continue;
         }
+        if (cellDeltaPhiCut > 0.f &&
+            !math_utils::isPhiDifferenceBelow(currentTracklet.phi, nextTracklet.phi, cellDeltaPhiCut)) {
+          continue;
+        }
 
         const float deltaTanLambdaSigma = std::abs(currentTracklet.tanLambda - nextTracklet.tanLambda) / mTrkParams[iteration].CellDeltaTanLambdaSigma;
-        if (deltaTanLambdaSigma < mTrkParams[iteration].NSigmaCut) {
+        const float cellTanLNSigma = mTrkParams[iteration].CellDeltaTanLambdaNSigma > 0.f
+                                       ? mTrkParams[iteration].CellDeltaTanLambdaNSigma
+                                       : mTrkParams[iteration].NSigmaCut;
+        if (deltaTanLambdaSigma < cellTanLNSigma) {
 
           /// Track seed preparation. Clusters are numbered progressively from the innermost going outward.
           const int clusId[3]{

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -11,8 +11,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <format>
 #include <memory>
+#include <ranges>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <oneapi/tbb/task_arena.h>
 
@@ -51,6 +57,11 @@ void ITSTrackingInterface::initialise()
   auto trackParams = TrackingMode::getTrackingParameters(mMode);
   auto vertParams = TrackingMode::getVertexingParameters(mMode);
   overrideParameters(trackParams, vertParams);
+  for (auto& p : trackParams) {
+    if (p.PassFlags[IterationStep::SeedingVertexPass]) {
+      p.CreateArtefactLabels = mIsMC;
+    }
+  }
   LOGP(info, "Initializing tracker in {} phase reconstruction with {} passes for tracking and {}/{} for vertexing", TrackingMode::toString(mMode), trackParams.size(), o2::its::VertexerParamConfig::Instance().nIterations, vertParams.size());
   mTracker->setParameters(trackParams);
   mVertexer->setParameters(vertParams);
@@ -221,8 +232,9 @@ void ITSTrackingInterface::run(framework::ProcessingContext& pc)
 
   float vertexerElapsedTime{0.f}, trackerElapsedTime{0.f};
   if (mRunVertexer) {
-    // Run seeding vertexer
-    vertexerElapsedTime = mVertexer->clustersToVertices(logger);
+    vertexerElapsedTime = o2::its::TrackerParamConfig::Instance().seedingVertexIteration
+                            ? mTracker->clustersToVertices(logger)
+                            : mVertexer->clustersToVertices(logger);
     const auto& vtx = mTimeFrame->getPrimaryVertices();
     vertices.insert(vertices.begin(), vtx.begin(), vtx.end());
     if (mIsMC) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
@@ -27,12 +27,6 @@
 #pragma link C++ class o2::its::TrackingFrameInfo + ;
 #pragma link C++ class std::vector < o2::its::TrackingFrameInfo> + ;
 
-#pragma link C++ class o2::its::Line + ;
-#pragma link C++ class std::vector < o2::its::Line> + ;
-
-#pragma link C++ class o2::its::ClusterLines + ;
-#pragma link C++ class std::vector < o2::its::ClusterLines> + ;
-
 #pragma link C++ class o2::its::FastMultEstConfig + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::its::FastMultEstConfig> + ;
 

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -369,11 +369,11 @@ void VertexerTraits<NLayers>::computeVertices(const int iteration)
     auto& lines = mTimeFrame->getLines(rofId);
     auto clusters = line_vertexer::buildClusters(std::span<const Line>{lines.data(), lines.size()}, settings);
     deepVectorClear(lines); // not needed after
-    auto clusterBeamDistance2 = [&](const ClusterLines& cluster) {
+    auto clusterBeamDistance2 = [&](const line_vertexer::ClusterWithLines& cluster) {
       return (mTimeFrame->getBeamX() - cluster.getVertex()[0]) * (mTimeFrame->getBeamX() - cluster.getVertex()[0]) +
              (mTimeFrame->getBeamY() - cluster.getVertex()[1]) * (mTimeFrame->getBeamY() - cluster.getVertex()[1]);
     };
-    auto clusterBetter = [&](const ClusterLines& lhs, const ClusterLines& rhs) {
+    auto clusterBetter = [&](const line_vertexer::ClusterWithLines& lhs, const line_vertexer::ClusterWithLines& rhs) {
       if (lhs.getSize() != rhs.getSize()) {
         return lhs.getSize() > rhs.getSize();
       }
@@ -394,7 +394,7 @@ void VertexerTraits<NLayers>::computeVertices(const int iteration)
     for (const auto& cluster : clusters) {
       minClusterZ = std::min(minClusterZ, cluster.getVertex()[2]);
     }
-    bounded_vector<ClusterLines> deduplicated(mMemoryPool.get());
+    bounded_vector<line_vertexer::ClusterWithLines> deduplicated(mMemoryPool.get());
     deduplicated.reserve(clusters.size());
     std::unordered_map<int, std::vector<int>> keptByZBin;
     for (auto& candidate : clusters) {
@@ -451,7 +451,7 @@ void VertexerTraits<NLayers>::computeVertices(const int iteration)
       return;
     }
 
-    auto countSharedLabels = [](const ClusterLines& lhs, const ClusterLines& rhs) {
+    auto countSharedLabels = [](const line_vertexer::ClusterWithLines& lhs, const line_vertexer::ClusterWithLines& rhs) {
       size_t shared = 0;
       auto lhsIt = lhs.getLabels().begin();
       auto rhsIt = rhs.getLabels().begin();
@@ -532,7 +532,7 @@ void VertexerTraits<NLayers>::computeVertices(const int iteration)
         continue;
       }
 
-      Vertex vertex{cluster.getVertex().data(),
+      Vertex vertex{cluster.getVertex(),
                     cluster.getRMS2(),
                     (ushort)cluster.getSize(),
                     cluster.getAvgDistance2()};
@@ -547,7 +547,7 @@ void VertexerTraits<NLayers>::computeVertices(const int iteration)
         for (auto& index : cluster.getLabels()) {
           labels.push_back(lineLabels[index]);
         }
-        const auto mainLabel = computeMain(labels);
+        const auto mainLabel = computeMainVertexLabel(labels);
         rofLabels[rofId].push_back(mainLabel);
       }
     }

--- a/Detectors/ITSMFT/common/tracking/include/ITSMFTTracking/Constants.h
+++ b/Detectors/ITSMFT/common/tracking/include/ITSMFTTracking/Constants.h
@@ -34,11 +34,15 @@ constexpr float UnsetValue = -999.f;                  // global unset value
 constexpr float Radl = 9.36f;                         // Radiation length of Si [cm]
 constexpr float Rho = 2.33f;                          // Density of Si [g/cm^3]
 constexpr int MaxIter = 4;                            // Max. supported iterations
+constexpr int MaxSeedingPasses = 2;                   // seeding + UPC passes optionally appended after the tracking iterations
 constexpr int MaxSelectedTrackletsPerCluster = 100;   // vertexer: max lines per cluster
 constexpr int NumberOfConcurrentSeeds = 16;           // default split per worker for the final track fit/extraploation step
 constexpr int MinNumberOfConcurrentSeeds = (1 << 8);  // minimum chunk size for a worker for the final track fit/extraploation step
 constexpr int MaxNumberOfConcurrentSeeds = (1 << 12); // maximum chunk size for a worker for the final track fit/extraploation step
 constexpr float MaxTrackSeedQ2Pt = 1.e3f;             // maximum q/pt for track seeds
+
+constexpr int MaxBootstrapPasses = 5;               // beam bootstrap: cap on the re-trackleting passes
+constexpr float BeamConvergence2 = 5.e-3f * 5.e-3f; // beam bootstrap: stop below a (50 um)^2 beam shift
 
 namespace helpers
 {

--- a/Detectors/ITSMFT/common/tracking/include/ITSMFTTracking/ITSTrackingConfigParam.h
+++ b/Detectors/ITSMFT/common/tracking/include/ITSMFTTracking/ITSTrackingConfigParam.h
@@ -44,6 +44,14 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   // Artefacts selections
   int clusterContributorsCut = 2; // minimum number of contributors for an accepted final vertex
   int suppressLowMultDebris = 16; // suppress all vertices below this threshold if a vertex was already found in a rof
+  float lineMinPt = 0.10f;        // drop soft lines before the density scan
+  float fineZWindow = 0.010f;     // second, narrow density pass (dip search); <=0 disables
+  int fineMinDensity = 8;
+  float fineMaxDrift = 0.005f; // |z_fit - z_seed| cap on fine-only candidates; <=0 disables
+  float goodLineChi2Cut = 5.f;
+  float goodLinePtCut = 0.5f;
+  float goodContributorsSignificance = 0.070f; // emit threshold k, scaled by sqrt(ROF load); <=0 disables
+  float duplicateZScale = 0.7f;                // per-candidate dedup radius scale/sqrt(size); <=0 uses duplicateZCut
   int seedMemberRadiusTime = 0;
   int seedMemberRadiusZ = 2;
   int maxTrackletsPerCluster = 100;
@@ -84,18 +92,26 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   float pvRes = -1.f;
   int LUTbinsPhi = -1;
   int LUTbinsZ = -1;
-  float diamondPos[3] = {0.f, 0.f, 0.f};   // override the position of the vertex
-  bool useDiamond = false;                 // enable overriding the vertex position
-  bool perPrimaryVertexProcessing = false; // perform the full tracking considering the vertex hypotheses one at the time.
-  bool saveTimeBenchmarks = false;         // dump metrics on file
-  bool overrideBeamEstimation = false;     // use beam position from meanVertex CCDB object
-  int trackingMode = -1;                   // -1: unset, 0=sync, 1=async, 2=cosmics used by gpuwf only
-  bool doUPCIteration = false;             // Perform an additional iteration for UPC events on tagged vertices. You want to combine this config with VertexerParamConfig.nIterations=2
-  int nIterations = constants::MaxIter;    // overwrite the number of iterations
-  int reseedIfShorter = 6;                 // for the final refit reseed the track with circle if they are shorter than this value
-  bool shiftRefToCluster{true};            // TrackFit: after update shift the linearization reference to cluster
-  bool repeatRefitOut{false};              // repeat outward refit using inward refit as a seed
-  bool createArtefactLabels{false};        // create on-the-fly labels for the artefacts
+  float diamondPos[3] = {0.f, 0.f, 0.f};                    // override the position of the vertex
+  bool useDiamond = false;                                  // enable overriding the vertex position
+  bool perPrimaryVertexProcessing = false;                  // perform the full tracking considering the vertex hypotheses one at the time.
+  bool seedingVertexIteration = false;                      // prepend a seeding-vertex iteration (diamond->cell->line->parallel seeding) to the tracker passes
+  float diamondTrackletingNSigmaCut = 6.6136f;              // z-window n-sigma for the diamond trackleting (gates the cell tanLambda too unless the next one is set)
+  float diamondCellTanLambdaNSigma = 2.5f;                  // cell tanLambda gate, split out from the trackleting n-sigma; <=0 reuses it
+  float diamondTrackletingPVres = 0.9676f;                  // effective PV resolution [cm] feeding the trackleting z-sigma
+  float diamondTrackletingCellDeltaTanLambdaSigma = 0.007f; // cell tanLambda sigma for the diamond celling
+  float diamondTrackletingCellDeltaPhiMinPt = -1.f;
+  int cellLineSharedClusterCut = 1; // Max clusters a cell->Line may share with already-accepted Lines before being dropped.
+
+  bool saveTimeBenchmarks = false;      // dump metrics on file
+  bool overrideBeamEstimation = false;  // use beam position from meanVertex CCDB object
+  int trackingMode = -1;                // -1: unset, 0=sync, 1=async, 2=cosmics used by gpuwf only
+  bool doUPCIteration = false;          // Perform an additional iteration for UPC events on tagged vertices. You want to combine this config with VertexerParamConfig.nIterations=2
+  int nIterations = constants::MaxIter; // overwrite the number of iterations
+  int reseedIfShorter = 6;              // for the final refit reseed the track with circle if they are shorter than this value
+  bool shiftRefToCluster{true};         // TrackFit: after update shift the linearization reference to cluster
+  bool repeatRefitOut{false};           // repeat outward refit using inward refit as a seed
+  bool createArtefactLabels{false};     // create on-the-fly labels for the artefacts
   bool trackFollowerTop[constants::MaxIter] = {};
   bool trackFollowerBot[constants::MaxIter] = {};
   float trackFollowerNSigmaCutZ = 1.f;

--- a/Detectors/ITSMFT/common/tracking/include/ITSMFTTracking/MathUtils.h
+++ b/Detectors/ITSMFT/common/tracking/include/ITSMFTTracking/MathUtils.h
@@ -129,6 +129,20 @@ GPUhdi() float MSangle(float mass, float p, float xX0)
   return 0.0136f * o2::gpu::CAMath::Sqrt(xX0) * (1.f + 0.038f * o2::gpu::CAMath::Log(xX0)) / (beta * p);
 }
 
+GPUhdi() float cellDeltaPhiBound(const float bz, const float ptMin,
+                                 const float rIn, const float rMid, const float rOut,
+                                 const float msAngle)
+{
+  if (ptMin <= 0.f) {
+    return -1.f;
+  }
+  const float oneOverR = 0.001f * 0.3f * o2::gpu::CAMath::Abs(bz) / ptMin; // 1 / curvature radius [1/cm]
+  const float sA = o2::gpu::CAMath::Min(0.25f * (rIn + rMid) * oneOverR, 1.f - 1.e-6f);
+  const float sB = o2::gpu::CAMath::Min(0.25f * (rMid + rOut) * oneOverR, 1.f - 1.e-6f);
+  const float bound = 2.f * (o2::gpu::CAMath::ASin(sB) - o2::gpu::CAMath::ASin(sA)) + 2.f * msAngle;
+  return o2::gpu::CAMath::Min(bound, static_cast<float>(o2::constants::math::PI));
+}
+
 } // namespace o2::its::math_utils
 
 #endif


### PR DESCRIPTION
Adds an optional seeding vertexer that runs as a prepended tracker pass (diamond trackleting -> cells -> lines -> parallel seeding), on both the CPU and GPU traits.
Additionally, unsorted clusters are loaded to GPU and then sorted on GPU.

To set it:
ITSCATrackerParam.seedingVertexIteration=1;
ITSVertexerParam.useParallelSeeding=1;

Tuned parameters for Pb--Pb:

ITSCATrackerParam.seedingVertexIteration=1;ITSVertexerParam.useParallelSeeding=1;ITSVertexerParam.useTruthSeeding=0;ITSCATrackerParam.diamondTrackletingPVres=1.5102214480735774;ITSCATrackerParam.diamondTrackletingNSigmaCut=2.976946815605669;ITSCATrackerParam.diamondTrackletingCellDeltaTanLambdaSigma=0.005566295924057422;ITSCATrackerParam.diamondCellTanLambdaNSigma=2.5;ITSCATrackerParam.diamondTrackletingCellDeltaPhiMinPt=0.12;ITSCATrackerParam.cellLineSharedClusterCut=1;ITSVertexerParam.clusterCut=0.07;ITSVertexerParam.pairCut=0.025684202919354766;ITSVertexerParam.phiCut=0.008875191490279988;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.lineMinPt=0.10;ITSVertexerParam.nSigmaCut=0.0016;ITSVertexerParam.goodLineChi2Cut=9.814679066181695;ITSVertexerParam.goodLinePtCut=0.12;ITSVertexerParam.goodContributorsSignificance=0.070;ITSVertexerParam.suppressLowMultDebris=13;ITSVertexerParam.fineZWindow=0.010;ITSVertexerParam.fineMinDensity=8;ITSVertexerParam.fineMaxDrift=0.005;ITSVertexerParam.duplicateZScale=0.7;ITSVertexerParam.duplicateZCut=0.1388966993405415;

Tuned parameters for pp:

ITSCATrackerParam.seedingVertexIteration=1;ITSVertexerParam.useParallelSeeding=1;ITSVertexerParam.useTruthSeeding=0;ITSCATrackerParam.diamondTrackletingPVres=3.74344532796542;ITSCATrackerParam.diamondTrackletingNSigmaCut=5.352263543811316;ITSCATrackerParam.diamondTrackletingCellDeltaTanLambdaSigma=0.002563403956702525;ITSCATrackerParam.diamondCellTanLambdaNSigma=3.257473162361808;ITSCATrackerParam.diamondTrackletingCellDeltaPhiMinPt=0.09407482537938365;ITSCATrackerParam.cellLineSharedClusterCut=3;ITSVertexerParam.clusterCut=0.05557266167329535;ITSVertexerParam.pairCut=0.05176031785438137;ITSVertexerParam.phiCut=0.017639175978851104;ITSVertexerParam.clusterContributorsCut=2;ITSVertexerParam.lineMinPt=0.1;ITSVertexerParam.nSigmaCut=0.0016;ITSVertexerParam.goodLineChi2Cut=9.814679066181695;ITSVertexerParam.goodLinePtCut=0.12;ITSVertexerParam.goodContributorsSignificance=0.07;ITSVertexerParam.suppressLowMultDebris=13;ITSVertexerParam.fineZWindow=0.013014502308220061;ITSVertexerParam.fineMinDensity=4;ITSVertexerParam.fineMaxDrift=0.004003953018135234;ITSVertexerParam.duplicateZScale=0.1230148343342053;ITSVertexerParam.duplicateZCut=0.06571512005272727;
