### PR TITLE
MFT: Fix negative capacity tori

### DIFF
--- a/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
@@ -5582,10 +5582,10 @@ void HeatExchanger::createCoolingPipes(Int_t half, Int_t disk)
     }
     TGeoVolume* Torus2 =
       gGeoManager->MakeTorus(Form("Torus2_H%d_D%d", half, disk), mPipe,
-                             radius2, rin, rout, 0., -90.);
+                             radius2, rin, rout, 270., 90.);
     TGeoVolume* TorusW2 =
       gGeoManager->MakeTorus(Form("TorusW2_H%d_D%d", half, disk), mWater,
-                             radius2, 0., rin, 0., -90.);
+                             radius2, 0., rin, 270., 90.);
     TGeoRotation* rTorus2 = new TGeoRotation("rotationTorus2", 180.0, 0.0, 0.0);
     rTorus2->RegisterYourself();
     TGeoCombiTrans* transfoTorus2 = new TGeoCombiTrans(


### PR DESCRIPTION
The twelve `Torus2` and `TorusW2` volumes of the heat exchanger were defined with a negative delta-phi. ROOT does not normalise this value, resulting in a negative volume capacity. As a consequence, no points were found inside these volumes and neither the pipe bends nor the water contributed any material.

The sectors are now defined as the equivalent positive 270°–90° sector. This is the intended quadrant, and the torus ends now match exactly the adjacent `Tube2` and `Tube3` end faces for all six half/disk combinations.

The change also makes the geometry exportable to GDML, which Geant4 rejects when a torus has a negative delta-phi.

https://its.cern.ch/jira/browse/O2-7153