### PR TITLE
PIPE: fix duplicated RB26/2 bellow and restore the empty RB26/3 bellow

### DIFF
--- a/Detectors/Passive/src/Pipe.cxx
+++ b/Detectors/Passive/src/Pipe.cxx
@@ -2300,9 +2300,25 @@ void Pipe::ConstructGeometry()
   TGeoVolume* voRB26s3Bellow =
     new TGeoVolume("RB26s3Bellow", new TGeoTube(kRB26s3BellowRi, kRB26s3BellowRo, zBellowTot), kMedVacHC);
 
-  // RB26s3Bellow is left without plies. The wiggle stack that stood here was a copy of the
-  // RB26/2 code and filled voRB26s2Bellow a second time; filling it with the RB26/3 wiggle
-  // would change the material budget and is a separate fix.
+  // Positioning of the volumes.
+  //
+  // A thirteen-convolution bellow has fourteen inner roots, so one lower plie
+  // leads the thirteen wiggles. The pitch is not 4*PlieR - 2*PlieThickness: a
+  // torus-and-disc wiggle is longer than the convolution it stands for, and at
+  // that pitch the stack does not fit the bellow. There is no room to grow it
+  // either, since only 0.01 cm separates this bellow from the right welding
+  // tube. The pitch is therefore the one that makes the fourteen roots span the
+  // bellow exactly, which is 1.5 per cent shorter.
+  const Float_t kRB26s3PliePitch =
+    (2. * zBellowTot - 2. * kRB26s3PlieR) / kRB26s3NumberOfPlies;
+  const Float_t kRB26s3RootToWiggle = 3. * kRB26s3PlieR - 5. * kRB26s3PlieThickness / 2.;
+
+  z0 = -zBellowTot + kRB26s3PlieR;
+  voRB26s3Bellow->AddNode(voRB26s3WiggleL, 1, new TGeoTranslation(0., 0., z0));
+  for (Int_t iw = 0; iw < kRB26s3NumberOfPlies; iw++) {
+    Float_t zpos = z0 + (iw + 1) * kRB26s3PliePitch - kRB26s3RootToWiggle;
+    voRB26s3Bellow->AddNode(voRB26s3Wiggle, iw + 1, new TGeoTranslation(0., 0., zpos));
+  }
 
   voRB26s3Compensator->AddNode(voRB26s3Bellow, 1,
                                new TGeoTranslation(0., 0., kRB26s3WeldingTubeLeftL + zBellowTot));

--- a/Detectors/Passive/src/Pipe.cxx
+++ b/Detectors/Passive/src/Pipe.cxx
@@ -2300,15 +2300,9 @@ void Pipe::ConstructGeometry()
   TGeoVolume* voRB26s3Bellow =
     new TGeoVolume("RB26s3Bellow", new TGeoTube(kRB26s3BellowRi, kRB26s3BellowRo, zBellowTot), kMedVacHC);
 
-  // Positioning of the volumes
-  z0 = -kRB26s2BellowUndL / 2. + kRB26s2ConnectionPlieR;
-  voRB26s2Bellow->AddNode(voRB26s2WiggleL, 1, new TGeoTranslation(0., 0., z0));
-  z0 += kRB26s2ConnectionPlieR;
-  zsh = 4. * kRB26s2PlieR - 2. * kRB26s2PlieThickness;
-  for (Int_t iw = 0; iw < kRB26s2NumberOfPlies; iw++) {
-    Float_t zpos = z0 + iw * zsh;
-    voRB26s2Bellow->AddNode(voRB26s2Wiggle, iw + 1, new TGeoTranslation(0., 0., zpos - kRB26s2PlieThickness));
-  }
+  // RB26s3Bellow is left without plies. The wiggle stack that stood here was a copy of the
+  // RB26/2 code and filled voRB26s2Bellow a second time; filling it with the RB26/3 wiggle
+  // would change the material budget and is a separate fix.
 
   voRB26s3Compensator->AddNode(voRB26s3Bellow, 1,
                                new TGeoTranslation(0., 0., kRB26s3WeldingTubeLeftL + zBellowTot));

