### PR TITLE
GPU: support loading dynamic libraries on macOS

### DIFF
--- a/GPU/GPUTracking/utils/qlibload.h
+++ b/GPU/GPUTracking/utils/qlibload.h
@@ -21,6 +21,12 @@
 #define LIBRARY_LOAD(name) LoadLibraryEx(name, nullptr, nullptr)
 #define LIBRARY_CLOSE FreeLibrary
 #define LIBRARY_FUNCTION GetProcAddress
+#elif defined(__APPLE__)
+#define LIBRARY_EXTENSION ".dylib"
+#define LIBRARY_TYPE void*
+#define LIBRARY_LOAD(name) dlopen(name, RTLD_NOW)
+#define LIBRARY_CLOSE dlclose
+#define LIBRARY_FUNCTION dlsym
 #else
 #define LIBRARY_EXTENSION ".so"
 #define LIBRARY_TYPE void*


### PR DESCRIPTION

qlibload.h knew about Linux and Windows only, so any dlopen-based backend
loader was unbuildable on macOS. Adds the __APPLE__ branch (.dylib, dlopen).
Independent of any GPU backend.
