### PR TITLE
Fix geometry overlaps found by geometry-doctor

### DIFF
--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -294,6 +294,13 @@ void Detector::SetCablesA(TGeoVolume* stl)
 
   TVirtualMC::GetMC()->Gsvolu("0CAA", "BOX", getMediumID(kAir), pcableplane, 3); // container for cables
   TGeoVolume* cableplane = gGeoManager->GetVolume("0CAA");
+  // A hole for the beam pipe. The cable container spans the whole A-side face and
+  // would otherwise fill the pipe bore, which belongs to the beam-pipe vacuum. The
+  // pipe outer radius here is 2.5 cm and the nearest cable sits at r = 5.68 cm.
+  const float kBeamPipeHoleRadius = 3.;
+  new TGeoBBox("0CAAbox", pcableplane[0], pcableplane[1], pcableplane[2]);
+  new TGeoTube("0CAAhole", 0., kBeamPipeHoleRadius, pcableplane[2] + 0.1);
+  cableplane->SetShape(new TGeoCompositeShape("0CAAshape", "0CAAbox-0CAAhole"));
   //  float zcableplane = -mStartA[2] + 2 * mInStart[2] + pcableplane[2];
   int na = 0;
   double xcell[24], ycell[24];

--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
@@ -55,7 +55,7 @@ class Detector : public o2::base::DetImpl<Detector>
   void EndOfEvent() override { Reset(); }
 
   // for the geometry sub-parts
-  TGeoVolume* createAbsorber(float tickness);
+  TGeoVolume* createAbsorber(int chamber, float tickness);
   TGeoVolume* createChamber(int number);
   TGeoVolume* CreateCradle();
   TGeoVolume* CradleBaseVolume(TGeoMedium* med, double l[7], const char* name);

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -538,12 +538,15 @@ void Detector::createMaterials()
   Medium(kAr, "Ar", matId, unsens, itgfld, maxfld, tmaxfd, stemax, deemax, epsil, stmin);
 }
 //**************************************************************************************************
-TGeoVolume* Detector::createAbsorber(float tickness)
+TGeoVolume* Detector::createAbsorber(int chamber, float tickness)
 {
   double cm = 1, mm = 0.1 * cm, um = 0.001 * mm; // default is cm
   auto& matmgr = o2::base::MaterialManager::Instance();
   TGeoMedium* al = matmgr.getTGeoMedium("HMP_Al");
-  TGeoVolume* abs = gGeoManager->MakeBox("Habs", al, tickness * mm / 2, 1300.00 * mm / 2, 1300 * mm / 2);
+  // one volume per chamber: the two plates differ in thickness, so a shared name
+  // would leave two different volumes answering to "Habs" and two placements whose
+  // node paths are both /cave_1/barrel_1/Habs_0
+  TGeoVolume* abs = gGeoManager->MakeBox(Form("Habs%d", chamber), al, tickness * mm / 2, 1300.00 * mm / 2, 1300 * mm / 2);
   return abs;
 }
 //**************************************************************************************************
@@ -1260,8 +1263,8 @@ void Detector::ConstructGeometry()
 
   TGeoVolume* hmpcradle = CreateCradle();
 
-  TGeoVolume* hmpidabs_cham2 = createAbsorber(40.0);
-  TGeoVolume* hmpidabs_cham4 = createAbsorber(80.0);
+  TGeoVolume* hmpidabs_cham2 = createAbsorber(2, 40.0);
+  TGeoVolume* hmpidabs_cham4 = createAbsorber(4, 80.0);
 
   double theta = 33.5;
 
@@ -1270,14 +1273,14 @@ void Detector::ConstructGeometry()
   pMatrixAbs2->SetTranslation(trans2);
   pMatrixAbs2->RotateZ(theta);
 
-  gGeoManager->GetVolume("barrel")->AddNode(hmpidabs_cham2, 0, pMatrixAbs2);
+  gGeoManager->GetVolume("barrel")->AddNode(hmpidabs_cham2, 2, pMatrixAbs2);
 
   TGeoHMatrix* pMatrixAbs4 = new TGeoHMatrix;
   const double trans4[] = {435., 0., 155.};
   pMatrixAbs4->SetTranslation(trans4);
   pMatrixAbs4->RotateZ(theta);
 