--- a/Detectors/Passive/src/PipeRun4.cxx
+++ b/Detectors/Passive/src/PipeRun4.cxx
@@ -2165,15 +2165,9 @@ void PipeRun4::ConstructGeometry()
   float zBellowTot = kRB26s3NumberOfPlies * (static_cast<TGeoBBox*>(voRB26s3Wiggle->GetShape()))->GetDZ();
   TGeoVolume* voRB26s3Bellow = new TGeoVolume("RB26s3Bellow", new TGeoTube(kRB26s3BellowRi, kRB26s3BellowRo, zBellowTot), kMedVacHC);
 
-  // Positioning of the volumes
-  z0 = -kRB26s2BellowUndL / 2. + kRB26s2ConnectionPlieR;
-  voRB26s2Bellow->AddNode(voRB26s2WiggleL, 1, new TGeoTranslation(0., 0., z0));
-  z0 += kRB26s2ConnectionPlieR;
-  zsh = 4. * kRB26s2PlieR - 2. * kRB26s2PlieThickness;
-  for (int iw = 0; iw < kRB26s2NumberOfPlies; iw++) {
-    float zpos = z0 + iw * zsh;
-    voRB26s2Bellow->AddNode(voRB26s2Wiggle, iw + 1, new TGeoTranslation(0., 0., zpos - kRB26s2PlieThickness));
-  }
+  // RB26s3Bellow is left without plies. The wiggle stack that stood here was a copy of the
+  // RB26/2 code and filled voRB26s2Bellow a second time; filling it with the RB26/3 wiggle
+  // would change the material budget and is a separate fix.
 
   voRB26s3Compensator->AddNode(voRB26s3Bellow, 1, new TGeoTranslation(0., 0., kRB26s3WeldingTubeLeftL + zBellowTot));
 

--- a/Detectors/Passive/src/PipeRun4.cxx
+++ b/Detectors/Passive/src/PipeRun4.cxx
@@ -2165,9 +2165,25 @@ void PipeRun4::ConstructGeometry()
   float zBellowTot = kRB26s3NumberOfPlies * (static_cast<TGeoBBox*>(voRB26s3Wiggle->GetShape()))->GetDZ();
   TGeoVolume* voRB26s3Bellow = new TGeoVolume("RB26s3Bellow", new TGeoTube(kRB26s3BellowRi, kRB26s3BellowRo, zBellowTot), kMedVacHC);
 
-  // RB26s3Bellow is left without plies. The wiggle stack that stood here was a copy of the
-  // RB26/2 code and filled voRB26s2Bellow a second time; filling it with the RB26/3 wiggle
-  // would change the material budget and is a separate fix.
+  // Positioning of the volumes.
+  //
+  // A thirteen-convolution bellow has fourteen inner roots, so one lower plie
+  // leads the thirteen wiggles. The pitch is not 4*PlieR - 2*PlieThickness: a
+  // torus-and-disc wiggle is longer than the convolution it stands for, and at
+  // that pitch the stack does not fit the bellow. There is no room to grow it
+  // either, since only 0.01 cm separates this bellow from the right welding
+  // tube. The pitch is therefore the one that makes the fourteen roots span the
+  // bellow exactly, which is 1.5 per cent shorter.
+  const float kRB26s3PliePitch =
+    (2. * zBellowTot - 2. * kRB26s3PlieR) / kRB26s3NumberOfPlies;
+  const float kRB26s3RootToWiggle = 3. * kRB26s3PlieR - 5. * kRB26s3PlieThickness / 2.;
+
+  z0 = -zBellowTot + kRB26s3PlieR;
+  voRB26s3Bellow->AddNode(voRB26s3WiggleL, 1, new TGeoTranslation(0., 0., z0));
+  for (int iw = 0; iw < kRB26s3NumberOfPlies; iw++) {
+    float zpos = z0 + (iw + 1) * kRB26s3PliePitch - kRB26s3RootToWiggle;
+    voRB26s3Bellow->AddNode(voRB26s3Wiggle, iw + 1, new TGeoTranslation(0., 0., zpos));
+  }
 
   voRB26s3Compensator->AddNode(voRB26s3Bellow, 1, new TGeoTranslation(0., 0., kRB26s3WeldingTubeLeftL + zBellowTot));
 


