### PR TITLE
GPU: add METAL to the device type enumeration

### DIFF
--- a/GPU/GPUTracking/DataTypes/GPUDataTypesConfig.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypesConfig.h
@@ -32,7 +32,7 @@ namespace gpudatatypes
 {
 // clang-format off
 enum class GeometryType : uint32_t { RESERVED_GEOMETRY = 0, ALIROOT = 1, O2 = 2 };
-enum DeviceType : uint32_t { INVALID_DEVICE = 0, CPU = 1, CUDA = 2, HIP = 3, OCL = 4 };
+enum DeviceType : uint32_t { INVALID_DEVICE = 0, CPU = 1, CUDA = 2, HIP = 3, OCL = 4, METAL = 5 };
 enum class GeneralStep : uint32_t { Prepare = 1, QA = 2 };
 // clang-format on
 
@@ -57,8 +57,8 @@ enum class InOutType : uint32_t { TPCClusters = 1,
                                   TPCRaw = 64,
                                   ITSClusters = 128,
                                   ITSTracks = 256 };
-#ifndef __OPENCL__
-static constexpr const char* const DEVICE_TYPE_NAMES[] = {"INVALID", "CPU", "CUDA", "HIP", "OCL"};
+#if !defined(__OPENCL__) && !defined(__METAL__)
+static constexpr const char* const DEVICE_TYPE_NAMES[] = {"INVALID", "CPU", "CUDA", "HIP", "OCL", "METAL"};
 static constexpr const char* const RECO_STEP_NAMES[] = {"TPC Transformation", "TPC Sector Tracking", "TPC Track Merging and Fit", "TPC Compression", "TRD Tracking", "ITS Tracking", "TPC dEdx Computation", "TPC Cluster Finding", "TPC Decompression", "Global Refit"};
 static constexpr const char* const GENERAL_STEP_NAMES[] = {"Prepare", "QA"};
 constexpr static int32_t N_RECO_STEPS = sizeof(gpudatatypes::RECO_STEP_NAMES) / sizeof(gpudatatypes::RECO_STEP_NAMES[0]);


### PR DESCRIPTION

Purely additive: a new DeviceType value and its name. GetDeviceType() walks
DEVICE_TYPE_NAMES, so the table is the only other place that needs to know.
The name table is excluded under __METAL__ for the same reason it is under
__OPENCL__ -- no host strings in device code.
