### PR TITLE
Fix out-of-range hit access in the TOF hit merging

### DIFF
--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -92,7 +92,9 @@ Bool_t Detector::ProcessHits(FairVolume* v)
   Geo::getPadDxDyDz(pos, det, delta);
   auto channel = Geo::getIndex(det);
   HitType newhit(posx, posy, posz, time, enDep, trackID, sensID);
-  if (channel != mLastChannelID || !isMergable(newhit, mHits->back())) {
+  // an invalid channel (getIndex returns -1 off a valid pad) never merges, and
+  // there is nothing to merge with before the first hit of the event
+  if (channel < 0 || mHits->empty() || channel != mLastChannelID || !isMergable(newhit, mHits->back())) {
     mHits->push_back(newhit);
     stack->addHit(GetDetId());
   } else {


### PR DESCRIPTION
This fixes a crash in TOF ProcessHits when the first step of an event cannot be assigned to a pad.

- Geo::getIndex returns -1 when the position does not resolve to a valid sector/plate/strip.
- mLastChannelID is -1 at the start of every event, so channel == mLastChannelID holds, the || does not short-circuit, and mHits->back() is called on an empty vector, giving "free(): invalid pointer".
- The merging condition now requires a non-empty hit vector and a valid channel, so an off-pad step always starts a new hit.