### PR DESCRIPTION
The RB26/3 axial compensator in the ALICE beam pipe contains a bellow with 13 steel convolutions. A 2019 geometry fix accidentally changed the `s3` references in this block to `s2`. As a result, the RB26/2 bellow was placed twice, while the RB26/3 bellow was left empty.

The duplicated RB26/2 volumes do not add material, since they are exactly coincident with the existing volumes. They can nevertheless make the geometry ambiguous for navigation. More importantly, the missing RB26/3 bellow removes about 2.87 kg of steel from the simulated detector.

This PR fixes both issues in `Pipe.cxx` and `PipeRun4.cxx`:

* remove the duplicated RB26/2 bellow placements;
* restore the 13 RB26/3 convolutions.

Simply restoring the old code is not sufficient: the original bellow was about 0.85 mm too long for the available space and therefore had an overlap. The convolution pitch is reduced by 1.5 %, so that the 13 convolutions fit without overlap while keeping the dimensions and 0.6 mm steel wall thickness from the construction drawing (LHCVC2A_0065, EDMS 662891).

The geometry was checked directly from the exported ROOT geometry. Removing the duplicate volumes does not change any material integral or move any geometry. With the RB26/3 bellow restored, the material agrees with the pre-2019 geometry at the web and crest radii. The remaining difference at the root radius comes from two plies that extended outside their mother volume in the old geometry and were therefore not seen by point location.

The change is local to the RB26/3 compensator, corresponding to approximately `4.98 < η < 5.13`. No other part of the detector geometry is affected.

---

## Checks

All numbers are read back from the exported `o2sim_geometry.root`. No simulation, no seed and no production cut is involved, so geometries built from different versions of the code remain comparable. Four states were built against the same `daily-20260831-0000-1` dependency set:

| | |
|---|---|
| **A** | master |
| **B** | duplicate RB26/2 placements removed |
| **C** | RB26/3 convolutions also restored (this PR) |
| **H** | the pre-2019 `Pipe.cxx` |

Material along three rays through the compensator, in g/cm², over a window containing the whole bellow:

| ray | A | B | C | H | C − A | C − H |
|---|---|---|---|---|---|---|
| R = 15.2 cm (roots) | 57.31163 | 57.31163 | 74.72872 | 73.48407 | +17.41709 | +1.24465 |
| R = 16.0 cm (webs) | 7.74438 | 7.74438 | 20.03718 | 20.03718 | +12.29280 | 0.00000 |
| R = 16.8 cm (crests) | 6.31164 | 6.31164 | 20.50880 | 20.50880 | +14.19716 | 0.00000 |

A and B agree to every digit, and A → B removes 15 node objects, expanding to 71 nodes and 57 leaf placements. `CheckOverlaps(0.001)` reports the same single pre-existing overlap for A, B and C. For H it additionally reports `RB26s3Bellow` extruded by 0.22680 cm and 0.15840 cm, which is the origin of the C − H difference at the root radius.

A ray at the radius of the ply webs, showing the empty compensator in master and the 26 web crossings once the convolutions are back:

![z scan at the web radius](https://raw.githubusercontent.com/sawenzel/AliceO2/rb26-bellow-plots/p1_zscan_R16.png)

The same at the radius of the roots, where the pre-2019 geometry is lower by 1.244 g/cm²:

![z scan at the root radius](https://raw.githubusercontent.com/sawenzel/AliceO2/rb26-bellow-plots/p3_zscan_R152.png)

Material budget from the interaction point, with the difference to master below:

![material budget vs eta](https://raw.githubusercontent.com/sawenzel/AliceO2/rb26-bellow-plots/p2_eta.png)