-  gGeoManager->GetVolume("barrel")->AddNode(hmpidabs_cham4, 0, pMatrixAbs4);
+  gGeoManager->GetVolume("barrel")->AddNode(hmpidabs_cham4, 4, pMatrixAbs4);
 
   for (Int_t iCh = 0; iCh <= 6; iCh++) { // place 7 chambers
     TGeoVolume* hmpid = createChamber(iCh);

--- a/Detectors/MUON/MCH/Geometry/Creator/src/Station1Geometry.cxx
+++ b/Detectors/MUON/MCH/Geometry/Creator/src/Station1Geometry.cxx
@@ -892,18 +892,18 @@ void createFrame(int chamber)
   y = 2 * (kHyInHFrame + kHyH1mm) + kIAF + kHyV1mm;
   Mlayer->AddNode(gGeoManager->GetVolume("SQ01"), 1, new TGeoTranslation(x, y, z));
 
-  // TopFrameAnode - place 2 layers of TopFrameAnode cuboids
+  // TopFrameAnode - place 2 layers of TopFrameAnode cuboids. The Inox layer is
+  // stacked on top of the Epoxy one, as for SQ17to23/SQ18to24 below, so its centre
+  // sits at the Epoxy half-thickness and not at its own.
   x = kHxTFA;
   y = 2 * (kHyInHFrame + kHyH1mm + kHyInVFrame) + kIAF + kHyTFA;
-  z = kHzOuterFrameInox;
-  Mlayer->AddNode(gGeoManager->GetVolume("SQ02"), 1, new TGeoTranslation(x, y, -z));
-  Mlayer->AddNode(gGeoManager->GetVolume("SQ03"), 1, new TGeoTranslation(x, y, z));
+  Mlayer->AddNode(gGeoManager->GetVolume("SQ02"), 1, new TGeoTranslation(x, y, -kHzOuterFrameInox));
+  Mlayer->AddNode(gGeoManager->GetVolume("SQ03"), 1, new TGeoTranslation(x, y, kHzOuterFrameEpoxy));
 
   // TopFrameAnode - place 2 layers of 2 trapezoids (SQ04 - SQ07)
   x += kHxTFA + 2 * kH1FAA;
-  z = kHzOuterFrameInox;
-  Mlayer->AddNode(gGeoManager->GetVolume("SQ04toSQ06"), 1, new TGeoTranslation(x, y, -z));
-  Mlayer->AddNode(gGeoManager->GetVolume("SQ05toSQ07"), 1, new TGeoTranslation(x, y, z));
+  Mlayer->AddNode(gGeoManager->GetVolume("SQ04toSQ06"), 1, new TGeoTranslation(x, y, -kHzOuterFrameInox));
+  Mlayer->AddNode(gGeoManager->GetVolume("SQ05toSQ07"), 1, new TGeoTranslation(x, y, kHzOuterFrameEpoxy));
 
   // TopAnode1 - place 2 layers
   x = 6.8 + kDeltaQuadLHC;

--- a/Detectors/Passive/src/Pipe.cxx
+++ b/Detectors/Passive/src/Pipe.cxx
@@ -741,21 +741,22 @@ void Pipe::ConstructGeometry()
   zPos = aluSideA->GetZ(13) + flangeASteelRing->GetDz();
   barrel->AddNode(voflangeASteelRing, 1, new TGeoTranslation(0., 30., zPos));
 
-  // The vacuum inside aluSideA and flangeASteelRing
-  TGeoPcon* aluSideAVac = new TGeoPcon(0., 360., 8);
+  // The vacuum inside the aluminium section. aluSideA is a hollow Pcon, so it does
+  // not contain its own bore and the vacuum is a daughter of the barrel. The bore
+  // is kept at the third section's inner radius all the way to kZ36: the wider
+  // flange bore beyond it is occupied by the RB24 vacuum modules.
+  TGeoPcon* aluSideAVac = new TGeoPcon(0., 360., 6);
   aluSideAVac->DefineSection(0, aluSideA->GetZ(0), 0., aluSideA->GetRmin(0));
   aluSideAVac->DefineSection(1, aluSideA->GetZ(1), 0., aluSideA->GetRmin(1));
   aluSideAVac->DefineSection(2, aluSideA->GetZ(2), 0., aluSideA->GetRmin(2));
   aluSideAVac->DefineSection(3, aluSideA->GetZ(7), 0., aluSideA->GetRmin(7));
   aluSideAVac->DefineSection(4, aluSideA->GetZ(8), 0., aluSideA->GetRmin(8));
-  aluSideAVac->DefineSection(5, aluSideA->GetZ(11), 0., aluSideA->GetRmin(11));
-  aluSideAVac->DefineSection(6, aluSideA->GetZ(12), 0., aluSideA->GetRmin(12));
-  aluSideAVac->DefineSection(7, aluSideA->GetZ(13), 0., aluSideA->GetRmin(13));
+  aluSideAVac->DefineSection(5, aluSideA->GetZ(13), 0., aluSideA->GetRmin(9));
 
   TGeoVolume* voaluSideAVac = new TGeoVolume("aluSideAVac", aluSideAVac, kMedVac);
   voaluSideAVac->SetLineColor(kGreen);
   voaluSideAVac->SetVisibility(1);
-  voaluSideA->AddNode(voaluSideAVac, 1, gGeoIdentity);
+  barrel->AddNode(voaluSideAVac, 1, new TGeoTranslation(0., 30., 0.));
 
   // The support ring on A Side
   TGeoTube* sideASuppRing = new TGeoTube(kAluminum2ndSectionOuterRadius, kSupportRingRmax, kSupportRingLength / 2.);

--- a/Detectors/Passive/src/Pipe.cxx
+++ b/Detectors/Passive/src/Pipe.cxx
@@ -695,7 +695,9 @@ void Pipe::ConstructGeometry()
   Float_t rMin, rMax;
   Float_t zPos;
 
-  // The Aluminum Section till Flange
+  // The Aluminum Section till Flange. The sections are first defined with the real
+  // wall, so that the vacuum bore can be read off them, and the mother is then
+  // opened up to the beam axis so that it contains that bore itself.
   TGeoPcon* aluSideA = new TGeoPcon(0., 360., 14);
   rMax = kAluminum1stSectionOuterRadius;
   rMin = rMax - kAluminumSectionThickness;
@@ -727,9 +729,32 @@ void Pipe::ConstructGeometry()
   aluSideA->DefineSection(12, kZ35 + kAluminumSectionThickness, rMin, rMax);
   aluSideA->DefineSection(13, kZ36, rMin, rMax);
 
+  // The vacuum inside aluSideA, taken from the wall radii before they are zeroed.
+  TGeoPcon* aluSideAVac = new TGeoPcon(0., 360., 8);
+  aluSideAVac->DefineSection(0, aluSideA->GetZ(0), 0., aluSideA->GetRmin(0));
+  aluSideAVac->DefineSection(1, aluSideA->GetZ(1), 0., aluSideA->GetRmin(1));
+  aluSideAVac->DefineSection(2, aluSideA->GetZ(2), 0., aluSideA->GetRmin(2));
+  aluSideAVac->DefineSection(3, aluSideA->GetZ(7), 0., aluSideA->GetRmin(7));
+  aluSideAVac->DefineSection(4, aluSideA->GetZ(8), 0., aluSideA->GetRmin(8));
+  aluSideAVac->DefineSection(5, aluSideA->GetZ(11), 0., aluSideA->GetRmin(11));
+  aluSideAVac->DefineSection(6, aluSideA->GetZ(12), 0., aluSideA->GetRmin(12));
+  aluSideAVac->DefineSection(7, aluSideA->GetZ(13), 0., aluSideA->GetRmin(13));
+
+  // Open the aluminium to the beam axis. Without this the vacuum daughter lies
+  // entirely outside its mother, the navigator never enters it, and the bore is
+  // filled with the barrel's air instead of vacuum.
+  for (Int_t iSec = 0; iSec < aluSideA->GetNz(); ++iSec) {
+    aluSideA->DefineSection(iSec, aluSideA->GetZ(iSec), 0., aluSideA->GetRmax(iSec));
+  }
+
   TGeoVolume* voaluSideA = new TGeoVolume("aluSideA", aluSideA, kMedAlu2219);
   voaluSideA->SetLineColor(kBlue);
   barrel->AddNode(voaluSideA, 1, new TGeoTranslation(0., 30., 0.));
+
+  TGeoVolume* voaluSideAVac = new TGeoVolume("aluSideAVac", aluSideAVac, kMedVac);
+  voaluSideAVac->SetLineColor(kGreen);
+  voaluSideAVac->SetVisibility(1);
+  voaluSideA->AddNode(voaluSideAVac, 1, gGeoIdentity);
 
   // The Stainless Steel Flange Ring
   rMax = kFlangeAExternalRadius;
@@ -740,23 +765,6 @@ void Pipe::ConstructGeometry()
   voflangeASteelRing->SetLineColor(kRed);
   zPos = aluSideA->GetZ(13) + flangeASteelRing->GetDz();
   barrel->AddNode(voflangeASteelRing, 1, new TGeoTranslation(0., 30., zPos));
-
-  // The vacuum inside the aluminium section. aluSideA is a hollow Pcon, so it does
-  // not contain its own bore and the vacuum is a daughter of the barrel. The bore
-  // is kept at the third section's inner radius all the way to kZ36: the wider
-  // flange bore beyond it is occupied by the RB24 vacuum modules.
-  TGeoPcon* aluSideAVac = new TGeoPcon(0., 360., 6);
-  aluSideAVac->DefineSection(0, aluSideA->GetZ(0), 0., aluSideA->GetRmin(0));
-  aluSideAVac->DefineSection(1, aluSideA->GetZ(1), 0., aluSideA->GetRmin(1));
-  aluSideAVac->DefineSection(2, aluSideA->GetZ(2), 0., aluSideA->GetRmin(2));
-  aluSideAVac->DefineSection(3, aluSideA->GetZ(7), 0., aluSideA->GetRmin(7));
-  aluSideAVac->DefineSection(4, aluSideA->GetZ(8), 0., aluSideA->GetRmin(8));
-  aluSideAVac->DefineSection(5, aluSideA->GetZ(13), 0., aluSideA->GetRmin(9));
-
-  TGeoVolume* voaluSideAVac = new TGeoVolume("aluSideAVac", aluSideAVac, kMedVac);
-  voaluSideAVac->SetLineColor(kGreen);
-  voaluSideAVac->SetVisibility(1);
-  barrel->AddNode(voaluSideAVac, 1, new TGeoTranslation(0., 30., 0.));
 
   // The support ring on A Side
   TGeoTube* sideASuppRing = new TGeoTube(kAluminum2ndSectionOuterRadius, kSupportRingRmax, kSupportRingLength / 2.);


### PR DESCRIPTION
Fixes hidden material defects found by geometry-doctor

```
o2-sim-geometry-doctor --geometry-file o2sim_geometry.root --reachability-only --reachability-samples 100

ALICE simulation geometry doctor -- reachability audit

  geometry      : o2sim_geometry.root
  volumes       : 8898, media 391

reachability: asking the navigator to find every placement from inside its own shape

  **unreachable** -- these carry no material and produce no hits:
    mother       medium                sampled  path
    aluSideA     PIPE_VACUUM               100  /cave_1/barrel_1/aluSideA_1/aluSideAVac_1
    SQM1         MCH_Inox                  100  /cave_1/YOUT1_1/SC01I_0/Quadrant (chamber 1)_100/SQM1_1/SQ03_1
    SQM1         MCH_Inox                  100  /cave_1/YOUT1_1/SC01I_0/Quadrant (chamber 1)_100/SQM1_1/SQ05toSQ07_1
    SQM2         MCH_Inox                  100  /cave_1/YOUT1_1/SC02I_2/Quadrant (chamber 2)_200/SQM2_1/SQ03_1
    SQM2         MCH_Inox                  100  /cave_1/YOUT1_1/SC02I_2/Quadrant (chamber 2)_200/SQM2_1/SQ05toSQ07_1
```