### PR TITLE
Fix a misplaced prepreg strip in the TPC inner field cage

### DIFF
--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -1386,7 +1386,7 @@ void Detector::ConstructTPCGeometry()
   tv100->AddNode(tvep1, 1, new TGeoTranslation(0., 0., -177.925)); // epoxy
   tv100->AddNode(tvep1, 2, new TGeoTranslation(0., 0., 177.925));
   tv100->AddNode(tvpr1, 1, new TGeoTranslation(0., 0., -177.925)); // prepreg strip
-  tv100->AddNode(tvpr1, 2, new TGeoTranslation(0., 0., -177.925));
+  tv100->AddNode(tvpr1, 2, new TGeoTranslation(0., 0., 177.925));
   //
   // second segment - rotation 120 deg.
   //


### PR DESCRIPTION
This fixes a copy-paste error that put both copies of an outer prepreg strip on the C side and none on the A side.

- TPC_PRSTR1 copy 2 was placed at z = -177.925 like copy 1, where every neighbouring pair (sandwich, epoxy, and the rotated segments) places its second copy at +177.925.
- The strip now sits at +177.925; the world-position census changes from 4 at -177.925 / 2 at +177.925 to the intended 3 / 3.
- Found by a TGeo to STEP round-trip study; TGeoManager::CheckOverlaps reports 0 overlaps on TPC either way, so it could not have flagged the coincident pair.