### PR TITLE
[MUON] Fix assignment of GlobalFwdTrack from base class

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalFwdTrack.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalFwdTrack.h
@@ -34,6 +34,19 @@ class GlobalFwdTrack : public o2::track::TrackParCovFwd, public o2::dataformats:
   GlobalFwdTrack(o2::track::TrackParCovFwd const& t) { *this = t; }
   ~GlobalFwdTrack() = default;
 
+  GlobalFwdTrack& operator=(const TrackParCovFwd& rhs)
+  {
+    o2::track::TrackParCovFwd::operator=(rhs);
+    return *this;
+  }
+
+  GlobalFwdTrack& operator=(const GlobalFwdTrack& rhs)
+  {
+    o2::track::TrackParCovFwd::operator=(rhs);
+    o2::dataformats::MatchInfoFwd::operator=(rhs);
+    return *this;
+  }
+
   SMatrix5 computeResiduals2Cov(const o2::track::TrackParCovFwd& t) const
   {
     SMatrix5 Residuals2Cov;


### PR DESCRIPTION
The fix introduces an explicit assignment operator between the GlobalFwdTrack class and its TrackParCovFwd base class.

This prevents a SEGFAULT in this kind of assignment:
```
    o2::track::TrackParCovFwd trackParCovFwd;
    o2::dataformats::GlobalFwdTrack globalFwdTrack;
    globalFwdTrack = trackParCovFwd;
```