### PR TITLE
Upgrades: clusterer will prioritize labels with lower trackIndex

### DIFF
--- a/Detectors/Upgrades/ALICE3/IOTOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/Upgrades/ALICE3/IOTOF/reconstruction/src/Clusterer.cxx
@@ -160,7 +160,7 @@ void Clusterer::ClustererThread::finishChipSingleHitFast(gsl::span<const Digit> 
     int nlab = 0;
     fetchMCLabels(digitIdx, labelsDigPtr, nlab);
     const auto cnt = static_cast<uint32_t>(clusters.size());
-    for (int i = nlab; i--;) {
+    for (int i = 0; i < nlab; i++) {
       labels.addElement(cnt, labelsBuff[i]);
     }
   }
@@ -182,23 +182,28 @@ void Clusterer::ClustererThread::finishChipSingleHitFast(gsl::span<const Digit> 
 //__________________________________________________
 void Clusterer::ClustererThread::fetchMCLabels(uint32_t digID, const ConstDigitTruth* labelsDig, int& nfilled)
 {
-  if (nfilled >= MaxLabels) {
-    return;
-  }
   if (!labelsDig || digID >= labelsDig->getIndexedSize()) {
     return;
   }
-  const auto& lbls = labelsDig->getLabels(digID);
-  for (int i = lbls.size(); i--;) {
-    int ic = nfilled;
-    for (; ic--;) {
-      if (labelsBuff[ic] == lbls[i]) {
-        return; // already present
+  auto sortBuffer = [this]() { std::sort(this->labelsBuff.begin(), this->labelsBuff.end(), [](Label const& a, Label const& b) { return a.getTrackID() < b.getTrackID(); }); };
+  for (const auto& label : labelsDig->getLabels(digID)) {
+    bool skip = false;
+    for (int ic = 0; ic < nfilled; ic++) {
+      if (labelsBuff[ic] == label) {
+        skip = true;
+        break;
       }
     }
-    labelsBuff[nfilled++] = lbls[i];
-    if (nfilled >= MaxLabels) {
-      break;
+    if (!skip) {
+      if (nfilled < MaxLabels) {
+        labelsBuff[nfilled++] = label;
+        if (nfilled == MaxLabels) {
+          sortBuffer();
+        }
+      } else if (labelsBuff.back().getTrackID() > label.getTrackID()) {
+        labelsBuff.back() = label;
+        sortBuffer();
+      }
     }
   }
 }

--- a/Detectors/Upgrades/ALICE3/TRKFT3/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/Upgrades/ALICE3/TRKFT3/common/reconstruction/src/Clusterer.cxx
@@ -372,7 +372,7 @@ void Clusterer<DetID>::ClustererThread::finishChipSingleHitFast(gsl::span<const 
     int nlab = 0;
     fetchMCLabels(hit, labelsDigPtr, nlab);
     const auto cnt = static_cast<uint32_t>(clusters.size());
-    for (int i = nlab; i--;) {
+    for (int i = 0; i < nlab; i++) {
       labels.addElement(cnt, labelsBuff[i]);
     }
   }
@@ -404,7 +404,7 @@ void Clusterer<DetID>::ClustererThread::streamCluster(const BBox& bbox,
 {
   if (doLabels) {
     const auto cnt = static_cast<uint32_t>(clusters.size());
-    for (int i = nlab; i--;) {
+    for (int i = 0; i < nlab; i++) {
       labels.addElement(cnt, labelsBuff[i]); // accumulate in thread-local buffer
     }
   }
@@ -438,23 +438,28 @@ void Clusterer<DetID>::ClustererThread::streamCluster(const BBox& bbox,
 template <int DetID>
 void Clusterer<DetID>::ClustererThread::fetchMCLabels(uint32_t digID, const ConstDigitTruth* labelsDig, int& nfilled)
 {
-  if (nfilled >= MaxLabels) {
-    return;
-  }
   if (!labelsDig || digID >= labelsDig->getIndexedSize()) {
     return;
   }
-  const auto& lbls = labelsDig->getLabels(digID);
-  for (int i = lbls.size(); i--;) {
-    int ic = nfilled;
-    for (; ic--;) {
-      if (labelsBuff[ic] == lbls[i]) {
-        return; // already present
+  auto sortBuffer = [this]() { std::sort(this->labelsBuff.begin(), this->labelsBuff.end(), [](Label const& a, Label const& b) { return a.getTrackID() < b.getTrackID(); }); };
+  for (const auto& label : labelsDig->getLabels(digID)) {
+    bool skip = false;
+    for (int ic = 0; ic < nfilled; ic++) {
+      if (labelsBuff[ic] == label) {
+        skip = true;
+        break;
       }
     }
-    labelsBuff[nfilled++] = lbls[i];
-    if (nfilled >= MaxLabels) {
-      break;
+    if (!skip) {
+      if (nfilled < MaxLabels) {
+        labelsBuff[nfilled++] = label;
+        if (nfilled == MaxLabels) {
+          sortBuffer();
+        }
+      } else if (labelsBuff.back().getTrackID() > label.getTrackID()) {
+        labelsBuff.back() = label;
+        sortBuffer();
+      }
     }
   }
 }

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/Clusterer.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/Clusterer.h
@@ -283,7 +283,7 @@ void Clusterer::streamCluster(const std::vector<PixelData>& pixbuf, const std::a
 {
   if (labelsClusPtr && lblBuff) { // MC labels were requested
     auto cnt = compClusPtr->size();
-    for (int i = nlab; i--;) {
+    for (int i = 0; i < nlab; i++) {
       labelsClusPtr->addElement(cnt, (*lblBuff)[i]);
     }
   }

--- a/Detectors/Upgrades/ITS3/reconstruction/src/Clusterer.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/Clusterer.cxx
@@ -318,7 +318,7 @@ void Clusterer::ClustererThread::finishChipSingleHitFast(uint32_t hit, ChipPixel
     int nlab = 0;
     fetchMCLabels(curChipData->getStartID() + hit, labelsDigPtr, nlab);
     auto cnt = compClusPtr->size();
-    for (int i = nlab; i--;) {
+    for (int i = 0; i < nlab; i++) {
       labelsClusPtr->addElement(cnt, labelsBuff[i]);
     }
   }
@@ -454,20 +454,25 @@ void Clusterer::ClustererThread::updateChip(const ChipPixelData* curChipData, ui
 void Clusterer::ClustererThread::fetchMCLabels(int digID, const ConstMCTruth* labelsDig, int& nfilled)
 {
   // transfer MC labels to cluster
-  if (nfilled >= MaxLabels) {
-    return;
-  }
-  const auto& lbls = labelsDig->getLabels(digID);
-  for (int i = lbls.size(); i--;) {
-    int ic = nfilled;
-    for (; ic--;) { // check if the label is already present
-      if (labelsBuff[ic] == lbls[i]) {
-        return; // label is found, do nothing
+  auto sortBuffer = [this]() { std::sort(this->labelsBuff.begin(), this->labelsBuff.end(), [](Label const& a, Label const& b) { return a.getTrackID() < b.getTrackID(); }); };
+  for (const auto& label : labelsDig->getLabels(digID)) {
+    bool skip = false;
+    for (int ic = 0; ic < nfilled; ic++) { // check if the label is already present
+      if (labelsBuff[ic] == label) {
+        skip = true;
+        break;
       }
     }
-    labelsBuff[nfilled++] = lbls[i];
-    if (nfilled >= MaxLabels) {
-      break;
+    if (!skip) { // are there still slots to add it?
+      if (nfilled < MaxLabels) {
+        labelsBuff[nfilled++] = label;
+        if (nfilled == MaxLabels) { // we filled the buffer, sort labels in the trackID increasing order
+          sortBuffer();
+        }
+      } else if (labelsBuff.back().getTrackID() > label.getTrackID()) {
+        labelsBuff.back() = label;
+        sortBuffer();
+      }
     }
   }
   //


### PR DESCRIPTION
Extending PR15782 to upgrade classes which replicated the cluster label building from the ITS: 

The HIP may produce a large number of delta electrons (e.g. a magnetic monopole typically produces a few 10K deltas in the barrel). Since we limit the number of saved MC labels per ITS/MFT cluster to Clusterer::MaxLabels (=10), in a large cluster receiving contributions from both the HIP and its delta rays, the HIP label might not be saved if MaxLabels delta electrons contributing to the same cluster have already been accounted for (the order is quasi-random).

To minimize the chance of such label loss, assuming that the track ID of the HIP is smaller than those of its delta rays, when there is no free slot left in the label buffer, the new label (e.g. that of the HIP) will replace the label with the largest track ID already present in the buffer.