### PR TITLE
Clusterer will prioritize labels with lower trackIndex

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -170,6 +170,7 @@ void Clusterer::ClustererThread::process(uint16_t chip, uint16_t nChips, CompClu
   if (stats.empty() || stats.back().firstChip + stats.back().nChips != chip) { // there is a jump, register new block
     stats.emplace_back(ThreadStat{.firstChip = chip, .nChips = 0, .firstClus = uint32_t(compClusPtr->size()), .firstPatt = patternsPtr ? uint32_t(patternsPtr->size()) : 0, .nClus = 0, .nPatt = 0});
   }
+
   for (int ic = 0; ic < nChips; ic++) {
     auto* curChipData = parent->mFiredChipsPtr[chip + ic];
     auto chipID = curChipData->getChipID();
@@ -316,7 +317,7 @@ void Clusterer::ClustererThread::finishChipSingleHitFast(uint32_t hit, ChipPixel
     int nlab = 0;
     fetchMCLabels(curChipData->getStartID() + hit, labelsDigPtr, nlab);
     auto cnt = compClusPtr->size();
-    for (int i = nlab; i--;) {
+    for (int i = 0; i < nlab; i++) {
       labelsClusPtr->addElement(cnt, labelsBuff[i]);
     }
   }
@@ -436,20 +437,27 @@ void Clusterer::ClustererThread::updateChip(const ChipPixelData* curChipData, ui
 void Clusterer::ClustererThread::fetchMCLabels(int digID, const ConstMCTruth* labelsDig, int& nfilled)
 {
   // transfer MC labels to cluster
-  if (nfilled >= MaxLabels) {
-    return;
-  }
-  const auto& lbls = labelsDig->getLabels(digID);
-  for (int i = lbls.size(); i--;) {
-    int ic = nfilled;
-    for (; ic--;) { // check if the label is already present
-      if (labelsBuff[ic] == lbls[i]) {
-        return; // label is found, do nothing
+  auto sortBuffer = [this]() { std::sort(this->labelsBuff.begin(), this->labelsBuff.end(), [](Label const& a, Label const& b) { return a.getTrackID() < b.getTrackID(); }); };
+  for (const auto& l : labelsDig->getLabels(digID)) {
+    bool skip = false;
+    for (int ic = 0; ic < nfilled; ic++) { // check if the label is already present
+      if (labelsBuff[ic] == l) {
+        skip = true;
+        break;
       }
     }
-    labelsBuff[nfilled++] = lbls[i];
-    if (nfilled >= MaxLabels) {
-      break;
+    if (!skip) { // are there still slots to add it?
+      if (nfilled < MaxLabels) {
+        labelsBuff[nfilled++] = l;
+        if (nfilled == MaxLabels) { // we filled the buffer, sort labels in the trackID increasing order, to increase chances of not losing more primary at next filling
+          sortBuffer();
+        }
+      } else { // buffer is full and sorted in trackID increasing order, substitute the old highest track ID if it is higher than the new label
+        if (labelsBuff.back().getTrackID() > l.getTrackID()) {
+          labelsBuff.back() = l; // substitute and re-sort
+          sortBuffer();
+        }
+      }
     }
   }
   //


### PR DESCRIPTION
The HIP may produce a large number of delta electrons (e.g. a magnetic monopole typically produces a few 10K deltas in the barrel). Since we limit the number of saved MC labels per ITS/MFT cluster to `Clusterer::MaxLabels` (=10), in a large cluster receiving contributions from both the HIP and its delta rays, the HIP label might not be saved if MaxLabels delta electrons contributing to the same cluster have already been accounted for (the order is quasi-random).

To minimize the chance of such label loss, assuming that the track ID of the HIP is smaller than those of its delta rays, when there is no free slot left in the label buffer, the new label (e.g. that of the HIP) will replace the label with the largest track ID already present in the buffer.