### PR TITLE
small changes in handling empty TF

### DIFF
--- a/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
@@ -189,7 +189,7 @@ void DigitReader<N>::run(ProcessingContext& pc)
         std::vector<int> rofOld2New;
         rofOld2New.resize(mDigROFRec[0]->size(), -1);
 
-        if (mDigROFRec[0]->front().getBCData() <= irMax && (mDigROFRec[0]->back().getBCData() + mROFLengthInBC - 1) >= irMin) { // there is an overlap
+        if (!mDigROFRec[0]->empty() && mDigROFRec[0]->front().getBCData() <= irMax && (mDigROFRec[0]->back().getBCData() + mROFLengthInBC - 1) >= irMin) { // there is an overlap
           for (int irof = 0; irof < (int)mDigROFRec[0]->size(); irof++) {
             const auto& rof = mDigROFRec[0]->at(irof);
             if (irfSel.check({rof.getBCData(), rof.getBCData() + mROFLengthInBC - 1}) != -1) {
@@ -208,7 +208,7 @@ void DigitReader<N>::run(ProcessingContext& pc)
             }
           }
         }
-        if (mDigROFRec[0]->back().getBCData() + mROFLengthInBC - 1 < irMax) { // need to check the next entry
+        if (mDigROFRec[0]->empty() || mDigROFRec[0]->back().getBCData() + mROFLengthInBC - 1 < irMax) { // need to check the next entry
           ent++;
           continue;
         }

--- a/Detectors/MUON/MCH/IO/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MCH/IO/src/DigitReaderSpec.cxx
@@ -152,7 +152,11 @@ class DigitsReaderDeviceDPL
     // get the IR frames to select
     auto irFrames = pc.inputs().get<gsl::span<dataformats::IRFrame>>("driverInfo");
 
-    if (!irFrames.empty()) {
+    if (mTreeReader.GetEntries() == 0) {
+      // A timeframe holds no collision at all whenever the interaction rate is low enough, and the
+      // digit tree then has no entry. Nothing to select. Send empty containers.
+      LOG(info) << "digit tree has no entry, sending empty output";
+    } else if (!irFrames.empty()) {
       utils::IRFrameSelector irfSel{};
       irfSel.setSelectedIRFrames(irFrames, 0, 0, -mTimeOffset, true);
       const auto irMin = irfSel.getIRFrames().front().getMin();

--- a/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
@@ -146,7 +146,11 @@ class DigitsReaderDeviceDPL
     // get the IR frames to select
     auto irFrames = pc.inputs().get<gsl::span<dataformats::IRFrame>>("driverInfo");
 
-    if (!irFrames.empty()) {
+    if (mTreeReader.GetEntries() == 0) {
+      // A timeframe holds no collision at all whenever the interaction rate is low enough, and the
+      // digit tree then has no entry. Nothing to select. Send empty containers.
+      LOG(info) << "digit tree has no entry, sending empty output";
+    } else if (!irFrames.empty()) {
       utils::IRFrameSelector irfSel{};
       irfSel.setSelectedIRFrames(irFrames, 0, 0, 0, true);
       const auto irMin = irfSel.getIRFrames().front().getMin();

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -62,7 +62,7 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     if (labels.getIndexedSize() != digits.size()) {
       LOGP(error, "Number of labels != number of digits");
     }
-    LOGP(info, "Number of signal pileup : {} ({} %)", nPileup, digits.empty() ? 0. : 100.* nPileup / digits.size());
+    LOGP(info, "Number of signal pileup : {} ({} %)", nPileup, digits.empty() ? 0. : 100. * nPileup / digits.size());
     auto tEnd = std::chrono::high_resolution_clock::now();
     auto duration = tEnd - start;
     auto d = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -15,7 +15,6 @@
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DetectorsBase/BaseDPLDigitizer.h"
-#include "DetectorsRaw/HBFUtils.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataProcessorSpec.h"
@@ -63,7 +62,7 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     if (labels.getIndexedSize() != digits.size()) {
       LOGP(error, "Number of labels != number of digits");
     }
-    LOGP(info, "Number of signal pileup : {} ({} %)", nPileup, 100. * nPileup / digits.size());
+    LOGP(info, "Number of signal pileup : {} ({} %)", nPileup, digits.empty() ? 0. : 100.* nPileup / digits.size());
     auto tEnd = std::chrono::high_resolution_clock::now();
     auto duration = tEnd - start;
     auto d = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
@@ -104,20 +103,12 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     }
 
     // generate noise-only signals between first and last collisions ± 100 BC (= 25 ADC samples).
-    // A timeframe can hold no collision at all when the interaction rate is low; take the range
-    // from the timeframe itself in that case, since there are no collisions to take it from.
-    int64_t firstLong, lastLong;
-    if (eventRecords.empty()) {
-      const auto& hbf = o2::raw::HBFUtils::Instance();
-      firstLong = InteractionRecord(0, hbf.orbitFirstSampled).toLong();
-      lastLong = InteractionRecord(0, hbf.orbitFirstSampled + hbf.nHBFPerTF).toLong();
-    } else {
-      firstLong = eventRecords.front().toLong();
-      lastLong = eventRecords.back().toLong();
+    // A timeframe can hold no collision at all when the interaction rate is low; skip it in that case.
+    if (!eventRecords.empty()) {
+      auto firstIR = InteractionRecord::long2IR(std::max(int64_t(0), eventRecords.front().toLong() - timeOffset - 100));
+      auto lastIR = InteractionRecord::long2IR(std::max(int64_t(0), eventRecords.back().toLong() - timeOffset + 100));
+      mDigitizer->addNoise(firstIR, lastIR);
     }
-    auto firstIR = InteractionRecord::long2IR(std::max(int64_t(0), firstLong - timeOffset - 100));
-    auto lastIR = InteractionRecord::long2IR(std::max(int64_t(0), lastLong - timeOffset + 100));
-    mDigitizer->addNoise(firstIR, lastIR);
 
     // digitize
     std::vector<Digit> digits{};


### PR DESCRIPTION
Hi @sawenzel ,
This is a follow up on #15705 and #15714.
- If there is no collision, we can as well skip entirely the noise-only digit generation to save time and send empty containers. 
- I think a protection was missing in the MCH and MID digit readers when using IR frames.
Cheers,
Philippe