### PR TITLE
[ALICE3] TF3: store BC and TDC in digits

### DIFF
--- a/Detectors/Upgrades/ALICE3/IOTOF/DataFormatsIOTOF/include/DataFormatsIOTOF/Digit.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/DataFormatsIOTOF/include/DataFormatsIOTOF/Digit.h
@@ -28,14 +28,16 @@ class Digit : public o2::itsmft::Digit
 {
  public:
   ~Digit() = default;
-  Digit(UShort_t chipindex = 0, UShort_t row = 0, UShort_t col = 0, Int_t charge = 0, double time = 0.)
-    : o2::itsmft::Digit(chipindex, row, col, charge), mTime(time) {};
+  Digit(UShort_t chipindex = 0, UShort_t row = 0, UShort_t col = 0, Int_t charge = 0, double time = 0., ULong64_t bc = 0, Int_t tdc = 0)
+    : o2::itsmft::Digit(chipindex, row, col, charge), mTime(time), mBc(bc), mTdc(tdc) {};
 
   // Setters
   void setTime(double time) { mTime = time; }
 
   // Getters
   double getTime() const { return mTime; }
+  ULong64_t getBc() const { return mBc; }
+  Int_t getTdc() const { return mTdc; }
 
   static UInt_t getOrderingKey(UShort_t chipindex, UShort_t row, UShort_t col)
   {
@@ -44,6 +46,8 @@ class Digit : public o2::itsmft::Digit
 
  private:
   double mTime = 0.; ///< Measured time (ns)
+  ULong64_t mBc = 0;  ///< BC
+  Int_t mTdc = 0;    ///< tdc time
   ClassDefNV(Digit, 1);
 };
 
@@ -59,9 +63,9 @@ struct McLabelRef {
 class LabeledDigit : public Digit
 {
  public:
-  LabeledDigit(UShort_t chipindex = 0, UShort_t row = 0, UShort_t col = 0, Int_t charge = 0, double time = 0.,
+  LabeledDigit(UShort_t chipindex = 0, UShort_t row = 0, UShort_t col = 0, Int_t charge = 0, double time = 0., ULong64_t bc = 0, Int_t tdc = 0,
                o2::MCCompLabel label = 0)
-    : Digit(chipindex, row, col, charge, time), mLabel(label) {}
+    : Digit(chipindex, row, col, charge, time, bc, tdc), mLabel(label) {}
 
   void setLabel(McLabelRef label) { mLabel = label; }
   McLabelRef getLabel() const { return mLabel; }

--- a/Detectors/Upgrades/ALICE3/IOTOF/DataFormatsIOTOF/include/DataFormatsIOTOF/Digit.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/DataFormatsIOTOF/include/DataFormatsIOTOF/Digit.h
@@ -49,7 +49,7 @@ class Digit : public o2::itsmft::Digit
 
  private:
   double mTime = 0.; ///< Measured time (ns)
-  ULong64_t mBc = 0;  ///< BC
+  ULong64_t mBc = 0; ///< BC
   Int_t mTdc = 0;    ///< tdc time
   ClassDefNV(Digit, 1);
 };

--- a/Detectors/Upgrades/ALICE3/IOTOF/DataFormatsIOTOF/include/DataFormatsIOTOF/Digit.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/DataFormatsIOTOF/include/DataFormatsIOTOF/Digit.h
@@ -19,6 +19,7 @@
 #ifndef ALICEO2_IOTOF_DIGIT_H
 #define ALICEO2_IOTOF_DIGIT_H
 
+#include "CommonConstants/LHCConstants.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsITSMFT/Digit.h"
 
@@ -39,9 +40,11 @@ class Digit : public o2::itsmft::Digit
   ULong64_t getBc() const { return mBc; }
   Int_t getTdc() const { return mTdc; }
 
-  static UInt_t getOrderingKey(UShort_t chipindex, UShort_t row, UShort_t col)
+  static ULong64_t getOrderingKey(ULong64_t bc, UShort_t row, UShort_t col)
   {
-    return (static_cast<UInt_t>(chipindex) << 16) | (static_cast<UInt_t>(row) << 8) | static_cast<UInt_t>(col);
+    uint32_t orbit = bc / o2::constants::lhc::LHCMaxBunches;
+    uint16_t bunch = bc % o2::constants::lhc::LHCMaxBunches;
+    return (static_cast<ULong64_t>(orbit) << 32) | (static_cast<UInt_t>(bunch) << 16) | (static_cast<UInt_t>(row) << 8) | static_cast<UInt_t>(col);
   }
 
  private:

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/include/IOTOFSimulation/Chip.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/include/IOTOFSimulation/Chip.h
@@ -76,11 +76,11 @@ class Chip
   /// reset points container
   o2::iotof::LabeledDigit* findDigit(ULong64_t key);
 
-  void addDigit(UShort_t row, UShort_t col, Int_t charge, double time, o2::MCCompLabel label);
+  void addDigit(UShort_t row, UShort_t col, Int_t charge, double time, ULong64_t bc, Int_t tdc, o2::MCCompLabel label);
 
  protected:
-  Int_t mChipIndex = -1;                                ///< Chip ID
-  bool mDisabled = false;                               ///< Flag to indicate if the chip is disabled (e.g. due to dead channels)
+  Int_t mChipIndex = -1;                                     ///< Chip ID
+  bool mDisabled = false;                                    ///< Flag to indicate if the chip is disabled (e.g. due to dead channels)
   std::map<ULong64_t, o2::iotof::LabeledDigit> mDigits; ///< Map of fired digits, possibly in multiple frames
 
   ClassDefNV(Chip, 1);

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/include/IOTOFSimulation/Chip.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/include/IOTOFSimulation/Chip.h
@@ -79,8 +79,8 @@ class Chip
   void addDigit(UShort_t row, UShort_t col, Int_t charge, double time, ULong64_t bc, Int_t tdc, o2::MCCompLabel label);
 
  protected:
-  Int_t mChipIndex = -1;                                     ///< Chip ID
-  bool mDisabled = false;                                    ///< Flag to indicate if the chip is disabled (e.g. due to dead channels)
+  Int_t mChipIndex = -1;                                ///< Chip ID
+  bool mDisabled = false;                               ///< Flag to indicate if the chip is disabled (e.g. due to dead channels)
   std::map<ULong64_t, o2::iotof::LabeledDigit> mDigits; ///< Map of fired digits, possibly in multiple frames
 
   ClassDefNV(Chip, 1);

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/include/IOTOFSimulation/DPLDigitizerParam.h
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/include/IOTOFSimulation/DPLDigitizerParam.h
@@ -28,6 +28,7 @@ struct DPLDigitizerParam : public o2::conf::ConfigurableParamHelper<DPLDigitizer
 
   double timeOffset = 0.;                 ///< time offset (in seconds!) to calculate ROFrame from hit time
   float timeResolution = 0.020f;          ///< time resolution sigma in ns (20 ps default)
+  float tdcBin = 0.010f;                  ///< TDC time bin (10 ps default)
   float efficiency = 0.98f;               ///< detection efficiency
   int chargeThreshold = 100;              ///< charge threshold in Nelectrons
   int minChargeToAccount = 7;             ///< minimum charge contribution to account

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Chip.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Chip.cxx
@@ -32,8 +32,8 @@ Chip::Chip(Int_t index)
 {
 }
 //_______________________________________________________________________
-void Chip::addDigit(UShort_t row, UShort_t col, Int_t charge, double time, o2::MCCompLabel label)
+void Chip::addDigit(UShort_t row, UShort_t col, Int_t charge, double time, ULong64_t bc, Int_t tdc, o2::MCCompLabel label)
 {
   ULong64_t key = Digit::getOrderingKey(mChipIndex, row, col);
-  mDigits.emplace(std::make_pair(key, LabeledDigit(mChipIndex, row, col, charge, time, label)));
+  mDigits.emplace(std::make_pair(key, LabeledDigit(mChipIndex, row, col, charge, time, bc, tdc, label)));
 }

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Chip.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Chip.cxx
@@ -34,6 +34,6 @@ Chip::Chip(Int_t index)
 //_______________________________________________________________________
 void Chip::addDigit(UShort_t row, UShort_t col, Int_t charge, double time, ULong64_t bc, Int_t tdc, o2::MCCompLabel label)
 {
-  ULong64_t key = Digit::getOrderingKey(mChipIndex, row, col);
+  ULong64_t key = Digit::getOrderingKey(bc, row, col);
   mDigits.emplace(std::make_pair(key, LabeledDigit(mChipIndex, row, col, charge, time, bc, tdc, label)));
 }

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
@@ -318,7 +318,7 @@ void Digitizer::fillOutputContainer()
       }
 
       int digitID = mDigits->size();
-      mDigits->emplace_back(digit.getChipIndex(), digit.getRow(), digit.getColumn(), digit.getCharge(), digit.getTime());
+      mDigits->emplace_back(digit.getChipIndex(), digit.getRow(), digit.getColumn(), digit.getCharge(), digit.getTime(), digit.getBc(), digit.getTdc());
       if (mMCLabels) {
         mMCLabels->addElement(digitID, digit.getLabel().mLabel);
       }
@@ -342,15 +342,17 @@ void Digitizer::fillOutputContainer()
   // mExtraLabelBuffer.pop_front();
 }
 
-// have a addDigit funtion?
+// have a addDigit function?
 
 void Digitizer::registerDigits(Chip& chip, uint32_t roFrame, double time, int nROF,
                                uint16_t row, uint16_t col, int nElectrons, o2::MCCompLabel& label)
 {
   (void)nROF;
 
+  const auto& digitizerParams = o2::iotof::DPLDigitizerParam::Instance();
+
   uint64_t nbc = static_cast<uint64_t>(time / o2::constants::lhc::LHCBunchSpacingNS);
-  int tdc = int((time - nbc * o2::constants::lhc::LHCBunchSpacingNS) / .01);
+  int tdc = int((time - nbc * o2::constants::lhc::LHCBunchSpacingNS) / digitizerParams.tdcBin);
   nbc += mEventTime.toLong();
 
   LOG(debug) << nbc << "\t" << tdc;
@@ -359,7 +361,7 @@ void Digitizer::registerDigits(Chip& chip, uint32_t roFrame, double time, int nR
   o2::iotof::LabeledDigit* existingDigit = chip.findDigit(key);
   if (!existingDigit) {
     // No existing digit, create a new one
-    chip.addDigit(row, col, nElectrons, time, label);
+    chip.addDigit(row, col, nElectrons, time, nbc, tdc, label);
   } else {
     // Digit already exists, update charge and labels
     const int storedCharge = existingDigit->getCharge();

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
@@ -123,12 +123,11 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, int evID, int srcID)
 
   // Get hit time and apply smearing
   // Hit time is in seconds, convert to ns and add event time
-  double hitTime = hit.GetTime() * sec2ns;      // convert to ns
-  double eventTimeNS = mEventTime.getTimeNS();  // event time since orbit 0
+  double hitTime = hit.GetTime() * sec2ns;       // convert to ns
+  double eventTimeNS = mEventTime.getTimeNS();   // event time since orbit 0
   double eventTimeInBC = mEventTime.getTimeOffsetWrtBC();
-//  double absoluteTime = hitTime + eventTimeNS;  // absolute time
-  double absoluteTime = hitTime + eventTimeInBC; // absolute time
-  double smearedTime = smearTime(absoluteTime); // apply detector resolution
+  double hitTimeWrtBC = hitTime + eventTimeInBC; // absolute time
+  double smearedTime = smearTime(hitTimeWrtBC);  // apply detector resolution
 
   if (chipID < 0 || chipID >= mGeometry->getSize() || mGeometry->getSize() < 1) {
     LOG(debug) << "Invalid detector ID: " << chipID << ", geometry size: " << mGeometry->getSize();
@@ -356,12 +355,13 @@ void Digitizer::registerDigits(Chip& chip, uint32_t roFrame, double time, int nR
   nbc += mEventTime.toLong();
 
   LOG(debug) << nbc << "\t" << tdc;
+  double absoluteTime = tdc * digitizerParams.tdcBin * 1.e-9 + nbc * o2::constants::lhc::LHCBunchSpacingNS;
 
   auto key = o2::iotof::Digit::getOrderingKey(chip.getChipIndex(), row, col);
   o2::iotof::LabeledDigit* existingDigit = chip.findDigit(key);
   if (!existingDigit) {
     // No existing digit, create a new one
-    chip.addDigit(row, col, nElectrons, time, nbc, tdc, label);
+    chip.addDigit(row, col, nElectrons, absoluteTime, nbc, tdc, label);
   } else {
     // Digit already exists, update charge and labels
     const int storedCharge = existingDigit->getCharge();

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
@@ -125,7 +125,9 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, int evID, int srcID)
   // Hit time is in seconds, convert to ns and add event time
   double hitTime = hit.GetTime() * sec2ns;      // convert to ns
   double eventTimeNS = mEventTime.getTimeNS();  // event time since orbit 0
-  double absoluteTime = hitTime + eventTimeNS;  // absolute time
+  double eventTimeInBC = mEventTime.getTimeOffsetWrtBC();
+//  double absoluteTime = hitTime + eventTimeNS;  // absolute time
+  double absoluteTime = hitTime + eventTimeInBC; // absolute time
   double smearedTime = smearTime(absoluteTime); // apply detector resolution
 
   if (chipID < 0 || chipID >= mGeometry->getSize() || mGeometry->getSize() < 1) {
@@ -340,10 +342,18 @@ void Digitizer::fillOutputContainer()
   // mExtraLabelBuffer.pop_front();
 }
 
+// have a addDigit funtion?
+
 void Digitizer::registerDigits(Chip& chip, uint32_t roFrame, double time, int nROF,
                                uint16_t row, uint16_t col, int nElectrons, o2::MCCompLabel& label)
 {
   (void)nROF;
+
+  uint64_t nbc = static_cast<uint64_t>(time / o2::constants::lhc::LHCBunchSpacingNS);
+  int tdc = int((time - nbc * o2::constants::lhc::LHCBunchSpacingNS) / .01);
+  nbc += mEventTime.toLong();
+
+  LOG(debug) << nbc << "\t" << tdc;
 
   auto key = o2::iotof::Digit::getOrderingKey(chip.getChipIndex(), row, col);
   o2::iotof::LabeledDigit* existingDigit = chip.findDigit(key);

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
@@ -123,11 +123,10 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, int evID, int srcID)
 
   // Get hit time and apply smearing
   // Hit time is in seconds, convert to ns and add event time
-  double hitTime = hit.GetTime() * sec2ns;       // convert to ns
-  double eventTimeNS = mEventTime.getTimeNS();   // event time since orbit 0
-  double eventTimeInBC = mEventTime.getTimeOffsetWrtBC();
-  double hitTimeWrtBC = hitTime + eventTimeInBC; // absolute time
-  double smearedTime = smearTime(hitTimeWrtBC);  // apply detector resolution
+  double hitTime = hit.GetTime() * sec2ns;                // convert to ns
+  double eventTimeInBC = mEventTime.getTimeOffsetWrtBC(); // event time wrt bc
+  double hitTimeWrtBC = hitTime + eventTimeInBC;          // hit time wrt bc
+  double smearedTime = smearTime(hitTimeWrtBC);           // apply detector resolution
 
   if (chipID < 0 || chipID >= mGeometry->getSize() || mGeometry->getSize() < 1) {
     LOG(debug) << "Invalid detector ID: " << chipID << ", geometry size: " << mGeometry->getSize();
@@ -340,8 +339,6 @@ void Digitizer::fillOutputContainer()
   // mExtraLabelBuffer.emplace_back(mExtraLabelBuffer.front().release()); // move current buffer to the end
   // mExtraLabelBuffer.pop_front();
 }
-
-// have a addDigit function?
 
 void Digitizer::registerDigits(Chip& chip, uint32_t roFrame, double time, int nROF,
                                uint16_t row, uint16_t col, int nElectrons, o2::MCCompLabel& label)

--- a/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/simulation/src/Digitizer.cxx
@@ -357,7 +357,7 @@ void Digitizer::registerDigits(Chip& chip, uint32_t roFrame, double time, int nR
   LOG(debug) << nbc << "\t" << tdc;
   double absoluteTime = tdc * digitizerParams.tdcBin * 1.e-9 + nbc * o2::constants::lhc::LHCBunchSpacingNS;
 
-  auto key = o2::iotof::Digit::getOrderingKey(chip.getChipIndex(), row, col);
+  auto key = o2::iotof::Digit::getOrderingKey(nbc, row, col);
   o2::iotof::LabeledDigit* existingDigit = chip.findDigit(key);
   if (!existingDigit) {
     // No existing digit, create a new one


### PR DESCRIPTION
* The digit time is saved both as absolute time (double) and as bc + tdc.
* A 10 ps TDC bin is set by default
* The bc is used in the digit map of chips